### PR TITLE
initial support for filters in `where` clauses

### DIFF
--- a/src/fluree/db/query/analytical_filter.cljc
+++ b/src/fluree/db/query/analytical_filter.cljc
@@ -174,6 +174,12 @@
 
                   :else acc)) [] filters))
 
+(defn extract-combined-filter
+  [filter-maps]
+  (some->> filter-maps
+      (mapv :function)
+      (apply every-pred))) 
+
 (defmacro coalesce
   "Evaluates args in order. The result of the first arg not to return error gets returned."
   ([] (throw (ex-info "COALESCE evaluation failed on all forms." {:status 400 :error :db/invalid-query})))

--- a/src/fluree/db/query/analytical_filter.cljc
+++ b/src/fluree/db/query/analytical_filter.cljc
@@ -177,8 +177,8 @@
 (defn extract-combined-filter
   [filter-maps]
   (some->> filter-maps
-      (mapv :function)
-      (apply every-pred))) 
+      (map :function)
+      (apply every-pred)))
 
 (defmacro coalesce
   "Evaluates args in order. The result of the first arg not to return error gets returned."

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -193,7 +193,7 @@
         [fun _] (filter/extract-filter-fn filter-code fn-vars)]
     {:variable o-var
      :params   params
-     :fn-str   (str "(fn " params " " fun)
+     :fn-str   (str "(fn " params " " fun ")")
      :function (filter/make-executable params fun)}))
 
 

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -144,8 +144,7 @@
       (if found-var?
         where*
         (throw (ex-info (str "Filter function uses variable: " variable
-                             " however that variable is not used in a where statement "
-                             "or was already used in another filter function.")
+                             " however that variable is not used in a where statement ")
                         {:status 400 :error :db/invalid-query}))))))
 
 (defn get-vars

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -1187,7 +1187,7 @@
 
 ;; TODO - only capture :select, :where, :limit - need to get others
 (defn parse*
-  [db {:keys [opts prettyPrint filter context depth
+  [db {:keys [opts prettyPrint context depth
               orderBy order-by groupBy group-by] :as query-map} supplied-vars]
   (log/trace "parse* query-map:" query-map)
   (let [op-type           (cond
@@ -1233,7 +1233,6 @@
                                                     prettyPrint
                                                     (:prettyPrint opts))
                                    :compact-fn    (json-ld/compact-fn context*)}
-                                  filter (add-filter filter supplied-var-keys) ;; note, filter maps can/should also be inside :where clause
                                   order-by* (add-order-by order-by*)
                                   group-by* (add-group-by group-by*)
                                   true (consolidate-ident-vars) ;; add top-level :ident-vars consolidating all where clause's :ident-vars

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -1191,7 +1191,7 @@
               orderBy order-by groupBy group-by] :as query-map} supplied-vars]
   (log/trace "parse* query-map:" query-map)
   (let [op-type           (cond
-                            (some #{:select :selectOne :selectReduced :selectDistince} (keys query-map))
+                            (some #{:select :selectOne :selectReduced :selectDistinct} (keys query-map))
                             :select
 
                             (contains? query-map :delete)

--- a/src/fluree/db/query/analytical_parse.cljc
+++ b/src/fluree/db/query/analytical_parse.cljc
@@ -452,7 +452,11 @@
                        where*)))
 
             :filter
-            (recur r (into filters (:filter where-map)) hoisted-bind all-vars where*)
+            (let [{:keys [filter]} where-map]
+              (if-not (sequential? filter)
+                (throw (ex-info (str "Filter clause must be a vector/array, provided: " filter)
+                                {:status 400 :error :db/invalid-query}))
+                (recur r (into filters filter) hoisted-bind all-vars where*)))
 
             ;; else
             (recur r filters hoisted-bind all-vars (conj where* where-map))))

--- a/src/fluree/db/query/compound.cljc
+++ b/src/fluree/db/query/compound.cljc
@@ -77,28 +77,6 @@
     out-ch))
 
 
-(defn get-chan
-  [db prev-chan error-ch clause t]
-  (let [out-ch (async/chan 2)
-        {:keys [type s p o idx flake-x-form passthrough-fn optional? nils-fn]} clause
-        {s-var :variable, s-in-n :in-n} s
-        {o-var :variable, o-in-n :in-n} o]
-    (async/go
-      (loop []
-        (if-let [next-in (async/<! prev-chan)]
-          (let []
-            (if s-in-n
-              (let [s-vals-chan (next-chunk-s db error-ch next-in optional? s p idx t flake-x-form passthrough-fn)]
-                (loop []
-                  (when-let [next-s (async/<! s-vals-chan)]
-                    (async/>! out-ch (if nils-fn
-                                       (nils-fn next-s)
-                                       next-s))
-                    (recur)))))
-            (recur))
-          (async/close! out-ch))))
-    out-ch))
-
 (defn where-clause-tuple-chunk
   "Processes a chunk of input to a tuple where clause, and pushes output to out-chan."
   [db next-in out-ch error-ch clause t]

--- a/src/fluree/db/query/compound.cljc
+++ b/src/fluree/db/query/compound.cljc
@@ -19,10 +19,9 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn query-range-opts
-  [idx t s p o]
+  [idx t s p {:keys [filter] :as o}]
   (let [start-flake (flake/create s p o nil nil nil util/min-integer)
-        end-flake   (flake/create s p o nil nil nil util/max-integer)
-        get-filter #(get-in % [:filter :function])]
+        end-flake   (flake/create s p o nil nil nil util/max-integer)]
     {:idx         idx
      :from-t      t
      :to-t        t
@@ -30,7 +29,7 @@
      :start-flake start-flake
      :end-test    <=
      :end-flake   end-flake
-     :object-fn (get-filter o)}))
+     :object-fn (filter/extract-combined-filter filter)}))
 
 
 (defn next-chunk-s

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -7,42 +7,64 @@
 
 
 (deftest ^:integration filter-test
-  (testing "Testing filter in where clause"
-    (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/filter" {:context {:ex "http://example.org/ns/"}})
-          db     @(fluree/stage
-                    ledger
-                    [{:id           :ex/brian,
-                      :type         :ex/User,
-                      :schema/name  "Brian"
-                      :ex/last      "Smith"
-                      :schema/email "brian@example.org"
-                      :schema/age   50
-                      :ex/favNums   7
-                      :ex/scores    [76 80 15]}
-                     {:id           :ex/alice,
-                      :type         :ex/User,
-                      :schema/name  "Alice"
-                      :ex/last      "Smith"
-                      :schema/email "alice@example.org"
-                      :ex/favColor  "Green"
-                      :schema/age   42
-                      :ex/favNums   [42, 76, 9]
-                      :ex/scores    [102 92.5 90]}
-                     {:id          :ex/cam,
-                      :type        :ex/User,
-                      :schema/name "Cam"
-                      :ex/last     "Jones"
-                      :schema/email    "cam@example.org"
-                      :schema/age  34
-                      :ex/favNums  [5, 10]
-                      :ex/scores   [97.2 100 80]
-                      :ex/friend   [:ex/brian :ex/alice]}])]
+  (let [conn   (test-utils/create-conn)
+        ledger @(fluree/create conn "query/filter" {:context {:ex "http://example.org/ns/"}})
+        db     @(fluree/stage
+                 ledger
+                 [{:id           :ex/brian,
+                   :type         :ex/User,
+                   :schema/name  "Brian"
+                   :ex/last      "Smith"
+                   :schema/email "brian@example.org"
+                   :schema/age   50
+                   :ex/favNums   7
+                   :ex/scores    [76 80 15]}
+                  {:id           :ex/alice,
+                   :type         :ex/User,
+                   :schema/name  "Alice"
+                   :ex/last      "Smith"
+                   :schema/email "alice@example.org"
+                   :ex/favColor  "Green"
+                   :schema/age   42
+                   :ex/favNums   [42, 76, 9]
+                   :ex/scores    [102 92.5 90]}
+                  {:id          :ex/cam,
+                   :type        :ex/User,
+                   :schema/name "Cam"
+                   :ex/last     "Jones"
+                   :schema/email    "cam@example.org"
+                   :schema/age  34
+                   :ex/favNums  [5, 10]
+                   :ex/scores   [97.2 100 80]
+                   :ex/friend   [:ex/brian :ex/alice]}])]
 
+    (testing "single filter"
       (is (= [["Brian" 50]]
              @(fluree/query db {:select ['?name '?age]
                                 :where  [['?s :rdf/type :ex/User]
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
-                                         {:filter ["(> ?age 45)"]}]}))))))
+                                         {:filter ["(> ?age 45)"]}]})))
+      (is (= [["Alice" 42]
+              ["Brian" 50]]
+             @(fluree/query db {:select ['?name '?age]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/age '?age]
+                                         ['?s :schema/name '?name]
+                                         {:filter ["(> ?age 40)"]}]}))))
+    (testing "multiple filters on same var"
+      (is (= [["Alice" 42]]
+             @(fluree/query db {:select ['?name '?age]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/age '?age]
+                                         ['?s :schema/name '?name]
+                                         {:filter ["(> ?age 40)", "(< ?age 50)"]}]}))))
+    (testing "multiple filters, different vars"
+      (is (= [["Brian" "Smith"]]
+             @(fluree/query db {:select ['?name '?last]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/age '?age]
+                                         ['?s :schema/name '?name]
+                                         ['?s :ex/last '?last]
+                                         {:filter ["(> ?age 45)", "(strEnds ?last \"ith\") "]}]}))))))
 

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -1,0 +1,48 @@
+(ns fluree.db.query.filter-query-test
+  (:require
+    [clojure.test :refer :all]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    #_[fluree.db.util.log :as log]))
+
+
+(deftest ^:integration filter-test
+  (testing "Testing filter in where clause"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "query/filter" {:context {:ex "http://example.org/ns/"}})
+          db     @(fluree/stage
+                    ledger
+                    [{:id           :ex/brian,
+                      :type         :ex/User,
+                      :schema/name  "Brian"
+                      :ex/last      "Smith"
+                      :schema/email "brian@example.org"
+                      :schema/age   50
+                      :ex/favNums   7
+                      :ex/scores    [76 80 15]}
+                     {:id           :ex/alice,
+                      :type         :ex/User,
+                      :schema/name  "Alice"
+                      :ex/last      "Smith"
+                      :schema/email "alice@example.org"
+                      :ex/favColor  "Green"
+                      :schema/age   42
+                      :ex/favNums   [42, 76, 9]
+                      :ex/scores    [102 92.5 90]}
+                     {:id          :ex/cam,
+                      :type        :ex/User,
+                      :schema/name "Cam"
+                      :ex/last     "Jones"
+                      :schema/email    "cam@example.org"
+                      :schema/age  34
+                      :ex/favNums  [5, 10]
+                      :ex/scores   [97.2 100 80]
+                      :ex/friend   [:ex/brian :ex/alice]}])]
+
+      (is (= [["Brian" 50]]
+             @(fluree/query db {:select ['?name '?age]
+                                :where  [['?s :rdf/type :ex/User]
+                                         ['?s :schema/age '?age]
+                                         ['?s :schema/name '?name]
+                                         {:filter ["(> ?age 45)"]}]}))))))
+

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -17,8 +17,7 @@
                    :ex/last      "Smith"
                    :schema/email "brian@example.org"
                    :schema/age   50
