### PR TITLE
FC-783 nodejs improvements/changes for closed api

### DIFF
--- a/src-nodejs/flureenjs.cljs
+++ b/src-nodejs/flureenjs.cljs
@@ -371,15 +371,6 @@
 ;; Ledger/DB Operations
 ;;
 ;; ======================================
-
-
-(defn ^:export db
-  "Returns a queryable database from the connection."
-  [conn ledger & [opts]]
-  (-> opts
-      (js->clj :keywordize-keys true)
-      (as-> clj-opts (db-instance conn ledger clj-opts))))
-
 (defn ^:private ledger-db
   "Returns a queryable database from the connection for the specified ledger."
   ([conn ledger]
@@ -424,6 +415,12 @@
            (async/close! pc))))
      pc)))
 
+(defn ^:export db
+  "Returns a queryable database from the connection."
+  [conn ledger & [opts]]
+  (-> opts
+      (js->clj :keywordize-keys true)
+      (as-> clj-opts (db-instance conn ledger clj-opts))))
 
 (defn ^:export db-p
   "Returns a queryable database from the connection."

--- a/src-nodejs/flureenjs.cljs
+++ b/src-nodejs/flureenjs.cljs
@@ -415,7 +415,7 @@
                auth'        (or auth (if jwt
                                        ["_auth/id" (-> (conn-handler/validate-token conn jwt)
                                                        :sub)]))
-               perm-db       (-> (<? (ledger/db conn ledger (assoc opts :auth auth')))
+               perm-db       (-> (<? (ledger-db conn ledger (assoc opts :auth auth')))
                                  (assoc :conn conn :network network :dbid ledger-id))]
            (async/put! pc perm-db))
          (catch :default e

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -331,7 +331,6 @@
                url          (str address "/fdb/storage/" path)
                headers      (cond-> {"Accept" #?(:clj  "avro/binary"
                                                  :cljs "application/json")}
-                                    jwt' (assoc "X-fdb-jwt" jwt')
                                     jwt' (assoc "Authorization" (str "Bearer " jwt')))
                headers*     (if private
                               (-> (http-signatures/sign-request "get" url {:headers headers} private)
@@ -550,11 +549,7 @@
                                                 #?(:clj  nil
                                                    :cljs keep-alive-fn))
                             :add-listener     (partial add-listener* state-atom)
-                            :remove-listener  (partial remove-listener* state-atom)
-                            :add-token        #?(:clj nil
-                                                 :cljs (if (identical? *target* "nodejs")
-                                                         (partial add-token)
-                                                         nil))}]
+                            :remove-listener  (partial remove-listener* state-atom)}]
     (map->Connection settings)))
 
 (defn close!

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -331,7 +331,6 @@
                url          (str address "/fdb/storage/" path)
                headers      (cond-> {"Accept" #?(:clj  "avro/binary"
                                                  :cljs "application/json")}
-                                    private (assoc "X-fdb-pri" private)
                                     jwt' (assoc "X-fdb-jwt" jwt')
                                     jwt' (assoc "Authorization" (str "Bearer " jwt')))
                headers*     (if private

--- a/src/fluree/db/connection_js.cljs
+++ b/src/fluree/db/connection_js.cljs
@@ -40,6 +40,7 @@
 ;; Connection
 ;;
 ;; ======================================
+;; TODO: deprecated
 (defn authenticate
   "Authenticate with Fluree On-Demand"
   ([conn account user password] (authenticate conn account user password nil))

--- a/src/fluree/db/connection_js.cljs
+++ b/src/fluree/db/connection_js.cljs
@@ -8,7 +8,7 @@
             [fluree.db.util.log :as log]
             [fluree.db.token-auth :as token-auth]))
 
-
+;; TODO: deprecated
 (defn dbaas?
   "Returns open-api? setting from connection object"
   [conn]

--- a/src/fluree/db/query/block.cljc
+++ b/src/fluree/db/query/block.cljc
@@ -1,14 +1,22 @@
 (ns fluree.db.query.block
   (:require [fluree.db.storage.core :as storage]
-            #?(:clj [fluree.db.permissions-validate :as perm-validate])
+            [fluree.db.permissions-validate :as perm-validate]
             #?(:clj  [clojure.core.async :refer [>! <! >!! <!! go chan buffer close! thread
                                                  alts! alts!! timeout] :as async]
                :cljs [cljs.core.async :refer [go <!] :as async])
             [fluree.db.util.core :as util]
             [fluree.db.util.async :refer [<?]]))
 
