### PR TITLE
FC-1127 Fix for exceptions through in permissions SmartFunctions

### DIFF
--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -46,9 +46,15 @@
                                      (:fnstr (meta f)) ": " #?(:clj (.getMessage e) :cljs (str e)))
                                 {:status 400
                                  :error  :db/db-function-error})))]
-            (if res
-              true
-              (recur r)))
+            (cond
+              (util/exception? res)
+              res
+
+              (not res)                                     ;; not yet a true response, try next
+              (recur r)
+
+              :else                                         ;; first true response will allow
+              true))
           false)))))
 
 

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -189,7 +189,7 @@
   "Starting with flakes grouped by subject id, filters the flakes until
   either flake-limit or subject-limit reached."
   [db subject-groups flake-start subject-start flake-limit subject-limit]
-  (async/go
+  (go-try
     (loop [[subject-flakes & r] subject-groups
            flake-count   flake-start
            subject-count subject-start


### PR DESCRIPTION
Fixes issues where exception thrown inside SmartFunction (i.e. invalid predicate name) return value not explicitly checked for exception, resulting in a 'truthy' value check.