### PR TITLE
FC-1146 fix/dropped fulltext indexes

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -115,11 +115,12 @@
                        close]
   #?@(:clj
       [full-text/IndexConnection
-       (open-storage [conn network dbid lang]
-                     (-> conn
-                         :meta
-                         :file-storage-path
-                         (full-text/disk-index network dbid lang)))]))
+       (open-storage [{:keys [storage-type] :as conn} network dbid lang]
+                     (when (= storage-type :file)
+                       (-> conn
+                           :meta
+                           :file-storage-path
+                           (full-text/disk-index network dbid lang))))]))
 
 
 (defn- normalize-servers

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -9,6 +9,7 @@
             [#?(:cljs cljs.cache :clj clojure.core.cache) :as cache]
             [fluree.db.session :as session]
             #?(:clj [fluree.crypto :as crypto])
+            #?(:clj [fluree.db.full-text :as full-text])
             [fluree.db.util.xhttp :as xhttp]
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.async :refer [<? go-try channel?]]
@@ -111,7 +112,14 @@
                        tx-private-key tx-key-id
                        meta
                        add-listener remove-listener
-                       close])
+                       close]
+  #?@(:clj
+      [full-text/IndexConnection
+       (open-storage [conn network dbid lang]
+                     (-> conn
+                         :meta
+                         :file-storage-path
+                         (full-text/disk-index network dbid lang)))]))
 
 
 (defn- normalize-servers

--- a/src/fluree/db/full_text/block_registry.clj
+++ b/src/fluree/db/full_text/block_registry.clj
@@ -1,0 +1,46 @@
+(ns fluree.db.full-text.block-registry
+  (:refer-clojure :exclude [read])
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import java.io.File))
+
+(defprotocol BlockRegistry
+  (read [r])
+  (register [r status])
+  (reset [r]))
+
+(defrecord DiskRegistry [^File file]
+  BlockRegistry
+  (read
+    [_]
+    (when (.exists file)
+      (-> file slurp edn/read-string)))
+  (register
+    [_ status]
+    (->> status prn-str (spit file)))
+  (reset
+    [_]
+    (when (.exists file)
+      (io/delete-file file))))
+
+(defn disk-registry
+  [base-path]
+  (let [path (str/join "/" [base-path "block_registry.edn"])]
+    (-> path io/as-file ->DiskRegistry)))
+
+(defrecord MemoryRegistry [state]
+  BlockRegistry
+  (read
+    [_]
+    @state)
+  (register
+    [_ status]
+    (reset! state status))
+  (reset
+    [_]
+    (reset! state nil)))
+
+(defn memory-registry
+  []
+  (->MemoryRegistry (atom nil)))

--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -383,16 +383,11 @@
              (throw (ex-info "Full text search is not supported in when running in-memory"
                              {:status 400
                               :error  :db/invalid-query}))
-             (let [[var search search-param]
-                   clause
-
-                   var   (variable? var)
-                   store (-> conn
-                             :meta
-                             :file-storage-path
-                             (full-text/storage-path db)
-                             full-text/storage)]
-               (full-text/search db store [var search search-param])))))
+             (let [lang (-> db :settings :language (or :default))
+                   [var search search-param] clause
+                   var (variable? var)]
+               (with-open [store (full-text/open-storage conn network dbid lang)]
+                 (full-text/search db store [var search search-param]))))))
 
 
 ;; Can be: ["?item" "rdf:type" "person"]

--- a/test/fluree/db/full_text_test.clj
+++ b/test/fluree/db/full_text_test.clj
@@ -1,0 +1,33 @@
+(ns fluree.db.full-text-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.flake :as flake]
+            [fluree.db.full-text :as full-text]))
+
+(deftest full-text-index-test
+  (testing "full-text index"
+    (let [lang :en]
+      (with-open [idx (full-text/memory-index lang)]
+        (testing "after initialization"
+          (-> idx full-text/writer .close)
+          (testing "populated with predicates for a subject"
+            (let [cid       12345
+                  subj-num  10
+                  subj-id   (flake/->sid cid subj-num)
+                  pred-vals {1001 "foo", 1002 "bar"}]
+              (with-open [wrtr (full-text/writer idx)]
+                (full-text/put-subject idx wrtr subj-id pred-vals)
+                (.commit wrtr)
+                (let [subject-under-test (full-text/get-subject idx subj-id)]
+                  (is (and (= "foo" (:1001 subject-under-test))
+                           (= "bar" (:1002 subject-under-test)))
+                      "populated subject can be retrieved")))
+              (testing "when updating a single predicate"
+                (let [pred-update {1001 "baz"}]
+                  (with-open [wrtr (full-text/writer idx)]
+                    (full-text/put-subject idx wrtr subj-id pred-update)
+                    (.commit wrtr)
+                    (let [subject-under-test (full-text/get-subject idx subj-id)]
+                      (is (= "baz" (:1001 subject-under-test))
+                          "the updated predicate can be retrieved")
+                      (is (= "bar" (:1002 subject-under-test))
+                          "unchanged predicates are retained"))))))))))))

--- a/test/fluree/db/full_text_test.clj
+++ b/test/fluree/db/full_text_test.clj
@@ -30,4 +30,6 @@
                       (is (= "baz" (:1001 subject-under-test))
                           "the updated predicate can be retrieved")
                       (is (= "bar" (:1002 subject-under-test))
-                          "unchanged predicates are retained"))))))))))))
+                          "unchanged predicates are retained")
+                      (is (not (-> subject-under-test vals set (contains? "foo")))
+                          "previous predicate values are not retained"))))))))))))


### PR DESCRIPTION
When a predicate value was updated for full text indexes was updated, all the previously stored predicate values that were not updated would be dropped. This was because of quirks in the underlying lucene api and the way we were calling it. Instead of merging document updates, it deleted the previous document and replaced it with the updates. In fixing that bug, I found (well, revealed) another bug where stale data was kept around after updates because we weren't sanitizing inputs to full text storage in the same way the clojure lucene api was sanitizing outputs.

I don't like to post bug fixes without a test that would have caught the bug in the first place, so most of this code is a refactor for making testing easier. I abstracted the full-text storage api behind a protocol and used that to allow for pluggable storage back ends that allow us to use disk-backed lucene in productions but memory-backed lucene in tests.

This has the added benefit of allowing us to enable full-text search in an totally in-memory fluree (but a little more work is needed to allow for that). 