### PR TITLE
FC-1098 - Changes to support full reindexing even with large predicate indexing changes

### DIFF
--- a/src/fluree/db/dbproto.cljc
+++ b/src/fluree/db/dbproto.cljc
@@ -34,8 +34,8 @@
   (-subid [db ident] [db ident strict?] "Returns subject ID if exists, else nil")
   (-search [db fparts] "Performs a slice, but determines best index to use.")
   (-query [db query] [db query opts] "Performs a query.")
-  (-with [db block flakes] "Applies flakes to this db as a new block with possibly multiple 't' transactions.")
-  (-with-t [db flakes] "Applies flakes to this db as a new 't', but retains current block.")
+  (-with [db block flakes] [db block flakes opts] "Applies flakes to this db as a new block with possibly multiple 't' transactions.")
+  (-with-t [db flakes] [db flakes opts] "Applies flakes to this db as a new 't', but retains current block.")
   (-add-predicate-to-idx [db pred-id] "Adds predicate to idx, return updated db."))
 
 


### PR DESCRIPTION
Currently, predicate indexing changes are limited to novelty-max in size. This allows any arbitrary size, but only when reindexing.

This is a nice feature in general, but here to support the FC-1098 indexing underflow support issue.