### PR TITLE
Fix/ssc var bind

### DIFF
--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -372,13 +372,13 @@
   There can be multiple vars in the filter function which can utilize the original query's 'vars' map,
   however there should be exactly one var in the filter fn that isn't in that map - which should be the
   var that will receive flake/o."
-  [params supplied-vars]
-  (let [non-assigned-vars (remove #(contains? supplied-vars %) params)]
+  [params all-vars]
+  (let [non-assigned-vars (remove #(contains? all-vars %) params)]
     (case (count non-assigned-vars)
       1 (first non-assigned-vars)
       0 (throw (ex-info (str "Query filter function has no variable assigned to it, all parameters "
                              "exist in the 'vars' map. Filter function params: " params ". "
-                             "Vars assigned in query: " (vec (keys supplied-vars)) ".")
+                             "Vars assigned in query: " all-vars ".")
                         {:status 400
                          :error  :db/invalid-query}))
       ;; else
@@ -390,13 +390,13 @@
 
 (defn parse-filter-fn
   "Evals, and returns query function."
-  [filter-fn supplied-vars]
+  [filter-fn all-vars]
   (let [filter-code (safe-read-fn filter-fn)
         fn-vars     (or (not-empty (get-vars filter-code))
                         (throw (ex-info (str "Filter function must contain a valid variable. Provided: " key)
                                         {:status 400 :error :db/invalid-query})))
         params      (vec fn-vars)
-        o-var       (get-object-var params supplied-vars)
+        o-var       (get-object-var params all-vars)
         [fun _] (filter/extract-filter-fn filter-code fn-vars)]
     {:variable o-var
      :params   params
@@ -405,14 +405,14 @@
 
 
 (defn add-filter
-  [{:keys [where] :as parsed-query} filter supplied-vars]
+  [{:keys [where] :as parsed-query} filter all-vars]
   (if-not (sequential? filter)
     (throw (ex-info (str "Filter clause must be a vector/array, provided: " filter)
                     {:status 400 :error :db/invalid-query}))
     (loop [[filter-fn & r] filter
            parsed-query* parsed-query]
       (if filter-fn
-        (let [parsed (parse-filter-fn filter-fn supplied-vars)]
+        (let [parsed (parse-filter-fn filter-fn all-vars)]
           (recur r (assoc parsed-query* :where (add-filter-where where parsed))))
         parsed-query*))))
 
@@ -546,6 +546,7 @@
 (defn parse-where-tuple
   "Parses where clause tuples (not maps)"
   [supplied-vars db s p o]
+  [all-vars db s p o]
   (let [fulltext? (str/starts-with? p "fullText:")
         rdf-type? (or (= "rdf:type" p)
                       (= "a" p))
@@ -623,7 +624,7 @@
 (defn parse-remote-tuple
   "When a specific DB is used (not default) for a where statement.
   This is in the form of a 4-tuple where clause."
-  [supplied-vars db s p o]
+  [all-vars db s p o]
   {:db   db
    :type :remote-tuple
    :s    s
@@ -631,7 +632,7 @@
    :o    o}
   ;; TODO - once we support multiple sources, below will attempt to resolve predicates into pids
   ;; TODO - for now, we just let them all through.
-  #_(-> (parse-where-tuple supplied-vars nil s p o)
+  #_(-> (parse-where-tuple all-vars nil s p o)
         (assoc :db db
                :type :remote-tuple
                :s s :p p :o o)))
@@ -643,38 +644,38 @@
     (throw (ex-info (str "Invalid where clause, must be a vector of tuples and/or maps: " where)
                     {:status 400 :error :db/invalid-query})))
   (loop [[where-smt & r] where
-         filters        []
-         hoisted-bind   {}                                  ;; bindings whose values are scalars are hoisted to the top level.
-         supplied-vars* supplied-vars
-         where*         []]
+         filters      []
+         hoisted-bind {}                                    ;; bindings whose values are scalars are hoisted to the top level.
+         all-vars     supplied-vars
+         where*       []]
     (if where-smt
       (cond
         (map? where-smt)
-        (let [{:keys [type] :as where-map} (parse-where-map db where* where-smt supplied-vars*)]
+        (let [{:keys [type] :as where-map} (parse-where-map db where* where-smt all-vars)]
           (case type
             :bind
             (let [{:keys [aggregates scalars]} where-map]
               (recur r
                      filters
                      (merge hoisted-bind scalars)
-                     (merge supplied-vars* aggregates scalars)
+                     (set (concat all-vars (keys aggregates) (keys scalars)))
                      (if (not-empty aggregates)             ;; if all scalar bindings, no need to add extra where statement
                        (conj where* {:type :bind, :aggregates aggregates})
                        where*)))
 
             :filter
-            (recur r (conj filters (:filter where-map)) hoisted-bind supplied-vars* where*)
+            (recur r (conj filters (:filter where-map)) hoisted-bind all-vars where*)
 
             ;; else
-            (recur r filters hoisted-bind supplied-vars* (conj where* where-map))))
+            (recur r filters hoisted-bind all-vars (conj where* where-map))))
 
         (sequential? where-smt)
         (let [tuple-count (count where-smt)
               where-smt*  (case tuple-count
-                            3 (apply parse-where-tuple supplied-vars* db where-smt)
+                            3 (apply parse-where-tuple all-vars db where-smt)
                             4 (if (= "$fdb" (first where-smt)) ;; $fdb refers to default/main db, parse as 3-tuple
-                                (apply parse-where-tuple supplied-vars* db (rest where-smt))
-                                (apply parse-remote-tuple supplied-vars* where-smt))
+                                (apply parse-where-tuple all-vars db (rest where-smt))
+                                (apply parse-remote-tuple all-vars where-smt))
                             2 (apply parse-binding-tuple where-smt)
                             ;; else
                             (if (sequential? (first where-smt))
@@ -686,7 +687,7 @@
           (recur r
                  filters
                  hoisted-bind
-                 supplied-vars*
+                 all-vars
                  (conj where* where-smt*)))
 
         :else
@@ -696,7 +697,7 @@
                             (reduce (fn [where' filter]
                                       (-> {:where where'}
                                           ;; add-filter allows calling on final parsed query, need to add/remove :where keys when inside :where parsing
-                                          (add-filter filter supplied-vars*)
+                                          (add-filter filter all-vars)
                                           :where))
                                     where* filters)
                             where*)]

--- a/src/fluree/db/query/subject_crawl/common.cljc
+++ b/src/fluree/db/query/subject_crawl/common.cljc
@@ -128,3 +128,26 @@
     (let [sorted (cond-> (sort-by (fn [result] (get result predicate)) results)
                          (= :desc order) reverse)]
       (vec (take limit sorted)))))
+
+(defn resolve-ident-vars
+  "When some variables may be idents (two-tuples) they need to get resolved into
+  subject _id values before executing query."
+  [db vars ident-vars]
+  (go-try
+    (loop [[ident-var & r] ident-vars
+           vars* vars]
+      (if ident-var
+        (let [v (get vars ident-var)]
+          (cond
+            (int? v)
+            (recur r vars*)
+
+            (util/pred-ident? v)
+            (recur r (assoc vars* ident-var (or (<? (dbproto/-subid db v)) 0)))
+
+            :else
+            (throw (ex-info (str "Invalid identity provided in variable: " ident-var
+                                 ". Must be a two-tuple identity, IRI, or integer id. "
+                                 "Provided: " v)
+                            {:status 400 :error :db/invalid-query}))))
+        vars*))))

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -66,7 +66,7 @@
   (c) filter subjects based on subsequent where clause(s)
   (d) apply offset/limit for (c)
   (e) send result into :select graph crawl"
-  [db {:keys [vars where limit offset fuel rel-binding? order-by] :as parsed-query}]
+  [db {:keys [vars ident-vars where limit offset fuel rel-binding? order-by] :as parsed-query}]
   (let [error-ch    (async/chan)
         f-where     (first where)
         rdf-type?   (= :rdf/type (:type f-where))
@@ -83,6 +83,7 @@
                      :select-spec   select-spec
                      :error-ch      error-ch
                      :vars          vars
+                     :ident-vars    ident-vars
                      :filter-map    filter-map
                      :limit         (if order-by util/max-long limit) ;; if ordering, limit performed by finish-fn after sort
                      :offset        offset


### PR DESCRIPTION
Fixes FC-1422 - using identity variable bindings in simple-subject-crawl queries.

@cap10morgan If you wouldn't mind adding the tests you made in the last PR into this one so we have future coverage that would be great.

Here's a small example query that did not work:
```
{
  where: [
    ["?t", "test/description", "?description"]
    ["?t", "test/count", "?count"],
    ["?t", "test/user", "?username"],
  ],
  select: { "?t": ["description", "count", "user"] },
  vars: {
    "?username": ["_user/username", "jake"],
  },
}
```
Before PRs #164 & #166 were merged that worked. But after it returns status: 200 but an empty vector/array result with the below schema and data transacted:
Schema:
```
[
  {
    _id: "_collection",
    name: "test",
  },
  {
    _id: "_predicate",
    name: "test/description",
    type: "string",
  },
  {
    _id: "_predicate",
    name: "test/count",
    type: "int",
  },
  {
    _id: "_predicate",
    name: "test/user",
    type: "ref",
    multi: false,
    restrictCollection: "_user",
  },
]
```
Data:
```
[
  {
    _id: "_user$jake",
    "_user/username": "jake",
  },
  {
    _id: "test$first",
    "test/description": "first test",
    "test/count": 0,
    "test/user": "_user$jake",
  },
  {
    _id: "test$second",
    "test/description": "second test",
    "test/count": 1,
  },
  {
    _id: "test$third",
    "test/description": "third test",
    "test/count": 2,
  },
]

```