### PR TITLE
FC-1419 Fix/limit+order

### DIFF
--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -573,6 +573,11 @@
                       {:variable (:variable parsed-filter-map)
                        :filter   parsed-filter-map})
 
+                    rdf-type?
+                    (if (= "_block" o)
+                      (value-type-map "_tx")                ;; _block gets aliased to _tx
+                      (value-type-map o))
+
                     :else
                     (value-type-map o))
         idx       (cond
@@ -741,7 +746,7 @@
    :order     - :asc or :desc
    :predicate - predicate name, if :predicate type
    :variable  - variable name, if :variable type"
-  [{:keys [where] :as parsed-query} db order-by]
+  [{:keys [where] :as parsed-query} order-by]
   (let [{:keys [variable] :as parsed-order-by} (parse-order-by order-by)]
     (when (and variable (not (variable-in-where? variable where)))
       (throw (ex-info (str "Order by specifies a variable, " variable
@@ -859,6 +864,8 @@
         supplied-var-keys (if rel-binding?
                             (-> supplied-vars first keys set)
                             (-> supplied-vars keys set))
+        orderBy*          (or orderBy (:orderBy opts))
+        groupBy*          (or groupBy (:groupBy opts))
         parsed            (cond-> {:strategy      :legacy
                                    :rel-binding?  rel-binding?
                                    :where         (parse-where db query-map' supplied-var-keys)
@@ -871,8 +878,8 @@
                                                     prettyPrint
                                                     (:prettyPrint opts))}
                                   filter (add-filter filter supplied-var-keys) ;; note, filter maps can/should also be inside :where clause
-                                  orderBy (add-order-by db (or orderBy (:orderBy opts)))
-                                  groupBy (add-group-by (or groupBy (:groupBy opts)))
+                                  orderBy* (add-order-by orderBy*)
+                                  groupBy* (add-group-by groupBy*)
                                   true (add-select-spec query-map'))]
     (or (re-parse-as-simple-subj-crawl parsed)
         parsed)))

--- a/src/fluree/db/query/subject_crawl/common.cljc
+++ b/src/fluree/db/query/subject_crawl/common.cljc
@@ -121,10 +121,10 @@
   - :order - :asc or :desc
   - :predicate - if type = :predicate, contains predicate pid or name
   - :variable - if type = :variable, contains variable name (not supported for simple subject crawl)"
-  [results {:keys [type order predicate]}]
+  [results {:keys [type order predicate]} limit]
   (if (= :variable type)
     (throw (ex-info "Ordering by a variable not supported in this type of query."
                     {:status 400 :error :db/invalid-query}))
-    (cond-> (sort-by (fn [result] (get result predicate)) results)
-            (= :desc order) reverse
-            true vec)))
+    (let [sorted (cond-> (sort-by (fn [result] (get result predicate)) results)
+                         (= :desc order) reverse)]
+      (vec (take limit sorted)))))

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -40,7 +40,7 @@
   - order-by exists, in which case we need to perform a sort
   - selectOne? exists, in which case we take the (first result)
   - pretty-print is true, in which case each result needs to get embedded in a map"
-  [{:keys [selectOne? order-by pretty-print] :as parsed-query}]
+  [{:keys [selectOne? order-by pretty-print limit] :as parsed-query}]
   (let [fns (cond-> []
                     selectOne? (conj (fn [result] (first result)))
                     pretty-print (conj (let [select-var (-> parsed-query
@@ -52,7 +52,7 @@
                                                             (subs 1))]
                                          (fn [result]
                                            (mapv #(array-map select-var %) result))))
-                    order-by (conj (fn [result] (order-results result order-by))))]
+                    order-by (conj (fn [result] (order-results result order-by limit))))]
     (if (empty? fns)
       identity
       (apply comp fns))))

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -66,7 +66,7 @@
   (c) filter subjects based on subsequent where clause(s)
   (d) apply offset/limit for (c)
   (e) send result into :select graph crawl"
-  [db {:keys [vars where limit offset fuel rel-binding?] :as parsed-query}]
+  [db {:keys [vars where limit offset fuel rel-binding? order-by] :as parsed-query}]
   (let [error-ch    (async/chan)
         f-where     (first where)
         rdf-type?   (= :rdf/type (:type f-where))
@@ -84,7 +84,7 @@
                      :error-ch      error-ch
                      :vars          vars
                      :filter-map    filter-map
-                     :limit         limit
+                     :limit         (if order-by util/max-long limit) ;; if ordering, limit performed by finish-fn after sort
                      :offset        offset
                      :permissioned? (not (get-in db [:permissions :root?]))
                      :parallelism   3

--- a/src/fluree/db/query/subject_crawl/legacy.cljc
+++ b/src/fluree/db/query/subject_crawl/legacy.cljc
@@ -106,7 +106,7 @@
 
 (defn basic-to-analytical-transpiler
   [query-map]
-  (let [{:keys [select selectOne selectDistinct where from limit offset component orderBy vars]} query-map
+  (let [{:keys [select selectOne selectDistinct where from vars]} query-map
         selectKey  (cond select :select
                          selectOne :selectOne
                          selectDistinct :selectDistinct)

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -7,7 +7,7 @@
             [fluree.db.flake :as flake]
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.log :as log]
-            [fluree.db.query.subject-crawl.common :refer [where-subj-xf result-af subj-perm-filter-fn filter-subject order-results]]
+            [fluree.db.query.subject-crawl.common :refer [where-subj-xf result-af subj-perm-filter-fn filter-subject]]
             [fluree.db.dbproto :as dbproto]))
 
 #?(:clj (set! *warn-on-reflection* true))


### PR DESCRIPTION
With simple-subject-crawl queries, if orderBy (sorting) is applied to query results in addition to a :limit, the limit must be taking after sorting not before as it was doing.