### PR TITLE
Return a relative path from block-storage-path

### DIFF
--- a/src/fluree/db/storage/core.cljc
+++ b/src/fluree/db/storage/core.cljc
@@ -19,11 +19,9 @@
 
 #?(:clj
    (defn block-storage-path
-     "For a ledger server, will return the storage path it is using for blocks for a given ledger."
-     [conn network dbid]
-     (let [storage-path (-> conn :meta :file-storage-path)]
-       (when storage-path
-         (io/file storage-path network dbid "block")))))
+     "For a ledger server, will return the relative storage path it is using for blocks for a given ledger."
+     [network dbid]
+     (io/file network dbid "block")))
 
 (defn storage-exists?
   "Returns truthy if the provided key exists in storage."


### PR DESCRIPTION
The only place this gets called (dbsync2 in ledger) already has the root storage path, so this just needs to return a relative path into that. This was breaking dbsync b/c it was repeating the root path in its return value and dbsync couldn't find anything.

Counterpart to https://github.com/fluree/ledger/pull/14