### PR TITLE
Replace pauses with current time stubs in iso8601 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Run tests & build Docker image
-    runs-on: [self-hosted, docker]
+    runs-on: [linux, large, docker]
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: docker/setup-buildx-action@v2.2.1

--- a/src/fluree/db/json_ld/commit.cljc
+++ b/src/fluree/db/json_ld/commit.cljc
@@ -185,7 +185,9 @@
                           did
                           (ledger-proto/-did ledger))
         ctx-used-atom (atom {})
-        compact-fn    (json-ld/compact-fn context* ctx-used-atom)]
+        compact-fn    (json-ld/compact-fn context* ctx-used-atom)
+        commit-time   (util/current-time-iso)]
+    (log/debug "Committing t" t "at" commit-time)
     {:alias          (ledger-proto/-alias ledger)
      :push?          (not (false? push?))
      :t              (- t)
@@ -193,7 +195,7 @@
      :prev-commit    (:address commit)
      :prev-dbid      (:dbid commit)
      :ledger-address nil                                    ;; TODO
-     :time           (util/current-time-iso)
+     :time           commit-time
      :context        context*
      :private        private*
      :did            did*

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -17,37 +17,74 @@
                     "Back to the Future" "Back to the Future Part II"}
                   (map :schema/name movies))))))
 
-(deftest ^:slow query-with-iso8601-string-t-value-test
+(deftest query-with-iso8601-string-t-value-test
   (testing "only gets results from before that time"
     (let [;conn         (test-utils/create-conn) ; doesn't work see comment below
-          conn         @(fluree/connect {:method :memory
-                                         :defaults
-                                         {:context
-                                          test-utils/default-context}})
-                                          ;; if the :did default below is present on the conn
-                                          ;; (as it is w/ test-utils/create-conn)
-                                          ;; then the tests below fail at the last check
-                                          ;; b/c they can't see the last movie transacted
-                                          ;; when queried by ISO-8601 string ONLY
-                                          ;; (o/w it shows up just fine)
-                                          ;:did (fluree.db.did/private->did-map test-utils/default-private-key)}})
-          start        (System/currentTimeMillis)
-          ledger       (test-utils/load-movies conn 500)
-          one-loaded   (util/epoch-ms->iso-8601-str (+ start 400))
-          three-loaded (util/epoch-ms->iso-8601-str (+ start 900))
-          after        (util/epoch-ms->iso-8601-str (+ 60000 (System/currentTimeMillis)))
-          db           (fluree/db ledger)
-          base-query   {:select '{?s [:*]}
-                        :where  '[[?s :rdf/type :schema/Movie]]}
-          one-movie    @(fluree/query db (assoc base-query :t one-loaded))
-          three-movies @(fluree/query db (assoc base-query :t three-loaded))
-          all-movies   @(fluree/query db (assoc base-query :t after))
-          too-early    @(fluree/query db (assoc base-query
-                                           :t (util/epoch-ms->iso-8601-str
-                                                (- start (* 24 60 60 1000)))))]
+          conn                   @(fluree/connect {:method :memory
+                                                   :defaults
+                                                   {:context
+                                                    test-utils/default-context}})
+          ;; if the :did default below is present on the conn
+          ;; (as it is w/ test-utils/create-conn)
+          ;; then the tests below fail at the last check
+          ;; b/c they can't see the last movie transacted
+          ;; when queried by ISO-8601 string ONLY
+          ;; (o/w it shows up just fine)
+          ;:did (fluree.db.did/private->did-map test-utils/default-private-key)}})
+          start-iso              "2022-10-05T00:00:00Z"
+          start                  (util/str->epoch-ms start-iso)
+          three-loaded-millis    (+ start 60000)
+          all-loaded-millis      (+ three-loaded-millis 60000)
+          three-loaded-iso       (util/epoch-ms->iso-8601-str three-loaded-millis)
+          all-loaded-iso         (util/epoch-ms->iso-8601-str all-loaded-millis)
+          after-one-loaded-iso   (util/epoch-ms->iso-8601-str (+ start 5000))
+          after-three-loaded-iso (util/epoch-ms->iso-8601-str (+ three-loaded-millis
+                                                                 5000))
+          after-all-loaded-iso   (util/epoch-ms->iso-8601-str (+ all-loaded-millis
+                                                                 5000))
+          too-early-iso          (util/epoch-ms->iso-8601-str (- start
+                                                                 (* 24 60 60 1000)))
+          ledger                 @(fluree/create conn "iso8601/test")
+          _                      (with-redefs-fn {#'util/current-time-millis
+                                                  (fn [] start)
+                                                  #'util/current-time-iso
+                                                  (fn [] start-iso)}
+                                   (fn []
+                                     (let [db1 @(fluree/stage
+                                                  ledger
+                                                  (first test-utils/movies))]
+                                       @(fluree/commit! db1))))
+          _                      (with-redefs-fn {#'util/current-time-millis
+                                                  (fn [] three-loaded-millis)
+                                                  #'util/current-time-iso
+                                                  (fn [] three-loaded-iso)}
+                                   (fn []
+                                     (let [db2 @(fluree/stage
+                                                  ledger
+                                                  (second test-utils/movies))]
+                                       @(fluree/commit! db2))))
+          _                      (with-redefs-fn {#'util/current-time-millis
+                                                  (fn [] all-loaded-millis)
+                                                  #'util/current-time-iso
+                                                  (fn [] all-loaded-iso)}
+                                   (fn []
+                                     (let [db3 @(fluree/stage
+                                                  ledger
+                                                  (nth test-utils/movies 2))]
+                                       @(fluree/commit! db3))))
+          db                     (fluree/db ledger)
+          base-query             {:select '{?s [:*]}
+                                  :where  '[[?s :rdf/type :schema/Movie]]}
+          one-movie              @(fluree/query db (assoc base-query
+                                                     :t after-one-loaded-iso))
+          three-movies           @(fluree/query db (assoc base-query
+                                                     :t after-three-loaded-iso))
+          all-movies             @(fluree/query db (assoc base-query
+                                                     :t after-all-loaded-iso))
+          too-early              @(fluree/query db (assoc base-query
+                                                     :t too-early-iso))]
       (is (= 1 (count one-movie)))
       (is (= 3 (count three-movies)))
       (is (= 4 (count all-movies)))
       (is (util/exception? too-early))
       (is (re-matches #"There is no data as of .+" (ex-message too-early))))))
-

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -83,15 +83,13 @@
                                        :did     did}})))
 
 (defn load-movies
-  ([conn] (load-movies conn 0))
-  ([conn pause]
-   (let [ledger @(fluree/create conn "test/movies")]
-     (doseq [movie movies]
-       (let [staged @(fluree/stage ledger movie)]
-         @(fluree/commit! staged {:message (str "Commit " (get movie "name"))
-                                  :push? true}))
-       #?(:clj (Thread/sleep ^long pause)))
-     ledger)))
+  [conn]
+  (let [ledger @(fluree/create conn "test/movies")]
+    (doseq [movie movies]
+      (let [staged @(fluree/stage ledger movie)]
+        @(fluree/commit! staged {:message (str "Commit " (get movie "name"))
+                                 :push? true})))
+    ledger))
 
 (defn load-people
   [conn]


### PR DESCRIPTION
I know stubs are gross, but I think they're probably the better solution here.