### PR TITLE
FC-973 applied sort to groupBy, then applied limit/offset

### DIFF
--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -606,7 +606,7 @@
                                            inVector? tuple-res
                                            :else (first tuple-res)))) tuples)))))
 
-(defn process-ad-hoc-group
+(defn- process-ad-hoc-group
   ([db res select-spec opts]
    (process-ad-hoc-group db res select-spec nil opts))
   ([db {:keys [vars] :as res} {:keys [aggregates orderBy offset groupBy select limit selectDistinct? inVector? prettyPrint] :as select-spec} group-limit opts]
@@ -623,10 +623,10 @@
                    {:keys [headers tuples]} (if orderBy
                                               (order-offset-and-limit-results orderBy res+agg offset group-limit)
                                               res+agg)
-                   tuples  (if (and (not orderBy) (or limit offset))
-                             (->> (drop offset tuples)
-                                  (take limit))
-                             tuples)
+                   ;tuples  (if (and (not orderBy) (or limit offset))
+                   ;          (->> (drop offset tuples)
+                   ;               (take limit))
+                   ;          tuples)
                    res     (<? (format-filter-tuples db tuples select-spec headers vars (dissoc opts :limit :offset :orderBy :groupBy)))]
                ;; TODO - drop unused columns, and calculate distinct before resolving all vals
                (if selectDistinct?
@@ -655,58 +655,70 @@
       {} tuples)))
 
 (defn process-ad-hoc-res
-  [db {:keys [headers vars] :as res} {:keys [groupBy orderBy limit selectOne? selectDistinct? inVector? offset] :as
-                                            select-spec} opts]
+  [db
+   {:keys [headers vars] :as res}
+   {:keys [groupBy orderBy limit selectOne? selectDistinct? inVector? offset] :as select-spec}
+   opts]
   (go-try (if groupBy
-            (let [group-map (ad-hoc-group-by res groupBy)
-                  order-fn  (cond (and orderBy (= (second orderBy) groupBy))
-                                  (if (= (first orderBy) "DESC")
+            (let [orderBy'  (if orderBy orderBy ["ASC" groupBy])
+                  order-fn  (cond (and orderBy' (= (second orderBy') groupBy))
+                                  (if (= (first orderBy') "DESC")
                                     (fn [x y] (* -1 (compare-fn x y)))
                                     compare-fn)
 
-                                  (not orderBy)
-                                  nil
-
-                                  (and orderBy ((set groupBy) (second orderBy)))
+                                  (and (coll? groupBy) (string? (second orderBy')))
                                   (let [orderByIdx     (util/index-of groupBy (second orderBy))
                                         orderDirection (first orderBy)]
                                     (if (= "DESC" orderDirection)
                                       (fn [x y] (* -1 (compare-fn (nth x orderByIdx) (nth y orderByIdx))))
                                       (fn [x y] (compare-fn (nth x orderByIdx) (nth y orderByIdx)))))
 
-                                  :else nil)]
+                                  :else nil)
+                  group-map (cond->> (ad-hoc-group-by res groupBy)
+                                     ;?sort for selectOne?
+                                     order-fn (into (sorted-map-by order-fn)))]
               (if selectOne?
                 (let [k (first (keys group-map))
                       v (<? (process-ad-hoc-group db {:headers headers
                                                       :vars    vars
                                                       :tuples  (first (vals group-map))} select-spec limit opts))]
                   {k v})
-                (let [res (loop [[group-key & r-k] (keys group-map)
-                                 [group & r] (vals group-map)
-                                 item-count 0
-                                 offset     offset
-                                 res        {}]
-                            (cond (nil? group)
-                                  res
+                ; loop through map of groups
+                (loop [[group-key & r-k] (keys group-map)
+                       [group & r] (vals group-map)
+                       limit      (if (= 0 limit) nil limit) ; limit of 0 is ALL
+                       offset     (or offset 0)
+                       acc        {}]
+                  (let [group-count (count group)
+                        group-as-res {:headers headers :vars vars :tuples group}]
+                    (cond
+                      ;? process all groups
+                      (nil? group) acc
 
-                                  (> offset 0)
-                                  (recur r-k r item-count (dec offset) res)
+                      ;? exceeded limit
+                      (and limit (< limit 1)) acc
 
-                                  :else
-                                  (let [item-count   (+ item-count (count group))
-                                        group-as-res {:headers headers :vars vars :tuples group}]
-                                    (cond (> limit item-count)
-                                          (recur r-k r item-count offset
-                                                 (assoc res group-key (<? (process-ad-hoc-group db group-as-res select-spec opts))))
+                      ;? last item in this group is BEFORE offset - skip
+                      (>= offset group-count)
+                      (recur r-k r limit (- offset group-count) acc)
 
-                                          (= limit item-count)
-                                          (assoc res group-key (<? (process-ad-hoc-group db group-as-res select-spec opts)))
-
-                                          (< limit item-count)
-                                          (assoc res group-key (<? (process-ad-hoc-group db group-as-res select-spec (- (count group) (- item-count limit)) opts)))))))]
-                  (if order-fn
-                    (into (sorted-map-by order-fn) res)
-                    res))))
+                      :else
+                      ; 1) set orderBy to nil so order-offset-and-limit-results is not executed
+                      ; 2) set offset to 0 so a drop is not performed
+                      ; 3) then call process-ad-hoc-group
+                      (-> (cond->> (<? (process-ad-hoc-group
+                                         db
+                                         group-as-res
+                                         (assoc select-spec :orderBy nil :offset 0 :limit limit)
+                                         (assoc opts :offset 0 :limit limit)))
+                                   (< 0 offset) (drop offset)
+                                   (and limit (< 0 limit)) (take limit))
+                          (as-> res' (recur r-k
+                                            r
+                                            (when-not (nil? limit) (- limit (count res')))
+                                            (if (<= 0 offset) 0 (- offset (- group-count (count res'))))
+                                            (if (or (nil? res') (empty? res')) acc (assoc acc group-key res'))) )))))))
+            ; no group by
             (let [limit (if selectOne? 1 limit)
                   res   (<? (process-ad-hoc-group db res select-spec limit opts))]
               (cond (not (coll? res)) (if inVector? [res] res)


### PR DESCRIPTION
Modified/centralized logic to apply sort, then limit & offset.  There are a couple of places where the sort, offset & limit are still applied.  Further improvements to the group by, sort and limit/offset functionality will be tracked under FC-1002.

* If an orderBy clause is not specified, the aggregated results are sorted based on the groupBy expression.  [This is standard per SPARQL v1.1]
* selectOne: Note that the results are sorted and then the first one is taken.  
* selectDistinct: the limit/offset are applied to the sorted aggregates.  This option provides the standard behavior for groupBy.
* select: dependent on the query, FlureeQL will return all items, with aggregates, that satisfy the where clause.  There can be multiple items per groupBy key because the "distinct" values may not have been included in the select.  In this case, each graph item is counted.

A good example:
Jasper's favorite numbers are 1, 2, 3, 4.
I submit a query looking for all favorite numbers; but, I only include the sum in the select clause.  There will be 4 rows for Jasper that will be counted in the result set because a "row" is generate for each favorite number.