-;; TODO - for nodejs we need to re-enable permissions for javascript but in a way code only
-;; TODO - exists for nodejs compilation
+(defn- filter-block-flakes
+  "Applies filter(s) to flakes in a block"
+  [db block]
+  (let [root? (-> db :permissions :root?)]
+    (if root?
+      block
+      {:block  (:block block)
+       :t      (:t block)
+       :flakes (<? (perm-validate/allow-flakes? db (:flakes block)))})))
+
 (defn block-range
   "Returns a async channel containing each of the blocks from start (inclusive) to end if provided (inclusive). Should received PERMISSIONED db."
   [db start end opts]
@@ -22,12 +30,10 @@
             res         (<? (storage/block conn network dbid next-block))
             root?       (-> db :permissions :root?)
             ;; Note this bypasses all permissions in CLJS for now!
-            res #?(:cljs res                                ;; always allow for now
-                   :clj (if root?
-                          res
-                          {:block  (:block res)
-                           :t      (:t res)
-                           :flakes (<? (perm-validate/allow-flakes? db (:flakes res)))}))
+            res #?(:cljs (if (identical? "nodejs" cljs.core/*target*)
+                           (filter-block-flakes db res)
+                           res)  ;; browser: always allow for now
+                   :clj (filter-block-flakes db res))
             acc'        (concat acc [res])]
         (if (or (= next-block last-block) (util/exception? res))
           acc'

--- a/src/fluree/db/query/block.cljc
+++ b/src/fluree/db/query/block.cljc
@@ -4,18 +4,26 @@
             #?(:clj  [clojure.core.async :refer [>! <! >!! <!! go chan buffer close! thread
                                                  alts! alts!! timeout] :as async]
                :cljs [cljs.core.async :refer [go <!] :as async])
-            [fluree.db.util.core :as util]
-            [fluree.db.util.async :refer [<?]]))
+            [fluree.db.util.core :as util :refer [try* catch*]]
+            [fluree.db.util.async :refer [<?]]
+            [fluree.db.util.log :as log]))
 
 (defn- filter-block-flakes
   "Applies filter(s) to flakes in a block"
   [db block]
   (let [root? (-> db :permissions :root?)]
-    (if root?
-      block
-      {:block  (:block block)
-       :t      (:t block)
-       :flakes (<? (perm-validate/allow-flakes? db (:flakes block)))})))
+    (async/go
+      (try*
+        (if root?
+          block
+          {:block  (:block block)
+           :t      (:t block)
+           :flakes (<? (perm-validate/allow-flakes? db (:flakes block)))})
+        (catch* e
+                (log/error (str "Unable to validate permissions on block " (:block block) " error: " e))
+                {:block (:block block)
+                 :t     (:t block)
+                 :flakes []})))))
 
 (defn block-range
   "Returns a async channel containing each of the blocks from start (inclusive) to end if provided (inclusive). Should received PERMISSIONED db."
@@ -28,12 +36,10 @@
       (let [{:keys [conn network dbid]} db
             last-block  (or end start)                      ;; allow for nil end-block for now
             res         (<? (storage/block conn network dbid next-block))
-            root?       (-> db :permissions :root?)
-            ;; Note this bypasses all permissions in CLJS for now!
             res #?(:cljs (if (identical? "nodejs" cljs.core/*target*)
-                           (filter-block-flakes db res)
+                           (<? (filter-block-flakes db res))
                            res)  ;; browser: always allow for now
-                   :clj (filter-block-flakes db res))
+                   :clj (<? (filter-block-flakes db res)))
             acc'        (concat acc [res])]
         (if (or (= next-block last-block) (util/exception? res))
           acc'

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -6,7 +6,7 @@
             [fluree.db.flake :as flake #?@(:cljs [:refer [Flake]])]
             #?(:clj  [clojure.core.async :refer [go <!] :as async]
                :cljs [cljs.core.async :refer [go <!] :as async])
-            #?(:clj [fluree.db.permissions-validate :as perm-validate])
+            [fluree.db.permissions-validate :as perm-validate]
             [fluree.db.util.async :refer [<? go-try]])
   #?(:clj (:import (fluree.db.flake Flake)))
   #?(:cljs (:require-macros [fluree.db.util.async])))
