### PR TITLE
JRA-635 Fix util.log namespaces by making util.log fns into macros

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps  {org.clojure/clojure             {:mvn/version "1.10.3"}
-         org.clojure/clojurescript       {:mvn/version "1.10.891"}
+         org.clojure/clojurescript       {:mvn/version "1.10.914"}
          org.clojure/core.async          {:mvn/version "1.5.648"}
          org.clojure/core.cache          {:mvn/version "1.0.225"}
          org.clojars.mmb90/cljs-cache    {:mvn/version "0.1.4"}
@@ -11,7 +11,7 @@
          instaparse/instaparse           {:mvn/version "1.4.10"}
 
          ;; logging
-         org.clojure/tools.logging       {:mvn/version "1.2.2"}
+         org.clojure/tools.logging       {:mvn/version "1.2.4"}
          logback-bundle/core-bundle      {:mvn/version "0.3.0"}
          org.slf4j/slf4j-api             {:mvn/version "1.7.32"}
 
@@ -63,7 +63,7 @@
 
   :cljtest
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha    {:mvn/version "1.60.972"}
+   :extra-deps  {lambdaisland/kaocha    {:mvn/version "1.60.977"}
                  org.clojure/test.check {:mvn/version "1.1.1"}}
    :main-opts   ["-m" "kaocha.runner"]}
 
@@ -122,7 +122,7 @@
    :main-opts   ["-m" "cloverage.coverage" "-p" "src" "-s" "test" "--output" "scanning_results/coverage"]}
 
   :eastwood
-  {:extra-deps {jonase/eastwood {:mvn/version "1.0.0"}}
+  {:extra-deps {jonase/eastwood {:mvn/version "1.1.1"}}
    ;; Remove the exclude-linter for :def-in-def below
    ;; when the SCI smartfunctions runner lands. It's
    ;; only there for the `defn` inside
@@ -139,5 +139,5 @@
    :main-opts  ["-m" "antq.core"]}
 
   :clj-kondo
-  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.12.16"}}
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.12.19"}}
    :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scrypt-js": "^3.0.1",
     "source-map-support": "^0.5.21",
     "utf-8-validate": "^5.0.8",
-    "ws": "^8.3.0"
+    "ws": "^8.4.0"
   },
   "browser": {
     "ws": false

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -530,7 +530,7 @@
                              (reset! default-cache-atom (default-object-cache-factory memory-object-size))
                              ;; user-supplied close function
                              (when (fn? close-fn) (close-fn))
-                             (log/info :conn-closed))
+                             (log/info "connection closed"))
         servers*           (normalize-servers servers transactor?)
         storage-read*      (or storage-read (default-storage-read conn-id servers* opts))
         storage-exists*    (or storage-exists storage-read (default-storage-read conn-id servers* opts))

--- a/src/fluree/db/performance.clj
+++ b/src/fluree/db/performance.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [criterium.core :as criterium]
             [fluree.db.api :as fdb]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)

--- a/src/fluree/db/query/http_signatures.cljc
+++ b/src/fluree/db/query/http_signatures.cljc
@@ -75,7 +75,7 @@
   with it. If it exists and is invalid, throws exception."
   [req]
   (when-let [sig-header-str (get (:headers req) "signature")]
-    (log/trace (str "Verifying http signature header: " sig-header-str))
+    (log/trace "Verifying http signature header:" sig-header-str)
     (verify-signature-header* req sig-header-str)))
 
 

--- a/src/fluree/db/session.cljc
+++ b/src/fluree/db/session.cljc
@@ -323,21 +323,24 @@
     (let [msg     (<? update-chan)
           session (from-cache network ledger-id)]
       (cond
-        (nil? msg)                                          ;; channel closed, likely connection closed. If it wasn't force close just in case.
-        (log/info (str "Channel closed for session updates for: " network "/" ledger-id "."))
+        (nil? msg) ;; channel closed, likely connection closed. If it wasn't force close just in case.
+        (log/info "Channel closed for session updates for:" (str network "/" ledger-id))
 
-        (nil? session)                                      ;; unlikely to happen... if channel was closed previous condition would trigger
-        (log/warn (str "Ledger update received for session that is no longer open: " network "/" ledger-id ". Message: " (pr-str (first msg))))
+        (nil? session) ;; unlikely to happen... if channel was closed previous condition would trigger
+        (log/warn "Ledger update received for session that is no longer open:" (str network "/" ledger-id)
+                  "Message: " (first msg))
 
         :else
         (do
           (try*
             (let [[event-type event-data] msg]
-              (log/trace (str "[process-ledger-updates[" network "/$" ledger-id "]: ") (util/trunc (pr-str msg) 200))
+              (log/trace "[process-ledger-updates[" (str network "/" ledger-id) "]: "
+                         (util/trunc (pr-str msg) 200))
               (<? (process-ledger-update session event-type event-data)))
             (catch* e
-                    (log/error e "Exception processing ledger updates for message: " msg)))
+              (log/error e "Exception processing ledger updates for message:" msg)))
           (recur))))))
+
 
 (defn- session-factory
   "Creates a connection without first checking if db exists. Only useful if reloading
@@ -488,7 +491,7 @@
                  (async/go-loop []
                    (let [req (async/<! (:transact-chan session))]
                      (if (nil? req)
-                       (log/info (str "Transactor session closing for db: " network "/$" ledger-id "[" ledger-alias "]"))
+                       (log/info "Transactor session closing for db:" (str network "/" ledger-id "[" ledger-alias "]"))
                        ;; do some initial validation, then send to handler for synchronous processing
                        (do (transact-handler conn req)
                            (recur))))))))


### PR DESCRIPTION
Previously if you used fluree.db.util.log fns logs would all appear to come from fluree.db.util.log (and you had to configure the logger w/ that name to log at the desired level, etc.) and not the namespace where you were calling the log/whatever fn. This fixes that by making them macros instead, so the compiler embeds the expanded logging call directly into the place you're using it and it retains that context as a result. Works in both CLJ and CLJS.

I wasted too much time trying to log from a namespace that was configured at TRACE level when the logs were actually coming from fluree.db.util.log the whole time. So I decided to take another crack at this (I had attempted it once before in 2020 but whatever I did back then wasn't fixing it; this did so yay!).

I'll have another PR for ledger w/ some fixes and that switches all logging to this. Lots of logging calls in there were going directly to clojure.tools.logging (perhaps in large part due to the issue this PR fixes).