### PR TITLE
#240 Allows @context @reverse declarations in queries to return prope…

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
          cheshire/cheshire               {:mvn/version "5.11.0"}
          instaparse/instaparse           {:mvn/version "1.4.12"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :sha "c22e943a9c4618379759eb9e2ca0cd384e1a1882"}
+                                          :sha "0614a222e0197ca654449ac3b1a1125608d3ec7b"}
 
 
          ;; logging

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -214,7 +214,7 @@
 
 (defn novelty-subrange
   [{:keys [rhs leftmost?], first-flake :first, :as node} through-t novelty]
-  (log/debug "novelty-subrange: first-flake:" first-flake "\nrhs:" rhs "\nleftmost?" leftmost?)
+  (log/trace "novelty-subrange: first-flake:" first-flake "\nrhs:" rhs "\nleftmost?" leftmost?)
   (let [subrange (cond
                    ;; standard case: both left and right boundaries
                    (and rhs (not leftmost?))

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -1172,7 +1172,7 @@
 (defn parse*
   [db {:keys [opts prettyPrint filter context depth
               orderBy order-by groupBy group-by] :as query-map} supplied-vars]
-  (log/debug "parse* query-map:" query-map)
+  (log/trace "parse* query-map:" query-map)
   (let [op-type           (cond
                             (some #{:select :selectOne :selectReduced :selectDistince} (keys query-map))
                             :select

--- a/src/fluree/db/query/json_ld/select.cljc
+++ b/src/fluree/db/query/json_ld/select.cljc
@@ -72,19 +72,26 @@
               pid    (:id spec)
               depth* (if (zero? depth)
                        0
-                       (dec depth))]
-          (assoc acc pid (-> spec
-                             (assoc :spec (expand-selection db context depth* v)
-                                    :as k))))
+                       (dec depth))
+              reverse? (boolean (get-in context [k :reverse]))
+              spec* (-> spec
+                        (assoc :spec (expand-selection db context depth* v)
+                               :as k))]
+          (if reverse?
+            (assoc-in acc [:reverse pid] spec*)
+            (assoc acc pid spec*)))
 
         (#{"*" :* '*} select-item)
         (assoc acc :wildcard? true)
 
         :else
-        (let [iri  (json-ld/expand-iri select-item context)
-              spec (get-in schema [:pred iri])
-              pid  (:id spec)]
-          (assoc acc pid (assoc spec :as select-item)))))
+        (let [iri      (json-ld/expand-iri select-item context)
+              spec     (get-in schema [:pred iri])
+              pid      (:id spec)
+              reverse? (boolean (get-in context [select-item :reverse]))]
+          (if reverse?
+            (assoc-in acc [:reverse pid] (assoc spec :as select-item))
+            (assoc acc pid (assoc spec :as select-item))))))
     {:depth depth} selection))
 
 

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -66,7 +66,7 @@
   (e) send result into :select graph crawl"
   [db {:keys [vars ident-vars where limit offset fuel rel-binding? order-by
               compact-fn opts] :as parsed-query}]
-  (log/debug "Running simple subject crawl query:" parsed-query)
+  (log/trace "Running simple subject crawl query:" parsed-query)
   (let [error-ch    (async/chan)
         f-where     (first where)
         rdf-type?   (= :rdf/type (:type f-where))
@@ -97,7 +97,7 @@
                      :query         parsed-query
                      :result-fn     result-fn
                      :finish-fn     finish-fn}]
