### PR TITLE
Fix var binding in queries

### DIFF
--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -29,9 +29,9 @@
                         {:status 400 :error :db/invalid-query})))
       res)
     (catch* e
-            (log/warn "Invalid query function attempted: " code-str " with error message: " (ex-message e))
-            (throw (ex-info (code-str "Invalid query function: " code-str)
-                            {:status 400 :error :db/invalid-query})))))
+      (log/warn "Invalid query function attempted: " code-str " with error message: " (ex-message e))
+      (throw (ex-info (code-str "Invalid query function: " code-str)
+                      {:status 400 :error :db/invalid-query})))))
 
 (def built-in-aggregates
   (letfn [(sum [coll] (reduce + 0 coll))
@@ -137,7 +137,7 @@
   Checks that has 3 elements to the form, and the last element
   is a symbol that starts with a '?'. Else will throw."
   [as-fn-parsed]
-  (when-not (and (= 3 (count as-fn-parsed))                 ;; e.g. (as (sum ?nums) ?sum) - will always have 3 elements
+  (when-not (and (= 3 (count as-fn-parsed)) ;; e.g. (as (sum ?nums) ?sum) - will always have 3 elements
                  (symbol? (last as-fn-parsed)))
     (throw (ex-info (str "Invalid aggregate function using 'as': " (pr-str as-fn-parsed))
                     {:status 400 :error :db/invalid-query})))
@@ -267,7 +267,7 @@
                     {:status 400 :error :db/invalid-query})))
   (let [code (safe-read-fn having)
         [params code*] (parse-having-code code having)]
-    {:variable nil                                          ;; not used for 'having' fn execution
+    {:variable nil ;; not used for 'having' fn execution
      :params   params
      :fn-str   (str "(fn " params " " code)
      :function (filter/make-executable params code*)}))
@@ -288,7 +288,7 @@
 
 
 (defn add-select-spec
-  [{:keys [group-by order-by limit offset pretty-print] :as parsed-query}
+  [{:keys [limit offset pretty-print] :as parsed-query}
    {:keys [selectOne select selectDistinct selectReduced opts orderBy groupBy having] :as _query-map'}]
   (let [select-smt    (or selectOne select selectDistinct selectReduced)
         selectOne?    (boolean selectOne)
@@ -450,7 +450,7 @@
   (let [[clause-type clause-val] (first map-clause)]
     (case clause-type
       :filter
-      {:type   :filter                                      ;; will process all filters after where completed.
+      {:type   :filter ;; will process all filters after where completed.
        :filter clause-val}
 
       :optional
@@ -477,7 +477,7 @@
                              "and binding scalars, or aggregates, as values.")
                         {:status 400 :error :db/invalid-query})))
 
-      :minus                                                ;; negation - SPARQL 1.1, not yet supported
+      :minus ;; negation - SPARQL 1.1, not yet supported
       (throw (ex-info (str "Invalid where clause, Fluree does not yet support the 'minus' operation.")
                       {:status 400 :error :db/invalid-query}))
 
@@ -562,7 +562,7 @@
                                         db (pred-id-strict db))
                     :else (cond->> p
                                    db (pred-id-strict db)))
-        p-idx?    (when p* (dbproto/-p-prop db :idx? p*))   ;; is the predicate indexed?
+        p-idx?    (when p* (dbproto/-p-prop db :idx? p*)) ;; is the predicate indexed?
         p-tag?    (when p* (= :tag (dbproto/-p-prop db :type p)))
         o*        (cond
                     p-tag?
@@ -575,7 +575,7 @@
 
                     rdf-type?
                     (if (= "_block" o)
-                      (value-type-map "_tx")                ;; _block gets aliased to _tx
+                      (value-type-map "_tx") ;; _block gets aliased to _tx
                       (value-type-map o))
 
                     :else
@@ -616,7 +616,7 @@
      :s      s*
      :p      p*
      :o      o*
-     :recur  recur-n                                        ;; will only show up if recursion specified.
+     :recur  recur-n ;; will only show up if recursion specified.
      :p-tag? p-tag?
      :p-idx? p-idx?}))
 
@@ -644,7 +644,7 @@
                     {:status 400 :error :db/invalid-query})))
   (loop [[where-smt & r] where
          filters        []
-         hoisted-bind   {}                                  ;; bindings whose values are scalars are hoisted to the top level.
+         hoisted-bind   {} ;; bindings whose values are scalars are hoisted to the top level.
          supplied-vars* supplied-vars
          where*         []]
     (if where-smt
@@ -658,7 +658,7 @@
                      filters
                      (merge hoisted-bind scalars)
                      (merge supplied-vars* aggregates scalars)
-                     (if (not-empty aggregates)             ;; if all scalar bindings, no need to add extra where statement
+                     (if (not-empty aggregates) ;; if all scalar bindings, no need to add extra where statement
                        (conj where* {:type :bind, :aggregates aggregates})
                        where*)))
 
@@ -825,7 +825,7 @@
   [supplied-vars]
   (let [ks (keys supplied-vars)]
     (->> (vals supplied-vars)
-         (mapv #(if (sequential? %)                         ;; scalar values get turned into infite lazy seqs of value
+         (mapv #(if (sequential? %) ;; scalar values get turned into infite lazy seqs of value
                   %
                   (repeat %)))
          (apply interleave)
@@ -860,6 +860,7 @@
 ;; TODO - only capture :select, :where, :limit - need to get others
 (defn parse*
   [db {:keys [opts prettyPrint filter orderBy groupBy] :as query-map'} supplied-vars]
+  (log/debug "parse* query-map:" query-map' "\nsupplied-vars:" supplied-vars)
   (let [rel-binding?      (sequential? supplied-vars)
         supplied-var-keys (if rel-binding?
                             (-> supplied-vars first keys set)

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -25,6 +25,7 @@
 
 (defn relationship-binding
   [{:keys [rdf-type? vars] :as opts}]
+  (log/debug "relationship-binding opts:" opts)
   (async/go-loop [[next-vars & rest-vars] vars
                   acc []]
     (if next-vars
@@ -32,6 +33,7 @@
             res   (if rdf-type?
                     (<? (rdf-type-crawl opts'))
                     (<? (subj-crawl opts')))]
+        (log/debug "relationship-binding next-vars:" next-vars "\nres:" res)
         (recur rest-vars (into acc res)))
       acc)))
 
@@ -92,7 +94,9 @@
                      :query         parsed-query
                      :finish-fn     finish-fn}]
     (if rel-binding?
-      (relationship-binding opts)
+      (let [rel-binds (relationship-binding opts)]
+        (log/debug "rel bind vars:" rel-binds)
+        rel-binds)
       (if rdf-type?
         (rdf-type-crawl opts)
         (subj-crawl opts)))))

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -117,6 +117,7 @@
   (when (and (subject-crawl? parsed-query)
              (simple-subject-crawl? parsed-query)
              (not (:group-by parsed-query))
-             (not= :variable (some-> parsed-query :order-by :type)))
+             (not= :variable (some-> parsed-query :order-by :type))
+             (not (not-empty (:supplied-vars parsed-query))))
     ;; following will return nil if parts of where clause exclude it from being a simple-subject-crawl
     (simple-subject-merge-where parsed-query)))

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -88,8 +88,11 @@
                       (-> first-where :s :variable))]
     (when first-s
       (log/debug "simple-subject-merge-where first-s:" first-s)
+      (log/debug "simple-subject-merge-where rest-where:" rest-where)
       (if (empty? rest-where)
-        (assoc parsed-query :strategy :simple-subject-crawl)
+        (do
+          (log/debug "simple-subject-merge-where setting strategy to :simple-subject-crawl")
+          (assoc parsed-query :strategy :simple-subject-crawl))
         (if-let [subj-filter-map (merge-wheres-to-filter first-s rest-where supplied-vars)]
           (assoc parsed-query :where [first-where
                                       {:s-filter subj-filter-map}]

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -125,7 +125,7 @@
              (simple-subject-crawl? parsed-query)
              (not (:group-by parsed-query))
              (not= :variable (some-> parsed-query :order-by :type))
-             (not (not-empty (:supplied-vars parsed-query))))
+             (empty? (:supplied-vars parsed-query)))
     (log/debug "re-parse-as-simple-subj-crawl might be SSC if where clause passes muster")
     ;; following will return nil if parts of where clause exclude it from being a simple-subject-crawl
     (simple-subject-merge-where parsed-query)))

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -128,7 +128,7 @@
              (simple-subject-crawl? parsed-query)
              (not (:group-by parsed-query))
              (not= :variable (some-> parsed-query :order-by :type))
-             (empty? (:supplied-vars parsed-query)))
+             (empty? (:supplied-vars parsed-query))) ; TODO: Seems like this should work for SSC queries, but it didn't seem to. Needs more debugging & then delete this guard. - WSM 2022-07-11
     (log/debug "re-parse-as-simple-subj-crawl might be SSC if where clause passes muster")
     ;; following will return nil if parts of where clause exclude it from being a simple-subject-crawl
     (simple-subject-merge-where parsed-query)))


### PR DESCRIPTION
Fixes FC-1422. The actual fix code is in 9aa37c53c0e5817eef38f8da4a515d5d32ef47bb & 8419444756e0bc54f864d527de29a59874b399f8. The other commits are debug logging and formatting fixes.

I'm not sure if this is the right / best fix, as there does appear to be code to handle var binding in simple subject crawl queries. But it is not working (at least for the queries I'm trying it with) and I'm not sure why after watching all of the new debug logs I'm adding in here.

Here's a small example query that I can't make work w/ the simple-subject-crawl code:

```javascript
{
  where: [
    ["?t", "test/description", "?description"]
    ["?t", "test/count", "?count"],
    ["?t", "test/user", "?username"],
  ],
  select: { "?t": ["description", "count", "user"] },
  vars: {
    "?username": ["_user/username", "jake"],
  },
}
```

Before PRs #164 & #166 were merged that worked. But after it returns `status: 200` but an empty vector/array result with the below schema and data transacted:

Schema:

```javascript
[
  {
    _id: "_collection",
    name: "test",
  },
  {
    _id: "_predicate",
    name: "test/description",
    type: "string",
  },
  {
    _id: "_predicate",
    name: "test/count",
    type: "int",
  },
  {
    _id: "_predicate",
    name: "test/user",
    type: "ref",
    multi: false,
    restrictCollection: "_user",
  },
]
```

Data:

```javascript
[
  {
    _id: "_user$jake",
    "_user/username": "jake",
  },
  {
    _id: "test$first",
    "test/description": "first test",
    "test/count": 0,
    "test/user": "_user$jake",
  },
  {
    _id: "test$second",
    "test/description": "second test",
    "test/count": 1,
  },
  {
    _id: "test$third",
    "test/description": "third test",
    "test/count": 2,
  },
]
```