### PR TITLE
opst index range not returning correct results, perf improve

### DIFF
--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -89,15 +89,12 @@
     out))
 
 (defn resolve-match-flake
-  [db test parts]
-  (go-try
-    (let [[s p o t op m] parts
-          s' (<? (resolve-subid db s))
-          [o' dt] (if (vector? o)
-                    [(first o) (second o)]
-                    [o nil])
-          m' (or m (if (identical? >= test) util/min-integer util/max-integer))]
-      (flake/create s' p o' dt t op m'))))
+  [test s p o t op m]
+  (let [[o' dt] (if (vector? o)
+                  [(first o) (second o)]
+                  [o nil])
+        m' (or m (if (identical? >= test) util/min-integer util/max-integer))]
+    (flake/create s p o' dt t op m')))
 
 (defn resolved-leaf?
   [node]
@@ -285,12 +282,11 @@
           :or   {from-t t, to-t t}}
          opts
 
-         idx-compare (get-in db [:comparators idx])
          start-parts (match->flake-parts db idx start-match)
          end-parts   (match->flake-parts db idx end-match)]
      (go-try
-      (let [start-flake (<? (resolve-match-flake db start-test start-parts))
-            end-flake   (<? (resolve-match-flake db end-test end-parts))
+      (let [start-flake (apply resolve-match-flake db start-test start-parts)
+            end-flake   (apply resolve-match-flake db end-test end-parts)
             error-ch    (chan)
             range-ch    (index-range* db
                                       error-ch
@@ -330,9 +326,7 @@
    (index-range db idx start-test start-match end-test end-match {}))
   ([{:keys [permissions t] :as db} idx start-test start-match end-test end-match
     {:keys [object-fn] :as opts}]
-   (let [idx-compare (get-in db [:comparators idx])
-
-         [s1 p1 o1 t1 op1 m1]
+   (let [[s1 p1 o1 t1 op1 m1]
          (match->flake-parts db idx start-match)
 
          [s2 p2 o2 t2 op2 m2]
@@ -345,25 +339,29 @@
                                [[o1 o2] object-fn])]
 
      (go-try
-      (let [start-flake (<? (resolve-match-flake db start-test [s1 p1 o1 t1 op1 m1]))
-            end-flake   (<? (resolve-match-flake db end-test [s2 p2 o2 t2 op2 m2]))
-            error-ch    (chan)
-            range-ch    (index-range* db
-                                      error-ch
-                                      (assoc opts
-                                             :idx         idx
-                                             :from-t      t
-                                             :to-t        t
-                                             :start-test  start-test
-                                             :start-flake start-flake
-                                             :end-test    end-test
-                                             :end-flake   end-flake
-                                             :object-fn   object-fn))]
-        (async/alt!
-          error-ch ([e]
-                    (throw e))
-          range-ch ([idx-range]
-                    idx-range)))))))
+       (let [start-flake (if (or (number? s1) (nil? s1))
+                           (resolve-match-flake start-test s1 p1 o1 t1 op1 m1)
+                           (resolve-match-flake start-test (<? (resolve-subid db s1)) p1 o1 t1 op1 m1))
+             end-flake   (if (or (number? s2) (nil? s2))
+                           (resolve-match-flake end-test s2 p2 o2 t2 op2 m2)
+                           (resolve-match-flake end-test (<? (resolve-subid db 2)) p2 o2 t2 op2 m2))
+             error-ch    (chan)
+             range-ch    (index-range* db
+                                       error-ch
+                                       (assoc opts
+                                         :idx idx
+                                         :from-t t
+                                         :to-t t
+                                         :start-test start-test
+                                         :start-flake start-flake
+                                         :end-test end-test
+                                         :end-flake end-flake
+                                         :object-fn object-fn))]
+         (async/alt!
+           error-ch ([e]
+                     (throw e))
+           range-ch ([idx-range]
+                     idx-range)))))))
 
 (defn non-nil-non-boolean?
   [o]


### PR DESCRIPTION
opst range calls were not producing accurate results under certain circumstances

While looking at index-range, there were two blocking async calls that were frequently not needed. By making them only perform the async ops when needed it reduced time required for small lookups from an average of > 100µs to ~80µs.

The code is slightly less pretty, but given this is the most common operation we perform a 20% speed boost is welcome.
