### PR TITLE
Eliminate all use of goog.string.format & fix bug

### DIFF
--- a/src-cljs/flureedb.cljs
+++ b/src-cljs/flureedb.cljs
@@ -16,7 +16,6 @@
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.db.query.http-signatures :as http-signatures]
-            [goog.string.format]
     ;shared clojurescript code
             [fluree.db.api-js :as fdb-js]
             [fluree.db.connection-js :as conn-handler]))

--- a/src-nodejs/flureenjs.cljs
+++ b/src-nodejs/flureenjs.cljs
@@ -27,7 +27,6 @@
             [fluree.db.util.core :as util]
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
-            [goog.string.format]
             [cljs.nodejs :as node-js]                       ;; NodeJS support
 
     ; shared clojurescript code

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -198,15 +198,7 @@
         (recur fuel cache (first rest-blocks) (rest rest-blocks) acc')
         acc'))))
 
-(defn- response-time-formatted
-  "Returns response time, formatted as string. Must provide start time of request
-   for clj as (System/nanoTime), or for cljs epoch milliseconds"
-  [start-time]
-  #?(:clj  (-> (- (System/nanoTime) start-time)
-               (/ 1000000)
-               (#(format "%.2fms" (float %))))
-     :cljs (-> (- (util/current-time-millis) start-time)
-               (str "ms"))))
+
 
 
 (defn block-range
@@ -242,7 +234,7 @@
                    (doall result')
                    result')
          :fuel   100
-         :time   (response-time-formatted start)}
+         :time   (util/response-time-formatted start)}
         result'))))
 
 
@@ -405,7 +397,7 @@
         {:status 200
          :result result
          :fuel   @fuel
-         :time   (response-time-formatted start)
+         :time   (util/response-time-formatted start)
          :block  (:block db*)}
         result))))
 
@@ -458,7 +450,7 @@
               {:result response
                :fuel   fuel-global
                :status status-global
-               :time   (response-time-formatted start-time)}
+               :time   (util/response-time-formatted start-time)}
               response)
             (let [{:keys [meta _remove-meta?]} (get-in queries [alias :opts])
                   res            (async/<! port)

--- a/src/fluree/db/api_js.cljs
+++ b/src/fluree/db/api_js.cljs
@@ -90,8 +90,6 @@
                      :else
                      acc)) {} prefixes))
 
-(defn format-duration-millis [start end]
-  (str (- end start) "ms"))
 
 ;; ======================================
 ;;
@@ -144,7 +142,7 @@
                 :result (if (sequential? result)
                           (doall result) result)
                 :fuel   @fuel
-                :time   (format-duration-millis start-ms (util/current-time-millis))
+                :time   (util/response-time-formatted start-ms)
                 :block  (:block db*)}
 
                :else
@@ -434,7 +432,7 @@
                                   (doall result')
                                   result')
                         :fuel   100
-                        :time   (format-duration-millis start (util/current-time-millis))}
+                        :time   (util/response-time-formatted start)}
                        result')]
          result*)
        (catch :default e

--- a/src/fluree/db/api_js.cljs
+++ b/src/fluree/db/api_js.cljs
@@ -13,7 +13,6 @@
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.db.util.core :as util]
-            [goog.string.format]
             [fluree.db.connection-js :as conn-handler]))
 
 ;; supporting code for JS APIS (webworker, flureedb (both browser and nodejs)
@@ -91,6 +90,8 @@
                      :else
                      acc)) {} prefixes))
 
+(defn format-duration-millis [start end]
+  (str (- end start) "ms"))
 
 ;; ======================================
 ;;
@@ -143,9 +144,7 @@
                 :result (if (sequential? result)
                           (doall result) result)
                 :fuel   @fuel
-                :time   (-> (- (util/current-time-millis) start-ms)
-                            (/ 1000000)
-                            (#(goog.string/format "%.2fms" (float %))))
+                :time   (format-duration-millis start-ms (util/current-time-millis))
                 :block  (:block db*)}
 
                :else
@@ -435,9 +434,7 @@
                                   (doall result')
                                   result')
                         :fuel   100
-                        :time   (-> (- (util/current-time-millis) start)
-                                    (/ 1000000)
-                                    (#(goog.string/format "%.2fms" (float %))))}
+                        :time   (format-duration-millis start (util/current-time-millis))}
                        result')]
          result*)
        (catch :default e

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -58,8 +58,8 @@
                       (.getClass e')
                       msg)
             args' (if (coll? args) (str/join " " args) args)]
-        (format "Error in database function: %s: %s. Provided: %s"
-                function-name err-msg args'))
+        (clojure.core/str "Error in database function: " function-name ": "
+                          err-msg ". Provided: " args'))
       {:status 400
        :error  :db/invalid-fn})))
 

--- a/src/fluree/db/query/analytical_wikidata.cljc
+++ b/src/fluree/db/query/analytical_wikidata.cljc
@@ -6,8 +6,6 @@
     [fluree.db.util.log :as log]
     #?(:clj  [clojure.core.async :as async]
        :cljs [cljs.core.async :as async])
-    #?(:cljs [goog.string :as gstring])
-    #?(:cljs [goog.string.format])
     [fluree.db.util.async :refer [<? go-try merge-into?]]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -85,8 +83,8 @@
            (= "$wd" (first clause)) (drop 1)
            true                     (map wikiDataVar?)
            true                     (str/join " ")
-           true                     (#?(:clj format :cljs gstring/format) "%s .")
-           optional?                (#?(:clj format :cljs gstring/format) "OPTIONAL {%s}")))
+           true                     (#(str % " ."))
+           optional?                (#(str "OPTIONAL {" % "}"))))
 
 (defn parse-prefixes
   [prefixes]

--- a/src/fluree/db/util/core.cljc
+++ b/src/fluree/db/util/core.cljc
@@ -96,6 +96,18 @@
   #?(:clj  (System/currentTimeMillis)
      :cljs (.getTime (js/Date.))))
 
+
+(defn response-time-formatted
+  "Returns response time, formatted as string. Must provide start time of request
+   for clj as (System/nanoTime), or for cljs epoch milliseconds"
+  [start-time]
+  #?(:clj  (-> (- (System/nanoTime) start-time)
+               (/ 1000000)
+               (#(format "%.2fms" (float %))))
+     :cljs (-> (- (current-time-millis) start-time)
+               (str "ms"))))
+
+
 (defn deep-merge [v & vs]
   (letfn [(rec-merge [v1 v2]
             (if (and (map? v1) (map? v2))


### PR DESCRIPTION
...in query time reporting in CLJS. Looks like the code was copied over from code that starts with nanoseconds.