### PR TITLE
FC-1431: fix/unresolve nodes

### DIFF
--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -54,6 +54,12 @@
     (leaf? node)   (not (nil? (:flakes node)))
     (branch? node) (not (nil? (:children node)))))
 
+(defn unresolve
+  [node]
+  (cond
+    (leaf? node)   (dissoc node :flakes)
+    (branch? node) (dissoc node :children)))
+
 (defn lookup
   [branch flake]
   (when (and (branch? branch)

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -145,7 +145,8 @@
 
 (defn child-entry
   [{:keys [first] :as node}]
-  [first node])
+  (let [child-node (unresolve node)]
+    [first child-node]))
 
 (defn child-map
   "Returns avl sorted map whose keys are the first flakes of the index node

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -33,8 +33,8 @@
 
 (defprotocol Resolver
   (resolve [r node]
-    "Populate index branch and leaf node maps with either their child node
-     attributes or the flakes the store, respectively."))
+    "Populate the supplied index branch or leaf node maps with either the child
+     node attributes or the flakes they store, respectively."))
 
 (defn try-resolve
   [r error-ch node]
@@ -55,6 +55,8 @@
     (branch? node) (not (nil? (:children node)))))
 
 (defn unresolve
+  "Clear the populated child node attributes from the supplied `node` map if it
+  represents a branch, or the populated flakes if `node` represents a leaf."
   [node]
   (cond
     (leaf? node)   (dissoc node :flakes)


### PR DESCRIPTION
This patch adds an index api function to remove the cached `:flakes`/`:children` attributes from resolved nodes to save memory when we're finished processing these nodes. 