@@ -131,7 +131,9 @@
            from-t             (or (:from-t opts) (:t db))
            to-t               (:to-t opts)
            ;; Note this bypasses all permissions in CLJS for now!
-           no-filter?         #?(:cljs true                         ;; always allow for now
+           no-filter?         #?(:cljs (if (identical? "nodejs" cljs.core/*target*)
+                                         (perm-validate/no-filter? permissions s1 s2 p1 p2)
+                                         true)  ;; browser: always allow for now
                                  :clj (perm-validate/no-filter? permissions s1 s2 p1 p2))
            novelty            (get-in db [:novelty idx])
            root-node          (-> db
@@ -162,8 +164,12 @@
                                   (into acci acc)
                                   (recur r
                                          (inc i')
-                                         ;; Note this bypasses all permissions in CLJS for now!
-                                         #?(:cljs acci      ;; always allow for now
+                                         ;; browser: bypasses all permissions in CLJS for now!
+                                         #?(:cljs (if (identical? "nodejs" cljs.core/*target*)
+                                                    (if (<? (perm-validate/allow-flake? db f))
+                                                      acci
+                                                      (disj acci f))
+                                                    acci)
                                             :clj  (if (<? (perm-validate/allow-flake? db f))
                                                     acci
                                                     (disj acci f)))))))
