### PR TITLE
Updates index-range to support datatype as part of range call

### DIFF
--- a/src/fluree/db/dbproto.cljc
+++ b/src/fluree/db/dbproto.cljc
@@ -8,6 +8,7 @@
   (-c-prop [db property collection] "Returns schema property for a collection.")
   (-p-prop [db property predicate] "Returns the property specified for the given predicate.")
   (-class-prop [db property class] "Return class properties")
+  (-expand-iri [db iri] [db iri context])
   ;; following return async chans
   (-tag [db tag-id] [db tag-id pred] "Returns resolved tag, shortens namespace if pred provided.")
   (-tag-id [db tag-name] [db tag-name pred] "Returns the tag sid. If pred provided will namespace tag if not already.")

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -92,13 +92,11 @@
   [db test parts]
   (go-try
     (let [[s p o t op m] parts
-          s'       (<? (resolve-subid db s))
-          o-ident? (util/pred-ident? o)
-          o'       (if o-ident?
-                     (<? (dbproto/-subid db o))
-                     o)
-          m'       (or m (if (identical? >= test) util/min-integer util/max-integer))
-          dt       (when o-ident? const/$xsd:anyURI)]
+          s' (<? (resolve-subid db s))
+          [o' dt] (if (vector? o)
+                    [(first o) (second o)]
+                    [o nil])
+          m' (or m (if (identical? >= test) util/min-integer util/max-integer))]
       (flake/create s' p o' dt t op m'))))
 
 (defn resolved-leaf?

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -1,0 +1,95 @@
+(ns fluree.db.query.index-range-test
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer :all]
+    [fluree.db.test-fixtures :as test]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.util.log :as log]
+    [fluree.db.flake :as flake]))
+
+
+(use-fixtures :once test/test-system)
+
+(deftest index-range-scans
+  (testing "Various index range scans using the API."
+    (let [conn    test/memory-conn
+          ledger  @(fluree/create conn "query/index-range"
+                                  {:context {:ex "http://example.org/ns/"}})
+          db      @(fluree/stage
+                     ledger
+                     [{:id           :ex/brian,
+                       :type         :ex/User,
+                       :schema/name  "Brian"
+                       :schema/email "brian@example.org"
+                       :schema/age   50
+                       :ex/favNums   7}
+                      {:id           :ex/alice,
+                       :type         :ex/User,
+                       :schema/name  "Alice"
+                       :schema/email "alice@example.org"
+                       :schema/age   50
+                       :ex/favNums   [42, 76, 9]}
+                      {:id           :ex/cam,
+                       :type         :ex/User,
+                       :schema/name  "Cam"
+                       :schema/email "cam@example.org"
+                       :schema/age   34
+                       :ex/favNums   [5, 10]
+                       :ex/friend    [:ex/brian :ex/alice]}])
+          cam-sid @(fluree/internal-id db :ex/cam)]
+
+      (is (= "http://example.org/ns/cam"
+             (fluree/expand-iri db :ex/cam))
+          "Expanding compact IRI is broken, likely other tests will fail.")
+
+      (is (int? cam-sid)
+          "The compact IRI did not resolve to an integer subject id.")
+
+      (testing "Slice operations"
+        (testing "Slice for subject id only"
+          (let [alice-sid @(fluree/internal-id db :ex/alice)]
+            (is (= (->> @(fluree/slice db :spot [alice-sid])
+                        (mapv flake/Flake->parts))
+                   [[alice-sid 0 "http://example.org/ns/alice" 1 -1 true nil]
+                    [alice-sid 200 1014 0 -1 true nil]
+                    [alice-sid 1015 "Alice" 1 -1 true nil]
+                    [alice-sid 1016 "alice@example.org" 1 -1 true nil]
+                    [alice-sid 1017 50 7 -1 true nil]
+                    [alice-sid 1018 9 7 -1 true nil]
+                    [alice-sid 1018 42 7 -1 true nil]
+                    [alice-sid 1018 76 7 -1 true nil]])
+                "Slice should return a vector of flakes for only Alice")))
+
+        (testing "Slice for subject + predicate"
+          (let [alice-sid   @(fluree/internal-id db :ex/alice)
+                favNums-pid @(fluree/internal-id db :ex/favNums)]
+            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid])
+                        (mapv flake/Flake->parts))
+                   [[alice-sid favNums-pid 9 7 -1 true nil]
+                    [alice-sid favNums-pid 42 7 -1 true nil]
+                    [alice-sid favNums-pid 76 7 -1 true nil]])
+                "Slice should only return Alice's favNums (multi-cardinality)")))
+
+        (testing "Slice for subject + predicate + value"
+          (let [alice-sid   @(fluree/internal-id db :ex/alice)
+                favNums-pid @(fluree/internal-id db :ex/favNums)]
+            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid 42])
+                        (mapv flake/Flake->parts))
+                   [[alice-sid favNums-pid 42 7 -1 true nil]])
+                "Slice should only return the specified favNum value")))
+
+        (testing "Slice for subject + predicate + value + datatype"
+          (let [alice-sid   @(fluree/internal-id db :ex/alice)
+                favNums-pid @(fluree/internal-id db :ex/favNums)]
+            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 7]])
+                        (mapv flake/Flake->parts))
+                   [[alice-sid favNums-pid 42 7 -1 true nil]])
+                "Slice should only return the specified favNum value with matching datatype")))
+
+        (testing "Slice for subject + predicate + value + mismatch datatype"
+          (let [alice-sid   @(fluree/internal-id db :ex/alice)
+                favNums-pid @(fluree/internal-id db :ex/favNums)]
+            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 8]])
+                        (mapv flake/Flake->parts))
+                   [])
+                "We specify a different datatype for the value, nothing should be returned")))))))


### PR DESCRIPTION
Index-range now supports including datatype as part of the match criteria, if needed.

e.g. `(index-range db :spot = [s p o])` still works the way it always did, but now if you want to ensure exact datatype matches you can do: `(index-range db :spot = [s p [o-value o-datatype]])`

With multiple data types, you could have two strings that look equivalent but are not... eg.:
```
{@value: "2022",
 @type: "xsd:gYear"}
```
and
```
{@value: "2022",
 @type: "xsd:string"}
```
This new feature allows one or the other to be specified if needed. If datatype is not important, just specifying `(index-range db :spot = [s p "2022"])` would still work and return both values. To only get the string datatype value above, you'd instead do: `(index-range db :spot = [s p ["2022" const/$xsd:string]])`

This PR also adds some new APIs to allow directly interacting with the indexes, and also adds some basic tests for index-range.

