### PR TITLE
add aliases to build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: deps jar install deploy nodejs browser clean
 
 target/fluree-db.jar: pom.xml out src/deps.cljs src/**/* resources/**/*
-	clojure -M:jar
+	clojure -A:jar -M:jar
 
 jar: target/fluree-db.jar
 
@@ -34,7 +34,7 @@ src/deps.cljs: package.json
 	clojure -M:js-deps
 
 install: target/fluree-db.jar
-	clojure -M:install
+	clojure -A:install -M:install
 
 deploy: target/fluree-db.jar
 	clojure -M:deploy


### PR DESCRIPTION
Hello! I am excited to explore this project.

Following the readme to build locally, when I tried entering

`make install`

I was met with

```shell
make install
clojure -M:jar
Execution error (FileNotFoundException) at clojure.main/main (main.java:40).
Could not locate hf/depstar/jar__init.class, hf/depstar/jar.clj or hf/depstar/jar.cljc on classpath.
```
To which adding the aliases for the extra deps resolves (in the case of having clojure-1.10.1.645 installed)