### PR TITLE
FC-1411 Feature - 'having' in 'groupBy' queries

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -136,7 +136,6 @@
   ['?email '?name '?x '?e]
   The return value would be: [3 1]"
   [vars headers]
-  (log/warn "get-tuple-indexes: [vars headers]" [vars headers])
   (reduce (fn [acc var-smt]
             (if-let [var (or (variable? var-smt)
                              (:variable var-smt))]

--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -96,8 +96,13 @@
                        :else
                        (update acc :search #(conj % key))))) {:search [] :rel {} :opts {}} clause))
 
-(defn get-ns-arrays [ns arrays]
-  (map (fn [array] (map #(nth array %) ns)) arrays))
+(defn transform-tuples-to-idxs
+  "Returns an updated list of tuples that only contains tuple indexes from idx.
+  e.g.:
+  idx is a list of indexes, eg. [2 0 4]
+  Thus, the return will be 3-tuples of nth 2, 0, 4 respectively."
+  [idxs tuples]
+  (map (fn [tuple] (map #(nth tuple %) idxs)) tuples))
 
 (defn clause->keys
   [clause]
@@ -122,14 +127,31 @@
               (if (a-keys key)
                 (conj acc key) acc)) [] b-keys)))
 
+
+(defn get-tuple-indexes
+  "Returns index positions of vars within headers.
+  e.g. if vars were:
+  ['?e '?name]
+  and headers were:
+  ['?email '?name '?x '?e]
+  The return value would be: [3 1]"
+  [vars headers]
+  (log/warn "get-tuple-indexes: [vars headers]" [vars headers])
+  (reduce (fn [acc var-smt]
+            (if-let [var (or (variable? var-smt)
+                             (:variable var-smt))]
+              (conj acc (util/index-of headers var))
+              (throw
+                (ex-info (str var-smt " cannot be retrieved from the results. "
+                              "Check that it is declared in your where clause.")
+                         {:status 400 :error :db/invalid-query}))))
+          [] vars))
+
+
 (defn select-from-tuples
   [vars tuples]
-  (let [ns (reduce (fn [acc var-smt]
-                     (if-let [var (or (variable? var-smt)
-                                      (:variable var-smt))]
-                       (conj acc (util/index-of (:headers tuples) var))
-                       (throw (ex-info (str var-smt " cannot be retrieved from the results. Check that it is declared in your where clause.") {:status 400 :error :db/invalid-query})))) [] vars)]
-    (get-ns-arrays ns (:tuples tuples))))
+  (let [idxs (get-tuple-indexes vars (:headers tuples))]
+    (transform-tuples-to-idxs idxs (:tuples tuples))))
 
 (defn add-fuel
   [add-amount fuel max-fuel]
@@ -305,7 +327,7 @@
                                                  (if search-val
                                                    (recur (concat acc (<? (query-range/index-range db :spot = [search-val predicate]))) r)
                                                    acc))
-                                        tuples (get-ns-arrays [0 2] res)
+                                        tuples (transform-tuples-to-idxs [0 2] res)
                                         acc*   (tuples->map acc tuples)]
                                     (recur acc* (inc depth)))))))
 
@@ -324,7 +346,7 @@
                                          (let [idx-of    (util/index-of clause (str common-key))
                                                k         (condp = idx-of 0 :subject-fn 1 :predicate-fn 2 :object-fn)
                                                res-idx   (util/index-of headers common-key)
-                                               v         (into #{} (map first (get-ns-arrays [res-idx] tuples)))
+                                               v         (into #{} (map first (transform-tuples-to-idxs [res-idx] tuples)))
                                                single-v? (= 1 (count v))
                                                v         (if (and (not single-v?) object-fn (= k object-fn))
                                                            (comp v object-fn)
@@ -344,7 +366,7 @@
                 ;                     subject-fn    (filter #(subject-fn (.-s %)))
                 ;                     predicate-fn  (filter #(predicate-fn (.-p %))))
                 _           (add-fuel (count res) fuel max-fuel)
-                tuples      (get-ns-arrays (vals rel) res)
+                tuples      (transform-tuples-to-idxs (vals rel) res)
                 tuples'     (if recur-depth
                               (let [clause-1st (first clause')
                                     var-first? (variable? (first clause))
@@ -524,31 +546,37 @@
      'variance       variance}))
 
 
-(defn aggregate? [x] (and (string? x)
-                          (re-matches #"^\(.+\)$" x)))
+(defn aggregate?
+  [x]
+  (and (string? x)
+       (re-matches #"^\(.+\)$" x)))
 
-(defn interm-aggregate? [x] (and (string? x)
-                                 (re-matches #"^#\(.+\)$" x)))
+(defn interm-aggregate?
+  [x]
+  (and (string? x)
+       (re-matches #"^#\(.+\)$" x)))
 
-(defn parse-aggregate [x valid-var]
-  (let [list-agg   (#?(:clj read-string :cljs cljs.reader/read-string) x)
-        as?        (= 'as (first list-agg))
-        as         (if as? (-> (str "?" (last list-agg)) symbol) (->> list-agg (str "?") symbol))
-        func-list  (if as? (let [func-list (second list-agg)]
-                             (if (coll? func-list) func-list
-                                                   (throw (ex-info (str "Invalid aggregate selection. As can only be used in conjunction with other functions. Provided: " x)
-                                                                   {:status 400 :error :db/invalid-query})))) list-agg)
-        list-count (count func-list)
-        [fun arg var] (cond (= 3 list-count) [(first func-list) (second func-list) (last func-list)]
-                            (and (= 2 list-count) (= 'sample (first func-list)))
-                            (throw (ex-info (str "The sample aggregate function takes two arguments: n and a variable, provided: " x)
-                                            {:status 400 :error :db/invalid-query}))
-                            (= 2 list-count) [(first func-list) nil (last func-list)]
-                            :else (throw (ex-info (str "Invalid aggregate selection, provided: " x)
-                                                  {:status 400 :error :db/invalid-query})))
+(defn parse-aggregate*
+  "Returns map of aggregate function executable code or error if invalid aggregate function."
+  [parsed-code as valid-var]
+  (let [list-count (count parsed-code)
+        [fun arg var] (cond
+                        (= 3 list-count)
+                        [(first parsed-code) (second parsed-code) (last parsed-code)]
+
+                        (= 2 list-count)
+                        (if (= 'sample (first parsed-code))
+                          (throw (ex-info (str "The sample aggregate function takes two arguments: n and a variable, provided: "
+                                               (pr-str parsed-code))
+                                          {:status 400 :error :db/invalid-query}))
+                          [(first parsed-code) nil (last parsed-code)])
+
+                        :else
+                        (throw (ex-info (str "Invalid aggregate selection, provided: " (pr-str parsed-code))
+                                        {:status 400 :error :db/invalid-query})))
         agg-fn     (if-let [agg-fn (built-in-aggregates fun)]
                      (if arg (fn [coll] (agg-fn arg coll)) agg-fn)
-                     (throw (ex-info (str "Invalid aggregate selection function, provided: " x)
+                     (throw (ex-info (str "Invalid aggregate selection function, provided: " (pr-str parsed-code))
                                      {:status 400 :error :db/invalid-query})))
         [agg-fn variable] (let [distinct? (and (coll? var) (= (first var) 'distinct))
                                 variable  (if distinct? (second var) var)
@@ -556,17 +584,35 @@
                                                         agg-fn)]
                             [agg-fn variable])
         _          (when-not (valid-var variable)
-                     (throw (ex-info (str "Invalid select variable in aggregate select, provided: " x)
+                     (throw (ex-info (str "Invalid select variable in aggregate select, provided: " (pr-str parsed-code))
                                      {:status 400 :error :db/invalid-query})))]
     {:variable variable
      :as       as
      :code     agg-fn}))
 
 
+(defn parse-aggregate
+  "Parses string aggregate function and returns execution map if valid."
+  [x valid-var]
+  (let [list-agg  (#?(:clj read-string :cljs cljs.reader/read-string) x)
+        as?       (= 'as (first list-agg))
+        as        (if as?
+                    (-> (str "?" (last list-agg)) symbol)
+                    (->> list-agg (str "?") symbol))
+        func-list (if as?
+                    (let [func-list (second list-agg)]
+                      (if (coll? func-list)
+                        func-list
+                        (throw (ex-info (str "Invalid aggregate selection. As can only be used in conjunction with other functions. Provided: " x)
+                                        {:status 400 :error :db/invalid-query}))))
+                    list-agg)]
+    (parse-aggregate* func-list as valid-var)))
+
+
 (defn calculate-aggregate
-  [res agg]
-  (let [{:keys [variable as function]} agg
-        agg-params (flatten (select-from-tuples [variable] res))
+  [tuples aggregate-fn-map]
+  (let [{:keys [variable as function]} aggregate-fn-map
+        agg-params (flatten (select-from-tuples [variable] tuples))
         agg-result (function agg-params)]
     [as agg-result]))
 

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -667,7 +667,9 @@
         (let [tuple-count (count where-smt)
               where-smt*  (case tuple-count
                             3 (apply parse-where-tuple supplied-vars* db where-smt)
-                            4 (apply parse-remote-tuple supplied-vars* where-smt)
+                            4 (if (= "$fdb" (first where-smt)) ;; $fdb refers to default/main db, parse as 3-tuple
+                                (apply parse-where-tuple supplied-vars* db (rest where-smt))
+                                (apply parse-remote-tuple supplied-vars* where-smt))
                             2 (apply parse-binding-tuple where-smt)
                             ;; else
                             (if (sequential? (first where-smt))

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -181,8 +181,8 @@
 
 
 (defn parse-aggregate
-  "Parses an aggreage function string and returns map with keys:
-  :variable - oinput variable sysmbol
+  "Parses an aggregate function string and returns map with keys:
+  :variable - input variable symbol
   :as - return variable/binding name
   :fn-str - original function string, for use in reporting errors
   :function - executable function."

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -144,50 +144,60 @@
   (last as-fn-parsed))
 
 
-(defn parse-aggregate
-  [aggregate-fn-str]
-  (let [list-agg   (safe-read-fn aggregate-fn-str)
-        as?        (= 'as (first list-agg))
-        func-list  (if as?
-                     (second list-agg)
-                     list-agg)
-        _          (when-not (coll? func-list)
-                     (throw (ex-info (str "Invalid aggregate selection. As can only be used in conjunction with other functions. Provided: " aggregate-fn-str)
-                                     {:status 400 :error :db/invalid-query})))
-        list-count (count func-list)
+(defn parse-aggregate*
+  [fn-parsed fn-str as]
+  (let [list-count (count fn-parsed)
         [fun arg var] (cond (= 3 list-count)
-                            [(first func-list) (second func-list) (last func-list)]
+                            [(first fn-parsed) (second fn-parsed) (last fn-parsed)]
 
-                            (and (= 2 list-count) (= 'sample (first func-list)))
-                            (throw (ex-info (str "The sample aggregate function takes two arguments: n and a variable, provided: " aggregate-fn-str)
+                            (and (= 2 list-count) (= 'sample (first fn-parsed)))
+                            (throw (ex-info (str "The sample aggregate function takes two arguments: n and a variable, provided: " fn-str)
                                             {:status 400 :error :db/invalid-query}))
 
                             (= 2 list-count)
-                            [(first func-list) nil (last func-list)]
+                            [(first fn-parsed) nil (last fn-parsed)]
 
                             :else
-                            (throw (ex-info (str "Invalid aggregate selection, provided: " aggregate-fn-str)
+                            (throw (ex-info (str "Invalid aggregate selection, provided: " fn-str)
                                             {:status 400 :error :db/invalid-query})))
         agg-fn     (if-let [agg-fn (built-in-aggregates fun)]
                      (if arg (fn [coll] (agg-fn arg coll)) agg-fn)
-                     (throw (ex-info (str "Invalid aggregate selection function, provided: " aggregate-fn-str)
+                     (throw (ex-info (str "Invalid aggregate selection function, provided: " fn-str)
                                      {:status 400 :error :db/invalid-query})))
         [agg-fn variable] (let [distinct? (and (coll? var) (= (first var) 'distinct))
                                 variable  (if distinct? (second var) var)
                                 agg-fn    (if distinct? (fn [coll] (-> coll distinct agg-fn))
                                                         agg-fn)]
                             [agg-fn variable])
-        as         (if as?
-                     (extract-aggregate-as list-agg)
-                     (symbol (str variable "-" fun)))]
+        as'        (or as (symbol (str variable "-" fun)))]
     (when-not (and (symbol? variable)
                    (= \? (first (name variable))))
-      (throw (ex-info (str "Variables used in aggregate functions must start with a '?'. Provided: " aggregate-fn-str)
+      (throw (ex-info (str "Variables used in aggregate functions must start with a '?'. Provided: " fn-str)
                       {:status 400 :error :db/invalid-query})))
     {:variable variable
-     :as       as
-     :fn-str   aggregate-fn-str
+     :as       as'
+     :fn-str   fn-str
      :function agg-fn}))
+
+
+(defn parse-aggregate
+  "Parses an aggreage function string and returns map with keys:
+  :variable - oinput variable sysmbol
+  :as - return variable/binding name
+  :fn-str - original function string, for use in reporting errors
+  :function - executable function."
+  [aggregate-fn-str]
+  (let [list-agg  (safe-read-fn aggregate-fn-str)
+        as?       (= 'as (first list-agg))
+        func-list (if as?
+                    (second list-agg)
+                    list-agg)
+        _         (when-not (coll? func-list)
+                    (throw (ex-info (str "Invalid aggregate selection. As can only be used in conjunction with other functions. Provided: " aggregate-fn-str)
+                                    {:status 400 :error :db/invalid-query})))
+        as        (when as?
+                    (extract-aggregate-as list-agg))]
+    (parse-aggregate* func-list aggregate-fn-str as)))
 
 
 (defn variable-in-where?
@@ -215,6 +225,53 @@
     {:variable  var-as-symbol
      :selection selection}))
 
+(defn parse-having-code
+  "Returns two-tuple of [params updated-code]
+  where params are the function parameters and updated-code is a revised version of
+  code-parsed where all functions within the code are mapped to actual executable functions."
+  [code-parsed code-string]
+  (let [[form-f & form-r] code-parsed
+        form-f' (or (get built-in-aggregates form-f)
+                    (get filter/filter-fns-with-ns (str form-f)))
+        vars    (into #{} (filter symbol? form-r))]
+    (loop [[form-next & form-rest] form-r
+           vars* vars
+           acc   []]
+      (if form-next
+        (let [[params item] (if (list? form-next)
+                              (parse-having-code form-next code-string)
+                              [nil (cond
+                                     (symbol? form-next) (if-not (str/starts-with? (str form-next) "?")
+                                                           (throw (ex-info (str "Invalid variable name '" form-next
+                                                                                "' in having function: " code-string
+                                                                                ". All vars must start with '?'.")
+                                                                           {:status 400 :error :db/invalid-query}))
+                                                           form-next)
+                                     (string? form-next) form-next
+                                     (boolean? form-next) form-next
+                                     (number? form-next) form-next
+                                     :else (throw (ex-info (str "Invalid having function: " code-string
+                                                                ". Only scalar types allowed besides functions: " form-next ".")
+                                                           {:status 400 :error :db/invalid-query})))])
+              vars** (if params
+                       (into vars* params)
+                       vars*)]
+          (recur form-rest vars** (conj acc item)))
+        [(vec vars*) (cons form-f' acc)]))))
+
+
+(defn parse-having
+  [having]
+  (when-not (aggregate? having)
+    (throw (ex-info (str "Invalid 'having' statement aggregate: " having)
+                    {:status 400 :error :db/invalid-query})))
+  (let [code (safe-read-fn having)
+        [params code*] (parse-having-code code having)]
+    {:variable nil                                          ;; not used for 'having' fn execution
+     :params   params
+     :fn-str   (str "(fn " params " " code)
+     :function (filter/make-executable params code*)}))
+
 
 (defn parse-select
   [select-smt]
@@ -232,7 +289,7 @@
 
 (defn add-select-spec
   [{:keys [group-by order-by limit offset pretty-print] :as parsed-query}
-   {:keys [selectOne select selectDistinct selectReduced opts orderBy groupBy] :as _query-map'}]
+   {:keys [selectOne select selectDistinct selectReduced opts orderBy groupBy having] :as _query-map'}]
   (let [select-smt    (or selectOne select selectDistinct selectReduced)
         selectOne?    (boolean selectOne)
         limit*        (if selectOne? 1 limit)
@@ -249,13 +306,16 @@
                           (if (vector? orderBy) orderBy ["ASC" orderBy])
                           (throw (ex-info (str "Invalid orderBy clause, must be variable or two-tuple formatted ['ASC' or 'DESC', var]. Provided: " orderBy)
                                           {:status 400
-                                           :error  :db/invalid-query}))))]
+                                           :error  :db/invalid-query}))))
+        having*       (or having (:having opts))
+        having-parsed (when having* (parse-having having*))]
     (assoc parsed-query :limit limit*
                         :selectOne? selectOne?
                         :select {:select           parsed-select
                                  :aggregates       (not-empty aggregates)
                                  :expandMaps?      expandMap?
                                  :orderBy          orderBy*
+                                 :having           having-parsed
                                  :groupBy          (or (:groupBy opts) groupBy)
                                  :componentFollow? (:component opts)
                                  :limit            limit*


### PR DESCRIPTION
This adds support for 'having' in  'groupBy' queries. Using the sample chat data, this would allow a query like:
```
{:select "(sum ?favNums)"
  :where  [["?e" "person/favNums" "?favNums"]]
  :groupBy "?e"
  :having "(< 200 (sum ?favNums))"}
```

or even a compound condition like:
```
{:select "(sum ?favNums)"
  :where  [["?e" "person/favNums" "?favNums"]]
  :groupBy "?e"
  :having "(and (< 200 (sum ?favNums)) (> 1900 (sum ?favNums)))"}
```

This also adds support for the SPARQL parser to support HAVING, but as of right now does not support compounded conditions. The following will work:
```
SELECT (SUM(?favNums) AS ?sumNums)
 WHERE {
        ?e fdb:person/favNums ?favNums. 
 } 
 GROUP BY ?e 
 HAVING(SUM(?favNums) > 1000)
```