### PR TITLE
Feature/graph select perf

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -10,6 +10,7 @@
             [fluree.db.flake :as flake #?@(:cljs [:refer [Flake]])]
             [fluree.db.query.analytical-wikidata :as wikidata]
             [fluree.db.query.analytical-filter :as filter]
+            [fluree.db.query.union :as union]
             [clojure.string :as str]
             [fluree.db.util.log :as log]
             #?(:cljs [cljs.reader])
@@ -385,7 +386,7 @@
                               :error  :db/invalid-query}))
              (let [lang (-> db :settings :language (or :default))
                    [var search search-param] clause
-                   var (variable? var)]
+                   var  (variable? var)]
                (with-open [store (full-text/open-storage conn network dbid lang)]
                  (full-text/search db store [var search search-param]))))))
 
@@ -661,39 +662,6 @@
      :vars    (merge (:vars a-tuples) (:vars b-tuples))
      :tuples  c-tuples}))
 
-(defn outer-union
-  "UNION clause takes a left-hand side, which is inner-joined, and a right-hand side, which is inner-joined.
-  Any tuples unbound by the other set are included."
-  [a-tuples b-tuples]
-  (let [common-keys               (intersecting-keys-tuples a-tuples b-tuples)
-        a-idxs                    (map #(util/index-of (:headers a-tuples) %) common-keys)
-        b-idxs                    (map #(util/index-of (:headers b-tuples) %) common-keys)
-        b-not-idxs                (-> b-tuples :headers count (#(range 0 %))
-                                      set (set/difference (set b-idxs)) (#(apply vector %)))
-        ; We find all the rows where a-tuples are matched - or we nil them
-        ; we also return all the b-tuple row nums that were matched.
-        [c-tuples b-matched-rows] (reduce
-                                    (fn [[c-tuples b-matched-rows] a-tuple]
-                                      (let [[matches matched-rows] (find-match+row-nums a-tuple a-idxs (:tuples b-tuples) b-idxs b-not-idxs)
-                                            matches (or matches [(concat a-tuple (repeat (count b-not-idxs) nil))])]
-                                        ;; TODO - revise this fn - below was susceptible to stack overflows, quick fix to retain original ordering in case important
-                                        [(into (vec c-tuples) matches) #_(concat c-tuples matches)
-                                         (set/union b-matched-rows matched-rows)]))
-                                    [[] #{}] (:tuples a-tuples))
-        b-unmatched-rows          (remove b-matched-rows (range 0 (count (:tuples b-tuples))))
-        c-headers                 (concat (:headers a-tuples) (map #(nth (:headers b-tuples) %) b-not-idxs))
-        ;; For unmatched b-tuples, need to follow the pattern of c-headers, returning nil when there's no match
-        b-idxs->c-idxs            (map #(util/index-of (:headers b-tuples) %) c-headers)
-        c-from-unmatched-b-tuples (map (fn [b-row]
-                                         (let [b-tuple (into [] (nth (:tuples b-tuples) b-row))]
-                                           (map (fn [c-idx]
-                                                  (if (nil? c-idx) nil (get b-tuple c-idx)))
-                                                b-idxs->c-idxs)))
-                                       b-unmatched-rows)
-        c-tuples                  (concat c-tuples c-from-unmatched-b-tuples)]
-    {:headers c-headers
-     :vars    (merge (:vars a-tuples) (:vars b-tuples))
-     :tuples  c-tuples}))
 
 (declare resolve-where-clause)
 
@@ -814,7 +782,7 @@
                                           new-res (keys vars))
                         new-res** (res-absorb-vars new-res*)]
                     (if tuples
-                      (recur rest (outer-union tuples new-res**))
+                      (recur rest (union/results tuples new-res**))
                       (recur rest new-res**)))
                   [tuples r]))
 

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -374,23 +374,6 @@
         res))))
 
 
-
-
-;(defn flakes->res-xf
-;  "Transducer for filling out a result from a sequence of
-;  flakes all from the same subject."
-;  [db cache fuel max-fuel select-spec]
-;  (fn [xf]
-;    (fn
-;      ([] (xf))                                             ;; transducer start
-;      ([result] (xf result))                                ;; transducer stop
-;      ([result flakes]
-;       (if-let [res (flakes->res db cache fuel max-fuel select-spec flakes)]
-;         (xf result res)
-;         ;; if no response, just return result which will include nothing in the result set
-;         result)))))
-
-
 ;; TODO - use pipeline-async to do selects in parallel
 (defn flake-select
   "Runs a select statement based on a sequence of flakes."
@@ -414,15 +397,8 @@
        (->> flakes-by-sub
             (map #(flakes->res db cache fuel max-fuel select-spec %))
             (merge-into? [])
-            (<?))
+            (<?))))))
 
