### PR TITLE
FC-1239 Improve and catch additional transaction-related exceptions

### DIFF
--- a/src/fluree/db/util/tx.clj
+++ b/src/fluree/db/util/tx.clj
@@ -16,33 +16,38 @@
   some additional checks. This can be done before putting the command into the queue for processing.
 
   Puts original :cmd string and :sig string into this one map for use downstream."
-  [{:keys [sig cmd]}]
-  ;; TODO - here again we calc the sha3 id, I think redundant at this point
-  (let [cmd-map       (-> (json/parse cmd)
-                          (assoc :txid (crypto/sha3-256 cmd) ;; don't trust their id if provided
+  [{:keys [command id] :as cmd-data}]
+  (let [{:keys [sig cmd]} command
+        cmd-map       (-> (try (json/parse cmd)
+                               (catch Exception _
+                                 (throw (ex-info (format "Transaction %s is not valid JSON, ignoring." id)
+                                                 {:status 400 :error :db/invalid-transaction}))))
+                          (assoc :txid id
                                  :cmd cmd
                                  :sig sig))
-
-        sig-authority (crypto/account-id-from-message cmd sig) ;; throws if invalid signature
+        sig-authority (try (crypto/account-id-from-message cmd sig)
+                           (catch Exception _
+                             (throw (ex-info (format "Transaction %s has an invalid signature." id)
+                                             {:status 400 :error :db/invalid-transaction}))))
         ;; merge everything together into one map for transaction.
         current-time  (System/currentTimeMillis)
         {:keys [auth authority expire]} cmd-map
         expired?      (and expire (< expire current-time))
         _             (when expired?
-                        (throw (ex-info (format "Transaction is expired. Current time: %s expire time: %s." current-time expire)
+                        (throw (ex-info (format "Transaction %s is expired. Current time: %s expire time: %s." id current-time expire)
                                         {:status 400 :error :db/invalid-transaction})))
         cmd-map*      (cond
                         (and (nil? auth) (nil? authority))
                         (assoc cmd-map :auth sig-authority)
 
                         (and (nil? auth) authority)
-                        (throw (ex-info (str "An authority without an auth is not allowed.")
+                        (throw (ex-info (format "Transaction %s invalid. An authority without an auth is not allowed." id)
                                         {:status 400 :error :db/invalid-transaction}))
 
                         (and auth authority)
                         (if (= authority sig-authority)
                           cmd-map
-                          (throw (ex-info (format "Signing authority: %s does not match command authority: %s." sig-authority authority)
+                          (throw (ex-info (format "Transaction %s is invalid. Signing authority: %s does not match command authority: %s." id sig-authority authority)
                                           {:status 400 :error :db/invalid-transaction})))
 
                         (and auth (nil? authority))


### PR DESCRIPTION
This is related to mostly changes in fluree/ledger to help improve error catching for invalid transactions. This adds some addition more helpful error messages. It does not require the fluree/ledger update to work and can be merged independently.