### PR TITLE
FC-1418 Fix/query  _block

### DIFF
--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -573,6 +573,11 @@
                       {:variable (:variable parsed-filter-map)
                        :filter   parsed-filter-map})
 
+                    rdf-type?                               ;; _block gets aliasted to _tx
+                    (if (= "_block" o)
+                      (value-type-map "_tx")
+                      (value-type-map o))
+
                     :else
                     (value-type-map o))
         idx       (cond

--- a/src/fluree/db/query/subject_crawl/legacy.cljc
+++ b/src/fluree/db/query/subject_crawl/legacy.cljc
@@ -106,7 +106,7 @@
 
 (defn basic-to-analytical-transpiler
   [query-map]
-  (let [{:keys [select selectOne selectDistinct where from limit offset component orderBy vars]} query-map
+  (let [{:keys [select selectOne selectDistinct where from vars]} query-map
         selectKey  (cond select :select
                          selectOne :selectOne
                          selectDistinct :selectDistinct)


### PR DESCRIPTION
With new query parser, _block file queries e.g. {:select ["*"] :from "_block"} stopped working, this fixes it.