### PR TITLE
Feature/deletes #215

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -373,12 +373,8 @@
   Returns core async channel containing result."
   [sources flureeQL]
   (go-try
-    (let [{:keys [select selectOne selectDistinct selectReduced from where construct block prefixes opts t]} flureeQL
-          _             (when-not (->> [select selectOne selectDistinct selectReduced]
-                                       (remove nil?) count (#(= 1 %)))
-                          (throw (ex-info (str "Only one type of select-key (select, selectOne, selectDistinct, selectReduced) allowed. Provided: " (pr-str flureeQL))
-                                          {:status 400
-                                           :error  :db/invalid-query})))
+    (let [{:keys [select selectOne selectDistinct selectReduced construct
+                  from where block prefixes opts t]} flureeQL
           db            (if (async-util/channel? sources)   ;; only support 1 source currently
                           (<? sources)
                           sources)
@@ -394,7 +390,8 @@
           opts*         (assoc opts :sources source-opts
                                     :max-fuel (or (:fuel opts) 1000000)
                                     :fuel fuel)
-          _             (when-not (and (or select selectOne selectDistinct selectReduced construct) (or from where))
+          _             (when-not (and (or select selectOne selectDistinct selectReduced construct)
+                                       (or from where))
                           (throw (ex-info (str "Invalid query.")
                                           {:status 400
                                            :error  :db/invalid-query})))

--- a/src/fluree/db/query/subject_crawl/legacy.cljc
+++ b/src/fluree/db/query/subject_crawl/legacy.cljc
@@ -112,9 +112,7 @@
                          selectOne :selectOne
                          selectDistinct :selectDistinct)
         select-smt (or select selectOne selectDistinct)
-        json-ld?   (= :json-ld (dbproto/-db-type db))
-        multi-subj (when (and (sequential? from)
-                              (or json-ld? (every? util/subj-ident? from)))
+        multi-subj (when (sequential? from)
                      from)
         vars*      (if multi-subj
                      (assoc vars "?__subj" from)
@@ -125,17 +123,14 @@
                      [["?s" "_id" "?__subj"]]
 
                      (string? where)
-                     (if json-ld?
-                       (throw (ex-info "String where queries not allowed for json-ld databases."
-                                       {:status 400 :error :db/invalid-query}))
-                       (cond->> (into-where where)
-                                from (into [["?s" "rdf:type" from]])))
+                     (throw (ex-info "String where queries not allowed for json-ld databases."
+                                     {:status 400 :error :db/invalid-query}))
 
                      ; Single subject - subject _id
                      (number? from)
                      [["?s" "_id" from]]
 
-                     (and json-ld? (or (string? from) (keyword? from)))
+                     (or (string? from) (keyword? from))
                      [["?s" "@id" from]]
 
                      ;; Legacy predicate-based query

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -114,10 +114,11 @@
   e.g.
   {:select {?subjects ['*']
    :where [...]}"
-  [parsed-query]
-  (when (and (subject-crawl? parsed-query)
+  [{:keys [op-type order-by group-by] :as parsed-query}]
+  (when (and (= :select op-type)
+             (subject-crawl? parsed-query)
              (simple-subject-crawl? parsed-query)
-             (not (:group-by parsed-query))
-             (not= :variable (some-> parsed-query :order-by :type)))
+             (not group-by)
+             (not= :variable (:type order-by)))
     ;; following will return nil if parts of where clause exclude it from being a simple-subject-crawl
     (simple-subject-merge-where parsed-query)))

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -12,18 +12,20 @@
           ledger           @(fluree/create conn "tx/delete" {:context {:ex "http://example.org/ns/"}})
           db               @(fluree/stage
                               ledger
-                              {:graph [{:id          :ex/alice,
-                                        :type        :ex/User,
-                                        :schema/name "Alice"
-                                        :schema/age  42}
+                              {:graph [{:id           :ex/alice,
+                                        :type         :ex/User,
+                                        :schema/name  "Alice"
+                                        :schema/email "alice@flur.ee"
+                                        :schema/age   42}
                                        {:id          :ex/bob,
                                         :type        :ex/User,
                                         :schema/name "Bob"
                                         :schema/age  22}
-                                       {:id          :ex/jane,
-                                        :type        :ex/User,
-                                        :schema/name "Jane"
-                                        :schema/age  30}]})
+                                       {:id           :ex/jane,
+                                        :type         :ex/User,
+                                        :schema/name  "Jane"
+                                        :schema/email "jane@flur.ee"
+                                        :schema/age   30}]})
 
           ;; delete everything for :ex/alice
           db-subj-delete   @(fluree/stage db
@@ -34,6 +36,12 @@
           db-subj-pred-del @(fluree/stage db
                                           {:delete [:ex/bob :schema/age '?o]
                                            :where  [[:ex/bob :schema/age '?o]]})
+
+          ;; delete all subjects with a :schema/email predicate
+          db-all-preds     @(fluree/stage db
+                                          {:delete ['?s '?p '?o]
+                                           :where  [['?s :schema/email '?x]
+                                                    ['?s '?p '?o]]})
 
           ;; delete all subjects where :schema/age = 30
           db-age-delete    @(fluree/stage db
@@ -54,6 +62,12 @@
               :rdf/type    [:ex/User],
               :schema/name "Bob"})
           "Only Jane and Cam should be left in the db.")
+
+      (is (= @(fluree/query db-all-preds
+                            {:select '?name
+                             :where  [['?s :schema/name '?name]]})
+             ["Bob"])
+          "Only Bob doesn't have an email.")
 
       (is (= @(fluree/query db-age-delete
                             {:select '?name

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -1,0 +1,62 @@
+(ns fluree.db.transact.delete-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.test-fixtures :as test]
+            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.util.log :as log]))
+
+(use-fixtures :once test/test-system)
+
+(deftest deleting-data
+  (testing "Deletions of entire subjects."
+    (let [conn             test/memory-conn
+          ledger           @(fluree/create conn "tx/delete" {:context {:ex "http://example.org/ns/"}})
+          db               @(fluree/stage
+                              ledger
+                              {:graph [{:id          :ex/alice,
+                                        :type        :ex/User,
+                                        :schema/name "Alice"
+                                        :schema/age  42}
+                                       {:id          :ex/bob,
+                                        :type        :ex/User,
+                                        :schema/name "Bob"
+                                        :schema/age  22}
+                                       {:id          :ex/jane,
+                                        :type        :ex/User,
+                                        :schema/name "Jane"
+                                        :schema/age  30}]})
+
+          ;; delete everything for :ex/alice
+          db-subj-delete   @(fluree/stage db
+                                          {:delete [:ex/alice '?p '?o]
+                                           :where  [[:ex/alice '?p '?o]]})
+
+          ;; delete any :schema/age values for :ex/bob
+          db-subj-pred-del @(fluree/stage db
+                                          {:delete [:ex/bob :schema/age '?o]
+                                           :where  [[:ex/bob :schema/age '?o]]})
+
+          ;; delete all subjects where :schema/age = 30
+          db-age-delete    @(fluree/stage db
+                                          {:delete ['?s '?p '?o]
+                                           :where  [['?s :schema/age 30]
+                                                    ['?s '?p '?o]]})]
+
+      (is (= @(fluree/query db-subj-delete
+                            {:select '?name
+                             :where  [['?s :schema/name '?name]]})
+             ["Jane" "Bob"])
+          "Only Jane and Cam should be left in the db.")
+
+      (is (= @(fluree/query db-subj-pred-del
+                            {:selectOne [:*]
+                             :from      :ex/bob})
+             {:id          :ex/bob,
+              :rdf/type    [:ex/User],
+              :schema/name "Bob"})
+          "Only Jane and Cam should be left in the db.")
+
+      (is (= @(fluree/query db-age-delete
+                            {:select '?name
+                             :where  [['?s :schema/name '?name]]})
+             ["Bob" "Alice"])
+          "Only Bob and Alice should be left in the db."))))


### PR DESCRIPTION
This addresses #215 and adds a deletion capability to Fluree which can leverage a query :where clause to define exact data to remove. This is a substantial increase in capability to current Fluree's delete capability which always requires one to know the subject being removed, and anything more complex than simple deletes can require `compare and swap` operations.

You can now issue the following as examples (see new tests for full detail)

Delete everything for a subject:
```
@(fluree/stage db
{:delete [:ex/alice '?p '?o]
 :where  [[:ex/alice '?p '?o]]})
```

Delete all values for a subject+predicate:
```
{:delete [:ex/bob :schema/age '?o]
 :where  [[:ex/bob :schema/age '?o]]}
```

_**What's completely new however is that you can target other information based on predicates + values:**_

Delete all subjects that have an email address:
```
{:delete ['?s '?p '?o]
 :where  [['?s :schema/email '?x]
          ['?s '?p '?o]]}
```

Delete all subjects who are 30 years old:
```
{:delete ['?s '?p '?o]
 :where  [['?s :schema/age 30]
          ['?s '?p '?o]]}
```

