### PR TITLE
FC-1036 Fix to enable export of BigDecimal as string (default) or (number)

### DIFF
--- a/src/fluree/db/util/json.cljc
+++ b/src/fluree/db/util/json.cljc
@@ -1,7 +1,7 @@
 (ns fluree.db.util.json
   (:require #?(:clj [cheshire.core :as cjson])
             #?(:clj [cheshire.parse :as cparse])
-            #?(:clj [cheshire.generate :refer [add-encoder encode-seq]])
+            #?(:clj [cheshire.generate :refer [add-encoder encode-seq remove-encoder]])
             #?(:clj [fluree.db.flake])
             #?(:cljs [goog.object :as gobject])
             [fluree.db.util.bytes :as butil]
@@ -14,6 +14,16 @@
 #?(:clj (add-encoder Flake encode-seq))
 
 #?(:clj (add-encoder (Class/forName "[B") encode-seq))
+
+#?(:clj
+   (defn encode-BigDecimal-as-string
+     "Turns on/off json-encoding of a java.math.Bigdecimal as a string"
+     [enable]
+     (if enable
+       (add-encoder java.math.BigDecimal
+                     (fn [n jsonGenerator]
+                       (.writeString jsonGenerator (str n))))
+       (remove-encoder java.math.BigDecimal))))
 
 ;;https://purelyfunctional.tv/mini-guide/json-serialization-api-clojure/
 #?(:cljs

--- a/test/fluree/db/util/json_test.cljc
+++ b/test/fluree/db/util/json_test.cljc
@@ -1,0 +1,195 @@
+(ns fluree.db.util.json-test
+  (:require #?@(:clj  [[clojure.test :refer :all]
+                       [cheshire.core :as cjson]]
+                :cljs [[cljs.test :refer-macros [deftest is testing]]])
+            [fluree.db.util.bytes :as u-bytes]
+            [fluree.db.util.json :as json])
+  #?(:clj
+     (:import (java.io ByteArrayInputStream)
+              (java.math BigDecimal)
+              (java.lang Double Float Integer)
+              (clojure.lang PersistentArrayMap))))
+
+(defn abs [x] (if (> x 0) x (* -1 x)))
+
+;; Clojure-specific
+#?(:clj
+   (defn string->stream
+     ([s] (string->stream s "UTF-8"))
+     ([s encoding]
+      (-> s
+          (.getBytes encoding)
+          (ByteArrayInputStream.)))))
+
+#?(:clj
+   (def float-conv-delta
+     (let [x-conv (-> Float/MAX_VALUE str (Double/parseDouble))
+           x-orig (double Float/MAX_VALUE)]
+       (float (- x-conv x-orig)))))
+
+
+;; General Comments
+;; all java.lang.Float, java.lang.Double and java.math.BigDecimal values
+;; are parsed as BigDecimals when cheshire's use-bigdecimals? is true.
+;; Fluree engine handles this by looking up the schema & coercing the
+;; input value into the appropriate type.
+;; ----------
+;; CLojure: Float/JSON Parse: The Float max value (3.4028235E+38) is cast
+;; to a double, unless explicitly set using Float/MAX_VALUE. So, the test
+;; comparisons for these values use a Double, with a conversion delta of
+;; 3.3614711319430846E30
+#?(:clj
+   (deftest db-util-json-test
+     (testing "parse stream"
+       (testing "normal values"
+         (let [x  {:_id "parser"
+                   :name "test-01"
+                   :fv   (float 3.11112)
+                   :dv   (double 1.8111111125989)
+                   :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                   :biv  (bigint 1.8374872394873333e+89)
+                   :iv   (int 72356)}
+               x' (-> x (cjson/encode) (string->stream))
+               x* (json/parse x')]
+           (is (instance? ByteArrayInputStream x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           (is (= (:fv x) (-> x* :fv float)))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:bdv x) (:bdv x*)))
+           (is (= (:biv x) (:biv x*)))
+           (is (= (:iv x) (:iv x*)))))
+       (testing "minimum values"
+         (let [x  {:_id "parser"
+                   :name "test-02"
+                   :fv   Float/MIN_VALUE
+                   :dv   Double/MIN_VALUE
+                   :iv   Integer/MIN_VALUE}
+               x' (-> x (cjson/encode) (string->stream))
+               x* (json/parse x')]
+           (is (instance? ByteArrayInputStream x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           (is (= (-> x :fv) (-> x* :fv float)) )
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:iv x) (:iv x*)))))
+       (testing "maximum values"
+         (let [x  {:_id "parser"
+                   :name "test-03"
+                   :fv   (- Float/MAX_VALUE float-conv-delta)
+                   :dv   Double/MAX_VALUE
+                   :iv   Integer/MAX_VALUE}
+               x' (-> x (cjson/encode) (string->stream))
+               x* (json/parse x')]
+           (is (instance? ByteArrayInputStream x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           ; the value of Float/MAX_VALUE is actually allocated as a double
+           ; using MAX_VALUE less conversion delta
+           (= (-> x :fv) (-> x* :fv float))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:iv x) (:iv x*))))))
+     (testing "parse json stringify"
+       (testing "normal values"
+         (let [x  {:_id "parser"
+                   :name "test-04"
+                   :fv   (float 3.11112)
+                   :dv   (double 1.8111111125989)
+                   :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                   :biv  (bigint 1.8374872394873333e+89)
+                   :iv   (int 72356)}
+               x' (json/stringify x)
+               x* (json/parse x')]
+           (is (string? x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           (is (= (:fv x) (-> x* :fv float)))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:bdv x) (:bdv x*)))
+           (is (= (:biv x) (:biv x*)))
+           (is (= (:iv x) (:iv x*)))))
+       (testing "minimum values"
+         (let [x  {:_id "parser"
+                   :name "test-05"
+                   :fv   Float/MIN_VALUE
+                   :dv   Double/MIN_VALUE
+                   :iv   Integer/MIN_VALUE}
+               x' (json/stringify x)
+               x* (json/parse x')]
+           (is (string? x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           (is (= (:fv x) (-> x* :fv float)))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:iv x) (:iv x*)))))
+       (testing "maximum values"
+         (let [x  {:_id "parser"
+                   :name "test-06"
+                   :fv   (- Float/MAX_VALUE float-conv-delta)
+                   :dv   Double/MAX_VALUE
+                   :iv   Integer/MAX_VALUE}
+               x' (json/stringify x)
+               x* (json/parse x')]
+           (is (string? x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           ; the value of Float/MAX_VALUE is actually allocated as a double
+           ; using MAX_VALUE less conversion delta
+           (= (-> x :fv) (-> x* :fv float))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:iv x) (:iv x*))))))
+     (testing "parse byte-array"
+       (testing "normal values"
+         (let [x  {:_id "parser"
+                   :name "test-07"
+                   :fv   (float 3.11112)
+                   :dv   (double 1.8111111125989)
+                   :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                   :biv  (bigint 1.8374872394873333e+89)
+                   :iv   (int 72356)}
+               x' (-> x cjson/encode u-bytes/string->UTF8)
+               x* (json/parse x')]
+           (is (bytes? x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           (is (= (:fv x) (-> x* :fv float)))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:bdv x) (:bdv x*)))
+           (is (= (:biv x) (:biv x*)))
+           (is (= (:iv x) (:iv x*)))))
+       (testing "minimum values"
+         (let [x  {:_id "parser"
+                   :name "test-08"
+                   :fv   Float/MIN_VALUE
+                   :dv   Double/MIN_VALUE
+                   :iv   Integer/MIN_VALUE}
+               x' (-> x cjson/encode u-bytes/string->UTF8)
+               x* (json/parse x')]
+           (is (bytes? x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           (is (= (:fv x) (-> x* :fv float)))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:iv x) (:iv x*)))))
+       (testing "maximum values"
+         (let [x  {:_id "parser"
+                   :name "test-09"
+                   :fv   (- Float/MAX_VALUE float-conv-delta)
+                   :dv   Double/MAX_VALUE
+                   :iv   Integer/MAX_VALUE}
+               x' (-> x cjson/encode u-bytes/string->UTF8)
+               x* (json/parse x')]
+           (is (bytes? x'))
+           (is (instance? PersistentArrayMap x*))
+           (is (= (:name x) (:name x*)))
+           ; the value of Float/MAX_VALUE is actually allocated as a double
+           ; using MAX_VALUE less conversion delta
+           (= (-> x :fv) (-> x* :fv float))
+           (is (= (:dv x) (-> x* :dv double)))
+           (is (= (:iv x) (:iv x*))))))))
+
+#?(:cljs
+   (deftest db-util-json-test
+     (testing "boolean"
+       (is (= (float 0) (double 0))))))
+

--- a/test/fluree/db/util/json_test.cljc
+++ b/test/fluree/db/util/json_test.cljc
@@ -40,153 +40,316 @@
 ;; 3.3614711319430846E30
 #?(:clj
    (deftest db-util-json-test
-     (testing "parse stream"
-       (testing "normal values"
-         (let [x  {:_id "parser"
-                   :name "test-01"
-                   :fv   (float 3.11112)
-                   :dv   (double 1.8111111125989)
-                   :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
-                   :biv  (bigint 1.8374872394873333e+89)
-                   :iv   (int 72356)}
-               x' (-> x (cjson/encode) (string->stream))
-               x* (json/parse x')]
-           (is (instance? ByteArrayInputStream x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           (is (= (:fv x) (-> x* :fv float)))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:bdv x) (:bdv x*)))
-           (is (= (:biv x) (:biv x*)))
-           (is (= (:iv x) (:iv x*)))))
-       (testing "minimum values"
-         (let [x  {:_id "parser"
-                   :name "test-02"
-                   :fv   Float/MIN_VALUE
-                   :dv   Double/MIN_VALUE
-                   :iv   Integer/MIN_VALUE}
-               x' (-> x (cjson/encode) (string->stream))
-               x* (json/parse x')]
-           (is (instance? ByteArrayInputStream x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           (is (= (-> x :fv) (-> x* :fv float)) )
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:iv x) (:iv x*)))))
-       (testing "maximum values"
-         (let [x  {:_id "parser"
-                   :name "test-03"
-                   :fv   (- Float/MAX_VALUE float-conv-delta)
-                   :dv   Double/MAX_VALUE
-                   :iv   Integer/MAX_VALUE}
-               x' (-> x (cjson/encode) (string->stream))
-               x* (json/parse x')]
-           (is (instance? ByteArrayInputStream x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           ; the value of Float/MAX_VALUE is actually allocated as a double
-           ; using MAX_VALUE less conversion delta
-           (= (-> x :fv) (-> x* :fv float))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:iv x) (:iv x*))))))
-     (testing "parse json stringify"
-       (testing "normal values"
-         (let [x  {:_id "parser"
-                   :name "test-04"
-                   :fv   (float 3.11112)
-                   :dv   (double 1.8111111125989)
-                   :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
-                   :biv  (bigint 1.8374872394873333e+89)
-                   :iv   (int 72356)}
-               x' (json/stringify x)
-               x* (json/parse x')]
-           (is (string? x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           (is (= (:fv x) (-> x* :fv float)))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:bdv x) (:bdv x*)))
-           (is (= (:biv x) (:biv x*)))
-           (is (= (:iv x) (:iv x*)))))
-       (testing "minimum values"
-         (let [x  {:_id "parser"
-                   :name "test-05"
-                   :fv   Float/MIN_VALUE
-                   :dv   Double/MIN_VALUE
-                   :iv   Integer/MIN_VALUE}
-               x' (json/stringify x)
-               x* (json/parse x')]
-           (is (string? x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           (is (= (:fv x) (-> x* :fv float)))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:iv x) (:iv x*)))))
-       (testing "maximum values"
-         (let [x  {:_id "parser"
-                   :name "test-06"
-                   :fv   (- Float/MAX_VALUE float-conv-delta)
-                   :dv   Double/MAX_VALUE
-                   :iv   Integer/MAX_VALUE}
-               x' (json/stringify x)
-               x* (json/parse x')]
-           (is (string? x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           ; the value of Float/MAX_VALUE is actually allocated as a double
-           ; using MAX_VALUE less conversion delta
-           (= (-> x :fv) (-> x* :fv float))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:iv x) (:iv x*))))))
-     (testing "parse byte-array"
-       (testing "normal values"
-         (let [x  {:_id "parser"
-                   :name "test-07"
-                   :fv   (float 3.11112)
-                   :dv   (double 1.8111111125989)
-                   :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
-                   :biv  (bigint 1.8374872394873333e+89)
-                   :iv   (int 72356)}
-               x' (-> x cjson/encode u-bytes/string->UTF8)
-               x* (json/parse x')]
-           (is (bytes? x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           (is (= (:fv x) (-> x* :fv float)))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:bdv x) (:bdv x*)))
-           (is (= (:biv x) (:biv x*)))
-           (is (= (:iv x) (:iv x*)))))
-       (testing "minimum values"
-         (let [x  {:_id "parser"
-                   :name "test-08"
-                   :fv   Float/MIN_VALUE
-                   :dv   Double/MIN_VALUE
-                   :iv   Integer/MIN_VALUE}
-               x' (-> x cjson/encode u-bytes/string->UTF8)
-               x* (json/parse x')]
-           (is (bytes? x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           (is (= (:fv x) (-> x* :fv float)))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:iv x) (:iv x*)))))
-       (testing "maximum values"
-         (let [x  {:_id "parser"
-                   :name "test-09"
-                   :fv   (- Float/MAX_VALUE float-conv-delta)
-                   :dv   Double/MAX_VALUE
-                   :iv   Integer/MAX_VALUE}
-               x' (-> x cjson/encode u-bytes/string->UTF8)
-               x* (json/parse x')]
-           (is (bytes? x'))
-           (is (instance? PersistentArrayMap x*))
-           (is (= (:name x) (:name x*)))
-           ; the value of Float/MAX_VALUE is actually allocated as a double
-           ; using MAX_VALUE less conversion delta
-           (= (-> x :fv) (-> x* :fv float))
-           (is (= (:dv x) (-> x* :dv double)))
-           (is (= (:iv x) (:iv x*))))))))
+     (testing ":fdb-json-bigdec-string: true"
+       (json/encode-BigDecimal-as-string true)
+       (testing "parse stream"
+         (testing "normal values"
+           (let [x  {:_id "parser"
+                     :name "test-01"
+                     :fv   (float 3.11112)
+                     :dv   (double 1.8111111125989)
+                     :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                     :biv  (bigint 1.8374872394873333e+89)
+                     :iv   (int 72356)}
+                 x' (-> x (cjson/encode) (string->stream))
+                 x* (json/parse x')]
+             (is (instance? ByteArrayInputStream x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (string? (:bdv x*)))
+             (is (number? (:fv x*)))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:bdv x) (-> x* :bdv bigdec)))
+             (is (= (:biv x) (:biv x*)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "minimum values"
+           (let [x  {:_id "parser"
+                     :name "test-02"
+                     :fv   Float/MIN_VALUE
+                     :dv   Double/MIN_VALUE
+                     :iv   Integer/MIN_VALUE}
+                 x' (-> x (cjson/encode) (string->stream))
+                 x* (json/parse x')]
+             (is (instance? ByteArrayInputStream x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             (is (= (-> x :fv) (-> x* :fv float)) )
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "maximum values"
+           (let [x  {:_id "parser"
+                     :name "test-03"
+                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :dv   Double/MAX_VALUE
+                     :iv   Integer/MAX_VALUE}
+                 x' (-> x (cjson/encode) (string->stream))
+                 x* (json/parse x')]
+             (is (instance? ByteArrayInputStream x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             ; the value of Float/MAX_VALUE is actually allocated as a double
+             ; using MAX_VALUE less conversion delta
+             (= (-> x :fv) (-> x* :fv float))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*))))))
+       (testing "parse json stringify"
+         (testing "normal values"
+           (let [x  {:_id "parser"
+                     :name "test-04"
+                     :fv   (float 3.11112)
+                     :dv   (double 1.8111111125989)
+                     :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                     :biv  (bigint 1.8374872394873333e+89)
+                     :iv   (int 72356)}
+                 x' (json/stringify x)
+                 x* (json/parse x')]
+             (is (string? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (string? (:bdv x*)))
+             (is (number? (:fv x*)))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:bdv x) (-> x* :bdv bigdec)))
+             (is (= (:biv x) (:biv x*)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "minimum values"
+           (let [x  {:_id "parser"
+                     :name "test-05"
+                     :fv   Float/MIN_VALUE
+                     :dv   Double/MIN_VALUE
+                     :iv   Integer/MIN_VALUE}
+                 x' (json/stringify x)
+                 x* (json/parse x')]
+             (is (string? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "maximum values"
+           (let [x  {:_id "parser"
+                     :name "test-06"
+                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :dv   Double/MAX_VALUE
+                     :iv   Integer/MAX_VALUE}
+                 x' (json/stringify x)
+                 x* (json/parse x')]
+             (is (string? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             ; the value of Float/MAX_VALUE is actually allocated as a double
+             ; using MAX_VALUE less conversion delta
+             (= (-> x :fv) (-> x* :fv float))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*))))))
+       (testing "parse byte-array"
+         (testing "normal values"
+           (let [x  {:_id "parser"
+                     :name "test-07"
+                     :fv   (float 3.11112)
+                     :dv   (double 1.8111111125989)
+                     :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                     :biv  (bigint 1.8374872394873333e+89)
+                     :iv   (int 72356)}
+                 x' (-> x cjson/encode u-bytes/string->UTF8)
+                 x* (json/parse x')]
+             (is (bytes? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (string? (:bdv x*)))
+             (is (number? (:fv x*)))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:bdv x) (-> x* :bdv bigdec)))
+             (is (= (:biv x) (:biv x*)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "minimum values"
+           (let [x  {:_id "parser"
+                     :name "test-08"
+                     :fv   Float/MIN_VALUE
+                     :dv   Double/MIN_VALUE
+                     :iv   Integer/MIN_VALUE}
+                 x' (-> x cjson/encode u-bytes/string->UTF8)
+                 x* (json/parse x')]
+             (is (bytes? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "maximum values"
+           (let [x  {:_id "parser"
+                     :name "test-09"
+                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :dv   Double/MAX_VALUE
+                     :iv   Integer/MAX_VALUE}
+                 x' (-> x cjson/encode u-bytes/string->UTF8)
+                 x* (json/parse x')]
+             (is (bytes? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             ; the value of Float/MAX_VALUE is actually allocated as a double
+             ; using MAX_VALUE less conversion delta
+             (= (-> x :fv) (-> x* :fv float))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))))
+     (testing ":fdb-json-bigdec-string: false"
+       (json/encode-BigDecimal-as-string false)
+       (testing "parse stream"
+         (testing "normal values"
+           (let [x  {:_id "parser"
+                     :name "test-01"
+                     :fv   (float 3.11112)
+                     :dv   (double 1.8111111125989)
+                     :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                     :biv  (bigint 1.8374872394873333e+89)
+                     :iv   (int 72356)}
+                 x' (-> x (cjson/encode) (string->stream))
+                 x* (json/parse x')]
+             (is (instance? ByteArrayInputStream x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (number? (:bdv x*)))
+             (is (number? (:fv x*)))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:bdv x) (:bdv x*)))
+             (is (= (:biv x) (:biv x*)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "minimum values"
+           (let [x  {:_id "parser"
+                     :name "test-02"
+                     :fv   Float/MIN_VALUE
+                     :dv   Double/MIN_VALUE
+                     :iv   Integer/MIN_VALUE}
+                 x' (-> x (cjson/encode) (string->stream))
+                 x* (json/parse x')]
+             (is (instance? ByteArrayInputStream x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             (is (= (-> x :fv) (-> x* :fv float)) )
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "maximum values"
+           (let [x  {:_id "parser"
+                     :name "test-03"
+                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :dv   Double/MAX_VALUE
+                     :iv   Integer/MAX_VALUE}
+                 x' (-> x (cjson/encode) (string->stream))
+                 x* (json/parse x')]
+             (is (instance? ByteArrayInputStream x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             ; the value of Float/MAX_VALUE is actually allocated as a double
+             ; using MAX_VALUE less conversion delta
+             (= (-> x :fv) (-> x* :fv float))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*))))))
+       (testing "parse json stringify"
+         (testing "normal values"
+           (let [x  {:_id "parser"
+                     :name "test-04"
+                     :fv   (float 3.11112)
+                     :dv   (double 1.8111111125989)
+                     :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                     :biv  (bigint 1.8374872394873333e+89)
+                     :iv   (int 72356)}
+                 x' (json/stringify x)
+                 x* (json/parse x')]
+             (is (string? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (number? (:bdv x*)))
+             (is (number? (:fv x*)))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:bdv x) (:bdv x*)))
+             (is (= (:biv x) (:biv x*)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "minimum values"
+           (let [x  {:_id "parser"
+                     :name "test-05"
+                     :fv   Float/MIN_VALUE
+                     :dv   Double/MIN_VALUE
+                     :iv   Integer/MIN_VALUE}
+                 x' (json/stringify x)
+                 x* (json/parse x')]
+             (is (string? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "maximum values"
+           (let [x  {:_id "parser"
+                     :name "test-06"
+                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :dv   Double/MAX_VALUE
+                     :iv   Integer/MAX_VALUE}
+                 x' (json/stringify x)
+                 x* (json/parse x')]
+             (is (string? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             ; the value of Float/MAX_VALUE is actually allocated as a double
+             ; using MAX_VALUE less conversion delta
+             (= (-> x :fv) (-> x* :fv float))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*))))))
+       (testing "parse byte-array"
+         (testing "normal values"
+           (let [x  {:_id "parser"
+                     :name "test-07"
+                     :fv   (float 3.11112)
+                     :dv   (double 1.8111111125989)
+                     :bdv  (bigdec 1.8333333333333332593184650249895639717578887939453125)
+                     :biv  (bigint 1.8374872394873333e+89)
+                     :iv   (int 72356)}
+                 x' (-> x cjson/encode u-bytes/string->UTF8)
+                 x* (json/parse x')]
+             (is (bytes? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (number? (:bdv x*)))
+             (is (number? (:fv x*)))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:bdv x) (:bdv x*)))
+             (is (= (:biv x) (:biv x*)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "minimum values"
+           (let [x  {:_id "parser"
+                     :name "test-08"
+                     :fv   Float/MIN_VALUE
+                     :dv   Double/MIN_VALUE
+                     :iv   Integer/MIN_VALUE}
+                 x' (-> x cjson/encode u-bytes/string->UTF8)
+                 x* (json/parse x')]
+             (is (bytes? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             (is (= (:fv x) (-> x* :fv float)))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))
+         (testing "maximum values"
+           (let [x  {:_id "parser"
+                     :name "test-09"
+                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :dv   Double/MAX_VALUE
+                     :iv   Integer/MAX_VALUE}
+                 x' (-> x cjson/encode u-bytes/string->UTF8)
+                 x* (json/parse x')]
+             (is (bytes? x'))
+             (is (instance? PersistentArrayMap x*))
+             (is (= (:name x) (:name x*)))
+             ; the value of Float/MAX_VALUE is actually allocated as a double
+             ; using MAX_VALUE less conversion delta
+             (= (-> x :fv) (-> x* :fv float))
+             (is (= (:dv x) (-> x* :dv double)))
+             (is (= (:iv x) (:iv x*)))))))))
 
 #?(:cljs
    (deftest db-util-json-test


### PR DESCRIPTION
Currently, BigDecimals are being truncated during json encoding of results.
This change:

- enables the recognition of BigDecimals (parsing/encoding)
- enables the encoding of BigDecimals either as string or number 

There will be a corresponding PR for the ledger to designate the encoding of BigDecimals as string or number.

@cap10morgan Please take a look at the unit tests.  The unit tests are for Clojure since the ClojureScript tests will be different (BigNumber versus java.lang.BigDecimal).  However, I could not get the test suite to automatically pick up a Clojure unit test (e.g., *.clj)
