### PR TITLE
Fix orderBy var in optional part of where clause

### DIFF
--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -204,6 +204,7 @@
   "Returns true if provided variable exists as a variable
   somewhere within the where clause."
   [variable where]
+  (log/debug "variable-in-where? variable:" variable "where:" where)
   (some (fn [{:keys [s o optional bind union] :as _where-smt}]
           (or (= (:variable o) variable)
               (= (:variable s) variable)

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -767,7 +767,7 @@
   (let [{:keys [variable] :as parsed-order-by} (parse-order-by order-by)]
     (when (and variable (not (variable-in-where? variable where)))
       (throw (ex-info (str "Order by specifies a variable, " variable
-                           " that is used in a where statement.")
+                           " that is not used in a where statement.")
                       {:status 400 :error :db/invalid-query})))
     (assoc parsed-query :order-by parsed-order-by)))
 

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -208,7 +208,7 @@
           (or (= (:variable o) variable)
               (= (:variable s) variable)
               (cond
-                optional (map #(variable-in-where? variable %) optional)
+                optional (some #(variable-in-where? variable %) optional)
                 bind (contains? (-> bind keys set) variable)
                 union (or (variable-in-where? variable (first union))
                           (variable-in-where? variable (second union))))))

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -212,7 +212,8 @@
                 :optional (variable-in-where? variable (:where where-smt))
                 :binding (= (:variable where-smt) variable)
                 :union (or (variable-in-where? variable (first (:where where-smt)))
-                           (variable-in-where? variable (second (:where where-smt)))))))
+                           (variable-in-where? variable (second (:where where-smt))))
+                nil)))
         where))
 
 (defn parse-map

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -205,14 +205,14 @@
   somewhere within the where clause."
   [variable where]
   (log/debug "variable-in-where? variable:" variable "where:" where)
-  (some (fn [{:keys [s o type bind union] :as where-smt}]
+  (some (fn [{:keys [s o type] :as where-smt}]
           (or (= (:variable o) variable)
               (= (:variable s) variable)
               (cond
                 (= type :optional) (variable-in-where? variable (:where where-smt))
-                bind (contains? (-> bind keys set) variable)
-                union (or (variable-in-where? variable (first union))
-                          (variable-in-where? variable (second union))))))
+                (= type :binding) (= (:variable where-smt) variable)
+                (= type :union) (or (variable-in-where? variable (first (:where where-smt)))
+                          (variable-in-where? variable (second (:where where-smt)))))))
         where))
 
 (defn parse-map

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -208,11 +208,11 @@
   (some (fn [{:keys [s o type] :as where-smt}]
           (or (= (:variable o) variable)
               (= (:variable s) variable)
-              (cond
-                (= type :optional) (variable-in-where? variable (:where where-smt))
-                (= type :binding) (= (:variable where-smt) variable)
-                (= type :union) (or (variable-in-where? variable (first (:where where-smt)))
-                          (variable-in-where? variable (second (:where where-smt)))))))
+              (case type
+                :optional (variable-in-where? variable (:where where-smt))
+                :binding (= (:variable where-smt) variable)
+                :union (or (variable-in-where? variable (first (:where where-smt)))
+                           (variable-in-where? variable (second (:where where-smt)))))))
         where))
 
 (defn parse-map

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -209,7 +209,7 @@
           (or (= (:variable o) variable)
               (= (:variable s) variable)
               (cond
-                optional (some #(variable-in-where? variable %) optional)
+                optional (variable-in-where? variable optional)
                 bind (contains? (-> bind keys set) variable)
                 union (or (variable-in-where? variable (first union))
                           (variable-in-where? variable (second union))))))

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -205,11 +205,11 @@
   somewhere within the where clause."
   [variable where]
   (log/debug "variable-in-where? variable:" variable "where:" where)
-  (some (fn [{:keys [s o optional bind union] :as _where-smt}]
+  (some (fn [{:keys [s o type bind union] :as where-smt}]
           (or (= (:variable o) variable)
               (= (:variable s) variable)
               (cond
-                optional (variable-in-where? variable optional)
+                (= type :optional) (variable-in-where? variable (:where where-smt))
                 bind (contains? (-> bind keys set) variable)
                 union (or (variable-in-where? variable (first union))
                           (variable-in-where? variable (second union))))))


### PR DESCRIPTION
Fixes FC-1430

I _think_ the error message was missing a "not" it was intended to have all along. Using `map` for the recursive search of the `optional` clause would give a collection of bool-ish values instead of one, ~~so I changed that to `some` instead (like the outer logic uses).~~ And then we fixed several other issues.