### PR TITLE
Inconsistent nested tx node results without IRIs, support multiple identical @id in same tx

### DIFF
--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -110,8 +110,8 @@
       (dec (flake/->sid const/$_shard 0))))
 
 (defn generate-new-sid
-  "Generates a new subject ID. Tried to identify properties and classes to
-  assign them the lower range of subject ids."
+  "Generates a new subject ID. If it is know this is a property or class will
+  assign the lower range of subject ids."
   [{:keys [id] :as node} referring-pid iris next-pid next-sid]
   (let [new-sid (or
                   (get predefined-properties id)

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -66,10 +66,9 @@
           "http://www.w3.org/ns/shacl#maxExclusive"             const/$sh:maxExclusive
           "http://www.w3.org/ns/shacl#maxInclusive"             const/$sh:maxInclusive
           ;; fluree
-          "https://ns.flur.ee/ledger#context"                   const/$fluree:context}))
+          "https://ns.flur.ee/ledger#context"                   const/$fluree:context
+          const/iri-default-context                             const/$fluree:default-context}))
 
-(def ^:const predefined-subjects
-  {const/iri-default-context const/$fluree:default-context})
 
 (defn flip-key-vals
   [map]
@@ -111,11 +110,17 @@
       (dec (flake/->sid const/$_shard 0))))
 
 (defn generate-new-sid
-  [{:keys [id] :as node} iris next-pid next-sid]
-  (let [new-sid (if (class-or-property? node)
-                  (next-pid)
-                  (or
-                    (get predefined-subjects id)
+  "Generates a new subject ID. Tried to identify properties and classes to
+  assign them the lower range of subject ids."
+  [{:keys [id] :as node} referring-pid iris next-pid next-sid]
+  (let [new-sid (or
+                  (get predefined-properties id)
+                  (if (or (class-or-property? node)
+                          (#{const/$sh:path const/$sh:ignoredProperties
+                             const/$sh:targetClass
+                             const/$sh:targetSubjectsOf const/$sh:targetObjectsOf}
+                           referring-pid))
+                    (next-pid)
                     (next-sid)))]
     (vswap! iris assoc id new-sid)
     new-sid))

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -86,7 +86,7 @@
     (let [{:keys [id type]} node
           existing-sid    (<? (get-iri-sid id db iris))
           sid             (or existing-sid
-                              (jld-ledger/generate-new-sid node iris next-pid next-sid))
+                              (jld-ledger/generate-new-sid node nil iris next-pid next-sid))
           type-assertions (if type
                             (loop [[type-item & r] type
                                    acc []]
@@ -118,7 +118,7 @@
                   acc*         (cond-> (if id ;; is a ref to another IRI
                                          (let [existing-sid (<? (get-iri-sid id db iris))
                                                ref-sid      (or existing-sid
-                                                                (jld-ledger/generate-new-sid v-map iris next-pid next-sid))]
+                                                                (jld-ledger/generate-new-sid v-map pid iris next-pid next-sid))]
                                            (cond-> (conj acc (flake/create sid pid ref-sid const/$xsd:anyURI t true nil))
                                              (nil? existing-sid) (conj (flake/create ref-sid const/$iri id const/$xsd:string t true nil))))
                                          (let [[value dt] (datatype/from-expanded v-map nil)]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -103,7 +103,6 @@
                                                 {:status 400 :error :db/shacl-validation}))))
                           [(flake/create sid pid value* dt t true m)])
 
-                        ;; otherwise should be an IRI 'ref' either as an :id, or mis-cast as a value that needs coercion
                         :else
                         (throw (ex-info (str "JSON-LD value must be a node or a value, instead found ambiguous value: " v-map)
                                         {:status 400 :error :db/invalid-transaction})))]
@@ -158,7 +157,7 @@
                                {:status 400 :error :db/invalid-transaction})))))))
 
 (defn json-ld-node->flakes
-  "Returns two-tupel of [sid node-flakes] that will contain the top-level sid
+  "Returns two-tuple of [sid node-flakes] that will contain the top-level sid
   and all flakes from the target node and all children nodes that ultimately get processed.
 
   If property-id is non-nil, it can be checked when assigning new subject id for the node


### PR DESCRIPTION
This closes both issues #286 and #301.

When a transaction had nested blank nodes, it would seemingly loose the intermediary nodes in each leaf. This is because blank nodes have no IRI, and when creating the reference flakes for the parent it would look up the assigned subject-id for the child IRI... or in this case look up 'nil'. When multiple nested blank nodes exist, there are new 'nil' IRIs assigned and it ends up with the last node created, not the direct child.

This fixes the issue by returning not only the child flakes, but the child's sid - this is resilient to multiple nested blank nodes now.

This also addresses the issue @aaj3f brought up of an exception in certain circumstances when using the same @id in multiple locations. This was typically done just as a pointer.... now the code tracks if a node had actual data or was just a pointer and will only throw if actual data is trying to be created in multiple spots with the same IRI.