### PR TITLE
Delete wikidata fn that was doing nothing before

### DIFF
--- a/src/fluree/db/query/analytical_wikidata.cljc
+++ b/src/fluree/db/query/analytical_wikidata.cljc
@@ -65,23 +65,10 @@
         (recur r (conj res clause)))
       res)))
 
-(defn wikiDataVar?
-  [string]
-  (cond
-    (and (string? string) (re-matches #"^wd(t)*:(P|Q)\d+$" string))
-    (symbol string)
-
-    (string? string)
-    (str "\"" string "\"")
-
-    :else
-    string))
-
 (defn ad-hoc-clause-to-wikidata
   [clause optional?]
   (cond->> clause
            (= "$wd" (first clause)) (drop 1)
-           true                     (map wikiDataVar?)
            true                     (str/join " ")
            true                     (#(str % " ."))
            optional?                (#(str "OPTIONAL {" % "}"))))
@@ -113,6 +100,7 @@
         full-query   (str prefixes " " select-smt " WHERE { " value-clause " "
                           where-smt " " optional-smt " " serviceLabel " } " (if limit (str "
                           LIMIT " limit)) " OFFSET " offset)] full-query)) >
+
 (def wikidataURL "https://query.wikidata.org/bigdata/namespace/wdq/sparql?format=json&query=")
 
 (defn submit-wikidata-query
@@ -124,10 +112,10 @@
                    ;      (str "Java/" (System/getProperty "java.version"))
                             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36"
                    ;)
-                   "Accept" "application/sparql-results+json"}
-          res     (<? (xhttp/get url {:headers         headers
-                                      :request-timeout 30000
-                                      :output-format   :wikidata}))] res)))
+                   "Accept" "application/sparql-results+json"}]
+      (<? (xhttp/get url {:headers         headers
+                          :request-timeout 30000
+                          :output-format   :wikidata})))))
 
 (defn submit+parse-wikidata-query
   [query]


### PR DESCRIPTION
...but is now breaking the wikidata test. It was just returning its arg unchanged before a recent "fix" identified by eastwood: the `:else string` was outside of the `cond` form so it was always just returning the `string` arg.

Here is the recent change that introduced the breakage: https://github.com/fluree/db/commit/b4386c56ea7f0d10fe756553ef6ddb6c99b37820#diff-e4e5deafe99e46520a1f321e4506502b225efd29876e571d6b10eb49b509c52d