### PR TITLE
FC-1275: Full text wildcard queries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -43,7 +43,7 @@
   :mvn/version     "1.0.0-rc30" ; Change this down in the docs alias too!
 
   :dev
-  {:extra-paths ["dev" "src-cljs" "src-nodejs" "src-docs"]
+  {:extra-paths ["dev" "test" "src-cljs" "src-nodejs" "src-docs"]
    :extra-deps {org.clojure/tools.namespace {:mvn/version "1.1.0"}
                 figwheel-sidecar/figwheel-sidecar {:mvn/version "0.5.20"}}}
 
@@ -141,4 +141,3 @@
   :clj-kondo
   {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.09.15"}}
    :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}
-

--- a/src/fluree/db/full_text.clj
+++ b/src/fluree/db/full_text.clj
@@ -199,7 +199,8 @@
         query  (build-query db domain param)
         res    (if (wildcard? param)
                  (lucene/wildcard-search storage query search-limit analyzer 0 search-limit)
-                 (lucene/search storage query search-limit analyzer 0 search-limit))]
+                 (lucene/search storage query search-limit analyzer 0 search-limit))
+        tuples (map #(->> % :_id read-string vector) res)]
     {:headers [var]
-     :tuples  (map #(->> % :_id read-string (conj [])) res)
+     :tuples  tuples
      :vars    {}}))