-                   :ex/favNums   7
-                   :ex/scores    [76 80 15]}
+                   :ex/favNums   7}
                   {:id           :ex/alice,
                    :type         :ex/User,
                    :schema/name  "Alice"
@@ -26,8 +25,7 @@
                    :schema/email "alice@example.org"
                    :ex/favColor  "Green"
                    :schema/age   42
-                   :ex/favNums   [42, 76, 9]
-                   :ex/scores    [102 92.5 90]}
+                   :ex/favNums   [42, 76, 9]}
                   {:id          :ex/cam,
                    :type        :ex/User,
                    :schema/name "Cam"
@@ -35,30 +33,31 @@
                    :schema/email    "cam@example.org"
                    :schema/age  34
                    :ex/favNums  [5, 10]
-                   :ex/scores   [97.2 100 80]
-                   :ex/friend   [:ex/brian :ex/alice]}])]
+                   :ex/friend   [:ex/brian :ex/alice]}
+                  {:id          :ex/david,
+                   :type        :ex/User,
+                   :schema/name "David"
+                   :ex/last     "Jones"
+                   :schema/email    "david@example.org"
+                   :schema/age  46
+                   :ex/favNums  [15 70]
+                   :ex/friend   [:ex/cam]}])]
 
     (testing "single filter"
-      (is (= [["Brian" 50]]
-             @(fluree/query db {:select ['?name '?age]
-                                :where  [['?s :rdf/type :ex/User]
-                                         ['?s :schema/age '?age]
-                                         ['?s :schema/name '?name]
-                                         {:filter ["(> ?age 45)"]}]})))
-      (is (= [["Alice" 42]
+      (is (= [["David" 46]
               ["Brian" 50]]
              @(fluree/query db {:select ['?name '?age]
                                 :where  [['?s :rdf/type :ex/User]
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
-                                         {:filter ["(> ?age 40)"]}]}))))
+                                         {:filter ["(> ?age 45)"]}]}))))
     (testing "multiple filters on same var"
-      (is (= [["Alice" 42]]
+      (is (= [["David" 46]]
              @(fluree/query db {:select ['?name '?age]
                                 :where  [['?s :rdf/type :ex/User]
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
-                                         {:filter ["(> ?age 40)", "(< ?age 50)"]}]}))))
+                                         {:filter ["(> ?age 45)", "(< ?age 50)"]}]}))))
     (testing "multiple filters, different vars"
       (is (= [["Brian" "Smith"]]
              @(fluree/query db {:select ['?name '?last]
@@ -66,5 +65,5 @@
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
                                          ['?s :ex/last '?last]
-                                         {:filter ["(> ?age 45)", "(strEnds ?last \"ith\") "]}]}))))))
+                                         {:filter ["(> ?age 45)", "(strEnds ?last \"ith\")"]}]}))))))
 


### PR DESCRIPTION
Part of https://github.com/fluree/db/issues/249

This PR adds some initial support for filters.

See test file for some examples of what's supported.

Some notes:
1. There was some verbiage in an error message that suggested it's invalid to reference the same var in multiple filter fns. However, I can find no indication that this should be invalid (and in fact, we have examples like this in our docs.) 

   So this PR supports that case, and I've [removed that language from the error message](https://github.com/fluree/db/commit/3a370fabc471969c2239578a83b294d44cf0a5b1).
2. This only supports filters that are inside the `where` clause.

   There was some some old code that referenced `filter` as a top-level key in the query map, but according to @bplatz we don't need to support this, so I removed code/comments that referenced that key.

3. This does not extend to queries that use the `simple-subject-crawl` strategy. That strategy has a bug in executing even basic queries that do not include a filter (see https://github.com/fluree/db/issues/269). 
   
   That needs to be addressed, and then if needed, support for filters can be added for that case as follow-on work.

4. Does not add support for nesting functions inside of filters (see comments below)