### PR TITLE
Update log code for new google closure version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure             {:mvn/version "1.10.3"}
-         org.clojure/clojurescript       {:mvn/version "1.10.879"}
          org.clojure/core.async          {:mvn/version "1.3.622"}
          org.clojure/core.cache          {:mvn/version "1.0.217"}
+         org.clojure/clojurescript       {:mvn/version "1.10.891"}
          org.clojars.mmb90/cljs-cache    {:mvn/version "0.1.4"}
          org.clojure/data.avl            {:mvn/version "0.1.0"}
          org.clojure/data.xml            {:mvn/version "0.2.0-alpha6"}

--- a/src/fluree/db/util/log.cljc
+++ b/src/fluree/db/util/log.cljc
@@ -1,7 +1,8 @@
 (ns fluree.db.util.log
   (:require #?(:clj  [clojure.tools.logging :as log]
                :cljs [goog.log :as glog]))
-  #?(:cljs (:import goog.debug.Console)))
+  #?(:cljs (:import [goog.debug Console]
+                    [goog.log Level])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -9,24 +10,24 @@
 ; Added deprecated parameter since compiling in strict mode
 #?(:cljs
    (def logger
-     (glog/getLogger "app" goog.log.Level.INFO)))
+     (glog/getLogger "app" Level.INFO)))
 
 #?(:cljs
-   (def levels {:severe  goog.debug.Logger.Level.SEVERE
-                :warning goog.debug.Logger.Level.WARNING
-                :info    goog.debug.Logger.Level.INFO
-                :config  goog.debug.Logger.Level.CONFIG
-                :fine    goog.debug.Logger.Level.FINE
-                :finer   goog.debug.Logger.Level.FINER
-                :finest  goog.debug.Logger.Level.FINEST}))
+   (def levels {:severe  Level.SEVERE
+                :warning Level.WARNING
+                :info    Level.INFO
+                :config  Level.CONFIG
+                :fine    Level.FINE
+                :finer   Level.FINER
+                :finest  Level.FINEST}))
 
 #?(:cljs
    (defn log-to-console! []
-     (.setCapturing (goog.debug.Console.) true)))
+     (.setCapturing (Console.) true)))
 
 #?(:cljs
    (defn set-level! [level]
-     (goog.log.setLevel logger (get levels level (:info levels)))))
+     (glog/setLevel logger (get levels level (:info levels)))))
 
 (defn fmt [msgs]
   (apply str (interpose " " (map pr-str msgs))))


### PR DESCRIPTION
The [latest ClojureScript release](https://clojurescript.org/news/2021-11-04-release) bumps the Google Closure version to one that has moved `goog.debug.Logger` to `goog.log`. This fixes the issues that arose in our `fluree.db.util.log` ns and updates things to the latest / recommended conventions in a few places.