### PR TITLE
Feature/cas

### DIFF
--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -93,7 +93,8 @@
                      'floor         (resolve 'fluree.db.dbfunctions.fns/floor)
                      'upper-case    (resolve 'fluree.db.dbfunctions.fns/upper-case)
                      'lower-case    (resolve 'fluree.db.dbfunctions.fns/lower-case)
-                     'uuid          (resolve 'fluree.db.dbfunctions.fns/uuid)})
+                     'uuid          (resolve 'fluree.db.dbfunctions.fns/uuid)
+                     'cas           (resolve 'fluree.db.dbfunctions.fns/cas)})
 
 (defn resolve-local-fn
   [f]

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -770,7 +770,7 @@
      (let [seed' (extract seed)
            max'  (clojure.core/or (extract max) 10)
            res   (fdb/rand seed' max')
-           entry [{:function "rand" :arguments [seed max] :result res} 10]]
+           entry [{:function "rand" :arguments [max seed] :result res} 10]]
        (add-stack ?ctx entry)
        res))))
 
@@ -805,5 +805,16 @@
     (let [num   (extract num)
           res   (fdb/floor num)
           entry [{:function "" :arguments [floor] :result res} 10]]
+      (add-stack ?ctx entry)
+      res)))
+
+(defn cas
+  {:doc      "Does a compare and set/swap operation as a transaction function."
+   :fdb/spec nil
+   :fdb/cost 20}
+  [?ctx compare-val new-val]
+  (go-try
+    (let [res   (<? (fdb/cas ?ctx compare-val new-val))
+          entry [{:function "" :arguments [compare-val new-val] :result res} 10]]
       (add-stack ?ctx entry)
       res)))

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -579,3 +579,34 @@
     (let [base (.nextDouble (java.util.Random. instant))
           num  (int (Math/floor (* base max')))] num)
     (catch* e (function-error e "rand" instant max'))))
+
+(defn cas
+  "Returns new-val if existing-val is equal to compare-val, else throws exception"
+  [?ctx compare-val new-val]
+  (go-try
+    (let [{:keys [sid pid db]} ?ctx
+          p-name      (dbproto/-p-prop db :name pid)
+          _           (when-not sid
+                        (throw (ex-info (str "Unable to execute cas as no subject id could be determined. Cas values: " compare-val new-val)
+                                        {:status 400
+                                         :error  :db/validation-error})))
+          _           (when-not p-name
+                        (throw (ex-info (str "Unable to execute cas as no predicate id could be determined. Cas values: " compare-val new-val)
+                                        {:status 400
+                                         :error  :db/validation-error})))
+          _           (when (dbproto/-p-prop db :multi pid)
+                        (throw (ex-info (str "Unable to execute cas on a multi-predicate: " p-name)
+                                        {:status 400
+                                         :error  :db/validation-error})))
+
+          query'      {:select "?current-val"
+                       :where  [[sid p-name "?current-val"]]
+                       :opts   {}}
+          [res fuel] (<? (query db query'))
+          current-val (first res)]
+      (if (= current-val compare-val)
+        new-val
+        (throw (ex-info (clojure.core/str "The current value: " current-val " does not match the comparison value: " compare-val ".")
+                        {:status 400
+                         :error  :db/validation-error}))))))
+

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -587,22 +587,22 @@
     (let [{:keys [sid pid db]} ?ctx
           p-name      (dbproto/-p-prop db :name pid)
           _           (when-not sid
-                        (throw (ex-info (str "Unable to execute cas as no subject id could be determined. Cas values: " compare-val new-val)
+                        (throw (ex-info (str "Unable to execute cas - subject id could be determined. Cas values: " compare-val new-val)
                                         {:status 400
                                          :error  :db/validation-error})))
           _           (when-not p-name
-                        (throw (ex-info (str "Unable to execute cas as no predicate id could be determined. Cas values: " compare-val new-val)
+                        (throw (ex-info (str "Unable to execute cas - predicate could be determined. Cas values: " compare-val new-val)
                                         {:status 400
                                          :error  :db/validation-error})))
           _           (when (dbproto/-p-prop db :multi pid)
-                        (throw (ex-info (str "Unable to execute cas on a multi-predicate: " p-name)
+                        (throw (ex-info (str "Unable to execute cas on a multi-cardinality predicate: " p-name)
                                         {:status 400
                                          :error  :db/validation-error})))
 
           query'      {:select "?current-val"
                        :where  [[sid p-name "?current-val"]]
                        :opts   {}}
-          [res fuel] (<? (query db query'))
+          [res _] (<? (query db query'))
           current-val (first res)]
       (if (= current-val compare-val)
         new-val

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -598,11 +598,9 @@
                         (throw (ex-info (str "Unable to execute cas on a multi-cardinality predicate: " p-name)
                                         {:status 400
                                          :error  :db/validation-error})))
-
-          query'      {:select "?current-val"
-                       :where  [[sid p-name "?current-val"]]
-                       :opts   {}}
-          [res _] (<? (query db query'))
+          [res _] (<? (query db {:select "?current-val"
+                                 :where  [[sid p-name "?current-val"]]
+                                 :opts   {}}))
           current-val (first res)]
       (if (= current-val compare-val)
         new-val


### PR DESCRIPTION
Added a compare and set / swap function for use as a transaction function. Example:
[{"_id": ["_user/username", "jdoe"]
   "givenName": "#(cas \"Jane\" \"Jane2\")"}]

This transaction would only succeed if jdoe's current 'givenName' value is 'Jane', in which case it would be modified to 'Jane2'. If the current value is anything else, the entire transaction will fail.