### PR TITLE
FC-1108 selectOne basic query was limiting flakes to 1, not subjects to 1

### DIFF
--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -440,7 +440,7 @@
 
          :else
          (recur r (inc n)
-                (conj acc (->> (<? (query-range/index-range db :spot = [s] {:limit limit}))
+                (conj acc (->> (<? (query-range/index-range db :spot = [s]))
                                ((fn [n] (flakes->res db cache fuel max-fuel select-spec n)))
                                (<?)))))))))
 


### PR DESCRIPTION
This fixes an issue where a selectOne passed the :limit 1 restriction to index-range for the subject query, where we really want all results for the subject, just limit it to only a single subject.