### PR TITLE
use file-storage-path key to agree with ledger repo

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -385,7 +385,7 @@
              (let [language    (-> db :settings :language)
                    [var search search-param] clause
                    var         (variable? var)
-                   storage-dir (-> db :conn :meta :storage-directory)
+                   storage-dir (-> db :conn :meta :file-storage-path)
                    store       (full-text/index-store storage-dir (:network db)
                                                       (:dbid db))]
                (full-text/search db store [var search search-param] language)))))


### PR DESCRIPTION
Full text queries were broken (I think during the S3 implementation) so that the query code was looking in the wrong place for the full text index. This changes the path back to agree with what's in the ledger repo.