### PR TITLE
FC-1363 Cache Tx Range 

### DIFF
--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -198,15 +198,13 @@
   before `t`."
   [t flakes]
   (->> flakes
-       (flakes-through t)
-       (group-by (juxt flake/s flake/p flake/o))
-       vals
+       (filter (complement (partial after-t? t)))
+       (partition-by (juxt flake/s flake/p flake/o))
        (mapcat (fn [flakes]
-                 (let [sorted-flakes (sort-by flake/t flakes)
-                       last-flake    (first sorted-flakes)]
+                 (let [last-flake (last flakes)]
                    (if (flake/op last-flake)
-                     (rest sorted-flakes)
-                     sorted-flakes))))))
+                     (butlast flakes)
+                     flakes))))))
 
 (defn t-range
   "Returns a sorted set of flakes that are not out of date between the

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -191,30 +191,6 @@
        (filter-after t)
        (flake/disj-all flakes)))
 
-(defn stale-by
-  "Returns a sequence of flakes from the sorted set `flakes` that are out of date
-  by the transaction `t` because `flakes` contains another flake with the same
-  subject and predicate and a transaction value later than that flake but on or
-  before `t`."
-  [t flakes]
-  (->> flakes
-       (filter (complement (partial after-t? t)))
-       (partition-by (juxt flake/s flake/p flake/o))
-       (mapcat (fn [flakes]
-                 (let [last-flake (last flakes)]
-                   (if (flake/op last-flake)
-                     (butlast flakes)
-                     flakes))))))
-
-(defn t-range
-  "Returns a sorted set of flakes that are not out of date between the
-  transactions `from-t` and `to-t`."
-  [from-t to-t flakes]
-  (let [stale-flakes (stale-by from-t flakes)
-        subsequent   (filter-after to-t flakes)
-        out-of-range (concat stale-flakes subsequent)]
-    (flake/disj-all flakes out-of-range)))
-
 (defn novelty-subrange
   [{:keys [rhs leftmost?], first-flake :first, :as node} through-t novelty]
   (let [subrange (cond
@@ -234,6 +210,33 @@
                    (and (nil? rhs) leftmost?)
                    novelty)]
     (flakes-through through-t subrange)))
+
+(defn stale-by
+  "Returns a sequence of flakes from the sorted set `flakes` that are out of date
+  by the transaction `t` because `flakes` contains another flake with the same
+  subject and predicate and a transaction value later than that flake but on or
+  before `t`."
+  [t flakes]
+  (->> flakes
+       (filter (complement (partial after-t? t)))
+       (partition-by (juxt flake/s flake/p flake/o))
+       (mapcat (fn [flakes]
+                 (let [last-flake (last flakes)]
+                   (if (flake/op last-flake)
+                     (butlast flakes)
+                     flakes))))))
+
+(defn t-range
+  "Returns a sorted set of flakes that are not out of date between the
+  transactions `from-t` and `to-t`."
+  [{:keys [flakes] leaf-t :t :as leaf} novelty from-t to-t]
+  (let [latest       (cond-> flakes
+                       (> leaf-t to-t)
+                       (flake/conj-all (novelty-subrange leaf to-t novelty)))
+        stale-flakes (stale-by from-t latest)
+        subsequent   (filter-after to-t latest)
+        out-of-range (concat stale-flakes subsequent)]
+    (flake/disj-all latest out-of-range)))
 
 (defn at-t
   "Find the value of `leaf` at transaction `t` by adding new flakes from

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -209,8 +209,8 @@
                                                (partition-all flake-limit)
                                                flakeset-xf)))]
         (async/take 1 flake-ch))
-      (let [empty-set (flake/sorted-set-by cmp)]
-        (async/reduce into empty-set flake-slices)))))
+      (-> (async/reduce into [] flake-slices)
+          (async/pipe (chan 1 flakeset-xf))))))
 
 (defn resolved-leaf?
   [node]

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -110,7 +110,7 @@
   [{:keys [from-t to-t novelty start-flake start-test end-flake end-test
            object-cache] :as opts}]
   (comp (map (fn [leaf]
-               (index/t-range leaf novelty from-t to-t)))
+               (index/t-range leaf novelty from-t to-t object-cache)))
         (map (fn [flakes]
                (flake/subrange flakes
                                start-test start-flake

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -210,9 +210,8 @@
                                                (partition-all flake-limit)
                                                flakeset-xf)))]
         (async/take 1 flake-ch))
-      (let [flake-vec-ch (async/reduce into [] flake-slices)]
-        (async/pipe flake-vec-ch
-                    (chan 1 flakeset-xf))))))
+      (let [empty-set (flake/sorted-set-by cmp)]
+        (async/reduce into empty-set flake-slices)))))
 
 (defn resolved-leaf?
   [node]
@@ -240,7 +239,7 @@
         in-range? (fn [node]
                     (intersects-range? node start-flake end-flake))
         query-xf  (extract-query-flakes (assoc opts :novelty novelty))]
-    (->> (index/tree-chan conn idx-root in-range? resolved-leaf? 8 query-xf error-ch)
+    (->> (index/tree-chan conn idx-root in-range? resolved-leaf? 1 query-xf error-ch)
          (filter-authorized db start-flake end-flake error-ch)
          (filter-subject-frame limit offset)
          (into-flake-set idx-cmp flake-limit))))


### PR DESCRIPTION
This patch has performance optimizations to the `stale-by` function taking advantage of the fact that the input flake sequence is already sorted, and it adds a cache to the `t-range` function to avoid unnecessary repeated filtering through the entire flake range.

This patch improves the performance of https://github.com/fluree/db/pull/155 on the first run to ~1700 ms, and in proves the second run performance from ~1300 ms to ~450 ms (in comparison with the pre-tspo commits taking ~250 ms on the second run)