### PR TITLE
FC-516 Full text index storage api update

### DIFF
--- a/src/fluree/db/full_text.clj
+++ b/src/fluree/db/full_text.clj
@@ -40,14 +40,12 @@
        (map :id)))
 
 (defn storage-path
-  [{:keys [conn network dbid] :as db}]
-  (let [base-path (-> db :conn :meta :file-storage-path)]
-    (str/join "/" [base-path network dbid "lucene"])))
+  [base-path {:keys [network dbid] :as db}]
+  (str/join "/" [base-path network dbid "lucene"]))
 
 (defn storage
-  [db]
-  (let [path (storage-path db)]
-    (lucene-store/disk-store path)))
+  [path]
+  (lucene-store/disk-store path))
 
 ;; TODO: determine size impact of these analyzers - can we package them
 ;;       separately if large impact?


### PR DESCRIPTION
This updates the full text index storage api so that the storage fn takes a path and db, and the storage-path fn takes a base path instead of a connection. This change makes it easier to figure out when to start the full text indexer or not because we can't rely on the storage type being set. 