### PR TITLE
Fix authenticated prefix queries

### DIFF
--- a/src/fluree/db/api/ledger.cljc
+++ b/src/fluree/db/api/ledger.cljc
@@ -88,6 +88,7 @@
           permissions (when roles'
                         (<? (permissions/permission-map db roles' :query)))]
       (assoc db :auth auth-sid
+                :auth-id auth
                 :roles roles'
                 :permissions permissions
                 :ctx ctx))))

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -382,7 +382,7 @@
           db            sources                             ;; only support 1 source currently
           db*           (if block (<? (time-travel/as-of-block (<? db) block)) (<? db))
           source-opts   (if prefixes
-                          (get-sources (:conn db*) (:network db*) (:auth db*) prefixes)
+                          (get-sources (:conn db*) (:network db*) (:auth-id db*) prefixes)
                           {})
           meta?         (:meta opts)
           fuel          (when (or (:fuel opts) meta?) (volatile! 0)) ;; only measure fuel if fuel budget provided, or :meta true


### PR DESCRIPTION
...by adding the original unresolved auth tuple to the db permissions under an :auth-id key. The pre-existing :auth key contains the resolved subject id (:_id) of the auth, which isn't appropriate for querying the other ledger(s) the prefix(es) are referencing.