### PR TITLE
FC-1335 added storage-delete key to the connection object

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -492,7 +492,7 @@
                                   ;; map of listener functions registered. key is two-tuple of [network dbid],
                                   ;; value is vector of single-argument callback functions that will receive [header data]
                                   :listeners    {}})
-        {:keys [storage-read storage-exists storage-write storage-rename storage-list
+        {:keys [storage-read storage-exists storage-write storage-rename storage-delete storage-list
                 parallelism req-chan sub-chan pub-chan default-network group
                 object-cache close-fn serializer
                 tx-private-key private-key-file memory
@@ -558,6 +558,7 @@
                             :storage-exists   storage-exists*
                             :storage-write    storage-write
                             :storage-rename   storage-rename
+                            :storage-delete   storage-delete
                             :object-cache     object-cache-fn
                             :parallelism      parallelism
                             :serializer       serializer


### PR DESCRIPTION
Added `storage-delete` key to connection object; providing access to a storage function that deletes block data