### PR TITLE
Reduce size of browser build; outputs to out/flureedb.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,30 +15,25 @@ jar: target/fluree-db.jar
 out:
 	mkdir out
 
-out/nodejs: out
-	mkdir out/nodejs
-
 package-lock.json node_modules: package.json
 	npm install && touch package-lock.json node_modules
 
-out/nodejs/flureenjs.js: package.json package-lock.json node_modules build-nodejs.edn deps.edn out/nodejs src/deps.cljs $(SOURCES) $(NODEJS_SOURCES) $(RESOURCES)
-	clojure -M:nodejs
+out/flureenjs.js: out package.json package-lock.json node_modules build-nodejs.edn deps.edn src/deps.cljs $(SOURCES) $(NODEJS_SOURCES) $(RESOURCES)
+	clojure -M:nodejs && cp out/nodejs/flureenjs.js out/flureenjs.js
 
-nodejs: out/nodejs/flureenjs.js
+nodejs: out/flureenjs.js
 
-out/browser: out
-	mkdir out/browser
+out/flureedb.js: out package.json package-lock.json node_modules build-browser.edn deps.edn src/deps.cljs $(SOURCES) $(BROWSER_SOURCES) $(RESOURCES)
+	clojure -M:browser && cp out/browser/main.js out/flureedb.js
 
-out/browser/flureedb.js: package.json package-lock.json node_modules build-browser.edn deps.edn out/browser src/deps.cljs $(SOURCES) $(BROWSER_SOURCES) $(RESOURCES)
-	clojure -M:browser
+browser: out/flureedb.js
 
-browser: out/browser/flureedb.js
 
 pom.xml: deps.edn
 	clojure -Spom
 
 deps:
-	clojure -Stree
+	clojure -P
 
 src/deps.cljs: package.json
 	clojure -M:js-deps

--- a/build-browser.edn
+++ b/build-browser.edn
@@ -10,6 +10,6 @@
  :externs            ["sjcl-externs.js"]
  :install-deps       true
  :npm-deps           {}
- :bundle-cmd         {:none    ["npx" "webpack" "out/browser/index.js" "-o" "out/browser/flureedb.js" "--mode=development"]
-                      :default ["npx" "webpack" "out/browser/index.js" "-o" "out/browser/flureedb.js"]}
+ :bundle-cmd         {:none    ["npx" "webpack" "out/browser/index.js" "-o" "out/browser/main.js" "--mode=development"]
+                      :default ["npx" "webpack" "out/browser/index.js" "-o" "out/browser/main.js"]}
  :closure-defines    {cljs.core/*global* "window"}}

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -11,6 +11,6 @@
     <h2>FlureeDB - mind your data!</h2>
     <p>View developer console for more messages.</p>
 </div>
-<script src="js/compiled/flureedb.js" type="text/javascript"></script>
+<script src="js/build/flureedb.js" type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
I didn't gain much insight into what was wrong here. The whole cljs compilation and bundling pipeline is an opaque, magical mess. I reached out to the CLJS experts of the world, and they didn't have much advice to offer in terms of getting more transparency into what the various tools are doing and why. So I think if we have to dive back into build size issues here in the future, we may have to explore building some tooling ourselves around that. It doesn't seem like a thing the upstream devs nor the community have really tackled yet.

But the final `out/flureedb.js` file is back down to 1.6M in here for reasons I can't fully explain. 😬 

At first it appeared as though the size reduction came from not bundling to a filename that matched a namespace (e.g. `flureedb`) since those generate intermediate .js files in the output-dir. But in subsequent tests I couldn't duplicate that behavior. I've left that split in for now just because it takes some undefined behavior off the table for reasoning about all this.