### PR TITLE
FC-837 remove deprecation syntax warnings

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -850,13 +850,10 @@
   (go-try (let [{:keys [vars where optional filter]} q-map
                 where-res    (<? (resolve-where-clause db where q-map vars fuel max-fuel opts))
                 optional-res (if optional
-                               (do
-                                 (log/warn (str "The query key: optional should be included in the 'where' array. The top-level 'optional' is being deprecated. Provided: " (pr-str q-map)))
-                                 (<? (optional->left-outer-joins db q-map optional where-res fuel max-fuel opts))) where-res)
+                               (<? (optional->left-outer-joins db q-map optional where-res fuel max-fuel opts))
+                               where-res)
                 filter-res   (if filter
-                               (do
-                                 (log/warn (str "The query key: filter should be included in the 'where' array. The top-level 'filter' is being deprecated. Provided: " (pr-str q-map)))
-                                 (tuples->filtered optional-res filter nil))
+                               (tuples->filtered optional-res filter nil)
                                optional-res)
                 res          filter-res]
             res)))

--- a/src/fluree/db/query/analytical_wikidata.cljc
+++ b/src/fluree/db/query/analytical_wikidata.cljc
@@ -87,9 +87,7 @@
 
 (defn generateWikiDataQuery
   [q-map clauses select-vars value-clause optional-clauses]
-  (let [_            (when (:wikidataOpts q-map)
-                       (log/warn (str "The Wikidata query option map should be included in the opts map. Top-level options are being deprecated. Provided: " (pr-str q-map))))
-        opts         (merge {:limit 100 :offset 0 :distinct false :language "en"}
+  (let [opts         (merge {:limit 100 :offset 0 :distinct false :language "en"}
                             (:wikidataOpts q-map) (get-in [:opts :wikidataOpts] q-map))
         {:keys [limit offset distinct language prefixes]} opts
         prefixes     (when prefixes (parse-prefixes prefixes))


### PR DESCRIPTION
removed warnings about "deprecated" syntax for analytical queries