### PR TITLE
FC-1409 Two-tuple binding aggregate fn binding error fix

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -560,7 +560,8 @@
                                      {:status 400 :error :db/invalid-query})))]
     {:variable variable
      :as       as
-     :code     agg-fn}))
+     :fn-str   x
+     :function agg-fn}))
 
 
 (defn calculate-aggregate


### PR DESCRIPTION
Fixes nil error with two-tuple bindings in where clause. e.g.

```
{:select ["?e" "?maxNum"]
               :where  [["?e" "person/favNums" "?favNums"]
                        ["?maxNum" "#(max ?favNums)"]]

               }
```