### PR TITLE
FC-1123 Fix for (now) smartfunction used in permissions

### DIFF
--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -27,6 +27,7 @@
           ctx     {:sid     sid
                    :auth_id (or (:auth db) (:auth permissions))
                    :db      root-db
+                   :instant (util/current-time-millis)
                    :state   (atom {:stack   []
                                    :credits 10000000
                                    :spent   0})}]


### PR DESCRIPTION
Adds :instant value into the context.

Quick fix for now, but when called from transactions it should pass the transaction :instant for consistency, that needs to get added.