### PR TITLE
Add basic policy support for query

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
          cheshire/cheshire               {:mvn/version "5.11.0"}
          instaparse/instaparse           {:mvn/version "1.4.12"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :sha     "2e69362f611def8cc6793c6ddf24e4671fb6f397"}
+                                          :sha     "0613d03a5657294a5575556f8eac68ab9f12705a"}
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.2.4"}

--- a/dev/json_ld/policy.clj
+++ b/dev/json_ld/policy.clj
@@ -1,0 +1,146 @@
+(ns json-ld.policy
+  (:require [fluree.db.json-ld.api :as fluree]
+            [fluree.db.util.async :refer [<?? go-try channel?]]
+            [fluree.db.did :as did]))
+
+(comment
+
+  (def ipfs-conn @(fluree/connect-ipfs
+                    {:server   nil                          ;; use default
+                     ;; ledger defaults used for newly created ledgers
+                     :defaults {:ipns    {:key "self"}      ;; publish to ipns by default using the provided key/profile
+                                :indexer {:reindex-min-bytes 9000
+                                          :reindex-max-bytes 10000000}
+                                :context {:id     "@id"
+                                          :type   "@type"
+                                          :xsd    "http://www.w3.org/2001/XMLSchema#"
+                                          :schema "http://schema.org/"
+                                          :sh     "http://www.w3.org/ns/shacl#"
+                                          :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                          :rdfs   "http://www.w3.org/2000/01/rdf-schema#"
+                                          :wiki   "https://www.wikidata.org/wiki/"
+                                          :skos   "http://www.w3.org/2008/05/skos#"
+                                          :f      "https://ns.flur.ee/ledger#"}
+                                :did     (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c")}}))
+
+  (def ledger @(fluree/create ipfs-conn "sf/a" {:context {:ex "http://example.org/ns/"}}))
+
+  (def db
+    @(fluree/stage
+       ledger
+       [{:id               :ex/alice,
+         :type             :ex/User,
+         :schema/name      "Alice"
+         :schema/email     "alice@flur.ee"
+         :schema/birthDate "2022-08-17"
+         :schema/ssn       "111-11-1111"
+         :ex/location      {:ex/state   "NC"
+                            :ex/country "USA"}}
+        {:id               :ex/john,
+         :type             :ex/User,
+         :schema/name      "John"
+         :schema/email     "john@flur.ee"
+         :schema/birthDate "2021-08-17"
+         :schema/ssn       "888-88-8888"}
+        {:id                   :ex/widget,
+         :type                 :ex/Product,
+         :schema/name          "Widget"
+         :schema/price         99.99
+         :schema/priceCurrency "USD"}
+        ;; assign root-did to :ex/rootRole
+        {:id      (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+         :f/roles :ex/rootRole}
+        ;; assign alice-did to :ex/userRole and also link the did to :ex/alice subject
+        {:id      (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+         :ex/user :ex/alice
+         :f/roles :ex/userRole}]))
+
+
+  ;; attach a did record to a 'root' role - you can call the role anything you want
+  (def db2
+    @(fluree/stage
+       db
+       {:id     (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+        :f/role :ex/rootRole}))
+
+  ;; attach a different did record to a different role
+  (def db3
+    @(fluree/stage
+       db2
+       {:id      (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+        :ex/user :ex/alice
+        :f/role  :ex/externalRole}))
+
+  ;; Note that already, one can query for everything unpermissioned - but either role hasn't been given any permissions so nothing will return
+  @(fluree/query db3 {:select {'?s [:* {:ex/location [:*]}]}
+                      :where  [['?s :rdf/type :ex/User]]})
+
+  ;; try to get a permissioned DB - but not rules exist yet!
+  @(fluree/wrap-policy db3 {:f/$identity (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+                            :f/role      :ex/rootRole})
+
+
+  ;; establish a root role that can do anything
+  (def db4
+    @(fluree/stage
+       db3
+       {:id           :ex/rootPolicy,
+        :type         [:f/Policy],
+        :f/targetNode :f/allNodes
+        :f/allow      [{:id           :ex/rootAccessAllow
+                        :f/targetRole :ex/rootRole          ;; keyword for a global role
+                        :f/action     [:f/view :f/modify]}]}))
+
+
+  ;; try some queries... default uses no permissions
+  @(fluree/query db4 {:select {'?s [:* {:ex/location [:*]}]}
+                      :where  [['?s :rdf/type :ex/User]]})
+
+  ;; try with the non-root role
+  (def perm-db @(fluree/wrap-policy db4 {:f/$identity (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+                                         :f/role      :ex/externalRole}))
+
+  @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
+                          :where  [['?s :rdf/type :ex/User]]})
+
+  ;; try with root role
+  (def perm-db @(fluree/wrap-policy db4 {:f/$identity (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+                                         :f/role      :ex/rootRole}))
+
+  @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
+                          :where  [['?s :rdf/type :ex/User]]})
+
+  (-> perm-db :permissions)
+
+  (def db5
+    @(fluree/stage
+       db4
+       {:id            :ex/UserPolicy,
+        :type          [:f/Policy],
+        :f/targetClass :ex/User
+        :f/allow       [{:id           :ex/globalViewAllow
+                         :f/targetRole :ex/externalRole     ;; keyword for a global role
+                         :f/action     [:f/view]}]
+        :f/property    [{:f/path  :schema/ssn
+                         :f/allow [{:id           :ex/ssnViewRule
+                                    :f/targetRole :ex/externalRole
+                                    :f/action     [:f/view]
+                                    :f/equals     {:list [:f/$identity :ex/user]}}]}]}))
+
+
+  ;; try with the non-root role
+  (def perm-db @(fluree/wrap-policy db5 {:f/$identity (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+                                         :f/role      :ex/externalRole}))
+  (-> perm-db :permissions)
+
+  ;; should see users, but only own SSN - and not location in crawl
+  @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
+                          :where  [['?s :rdf/type :ex/User]]})
+
+  ;; no product permissions
+  @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
+                          :where  [['?s :rdf/type :ex/Product]]})
+
+  )
+
+

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -340,9 +340,10 @@
           db            (if (async-util/channel? sources)   ;; only support 1 source currently
                           (<? sources)
                           sources)
-          db*           (if t
-                          (<? (time-travel/as-of db t))
-                          db)
+          db*           (-> (if t
+                              (<? (time-travel/as-of db t))
+                              db)
+                            (assoc-in [:permissions :cache] (atom {})))
           source-opts   (if prefixes
                           (get-sources (:conn db*) (:network db*) (:auth-id db*) prefixes)
                           {})

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -308,6 +308,14 @@
                                      e)))))
     return-chan))
 
+(defn class-ids
+  "Returns list of class-ids for given subject-id"
+  [db subject-id]
+  (go-try
+    (->>
+      (<? (query-range/index-range db :spot = [subject-id const/$rdf:type]))
+      (map flake/o))))
+
 (defn iri
   "Returns the iri for a given subject ID"
   [db subject-id compact-fn]
@@ -323,9 +331,7 @@
       (assoc current-db :permissions permissions))))
 
 (defn- graphdb-root-db [this]
-  (assoc this :permissions {:root?      true
-                            :collection {:all? true}
-                            :predicate  {:all? true}}))
+  (assoc this :permissions {:root?      true}))
 
 (defn- graphdb-c-prop [{:keys [schema]} property collection]
   ;; collection properties TODO-deprecate :id property below in favor of :partition
@@ -443,6 +449,7 @@
   (-tag-id [this tag-name pred] (graphdb-tag-id this tag-name pred))
   (-subid [this ident] (subid this ident false))
   (-subid [this ident strict?] (subid this ident strict?))
+  (-class-ids [this subject] (class-ids this subject))
   (-iri [this subject-id] (iri this subject-id identity))
   (-iri [this subject-id compact-fn] (iri this subject-id compact-fn))
   (-search [this fparts] (query-range/search this fparts))

--- a/src/fluree/db/dbproto.cljc
+++ b/src/fluree/db/dbproto.cljc
@@ -13,6 +13,7 @@
   (-tag [db tag-id] [db tag-id pred] "Returns resolved tag, shortens namespace if pred provided.")
   (-tag-id [db tag-name] [db tag-name pred] "Returns the tag sid. If pred provided will namespace tag if not already.")
   (-subid [db ident] [db ident strict?] "Returns subject ID if exists, else nil")
+  (-class-ids [db subject-id] "For the provided subject-id (long int), returns a list of class subject ids it is a member of (long ints)")
   (-iri [db subject-id] [db ident compact-fn] "Returns the IRI for the requested subject ID (json-ld only)")
   (-search [db fparts] "Performs a slice, but determines best index to use.")
   (-query [db query] [db query opts] "Performs a query.")

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -10,7 +10,8 @@
             [fluree.db.ledger.proto :as ledger-proto]
             [fluree.db.dbproto :as db-proto]
             [fluree.db.util.log :as log]
-            [fluree.db.query.range :as query-range])
+            [fluree.db.query.range :as query-range]
+            [fluree.db.json-ld.policy :as perm])
   (:refer-clojure :exclude [merge load range]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -227,6 +228,18 @@
      (throw (ex-info "DB opts not yet implemented"
                      {:status 500 :error :db/unexpected-error}))
      (ledger-proto/-db ledger opts))))
+
+
+(defn wrap-policy
+  "Wraps a db object with specified permission attributes.
+  When requesting a db from a ledger, permission attributes can
+  be requested at that point, however if one has a db already, this
+  allows the permission attributes to be modified.
+
+  Returns promise"
+  [db {:keys [f/$identity f/role f/credential]}]
+  (promise-wrap
+    (perm/wrap-policy db $identity role credential)))
 
 
 (defn query

--- a/src/fluree/db/json_ld/bootstrap.cljc
+++ b/src/fluree/db/json_ld/bootstrap.cljc
@@ -135,24 +135,25 @@
 
 
 (defn bootstrap-tx
-  [default-ctx dids]
+  [default-ctx]
   (let [ctx    (when default-ctx
                  (let [default-ctx* (normalize-default-ctx default-ctx)]
                    {"@id"     "fluree-default-context"
                     "@type"   ["Context"]
                     "context" default-ctx*}))
-        did-tx (when dids
-                 (dids-tx dids))]
-    {"@context" "https://ns.flur.ee/ledger/v1"
-     "@graph"   (cond-> default-tx
-                        ctx (conj ctx)
-                        did-tx (into did-tx))}))
+        graph (cond-> []
+                      ctx (conj ctx))]
+    (when (seq graph)
+      {"@context" "https://ns.flur.ee/ledger/v1"
+       "@graph"   graph})))
 
 (defn bootstrap
   "Bootstraps a permissioned JSON-LD db. Returns async channel."
-  [blank-db default-ctx dids]
-  (let [tx (bootstrap-tx default-ctx dids)]
-    (db-proto/-stage blank-db tx {:bootstrap? true})))
+  [blank-db default-ctx]
+  (let [tx (bootstrap-tx default-ctx)]
+    (if tx
+      (db-proto/-stage blank-db tx {:bootstrap? true})
+      blank-db)))
 
 (defn blank-db
   "When not bootstrapping with a transaction, bootstraps initial base set of flakes required for a db."

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -1,0 +1,244 @@
+(ns fluree.db.json-ld.policy
+  (:require [fluree.db.dbproto :as dbproto]
+            [fluree.db.util.async :refer [<? go-try]]
+            [clojure.core.async :as async]
+            [fluree.db.util.core :as util :refer [try* catch*]]
+            [fluree.db.util.log :as log]
+            [fluree.db.flake :as flake]
+            [fluree.db.json-ld.policy-validate :as validate]
+            [fluree.db.query.fql :refer [query]]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def restriction-properties
+  #{:f/equals :f/contains})
+
+;; TODO - update "fluree-root-rule"
+(defn all-rules
+  [db]
+  (go-try
+    ;; TODO - once supported, use context to always return :f/allow and :f/property as vectors so we don't need to coerce downstream
+    (<? (query db {:select {'?s [:*
+                                 {:rdf/type [:_id]}
+                                 {:f/allow [:* {:f/targetRole [:_id]}]}
+                                 {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
+                   :where  [['?s :rdf/type :f/Policy]]}))))
+
+
+(defn rules-for-roles
+  "Filters all rules into only those that apply to the given roles."
+  [roles all-rules]
+  (filter
+    (fn [rule]
+      ;; if a top-level (class rule) applies to any roles, can return immediately
+      (let [class-rule? (some->> (get rule :f/allow)
+                                 util/sequential
+                                 (some #(roles (get-in % [:f/targetRole :_id]))))]
+        ;; if class rules doesn't exist for roles, check if any property rules exist
+        (or class-rule?
+            (when-let [property-rules (get rule :f/property)]
+              (some
+                (fn [property-rule]
+                  (some->> (get property-rule :f/allow)
+                           util/sequential
+                           (some #(roles (get-in % [:f/targetRole :_id])))))
+                (util/sequential property-rules))))))
+    all-rules))
+
+(defn restrict-view?
+  "Given a restriction (the map value of an :f/allow property),
+  does it apply to view permissions?"
+  [restriction]
+  (= :f/view (get-in restriction [:f/action :id])))
+
+(defn restrict-modify?
+  "Given a restriction (the map value of an :f/allow property),
+  does it apply to modify permissions?"
+  [restriction]
+  (= :f/modify (get-in restriction [:f/action :id])))
+
+(defn restrict-rule?
+  "If a restriction rule is in place that must be evaluated,
+  meaning there are ':f/equals', ':f/contains', etc. restrictions."
+  [restriction]
+  (some restriction-properties (-> restriction keys)))
+
+(defn compile-restriction
+  "A restriction is the map value of an :f/allow property.
+
+  Returns a function with two args - first the permissions map which contains
+  the :ident and (soon) other metadata that might be used in evaluations, and
+  secondly the flake being evaluated."
+  [restriction]
+  (let [view?          (restrict-view? restriction)
+        restrict-rule? (restrict-rule? restriction)]
+    ;; TODO - for now this only looks for view rules, not modify rules. Need to address modify when working on txns
+    (when view?
+      (if restrict-rule?
+        (do
+          (log/warn "Not yet enforcing conditional restriction rules as found for: " restriction)
+          ;; return two-tuple of [async? fn]
+          [false (constantly false)])
+        [false (constantly true)]))))
+
+(defn subids
+  "Returns a vector of subids from the input collection as a single result async chan.
+  If any exception occurs during resolution, returns the error immediately."
+  [db subjects]
+  (async/go-loop [[next-sid & r] (map #(dbproto/-subid db %) subjects)
+                  acc []]
+    (if next-sid
+      (let [next-res (async/<! next-sid)]
+        (if (util/exception? next-res)
+          next-res
+          (recur r (conj acc (async/<! next-sid)))))
+      acc)))
+
+
+(defn compile-property-rules
+  "Returns a map with property ids as keys with two-tuple value of async? + policy function.
+
+  If function is async downstream the value will need to be retrieved downstream."
+  [db rule]
+  (go-try
+    (let [property-rules (util/sequential rule)]
+      (loop [[prop-rule & r] property-rules
+             acc {}]
+        (if prop-rule
+          (let [prop-sid      (<? (dbproto/-subid db (get-in prop-rule [:f/path :id])))
+                equals-rule   (some->> prop-rule :f/allow :f/equals (map :id))
+                contains-rule (some->> prop-rule :f/allow :f/contains (map :id))
+                ;; TODO - need to make sure only :f/view value for :f/action are included if for reads - could be done when selecting rules by filtering non :f/view
+                ident-first?  (= :f/$identity (or (first equals-rule)
+                                                  (first contains-rule)))
+                path          (if ident-first?
+                                (rest equals-rule)
+                                equals-rule)
+                path-pids     (<? (subids db path))
+                f             (cond
+                                equals-rule
+                                (fn [{:keys [permissions] :as db} flake]
+                                  (go-try
+                                    (let [path-val (or (get @(:cache permissions) equals-rule)
+                                                       (<? (validate/resolve-equals-rule db path-pids equals-rule)))]
+                                      (= (flake/s flake) path-val))))
+
+                                contains-rule
+                                (fn [{:keys [permisssions] :as db} flake]
+                                  (go-try
+                                    (let [path-val (or (get @(:cache permisssions) equals-rule)
+                                                       (<? (validate/resolve-contains-rule db path-pids equals-rule)))]
+                                      (= (flake/s flake) path-val)))))]
+            (when-not ident-first?
+              (log/warn (str "Policy f:equals and f:contains only supports equals paths that start with f:$identity currently. Provided: "
+                             equals-rule ". Ignoring.")))
+            ;; TODO - if multiple rules target the same path we need to concatenate them and should use an 'or' condition
+            (when (get acc prop-sid)
+              (log/warn (str "Multiple policy rules in the same class target the same property: "
+                             (get prop-rule :f/path) ". Only the last one encountered will be utilized.")))
+            (recur r (assoc acc prop-sid [true f])))
+          acc)))))
+
+(defn compile-class-rule
+  [db rule classes]
+  (go-try
+    (let [class-sids            (<? (subids db classes))
+          restrictions          (get rule :f/allow)
+          default-restrictions  (if (sequential? restrictions)
+                                  (let [all-restrictions (map compile-restriction restrictions)]
+                                    ;; return two-tuple of [async? fn]
+                                    [false (fn [db flake]
+                                             (some (fn [restriction-fn]
+                                                     (restriction-fn db flake)) all-restrictions))])
+                                  (compile-restriction restrictions))
+          property-restrictions (when-let [prop-rules (:f/property rule)]
+                                  (<? (compile-property-rules db prop-rules)))
+          all-restrictions      (assoc property-restrictions :default default-restrictions)]
+      ;; for each class targeted by the rule, map to each compiled fn
+      (reduce
+        (fn [acc class-sid]
+          (assoc acc class-sid all-restrictions))
+        {} class-sids))))
+
+
+(defn compile-node-rule
+  [db rule nodes]
+  (go-try
+    (let [node-sids             (<? (subids db nodes))
+          restrictions          (get rule :f/allow)
+          compiled-restrictions (if (sequential? restrictions)
+                                  (let [all-restrictions (map compile-restriction restrictions)]
+                                    (fn [x]
+                                      (some (fn [restriction-fn]
+                                              (restriction-fn x)) all-restrictions)))
+                                  (compile-restriction restrictions))]
+      (when (:f/property rule)
+        (log/warn "Currently, property based restrictions are not yet enforced. Found for nodes: " nodes))
+      ;; for each class targeted by the rule, map to each compiled fn
+      (if (and (= [:f/allNodes] nodes)
+               (nil? (->> node-sids first (get compiled-restrictions))))
+        {:root? true}
+        (reduce
+          (fn [acc node-sid]
+            (assoc acc node-sid compiled-restrictions))
+          {} node-sids)))))
+
+
+(defn compile-rule
+  [db rule]
+  (go-try
+    (let [classes (some->> rule :f/targetClass util/sequential (mapv :id))
+          nodes   (some->> rule :f/targetNode util/sequential (mapv :id))]
+      (cond
+        classes {:class (<? (compile-class-rule db rule classes))}
+        nodes {:node (<? (compile-node-rule db rule nodes))}))))
+
+
+(defn compile-rules
+  "Compiles rules into a fn that returns truthy if, when given a flake, is allowed."
+  [db rules]
+  ;; TODO - if multiple rules target the same class, we need to 'or' the rules together.
+  (->> rules
+       (map #(compile-rule db %))
+       async/merge
+       (async/into [])))
+
+
+(defn find-rules
+  "Returns all the rules for the provided roles as compiled functions"
+  [db {:keys [roles]}]
+  ;; TODO - no caching is being done here yet, need to implement for at least all-rules lookup
+  (go-try
+    (let [all-rules (<? (all-rules db))]
+      (rules-for-roles roles all-rules))))
+
+
+(defn wrap-policy
+  "Given a db object, wraps specified policy permissions"
+  [db identity role credential]
+  ;; TODO - not yet paying attention to verifiable credentials that are present
+  (async/go
+    (try*
+      (let [ident-sid      (<? (dbproto/-subid db identity))
+            role-sids      (if (sequential? role)
+                             (->> (<? (subids db role))
+                                  (into #{}))
+                             #{(<? (dbproto/-subid db role))})
+            permissions    {:ident ident-sid
+                            :roles role-sids
+                            :root? (empty? role-sids)}
+            rules          (<? (find-rules db permissions))
+            compiled-rules (->> (<? (compile-rules db rules))
+                                (apply merge))
+            root-rule?     (= compiled-rules
+                              {:node {:root? true}})
+            permissions*   (cond-> (assoc permissions :view compiled-rules)
+                                   root-rule? (assoc :root? true))]
+        (assoc db :permissions permissions*))
+      (catch* e
+              (if (= :db/invalid-query (:error (ex-data e)))
+                (throw (ex-info (str "There are no Fluree rules in the db, a policy-driven database cannot be retrieved. "
+                                     "If you have created rules, make sure they are of @type f:Rule.")
+                                {:status 400
+                                 :error  :db/invalid-policy}))
+                (throw e))))))

--- a/src/fluree/db/json_ld/policy_validate.cljc
+++ b/src/fluree/db/json_ld/policy_validate.cljc
@@ -1,0 +1,81 @@
+(ns fluree.db.json-ld.policy-validate
+  (:require [fluree.db.dbproto :as dbproto]
+            [fluree.db.util.async :refer [<? go-try]]
+            [clojure.core.async :as async]
+            [fluree.db.query.range :as query-range]
+            [fluree.db.flake :as flake]
+            [fluree.db.constants :as const]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.log :as log]))
+
+
+#?(:clj (set! *warn-on-reflection* true))
+
+
+(defn subids
+  "Returns a vector of subids from the input collection as a single result async chan.
+  If any exception occurs during resolution, returns the error immediately."
+  [db subjects]
+  (async/go-loop [[next-sid & r] (map #(dbproto/-subid db %) subjects)
+                  acc []]
+    (if next-sid
+      (let [next-res (async/<! next-sid)]
+        (if (util/exception? next-res)
+          next-res
+          (recur r (conj acc (async/<! next-sid)))))
+      acc)))
+
+
+(defn resolve-equals-rule
+  "When using an equals rule, calculates a given path's value and stores in local cache.
+
+  Equals should return a single value result. If anywhere along the path multiple results
+  are returned, it will choose the first one and log out a warning that equals is being
+  used with data that is not compliant (prefer f:contains)."
+  [{:keys [permissions] :as db} path-pids equals-rule]
+  (go-try
+    (let [{:keys [cache ident]} permissions
+          db-root (dbproto/-rootdb db)]
+      (loop [[next-pid & r] path-pids
+             last-result ident]
+        (if next-pid
+          (let [next-res (<? (query-range/index-range db-root :spot = [last-result next-pid]))
+                ;; in case of mixed data types, take the first IRI result - unless we
+                ;; are at the end of the path in which case take the first value regardless
+                next-val (some #(if (= const/$xsd:anyURI (flake/dt %))
+                                  (flake/o %)) next-res)]
+            (when (> (count next-res) 1)
+              (log/warn (str "f:equals used for identity " ident " and path: " equals-rule
+                             " however the query produces more than one result, the first one "
+                             " is being used which can product unpredictable results. "
+                             "Prefer f:contains when comparing with multiple results.")))
+            (recur r next-val))
+          (do
+            (swap! cache assoc equals-rule last-result)
+            last-result))))))
+
+
+(defn resolve-contains-rule
+  "When using a contains rule, calculates a given path's value and stores in local cache.
+
+  Contains, unlike 'equals' will return a set of all possible results at the leaf of the
+  defined path."
+  [{:keys [permissions] :as db} path-pids equals-rule]
+  (go-try
+    (let [{:keys [cache ident]} permissions]
+      (loop [[next-pid & rest-path] path-pids
+             last-results #{ident}]
+        (if next-pid
+          (loop [[next-result & r] last-results
+                 acc #{}]
+            (if next-result
+              (let [next-res (<? (query-range/index-range db :spot = [next-result next-pid]))]
+                (recur r (reduce (fn [acc* res-flake]
+                                   (if (= const/$xsd:anyURI (flake/dt res-flake))
+                                     (conj acc* (flake/o res-flake))
+                                     acc*))
+                                 acc next-res)))
+              (recur rest-path acc)))
+          (do
+            (swap! cache assoc equals-rule last-results)
+            last-results))))))

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -197,10 +197,9 @@
                            :indexer indexer
                            :conn    conn})
           blank-db      (jld-db/create ledger)
-          bootstrap?    (and (not blank?)
-                             (or context* did*))
+          bootstrap?    (and (not blank?) context*)
           db            (if bootstrap?
-                          (<? (bootstrap/bootstrap blank-db context* (:id did*)))
+                          (<? (bootstrap/bootstrap blank-db context*))
                           (bootstrap/blank-db blank-db))]
       ;; place initial 'blank' DB into ledger.
       (ledger-proto/-db-update ledger db)

--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -9,117 +9,36 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; goal is a quick check if we can not check every result. Many queries are small,
-;; so an extended effort in here is not worth the time, we can just check each result
-(defn no-filter?
-  "Quick check if we can skip filtering."
-  [permissions s1 s2 p1 p2]
-  (or (true? (:root? permissions))
-      (and s1 s2
-           ;; always allow a tag query
-           (= 3 (flake/sid->cid s1) (flake/sid->cid s2)))))
-
-(defn process-functions
-  [flake functions db permissions]
-  (async/go
-    (let [root-db (dbproto/-rootdb db)
-          sid     (flake/s flake)
-          ctx     {:sid     sid
-                   :auth_id (or (:auth db) (:auth permissions))
-                   :instant (util/current-time-millis)
-                   :cache   (:ctx-cache db)
-                   :db      root-db
-                   :state   (atom {:stack   []
-                                   :credits 10000000
-                                   :spent   0})}]
-      (loop [[f & r] functions]
-        (if f
-          (let [res (try*
-                      (let [result (f ctx)]
-                        (if (channel? result)
-                          (<? result)
-                          result))
-                      (catch* e
-                              (log/warn "Caught exception in database function: "
-                                        (:fnstr (meta f)) ": " #?(:clj (.getMessage e) :cljs (str e)))
-                              (log/error e)
-                              (ex-info
-                                (str "Caught exception in database function: "
-                                     (:fnstr (meta f)) ": " #?(:clj (.getMessage e) :cljs (str e)))
-                                {:status 400
-                                 :error  :db/db-function-error})))]
-            (cond
-              (util/exception? res)
-              res
-
-              (not res)                                     ;; not yet a true response, try next
-              (recur r)
-
-              :else                                         ;; first true response will allow
-              true))
-          false)))))
-
-
-(defn check-explicit-functions
-  [flake db permissions fns-paths]
-  (async/go
-    (let [trace? (:trace? permissions)]
-      (loop [[f & r] fns-paths
-             ;; if any explicit predicate exists, we will not check defaults - else we check defaults
-             check-defaults? true]
-        (let [funs   (get-in permissions f)
-              result (when (not (nil? funs))
-                       (if (boolean? funs)
-                         funs
-                         (async/<! (process-functions flake funs db permissions))))
-              ;; if we ever find a function explicitly assigned, don't check for
-              ;; collection defaults
-              check-defaults?* (if (nil? funs) check-defaults? false)]
-          (cond
-            ;; exception
-            (util/exception? result) result
-
-            ;; any truthy value means flake is allowed, don't check defaults
-            result
-            [true false]
-
-            ;; nothing left to check, cannot see flake
-            (empty? r)
-            [false check-defaults?*]
-
-            :else
-            (recur r check-defaults?*)))))))
-
-
-(defn root-permission?
-  "Returns true for root db permissions."
-  [permissions]
-  (true? (:root? permissions)))
-
 
 (defn allow-flake?
-  "Returns either:
+  "Returns one of:
   (a) exception if there was an error
   (b) truthy value if flake is allowed
-  (c) falsey value if flake not allowed"
-  ([db flake] (allow-flake? db flake (:permissions db)))
-  ([db flake permissions]
-   (async/go
-     (if (root-permission? permissions)
-       true
-       (let [cid       (flake/sid->cid (flake/s flake))
-             pid       (flake/p flake)
-             fns-paths [[:collection cid pid] [:collection cid :all] [:predicate pid]]
-             check     (async/<! (check-explicit-functions flake db permissions fns-paths))]
-         (if (util/exception? check)
-           check
-           (let [[result check-defaults?] check]
-             (if check-defaults?
-               (first                                       ;; returns two-tuple
-                 (async/<!
-                   (check-explicit-functions flake db permissions [[:collection cid :default]
-                                                                   [:collection :default]])))
-               result))))))))
+  (c) falsey value if flake not allowed
+
+  Note this should only be called if the db is permissioned, don't call if the root user as the results will
+  not come back correctly."
+  [{:keys [permissions] :as db} flake]
+  (go-try
+    (let [s         (flake/s flake)
+          p         (flake/p flake)
+          class-ids (or (get @(:cache permissions) s)
+                        (let [classes (<? (dbproto/-class-ids (dbproto/-rootdb db) (flake/s flake)))]
+                          ;; note, classes will return empty list if none found ()
+                          (swap! (:cache permissions) assoc s classes)
+                          classes))
+          fns       (keep #(or (get-in permissions [:view :class % p])
+                               (get-in permissions [:view :class % :default])) class-ids)]
+      (loop [[[async? f] & r] fns]
+        ;; TODO - all fns are currently sync - but that will change. Can check for presence of ch? in response, or ideally pass as meta which fns are sync or async
+        ;; return first truthy response, else false
+        (if f
+          (let [res (if async?
+                      (<? (f db flake))
+                      (f db flake))]
+            (or res
+                (recur r)))
+          false)))))
 
 
 (defn allow-flakes?
@@ -132,7 +51,7 @@
            acc []]
       (if flake (if (schema-util/is-schema-flake? flake)    ;; always allow schema flakes
                   (recur r (conj acc flake))
-                  (let [res (async/<! (allow-flake? db flake (:permissions db)))]
+                  (let [res (async/<! (allow-flake? db flake))]
                     (if (util/exception? res)
                       res
                       (if res

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -189,18 +189,14 @@
      flake-slices ; Note this bypasses all permissions in CLJS for now!
 
      :clj
-     (let [s1 (flake/s start)
-           p1 (flake/p start)
-           s2 (flake/s end)
-           p2 (flake/p end)]
-       (if (perm-validate/no-filter? permissions s1 s2 p1 p2)
-         flake-slices
-         (let [auth-fn (fn [flakes ch]
-                         (-> (authorize-flakes db error-ch flakes)
-                             (async/pipe ch)))
-               out-ch  (chan)]
-           (async/pipeline-async 2 out-ch auth-fn flake-slices)
-           out-ch)))))
+     (if (true? (:root? permissions))
+       flake-slices
+       (let [auth-fn (fn [flakes ch]
+                       (-> (authorize-flakes db error-ch flakes)
+                           (async/pipe ch)))
+             out-ch  (chan)]
+         (async/pipeline-async 2 out-ch auth-fn flake-slices)
+         out-ch))))
 
 (defn filter-subject-page
   "Returns a transducer to filter a stream of flakes to only contain flakes from

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -1,0 +1,120 @@
+(ns fluree.db.policy.basic-test
+  (:require
+    [clojure.test :refer :all]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.did :as did]
+    [fluree.db.util.log :as log]))
+
+
+(deftest ^:integration policy-enforcement
+  (testing "Testing basic policy enforcement."
+    (let [conn      (test-utils/create-conn)
+          ledger    @(fluree/create conn "policy/a" {:context {:ex "http://example.org/ns/"}})
+          root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+          alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+          db        @(fluree/stage
+                       ledger
+                       [{:id               :ex/alice,
+                         :type             :ex/User,
+                         :schema/name      "Alice"
+                         :schema/email     "alice@flur.ee"
+                         :schema/birthDate "2022-08-17"
+                         :schema/ssn       "111-11-1111"
+                         :ex/location      {:ex/state   "NC"
+                                            :ex/country "USA"}}
+                        {:id               :ex/john,
+                         :type             :ex/User,
+                         :schema/name      "John"
+                         :schema/email     "john@flur.ee"
+                         :schema/birthDate "2021-08-17"
+                         :schema/ssn       "888-88-8888"}
+                        {:id                   :ex/widget,
+                         :type                 :ex/Product,
+                         :schema/name          "Widget"
+                         :schema/price         99.99
+                         :schema/priceCurrency "USD"}
+                        ;; assign root-did to :ex/rootRole
+                        {:id     root-did
+                         :f/role :ex/rootRole}
+                        ;; assign alice-did to :ex/userRole and also link the did to :ex/alice via :ex/user
+                        {:id      alice-did
+                         :ex/user :ex/alice
+                         :f/role  :ex/userRole}])
+
+          db+policy @(fluree/stage
+                       db
+                       ;; add policy targeting :ex/rootRole that can view and modify everything
+                       [{:id           :ex/rootPolicy,
+                         :type         [:f/Policy],
+                         :f/targetNode :f/allNodes
+                         :f/allow      [{:id           :ex/rootAccessAllow
+                                         :f/targetRole :ex/rootRole ;; keyword for a global role
+                                         :f/action     [:f/view :f/modify]}]}
+                        ;; add a policy targeting :ex/userRole that can see all users, but only SSN if belonging to themselves
+                        {:id            :ex/UserPolicy,
+                         :type          [:f/Policy],
+                         :f/targetClass :ex/User
+                         :f/allow       [{:id           :ex/globalViewAllow
+                                          :f/targetRole :ex/userRole ;; keyword for a global role
+                                          :f/action     [:f/view]}]
+                         :f/property    [{:f/path  :schema/ssn
+                                          :f/allow [{:id           :ex/ssnViewRule
+                                                     :f/targetRole :ex/userRole
+                                                     :f/action     [:f/view]
+                                                     :f/equals     {:list [:f/$identity :ex/user]}}]}]}])
+          root-db   @(fluree/wrap-policy db+policy {:f/$identity root-did
+                                                    :f/role      :ex/rootRole})
+          alice-db  @(fluree/wrap-policy db+policy {:f/$identity alice-did
+                                                    :f/role      :ex/userRole})]
+
+      ;; root can see all user data
+      (is (= @(fluree/query root-db {:select {'?s [:* {:ex/location [:*]}]}
+                                     :where  [['?s :rdf/type :ex/User]]})
+             [{:id               :ex/john,
+               :rdf/type         [:ex/User],
+               :schema/name      "John",
+               :schema/email     "john@flur.ee",
+               :schema/birthDate "2021-08-17",
+               :schema/ssn       "888-88-8888"}
+              {:id               :ex/alice,
+               :rdf/type         [:ex/User],
+               :schema/name      "Alice",
+               :schema/email     "alice@flur.ee",
+               :schema/birthDate "2022-08-17",
+               :schema/ssn       "111-11-1111",
+               :ex/location      {:id         "_:f211106232532993",
+                                  :ex/state   "NC",
+                                  :ex/country "USA"}}])
+          "Both user records + all attributes should show")
+
+      ;; root can see all product data
+      (is (= @(fluree/query root-db {:select {'?s [:* {:ex/location [:*]}]}
+                                     :where  [['?s :rdf/type :ex/Product]]})
+             [{:id                   :ex/widget,
+               :rdf/type             [:ex/Product],
+               :schema/name          "Widget",
+               :schema/price         99.99,
+               :schema/priceCurrency "USD"}])
+          "The product record should show with all attributes")
+
+      ;; Alice cannot see product data as it was not explicitly allowed
+      (is (= @(fluree/query alice-db {:select {'?s [:*]}
+                                      :where  [['?s :rdf/type :ex/Product]]})
+             []))
+
+      ;; Alice can see all users, but can only see SSN for herself, and can't see the nested location
+      (is (= @(fluree/query alice-db {:select {'?s [:* {:ex/location [:*]}]}
+                                      :where  [['?s :rdf/type :ex/User]]})
+             [{:id               :ex/john,
+               :rdf/type         [:ex/User],
+               :schema/name      "John",
+               :schema/email     "john@flur.ee",
+               :schema/birthDate "2021-08-17"}
+              {:id               :ex/alice,
+               :rdf/type         [:ex/User],
+               :schema/name      "Alice",
+               :schema/email     "alice@flur.ee",
+               :schema/birthDate "2022-08-17",
+               :schema/ssn       "111-11-1111"}])
+          "Both users should show, but only SSN for Alice"))))

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -48,13 +48,13 @@
             (is (= (->> @(fluree/slice db :spot [alice-sid])
                         (mapv flake/Flake->parts))
                    [[alice-sid 0 "http://example.org/ns/alice" 1 -1 true nil]
-                    [alice-sid 200 1014 0 -1 true nil]
-                    [alice-sid 1015 "Alice" 1 -1 true nil]
-                    [alice-sid 1016 "alice@example.org" 1 -1 true nil]
-                    [alice-sid 1017 50 7 -1 true nil]
-                    [alice-sid 1018 9 7 -1 true nil]
-                    [alice-sid 1018 42 7 -1 true nil]
-                    [alice-sid 1018 76 7 -1 true nil]])
+                    [alice-sid 200 1002 0 -1 true nil]
+                    [alice-sid 1003 "Alice" 1 -1 true nil]
+                    [alice-sid 1004 "alice@example.org" 1 -1 true nil]
+                    [alice-sid 1005 50 7 -1 true nil]
+                    [alice-sid 1006 9 7 -1 true nil]
+                    [alice-sid 1006 42 7 -1 true nil]
+                    [alice-sid 1006 76 7 -1 true nil]])
                 "Slice should return a vector of flakes for only Alice")))
 
         (testing "Slice for subject + predicate"

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -82,15 +82,33 @@
           movies (test-utils/load-movies conn)
           db     (fluree/db movies)]
       (testing "basic analytical RFD type query"
-        (let [query-res @(fluree/query db {:selectOne {'?s [:* {:f/role [:*]}]}
-                                           :where     [['?s :rdf/type :f/DID]]})]
-          (is (= (dissoc query-res :id)                       ;; :id is a DID and will be unique per DB so exclude from comparison
-                 {:rdf/type [:f/DID],
-                  :f/role   {:id              "fluree-root-role",
-                             :rdf/type        [:f/Role],
-                             :skos/definition "Default role that gives full root access to a ledger.",
-                             :skos/prefLabel  "Root role",
-                             :f/rules         {:id "fluree-root-rule"}}})
+        (let [query-res @(fluree/query db {:select {'?s [:* {:schema/isBasedOn [:*]}]}
+                                           :where  [['?s :rdf/type :schema/Movie]]})]
+          (is (= query-res                                  ;; :id is a DID and will be unique per DB so exclude from comparison
+                 [{:id                               :wiki/Q230552,
+                   :rdf/type                         [:schema/Movie],
+                   :schema/name                      "Back to the Future Part III",
+                   :schema/disambiguatingDescription "1990 film by Robert Zemeckis",
+                   :schema/titleEIDR                 "10.5240/15F9-F913-FF25-8041-E798-O"}
+                  {:id                :wiki/Q109331, :rdf/type [:schema/Movie],
+                   :schema/name       "Back to the Future Part II",
+                   :schema/titleEIDR  "10.5240/5DA5-C386-2911-7E2B-1782-L",
+                   :schema/followedBy {:id :wiki/Q230552}}
+                  {:id                               :wiki/Q91540,
+                   :rdf/type                         [:schema/Movie],
+                   :schema/name                      "Back to the Future",
+                   :schema/disambiguatingDescription "1985 film by Robert Zemeckis",
+                   :schema/titleEIDR                 "10.5240/09A3-1F6E-3538-DF46-5C6F-I",
+                   :schema/followedBy                {:id :wiki/Q109331}}
+                  {:id                               :wiki/Q836821, :rdf/type [:schema/Movie],
+                   :schema/name                      "The Hitchhiker's Guide to the Galaxy",
+                   :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
+                   :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
+                   :schema/isBasedOn                 {:id            :wiki/Q3107329,
+                                                      :rdf/type      [:schema/Book],
+                                                      :schema/name   "The Hitchhiker's Guide to the Galaxy",
+                                                      :schema/isbn   "0-330-25864-8",
+                                                      :schema/author {:id :wiki/Q42}}}])
               "Standard bootstrap data isn't matching."))))))
 
 
@@ -126,132 +144,132 @@
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/simple-subject-crawl" {:context {:ex "http://example.org/ns/"}})
         db     @(fluree/stage
-                 ledger
-                 [{:id           :ex/brian,
-                   :type         :ex/User,
-                   :schema/name  "Brian"
-                   :ex/last      "Smith"
-                   :schema/email "brian@example.org"
-                   :schema/age   50
-                   :ex/favNums   7}
-                  {:id           :ex/alice,
-                   :type         :ex/User,
-                   :schema/name  "Alice"
-                   :ex/last      "Smith"
-                   :schema/email "alice@example.org"
-                   :ex/favColor  "Green"
-                   :schema/age   42
-                   :ex/favNums   [42, 76, 9]}
-                  {:id          :ex/cam,
-                   :type        :ex/User,
-                   :schema/name "Cam"
-                   :ex/last     "Jones"
-                   :schema/email    "cam@example.org"
-                   :schema/age  34
-                   :ex/favColor "Blue"
-                   :ex/favNums  [5, 10]
-                   :ex/friend   [:ex/brian :ex/alice]}
-                  {:id          :ex/david,
-                   :type        :ex/User,
-                   :schema/name "David"
-                   :ex/last     "Jones"
-                   :schema/email    "david@example.org"
-                   :schema/age  46
-                   :ex/favNums  [15 70]
-                   :ex/friend   [:ex/cam]}])]
+                  ledger
+                  [{:id           :ex/brian,
+                    :type         :ex/User,
+                    :schema/name  "Brian"
+                    :ex/last      "Smith"
+                    :schema/email "brian@example.org"
+                    :schema/age   50
+                    :ex/favNums   7}
+                   {:id           :ex/alice,
+                    :type         :ex/User,
+                    :schema/name  "Alice"
+                    :ex/last      "Smith"
+                    :schema/email "alice@example.org"
+                    :ex/favColor  "Green"
+                    :schema/age   42
+                    :ex/favNums   [42, 76, 9]}
+                   {:id           :ex/cam,
+                    :type         :ex/User,
+                    :schema/name  "Cam"
+                    :ex/last      "Jones"
+                    :schema/email "cam@example.org"
+                    :schema/age   34
+                    :ex/favColor  "Blue"
+                    :ex/favNums   [5, 10]
+                    :ex/friend    [:ex/brian :ex/alice]}
+                   {:id           :ex/david,
+                    :type         :ex/User,
+                    :schema/name  "David"
+                    :ex/last      "Jones"
+                    :schema/email "david@example.org"
+                    :schema/age   46
+                    :ex/favNums   [15 70]
+                    :ex/friend    [:ex/cam]}])]
     (testing "using `from`"
-      (is (= [{:id :ex/brian,
-               :rdf/type [:ex/User]
-               :schema/name "Brian"
-               :ex/last "Smith"
+      (is (= [{:id           :ex/brian,
+               :rdf/type     [:ex/User]
+               :schema/name  "Brian"
+               :ex/last      "Smith"
                :schema/email "brian@example.org"
-               :schema/age 50
-               :ex/favNums 7}]
+               :schema/age   50
+               :ex/favNums   7}]
              @(fluree/query db {:select [:*]
-                                :from :ex/brian}))))
+                                :from   :ex/brian}))))
     (testing "using `where`"
       (testing "id"
-        (is (= [{:id :ex/brian,
-                 :rdf/type [:ex/User]
-                 :schema/name "Brian"
-                 :ex/last "Smith"
+        (is (= [{:id           :ex/brian,
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Brian"
+                 :ex/last      "Smith"
                  :schema/email "brian@example.org"
-                 :schema/age 50
-                 :ex/favNums 7}]
+                 :schema/age   50
+                 :ex/favNums   7}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :id :ex/brian]]}))))
       (testing "iri"
-        (is (= [{:id :ex/david
-                 :rdf/type [:ex/User]
-                 :schema/name "David"
-                 :ex/last "Jones"
+        (is (= [{:id           :ex/david
+                 :rdf/type     [:ex/User]
+                 :schema/name  "David"
+                 :ex/last      "Jones"
                  :schema/email "david@example.org"
-                 :schema/age 46
-                 :ex/favNums [15 70]
-                 :ex/friend {:id :ex/cam}}
-                {:rdf/type [:ex/User]
+                 :schema/age   46
+                 :ex/favNums   [15 70]
+                 :ex/friend    {:id :ex/cam}}
+                {:rdf/type     [:ex/User]
                  :schema/email "cam@example.org"
-                 :ex/favNums [5 10]
-                 :schema/age 34
-                 :ex/last "Jones"
-                 :schema/name "Cam"
-                 :id :ex/cam
-                 :ex/friend [{:id :ex/brian} {:id :ex/alice}]
-                 :ex/favColor "Blue"}
-                {:id :ex/alice
-                 :rdf/type [:ex/User]
-                 :schema/name "Alice"
-                 :ex/last "Smith"
+                 :ex/favNums   [5 10]
+                 :schema/age   34
+                 :ex/last      "Jones"
+                 :schema/name  "Cam"
+                 :id           :ex/cam
+                 :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
+                 :ex/favColor  "Blue"}
+                {:id           :ex/alice
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Alice"
+                 :ex/last      "Smith"
                  :schema/email "alice@example.org"
-                 :schema/age 42
-                 :ex/favNums [9 42 76]
-                 :ex/favColor "Green"}
-                {:id :ex/brian
-                 :rdf/type [:ex/User]
-                 :schema/name "Brian"
-                 :ex/last "Smith"
+                 :schema/age   42
+                 :ex/favNums   [9 42 76]
+                 :ex/favColor  "Green"}
+                {:id           :ex/brian
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Brian"
+                 :ex/last      "Smith"
                  :schema/email "brian@example.org"
-                 :schema/age 50
-                 :ex/favNums 7}]
+                 :schema/age   50
+                 :ex/favNums   7}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :type :ex/User]]}))))
       (testing "tuple"
-        (is (= [{:id :ex/alice
-                 :rdf/type [:ex/User]
-                 :schema/name "Alice"
-                 :ex/last "Smith"
+        (is (= [{:id           :ex/alice
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Alice"
+                 :ex/last      "Smith"
                  :schema/email "alice@example.org"
-                 :schema/age 42
-                 :ex/favNums [9 42 76]
-                 :ex/favColor "Green"}]
+                 :schema/age   42
+                 :ex/favNums   [9 42 76]
+                 :ex/favColor  "Green"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/name "Alice"]]})))
-        (is (= [{:rdf/type [:ex/User]
+        (is (= [{:rdf/type     [:ex/User]
                  :schema/email "cam@example.org"
-                 :ex/favNums [5 10]
-                 :schema/age 34
-                 :ex/last "Jones"
-                 :schema/name "Cam"
-                 :id :ex/cam
-                 :ex/friend [{:id :ex/brian} {:id :ex/alice}]
-                 :ex/favColor "Blue"}
-                {:id :ex/alice
-                 :rdf/type [:ex/User]
-                 :schema/name "Alice"
-                 :ex/last "Smith"
+                 :ex/favNums   [5 10]
+                 :schema/age   34
+                 :ex/last      "Jones"
+                 :schema/name  "Cam"
+                 :id           :ex/cam
+                 :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
+                 :ex/favColor  "Blue"}
+                {:id           :ex/alice
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Alice"
+                 :ex/last      "Smith"
                  :schema/email "alice@example.org"
-                 :schema/age 42
-                 :ex/favNums [9 42 76]
-                 :ex/favColor "Green"}]
+                 :schema/age   42
+                 :ex/favNums   [9 42 76]
+                 :ex/favColor  "Green"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :ex/favColor "?color"]]})))
-        (is (= [{:id :ex/alice
-                 :rdf/type [:ex/User]
-                 :schema/name "Alice"
-                 :ex/last "Smith"
+        (is (= [{:id           :ex/alice
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Alice"
+                 :ex/last      "Smith"
                  :schema/email "alice@example.org"
-                 :schema/age 42
-                 :ex/favNums [9 42 76]
-                 :ex/favColor "Green"}]
+                 :schema/age   42
+                 :ex/favNums   [9 42 76]
+                 :ex/favColor  "Green"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/age 42]]})))))))

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -22,13 +22,13 @@
                                              :schema/name "Picasso"}}]})]
       (is (= @(fluree/query db {:select {'?s [:_id :* {:ex/favArtist [:_id :schema/name]}]}
                                 :where  [['?s :type :ex/User]]})
-             [{:_id          211106232532999,
+             [{:_id          211106232532993,
                :id           :ex/bob,
                :rdf/type     [:ex/User],
                :schema/name  "Bob",
-               :ex/favArtist {:_id         211106232533000
+               :ex/favArtist {:_id         211106232532994
                               :schema/name "Picasso"}}
-              {:_id         211106232532998,
+              {:_id         211106232532992,
                :id          :ex/alice,
                :rdf/type    [:ex/User],
                :schema/name "Alice"}])))))
@@ -70,59 +70,13 @@
               [:ex/alice :schema/name "Alice"]
               [:ex/alice :schema/email "alice@flur.ee"]
               [:ex/alice :schema/age 42]
-              ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6" :id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-              ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6" :rdf/type :f/DID]
-              ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6" :f/role "fluree-root-role"]
-              ["fluree-fn-false" :id "fluree-fn-false"]
-              ["fluree-fn-false" :rdf/type :f/Function]
-              ["fluree-fn-false" :skos/definition "Always denies access to any data when attached to a rule."]
-              ["fluree-fn-false" :skos/prefLabel "False function"]
-              ["fluree-fn-false" :f/code "false"]
-              [:f/opsAll :id "https://ns.flur.ee/ledger#opsAll"]
-              ["fluree-fn-true" :id "fluree-fn-true"]
-              ["fluree-fn-true" :rdf/type :f/Function]
-              ["fluree-fn-true" :skos/definition "Always allows full access to any data when attached to a rule."]
-              ["fluree-fn-true" :skos/prefLabel "True function"]
-              ["fluree-fn-true" :f/code "true"]
-              ["fluree-root-rule" :id "fluree-root-rule"]
-              ["fluree-root-rule" :rdf/type :f/Rule]
-              ["fluree-root-rule" :skos/definition "Default root rule, attached to fluree-root-role."]
-              ["fluree-root-rule" :skos/prefLabel "Root rule"]
-              ["fluree-root-rule" :f/allTypes true]
-              ["fluree-root-rule" :f/function "fluree-fn-true"]
-              ["fluree-root-rule" :f/operations :f/opsAll]
-              ["fluree-root-role" :id "fluree-root-role"]
-              ["fluree-root-role" :rdf/type :f/Role]
-              ["fluree-root-role" :skos/definition "Default role that gives full root access to a ledger."]
-              ["fluree-root-role" :skos/prefLabel "Root role"]
-              ["fluree-root-role" :f/rules "fluree-root-rule"]
               [:schema/age :id "http://schema.org/age"]
               [:schema/email :id "http://schema.org/email"]
               [:schema/name :id "http://schema.org/name"]
               [:ex/User :id "http://example.org/ns/User"]
               [:ex/User :rdf/type :rdfs/Class]
-              [:f/role :id "https://ns.flur.ee/ledger#role"]
-              [:f/role :rdf/type :id]
-              [:f/DID :id "https://ns.flur.ee/ledger#DID"]
-              [:f/DID :rdf/type :rdfs/Class]
               [:f/Context :id "https://ns.flur.ee/ledger#Context"]
               [:f/Context :rdf/type :rdfs/Class]
-              [:f/code :id "https://ns.flur.ee/ledger#code"]
-              [:f/Function :id "https://ns.flur.ee/ledger#Function"]
-              [:f/Function :rdf/type :rdfs/Class]
-              [:f/operations :id "https://ns.flur.ee/ledger#operations"]
-              [:f/operations :rdf/type :id]
-              [:f/function :id "https://ns.flur.ee/ledger#function"]
-              [:f/function :rdf/type :id]
-              [:f/allTypes :id "https://ns.flur.ee/ledger#allTypes"]
-              [:f/Rule :id "https://ns.flur.ee/ledger#Rule"]
-              [:f/Rule :rdf/type :rdfs/Class]
-              [:f/rules :id "https://ns.flur.ee/ledger#rules"]
-              [:f/rules :rdf/type :id]
-              [:skos/prefLabel :id "http://www.w3.org/2008/05/skos#prefLabel"]
-              [:skos/definition :id "http://www.w3.org/2008/05/skos#definition"]
-              [:f/Role :id "https://ns.flur.ee/ledger#Role"]
-              [:f/Role :rdf/type :rdfs/Class]
               [:f/context :id "https://ns.flur.ee/ledger#context"]
               [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
               [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]


### PR DESCRIPTION
This adds initial policy (smartfunction) support for queries only as per ticket #231. There are some query parts that do not yet check permissions which will be addressed in a separate ticket.

Note new test namespace `fluree.db.policy.basic-test` for examples.

Policy is added by creating an `f:Policy` @type that has an `f:targetRole` and an `f:targetClass` *or* `f:targetNode` (incomplete). The policy can have a set of rules under `f:allow` that permit actions that meet logic conditions, or rules that target just specific properties/predicates if specified using `f:property`.

If a user's identity is attached to a `f:role` that matches `f:targetRole` on a policy, then that policy is in effect when using a policy-enforcing db.

For example, a "root" role policy would look like this (in clojure):
```
{:id           :ex/rootPolicy,
 :type         [:f/Policy],
 :f/targetNode :f/allNodes
 :f/allow      [{:id           :ex/rootAccessAllow
                 :f/targetRole :ex/rootRole ;; keyword for a global role
                 :f/action     [:f/view :f/modify]}]}
```

This  targets all subjects (nodes) in the database using `:f/targetNode :f/allNodes` where `:f/allNodes` is a special keyword that Fluree recognizes and meaning everything.

The policy only targets one role via `:f/targetRole :ex/rootRole`, but could target multiple roles, and permits the actions of viewing and modifying with ` :f/action     [:f/view :f/modify]`.

To attach an identity to this role, the database can be used, however it is anticipated external authoritative sources of input might be used in the future (a trusted 3rd party Verifiable Credential).

Using the database, the attachment is a simple as this transaction:
```
{:id    "did:fluree:..."
 :f/role :ex/rootRole}
```

Automating the lookup of the did -> role is purposefully abstracted however to allow it to happen multiple ways. It is anticipated an out of the box HTTP server will look up this relationship automatically, but when using the library, any method can be chosen as to utilized a policy-driven database one must be requested from the 'root' database in this way:

```
(def policy-db
  @(fluree/wrap-policy db {:f/$identity "did:fluree:..."
                           :f/role      :ex/rootRole}))
```

Queries can then be executed against the policy-db.

Here both `:f/$identity` and `:f/role` are provided when requesting the permissioned DB, however only the role is required. If part of the policy, as the next example will show, takes into account the user's identity then the `:f/$identity` will need to be present for the rule to work.


As an example targeting a specific class and allowing special restrictions on specific properties, this example does this for the `:ex/userRole` role for only the class `:ex/User`, and also creates more specific view criteria for the property `:schema/ssn`.

```
{:id            :ex/UserPolicy,
 :type          [:f/Policy],
 :f/targetClass :ex/User
 :f/allow       [{:id           :ex/globalViewAllow
                  :f/targetRole :ex/userRole ;; keyword for a global role
                  :f/action     [:f/view]}]
 :f/property    [{:f/path  :schema/ssn
                  :f/allow [{:id           :ex/ssnViewRule
                             :f/targetRole :ex/userRole
                             :f/action     [:f/view]
                             :f/equals     {:list [:f/$identity :ex/user]}}]}]}
```

In this case, it will be important when calling the `fluree/wrap-policy` API to supply the `:f/$identity` in addition to `:f/role`, as identity is used in the condition for the specific rule around the property `:schema/ssn`. Note that condition uses `:f/equals` which will follow the relationship path from the identity through all elements listed - in this case the path is ` [:f/$identity :ex/user]`.

To register an identity for :ex/alice, and connect her identity to her user record we'll use `:ex/user` on the identity record so the path completes successfully.

In this case `:ex/alice` will be able to see all users, but will only see her own SSN an no others.

```
{:id      "did:fluree:....."
 :ex/user :ex/alice
 :f/role  :ex/userRole}
```