--- a/src/fluree/db/full_text.clj
+++ b/src/fluree/db/full_text.clj
@@ -182,8 +182,7 @@
                                           (into #{}))]
                    [{:_collection cid} search-params]))
         res    (if (wildcard? search-param)
-                 (do (println "wildcard!")
-                     (lucene/wildcard-search storage query search-limit analyzer 0 search-limit))
+                 (lucene/wildcard-search storage query search-limit analyzer 0 search-limit)
                  (lucene/search storage query search-limit analyzer 0 search-limit))]
     {:headers [var]
      :tuples  (map #(->> % :_id read-string (conj [])) res)

--- a/src/fluree/db/full_text.clj
+++ b/src/fluree/db/full_text.clj
@@ -88,15 +88,15 @@
      (.-p f)))
 
 (defn full-text-predicates
-  [db cid]
+  [db coll-name]
   (->> db
        :schema
        :pred
        vals
        (filter (fn [pred]
                  (and (:fullText pred)
-                      (= cid
-                         (-> pred :id flake/sid->cid)))))
+                      (str/starts-with? (:name pred)
+                                        (str coll-name "/")))))
        (map :id)))
 
 (defn sanitize

--- a/test/fluree/db/full_text_test.clj
+++ b/test/fluree/db/full_text_test.clj
@@ -10,13 +10,13 @@
     (let [lang :en]
       (with-open [idx (full-text/memory-index lang)]
         (testing "after initialization"
-          (-> idx full-text/writer .close)
           (testing "populated with predicates for a subject"
             (let [cid       12345
                   subj-num  10
                   subj-id   (flake/->sid cid subj-num)
                   pred-vals {1001 "foo", 1002 "bar"}]
-              (with-open [wrtr (full-text/writer idx)]
+              (with-open [wrtr (doto (full-text/writer idx)
+                                 .commit)]
                 (full-text/put-subject idx wrtr subj-id pred-vals)
                 (.commit wrtr)
                 (let [subject-under-test (full-text/get-subject idx subj-id)]

--- a/test/fluree/db/full_text_test.clj
+++ b/test/fluree/db/full_text_test.clj
@@ -63,18 +63,24 @@
                       "populated subject can be retrieved")))
               (testing "search"
                 (let [db (test-db)]
-                  (with-open [wrtr (full-text/writer idx)]
-                    (let [var                "?msg"
-                          search             (str "fullText:" bio-pred-name)
-                          param              "president"
-                          subject-under-test (full-text/search idx db [var search param])]
-                      (is (= [var]
-                             (:headers subject-under-test))
-                          "returns the correct headers")
-                      (is (some (fn [t]
-                                  (= t [subj-id]))
-                                (:tuples subject-under-test))
-                          "includes the subject id in the returned tuples list")))))
+                  (let [var                "?msg"
+                        search             (str "fullText:" bio-pred-name)
+                        param              "president"
+                        subject-under-test (full-text/search idx db [var search param])]
+                    (is (= [var]
+                           (:headers subject-under-test))
+                        "returns the correct headers")
+                    (is (some (fn [t]
+                                (= t [subj-id]))
+                              (:tuples subject-under-test))
+                        "includes the subject id in the returned tuples list")
+                    (testing "with wildcard"
+                      (let [param              "pres*"
+                            subject-under-test (full-text/search idx db [var search param])]
+                        (is (some (fn [t]
+                                    (= t [subj-id]))
+                                  (:tuples subject-under-test))
+                            "includes the subject id in the returned tuples list"))))))
               (testing "when updating a single predicate"
                 (let [bio-update  "No really, I was POTUS"
                       pred-update {bio-pred-id bio-update}]

--- a/test/fluree/db/full_text_test.clj
+++ b/test/fluree/db/full_text_test.clj
@@ -1,9 +1,24 @@
 (ns fluree.db.full-text-test
   (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.constants :as const]
+            [fluree.db.dbproto :refer [IFlureeDb]]
             [fluree.db.flake :as flake]
             [fluree.db.full-text :as full-text])
   (:import (java.io Closeable)
            (org.apache.lucene.index IndexWriter)))
+
+(def user-coll-id (inc const/$numSystemCollections))
+(def user-coll-name "user")
+
+(def handle-pred-id 200)
+(def handle-pred-name "user/handle")
+
+(def bio-pred-id 201)
+(def bio-pred-name "user/bio")
+
+(defn pid->keyword
+  [pid]
+  (-> pid str keyword))
 
 (deftest full-text-index-test
   (testing "full-text index"
@@ -14,31 +29,32 @@
             .commit
             .close)
           (testing "populated with predicates for a subject"
-            (let [cid       12345
-                  subj-num  10
-                  subj-id   (flake/->sid cid subj-num)
-                  text-1    "it is raining right now"
-                  text-2    "the sun is shining"
-                  pred-vals {1001 text-1, 1002 text-2}]
+            (let [subj-num  10
+                  subj-id   (flake/->sid-checked user-coll-id subj-num)
+                  handle    "mfillmore13"
+                  bio-1     "I actually was the president"
+                  pred-vals {handle-pred-id handle, bio-pred-id bio-1}]
               (with-open [wrtr (full-text/writer idx)]
                 (full-text/put-subject idx wrtr subj-id pred-vals)
                 (.commit wrtr)
                 (let [subject-under-test (full-text/get-subject idx subj-id)]
-                  (is (and (= text-1 (:1001 subject-under-test))
-                           (= text-2 (:1002 subject-under-test)))
+                  (is (and (= handle (get subject-under-test
+                                          (pid->keyword handle-pred-id)))
+                           (= bio-1 (get subject-under-test
+                                         (pid->keyword bio-pred-id))))
                       "populated subject can be retrieved")))
-              (testing "search"
-                )
               (testing "when updating a single predicate"
-                (let [text-update "the rain has stopped"
-                      pred-update {1001 text-update}]
+                (let [bio-update  "No really, I was POTUS"
+                      pred-update {bio-pred-id bio-update}]
                   (with-open [wrtr (full-text/writer idx)]
                     (full-text/put-subject idx wrtr subj-id pred-update)
                     (.commit wrtr)
                     (let [subject-under-test (full-text/get-subject idx subj-id)]
-                      (is (= text-update (:1001 subject-under-test))
+                      (is (= bio-update (get subject-under-test
+                                              (pid->keyword bio-pred-id)))
                           "the updated predicate can be retrieved")
-                      (is (= text-2 (:1002 subject-under-test))
+                      (is (= handle (get subject-under-test
+                                         (pid->keyword handle-pred-id)))
                           "unchanged predicates are retained")
-                      (is (not (-> subject-under-test vals set (contains? text-1)))
+                      (is (not (-> subject-under-test vals set (contains? bio-1)))
                           "previous predicate values are not retained"))))))))))))

--- a/test/fluree/db/full_text_test.clj
+++ b/test/fluree/db/full_text_test.clj
@@ -10,28 +10,35 @@
     (let [lang :en]
       (with-open [idx (full-text/memory-index lang)]
         (testing "after initialization"
+          (doto (full-text/writer idx)
+            .commit
+            .close)
           (testing "populated with predicates for a subject"
             (let [cid       12345
                   subj-num  10
                   subj-id   (flake/->sid cid subj-num)
-                  pred-vals {1001 "foo", 1002 "bar"}]
-              (with-open [wrtr (doto (full-text/writer idx)
-                                 .commit)]
+                  text-1    "it is raining right now"
+                  text-2    "the sun is shining"
+                  pred-vals {1001 text-1, 1002 text-2}]
+              (with-open [wrtr (full-text/writer idx)]
                 (full-text/put-subject idx wrtr subj-id pred-vals)
                 (.commit wrtr)
                 (let [subject-under-test (full-text/get-subject idx subj-id)]
-                  (is (and (= "foo" (:1001 subject-under-test))
-                           (= "bar" (:1002 subject-under-test)))
+                  (is (and (= text-1 (:1001 subject-under-test))
+                           (= text-2 (:1002 subject-under-test)))
                       "populated subject can be retrieved")))
+              (testing "search"
+                )
               (testing "when updating a single predicate"
-                (let [pred-update {1001 "baz"}]
+                (let [text-update "the rain has stopped"
+                      pred-update {1001 text-update}]
                   (with-open [wrtr (full-text/writer idx)]
                     (full-text/put-subject idx wrtr subj-id pred-update)
                     (.commit wrtr)
                     (let [subject-under-test (full-text/get-subject idx subj-id)]
-                      (is (= "baz" (:1001 subject-under-test))
+                      (is (= text-update (:1001 subject-under-test))
                           "the updated predicate can be retrieved")
-                      (is (= "bar" (:1002 subject-under-test))
+                      (is (= text-2 (:1002 subject-under-test))
                           "unchanged predicates are retained")
-                      (is (not (-> subject-under-test vals set (contains? "foo")))
+                      (is (not (-> subject-under-test vals set (contains? text-1)))
                           "previous predicate values are not retained"))))))))))))


### PR DESCRIPTION
After lots of head banging looking through our code and lucene configuration to try to figure out why wildcard queries weren't working, I decided to take a look at the source code for the [Clojure lucene adapter](https://github.com/federkasten/clucie) we're using.  There I found a completely [undocumented `wildcard-search`](https://github.com/federkasten/clucie/blob/master/src/clucie/core.clj#L106-L109) function in addition to the [well documented `search` and `phrase-search`](https://github.com/federkasten/clucie#usage) functions.

After adding code to use the wildcard api for search queries containing wildcards, I decided to refactor the search function a little bit because I had left it alone during the last full text refactor, and I also refactored the tests to test the search function (which was previously untested). Because the search function takes a `db` argument, I had to wire up a fake db record to exercise the new functionality.

Clucie, the clojure lucene api we're using, hasn't been updated since December 2018. I think we should think about either switching to another api like [`lucene-clj`](https://github.com/jaju/lucene-clj) or using bare lucene because I'm sure there are features and capabilities we're missing out on by using such an old library. I thought hard about doing that here, but I felt it should wait because of the risk that there could be time consuming incompatibilities. 