### PR TITLE
FC-1209: check for presence of file-storage-path meta instead of storage-type

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -116,11 +116,8 @@
   #?@(:clj
       [full-text/IndexConnection
        (open-storage [{:keys [storage-type] :as conn} network dbid lang]
-                     (when (= storage-type :file)
-                       (-> conn
-                           :meta
-                           :file-storage-path
-                           (full-text/disk-index network dbid lang))))]))
+                     (when-let [path (-> conn :meta :file-storage-path)]
+                       (full-text/disk-index path network dbid lang)))]))
 
 
 (defn- normalize-servers


### PR DESCRIPTION
The previous code assumed that the `:storage-type` key would always be set on the connection record but this seems not to be the case. Instead of checking for storage type, this patch checks if the `:file-storage-path` key is populated in the meta map. This key being set is a much more reliable proxy for checking for connections with file-backed storage.