### PR TITLE
FC-1429: Don't consider any flakes for a collection when no ecount set

### DIFF
--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -420,7 +420,11 @@
                     (let [partition (dbproto/-c-prop db :partition (last clause))
                           max-sid   (-> db :ecount (get partition))
                           min-sid   (flake/min-subject-id partition)
-                          flakes    (<? (query-range/index-range db :spot >= [max-sid] <= [min-sid]))
+                          flakes    (if-not max-sid
+                                      []
+                                      (<? (query-range/index-range db :spot
+                                                                   >= [max-sid]
+                                                                   <= [min-sid])))
                           xf        (comp (map (fn [^Flake f] [(.-s f)])) (distinct))]
                       {:headers [subject-var]
                        :tuples  (sequence xf flakes)

--- a/src/fluree/db/query/analytical.cljc
+++ b/src/fluree/db/query/analytical.cljc
@@ -420,11 +420,11 @@
                     (let [partition (dbproto/-c-prop db :partition (last clause))
                           max-sid   (-> db :ecount (get partition))
                           min-sid   (flake/min-subject-id partition)
-                          flakes    (if-not max-sid
-                                      []
+                          flakes    (if max-sid
                                       (<? (query-range/index-range db :spot
                                                                    >= [max-sid]
-                                                                   <= [min-sid])))
+                                                                   <= [min-sid]))
+                                      [])
                           xf        (comp (map (fn [^Flake f] [(.-s f)])) (distinct))]
                       {:headers [subject-var]
                        :tuples  (sequence xf flakes)


### PR DESCRIPTION
The max subject id used by the database for a particular collection is set on
the db in the `ecounts` map as flakes in that collection are added to the
ledger. There's no value set in the map for that collection before any flakes in
that collection have been added. This has the effect of making the collection
have no upper limit during query processing, and flakes in any collection that
comes after the one in question are considered for analytical queries.

This patch changes the query engine so it doesn't load any flakes from
collections that don't have an ecount set because the ecount not being set means
there aren't any flakes in that collection.