### PR TITLE
Use a wrapper of goog.string.format in CLJS

### DIFF
--- a/src-cljs/flureedb.cljs
+++ b/src-cljs/flureedb.cljs
@@ -16,7 +16,6 @@
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.db.query.http-signatures :as http-signatures]
-            [goog.string.format]
     ;shared clojurescript code
             [fluree.db.api-js :as fdb-js]
             [fluree.db.connection-js :as conn-handler]))

--- a/src-nodejs/flureenjs.cljs
+++ b/src-nodejs/flureenjs.cljs
@@ -27,7 +27,6 @@
             [fluree.db.util.core :as util]
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
-            [goog.string.format]
             [cljs.nodejs :as node-js]                       ;; NodeJS support
 
     ; shared clojurescript code

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -7,6 +7,7 @@
             [#?(:cljs cljs.core.async :clj clojure.core.async) :as async]
             [fluree.db.util.log :as log]
             [fluree.db.util.async :refer [go-try <?]]
+            #?(:cljs [fluree.db.util.string :refer [format]])
             [fluree.db.dbproto :as dbproto]
             [clojure.string :as str]
             #?(:cljs [fluree.db.flake :refer [Flake]]))

--- a/src/fluree/db/query/analytical_wikidata.cljc
+++ b/src/fluree/db/query/analytical_wikidata.cljc
@@ -6,8 +6,7 @@
     [fluree.db.util.log :as log]
     #?(:clj  [clojure.core.async :as async]
        :cljs [cljs.core.async :as async])
-    #?(:cljs [goog.string :as gstring])
-    #?(:cljs [goog.string.format])
+    #?(:cljs [fluree.db.util.string :refer [format]])
     [fluree.db.util.async :refer [<? go-try merge-into?]]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -85,8 +84,8 @@
            (= "$wd" (first clause)) (drop 1)
            true                     (map wikiDataVar?)
            true                     (str/join " ")
-           true                     (#?(:clj format :cljs gstring/format) "%s .")
-           optional?                (#?(:clj format :cljs gstring/format) "OPTIONAL {%s}")))
+           true                     (format "%s .")
+           optional?                (format "OPTIONAL {%s}")))
 
 (defn parse-prefixes
   [prefixes]

--- a/src/fluree/db/util/string.cljs
+++ b/src/fluree/db/util/string.cljs
@@ -1,0 +1,11 @@
+(ns fluree.db.util.string
+  (:require [goog.string :as gstring]
+            [goog.string.format]))
+
+
+;; ClojureScript used to have a cljs.core/format that wrapped
+;; goog.string.format but they took it out b/c it was too different from the
+;; Java stuff that clojure.core/format wraps. But our usage is so basic that
+;; this should suffice 99+% of the time. - WSM 2021-08-30
+(defn format [format-str & vals]
+  (apply gstring/format format-str vals))


### PR DESCRIPTION
There is no more `cljs.core/format` ([for years now](https://clojure.atlassian.net/browse/CLJS-324#comment-31935) it turns out), so this implements a wrapper for `goog.string.format` and uses that in CLJC files.

There are other ways to solve this, of course, but having a basic `format`-like string interpolator is handy and this allows more avoidance of reader conditionals.