### PR TITLE
FC-1075 string entire comp-op to build filter

### DIFF
--- a/src/fluree/db/query/sql.cljc
+++ b/src/fluree/db/query/sql.cljc
@@ -271,12 +271,14 @@
                                                     [[(::subj right) (::pred right) v]
                                                      [(::subj left) (::pred left) v]]))
 
+              ; this condition handles the <, <=, >, >= operations
               (#{\> \<} comp) (cond
                                 (and (::pred left)
                                      (::obj right)) (let [pred      (::pred left)
                                                           obj       (::obj right)
+                                                          comp'     (->> parse-map :comp-op (apply str))
                                                           field-var (template/build-var pred)
-                                                          filter-fn (template/build-fn-call [comp field-var obj])]
+                                                          filter-fn (template/build-fn-call [comp' field-var obj])]
                                                       [[template/collection-var pred field-var]
                                                        {:filter [filter-fn]}]))))))
 

--- a/test/fluree/db/query/sql_test.cljc
+++ b/test/fluree/db/query/sql_test.cljc
@@ -121,6 +121,36 @@
                  (:where subject))
               "correctly constructs the where clause")))
 
+      (testing "with 'greater than or equal' predicate"
+        (let [query   "SELECT name, email FROM person WHERE age >= 18"
+              subject (parse query)]
+
+          (is (= ["?personName" "?personEmail"]
+                 (:select subject))
+              "correctly constructs the select clause")
+
+          (is (= [["?person" "person/age" "?personAge"]
+                  {:filter ["(>= ?personAge 18)"]}
+                  ["?person" "person/name" "?personName"]
+                  ["?person" "person/email" "?personEmail"]]
+                 (:where subject))
+              "correctly constructs the where clause")))
+
+      (testing "with 'less than or equal' predicate"
+        (let [query   "SELECT name, email FROM person WHERE age <= 18"
+              subject (parse query)]
+
+          (is (= ["?personName" "?personEmail"]
+                 (:select subject))
+              "correctly constructs the select clause")
+
+          (is (= [["?person" "person/age" "?personAge"]
+                  {:filter ["(<= ?personAge 18)"]}
+                  ["?person" "person/name" "?personName"]
+                  ["?person" "person/email" "?personEmail"]]
+                 (:where subject))
+              "correctly constructs the where clause")))
+
       (testing "with a null predicate"
         (testing "negated"
           (let [query   "SELECT name, email FROM person WHERE email IS NOT NULL"


### PR DESCRIPTION
Fixed an issue where the entire comparison operator was not being used to create a filter.