### PR TITLE
#248 Add initial support for 'optional' queries (single statement only)

### DIFF
--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -1,0 +1,86 @@
+(ns fluree.db.query.optional-query-test
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer :all]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.util.log :as log]))
+
+(deftest ^:integration optional-queries
+  (testing "Testing various 'optional' query clauses."
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "query/optional" {:context {:ex "http://example.org/ns/"}})
+          db     @(fluree/stage
+                    ledger
+                    [{:id          :ex/brian,
+                      :type        :ex/User,
+                      :schema/name "Brian"
+                      :ex/friend   [:ex/alice]}
+                     {:id          :ex/alice,
+                      :type        :ex/User,
+                      :ex/favColor "Green"
+                      :schema/email "alice@flur.ee"
+                      :schema/name "Alice"}
+                     {:id          :ex/cam,
+                      :type        :ex/User,
+                      :schema/name "Cam"
+                      :schema/email "cam@flur.ee"
+                      :ex/friend   [:ex/brian :ex/alice]}])]
+
+      ;; basic single optional statement
+      (is (= @(fluree/query db {:select ['?name '?favColor]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/name '?name]
+                                         {:optional ['?s :ex/favColor '?favColor]}]})
+             [["Cam" nil]
+              ["Alice" "Green"]
+              ["Brian" nil]])
+          "Cam, Alice and Brian should all return, but only Alica has a favColor")
+
+      ;; including another pass-through variable - note Brian doesn't have an email
+      (is (= @(fluree/query db {:select ['?name '?favColor '?email]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/name '?name]
+                                         ['?s :schema/email '?email]
+                                         {:optional ['?s :ex/favColor '?favColor]}]})
+             [["Cam" nil "cam@flur.ee"]
+              ["Alice" "Green" "alice@flur.ee"]]))
+
+      ;; including another pass-through variable, but with 'optional' sandwiched
+      (is (= @(fluree/query db {:select ['?name '?favColor '?email]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/name '?name]
+                                         {:optional ['?s :ex/favColor '?favColor]}
+                                         ['?s :schema/email '?email]]})
+             [["Cam" nil "cam@flur.ee"]
+              ["Alice" "Green" "alice@flur.ee"]]))
+
+      ;; query with two optionals!
+      (is (= @(fluree/query db {:select ['?name '?favColor '?email]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/name '?name]
+                                         {:optional ['?s :ex/favColor '?favColor]}
+                                         {:optional ['?s :schema/email '?email]}]})
+             [["Cam" nil "cam@flur.ee"]
+              ["Alice" "Green" "alice@flur.ee"]
+              ["Brian" nil nil]]))
+
+      ;; optional with unnecessary embedded vector statement
+      (is (= @(fluree/query db {:select ['?name '?favColor]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/name '?name]
+                                         {:optional [['?s :ex/favColor '?favColor]]}]})
+             [["Cam" nil]
+              ["Alice" "Green"]
+              ["Brian" nil]])
+          "Cam, Alice and Brian should all return, but only Alica has a favColor")
+
+      ;; Multiple optional clauses should work as a left outer join between them
+      ;; TODO - not yet supported!!
+      (is (= (ex-message
+               @(fluree/query db {:select ['?name '?favColor '?email]
+                                  :where  [['?s :rdf/type :ex/User]
+                                           ['?s :schema/name '?name]
+                                           {:optional [['?s :ex/favColor '?favColor]
+                                                       ['?s :schema/email '?email]]}]}))
+             "Multi-statement optional clauses not yet supported!")))))


### PR DESCRIPTION
This adds back support for `optional` statements in queries.

See new optional query test namespace for examples.

Note that multi-statement optional queries are not yet supported (throws a 'not implemented yet' exception). See issue #251 

In the prior version of Fluree, optional statements were always wrapped inside a vector, even if just one statement. In this version single optional statements can just be declared (but can still be wrapped inside of a vector if desired). So the following two statements are equivalent:

```
{:select ['?name '?favColor]
 :where  [['?s :rdf/type :ex/User]
          ['?s :schema/name '?name]
          {:optional ['?s :ex/favColor '?favColor]}]}
```

```
{:select ['?name '?favColor]
 :where  [['?s :rdf/type :ex/User]
          ['?s :schema/name '?name]
          {:optional [['?s :ex/favColor '?favColor]]}]}
```

