### PR TITLE
FC-1040 Exception with full text search queries

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -382,9 +382,15 @@
              (throw (ex-info "Full text search is not supported in when running in-memory"
                              {:status 400
                               :error  :db/invalid-query}))
-             (let [[var search search-param] clause
-                   var         (variable? var)
-                   store       (full-text/storage db)]
+             (let [[var search search-param]
+                   clause
+
+                   var   (variable? var)
+                   store (-> conn
+                             :meta
+                             :file-storage-path
+                             (full-text/storage-path db)
+                             full-text/storage)]
                (full-text/search db store [var search search-param])))))
 
 


### PR DESCRIPTION
I did some refactoring of the full text storage directory but forgot to change the opening code on the query side. This patch fixes that. 