### PR TITLE
FC-998 update aleph/aleph to 0.4.7-alpha5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,7 @@
          clucie/clucie                     {:mvn/version "0.4.2"}
 
          ;; messaging
-         aleph/aleph                       {:mvn/version "0.4.6"}
+         aleph/aleph                       {:mvn/version "0.4.7-alpha5"}
 
          ;; benchmarking
          criterium/criterium               {:mvn/version "0.4.6"}


### PR DESCRIPTION
Verified that a shutdown error is fixed by upgrading to "Aleph 0.4.7-alpha5". 
Kudos to Bob Jordaens (xpertservice) for identifying the issue & finding the fix.