### PR TITLE
FC-1266 Fix/indexing hardening

### DIFF
--- a/src/fluree/db/session.cljc
+++ b/src/fluree/db/session.cljc
@@ -156,7 +156,9 @@
 
 
 (defn acquire-indexing-lock!
-  "Attempts to acquire indexing lock, and if successful returns true, else false."
+  "Attempts to acquire indexing lock. Returns two-tuple of [lock? promise-chan]
+  where lock? indicates if the lock was successful, and promise-chan is whatever
+  promise-chan is registered for indexing."
   [session pc]
   (let [swap-res (swap! (:state session)
                         (fn [s]

--- a/src/fluree/db/session.cljc
+++ b/src/fluree/db/session.cljc
@@ -143,7 +143,7 @@
   (swap! (:state session) assoc :db/db (full-load-existing-db session)))
 
 
-(defn indexing?
+(defn indexing-promise-ch
   "Returns block currently being indexed (truthy), or nil (falsey) if not currently indexing."
   [session]
   (:db/indexing @(:state session)))
@@ -157,18 +157,24 @@
 
 (defn acquire-indexing-lock!
   "Attempts to acquire indexing lock, and if successful returns true, else false."
-  [session block]
-  (swap! (:state session)
-         (fn [s]
-           (cond-> s
-                   (nil? (:db/indexing s)) (assoc :db/indexing block))))
-  ;; if we got the lock, indexing value will be same as block (true)
-  (= block (indexing? session)))
+  [session pc]
+  (let [swap-res (swap! (:state session)
+                        (fn [s]
+                          (if (nil? (:db/indexing s))
+                            (assoc s :db/indexing pc)
+                            s)))
+        res-pc (:db/indexing swap-res)
+        lock? (= pc res-pc)]
+    ;; return two-tuple of if lock was acquired and whatever promise channel is registered.
+    [lock? res-pc]))
+
 
 (defn release-indexing-lock!
   "Releases indexing lock, and updates the last indexed value on the connection with provided block number."
   [session block]
-  (swap! (:state session) assoc :db/indexing nil :db/indexed block))
+  (swap! (:state session)
+         (fn [s]
+           (assoc s :db/indexing nil :db/indexed block))))
 
 
 (def alias->id-cache (atom #?(:clj  (cache/fifo-cache-factory {:threshold 100})
@@ -233,7 +239,8 @@
         ;; no-op
         ;; TODO - we can avoid logging here if we are the transactor
         (<= block current-block)
-        (log/info (str (:network session) "/$" (:dbid session) ": Received block " block ", but DB is already more current. No-op."))
+        (log/info (str (:network session) "/" (:dbid session) ": Received block: " block
+                       ", but DB is already more current at block: " current-block ". No-op."))
 
         ;; next block is correct, update cached db
         (= block (+ 1 current-block))


### PR DESCRIPTION
FC-1266 - this uses the current indexing lock, but instead of just storing a block it stores a promise chan that will eventually resolve to the DB once indexing finishes. This is used by the transactor to improve indexing updates during heavy transaction load.