### PR TITLE
Use :file-storage-path instead of old :storage-directory

### DIFF
--- a/src/fluree/db/storage/core.cljc
+++ b/src/fluree/db/storage/core.cljc
@@ -21,7 +21,7 @@
    (defn block-storage-path
      "For a ledger server, will return the storage path it is using for blocks for a given ledger."
      [conn network dbid]
-     (let [storage-path (-> conn :meta :storage-directory)]
+     (let [storage-path (-> conn :meta :file-storage-path)]
        (when storage-path
          (io/file storage-path network dbid "block")))))
 


### PR DESCRIPTION
It looks like this might have affected dbsync (the only thing that calls this `block-storage-path` function). Note that this only returns meaningful data when using `:file` storage. Under `:s3` storage, I _think_ it wouldn't even get as far as calling this b/c blocks should always be already in the shared S3 bucket. But this area could definitely use some more testing.