### PR TITLE
Wrap flureenjs package in a UMD module

### DIFF
--- a/build-nodejs.edn
+++ b/build-nodejs.edn
@@ -5,4 +5,23 @@
  :optimizations :simple
  :pretty-print  false
  :install-deps  true
- :npm-deps      {}}
+ :npm-deps      {}
+ :hashbang      false
+ :output-wrapper "(function (root, factory) {
+if (typeof define === 'function' && define.amd) {
+// AMD. Register as an anonymous module.
+define([], factory);
+} else if (typeof module === 'object' && module.exports) {
+// Node. Does not work with strict CommonJS, but
+// only CommonJS-like environments that support module.exports,
+// like Node.
+module.exports = factory();
+} else {
+// Browser globals (root is window)
+root.returnExports = factory();
+}
+}(this, function () {
+// CLJS-COMPILED-OUTPUT-HERE
+%s
+return flureenjs;
+}));"}

--- a/dev/nodejs/index.js
+++ b/dev/nodejs/index.js
@@ -1,0 +1,18 @@
+const flureenjs = require("@fluree/flureenjs");
+
+const flureeServerUrl = "http://localhost:8090";
+const ledger = "dan/test1";
+
+console.log('flureenjs', flureenjs);
+
+async function go() {
+
+  const conn = await flureenjs.connect(flureeServerUrl);
+  const db = await flureenjs.db(conn, ledger);
+
+  const results = await flureenjs.query(db, {select: ["*"], from: "_collection"})
+
+  console.log(results);
+};
+
+go();

--- a/dev/nodejs/package.json
+++ b/dev/nodejs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "flureenjstest",
+  "version": "0.0.0",
+  "description": "Use this to test builds of flureenjs",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@fluree/flureenjs": "../../out/flureenjs.js"
+  }
+}


### PR DESCRIPTION
We were missing the hashbang remover and UMD wrapper that we need in order for node
projects to successfully use our functions. Tests didn't catch it because they run in
clojurescript land.

I've added a dev area for manually testing the output. The workflow is:
make nodejs
(then, inside dev/nodejs)
rm -rf node_modules
npm install
node index.js

Fixes #FC-1413