### PR TITLE
Allow index's sid to be pulled in query results

### DIFF
--- a/src/fluree/db/query/json_ld/response.cljc
+++ b/src/fluree/db/query/json_ld/response.cljc
@@ -111,11 +111,13 @@
 (defn flakes->res
   "depth-i param is the depth of the graph crawl. Each successive 'ref' increases the graph depth, up to
   the requested depth within the select-spec"
-  [db cache compact-fn fuel-vol max-fuel {:keys [wildcard? depth reverse] :as select-spec} depth-i flakes]
+  [db cache compact-fn fuel-vol max-fuel {:keys [wildcard? _id? depth reverse] :as select-spec} depth-i flakes]
   (go-try
     (when (not-empty flakes)
       (loop [[p-flakes & r] (partition-by flake/p flakes)
-             acc {}]
+             acc (if _id?
+                   {:_id (flake/s (first flakes))}
+                   {})]
         (if p-flakes
           (let [ff    (first p-flakes)
                 p     (flake/p ff)

--- a/src/fluree/db/query/json_ld/select.cljc
+++ b/src/fluree/db/query/json_ld/select.cljc
@@ -84,6 +84,9 @@
         (#{"*" :* '*} select-item)
         (assoc acc :wildcard? true)
 
+        (#{"_id" :_id} select-item)
+        (assoc acc :_id? true)
+
         :else
         (let [iri      (json-ld/expand-iri select-item context)
               spec     (get-in schema [:pred iri])


### PR DESCRIPTION
With json-ld, we completely hide the underlying index's subject id integers in query results.

There may still be some advanced circumstances where getting this is desired (working with one now). This re-enables the ability to request :_id in the subject crawl as a special keyword to request the underlying sid.

ex this query in the test
```
@(fluree/query db {:select {'?s [:_id :* {:ex/favArtist [:_id :schema/name]}]}
                   :where  [['?s :type :ex/User]]})
```

Produces this result:
```
[{:_id          211106232532999,
  :id           :ex/bob,
  :rdf/type     [:ex/User],
  :schema/name  "Bob",
  :ex/favArtist {:_id         211106232533000
                 :schema/name "Picasso"}}
 {:_id         211106232532998,
  :id          :ex/alice,
  :rdf/type    [:ex/User],
  :schema/name "Alice"}]
```
