### PR TITLE
FC-1437: fix/query limit

### DIFF
--- a/src/fluree/db/query/fql_resp.cljc
+++ b/src/fluree/db/query/fql_resp.cljc
@@ -311,13 +311,13 @@
   "We only need to do this if there is an orderBy, otherwise limit and offset
   were performed in index-range."
   [sortPred sortOrder offset limit res]
-
   (if (vector? res)
     (cond->> res
-             sortPred (sort-by #(get % sortPred) compare-fn)
-             (= "DESC" sortOrder) (reverse)
-             offset (drop offset)
-             limit (take limit)) res))
+      sortPred             (sort-by #(get % sortPred) compare-fn)
+      (= "DESC" sortOrder) reverse
+      offset               (drop offset)
+      limit                (take limit))
+    res))
 
 
 (defn flakes->res

--- a/src/fluree/db/query/subject_crawl/common.cljc
+++ b/src/fluree/db/query/subject_crawl/common.cljc
@@ -124,13 +124,16 @@
   - :order - :asc or :desc
   - :predicate - if type = :predicate, contains predicate pid or name
   - :variable - if type = :variable, contains variable name (not supported for simple subject crawl)"
-  [results {:keys [type order predicate]} limit]
+  [results {:keys [type order predicate]} limit offset]
   (if (= :variable type)
     (throw (ex-info "Ordering by a variable not supported in this type of query."
                     {:status 400 :error :db/invalid-query}))
     (let [sorted (cond-> (sort-by (fn [result] (get result predicate)) results)
                          (= :desc order) reverse)]
-      (vec (take limit sorted)))))
+      (into []
+            (comp (drop offset)
+                  (take limit))
+            sorted))))
 
 (defn resolve-ident-vars
   "When some variables may be idents (two-tuples) they need to get resolved into
@@ -154,4 +157,3 @@
                                  "Provided: " v)
                             {:status 400 :error :db/invalid-query}))))
         vars*))))
-


### PR DESCRIPTION
Previously queries including `orderBy` clauses that were executed with the "simple subject crawl" strategy applied the offset before ordering but applied the limit after, causing them to be applied out of order. This patch applies both operations post ordering and ensures that the limit is applied _after_ the offset. 