### PR TITLE
Feature: use sci for smartfunctions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,7 +33,10 @@
 
          ;; cryptography
          com.fluree/crypto               {:mvn/version "0.3.9"}
-         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}}
+         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
+
+         ;; smartfunctions
+         org.babashka/sci                {:mvn/version "0.3.1"}}
 
  :paths ["src" "resources"]
 

--- a/src/fluree/db/api.clj
+++ b/src/fluree/db/api.clj
@@ -264,7 +264,7 @@
 
   Options include:
   - :alias       - Alias, if different than db-ident.
-  - :root        - Root account id to bootstrap with (string). Defaults to connection default account id.
+  - :owners      - Root account id(s) to bootstrap with (string collection). Defaults to connection default account id.
   - :doc         - Optional doc string about this db.
   - :fork        - If forking an existing db, ref to db (actual identity, not db-ident). Must exist in network db.
   - :forkBlock   - If fork is provided, optionally provide the block to fork at. Defaults to latest known.

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -545,10 +545,7 @@
                              (async/close! pub-chan)
                              (close-websocket conn-id)
                              (swap! state-atom assoc :close? true)
-                             ;; NOTE - when we allow permissions back in CLJS (browser), remove conditional below
-                             #?(:clj  (dbfunctions/clear-db-fn-cache)
-                                :cljs (when (identical? "nodejs" cljs.core/*target*)
-                                        (dbfunctions/clear-db-fn-cache)))
+                             (dbfunctions/clear-db-fn-cache)
                              (session/close-all-sessions conn-id)
                              (reset! default-cache-atom (default-object-cache-factory memory-object-size))
                              ;; user-supplied close function

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -545,7 +545,6 @@
                              (async/close! pub-chan)
                              (close-websocket conn-id)
                              (swap! state-atom assoc :close? true)
-                             (dbfunctions/clear-db-fn-cache)
                              (session/close-all-sessions conn-id)
                              (reset! default-cache-atom (default-object-cache-factory memory-object-size))
                              ;; user-supplied close function

--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -9,10 +9,6 @@
 
 (def ^:const local-fns-ns 'fluree.db.dbfunctions.fns)
 
-(defn clear-db-fn-cache
-  [])
-;; TODO: Implement this if we end needing a db fn cache w/ SCI
-
 (defn tx-fn?
   "Returns true if the arg is a string containing a transaction function."
   [v]

--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -1,15 +1,24 @@
 (ns fluree.db.dbfunctions.core
   (:require [sci.core :as sci]
             [fluree.db.dbfunctions.fns]
+            [fluree.db.dbproto :as dbproto]
             [fluree.db.util.core :refer [condps]]
             [fluree.db.util.async :refer [go-try <? channel?]]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [clojure.string :as str]))
+
+(def ^:const local-fns-ns 'fluree.db.dbfunctions.fns)
 
 (defn clear-db-fn-cache
   [])
 ;; TODO: Implement this if we end needing a db fn cache w/ SCI
 
-(def symbol-whitelist #{'?s '?user_id '?db '?o 'sid '?auth_id '?pid '?a '?pO})
+(defn tx-fn?
+  "Returns true if the arg is a string containing a transaction function."
+  [v]
+  (and (string? v) (re-matches #"^#\(.+\)$" v)))
+
+(def allowed-symbols #{'?s '?user_id '?db '?o 'sid '?auth_id '?pid '?a '?pO})
 
 (defmacro ns-public-vars
   "ClojureScript gets cranky if the arg to ns-publics isn't a quoted symbol
@@ -20,125 +29,198 @@
 (defn load-ns
   "Copies public vars in ns into SCI"
   [ns]
-  (reduce
-    (fn [ns-map [var-name var]]
-      (let [m        (meta var)
-            no-doc   (:no-doc m)
-            doc      (:doc m)
-            arglists (:arglists m)]
-        (if no-doc
-          ns-map
-          (assoc ns-map
-            var-name
-            (sci/new-var (symbol var-name) @var
-                         (cond-> {:ns   (sci/create-ns ns)
-                                  :name (:name m)}
-                                 (:macro m) (assoc :macro true)
-                                 doc (assoc :doc doc)
-                                 arglists (assoc :arglists arglists)))))))
-    {}
-    (ns-public-vars ns)))
+  (let [sci-ns (sci/create-ns ns)]
+    (reduce
+      (fn [ns-map [var-name var]]
+        (let [m        (meta var)
+              no-doc   (:no-doc m)
+              doc      (:doc m)
+              arglists (:arglists m)]
+          (if no-doc
+            ns-map
+            (assoc ns-map
+              var-name
+              (sci/new-var (symbol var-name) @var
+                           (cond-> {:ns   sci-ns
+                                    :name (:name m)}
+                                   (:macro m) (assoc :macro true)
+                                   doc (assoc :doc doc)
+                                   arglists (assoc :arglists arglists)))))))
+      {}
+      (ns-public-vars ns))))
 
 
 (def sci-ctx
   (delay
-    (sci/init {:namespaces {'clojure.core
-                            (load-ns 'fluree.db.dbfunctions.fns)}})))
+    (let [local-fn-vars (load-ns local-fns-ns)]
+      (log/debug "Loading local db fns:" local-fn-vars)
+      (sci/init {:namespaces {local-fns-ns local-fn-vars}}))))
+
+(defn parse-string [s]
+  (sci/parse-string @sci-ctx s))
+
+(defn eval-string [s]
+  (sci/eval-string* @sci-ctx s))
+
+(defn eval-form [f]
+  (sci/eval-form @sci-ctx f))
 
 
 (defn combine-fns
   "Given a collection of function strings, returns a combined function using
   the and function."
-  [fn-str-coll])
-;; TODO: Implement me
+  [fn-str-coll]
+  (if (> (count fn-str-coll) 1)
+    (str "(and " (str/join " " fn-str-coll) ")")
+    (first fn-str-coll)))
 
 
 (defn find-local-fn
+  "Tries to resolve a local pre-defined fn with fn-name. Returns a fn-map if
+  found, nil otherwise."
   [fn-name]
-  ;; TODO: Implement the rest of the fn-map return value
-  (let [{:keys [arglists] :as sci-fn-meta}
-        (sci/eval-string* @sci-ctx (str "(meta #'" fn-name ")"))]
-    (when sci-fn-meta
-      (let [first-arglist (first arglists)
-            args-set      (set first-arglist)
-            var-args?     (boolean (args-set '&))
-            arity         (when-not var-args?
-                            (set (map #(-> % count dec) arglists)))]
-        {:f         fn-name
-         :arity     arity
-         :var-args? var-args?}))))
+  (log/debug "Looking for local fn:" fn-name)
+  (let [sci-vars (eval-string (str "(ns-publics '" local-fns-ns ")"))]
+    (log/debug "SCI vars:" sci-vars)
+    (when ((-> sci-vars keys set) (symbol fn-name))
+      (log/debug "Found local fn:" fn-name)
+      (let [fn-var (symbol (str local-fns-ns) (str fn-name))
+
+            {:keys [arglists fdb/spec] :as sci-fn-meta}
+            (eval-string (str "(meta #'" fn-var ")"))]
+        (when sci-fn-meta
+          (log/debug "SCI fn metadata:" sci-fn-meta)
+          (let [first-arglist (first arglists)
+                args-set      (set first-arglist)
+                var-args?     (boolean (args-set '&))
+                arity         (when-not var-args?
+                                (set (map #(-> % count dec) arglists)))]
+            {:f         fn-var
+             :params    arglists
+             :arity     arity
+             :var-args? var-args?
+             :spec      spec}))))))
+
+(declare validate-form)
 
 (defn find-db-fn
   ([db fn-name] (find-db-fn db fn-name nil))
   ([db fn-name fn-type]
    (go-try
      ;; TODO: Implement caching here if necessary
-     (let [query {:selectOne ["_fn/params" "_fn/code" "_fn/spec"]
-                  :from      ["_fn/name" (name fn-name)]}]
-       ;; TODO: Finish this
-       {:f nil}))))
+     (log/debug "Looking for custom db fn:" fn-name)
+     (let [query           {:selectOne ["_fn/params" "_fn/code" "_fn/spec"]
+                            :from      ["_fn/name" (name fn-name)]}
+           res             (<? (dbproto/-query db query))
+           _               (when (empty? res)
+                             (throw
+                               (ex-info (str "Unknown function: "
+                                             (pr-str fn-name))
+                                        {:status 400, :error :db/invalid-fn})))
+           _               (log/debug "Custom db fn query results:" res)
+           params          (some-> res (get "_fn/params") parse-string)
+           _               (log/debug "Parsed params:" params)
+           code            (<? (validate-form db (parse-string
+                                                   (get res "_fn/code"))
+                                              fn-type params))
+           _               (log/debug "Validated code:" code)
+           spec            (get res "_fn/spec")
+           params-with-ctx (->> params
+                                (mapv symbol)
+                                (cons '?ctx)
+                                (into []))
+           custom-fn       (parse-string (str "(fn " params-with-ctx
+                                              " " code ")"))]
+       (log/debug "Found custom db fn:" (pr-str custom-fn))
+       {:f         custom-fn
+        :params    params
+        :arity     (hash-set (count params))
+        :var-args? false
+        :spec      spec
+        :code      nil}))))
 
 (defn valid-symbol?
   "Is the symbol sym valid with the given form type & params?"
   [type params sym]
-  (or (symbol-whitelist sym)
-      ((set params) sym)
+  (or (allowed-symbols sym)
+      ((->> params (map symbol) set) sym)
       (= type "functionDec")))
+
+(defn resolve-fn
+  "Resolves local or custom db-stored fn from fn-name string"
+  [db fn-name type]
+  (go-try
+    (or (find-local-fn fn-name)
+        (<? (find-db-fn db fn-name type)))))
 
 (defn validate-form
   ([db form] (validate-form db form nil nil))
   ([db form type] (validate-form db form type nil))
   ([db form type params]
    (go-try
+     (log/debug "Validating form:" form "- params:" params)
      (let [fn-name (when (list? form) (first form))
            args    (if fn-name (rest form) form)
            args-n  (count args)
-           fn-map  (when fn-name
-                     (or (find-local-fn fn-name)
-                         (<? (find-db-fn db fn-name type))))
-           {:keys [f arity arglist var-args?]} fn-map
-           args*   (loop [[arg & r] args
-                          acc []]
-                     (let [arg* (condps arg
-                                  (list? vector?)
-                                  (<? (validate-form db arg type params))
+           fn-map  (when fn-name (<? (resolve-fn db fn-name type)))
+           {:keys [f arity var-args?]} fn-map
+           args*   (when (seq args)
+                     (loop [[arg & r] args
+                            acc []]
+                       (log/debug "Validating arg:" arg)
+                       (let [arg* (condps arg
+                                    (list? vector?)
+                                    (<? (validate-form db arg type params))
 
-                                  (string? number? true? false? nil?) arg
+                                    (string? number? true? false? nil?) arg
 
-                                  #(and (symbol? %)
-                                        (valid-symbol? type params %)) arg
+                                    #(and (symbol? %)
+                                          (valid-symbol? type params %)) arg
 
-                                  (throw
-                                    (ex-info (str "Invalid element ("
-                                                  (pr-str arg) (type arg)
-                                                  ") in form: " (pr-str form)
-                                                  ".")
-                                             {:status 400
-                                              :error  :db/invalid-fn})))
-                           acc* (conj acc arg*)]
-                       (if (seq r)
-                         (recur r acc*)
-                         acc*)))]
+                                    (throw
+                                      (ex-info (str "Invalid element ("
+                                                    (pr-str arg) (type arg)
+                                                    ") in form: " (pr-str form)
+                                                    ".")
+                                               {:status 400
+                                                :error  :db/invalid-fn})))
+                             acc* (conj acc arg*)]
+                         (if (seq r)
+                           (recur r acc*)
+                           acc*))))]
        (if fn-name
-         (cons f (cons '?ctx args*))
-         form)))))
+         (let [validated-form (cons f (cons '?ctx args*))]
+           (log/debug "Validated fn form:" validated-form)
+           validated-form)
+         (do
+           (log/debug "Validated non-fn form:" form)
+           form))))))
 
 
 (defn parse-fn
-  ([db fn-str type] (parse-fn db fn-str type nil))
+  [db fn-str type params]
+  (go-try
+    (case fn-str
+      ("true" "false") (parse-string (str "(fn [_] " fn-str ")"))
+      (if (re-matches #"^\(.+\)$" fn-str)
+        (let [parsed-fn    (parse-string fn-str)
+              validated-fn (<? (validate-form db parsed-fn type params))]
+          (log/debug "Parsed & validated db fn:" validated-fn)
+          validated-fn)
+        (throw (ex-info "Bad function"
+                        {:status 400
+                         :error  :db/invalid-fn}))))))
+
+(defn parse-and-wrap-fn
+  ([db fn-str type] (parse-and-wrap-fn db fn-str type nil))
   ([db fn-str type params]
    (go-try
-     (case fn-str
-       ("true" "false") (sci/parse-string @sci-ctx (str "(fn [_] " fn-str ")"))
-       (if-not (re-matches #"^\(.+\)$" fn-str)
-         (throw (ex-info "Bad function"
-                         {:status 400
-                          :error  :db/invalid-fn}))
-         ;; TODO: Load & cache db fns too
-         (let [parsed-fn    (sci/parse-string @sci-ctx fn-str)
-               validated-fn (<? (validate-form db parsed-fn type params))]
-           (log/trace "Parsed & validated db fn:" validated-fn)
-           validated-fn))))))
+     (let [parsed  (<? (parse-fn db fn-str type params))
+           wrapped `(fn [~'?ctx] ~parsed)
+           f       (if (and params (= type "functionDec"))
+                     wrapped
+                     (eval-form wrapped))]
+       (with-meta f {:fnstr fn-str})))))
 
 (defn execute-tx-fn
   "Executes a transaction function"
@@ -151,10 +233,10 @@
                      :pid     p
                      :auth_id auth
                      :state   fuel}
-          f         (<? (parse-fn db fn-str "txn"))
-          f-wrapped `(fn [~'?ctx] ~f)
-          _         (log/debug "Evaluating wrapped fn:" f-wrapped)
-          res       (sci/eval-form @sci-ctx (list f-wrapped ctx))]
+          f-wrapped (<? (parse-and-wrap-fn db fn-str "txn"))
+          f-call    (list f-wrapped ctx)
+          _         (log/debug "Evaluating fn call:" f-call)
+          res       (eval-form f-call)]
       (if (channel? res)
         (<? res)
         res))))

--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -1,334 +1,87 @@
 (ns fluree.db.dbfunctions.core
-  (:refer-clojure :exclude [read-string])
-  (:require [#?(:cljs cljs.reader :clj clojure.edn) :refer [read-string]]
-            [#?(:cljs cljs.cache :clj clojure.core.cache) :as cache]
-            [fluree.db.dbproto :as dbproto]
-            [fluree.db.util.core :refer [try* catch*]]
-            [fluree.db.util.log :as log]
-            [fluree.db.util.async :refer [<? go-try channel?]]
-            [fluree.db.dbfunctions.fns :as fns]
-            [clojure.string :as str]))
+  (:require [sci.core :as sci]
+            [fluree.db.util.async :refer [go-try <? channel?]]
+            [fluree.db.dbfunctions.fns]
+            [fluree.db.util.log :as log]))
 
-#?(:clj (set! *warn-on-reflection* true))
+(defn clear-db-fn-cache
+  [])
+  ;; TODO: Implement this if we end needing a db fn cache w/ SCI
 
-(declare resolve-fn)
+(defn load-ns
+  "Copies public vars in ns into SCI"
+  [ns]
+  (reduce
+    (fn [ns-map [var-name var]]
+      (let [m        (meta var)
+            no-doc   (:no-doc m)
+            doc      (:doc m)
+            arglists (:arglists m)]
+        (if no-doc
+          ns-map
+          (assoc ns-map
+            var-name
+            (sci/new-var (symbol var-name) @var
+                         (cond-> {:ns   (sci/create-ns ns)
+                                  :name (:name m)}
+                                 (:macro m) (assoc :macro true)
+                                 doc (assoc :doc doc)
+                                 arglists (assoc :arglists arglists)))))))
+    {}
+    (ns-publics (quote ns))))
 
-(defn db-fn-cache-factory
-  "Returns an empty TTL cache for db-function caching.
-  Implication of this caching strategy is changes to db functions that get
-  update will take 5 seconds to recompile, benefit is that the same function
-  call for a ledger will not have to recompile every time."
-  []
-  (cache/ttl-cache-factory {} :ttl 5000))
 
-(def db-fn-cache (atom (db-fn-cache-factory)))
+(def sci-ctx
+  (delay
+    (sci/init {:namespaces {'clojure.core
+                            (load-ns 'fluree.db.dbfunctions.fns)}})))
 
-(defn clear-db-fn-cache []
-  (reset! db-fn-cache (db-fn-cache-factory)))
-
-
-(defn tx-fn?
-  "Returns true if this value is a transaction function."
-  [value]
-  (and (string? value) (re-matches #"^#\(.+\)$" value)))
-
-(def default-fn-map {'get           (resolve 'fluree.db.dbfunctions.fns/get)
-                     'get-all       (resolve 'fluree.db.dbfunctions.fns/get-all)
-                     'get-in        (resolve 'fluree.db.dbfunctions.fns/get-in)
-                     'ctx           (resolve 'fluree.db.dbfunctions.fns/ctx)
-                     'follow        (resolve 'fluree.db.dbfunctions.fns/get-all)
-                     'contains?     (resolve 'fluree.db.dbfunctions.fns/contains?)
-                     'relationship? (resolve 'fluree.db.dbfunctions.fns/relationship?)
-                     'query         (resolve 'fluree.db.dbfunctions.fns/query)
-                     'max-pred-val  (resolve 'fluree.db.dbfunctions.fns/max-pred-val)
-                     'max           (resolve 'fluree.db.dbfunctions.fns/max)
-                     'min           (resolve 'fluree.db.dbfunctions.fns/min)
-                     'inc           (resolve 'fluree.db.dbfunctions.fns/inc)
-                     'dec           (resolve 'fluree.db.dbfunctions.fns/dec)
-                     'now           (resolve 'fluree.db.dbfunctions.fns/now)
-                     '+             (resolve 'fluree.db.dbfunctions.fns/+)
-                     '-             (resolve 'fluree.db.dbfunctions.fns/-)
-                     '*             (resolve 'fluree.db.dbfunctions.fns/*)
-                     '/             (resolve 'fluree.db.dbfunctions.fns//)
-                     'quot          (resolve 'fluree.db.dbfunctions.fns/quot)
-                     'mod           (resolve 'fluree.db.dbfunctions.fns/mod)
-                     'rem           (resolve 'fluree.db.dbfunctions.fns/rem)
-                     '==            (resolve 'fluree.db.dbfunctions.fns/==)
-                     '=             (resolve 'fluree.db.dbfunctions.fns/==)
-                     'not=          (resolve 'fluree.db.dbfunctions.fns/not=)
-                     '>             (resolve 'fluree.db.dbfunctions.fns/>)
-                     '>=            (resolve 'fluree.db.dbfunctions.fns/>=)
-                     '?sid          (resolve 'fluree.db.dbfunctions.fns/?sid)
-                     '?pid          (resolve 'fluree.db.dbfunctions.fns/?pid)
-                     '?o            (resolve 'fluree.db.dbfunctions.fns/?o)
-                     '?s            (resolve 'fluree.db.dbfunctions.fns/?s)
-                     '?p            (resolve 'fluree.db.dbfunctions.fns/?p)
-                     'nil?          (resolve 'fluree.db.dbfunctions.fns/nil?)
-                     'empty?        (resolve 'fluree.db.dbfunctions.fns/empty?)
-                     'not           (resolve 'fluree.db.dbfunctions.fns/not)
-                     '?auth_id      (resolve 'fluree.db.dbfunctions.fns/?auth_id)
-                     '?user_id      (resolve 'fluree.db.dbfunctions.fns/?user_id)
-                     '<             (resolve 'fluree.db.dbfunctions.fns/<)
-                     '<=            (resolve 'fluree.db.dbfunctions.fns/<=)
-                     'boolean       (resolve 'fluree.db.dbfunctions.fns/boolean)
-                     're-find       (resolve 'fluree.db.dbfunctions.fns/re-find)
-                     'valid-email?  (resolve 'fluree.db.dbfunctions.fns/valid-email?)
-                     'and           (resolve 'fluree.db.dbfunctions.fns/and)
-                     'or            (resolve 'fluree.db.dbfunctions.fns/or)
-                     'count         (resolve 'fluree.db.dbfunctions.fns/count)
-                     'str           (resolve 'fluree.db.dbfunctions.fns/str)
-                     'subs          (resolve 'fluree.db.dbfunctions.fns/subs)
-                     'nth           (resolve 'fluree.db.dbfunctions.fns/nth)
-                     'if-else       (resolve 'fluree.db.dbfunctions.fns/if-else)
-                     '?pO           (resolve 'fluree.db.dbfunctions.fns/?pO)
-                     'objT          (resolve 'fluree.db.dbfunctions.fns/objT)
-                     'objF          (resolve 'fluree.db.dbfunctions.fns/objF)
-                     'flakes        (resolve 'fluree.db.dbfunctions.fns/flakes)
-                     'rand          (resolve 'fluree.db.dbfunctions.fns/rand)
-                     'hash-set      (resolve 'fluree.db.dbfunctions.fns/hash-set)
-                     'ceil          (resolve 'fluree.db.dbfunctions.fns/ceil)
-                     'floor         (resolve 'fluree.db.dbfunctions.fns/floor)
-                     'upper-case    (resolve 'fluree.db.dbfunctions.fns/upper-case)
-                     'lower-case    (resolve 'fluree.db.dbfunctions.fns/lower-case)
-                     'uuid          (resolve 'fluree.db.dbfunctions.fns/uuid)
-                     'cas           (resolve 'fluree.db.dbfunctions.fns/cas)})
-
-(defn resolve-local-fn
-  [f]
-  (let [{:keys [fdb/spec arglists]} (meta f)
-        arglist (first arglists)
-        &args?  (and ((into #{} arglist) (symbol "&"))
-                     ((into #{} arglist) (symbol "args")))
-        arity   (if-not &args?
-                  (into #{} (map #(- (count %) 1) arglists)))]
-    {:f      f
-     :params arglists
-     :arity  arity
-     :&args? &args?
-     :spec   spec
-     :code   nil}))
-
-#?(:cljs
-   (defn- build-fn
-     [var fun]
-     (eval `(fn [~var]
-              ~fun))))
-
-(defn- find-fn*
-  [db fn-name funType]
-  (go-try
-    (let [forward-time-travel-db? (:tt-id db)]
-      (or (when-not forward-time-travel-db?
-            (get @db-fn-cache [fn-name (:network db) (:dbid db)]))
-          (let [res (let [query       {:selectOne ["_fn/params" "_fn/code" "_fn/spec"]
-                                       :from      ["_fn/name" (name fn-name)]}
-                          res         (<? (dbproto/-query db query))
-                          _           (if (empty? res)
-                                        (throw (ex-info (str "Unknown function: " (pr-str fn-name))
-                                                        {:status 400
-                                                         :error  :db/invalid-fn})))
-                          params      (read-string (get res "_fn/params"))
-                          code        (<? (resolve-fn db (read-string (get res "_fn/code")) funType params))
-                          spec        (get res "_fn/spec")
-                          params'     (->> params
-                                           (mapv (fn [x] (symbol x)))
-                                           (cons '?ctx)
-                                           (into []))
-                          custom-func #?(:clj (list #'clojure.core/fn params' code)
-                                         :cljs (build-fn params' code))]
-                      {:f      custom-func
-                       :params params
-                       :arity  (hash-set (count params))
-                       :&args? false
-                       :spec   spec
-                       :code   nil})]
-            (when-not forward-time-travel-db?
-              (swap! db-fn-cache assoc [fn-name (:network db) (:dbid db)] res))
-            res)))))
-
-(defn find-fn
-  ([db fn-name]
-   (find-fn db fn-name nil))
-  ([db fn-name funType]
-   #?(:clj  (find-fn* db fn-name funType)
-      :cljs (cond
-              (identical? "nodejs" cljs.core/*target*)
-              (find-fn* db fn-name funType)
-              :else
-              (throw (ex-info "DB functions not yet supported in javascript!" {}))))))
 
 (defn combine-fns
-  "Given a collection of function strings, returns a combined function using the and function"
-  [fn-str-coll]
-  (if (> (count fn-str-coll) 1)
-    (str "(and " (str/join " " fn-str-coll) ")")
-    (first fn-str-coll)))
+  "Given a collection of function strings, returns a combined function using
+  the and function."
+  [fn-str-coll])
+;; TODO: Implement me
 
 
-(def allowed-symbols #{'?s '?user_id '?db '?o 'sid '?auth_id '?pid '?a '?pO})
+;; TODO: This needs to be recursive b/c fn calls can be nested
+;; good use case for clojure.walk? or maybe just plain ol' recursion?
+(defn- wrap-fn
+  [fn-form]
+  `(fn [~'?ctx] (~(first fn-form) ~'?ctx ~@(rest fn-form))))
 
-(defn parse-vector
-  "Ensures contents of vector are allowed"
-  ([db vec]
-   (parse-vector db vec nil nil))
-  ([db vec funType]
-   (parse-vector db vec funType nil))
-  ([db vec funType params]
-   (go-try
-     (loop [[x & r] vec
-            acc []]
-       (if (nil? x)
-         acc
-         (recur r
-                (conj acc
-                      (cond
-                        (string? x) x
-                        (number? x) x
-                        (symbol? x) (or (allowed-symbols x) (some #{x} (mapv #(symbol %) params)) (= funType "functionDec")
-                                        (throw (ex-info (str "Invalid symbol: " x " used in function." (pr-str vec))
-                                                        {:status 400
-                                                         :error  :db/invalid-fn})))
-                        (or (true? x) (false? x) (nil? x)) x
-                        (vector? x) (<? (parse-vector db x funType params))
-                        (nil? x) x
-                        (list? x) (<? (resolve-fn db x funType params))
-                        :else (throw (ex-info (str "Illegal element (" (pr-str x) ") in vector: " (pr-str vec) ".") {}))))))))))
-
-
-(defn find-local-fn*
-  "Looks up function in local-function map. If exists returns map of function details,
-  if doesn't exist returns nil."
-  [fn-name]
-  (when-let [local-fn (get default-fn-map (symbol fn-name))]
-    (resolve-local-fn local-fn)))
-
-
-(def find-local-fn (memoize find-local-fn*))
-
-
-(defn resolve-fn
-  "Resolves a full code form expression."
-  ([db form]
-   (resolve-fn db form nil nil))
-  ([db form type]
-   (resolve-fn db form type nil))
-  ([db form type params]
-   (go-try
-     (let [fn-name (first form)
-           args    (rest form)
-           args-n  (count args)
-           fn-map  (or (find-local-fn fn-name)
-                       (<? (find-fn db fn-name type)))
-           {:keys [f arity arglist &args?]} fn-map
-           _       (when (not (or &args? (arity args-n)))
-                     (throw (ex-info (str "Incorrect arity for function " fn-name ". Expected " arity ", provided: " args-n ".") {})))
-           args*   (loop [[arg & r] args
-                          acc []]
-                     (if (or arg (false? arg))
-                       (let [arg* (cond
-                                    (list? arg) (<? (resolve-fn db arg type params))
-                                    (string? arg) arg
-                                    (number? arg) arg
-                                    (symbol? arg) (or (allowed-symbols arg)
-                                                      (some #{arg} (mapv #(symbol %) params))
-                                                      (= type "functionDec")
-                                                      (throw (ex-info (str "Invalid symbol: " arg
-                                                                           " used in function argument: " (pr-str form))
-                                                                      {:status 400
-                                                                       :error  :db/invalid-fn})))
-                                    (or (true? arg)
-                                        (false? arg)
-                                        (nil? arg)) arg
-                                    (vector? arg) (<? (parse-vector db arg type params))
-                                    :else (throw (ex-info (str "Illegal element (" (pr-str arg) (type arg)
-                                                               ") in function argument: " (pr-str form) ".") {})))]
-                         (recur r (conj acc arg*))) acc))
-           form*   (cons f (cons '?ctx args*))]
-       form*))))
-
-
+;; TODO: Need to implement some of the checks from the old ns here
+;; e.g. symbol-whitelist, comparing symbols against args, etc.
+;; try to combine the list and vector processing
 (defn parse-fn
-  ([db fn-str type]
-   (parse-fn db fn-str type nil))
+  ([db fn-str type] (parse-fn db fn-str type nil))
   ([db fn-str type params]
-   (go-try
-     (if
-       (or (= fn-str "true") (= fn-str "false"))
-       (defn true-or-false [n] (read-string fn-str))
-
-       (try*
-         (when-not (re-matches #"(^\(.+\)$)" fn-str)
-           (throw (ex-info (str "Bad function")
-                           {:status 400
-                            :error  :db/invalid-fn})))
-
-         (let [form      (read-string fn-str)
-               resolved  (<? (resolve-fn db form type params))
-               f-wrapped `(fn [~'?ctx] ~resolved)
-               f         (if (and params (= type "functionDec"))
-                           f-wrapped
-                           (eval f-wrapped))]
-           (with-meta f {:fnstr fn-str}))
-
-         (catch* e
-                 (throw e)
-                 (throw (ex-info (str "Error parsing function: " fn-str)
-                                 {:status 400 :error :db/invalid-tx}))))))))
+   (case fn-str
+     ("true" "false") (sci/parse-string @sci-ctx (str "(fn [_] " fn-str ")"))
+     (if-not (re-matches #"^\(.+\)$" fn-str)
+       (throw (ex-info "Bad function"
+                       {:status 400
+                        :error  :db/invalid-fn}))
+       ;; TODO: Load & cache db fns too
+       (let [parsed-fn      (sci/parse-string @sci-ctx fn-str)
+             wrapped-fn     (wrap-fn parsed-fn)]
+         (log/trace "Parsed & wrapped db fn:" wrapped-fn)
+         wrapped-fn)))))
 
 
 (defn execute-tx-fn
   "Executes a transaction function"
-  [db auth_id credits s p o fuel block-instant]
+  [{:keys [db auth _credits s p o fuel block-instant]}]
   (go-try
-    (let [fn-str  (subs o 1)                                ;; remove preceding '#'
-          credits 10000000
-          ctx     {:db      db
-                   :instant block-instant
-                   :sid     s
-                   :pid     p
-                   :auth_id auth_id
-                   :state   fuel}
-          f       (<? (parse-fn db fn-str "txn" nil))
-          res     (f ctx)]
+    (let [fn-str (subs o 1) ; remove preceding '#'
+          ctx    {:db      db
+                  :instant block-instant
+                  :sid     s
+                  :pid     p
+                  :auth_id auth
+                  :state   fuel}
+          f      (parse-fn db fn-str "txn")
+          res    (sci/eval-form @sci-ctx (list f ctx))]
       (if (channel? res)
-        (<? res) res))))
-
-
-(comment
-
-  (def db nil)
-
-
-  (def db2 nil)
-
-
-  (def parsed (parse db nil nil 100 "(inc (inc (max-pred-val \"_block/instant\")))"))
-
-
-
-  (parsed {:db      db
-           :subject nil
-           :auth    nil
-           :credits 100
-           :state   (atom {:stack   []
-                           :credits 100})})
-
-
-  (cons 1 (cons 7 [2 3]))
-
-
-  (def test-fn "(max [1 2 3 4])")
-
-  db
-
-  (->> (parse-code-str test-fn)
-       #_(parse-form db))
-
-
-
-  (fn? (get default-fn-map 'max)))
-
-
-
-
-
+        (<? res)
+        res))))

--- a/src/fluree/db/dbfunctions/core.cljc
+++ b/src/fluree/db/dbfunctions/core.cljc
@@ -1,12 +1,21 @@
 (ns fluree.db.dbfunctions.core
   (:require [sci.core :as sci]
-            [fluree.db.util.async :refer [go-try <? channel?]]
             [fluree.db.dbfunctions.fns]
+            [fluree.db.util.core :refer [condps]]
+            [fluree.db.util.async :refer [go-try <? channel?]]
             [fluree.db.util.log :as log]))
 
 (defn clear-db-fn-cache
   [])
-  ;; TODO: Implement this if we end needing a db fn cache w/ SCI
+;; TODO: Implement this if we end needing a db fn cache w/ SCI
+
+(def symbol-whitelist #{'?s '?user_id '?db '?o 'sid '?auth_id '?pid '?a '?pO})
+
+(defmacro ns-public-vars
+  "ClojureScript gets cranky if the arg to ns-publics isn't a quoted symbol
+  literal at runtime. So we need this macro to make it chill out."
+  [ns]
+  `(ns-publics ~(quote ns)))
 
 (defn load-ns
   "Copies public vars in ns into SCI"
@@ -28,7 +37,7 @@
                                  doc (assoc :doc doc)
                                  arglists (assoc :arglists arglists)))))))
     {}
-    (ns-publics (quote ns))))
+    (ns-public-vars ns)))
 
 
 (def sci-ctx
@@ -44,44 +53,108 @@
 ;; TODO: Implement me
 
 
-;; TODO: This needs to be recursive b/c fn calls can be nested
-;; good use case for clojure.walk? or maybe just plain ol' recursion?
-(defn- wrap-fn
-  [fn-form]
-  `(fn [~'?ctx] (~(first fn-form) ~'?ctx ~@(rest fn-form))))
+(defn find-local-fn
+  [fn-name]
+  ;; TODO: Implement the rest of the fn-map return value
+  (let [{:keys [arglists] :as sci-fn-meta}
+        (sci/eval-string* @sci-ctx (str "(meta #'" fn-name ")"))]
+    (when sci-fn-meta
+      (let [first-arglist (first arglists)
+            args-set      (set first-arglist)
+            var-args?     (boolean (args-set '&))
+            arity         (when-not var-args?
+                            (set (map #(-> % count dec) arglists)))]
+        {:f         fn-name
+         :arity     arity
+         :var-args? var-args?}))))
 
-;; TODO: Need to implement some of the checks from the old ns here
-;; e.g. symbol-whitelist, comparing symbols against args, etc.
-;; try to combine the list and vector processing
+(defn find-db-fn
+  ([db fn-name] (find-db-fn db fn-name nil))
+  ([db fn-name fn-type]
+   (go-try
+     ;; TODO: Implement caching here if necessary
+     (let [query {:selectOne ["_fn/params" "_fn/code" "_fn/spec"]
+                  :from      ["_fn/name" (name fn-name)]}]
+       ;; TODO: Finish this
+       {:f nil}))))
+
+(defn valid-symbol?
+  "Is the symbol sym valid with the given form type & params?"
+  [type params sym]
+  (or (symbol-whitelist sym)
+      ((set params) sym)
+      (= type "functionDec")))
+
+(defn validate-form
+  ([db form] (validate-form db form nil nil))
+  ([db form type] (validate-form db form type nil))
+  ([db form type params]
+   (go-try
+     (let [fn-name (when (list? form) (first form))
+           args    (if fn-name (rest form) form)
+           args-n  (count args)
+           fn-map  (when fn-name
+                     (or (find-local-fn fn-name)
+                         (<? (find-db-fn db fn-name type))))
+           {:keys [f arity arglist var-args?]} fn-map
+           args*   (loop [[arg & r] args
+                          acc []]
+                     (let [arg* (condps arg
+                                  (list? vector?)
+                                  (<? (validate-form db arg type params))
+
+                                  (string? number? true? false? nil?) arg
+
+                                  #(and (symbol? %)
+                                        (valid-symbol? type params %)) arg
+
+                                  (throw
+                                    (ex-info (str "Invalid element ("
+                                                  (pr-str arg) (type arg)
+                                                  ") in form: " (pr-str form)
+                                                  ".")
+                                             {:status 400
+                                              :error  :db/invalid-fn})))
+                           acc* (conj acc arg*)]
+                       (if (seq r)
+                         (recur r acc*)
+                         acc*)))]
+       (if fn-name
+         (cons f (cons '?ctx args*))
+         form)))))
+
+
 (defn parse-fn
   ([db fn-str type] (parse-fn db fn-str type nil))
   ([db fn-str type params]
-   (case fn-str
-     ("true" "false") (sci/parse-string @sci-ctx (str "(fn [_] " fn-str ")"))
-     (if-not (re-matches #"^\(.+\)$" fn-str)
-       (throw (ex-info "Bad function"
-                       {:status 400
-                        :error  :db/invalid-fn}))
-       ;; TODO: Load & cache db fns too
-       (let [parsed-fn      (sci/parse-string @sci-ctx fn-str)
-             wrapped-fn     (wrap-fn parsed-fn)]
-         (log/trace "Parsed & wrapped db fn:" wrapped-fn)
-         wrapped-fn)))))
-
+   (go-try
+     (case fn-str
+       ("true" "false") (sci/parse-string @sci-ctx (str "(fn [_] " fn-str ")"))
+       (if-not (re-matches #"^\(.+\)$" fn-str)
+         (throw (ex-info "Bad function"
+                         {:status 400
+                          :error  :db/invalid-fn}))
+         ;; TODO: Load & cache db fns too
+         (let [parsed-fn    (sci/parse-string @sci-ctx fn-str)
+               validated-fn (<? (validate-form db parsed-fn type params))]
+           (log/trace "Parsed & validated db fn:" validated-fn)
+           validated-fn))))))
 
 (defn execute-tx-fn
   "Executes a transaction function"
   [{:keys [db auth _credits s p o fuel block-instant]}]
   (go-try
-    (let [fn-str (subs o 1) ; remove preceding '#'
-          ctx    {:db      db
-                  :instant block-instant
-                  :sid     s
-                  :pid     p
-                  :auth_id auth
-                  :state   fuel}
-          f      (parse-fn db fn-str "txn")
-          res    (sci/eval-form @sci-ctx (list f ctx))]
+    (let [fn-str    (subs o 1) ; remove preceding '#'
+          ctx       {:db      db
+                     :instant block-instant
+                     :sid     s
+                     :pid     p
+                     :auth_id auth
+                     :state   fuel}
+          f         (<? (parse-fn db fn-str "txn"))
+          f-wrapped `(fn [~'?ctx] ~f)
+          _         (log/debug "Evaluating wrapped fn:" f-wrapped)
+          res       (sci/eval-form @sci-ctx (list f-wrapped ctx))]
       (if (channel? res)
         (<? res)
         res))))

--- a/src/fluree/db/dbfunctions/ctx.cljc
+++ b/src/fluree/db/dbfunctions/ctx.cljc
@@ -43,7 +43,7 @@
                              first
                              flake/o)
           f          (when ctx-fn-str
-                       (<? (dbfunctions/parse-fn db-root ctx-fn-str "functionDec")))
+                       (<? (dbfunctions/parse-and-wrap-fn db-root ctx-fn-str "functionDec")))
           result     (when f (extract (f ?ctx)))
           result*    (if (sequential? result)
                        (set result)

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -32,7 +32,7 @@
           (recur r (conj acc (<? arg)))
           (recur r (conj acc arg)))))))
 
-(defn stack
+(defn- stack
   "Returns the current stack."
   [?ctx]
   (-> @(:state ?ctx)
@@ -104,7 +104,7 @@
   [?ctx arg]
   (go-try (let [arg   (extract arg)
                 res   (fdb/not arg)
-                entry [{:function "not?" :arguments [arg] :result res} 10]]
+                entry [{:function "not" :arguments [arg] :result res} 10]]
             (add-stack ?ctx entry)
             res)))
 

--- a/src/fluree/db/dbfunctions/fns.cljc
+++ b/src/fluree/db/dbfunctions/fns.cljc
@@ -42,12 +42,12 @@
   "Adds an entry to the current stack."
   [?ctx entry]
   (let [[res cost] entry]
-    (do
-      (log/debug "Smart function stack: " res)
-      (swap! (:state ?ctx) (fn [s]
-                             (assoc s :stack (conj (:stack s) entry)
-                                      :credits (fdb/- (:credits s) cost)
-                                      :spent (fdb/+ (:spent s) cost)))))))
+    (log/debug "Smart function stack:" res)
+    (swap! (:state ?ctx)
+           #(-> %
+                (update :stack conj entry)
+                (update :credits fdb/- cost)
+                (update :spent fdb/+ cost)))))
 
 (defn- raise
   "Throws an exception with the provided message."

--- a/src/fluree/db/dbfunctions/internal.cljc
+++ b/src/fluree/db/dbfunctions/internal.cljc
@@ -223,7 +223,7 @@
          result
          [result @fuel])))))
 
-(def pred-reverse-ref-re #"(?:([^/]+)/)_([^/]+)")
+(def ^:private pred-reverse-ref-re #"(?:([^/]+)/)_([^/]+)")
 
 (defn reverse-ref?
   "Reverse refs must be strings that include a '/_' in them, which characters before and after."

--- a/src/fluree/db/permissions.cljc
+++ b/src/fluree/db/permissions.cljc
@@ -32,7 +32,7 @@
            false
 
            (re-matches #"^\(.+\)$" fn-str)
-           (let [f-meta (<? (dbfunctions/parse-fn db fn-str "functionDec" params))]
+           (let [f-meta (<? (dbfunctions/parse-and-wrap-fn db fn-str "functionDec" params))]
              (swap! rule-fn-cache assoc fn-str f-meta)
              f-meta)
 


### PR DESCRIPTION
Smartfunctions running under [SCI](https://github.com/babashka/SCI)

As demoed in Winston. Note that this does not do any caching as I found the SCI-based smartfns w/o caching were about as fast as the old implementation w/ caching. If we find any evidence that that's not the case (or just opportunities to speed things up even more), I'd be happy to add some back in.

This will allow us to run smartfns in the browser and in native GraalVM binaries.

Part of CLI-2