### PR TITLE
FC-1076 remove extra distinct for analytical query without groupBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 # Changelog
 All notable changes to FlureeDB will be documented in this file.
 
-## 1.0.0
+## 1.0.0-rc15
+- Fix issue where selectDistinct executed twice for analytical queries (FC-1076)
+
+## 1.0.0-rc1
 - Add support for cas (compare and set) SmartFunction (FC-956)
 - Fix issues for nodejs permissions (FC-786)
 - Update ledger/db to use try*/catch* macro (FC-918)

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -738,7 +738,6 @@
                   res   (<? (process-ad-hoc-group db res select-spec limit opts))]
               (cond (not (coll? res)) (if inVector? [res] res)
                     selectOne? (first res)
-                    selectDistinct? (distinct res)
                     :else res)))))
 
 


### PR DESCRIPTION
The `selectDistinct` operation was moved in-line to correct issues with how `limit` and `offset` were applied to queries (process-ad-hoc-group).