### PR TITLE
Introduce tools.build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ALL_SOURCES := $(SOURCES) $(BROWSER_SOURCES) $(WEBWORKER_SOURCES) $(NODEJS_SOURC
 all: jar browser nodejs webworker js-packages docs
 
 target/fluree-db.jar: out node_modules src/deps.cljs $(ALL_SOURCES) $(RESOURCES)
-	clojure -X:jar
+	clojure -T:build jar
 
 jar: target/fluree-db.jar
 
@@ -44,7 +44,7 @@ src/deps.cljs: package.json
 	clojure -M:js-deps
 
 install: target/fluree-db.jar
-	clojure -M:install
+	clojure -T:build install
 
 deploy: target/fluree-db.jar
 	clojure -M:deploy
@@ -77,10 +77,10 @@ publish-webworker: js-packages/webworker/flureeworker.js
 publish-js: publish-nodejs publish-browser publish-webworker
 
 docs/fluree.db.api.html docs/index.html: src/fluree/db/api.clj
-	clojure -X:docs :output-path "\"$(@D)\""
+	clojure -T:build docs :output-path "\"$(@D)\""
 
 docs/%.html: docs/%.md
-	clojure -X:docs :output-path "\"$(@D)\""
+	clojure -T:build docs :output-path "\"$(@D)\""
 
 docs: docs/fluree.db.api.html docs/index.html $(DOCS_TARGETS)
 
@@ -108,8 +108,7 @@ eastwood:
 ci: test eastwood
 
 clean:
-	rm -rf target
+	clojure -T:build clean
 	rm -rf out/*
 	rm -rf docs/*.html
 	rm -rf node_modules
-	rm -f pom.xml

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,44 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]))
+
+(def lib 'com.fluree/db)
+(def version "2.0.0-beta2")
+
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file "target/fluree-db.jar")
+
+(def source-uri "https://github.com/fluree/db")
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib       lib
+                :version   version
+                :basis     basis
+                :src-dirs  ["src"]
+                :scm       {:url                 source-uri
+                            :connection          "scm:git:https://github.com/fluree/db.git"
+                            :developerConnection "scm:git:git@github.com:fluree/db.git"}})
+  (b/copy-dir {:src-dirs    ["src" "resources"]
+               :target-dir  class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file  jar-file}))
+
+(defn install [_]
+  (b/install {:basis     basis
+              :lib       lib
+              :version   version
+              :jar-file  jar-file
+              :class-dir class-dir}))
+
+(defn docs [{:keys [output-path]}]
+  ;; Seems like there should be a better way to do this, but I couldn't figure
+  ;; one out. If you try to run codox directly from here it can't find any of
+  ;; the project namespaces. Seems like codox would need a way to pass a basis
+  ;; into it. But this at least lets us inject the version set in here.
+  (let [opts (cond-> {:version version}
+                     output-path (assoc :output-path output-path))]
+    (b/process {:command-args ["clojure" "-X:docs" (pr-str opts)]})))

--- a/deps.edn
+++ b/deps.edn
@@ -41,9 +41,9 @@
  :paths ["src" "resources"]
 
  :aliases
- {:mvn/group-id    com.fluree
-  :mvn/artifact-id db
-  :mvn/version     "2.0.0-beta1" ; Change this down in the docs alias too!
+ {:build
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}}
+   :ns-default build}
 
   :dev
   {:extra-paths ["dev" "test" "src-cljs" "src-nodejs" "src-docs"]
@@ -86,29 +86,12 @@
   {:extra-paths ["src-cljs"]
    :main-opts   ["-m" "cljs.main" "--compile-opts" "build-webworker.edn" "--compile"]}
 
-  :jar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn      hf.depstar/jar
-   :exec-args    {:jar         "target/fluree-db.jar"
-                  :group-id    :mvn/group-id
-                  :artifact-id :mvn/artifact-id
-                  :version     :mvn/version
-                  :sync-pom    true}}
-
-  :install
-  {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
-   :main-opts    ["-m" "deps-deploy.deps-deploy" "install"
-                  "target/fluree-db.jar"]}
-
   :docs
   {:extra-deps {codox/codox {:mvn/version "0.10.8"}}
    :exec-fn    codox.main/generate-docs
    :exec-args  {:namespaces  [fluree.db.api]
                 :description "Fluree DB Clojure API Documentation"
                 :name        com.fluree/db
-                ;; TODO: Eliminate this copy of the version string
-                ;; I think that tools.build might be the best way to do that
-                :version     "2.0.0-beta1"
                 :output-path "docs"}}
 
   :deploy


### PR DESCRIPTION
Eliminates redundant version string in deps.edn and allows us to set some additional params in the generated pom.xml in the JAR file (like the `scm` params; FC-1213).

I don't _think_ this steps on the shadow-cljs.edn conversion in the `feature/jld` branch, but let me know if you'd like to merge that before this (or even target that branch with this change).