### PR TITLE
FC-1136 - need way to bind specific subject id in query: [?s _id 1234]

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -54,8 +54,8 @@
   (reduce-kv (fn [acc idx key]
                (let [key-as-var   (variable? key)
                      static-value (get interm-vars key-as-var)]
-                 (when (and (= idx 1) (not key-as-var)
-                            (not (try (dbproto/-p-prop db :name (re-find #"[_a-zA-Z0-9/]*" key)))))
+                 (when (and (= idx 1) (not key-as-var) (not= "_id" key)
+                            (not (dbproto/-p-prop db :name (re-find #"[_a-zA-Z0-9/]*" key))))
                    (throw (ex-info (str "Invalid predicate provided: " key)
                                    {:status 400
                                     :error  :db/invalid-query})))
@@ -328,7 +328,8 @@
                                                            v)]
                                            (if single-v?
                                              [acc (assoc clause' idx-of (first v))]
-                                             [(assoc acc k v) clause']))) [{} search] common-keys)
+                                             [(assoc acc k v) clause'])))
+                                       [{} search] common-keys)
                 ;; Currently, only pass in object-fn to search opts. Seems to be faster to filter
                 ;; subject after. I'm sure this depends on a number of variables
                 ;; TODO - determine what, when, and how to filter - in index range? after index-range?
@@ -769,7 +770,8 @@
                                                             headers)))
                          (calculate-aggregate res)
                          second)
-                    v)] {k var-value}))
+                    v)]
+    {k var-value}))
 
 (declare clause->tuples)
 

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -418,7 +418,11 @@
                                   (let [obj-fn (if-let [obj-fn (:object-fn opts)]
                                                  (fn [x] (and (obj-fn x) (= x o)))
                                                  (fn [x] (= x o)))]
-                                    (<? (index-range db :psot = [p s nil t] (assoc opts :object-fn obj-fn))))
+                                    ;; check for special case where search specifies _id and an integer, i.e. [nil _id 12345]
+                                    (if (and (= "_id" p) (int? o))
+                                      ;; TODO - below should not need a `take 1` - `:limit 1` does not work properly - likely fixed in tsop branch, remove take 1 once :limit works
+                                      (take 1 (<? (index-range db :spot = [o] (assoc opts :limit 1))))
+                                      (<? (index-range db :psot = [p s nil t] (assoc opts :object-fn obj-fn)))))
 
                                   p
                                   (<? (index-range db :psot = [p s o t] opts))


### PR DESCRIPTION
This fix addresses the issue of binding an already know _id value to a variable, i.e.: 
{:select {"?s" [:*]}
             :where [["?s" "_id" 351843720888320]]}

This can be done with the :vars map when using multiple where statements - but this doesn't work for either (a) a single where statement as above, or (b) inside an :optional clause, one might want to use the variable (i.e. ?s above) as a default value in which case binding via :vars would bind all ?s values.

The docs state you can do this binding using a two-tuple, i.e.:
{:select {"?s" [:*]}
             :where [["?s" 351843720888320]]}
however, this does not work and should be removed from the docs in favor of the former approach.