### PR TITLE
Fix/ledger response parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "bufferutil": "^4.0.3",
     "js-sha3": "^0.8.0",
     "scrypt-js": "^3.0.1",
-    "source-map-support": "^0.5.19",
+    "source-map-support": "^0.5.20",
     "utf-8-validate": "^5.0.5",
-    "ws": "^8.2.1"
+    "ws": "^8.2.2"
   },
   "browser": {
     "ws": false

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -350,7 +350,7 @@
                res          (<? (xhttp/get url {:request-timeout 5000
                                                 :headers         headers*
                                                 :output-format   #?(:clj  :binary
-                                                                    :cljs :text)}))]
+                                                                    :cljs :json)}))]
 
            res))))))
 

--- a/src/fluree/db/util/xhttp.cljc
+++ b/src/fluree/db/util/xhttp.cljc
@@ -188,7 +188,7 @@
                             (async/put! response-chan
                                         (case output-format
                                           :text data
-                                          :json data
+                                          :json (json/stringify data)
                                           ;; else
                                           (throw (ex-info "http get only supports output formats of json and text." {})))))))
                  (.catch (fn [err]


### PR DESCRIPTION
This is a bug I introduced while moving from goog.net.XhrIo to axios so that our http
requests work both from the browser and from node.

The ledger returns a js object #js {:status 200 ,,, :data #js {,,,}}. This is
transformed into clojure data. In the case that the caller requested the :json
output-format I was only returning the clojure data, which caused the json serializer to
blow up.

I also had to change the fluree.db.connection/default-storage-read function to request
:json output when in cljs mode. I'm a little confused as to how this worked before, but
it appears to work now.