### PR TITLE
Fix session/resolve-ledger & add some tests for it

### DIFF
--- a/test/fluree/db/session_test.cljc
+++ b/test/fluree/db/session_test.cljc
@@ -1,0 +1,12 @@
+(ns fluree.db.session-test
+  (:require #?@(:clj  [[clojure.test :refer :all]]
+                :cljs [[cljs.test :refer-macros [deftest is testing]]])
+            [fluree.db.session :refer [resolve-ledger]]))
+
+(deftest resolve-ledger-test
+  (testing "resolves a string ledger name"
+    (is (= ["net" "ledger"] (resolve-ledger "net/ledger"))))
+  (testing "resolves a namespaced keyword ledger name"
+    (is (= ["net" "ledger"] (resolve-ledger :net/ledger))))
+  (testing "resolves a vector of [network ledger-id]"
+    (is (= ["net" "ledger"] (resolve-ledger ["net" "ledger"])))))


### PR DESCRIPTION
I was looking into an error @jakep36 was seeing and noticed that `session/resolve-ledger` was returning something like `["network" "ledger" "ledger"]` when given a string arg like `"network/ledger"`.

So I fixed that and wrote some unit tests for it. I also added a single-arity option for `resolve-ledger` b/c it doesn't actually use the `conn` arg anywhere.

We're not really using the alias feature anymore, correct? I removed the logic for handling that, so let me know if that's not right.