### PR TITLE
Fix two flake issues

### DIFF
--- a/src/fluree/db/flake.cljc
+++ b/src/fluree/db/flake.cljc
@@ -95,7 +95,7 @@
 
              clojure.lang.Associative
              (entryAt [f k] (some->> (get f k nil) (clojure.lang.MapEntry k)))
-             (containsKey [_ k] (#{:s :p :o :t :op :m} k))
+             (containsKey [_ k] (boolean (#{:s :p :o :t :op :m} k)))
              (assoc [f k v] (assoc-flake f k v))
 
              Object


### PR DESCRIPTION
As discussed w/ @bplatz in Slack

1. Revert my change to the Flake print-method to make them 6-tuples again instead of maps
2. Fix a bug I found in Flake's containsKey implementation