### PR TITLE
Fix the case where parse* query-map has parse-json? instead of parseJSON

### DIFF
--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -904,6 +904,7 @@
 ;; TODO - only capture :select, :where, :limit - need to get others
 (defn parse*
   [db {:keys [opts prettyPrint filter orderBy groupBy] :as query-map'} supplied-vars]
+  (log/debug "parse* query-map':" query-map')
   (let [rel-binding?      (sequential? supplied-vars)
         supplied-var-keys (if rel-binding?
                             (-> supplied-vars first keys set)
@@ -913,7 +914,11 @@
         parsed            (cond-> {:strategy      :legacy
                                    :rel-binding?  rel-binding?
                                    :where         (parse-where db query-map' supplied-var-keys)
-                                   :opts          (-> opts (assoc :parse-json? (:parseJSON opts)) (dissoc :parseJSON))
+                                   :opts          (if (not (nil? (:parseJSON opts)))
+                                                    (-> opts
+                                                        (assoc :parse-json? (:parseJSON opts))
+                                                        (dissoc :parseJSON))
+                                                    opts)
                                    :limit         (get-limit query-map') ;; limit can be a primary key, or within :opts
                                    :offset        (get-offset query-map') ;; offset can be a primary key, or within :opts
                                    :fuel          (get-max-fuel query-map')

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -903,8 +903,8 @@
 
 ;; TODO - only capture :select, :where, :limit - need to get others
 (defn parse*
-  [db {:keys [opts prettyPrint filter orderBy groupBy] :as query-map'} supplied-vars]
-  (log/debug "parse* query-map':" query-map')
+  [db {:keys [opts prettyPrint filter orderBy groupBy] :as query-map} supplied-vars]
+  (log/debug "parse* query-map:" query-map)
   (let [rel-binding?      (sequential? supplied-vars)
         supplied-var-keys (if rel-binding?
                             (-> supplied-vars first keys set)
@@ -913,15 +913,15 @@
         groupBy*          (or groupBy (:groupBy opts))
         parsed            (cond-> {:strategy      :legacy
                                    :rel-binding?  rel-binding?
-                                   :where         (parse-where db query-map' supplied-var-keys)
+                                   :where         (parse-where db query-map supplied-var-keys)
                                    :opts          (if (not (nil? (:parseJSON opts)))
                                                     (-> opts
                                                         (assoc :parse-json? (:parseJSON opts))
                                                         (dissoc :parseJSON))
                                                     opts)
-                                   :limit         (get-limit query-map') ;; limit can be a primary key, or within :opts
-                                   :offset        (get-offset query-map') ;; offset can be a primary key, or within :opts
-                                   :fuel          (get-max-fuel query-map')
+                                   :limit         (get-limit query-map) ;; limit can be a primary key, or within :opts
+                                   :offset        (get-offset query-map) ;; offset can be a primary key, or within :opts
+                                   :fuel          (get-max-fuel query-map)
                                    :supplied-vars supplied-var-keys
                                    :pretty-print  (if (boolean? prettyPrint) ;; prettyPrint can be a primary key, or within :opts
                                                     prettyPrint
@@ -930,7 +930,7 @@
                                   orderBy* (add-order-by orderBy*) ;; add :order-by if specified
                                   groupBy* (add-group-by groupBy*) ;; add :group-by if specified
                                   true (consolidate-ident-vars) ;; add top-level :ident-vars consolidating all where clause's :ident-vars
-                                  true (add-select-spec query-map'))]
+                                  true (add-select-spec query-map))]
     (log/debug "parsed query:" parsed)
     (or (re-parse-as-simple-subj-crawl parsed)
         parsed)))


### PR DESCRIPTION
Sometimes the query-map coming into the `parse*` fn has a `:parseJSON` opt and sometimes it has `:parse-json?`. This handles both cases.

Would this issue go away if we just used `:parseJSON` internally too? Yes. Is not doing that a hill I'm willing to die on? Also yes. ;)