### PR TITLE
FC-1257 update unit tests related to float/BigDecimal conversion

### DIFF
--- a/test/fluree/db/util/json_test.cljc
+++ b/test/fluree/db/util/json_test.cljc
@@ -21,12 +21,6 @@
           (.getBytes encoding)
           (ByteArrayInputStream.)))))
 
-#?(:clj
-   (def float-conv-delta
-     (let [x-conv (-> Float/MAX_VALUE str (Double/parseDouble))
-           x-orig (double Float/MAX_VALUE)]
-       (float (- x-conv x-orig)))))
-
 
 ;; General Comments
 ;; all java.lang.Float, java.lang.Double and java.math.BigDecimal values
@@ -74,13 +68,13 @@
              (is (instance? ByteArrayInputStream x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             (is (= (-> x :fv) (-> x* :fv float)))
+             (is (= (:fv x) (-> x* :fv float)))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*)))))
          (testing "maximum values"
            (let [x  {:_id "parser"
                      :name "test-03"
-                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :fv   Float/MAX_VALUE
                      :dv   Double/MAX_VALUE
                      :iv   Integer/MAX_VALUE}
                  x' (-> x (cjson/encode) (string->stream))
@@ -88,10 +82,7 @@
              (is (instance? ByteArrayInputStream x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             ; the value of Float/MAX_VALUE is actually allocated as a double
-             ; using MAX_VALUE less conversion delta
-             ;; TODO: Fix this case
-             #_(is (= (:fv x) (-> x* :fv float)))
+             (is (= (:fv x) (.floatValue ^BigDecimal (:fv x*))))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*))))))
        (testing "parse json stringify"
@@ -132,7 +123,7 @@
          (testing "maximum values"
            (let [x  {:_id "parser"
                      :name "test-06"
-                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :fv   Float/MAX_VALUE
                      :dv   Double/MAX_VALUE
                      :iv   Integer/MAX_VALUE}
                  x' (json/stringify x)
@@ -140,10 +131,7 @@
              (is (string? x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             ; the value of Float/MAX_VALUE is actually allocated as a double
-             ; using MAX_VALUE less conversion delta
-             ;; TODO: Fix this case
-             #_(is (= (:fv x) (-> x* :fv float)))
+             (is (= (:fv x) (.floatValue ^BigDecimal (:fv x*))))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*))))))
        (testing "parse byte-array"
@@ -184,7 +172,7 @@
          (testing "maximum values"
            (let [x  {:_id "parser"
                      :name "test-09"
-                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :fv   Float/MAX_VALUE
                      :dv   Double/MAX_VALUE
                      :iv   Integer/MAX_VALUE}
                  x' (-> x cjson/encode u-bytes/string->UTF8)
@@ -192,10 +180,7 @@
              (is (bytes? x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             ; the value of Float/MAX_VALUE is actually allocated as a double
-             ; using MAX_VALUE less conversion delta
-             ;; TODO: Fix this case
-             #_(is (= (:fv x) (-> x* :fv float)))
+             (is (= (:fv x) (.floatValue ^BigDecimal (:fv x*))))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*)))))))
      (testing ":fdb-json-bigdec-string: false"
@@ -232,13 +217,13 @@
              (is (instance? ByteArrayInputStream x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             (is (= (-> x :fv) (-> x* :fv float)))
+             (is (= (:fv x) (-> x* :fv float)))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*)))))
          (testing "maximum values"
            (let [x  {:_id "parser"
                      :name "test-03"
-                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :fv   Float/MAX_VALUE
                      :dv   Double/MAX_VALUE
                      :iv   Integer/MAX_VALUE}
                  x' (-> x (cjson/encode) (string->stream))
@@ -246,10 +231,7 @@
              (is (instance? ByteArrayInputStream x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             ; the value of Float/MAX_VALUE is actually allocated as a double
-             ; using MAX_VALUE less conversion delta
-             ;; TODO: Fix this case
-             #_(is (= (:fv x) (-> x* :fv float)))
+             (is (= (:fv x) (.floatValue ^BigDecimal (:fv x*))))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*))))))
        (testing "parse json stringify"
@@ -290,7 +272,7 @@
          (testing "maximum values"
            (let [x  {:_id "parser"
                      :name "test-06"
-                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :fv   Float/MAX_VALUE
                      :dv   Double/MAX_VALUE
                      :iv   Integer/MAX_VALUE}
                  x' (json/stringify x)
@@ -298,10 +280,7 @@
              (is (string? x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             ; the value of Float/MAX_VALUE is actually allocated as a double
-             ; using MAX_VALUE less conversion delta
-             ;; TODO: Fix this case
-             #_(is (= (:fv x) (-> x* :fv float)))
+             (is (= (:fv x) (.floatValue ^BigDecimal (:fv x*))))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*))))))
        (testing "parse byte-array"
@@ -342,7 +321,7 @@
          (testing "maximum values"
            (let [x  {:_id "parser"
                      :name "test-09"
-                     :fv   (- Float/MAX_VALUE float-conv-delta)
+                     :fv   Float/MAX_VALUE
                      :dv   Double/MAX_VALUE
                      :iv   Integer/MAX_VALUE}
                  x' (-> x cjson/encode u-bytes/string->UTF8)
@@ -350,10 +329,7 @@
              (is (bytes? x'))
              (is (instance? PersistentArrayMap x*))
              (is (= (:name x) (:name x*)))
-             ; the value of Float/MAX_VALUE is actually allocated as a double
-             ; using MAX_VALUE less conversion delta
-             ;; TODO: Fix this case
-             #_(is (= (:fv x) (-> x* :fv float)))
+             (is (= (:fv x) (.floatValue ^BigDecimal (:fv x*))))
              (is (= (:dv x) (-> x* :dv double)))
              (is (= (:iv x) (:iv x*)))))))))
 


### PR DESCRIPTION
Updated unit tests to use the java.math.BigDecimal floatValue conversion