### PR TITLE
FC-1405 fix query parse that has recursion '+' syntax

### DIFF
--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -103,7 +103,10 @@
   [{:keys [where select] :as _parsed-query}]
   (let [select-var (-> select :select first :variable)]
     (when select-var                                        ;; for now exclude any filters on the first where, not implemented
-      (every? #(= select-var (-> % :s :variable)) where))))
+      (every? #(and (= select-var (-> % :s :variable))
+                    ;; exclude if any recursion specified in where statement (e.g. person/follows+3)
+                    (not (:recur %)))
+              where))))
 
 (defn re-parse-as-simple-subj-crawl
   "Returns true if query contains a single subject crawl.


### PR DESCRIPTION
When an analytical query has the '+' recursion syntax, e.g. person/follows+3, the new parsing / execution engine would break. This is because now parsing looks up valid predicates at parse time, and it is unable to find a matching predicate without parsing the recursion syntax first. This now properly identifies and parses this, e.g. to predicate: person/follows with recursion of 3.