### PR TITLE
FC-1383 - Fix HTTP digest calc on no-body reqs

### DIFF
--- a/src/fluree/db/query/http_signatures.cljc
+++ b/src/fluree/db/query/http_signatures.cljc
@@ -92,7 +92,7 @@
                           (throw (ex-info (str "Digest type of " hash-type " is not supported.")
                                           {:status 401 :error :db/invalid-auth})))
             body        (:body req)
-            body        (if (string? body) body (json/stringify body))
+            body        (if (or (nil? body) (string? body)) body (json/stringify body))
             _           (log/debug "verify-digest request body:" body)
             calc-digest (case hash-type
                           "SHA-256" (crypto/sha2-256 body :base64))


### PR DESCRIPTION
Closes FC-1383

Before:
w/ no body in the req, `(:body req) => nil`
`(string? nil) => false` so `json/stringify` got called on it, turning it into `"null"` which doesn't have the same sha265 hash as `""`.

After:
if the body is `nil`, pass it through unchanged. `crypto/sha2-256` treats `nil` the same as the empty string.