-       ;; sequential processing - will be slower for larger queries, but negligible for small queries. Fuel will always be accurate.
-       #_(loop [[sub-flakes & r] flakes-by-sub
-                acc []]
-           (if-not sub-flakes
-             acc
-             (let [res (<? (flakes->res db cache fuel max-fuel select-spec sub-flakes))]
-               (recur r (conj acc res)))))))))
 
 (defn subject-select
   "Like flake select, but takes a collection of subject ids which we

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -95,14 +95,16 @@
              limit (take limit)) res))
 
 (defn- add-pred
-  ([db cache fuel max-fuel acc pred-spec ^Flake flake componentFollow? recur?]
-   (add-pred db cache fuel max-fuel acc pred-spec ^Flake flake componentFollow? recur? {}))
-  ([db cache fuel max-fuel acc pred-spec ^Flake flake componentFollow? recur? offset-map]
+  "Adds a predicate to a select spec graph crawl. flakes input is a list of flakes
+  all with the same subject and predicate values."
+  ([db cache fuel max-fuel acc pred-spec flakes componentFollow? recur?]
+   (add-pred db cache fuel max-fuel acc pred-spec flakes componentFollow? recur? {}))
+  ([db cache fuel max-fuel acc pred-spec flakes componentFollow? recur? offset-map]
    (go-try
-     (let [compact?   (:compact? pred-spec) ;retain original value
+     (let [compact?   (:compact? pred-spec)                 ;retain original value
            pred-spec  (if (and (:wildcard? pred-spec) (nil? (:as pred-spec)))
                         ;; nested 'refs' can be wildcard, but also have a pred-spec... so only get a default wildcard spec if we have no other spec
-                        (wildcard-pred-spec db cache (.-p flake) (:compact? pred-spec))
+                        (wildcard-pred-spec db cache (.-p ^Flake (first flakes)) (:compact? pred-spec))
                         pred-spec)
            pred-spec' (cond-> pred-spec
                               (not (contains? pred-spec :componentFollow?)) (assoc :componentFollow? componentFollow?)
@@ -119,8 +121,11 @@
                                  (if (get offset-map p)
                                    (update offset-map p dec)
                                    (assoc offset-map p (dec offset)))]
+
+                                ;; check if have hit limit of predicate spec
                                 (and multi?
                                      (not orderBy)
+                                     limit
                                      (>= (count (get acc k)) limit))
                                 [nil offset-map]
 
@@ -128,44 +133,53 @@
                                 (and (not recur?)
                                      (or (:select pred-spec') (:wildcard? pred-spec')))
                                 (let [nested-select-spec (select-keys pred-spec' [:wildcard? :compact? :select])]
-                                  [(<? (cond->> (<? (query-range/index-range db :spot = [(.-o flake)]))
-                                                fuel (sequence (fuel-flake-transducer fuel max-fuel))
-                                                true ((fn [n] (flakes->res db cache fuel max-fuel nested-select-spec n)))))
+                                  [(loop [[^Flake flake & r] flakes
+                                          acc []]
+                                     (if-not flake
+                                       acc
+                                       (let [sub-sel (<? (query-range/index-range db :spot = [(.-o flake)]))]
+                                         (when fuel (vswap! fuel + (count sub-sel)))
+                                         (recur r (conj acc (<? (flakes->res db cache fuel max-fuel nested-select-spec sub-sel)))))))
                                    offset-map])
 
                                 ;; resolve tag
                                 (:tag? pred-spec')
-                                [(or (get @cache [(.-o flake) (:name pred-spec')])
-                                     (let [res (<? (dbproto/-tag db (.-o flake) (:name pred-spec')))]
-                                       (vswap! cache assoc [(.-o flake) (:name pred-spec')] res)
-                                       res)) offset-map]
+                                [(loop [[^Flake flake & r] flakes
+                                        acc []]
+                                   (if flake
+                                     (let [res (or (get @cache [(.-o flake) (:name pred-spec')])
+                                                   (let [res (<? (dbproto/-tag db (.-o flake) (:name pred-spec')))]
+                                                     (vswap! cache assoc [(.-o flake) (:name pred-spec')] res)
+                                                     res))]
+                                       (recur r (if res (conj acc res) acc)))
+                                     acc))
+                                 offset-map]
 
                                 ; is a component, get children
                                 (and componentFollow? (:component? pred-spec'))
-                                (let [children (<? (query-range/index-range db :spot = [(.-o flake)] {:limit (:limit pred-spec')}))]
-                                  (if (empty? children)
-                                    [{:_id (.-o flake)} offset-map] ;; no permission (empty results), so just return _id
-                                    [(<? (cond->> children
-                                                  fuel (sequence (fuel-flake-transducer fuel max-fuel))
-                                                  true ((fn [n] (flakes->res db cache fuel max-fuel {:wildcard? true :compact? compact?} n)))))
-                                     offset-map]))
+                                [(loop [[^Flake flake & r] flakes
+                                        acc []]
+                                   (if-not flake
+                                     acc
+                                     (let [children (<? (query-range/index-range db :spot = [(.-o flake)] {:limit (:limit pred-spec')}))
+                                           acc*     (if (empty? children)
+                                                      (conj acc {:_id (.-o flake)})
+                                                      (conj acc (<? (flakes->res db cache fuel max-fuel {:wildcard? true :compact? compact?} children))))]
+                                       (when fuel (vswap! fuel + (count children)))
+                                       (recur r acc*))))
+                                 offset-map]
 
                                 ;; if a ref, put out an {:_id ...}
                                 ref?
-                                [{:_id (.-o flake)} offset-map]
+                                [(mapv #(hash-map :_id (.-o ^Flake %)) flakes) offset-map]
 
                                 ;; else just output value
                                 :else
-                                [(.-o flake) offset-map])]
+                                [(mapv #(.-o ^Flake %) flakes) offset-map])]
        (cond
-         (and (not (nil? k-val)) multi?)
-         [(assoc acc k (conj (get acc k []) k-val)) offset-map]
-
-         (not (nil? k-val))
-         [(assoc acc k k-val) offset-map]
-
-         :else
-         [acc offset-map])))))
+         (empty? k-val) [acc offset-map]
+         multi? [(assoc acc k k-val) offset-map]
+         :else [(assoc acc k (first k-val)) offset-map])))))
 
 
 (defn full-select-spec
@@ -282,28 +296,32 @@
 
 
 
-;; TODO - reverse refs
 (defn flake->recur
-  ([db ^Flake flake select-spec acc fuel max-fuel cache]
-   (go-try
-     (let [recur-subject (.-o flake)                        ;; ref, so recur subject is the object of the incoming flake
-           {:keys [multi? as recur recur-seen recur-depth limit]} select-spec ;; recur contains # with requested recursion depth
-           seen?         (contains? recur-seen recur-subject) ;; subject has been seen before, stop recursion
-           max-depth?    (> recur-depth recur)              ;; reached max depth
-           sub-flakes    (cond->> (<? (query-range/index-range db :spot = [recur-subject]))
-                                  fuel (sequence (fuel-flake-transducer fuel max-fuel)))
-           stop?         (or seen? max-depth? (empty? sub-flakes))
-           add-result    (if multi?
-                           (fn [results as new-result]
-                             (update results as conjv new-result))
-                           (fn [results as new-result]
-                             (assoc results as new-result)))]
-       (if stop?
-         acc
-         (let [select-spec* (recur-select-spec select-spec flake)
+  "Performs recursion on a select spec graph crawl when specified. flakes input is list
+  of flakes all with the same subject and predicate values."
+  [db flakes select-spec results fuel max-fuel cache]
+  (go-try
+    (let [{:keys [multi? as recur-seen recur-depth limit]} select-spec ;; recur contains # with requested recursion depth
+          max-depth? (> recur-depth (:recur select-spec))]
+      (if max-depth?
+        results
+        (loop [[^Flake flake & r] flakes
+               i   0
+               acc []]
+          (if (or (not flake) (and limit (< i limit)))
+            (cond (empty? acc) results
+                  multi? (assoc results as acc)
+                  :else (assoc results as (first acc)))
+            (let [recur-subject (.-o flake)                 ;; ref, so recur subject is the object of the incoming flake
+                  seen?         (contains? recur-seen recur-subject) ;; subject has been seen before, stop recursion
 
-               res          (<? (flakes->res db cache fuel max-fuel select-spec* sub-flakes))]
-           (add-result acc as res)))))))
+                  sub-flakes    (cond->> (<? (query-range/index-range db :spot = [recur-subject]))
+                                         fuel (sequence (fuel-flake-transducer fuel max-fuel)))
+                  skip?         (or seen? (empty? sub-flakes))
+                  select-spec*  (recur-select-spec select-spec flake)]
+              (if skip?
+                (recur r (inc i) acc)
+                (recur r (inc i) (conj acc (<? (flakes->res db cache fuel max-fuel select-spec* sub-flakes))))))))))))
 
 
 (defn flakes->res
@@ -330,36 +348,35 @@
                                      (<?)
                                      (merge base-acc))
                                 base-acc)
-            result            (loop [flakes     flakes
+            result            (loop [p-flakes   (partition-by #(.-p ^Flake %) flakes)
                                      acc        acc+refs
                                      offset-map {}]
-                                (if (empty? flakes)
+                                (if (empty? p-flakes)
                                   acc
-                                  (let [f                (first flakes)
-                                        pred-spec        (get-in select-spec [:select :pred-id (.-p f)])
+                                  (let [FLAKES-P         (first p-flakes)
+                                        pred-spec        (get-in select-spec [:select :pred-id (.-p (first FLAKES-P))])
                                         componentFollow? (component-follow? pred-spec select-spec)
                                         [acc flakes' offset-map'] (cond
                                                                     (:recur pred-spec)
-                                                                    [(<? (flake->recur db f pred-spec acc fuel max-fuel cache))
-                                                                     (rest flakes) offset-map]
+                                                                    [(<? (flake->recur db FLAKES-P pred-spec acc fuel max-fuel cache))
+                                                                     (rest p-flakes) offset-map]
 
                                                                     pred-spec
-                                                                    (let [[acc offset-map] (<? (add-pred db cache fuel max-fuel acc pred-spec f componentFollow? false offset-map))]
-                                                                      [acc (rest flakes) offset-map])
+                                                                    (let [[acc offset-map] (<? (add-pred db cache fuel max-fuel acc pred-spec FLAKES-P componentFollow? false offset-map))]
+                                                                      [acc (rest p-flakes) offset-map])
 
                                                                     (:wildcard? select-spec)
-                                                                    [(first (<? (add-pred db cache fuel max-fuel acc
-                                                                                          select-spec f componentFollow? false)))
-                                                                     (rest flakes)
+                                                                    [(first (<? (add-pred db cache fuel max-fuel acc select-spec FLAKES-P componentFollow? false)))
+                                                                     (rest p-flakes)
                                                                      offset-map]
 
                                                                     (and (empty? (:select select-spec)) (:id? select-spec))
-                                                                    [{:_id (.-s f)} (rest flakes) offset-map]
+                                                                    [{:_id (.-s (first FLAKES-P))} (rest p-flakes) offset-map]
 
                                                                     :else
-                                                                    [acc (rest flakes) offset-map])
-                                        acc              (assoc acc :_id (.-s f))]
-                                    (recur flakes' acc offset-map'))))
+                                                                    [acc (rest p-flakes) offset-map])
+                                        acc*             (assoc acc :_id (.-s (first FLAKES-P)))]
+                                    (recur flakes' acc* offset-map'))))
             sort-preds        (reduce (fn [acc spec]
                                         (if (or (and (:multi? spec) (:orderBy spec))
                                                 (and (:reverse? spec) (:orderBy spec)))
@@ -418,10 +435,10 @@
          (recur r (inc n) acc)
 
          :else
-         (recur r (inc n)
-                (conj acc (->> (<? (query-range/index-range db :spot = [s]))
-                               ((fn [n] (flakes->res db cache fuel max-fuel select-spec n)))
-                               (<?)))))))))
+         (let [flakes (<? (query-range/index-range db :spot = [s]))]
+           (when fuel (vswap! fuel + (count flakes)))
+           (recur r (inc n) (conj acc (<? (flakes->res db cache fuel max-fuel select-spec flakes))))))))))
+
 
 (defn valid-where-predicate?
   [db p]

--- a/src/fluree/db/query/fql_parser.cljc
+++ b/src/fluree/db/query/fql_parser.cljc
@@ -251,7 +251,7 @@
   [db p compact?]
   (let [name (dbproto/-p-prop db :name p)]
     {:p          p
-     :limit      100
+     :limit      nil
      :name       name
      :as         (if (and compact? name)
                    (second (re-find #"/(.+)" name))

--- a/src/fluree/db/query/union.cljc
+++ b/src/fluree/db/query/union.cljc
@@ -1,0 +1,186 @@
+(ns fluree.db.query.union
+  (:require [fluree.db.util.core :as util]
+            [clojure.set :as set]
+            [fluree.db.util.log :as log]))
+
+
+(defn intersecting-keys-tuples
+  [a-tuples b-tuples]
+  (let [a-keys (-> a-tuples :headers set)
+        b-keys (-> b-tuples :headers)]
+    (reduce (fn [acc key]
+              (if (a-keys key)
+                (conj acc key)
+                acc))
+            [] b-keys)))
+
+
+(defn find-match+row-nums
+  "Given a single tuple from A, a-idxs, b-idxs, b-not-idxs, and b-tuples, return any tuples in b that match.
+  Along with their row-numbers"
+  [a-tuple a-idxs b-tuples b-idxs b-not-idxs]
+  (let [a-tuple-part (map #(nth a-tuple %) a-idxs)]
+    (reduce-kv (fn [[acc b-rows] row b-tuple]
+                 (if (= a-tuple-part (map #(nth b-tuple %) b-idxs))
+                   [(conj (or acc []) (concat a-tuple (map #(nth b-tuple %) b-not-idxs))) (conj b-rows row)]
+                   [acc b-rows]))
+               [nil #{}] (into [] b-tuples))))
+
+
+(defn nil-pad-tuples
+  "Pads n columns with nil values on either left or right hand side of tuples"
+  [tuples pad-n side]
+  (let [pad-seq (->> (repeat nil)                           ;; infinite list of nil values
+                     (take pad-n)                           ;; take on n number as per padding
+                     repeat)]                               ;; make resulting padded list infinite
+    (doall
+      (case side
+        :right (map concat tuples pad-seq)
+        :left (map concat pad-seq tuples)))))
+
+
+(defn non-intersecting
+  "Non-intersecting means there are no common variable bindings between the two tuples.
+  The result of this operation can be quite fast as it is just a concatenation of all results with
+  null values all columns that are not in each result set respectively."
+  [a-tuples b-tuples]
+  (let [a-headers (:headers a-tuples)
+        b-headers (:headers b-tuples)
+        c-tuples  (concat (nil-pad-tuples (:tuples a-tuples) (count b-headers) :right)
+                          (nil-pad-tuples (:tuples b-tuples) (count a-headers) :left))]
+    {:headers (concat a-headers b-headers)
+     :vars    (merge (:vars a-tuples) (:vars b-tuples))
+     :tuples  c-tuples}))
+
+
+(defn tuple-positions
+  "Returns a list containing the tuple-index for each provided subset header based on tuple headers.
+  i.e. if the tuple headers are (?x ?y ?z ?c) and the subset headers given is (?c ?y), it will
+  return (3 1) as the respective index points for those tuples."
+  [all-headers subset-headers]
+  (map #(util/index-of all-headers %) subset-headers))
+
+
+(defn all-intersecting
+  "Case where every variable is intersecting in union of two tuple sets."
+  [a-tuples b-tuples]
+  (let [a-headers (:headers a-tuples)
+        b-headers (:headers b-tuples)
+        a-data    (:tuples a-tuples)
+        b-data    (if (= a-headers b-headers)
+                    (:tuples b-tuples)                      ;; variable ordering is identical, no need to re-sort
+                    (let [positions (tuple-positions b-headers a-headers)]
+                      (map #(map (fn [i] (get % i)) positions) (:tuples b-tuples))))
+        b-pos-map (apply hash-map (interleave b-data (range)))
+        c-data    (loop [a-items    a-data
+                         b-pos-map* b-pos-map]
+                    (if (empty? a-items)
+                      (concat a-data (->> b-pos-map* (sort-by val) keys))
+                      (->> (first a-items)
+                           (dissoc b-pos-map*)
+                           (recur (rest a-items)))))]
+    {:headers a-headers
+     :vars    (merge (:vars a-tuples) (:vars b-tuples))
+     :tuples  c-data}))
+
+
+(defn b-data-map
+  "For situation where just some variables in a union intersect between the a-tuples and b-tuples,
+  creates a map of b-tuples where key is intersecting variables for fast lookup, and value is a
+  map of original tuple along with :idx which is the original order (row number) of b-tuples
+  to ensure consistent ordering.
+
+  Matches between a-tuples and b-tuples will remove entries from this map and merge results, entries
+  left in this map will be items in b-tuples that did not match a-tuples."
+  [b-common-idx b-data]
+  (loop [b-data* b-data
+         i       0
+         acc     {}]
+    (if (empty? b-data*)
+      acc
+      (let [tuple  (vec (first b-data*))
+            common (map #(get tuple %) b-common-idx)]
+        (recur (rest b-data*)
+               (inc i)
+               (assoc acc common {:idx   i
+                                  :tuple tuple}))))))
+
+
+(defn intersecting
+  "With common-headers already calculated, takes a list of headers and returns a
+   3-tuple of:
+    - common indexes, i.e (3, 1)
+    - not common indexes, i.e. (0, 2)
+    - not common headers, i.e. (?x, ?y)"
+  [common-headers headers]
+  (let [common-key?    (into #{} common-headers)
+        not-common     (filter #(not (common-key? %)) headers)
+        common-idx     (tuple-positions headers common-headers)
+        not-common-idx (tuple-positions headers not-common)]
+    [common-idx not-common-idx not-common]))
+
+
+(defn some-intersecting
+  "Some headers from a and/or b tuples intersect. Need to build out all columns.
+  Where common values exist for intersecting headers, merge into more complete rows.
+  Otherwise pad superset of headers as results with nil values for both a and b as
+  applicable."
+  [common-headers a-tuples b-tuples]
+  (let [a-headers    (:headers a-tuples)
+        b-headers    (:headers b-tuples)
+        a-data       (:tuples a-tuples)
+        b-data       (:tuples b-tuples)
+        a-common-idx (map #(util/index-of (:headers a-tuples) %) common-headers)
+        [b-common-idx b-only-idx b-only-headers] (intersecting common-headers b-headers)
+        b-pos-map    (b-data-map b-common-idx b-data)
+        a-nil-pad    (vec (repeat (count a-headers) nil))
+        b-nil-pad    (repeat (count b-only-headers) nil)
+        a-pad-fn     (fn [b-tuple]
+                       (concat
+                         (reduce
+                           (fn [acc [a-idx b-idx]]
+                             (assoc acc a-idx (get b-tuple b-idx)))
+                           a-nil-pad
+                           (partition 2 (interleave a-common-idx b-common-idx)))
+                         (map #(get b-tuple %) b-only-idx)))
+        c-data       (loop [a-data*    a-data
+                            b-pos-map* b-pos-map
+                            acc        []]
+                       (if (empty? a-data*)
+                         (let [only-b (->> (vals b-pos-map*)
+                                           (sort-by :idx)
+                                           (map #(a-pad-fn (:tuple %))))]
+                           (concat acc only-b))
+                         (let [a-item (vec (first a-data*))
+                               match  (map #(get a-item %) a-common-idx)]
+                           (if-let [b-match (get b-pos-map* match)]
+                             (recur (rest a-data*)
+                                    (dissoc b-pos-map* match)
+                                    (conj acc (concat a-item
+                                                      (map #(get (:tuple b-match) %) b-only-idx))))
+                             (recur (rest a-data*)
+                                    b-pos-map*
+                                    (conj acc (concat a-item
+                                                      b-nil-pad)))))))]
+    {:headers (concat a-headers b-only-headers)
+     :vars    (merge (:vars a-tuples) (:vars b-tuples))
+     :tuples  c-data}))
+
+
+(defn results
+  "Returns union (outer join) results of two statements."
+  [a-tuples b-tuples]
+  (let [common-keys   (intersecting-keys-tuples a-tuples b-tuples)
+        intersections (cond
+                        ;; no overlapping variables, will just create a big list with all columns + nils for non-values
+                        (zero? (count common-keys)) :none
+                        ;; every variable overlaps, just need to merge the two. Retain ordering consistency by always using a-tuples first
+                        (= (count common-keys)
+                           (count (:headers a-tuples))
+                           (count (:headers b-tuples))) :all
+                        ;; only some of the variables intersect, need to apply more granular approach
+                        :else :some)]
+    (case intersections
+      :none (non-intersecting a-tuples b-tuples)
+      :all (all-intersecting a-tuples b-tuples)
+      :some (some-intersecting common-keys a-tuples b-tuples))))

--- a/src/fluree/db/util/core.cljc
+++ b/src/fluree/db/util/core.cljc
@@ -53,10 +53,9 @@
      (cljs-exceptions/try* ~@body)
      (clj-exceptions/try* ~@body)))
 
-;; index-of from: https://gist.github.com/fgui/48443e08844e42c674cd
 (defn index-of [coll value]
-  (some (fn [[item idx]] (if (= value item) idx))
-        (partition 2 (interleave coll (iterate inc 0)))))
+  (some (fn [[item idx]] (when (= value item) idx))
+        (partition 2 (interleave coll (range)))))
 
 (defn random-uuid []
   "Generates random UUID in both clojure/script"


### PR DESCRIPTION
Addresses FC-1237. Select statement graph crawls for subjects with lots of predicates can be much faster. After this commit, a select [*] from <subject> for a subject with 20,000 predicates went from 800ms response to < 30ms response, ~25x improvement.

It accomplishes this by partitioning all flakes for a given subject by predicate - so that work around figuring out predicate info can be done once per subject instead of once per flake.

Performance for subjects with very few predicates appears to have no discernible difference but it is possible it is marginally slower.

The code that does graph crawls could use a refactor - large and confusing functions abound. I did not attempt that here to (a) address the issue quickly and (b) not adversely impact some larger outstanding pull requests that need to ultimately get merged.

Also addressed FC-1236. An arbitrary limit was placed on nested (ref) nodes in select graph crawls that limited results to 100 subjects. This is mostly unnecessary but also extremely confusing when you know there are some large number of refs but only 100 come back. There is now no limit, but a user can specify them as desired per node crawl.