### PR TITLE
Verify cred-wrapped transactions and queryies before processing

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -14,7 +14,8 @@
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.query.fql.resp :refer [flakes->res]]
-            [fluree.db.util.async :as async-util]))
+            [fluree.db.util.async :as async-util]
+            [fluree.db.json-ld.credential :as cred]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -333,11 +334,12 @@
   "Execute a query against a database source, or optionally
   additional sources if the query spans multiple data sets.
   Returns core async channel containing result."
-  [sources flureeQL]
+  [sources query]
   (go-try
-    (let [{:keys [select selectOne selectDistinct selectReduced construct
-                  from where prefixes opts t]} flureeQL
-          db            (if (async-util/channel? sources)   ;; only support 1 source currently
+    (let [{query :subject issuer :issuer} (<? (cred/verify query))
+          {:keys [select selectOne selectDistinct selectReduced construct
+                  from where prefixes opts t]} query
+          db            (if (async-util/channel? sources) ;; only support 1 source currently
                           (<? sources)
                           sources)
           db*           (-> (if t
@@ -350,15 +352,16 @@
           meta?         (:meta opts)
           fuel          (when (or (:fuel opts) meta?) (volatile! 0)) ;; only measure fuel if fuel budget provided, or :meta true
           opts*         (assoc opts :sources source-opts
-                                    :max-fuel (or (:fuel opts) 1000000)
-                                    :fuel fuel)
+                               :max-fuel (or (:fuel opts) 1000000)
+                               :fuel fuel
+                               :issuer issuer)
           _             (when-not (and (or select selectOne selectDistinct selectReduced construct)
                                        (or from where))
                           (throw (ex-info (str "Invalid query.")
                                           {:status 400
                                            :error  :db/invalid-query})))
           start #?(:clj (System/nanoTime) :cljs (util/current-time-millis))
-          result        (<? (fql/query db* (assoc flureeQL :opts opts*)))]
+          result        (<? (fql/query db* (assoc query :opts opts*)))]
       (if meta?
         {:status 200
          :result result

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -336,7 +336,8 @@
   Returns core async channel containing result."
   [sources query]
   (go-try
-    (let [{query :subject issuer :issuer} (<? (cred/verify query))
+    (let [{query :subject issuer :issuer} (or (<? (cred/verify query))
+                                              {:subject query})
           {:keys [select selectOne selectDistinct selectReduced construct
                   from where prefixes opts t]} query
           db            (if (async-util/channel? sources) ;; only support 1 source currently

--- a/src/fluree/db/json_ld/credential.cljc
+++ b/src/fluree/db/json_ld/credential.cljc
@@ -82,7 +82,7 @@
   credential is invalid an exception will be thrown."
   [credential]
   (go-try
-    (if-let [jws (get-in credential ["proof" "jws"])]
+    (when-let [jws (get-in credential ["proof" "jws"])]
       (let [subject (get credential "credentialSubject")
             issuer  (get credential "issuer")
             {:keys [header signature]} (deserialize-jws jws)
@@ -104,6 +104,4 @@
         (when (not (crypto/verify-signature pubkey signing-input signature))
           (throw (ex-info "Verification failed." {:error :credential/invalid-signature :credential credential})))
         ;; everything is good
-        {:subject subject :issuer issuer})
-      ;; nothing to be verified, is implicitly good
-      {:subject credential})))
+        {:subject subject :issuer issuer}))))

--- a/src/fluree/db/json_ld/credential.cljc
+++ b/src/fluree/db/json_ld/credential.cljc
@@ -77,7 +77,7 @@
                                                    private)))})))
 
 (defn verify
-  "I a credential and returns the credential subject and issuer id if it verifies. If
+  "Takes a credential and returns the credential subject and issuer id if it verifies. If
   credential does not have a jws returns the credential without verifying it. If the
   credential is invalid an exception will be thrown."
   [credential]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -482,5 +482,5 @@
     (let [{tx :subject issuer :issuer} (<? (cred/verify json-ld))]
       (if (and (contains? tx :delete)
                (contains? tx :where))
-        (<? (delete db util/max-integer tx (assoc opts {:issuer issuer})))
+        (<? (delete db util/max-integer tx (assoc opts :issuer issuer)))
         (<? (insert db tx (assoc opts :issuer issuer)))))))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -479,7 +479,8 @@
   Returns async channel that will contain updated db or exception."
   [db json-ld opts]
   (go-try
-    (let [{tx :subject issuer :issuer} (<? (cred/verify json-ld))]
+    (let [{tx :subject issuer :issuer} (or (<? (cred/verify json-ld))
+                                           {:subject json-ld})]
       (if (and (contains? tx :delete)
                (contains? tx :where))
         (<? (delete db util/max-integer tx (assoc opts :issuer issuer)))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -18,7 +18,8 @@
             [fluree.db.query.fql.parse :as q-parse]
             [fluree.db.query.exec.where :as where]
             [clojure.core.async :as async :refer [>!]]
-            [fluree.db.dbproto :as dbproto])
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.json-ld.credential :as cred])
   (:refer-clojure :exclude [vswap!]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -230,15 +231,16 @@
           [sid (into subj-flakes property-flakes)])))))
 
 (defn ->tx-state
-  [db {:keys [bootstrap?] :as _opts}]
+  [db {:keys [bootstrap? issuer] :as _opts}]
   (let [{:keys [block ecount schema branch ledger], db-t :t} db
         last-pid (volatile! (jld-ledger/last-pid db))
         last-sid (volatile! (jld-ledger/last-sid db))
         commit-t (-> (ledger-proto/-status ledger branch) branch/latest-commit-t)
         t        (-> commit-t inc -)]                       ;; commit-t is always positive, need to make negative for internal indexing
-    {:db-before     db
+    {:issuer        issuer
+     :db-before     db
      :bootstrap?    bootstrap?
-     :stage-update? (= t db-t)                              ;; if a previously staged db is getting updated again before committed
+     :stage-update? (= t db-t) ;; if a previously staged db is getting updated again before committed
      :refs          (volatile! (or (:refs schema) #{const/$rdf:type}))
      :t             t
      :new?          (zero? db-t)
@@ -247,7 +249,7 @@
      :last-sid      last-sid
      :next-pid      (fn [] (vswap! last-pid inc))
      :next-sid      (fn [] (vswap! last-sid inc))
-     :subj-mods     (atom {})                               ;; holds map of subj ids (keys) for modified flakes map with shacl shape and classes
+     :subj-mods     (atom {}) ;; holds map of subj ids (keys) for modified flakes map with shacl shape and classes
      :iris          (volatile! {})}))
 
 (defn final-ecount
@@ -407,7 +409,7 @@
 
 (defn insert
   "Performs insert transaction"
-  [{:keys [schema] :as db} json-ld opts]
+  [{:keys [schema issuer] :as db} json-ld opts]
   (go-try
     (let [default-ctx (if (:js? opts) (:context-str schema) (:context schema))
           tx-state    (->tx-state db opts)
@@ -426,8 +428,8 @@
   "Executes a delete statement"
   [{:keys [t] :as db} max-fuel json-ld opts]
   (go-try
-   (let [{:keys [db-before t] :as tx-state}
-         (->tx-state db nil)
+    (let [{:keys [db-before t] :as tx-state}
+         (->tx-state db opts)
 
          {:keys [delete] :as parsed-query}
          (-> json-ld
@@ -476,7 +478,9 @@
   "Stages changes, but does not commit.
   Returns async channel that will contain updated db or exception."
   [db json-ld opts]
-  (if (and (contains? json-ld :delete)
-           (contains? json-ld :where))
-    (delete db util/max-integer json-ld opts)
-    (insert db json-ld opts)))
+  (go-try
+    (let [{tx :subject issuer :issuer} (<? (cred/verify json-ld))]
+      (if (and (contains? tx :delete)
+               (contains? tx :where))
+        (<? (delete db util/max-integer tx (assoc opts {:issuer issuer})))
+        (<? (insert db tx (assoc opts :issuer issuer)))))))

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -10,6 +10,7 @@
    :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})
 
 (def example-cred-subject {"@context" {"a" "http://a.com/"} "a:foo" "bar"})
+(def example-issuer "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh")
 
 (def clj-generated-jws
   "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HDBFAiEA80-G5gUH6BT9D1Mc-YyWbjuwbL7nKfWj6BrsHS6whQ0CIAcjzJvo0sW52FIlgvxy0hPBKNWolIwLvoedG_4HQu_V")
@@ -17,13 +18,13 @@
 (def cljs-generated-jws
   "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HDBFAiEAy9MuRjVn_vwvEgQlsCJNnSYwCJEWU_UOg5U_R8--87wCID-qficJv-aCUotctcFGX-xTky1E08W2Y7utUCJZ3AZY")
 
-(def expected-credential
+(def example-credential
   {"@context"          "https://www.w3.org/2018/credentials/v1"
    "id"                ""
    "type"              ["VerifiableCredential" "CommitProof"]
-   "issuer"            "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
+   "issuer"            example-issuer
    "issuanceDate"      "1970-01-01T00:00:00.00000Z"
-   "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "bar"}
+   "credentialSubject" example-cred-subject
    "proof"             {"type"               "EcdsaSecp256k1RecoverySignature2020"
                         "created"            "1970-01-01T00:00:00.00000Z"
                         "verificationMethod" "did:key:z6DuABnw7XPbMksZo5wY4HweN8wPkEd7rCQM4YGgu8hPqrd5"
@@ -36,19 +37,26 @@
      (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
        (testing "generate"
          (let [cred (async/<!! (cred/generate example-cred-subject (:private auth)))]
-           (is (= expected-credential
+           (is (= example-credential
                   cred))))
+
        (testing "verify correct signature"
-         (let [clj-result (async/<!! (cred/verify expected-credential))
-               cljs-result (async/<!! (cred/verify (assoc-in expected-credential ["proof" "jws"] cljs-generated-jws)))]
-           (is (= true clj-result))
-           (is (= true cljs-result))))
+         (let [clj-result (async/<!! (cred/verify example-credential))
+               cljs-result (async/<!! (cred/verify (assoc-in example-credential ["proof" "jws"] cljs-generated-jws)))]
+           (is (= {:subject example-cred-subject :issuer example-issuer} clj-result))
+           (is (= {:subject example-cred-subject :issuer example-issuer} cljs-result))))
+
        (testing "verify incorrect signature"
-         (let [wrong-cred (assoc expected-credential "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "DIFFERENT!"})]
+         (let [wrong-cred (assoc example-credential "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "DIFFERENT!"})]
            (is (= "Unverifiable credential"
                   (-> (async/<!! (cred/verify wrong-cred))
                       (Throwable->map)
-                      (:cause)))))))))
+                      (:cause))))))
+
+       (testing "verify not a credential"
+         (let [non-cred example-cred-subject]
+           (is (= {:subject example-cred-subject}
+                  (async/<!! (cred/verify non-cred)))))))))
 
 #?(:cljs
    (deftest generate
@@ -56,7 +64,7 @@
               (async/go
                 (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
                   (let [cred (async/<! (cred/generate example-cred-subject (:private auth)))]
-                    (is (= expected-credential
+                    (is (= example-credential
                            cred))
                     (done)))))))
 
@@ -65,10 +73,10 @@
      (t/async done
               (async/go
                 (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
-                  (let [cljs-result (async/<! (cred/verify expected-credential))
-                        clj-result  (async/<! (cred/verify (assoc-in expected-credential ["proof" "jws"] clj-generated-jws)))]
-                    (is (= true cljs-result))
-                    (is (= true clj-result))
+                  (let [cljs-result (async/<! (cred/verify example-credential))
+                        clj-result  (async/<! (cred/verify (assoc-in example-credential ["proof" "jws"] clj-generated-jws)))]
+                    (is (= {:subject example-cred-subject :issuer example-issuer} cljs-result))
+                    (is (= {:subject example-cred-subject :issuer example-issuer} clj-result))
                     (done)))))))
 
 #?(:cljs
@@ -76,10 +84,19 @@
      (t/async done
               (async/go
                 (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
-                  (let [wrong-cred (assoc expected-credential "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "DIFFERENT!"})]
+                  (let [wrong-cred (assoc example-credential "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "DIFFERENT!"})]
                     (is (= "Unverifiable credential"
                            (-> (async/<! (cred/verify wrong-cred))
                                (.-message e))))
+                    (done)))))))
+#?(:cljs
+   (deftest verify-non-credential
+     (t/async done
+              (async/go
+                (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
+                  (let [non-cred example-cred-subject]
+                    (is (= {:subject non-cred}
+                           (async/<! (cred/verify non-cred))))
                     (done)))))))
 
 (comment

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -48,7 +48,7 @@
 
        (testing "verify incorrect signature"
          (let [wrong-cred (assoc example-credential "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "DIFFERENT!"})]
-           (is (= "Unverifiable credential"
+           (is (= "Verification failed."
                   (-> (async/<!! (cred/verify wrong-cred))
                       (Throwable->map)
                       (:cause))))))
@@ -85,7 +85,7 @@
               (async/go
                 (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
                   (let [wrong-cred (assoc example-credential "credentialSubject" {"@context" {"a" "http://a.com/"} "a:foo" "DIFFERENT!"})]
-                    (is (= "Unverifiable credential"
+                    (is (= "Verification failed."
                            (-> (async/<! (cred/verify wrong-cred))
                                (.-message e))))
                     (done)))))))

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -55,8 +55,7 @@
 
        (testing "verify not a credential"
          (let [non-cred example-cred-subject]
-           (is (= {:subject example-cred-subject}
-                  (async/<!! (cred/verify non-cred)))))))))
+           (is (nil? (async/<!! (cred/verify non-cred)))))))))
 
 #?(:cljs
    (deftest generate
@@ -95,8 +94,7 @@
               (async/go
                 (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
                   (let [non-cred example-cred-subject]
-                    (is (= {:subject non-cred}
-                           (async/<! (cred/verify non-cred))))
+                    (is (nil? (async/<! (cred/verify non-cred))))
                     (done)))))))
 
 (comment


### PR DESCRIPTION
This currently doesn't do anything with the issuer identity, but we can use that once a permission framework has been established to authorize whatever the issuer is attempting.

Fixes #292