-    (log/debug "simple-subject-crawl opts:" opts)
+    (log/trace "simple-subject-crawl opts:" opts)
     (if rel-binding?
       (relationship-binding opts)
       (if collection?

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -94,7 +94,7 @@
   "For queries that specify _id as the predicate, we will have a
   single subject as a value."
   [db error-ch vars {:keys [o] :as f-where}]
-  (log/debug "subjects-id-chan f-where:" f-where)
+  (log/trace "subjects-id-chan f-where:" f-where)
   (let [return-ch (async/chan)
         _id-val   (or (:value o)
                       (get vars (:variable o)))]
@@ -141,7 +141,7 @@
   [{:keys [db error-ch f-where limit offset parallelism vars ident-vars
            finish-fn] :as opts}]
   (go-try
-    (log/debug "subj-crawl opts:" opts)
+    (log/trace "subj-crawl opts:" opts)
     (let [{:keys [o p-ref?]} f-where
           vars*     (if ident-vars
                       (<? (resolve-ident-vars db vars ident-vars))

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -9,25 +9,19 @@
 (deftest ^:integration context-reverse-test
   (testing "Test that the @reverse context values pulls select values back correctly."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/revers" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "query/reverse" {:context {:ex "http://example.org/ns/"}})
           db     @(fluree/stage
                     ledger
                     [{:id           :ex/brian,
                       :type         :ex/User,
                       :schema/name  "Brian"
-                      :ex/last      "Smith"
-                      :schema/email "brian@example.org"
                       :ex/friend    [:ex/alice]}
                      {:id           :ex/alice,
                       :type         :ex/User,
-                      :schema/name  "Alice"
-                      :ex/last      "Smith"
-                      :schema/email "alice@example.org"}
+                      :schema/name  "Alice"}
                      {:id           :ex/cam,
                       :type         :ex/User,
                       :schema/name  "Cam"
-                      :ex/last      "Jones"
-                      :schema/email "cam@example.org"
                       :ex/friend    [:ex/brian :ex/alice]}])]
 
       (is (= @(fluree/query db {:context   {:friended {:reverse :ex/friend}}

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -1,0 +1,55 @@
+(ns fluree.db.query.reverse-query-test
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer :all]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.util.log :as log]))
+
+(deftest ^:integration context-reverse-test
+  (testing "Test that the @reverse context values pulls select values back correctly."
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "query/revers" {:context {:ex "http://example.org/ns/"}})
+          db     @(fluree/stage
+                    ledger
+                    [{:id           :ex/brian,
+                      :type         :ex/User,
+                      :schema/name  "Brian"
+                      :ex/last      "Smith"
+                      :schema/email "brian@example.org"
+                      :ex/friend    [:ex/alice]}
+                     {:id           :ex/alice,
+                      :type         :ex/User,
+                      :schema/name  "Alice"
+                      :ex/last      "Smith"
+                      :schema/email "alice@example.org"}
+                     {:id           :ex/cam,
+                      :type         :ex/User,
+                      :schema/name  "Cam"
+                      :ex/last      "Jones"
+                      :schema/email "cam@example.org"
+                      :ex/friend    [:ex/brian :ex/alice]}])]
+
+      (is (= @(fluree/query db {:context   {:friended {:reverse :ex/friend}}
+                                :selectOne [:schema/name :friended]
+                                :from      :ex/brian})
+             {:schema/name "Brian"
+              :friended    :ex/cam}))
+
+      (is (= @(fluree/query db {:context   {:friended {:reverse :ex/friend}}
+                                :selectOne [:schema/name :friended]
+                                :from      :ex/alice})
+             {:schema/name "Alice"
+              :friended    [:ex/cam :ex/brian]}))
+
+
+      (is (= @(fluree/query db {:context   {:friended {:reverse :ex/friend}}
+                                :selectOne [:schema/name {:friended [:*]}]
+                                :from      :ex/brian})
+             {:schema/name "Brian",
+              :friended    {:id           :ex/cam,
+                            :rdf/type     [:ex/User],
+                            :schema/name  "Cam",
+                            :ex/last      "Jones",
+                            :schema/email "cam@example.org",
+                            :ex/friend    [{:id :ex/brian} {:id :ex/alice}]}})))))

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -44,6 +44,4 @@
               :friended    {:id           :ex/cam,
                             :rdf/type     [:ex/User],
                             :schema/name  "Cam",
-                            :ex/last      "Jones",
-                            :schema/email "cam@example.org",
                             :ex/friend    [{:id :ex/brian} {:id :ex/alice}]}})))))


### PR DESCRIPTION
This addresses issue #240 and allows @reverse context values to return results in query graph crawls.

In this example, the context is aliasing the name `:friended` as the reverse of :ex/friend. This allows the graph to be crawled in reverse, and the context can be used to name the "reversed" variable anything they choose in the output.

```
 @(fluree/query db 
    {:context   {:friended {:reverse :ex/friend}}
     :selectOne [:schema/name :friended]
     :from      :ex/alice})
```
If you look at the source graph data:
```
[{:id :ex/brian,
  :type         :ex/User,
  :schema/name  "Brian"
  :ex/friend    [:ex/alice]}
 {:id           :ex/alice,
  :type         :ex/User,
  :schema/name  "Alice"}
 {:id           :ex/cam,
  :type         :ex/User,
  :schema/name  "Cam"
  :ex/friend    [:ex/brian :ex/alice]}]
```
 You'll see the results of the above query should be:
```
{:schema/name "Alice"
 :friended    [:ex/cam :ex/brian]}
```

Subsequent graph crawls are also supported, this query:
```
{:context   {:friended {:reverse :ex/friend}}
  :selectOne [:schema/name {:friended [:*]}]
  :from      :ex/brian}
```
will output:
```
{:schema/name "Brian",
 :friended    {:id           :ex/cam,
               :rdf/type     [:ex/User],
               :schema/name  "Cam",
               :ex/friend    [{:id :ex/brian} {:id :ex/alice}]}}
```
