### PR TITLE
Allow clj api to work with closed api ledger

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -360,8 +360,7 @@
                path         (str/replace k "_" "/")
                address      (async/<! (get-server conn-id servers))
                url          (str address "/fdb/storage/" path)
-               headers      (cond-> {"Accept" #?(:clj  "application/json"
-                                                 :cljs "application/json")}
+               headers      (cond-> {"Accept" "application/json"}
                                     jwt' (assoc "Authorization" (str "Bearer " jwt')))
                headers*     (if private
                               (-> (http-signatures/sign-request "get" url {:headers headers} private)
@@ -369,8 +368,7 @@
                               headers)
                res          (<? (xhttp/get url {:request-timeout 5000
                                                 :headers         headers*
-                                                :output-format   #?(:clj  :text
-                                                                    :cljs :json)}))]
+                                                :output-format   :json}))]
 
            res))))))
 
@@ -505,8 +503,7 @@
                 pub-chan         (async/chan)
                 memory?          false
                 storage-write    (fn [k v] (throw (ex-info (str "Storage write was not implemented on connection, but was called to store key: " k) {})))
-                serializer       #?(:clj  (json-serde)
-                                    :cljs (json-serde))
+                serializer       (json-serde)
                 transactor?      false
                 private-key-file "default-private-key.txt"}} opts
         memory-object-size (quot memory 100000)             ;; avg 100kb per cache object

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -360,7 +360,7 @@
                path         (str/replace k "_" "/")
                address      (async/<! (get-server conn-id servers))
                url          (str address "/fdb/storage/" path)
-               headers      (cond-> {"Accept" #?(:clj  "avro/binary"
+               headers      (cond-> {"Accept" #?(:clj  "application/json"
                                                  :cljs "application/json")}
                                     jwt' (assoc "Authorization" (str "Bearer " jwt')))
                headers*     (if private
@@ -369,7 +369,7 @@
                               headers)
                res          (<? (xhttp/get url {:request-timeout 5000
                                                 :headers         headers*
-                                                :output-format   #?(:clj  :binary
+                                                :output-format   #?(:clj  :text
                                                                     :cljs :json)}))]
 
            res))))))
@@ -505,7 +505,7 @@
                 pub-chan         (async/chan)
                 memory?          false
                 storage-write    (fn [k v] (throw (ex-info (str "Storage write was not implemented on connection, but was called to store key: " k) {})))
-                serializer       #?(:clj  (avro-serde)
+                serializer       #?(:clj  (json-serde)
                                     :cljs (json-serde))
                 transactor?      false
                 private-key-file "default-private-key.txt"}} opts

--- a/src/fluree/db/util/xhttp.cljc
+++ b/src/fluree/db/util/xhttp.cljc
@@ -133,7 +133,7 @@
   It is assumed body is already in a format that can be sent directly in request (already encoded).
 
   Options
-  - output-format - can be :text, :json or :binary (default text), or special format (wikidata) to handle wikidata errors, which come back as html.
+  - output-format - can be :text, :json, :edn or :binary (default :text), or special format (wikidata) to handle wikidata errors, which come back as html.
 
   "
   [url opts]
@@ -171,8 +171,8 @@
                              (throw-if-timeout response)
                              (async/put! response-chan
                                          (case output-format
-                                           :text (bs/to-string body)
-                                           (:json :wikidata) (-> body bs/to-string json/parse)
+                                           (:text :json) (bs/to-string body)
+                                           (:edn :wikidata) (-> body bs/to-string json/parse)
                                            ;; else
                                            (bs/to-byte-array body)))))))
        :cljs (-> axios


### PR DESCRIPTION
A closed api ledger will not send avro/binary on the wire. This commit changes the
default clojure connection to speak json - the default-read-fn now requests json instead
of avro, and the serializer now expects json.

FC-1372
FC-1370