### PR TITLE
FC-1241 invoke deserialize-db-root when data available

### DIFF
--- a/src/fluree/db/storage/core.cljc
+++ b/src/fluree/db/storage/core.cljc
@@ -513,9 +513,9 @@
   [conn network dbid block]
   (go-try
     (let [key  (ledger-root-key network dbid block)
-          data (storage-read conn key)]
+          data (<? (storage-read conn key))]
       (when data
-        (serdeproto/-deserialize-db-root (serde conn) (<? data))))))
+        (serdeproto/-deserialize-db-root (serde conn) data)))))
 
 
 (defn reify-db


### PR DESCRIPTION
modified call to invoke deserialization when data is available, versus checking the async channel.

There are no unit tests for serialization yet. FC-1224 was created to address that.