### PR TITLE
FC-1192 Add missing dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ package-lock.json
 /.clj-kondo/.cache
 /.eastwood
 /scanning_results
+.dir-locals.el

--- a/deps.edn
+++ b/deps.edn
@@ -40,6 +40,11 @@
   :mvn/artifact-id db
   :mvn/version "1.0.0-rc22"
 
+  :dev
+  {:extra-paths ["dev"]
+   :extra-deps {org.clojure/tools.namespace {:mvn/version "1.1.0"}
+                figwheel-sidecar/figwheel-sidecar {:mvn/version "0.5.20"}}}
+
   :cljstest
   {:extra-paths ["test"]
    :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}


### PR DESCRIPTION
Now we can use the dev/user.clj scratchpad. I also added the emacs project-specific
configuration file to the .gitignore file.