### PR TITLE
FC-1310 - Updated on main branch - Feature/ctx

### DIFF
--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -131,10 +131,10 @@
 (def ^:const $_shard:miners 121)
 (def ^:const $_shard:mutable 122)
 
-(def ^:const $_ctx:name 130)
-(def ^:const $_ctx:key 131)
-(def ^:const $_ctx:fn 132)
-(def ^:const $_ctx:doc 133)
+(def ^:const $_ctx:name 140)
+(def ^:const $_ctx:key 141)
+(def ^:const $_ctx:fn 142)
+(def ^:const $_ctx:doc 143)
 
 ;; tags
 ;; _predicate/type tags

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -21,8 +21,9 @@
 (def ^:const $_role 7)
 (def ^:const $_rule 8)
 (def ^:const $_setting 9)
+(def ^:const $_ctx 10)
 
-(def ^:const $numSystemCollections 9)
+(def ^:const $numSystemCollections 19)                      ;; max number reserved for 'system'
 (def ^:const $maxSystemPredicates 999)
 
 ;; predicate id constants
@@ -85,6 +86,7 @@
 (def ^:const $_role:id 70)
 (def ^:const $_role:doc 71)
 (def ^:const $_role:rules 72)
+(def ^:const $_role:ctx 73)
 
 (def ^:const $_rule:id 80)
 (def ^:const $_rule:doc 81)
@@ -128,6 +130,11 @@
 (def ^:const $_shard:name 120)
 (def ^:const $_shard:miners 121)
 (def ^:const $_shard:mutable 122)
+
+(def ^:const $_ctx:name 130)
+(def ^:const $_ctx:key 131)
+(def ^:const $_ctx:fn 132)
+(def ^:const $_ctx:doc 133)
 
 ;; tags
 ;; _predicate/type tags

--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -164,7 +164,7 @@
     (first fn-str-coll)))
 
 