@@ -188,7 +194,9 @@
       (if (or (nil? subject-flakes) (>= flake-count flake-limit) (>= subject-count subject-limit))
         [flake-count subject-count acc]
         (let [subject-filtered #?(:clj (<? (perm-validate/allow-flakes? db subject-flakes))
-                                  :cljs subject-flakes)
+                                  :cljs (if (identical? "nodejs" cljs.core/*target*)
+                                          (<? (perm-validate/allow-flakes? db subject-flakes))
+                                          subject-flakes))
               flakes-new-count         (count subject-filtered)
               subject-new-count        (if (= 0 flakes-new-count) 0 1)]
           (recur r (+ flake-count flakes-new-count)
@@ -278,7 +286,9 @@
                                   (dbproto/-resolve)
                                   (<?))
            node-start         (<? (find-next-valid-node root-node start-flake t novelty fast-forward-db?))
-           no-filter?         #?(:cljs true
+           no-filter?         #?(:cljs (if (identical? "nodejs" cljs.core/*target*)
+                                         (perm-validate/no-filter? permissions s1 s2 p1 p2)
+                                         true)
                                  :clj (perm-validate/no-filter? permissions s1 s2 p1 p2))]
        (if node-start (loop [next-node node-start
                              offset    offset               ;; offset counts down from the offset

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -6,7 +6,7 @@
             [fluree.db.flake :as flake #?@(:cljs [:refer [Flake]])]
             #?(:clj  [clojure.core.async :refer [go <!] :as async]
                :cljs [cljs.core.async :refer [go <!] :as async])
-            #?(:clj [fluree.db.permissions-validate :as perm-validate])
+            [fluree.db.permissions-validate :as perm-validate]
             [fluree.db.util.async :refer [<? go-try]])
   #?(:clj (:import (fluree.db.flake Flake)))
   #?(:cljs (:require-macros [fluree.db.util.async])))
@@ -131,10 +131,11 @@
            from-t             (or (:from-t opts) (:t db))
            to-t               (:to-t opts)
            ;; Note this bypasses all permissions in CLJS for now!
-           ;; Node.js: filtering is performed server-side based
-           ;; on the provided auth when blocks/updates are downloaded.
-           no-filter?         #?(:cljs true                         ;; always allow for now
-                                 :clj (perm-validate/no-filter? permissions s1 s2 p1 p2))
+           no-filter?         #?(:clj (perm-validate/no-filter? permissions s1 s2 p1 p2)
+                                 :cljs (if (identical? *target* "nodejs")
+                                         (perm-validate/no-filter? permissions s1 s2 p1 p2)
+                                         ;; always allow for browser-mode
+                                         true))
            novelty            (get-in db [:novelty idx])
            root-node          (-> db
                                   (get idx)
@@ -164,13 +165,17 @@
                                   (into acci acc)
                                   (recur r
                                          (inc i')
-                                         ;; Note this bypasses all permissions in CLJS for now!
-                                         ;; Node.js: filtering is performed server-side based
-                                         ;; on the provided auth when blocks/updates are downloaded.
-                                         #?(:cljs acci      ;; always allow for now
-                                            :clj  (if (<? (perm-validate/allow-flake? db f))
+                                         ;; Note this bypasses all permissions in CLJS (browser) for now!
+                                         #?(:clj  (if (<? (perm-validate/allow-flake? db f))
                                                     acci
-                                                    (disj acci f)))))))
+                                                    (disj acci f))
+                                            :cljs (if (identical? *target* "nodejs")
+                                                    ; check permissions for nodejs
+                                                    (if (<? (perm-validate/allow-flake? db f))
+                                                      acci
+                                                      (disj acci f))
+                                                    ; always include for browser
+                                                    acci))))))
                i*           (count acc*)
                more?        (and rhs
                                  (neg? (idx-compare rhs end-flake))
@@ -192,7 +197,9 @@
       (if (or (nil? subject-flakes) (>= flake-count flake-limit) (>= subject-count subject-limit))
         [flake-count subject-count acc]
         (let [subject-filtered #?(:clj (<? (perm-validate/allow-flakes? db subject-flakes))
-                                  :cljs subject-flakes)
+                                  :cljs (if (identical? *target* "nodejs")
+                                          (<? (perm-validate/allow-flakes? db subject-flakes))
+                                          subject-flakes))
               flakes-new-count         (count subject-filtered)
               subject-new-count        (if (= 0 flakes-new-count) 0 1)]
           (recur r (+ flake-count flakes-new-count)
@@ -282,8 +289,10 @@
                                   (dbproto/-resolve)
                                   (<?))
            node-start         (<? (find-next-valid-node root-node start-flake t novelty fast-forward-db?))
-           no-filter?         #?(:cljs true
-                                 :clj (perm-validate/no-filter? permissions s1 s2 p1 p2))]
+           no-filter?         #?(:clj (perm-validate/no-filter? permissions s1 s2 p1 p2)
+                                 :cljs (if (identical? *target* "nodejs")
+                                         (perm-validate/no-filter? permissions s1 s2 p1 p2)
+                                         true))]
        (if node-start (loop [next-node node-start
                              offset    offset               ;; offset counts down from the offset
                              i         0                    ;; i is count of flakes

--- a/src/fluree/db/session.cljc
+++ b/src/fluree/db/session.cljc
@@ -412,19 +412,6 @@
       (assoc session* :new? true)
       session*)))
 
-#?(:cljs (if (identical? *target* "nodejs")
-           (defn nodejs-access-token
-             [{:keys [conn dbid network]} {:keys [auth jwt]}]
-             (if-let [add-token-fn (:add-token conn)]
-               (if (and (nil? jwt) auth)
-                 ;; if closed-api mode without jwt, auth is required.
-                 ;; if any auth provided without jwt, request access
-                 ;; token for storage reads
-                 (go-try
-                   (->> (ops/send-operation conn :issue-access-token [[network dbid] auth])
-                        <?
-                        (add-token-fn conn))))))))
-
 ;; TO-DO check for expired jwt when specified
 (defn session
   "Returns connection to the given ledger, and ensures it is cached.
@@ -461,11 +448,6 @@
                ;; send a subscription request to this database. This is idempotent in the
                ;; unlikely case of multiple sessions simultaneously being created (of which only one will 'win').
                (ops/subscribe session opts)
-
-               ;; get an access token for Node.js library
-               ;; to download blocks in closed-api mode
-               #?(:cljs (if (identical? *target* "nodejs")
-                          (nodejs-access-token session opts)))
 
                ;; register a callback fn for this session to listen for updates and push onto update chan
                ((:add-listener conn) network ledger-id (:id session)


### PR DESCRIPTION
summary of changes by file/class:

flureenjs
* bumped version

fluree.db.api.ledger
* retrieve a permissioned ledger for nodejs (vs root) based on the provided authentication information (e.g., JWT, private key/auth)


fluree.db.connection
* corrected typo
* removed unused headers from default-storage-read
* modified generate-connection to clear db cache for nodejs

fluree.db.connection_js
* marked function(s) as deprecated - can remove after other javascript libraries are updated

fluree.db.dbfunctions.core
* extracted/consolidates find-fn logic for clj/nodejs usage

fluree.db.query.block
* re-enable permission checks for nodejs 
* extracted/consolidated filter logic for clj/nodejs

fluree.db.query.range
* re-enabled permission checks for nodejs
