### PR TITLE
FC-496 convert flakes to a vector for cljs

### DIFF
--- a/src-nodejs/flureenjs.cljs
+++ b/src-nodejs/flureenjs.cljs
@@ -705,16 +705,6 @@
 ;; Search/Time-travel
 ;;
 ;; ======================================
-(defn- ^:private block-Flakes->vector
-  [blocks]
-  (loop [[block & r] blocks
-         acc []]
-    (if block
-      (let [flakes (map flake/Flake->parts (:flakes block))]
-        (recur r (into acc [(assoc block :flakes flakes)])))
-      acc)))
-
-
 (defn ^:export search
   "Returns a promise containing search results of flake parts (flake-parts)."
   [db flake-parts]
@@ -989,7 +979,7 @@
                (js->clj :keywordize-keys true)
                (as-> clj-opts (query-block/block-range (<? db) start end clj-opts))
                <?
-               block-Flakes->vector
+               (query/block-Flakes->vector)
                clj->js
                (resolve))
            (catch :default e

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -326,6 +326,21 @@
                         acc))]
       (vals res))))
 
+#?(:cljs
+   (defn block-Flakes->vector
+     "Convert flakes into vectors.
+     Notes:
+     Cannot use IPrintWithWriter override since calls to storage-handler
+     download blocks using the #Flake format to support internal query
+     handling."
+    [blocks]
+    (loop [[block & r] blocks
+           acc []]
+      (if block
+        (let [flakes (map flake/Flake->parts (:flakes block))]
+          (recur r (into acc [(assoc block :flakes flakes)])))
+        acc))))
+
 (defn history-query-async
   [sources query-map]
   (go-try
@@ -349,7 +364,8 @@
                          resp     (<? (format-history-resp db flakes auth-set (or showAuth show-auth)))
                          resp'    (if (or prettyPrint pretty-print)
                                     (<? (format-blocks-resp-pretty db resp))
-                                    resp)]
+                                    #?(:clj  resp
+                                       :cljs (block-Flakes->vector resp)))]
                      (if meta? {:result resp'
                                 :fuel   (count flakes)
                                 :status 200}

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -334,12 +334,7 @@
      download blocks using the #Flake format to support internal query
      handling."
     [blocks]
-    (loop [[block & r] blocks
-           acc []]
-      (if block
-        (let [flakes (map flake/Flake->parts (:flakes block))]
-          (recur r (into acc [(assoc block :flakes flakes)])))
-        acc))))
+     (mapv (fn [block] (assoc block :flakes (mapv vec (:flakes block)))) blocks)))
 
 (defn history-query-async
   [sources query-map]


### PR DESCRIPTION
Modified history query, without pretty-print, to format results as a vector instead of a #FLake.  Changes involved moving block-Flakes->vector from flureenjs into shared code.

Note: Not able to use an override in IPrintWithWriter because blocks are downloaded from fluree into the JS cache using the default format.  We should take another look at the js format when the connection object is re-worked.