### PR TITLE
FC-1416: use memory-backed full text index for memory-backed connections

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -144,9 +144,11 @@
 
   #?@(:clj
       [full-text/IndexConnection
-       (open-storage [{:keys [storage-type] :as conn} network ledger-id lang]
-                     (when-let [path (-> conn :meta :file-storage-path)]
-                       (full-text/disk-index path network ledger-id lang)))]))
+       (open-storage [conn network ledger-id lang]
+                     (if (:memory conn)
+                       (full-text/memory-index lang)
+                       (when-let [path (-> conn :meta :file-storage-path)]
+                         (full-text/disk-index path network ledger-id lang))))]))
 
 (defn- normalize-servers
   "Split servers in a string into a vector.

--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -403,15 +403,11 @@
   #?(:cljs (throw (ex-info "Full text search is not supported in JS"
                            {:status 400
                             :error  :db/invalid-query}))
-     :clj  (if (:memory conn)
-             (throw (ex-info "Full text search is not supported in when running in-memory"
-                             {:status 400
-                              :error  :db/invalid-query}))
-             (let [lang (-> db :settings :language (or :default))
-                   [var search search-param] clause
-                   var  (variable? var)]
-               (with-open [^Closeable store (full-text/open-storage conn network ledger-id lang)]
-                 (full-text/search store db [var search search-param]))))))
+     :clj  (let [lang (-> db :settings :language (or :default))
+                 [var search search-param] clause
+                 var  (variable? var)]
+             (with-open [^Closeable store (full-text/open-storage conn network ledger-id lang)]
+               (full-text/search store db [var search search-param])))))
 
 
 ;; Can be: ["?item" "rdf:type" "person"]


### PR DESCRIPTION
This change is mainly to allow for end-to-end full text integration tests in ledger.