### PR TITLE
Make sure subClassOf predicate uses Class sid range

### DIFF
--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -116,7 +116,8 @@
   (let [new-sid (or
                   (get predefined-properties id)
                   (if (or (class-or-property? node)
-                          (#{const/$sh:path const/$sh:ignoredProperties
+                          (#{const/$rdfs:subClassOf
+                             const/$sh:path const/$sh:ignoredProperties
                              const/$sh:targetClass
                              const/$sh:targetSubjectsOf const/$sh:targetObjectsOf}
                            referring-pid))


### PR DESCRIPTION
Fluree still uses logic in generating and caching the schema that requires Classes (either RDF or OWL) to be in the lower subject-id address range. This issue fundamentally still needs to get addressed, as we may assign an SID to a subject not knowing it is Class, only to later learn it is being used as one.

Most common circumstances we can figure this out when creating the subject. This addresses one of those circumstances which it was not doing the right thing, where a new subject is being created as a subClassOf before the referred to node/Class itself was created.