-(def symbol-whitelist #{'?s '?user_id '?db '?o 'sid '?auth_id '?pid '?a '?pO})
+(def allowed-symbols #{'?s '?user_id '?db '?o 'sid '?auth_id '?pid '?a '?pO})
 
 (defn parse-vector
   "Ensures contents of vector are allowed"
@@ -183,7 +183,7 @@
                       (cond
                         (string? x) x
                         (number? x) x
-                        (symbol? x) (or (symbol-whitelist x) (some #{x} (mapv #(symbol %) params)) (= funType "functionDec")
+                        (symbol? x) (or (allowed-symbols x) (some #{x} (mapv #(symbol %) params)) (= funType "functionDec")
                                         (throw (ex-info (str "Invalid symbol: " x " used in function." (pr-str vec))
                                                         {:status 400
                                                          :error  :db/invalid-fn})))
@@ -228,7 +228,7 @@
                                     (list? arg) (<? (resolve-fn db arg type params))
                                     (string? arg) arg
                                     (number? arg) arg
-                                    (symbol? arg) (or (symbol-whitelist arg)
+                                    (symbol? arg) (or (allowed-symbols arg)
                                                       (some #{arg} (mapv #(symbol %) params))
                                                       (= type "functionDec")
                                                       (throw (ex-info (str "Invalid symbol: " arg

--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -35,6 +35,7 @@
 (def default-fn-map {'get           (resolve 'fluree.db.dbfunctions.fns/get)
                      'get-all       (resolve 'fluree.db.dbfunctions.fns/get-all)
                      'get-in        (resolve 'fluree.db.dbfunctions.fns/get-in)
+                     'ctx           (resolve 'fluree.db.dbfunctions.fns/ctx)
                      'follow        (resolve 'fluree.db.dbfunctions.fns/get-all)
                      'contains?     (resolve 'fluree.db.dbfunctions.fns/contains?)
                      'relationship? (resolve 'fluree.db.dbfunctions.fns/relationship?)

--- a/src/fluree/db/dbfunctions/ctx.cljc
+++ b/src/fluree/db/dbfunctions/ctx.cljc
@@ -1,0 +1,68 @@
+(ns fluree.db.dbfunctions.ctx
+  (:require [fluree.db.util.json :as json]
+            [fluree.db.dbfunctions.core :as dbfunctions]
+            [fluree.db.dbfunctions.fns :refer [extract]]
+            [fluree.db.util.async :refer [<? go-try channel?]]
+            [fluree.db.permissions-validate :as perm-validate]
+            [fluree.db.util.core :as util]
+            [fluree.db.query.range :as query-range]
+            [fluree.db.util.log :as log]
+            [fluree.db.constants :as const]
+            #?(:cljs [fluree.db.flake :refer [Flake]])
+            [fluree.db.dbproto :as dbproto])
+  #?(:clj (:import (fluree.db.flake Flake))))
+
+;; Handles context
+
+(defn ctx-flakes->k+fn
+  "Iterates over ctx-flakes to extract context key and context fn subject id as two-tuple"
+  [ctx-flakes]
+  (when (seq ctx-flakes)
+    (loop [[^Flake f & r] ctx-flakes
+           k nil
+           v nil]
+      (if (and k v)
+        [k v]
+        (when f
+          (cond
+            (= const/$_ctx:key (.-p f))
+            (recur r (.-o f) v)
+
+            (= const/$_ctx:fn (.-p f))
+            (recur r k (.-o f))
+
+            :else
+            (recur r k v)))))))
+
+
+(defn build
+  [db-root auth-id roles]
+  (go-try
+    (let [?ctx {:auth_id auth-id
+                :instant (util/current-time-millis)
+                :db      db-root
+                :state   (atom {:stack   []
+                                :credits 10000000
+                                :spent   0})}]
+      (loop [[role & r] roles
+             ctx {}]
+        (if role
+          (let [ctx-sid    (some-> (<? (query-range/index-range db-root :spot = [role const/$_role:ctx]))
+                                   first
+                                   (#(.-o ^Flake %)))
+                ctx-flakes (when ctx-sid (<? (query-range/index-range db-root :spot = [ctx-sid])))
+                [k fn-sid] (ctx-flakes->k+fn ctx-flakes)
+                ctx-fn-str (some-> (<? (query-range/index-range db-root :spot = [fn-sid const/$_fn:code]))
+                                   first
+                                   (#(.-o ^Flake %)))
+                f          (when ctx-fn-str
+                             (<? (dbfunctions/parse-fn db-root ctx-fn-str "functionDec")))
+                result     (when f (extract (f ?ctx)))
+                result*    (if (sequential? result)
+                             (set result)
+                             result)
+                ctx*       (if k
+                             (assoc ctx k result*)
+                             ctx)]
+            (recur r ctx*))
+          ctx)))))

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -326,7 +326,7 @@
       (raise ?ctx "Cannot access ?pO from this function interface"))))
 
 (defn get-all
-  {:doc      "Used to get-all values in a nested result set, or also can follow an subject down the provided path and returns a set of all matching subjects."
+  {:doc      "Used to get-all values in a nested result set, or also can follow a subject down the provided path and return a set of all matching subjects."
    :fdb/spec nil
    :fdb/cost "9 + length of path + query costs"}
   [?ctx subject path]

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -273,7 +273,7 @@
   {:doc      "Gets a value from an subject."
    :fdb/spec nil
    :fdb/cost 10}
-  [?ctx subject pred]
+  [{:keys [cache db] :as ?ctx} subject pred]
   (go-try
     (let [subject  (extract subject)
           pred     (extract pred)
@@ -282,7 +282,20 @@
                        (first subject)
                        subject)
                      subject)
-          res      (fdb/get subject' pred)
+          res      (cond
+                     (clojure.core/and (int? subject') cache)
+                     (clojure.core/or
+                       (clojure.core/get-in @cache [:get subject' pred])
+                       (let [resp (<? (fdb/get-subj-pred db subject' pred))]
+                         (vswap! cache assoc-in [:get subject' pred] resp)
+                         resp))
+
+
+                     (int? subject')
+                     (<? (fdb/get-subj-pred db subject' pred))
+
+                     :else
+                     (fdb/get subject' pred))
           entry    [{:function "get" :arguments [subject pred] :result res} 10]]
       (add-stack ?ctx entry)
       res)))

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -377,9 +377,9 @@
   (go-try
     (let [coll  (extract coll)
           coll' (if (set? coll) coll (-> coll flatten set))
-          key   (extract key)
-          res   (fdb/contains? coll' key)
-          entry [{:function "contains?" :arguments [coll' key] :result res} 10]]
+          key'  (extract key)
+          res   (fdb/contains? coll' key')
+          entry [{:function "contains?" :arguments [coll' key'] :result res} 10]]
       (add-stack ?ctx entry)
       res)))
 

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -345,6 +345,15 @@
       (add-stack ?ctx entry)
       res)))
 
+(defn ctx
+  {:doc      "Returns a value from the user's context if set. Provide the key or key sequence."
+   :fdb/spec nil
+   :fdb/cost 1}
+  [{:keys [db] :as ?ctx} key-or-ks]
+  (if (sequential? key-or-ks)
+    (clojure.core/get-in (:ctx db) key-or-ks)
+    (clojure.core/get (:ctx db) key-or-ks)))
+
 (defn contains?
   {:doc      "Returns true if key is present."
    :fdb/spec nil

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -460,12 +460,12 @@
     (try*
       (let [select (select-from-path path)
             query' {:selectOne select
-                    :from   sid
-                    :opts   {}}
+                    :from      sid
+                    :opts      {}}
             [res fuel] (<? (query (:db ?ctx) query'))
-            res* (get-all res (if (= "_id" (last path))
-                                path
-                                (conj path "_id")))]
+            res*   (get-all res (if (= "_id" (last path))
+                                  path
+                                  (conj path "_id")))]
         [res* (+ fuel (count path) 9)])
       (catch* e (function-error e "get-all" sid path)))))
 
@@ -481,7 +481,9 @@
   "Returns true if key is present."
   [coll key]
   (try*
-    (clojure.core/contains? coll key)
+    (if (sequential? key)
+      (some #(contains? coll %) key)
+      (clojure.core/contains? coll key))
     (catch* e (function-error e "contains?" coll key))))
 
 (defn hash-set

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -324,12 +324,22 @@
   If multi returns a vector, else a single value."
   [db sid pred]
   (go-try
-    (let [multi? (dbproto/-p-prop db :multi pred)
-          res (<? (query-range/index-range db :spot = [sid pred]))]
+
+    (let [reverse?  (and (string? pred) (re-matches #".+/_.+" pred))
+          pred*     (if reverse?
+                      (str/replace pred "/_" "/")
+                      pred)
+          multi?    (dbproto/-p-prop db :multi pred*)
+          res       (if reverse?
+                      (<? (query-range/index-range db :opst = [sid pred*]))
+                      (<? (query-range/index-range db :spot = [sid pred*])))
+          flake-val (if reverse?
+                      flake/s
+                      flake/o)]
       (when (seq res)
         (if multi?
-          (mapv flake/o res)
-          (-> res first flake/o))))))
+          (mapv flake-val res)
+          (flake-val (first res)))))))
 
 (defn now
   "Returns current epoch milliseconds."

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -408,7 +408,7 @@
     (catch* e (function-error e "floor" num))))
 
 (defn get-all
-  "Follows an subject down the provided path and returns a set of all matching subjects."
+  "Follows a result set down the provided path and returns a set of all matching subjects."
   [start-subject path]
   (try*
     (loop [[pred & r] path
@@ -429,6 +429,36 @@
           (recur r next-subjects)
           (->> next-subjects (remove nil?) set))))
     (catch* e (function-error e "get-all" start-subject path))))
+
+(defn- select-from-path
+  "Takes a path in a vector format and returns a select statement to crawl those vars.
+  e.g. convert: ['_user/_auth', 'groupMembership/_user', 'group/_admins']
+            to: {'_user/_auth' [{'groupMembership/_user' ['group/_admins']}]}"
+  [path]
+  (if (= 1 (count path))
+    path
+    (let [r-path (reverse path)]
+      (reduce
+        (fn [acc p] {p [acc]})
+        (first r-path)
+        (rest r-path)))))
+
+(defn follow-subject
+  "Follows a subject down the provided path and returns a set of all matching subjects."
+  [?ctx sid path]
+  (async/go
+    (try*
+      (let [select (select-from-path path)
+            query' {:selectOne select
+                    :from   sid
+                    :opts   {}}
+            [res fuel] (<? (query (:db ?ctx) query'))
+            res* (get-all res (if (= "_id" (last path))
+                                path
+                                (conj path "_id")))]
+        [res* (+ fuel (count path) 9)])
+      (catch* e (function-error e "get-all" sid path)))))
+
 
 (defn get-in
   "Returns the value in a nested structure"

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -561,7 +561,9 @@
 (defn ?auth_id
   [?ctx]
   (go-try (let [auth (:auth_id ?ctx)]
-            (<? (dbproto/-subid (:db ?ctx) auth)))))
+            (if (number? auth)
+              auth
+              (<? (dbproto/-subid (:db ?ctx) auth))))))
 
 (defn objT
   "Given an array of flakes, returns the sum of the objects of the true flakes"

--- a/src/fluree/db/graphdb.cljc
+++ b/src/fluree/db/graphdb.cljc
@@ -91,10 +91,10 @@
           idx?-map             (into {} (map (fn [p] [p (dbproto/-p-prop db :idx? p)]) add-preds))
           ref?-map             (into {} (map (fn [p] [p (dbproto/-p-prop db :ref? p)]) add-preds))
           flakes-bytes         (flake/size-bytes add-flakes)
-          schema-change?       (schema-util/schema-change? add-flakes)
+          system-chanage?      (schema-util/system-change? add-flakes)
           root-setting-change? (schema-util/setting-change? add-flakes)
           pred-ecount          (-> db :ecount (get const/$_predicate))
-          add-pred-to-idx?     (if schema-change? (schema-util/add-to-post-preds? add-flakes pred-ecount) [])
+          add-pred-to-idx?     (if system-chanage? (schema-util/add-to-post-preds? add-flakes pred-ecount) [])
           db*                  (loop [[add-pred & r] add-pred-to-idx?
                                       db db]
                                  (if add-pred
@@ -120,7 +120,7 @@
                             :novelty {:spot spot, :psot psot, :post post,
                                       :opst opst, :tspo tspo, :size flake-size})]
             (cond-> db*
-              (or schema-change?
+              (or system-chanage?
                   (-> db* :schema nil?))
               (assoc :schema (<? (schema/schema-map db*)))
 

--- a/src/fluree/db/graphdb.cljc
+++ b/src/fluree/db/graphdb.cljc
@@ -91,10 +91,10 @@
           idx?-map             (into {} (map (fn [p] [p (dbproto/-p-prop db :idx? p)]) add-preds))
           ref?-map             (into {} (map (fn [p] [p (dbproto/-p-prop db :ref? p)]) add-preds))
           flakes-bytes         (flake/size-bytes add-flakes)
-          system-chanage?      (schema-util/system-change? add-flakes)
+          system-change?       (schema-util/system-change? add-flakes)
           root-setting-change? (schema-util/setting-change? add-flakes)
           pred-ecount          (-> db :ecount (get const/$_predicate))
-          add-pred-to-idx?     (if system-chanage? (schema-util/add-to-post-preds? add-flakes pred-ecount) [])
+          add-pred-to-idx?     (if system-change? (schema-util/add-to-post-preds? add-flakes pred-ecount) [])
           db*                  (loop [[add-pred & r] add-pred-to-idx?
                                       db db]
                                  (if add-pred
@@ -120,7 +120,7 @@
                             :novelty {:spot spot, :psot psot, :post post,
                                       :opst opst, :tspo tspo, :size flake-size})]
             (cond-> db*
-              (or system-chanage?
+              (or system-change?
                   (-> db* :schema nil?))
               (assoc :schema (<? (schema/schema-map db*)))
 

--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -28,6 +28,7 @@
           ctx     {:sid     sid
                    :auth_id (or (:auth db) (:auth permissions))
                    :instant (util/current-time-millis)
+                   :cache   (:ctx-cache db)
                    :db      root-db
                    :state   (atom {:stack   []
                                    :credits 10000000

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -24,6 +24,16 @@
                         {:status 400, :error :db/invalid-predicate})))))
 
 
+(defn- coerce-predicate
+  "If a predicate is provided as a string value, coerce to pid"
+  [db pred]
+  (if (string? pred)
+    (or (dbproto/-p-prop db :id pred)
+        (throw (ex-info (str "Invalid predicate, does not exist: " pred)
+                        {:status 400, :error :db/invalid-predicate})))
+    pred))
+
+
 (defn- match->flake-parts
   "Takes a match from index-range, and based on the index
   returns flake-ordered components of [s p o t op m].
@@ -31,11 +41,11 @@
   [db idx match]
   (let [[p1 p2 p3 p4 op m] match]
     (case idx
-      :spot [p1 (dbproto/-p-prop db :id p2) p3 p4 op m]
-      :psot [p2 (dbproto/-p-prop db :id p1) p3 p4 op m]
-      :post [p3 (dbproto/-p-prop db :id p1) p2 p4 op m]
-      :opst [p3 (dbproto/-p-prop db :id p2) p1 p4 op m]
-      :tspo [p2 (dbproto/-p-prop db :id p3) p4 p1 op m])))
+      :spot [p1 (coerce-predicate db p2) p3 p4 op m]
+      :psot [p2 (coerce-predicate db p1) p3 p4 op m]
+      :post [p3 (coerce-predicate db p1) p2 p4 op m]
+      :opst [p3 (coerce-predicate db p2) p1 p4 op m]
+      :tspo [p2 (coerce-predicate db p3) p4 p1 op m])))
 
 
 (def ^{:private true :const true} subject-min-match [util/max-long])

--- a/src/fluree/db/util/schema.cljc
+++ b/src/fluree/db/util/schema.cljc
@@ -32,6 +32,8 @@
 (def ^:const tag-sid-start (flake/min-subject-id const/$_tag))
 (def ^:const tag-sid-end (flake/max-subject-id const/$_tag))
 
+(def ^:const sys-collection-end (flake/max-subject-id const/$numSystemCollections))
+
 (defn is-tx-meta-flake?
   "Returns true if this flake is for tx-meta"
   [f]
@@ -41,6 +43,11 @@
   "Returns true if flake is a schema flake."
   [f]
   (<= schema-sid-start (flake/s f) schema-sid-end))
+
+(defn is-system-flake?
+  "Returns true if flake is a in a system collection."
+  [f]
+  (<= 0 (flake/s f) sys-collection-end))
 
 (defn is-setting-flake?
   "Returns true if flake is a root setting flake."
@@ -97,6 +104,11 @@
 (defn setting-change?
   [flakes]
   (some is-setting-flake? flakes))
+
+(defn system-change?
+  "Returns true if any of the provided flakes are a in any system collection."
+  [flakes]
+  (some is-system-flake? flakes))
 
 
 (defn get-language-change

--- a/src/fluree/db/util/schema.cljc
+++ b/src/fluree/db/util/schema.cljc
@@ -106,7 +106,7 @@
   (some is-setting-flake? flakes))
 
 (defn system-change?
-  "Returns true if any of the provided flakes are a in any system collection."
+  "Returns true if any of the provided flakes are in any system collection."
   [flakes]
   (some is-system-flake? flakes))
 


### PR DESCRIPTION
Add new 'context' and associated smartfunctions

Allows relationship-based values to a user to be calculated once and then added to the query's context
Smartfunctions that evaluate conditions for every flake can access the pre-computed context values to speed up evaluation.
Corresponding fluree/ledger PR & tests at: https://github.com/fluree/ledger/pull/144

Example: to ensure _user can only see other _user from same organization, we'd typically evaluate this for every _user flake: (relationship? (?sid) ["org/_employees" "org/employees", "_user/auth"] (?auth_id))

Using a context, we can break up this evaluation into two parts:
Part 1: Calculate all orgs the permissioned _user is associated with just once and store in context:
{:_id       "_ctx$orgs"
 :_ctx/name "myorg" ;; <- unique identifier
 :_ctx/key  "orgs"      ;; <- context 'key' to store value in
 :_ctx/fn   {:_id      "_fn$getOrgs". ;; <- smartfunction calculates value
                  :_fn/name "getOrgs"
                  :_fn/code "(get-all (?auth_id) [\"_user/_auth\" \"org/_employees\"])"}}
Part 2: Still calculate permission for each _user flake, but leveraging precomputed value makes it much faster
{:_id      "_fn$userSameOrg",
 :_fn/name "userSameOrg",
;; Note: below uses new 'ctx' smartfunction to get context's 'orgs' value, only need to lookup single value now
 :_fn/code "(contains? (ctx \"orgs\") (get (?sid) \"org/_employees\"))", 
 :_fn/doc  "Returns truthy if _user is in same org(s) as requesting identity."}
While the use case here is mostly beneficial currently to speed up (relationship? ...) based smartfunctions, the context can provide the foundation of storing externally validated metadata about a user for comparison (e.g. a Verifiable Credential, or ABAC data from a SSO service).