### PR TITLE
Fix websocket connection

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -244,7 +244,6 @@
 (defn msg-producer
   "Shuffles outgoing messages to the web socket in order."
   [{:keys [state req-chan publish]
-    :or   {publish default-publish-fn}
     :as   conn}]
   (async/go-loop [i 0]
     (when-let [msg (async/<! req-chan)]
@@ -266,7 +265,8 @@
                  (ex-info (str "Request " req-id " timed out.")
                           {:status 408
                            :error  :db/timeout})))))
-         (let [published? (async/<! (publish conn [operation req-id data]))]
+         (let [publisher  (or publish default-publish-fn)
+               published? (async/<! (publisher conn [operation req-id data]))]
            (when-not (true? published?)
              (cond
                (util/exception? published?)


### PR DESCRIPTION
The :or destructing only works when the `:publish` key is absent from the map. In this
case, it was present but its value was `nil`, so the `default-publish-fn` was not
substituted.

I wasn't sure how best to handle that case with the destructuring syntax, so I went with
a dumber way of defaulting.