### PR TITLE
Make stage & commit! args more explicit

### DIFF
--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -392,12 +392,6 @@
          (when pred-name
            (<? (dbproto/-tag-id this (str pred-name ":" tag-name)))))))))
 
-(defn commit!
-  "Commits a db to ledger. Extracts ledger from db object"
-  [db opts]
-  (let [ledger (:ledger db)]
-    (ledger-proto/-commit! ledger db opts)))
-
 (defn index-update
   "If provided commit-index is newer than db's commit index, updates db by cleaning novelty.
   If it is not newer, returns original db."
@@ -426,10 +420,6 @@
                      spot psot post opst tspo
                      schema comparators novelty
                      permissions ecount]
-  ledger-proto/iCommit
-  (-commit! [db] (commit! db nil))
-  (-commit! [db opts] (commit! db opts))
-
   dbproto/IFlureeDb
   (-latest-db [this] (graphdb-latest-db this))
   (-rootdb [this] (graphdb-root-db this))

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -101,10 +101,7 @@
 (defrecord JsonLDLedger [id address alias context did indexer
                          state cache conn method]
   ledger-proto/iCommit
-  (-commit! [ledger] (commit! ledger nil nil))
-  (-commit! [ledger db-or-opts] (if (jld-db/json-ld-db? db-or-opts)
-                                  (commit! ledger db-or-opts nil)
-                                  (commit! ledger nil db-or-opts)))
+  (-commit! [ledger db] (commit! ledger db nil))
   (-commit! [ledger db opts] (commit! ledger db opts))
 
   ledger-proto/iLedger

--- a/src/fluree/db/ledger/proto.cljc
+++ b/src/fluree/db/ledger/proto.cljc
@@ -4,7 +4,7 @@
 
 (defprotocol iCommit
   ;; retrieving/updating DBs
-  (-commit! [db] [ledger-or-db db-or-opts] [ledger db opts] "Commits a db to a ledger."))
+  (-commit! [ledger db] [ledger db opts] "Commits a db to a ledger."))
 
 (defprotocol iLedger
   ;; retrieving/updating DBs

--- a/src/fluree/sdk/browser.cljs
+++ b/src/fluree/sdk/browser.cljs
@@ -47,11 +47,10 @@
                                                     (assoc :js? true)))))
 
 (defn ^:export commit
-  ([db] (.then (fluree/commit! db)
-               (fn [result] (clj->js result))))
   ([ledger db] (.then (fluree/commit! ledger db)
                       (fn [result] (clj->js result))))
-  ([ledger db opts] (.then (fluree/commit! ledger db (js->clj opts :keywordize-keys true))
+  ([ledger db opts] (.then (fluree/commit! ledger db
+                                           (js->clj opts :keywordize-keys true))
                            (fn [result] (clj->js result)))))
 
 (defn ^:export status

--- a/src/fluree/sdk/node.cljs
+++ b/src/fluree/sdk/node.cljs
@@ -35,9 +35,9 @@
                                                     (assoc :js? true)))))
 
 (defn ^:export commit
-  ([db] (fluree/commit! db))
   ([ledger db] (fluree/commit! ledger db))
-  ([ledger db opts] (fluree/commit! ledger db (js->clj opts :keywordize-keys true))))
+  ([ledger db opts] (fluree/commit! ledger db
+                                    (js->clj opts :keywordize-keys true))))
 
 (defn ^:export status
   ([ledger] (clj->js (fluree/status ledger)))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -12,11 +12,11 @@
        (let [conn         (test-utils/create-conn)
              ledger-alias "testledger"
              ledger       @(fluree/create conn ledger-alias)
-             db           @(fluree/stage ledger
+             db           @(fluree/stage (fluree/db ledger)
                                          [{:id           :f/me
                                            :type         :schema/Person
                                            :schema/fname "Me"}])]
-         @(fluree/commit! db)
+         @(fluree/commit! ledger db)
          (is @(fluree/exists? conn ledger-alias))
          (is (not @(fluree/exists? conn "notaledger"))))
 
@@ -26,11 +26,11 @@
            (let [conn         (<! (test-utils/create-conn))
                  ledger-alias "testledger"
                  ledger       (<p! (fluree/create conn ledger-alias))
-                 db           (<p! (fluree/stage ledger
+                 db           (<p! (fluree/stage (fluree/db ledger)
                                                  [{:id           :f/me
                                                    :type         :schema/Person
                                                    :schema/fname "Me"}]))]
-             (<p! (fluree/commit! db))
+             (<p! (fluree/commit! ledger db))
              (is (<p! (fluree/exists? conn ledger-alias)))
              (is (not (<p! (fluree/exists? conn "notaledger"))))
              (done)))))))

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -3,8 +3,7 @@
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
     [fluree.db.json-ld.api :as fluree]
-    [fluree.db.did :as did]
-    [fluree.db.util.log :as log]))
+    [fluree.db.did :as did]))
 
 
 (deftest ^:integration policy-enforcement
@@ -14,7 +13,7 @@
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db        @(fluree/stage
-                       ledger
+                       (fluree/db ledger)
                        [{:id               :ex/alice,
                          :type             :ex/User,
                          :schema/name      "Alice"

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -17,18 +17,19 @@
   (let [conn     (test-utils/create-conn)
         ledger   @(fluree/create conn "ledger/datatype")]
     (testing "Querying predicates with mixed datatypes"
-      (let [mixed-db  @(fluree/stage ledger [{:context     default-context
-                                              :id          :ex/coco
-                                              :type        :schema/Person
-                                              :schema/name "Coco"}
-                                             {:context     default-context
-                                              :id          :ex/halie
-                                              :type        :schema/Person
-                                              :schema/name "Halie"}
-                                             {:context     default-context
-                                              :id          :ex/john
-                                              :type        :schema/Person
-                                              :schema/name 3}])]
+      (let [mixed-db  @(fluree/stage (fluree/db ledger)
+                                     [{:context     default-context
+                                       :id          :ex/coco
+                                       :type        :schema/Person
+                                       :schema/name "Coco"}
+                                      {:context     default-context
+                                       :id          :ex/halie
+                                       :type        :schema/Person
+                                       :schema/name "Halie"}
+                                      {:context     default-context
+                                       :id          :ex/john
+                                       :type        :schema/Person
+                                       :schema/name 3}])]
         (is (= [{:id          :ex/halie
                  :rdf/type    [:schema/Person]
                  :schema/name "Halie"}]

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -2,15 +2,13 @@
   (:require
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
-    [fluree.db.json-ld.api :as fluree]
-    #_[fluree.db.util.log :as log]))
-
+    [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration filter-test
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/filter" {:context {:ex "http://example.org/ns/"}})
         db     @(fluree/stage
-                 ledger
+                  (fluree/db ledger)
                  [{:id           :ex/brian,
                    :type         :ex/User,
                    :schema/name  "Brian"
@@ -71,9 +69,9 @@
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"
       (is (= [{:id :ex/david,
-	      :rdf/type [:ex/User],
-	      :schema/name "David",
-	      :ex/last "Jones",
+               :rdf/type [:ex/User],
+               :schema/name "David",
+               :ex/last "Jones",
                :schema/email "david@example.org",
                :schema/age 46,
                :ex/favNums [15 70],
@@ -85,9 +83,9 @@
                :schema/email "brian@example.org",
                :schema/age 50,
                :ex/favNums 7}]
-               @(fluree/query db {:select {"?s" ["*"]}
-                                  :where  [["?s" :schema/age "?age"]
-                                           {:filter ["(> ?age 45)"]}]})))
+             @(fluree/query db {:select {"?s" ["*"]}
+                                :where  [["?s" :schema/age "?age"]
+                                         {:filter ["(> ?age 45)"]}]})))
       (is (= [{:id :ex/david,
                :rdf/type [:ex/User],
                :schema/name "David",
@@ -110,5 +108,5 @@
                :ex/favColor "Blue"}]
              @(fluree/query db {:select {"?s" ["*"]}
                                 :where  [["?s" :ex/favColor "?color"]
-                                           {:filter ["(strStarts ?color \"B\")"]}]}))))))
+                                         {:filter ["(strStarts ?color \"B\")"]}]}))))))
 

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -1,10 +1,10 @@
 (ns fluree.db.query.fql-parse-test
   (:require
-   [clojure.test :refer :all]
-   [fluree.db.query.exec.where :as where]
-   [fluree.db.test-utils :as test-utils]
-   [fluree.db.json-ld.api :as fluree]
-   [fluree.db.query.fql.parse :as parse]))
+    [clojure.test :refer :all]
+    [fluree.db.query.exec.where :as where]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.query.fql.parse :as parse]))
 
 (defn de-recordify-select
   "Select statements are parsed into records.
@@ -15,10 +15,10 @@
     (into {} select)))
 
 (deftest test-parse-query
-  (let  [conn   (test-utils/create-conn)
-         ledger @(fluree/create conn "query/parse" {:context {:ex "http://example.org/ns/"}})
-         db     @(fluree/stage
-                  ledger
+  (let [conn   (test-utils/create-conn)
+        ledger @(fluree/create conn "query/parse" {:context {:ex "http://example.org/ns/"}})
+        db     @(fluree/stage
+                  (fluree/db ledger)
                   [{:id           :ex/brian,
                     :type         :ex/User,
                     :schema/name  "Brian"
@@ -32,83 +32,81 @@
                     :schema/email "alice@example.org"
                     :schema/age   50
                     :ex/favNums   [42, 76, 9]}
-                   {:id           :ex/cam,
-                    :type         :ex/User,
-                    :schema/name  "Cam"
-                    :ex/email "cam@example.org"
-                    :schema/age   34
-                    :ex/favNums   [5, 10]
-                    :ex/friend    [:ex/brian :ex/alice]}])]
+                   {:id          :ex/cam,
+                    :type        :ex/User,
+                    :schema/name "Cam"
+                    :ex/email    "cam@example.org"
+                    :schema/age  34
+                    :ex/favNums  [5, 10]
+                    :ex/friend   [:ex/brian :ex/alice]}])]
     (testing "parse-analytical-query"
       (let [ssc {:select {"?s" ["*"]}
                  :where  [["?s" :schema/name "Alice"]]}
             {:keys [select where] :as parsed} (parse/parse-analytical-query ssc db)
             {::where/keys [patterns]} where]
-        (is (= {:var '?s
+        (is (= {:var       '?s
                 :selection ["*"]
-                :depth 0
-                :spec {:depth 0 :wildcard? true}}
+                :depth     0
+                :spec      {:depth 0 :wildcard? true}}
                (de-recordify-select select)))
         (is (= [[{::where/var '?s}
-	         {::where/val 1003
-                  ::where/datatype 7}
-	         {::where/val "Alice"
-                  ::where/datatype 1}]]
+                 {::where/val 1003 ::where/datatype 7}
+                 {::where/val "Alice" ::where/datatype 1}]]
                patterns)))
       (let [vars-query {:select {"?s" ["*"]}
-                      :where  [["?s" :schema/name '?name]]
-                      :vars {'?name "Alice"} }
+                        :where  [["?s" :schema/name '?name]]
+                        :vars   {'?name "Alice"}}
             {:keys [select where vars] :as parsed} (parse/parse-analytical-query vars-query db)
             {::where/keys [patterns]} where]
-        (is (= {'?name	  
+        (is (= {'?name
                 {::where/var '?name
                  ::where/val "Alice"}}
                vars))
-        (is (= {:var '?s
+        (is (= {:var       '?s
                 :selection ["*"]
-                :depth 0
-                :spec {:depth 0 :wildcard? true}}
+                :depth     0
+                :spec      {:depth 0 :wildcard? true}}
                (de-recordify-select select)))
         (is (= [[{::where/var '?s}
-                 {::where/val 1003
+                 {::where/val      1003
                   ::where/datatype 7}
                  {::where/var '?name}]]
                patterns)))
-      (let [query  {:context {:ex "http://example.org/ns/"}
-                    :select  ['?name '?age '?email]
-                    :where   [['?s :schema/name "Cam"]
-                              ['?s :ex/friend '?f]
-                              ['?f :schema/name '?name]
-                              ['?f :schema/age '?age]
-                              ['?f :ex/email '?email]]}
+      (let [query {:context {:ex "http://example.org/ns/"}
+                   :select  ['?name '?age '?email]
+                   :where   [['?s :schema/name "Cam"]
+                             ['?s :ex/friend '?f]
+                             ['?f :schema/name '?name]
+                             ['?f :schema/age '?age]
+                             ['?f :ex/email '?email]]}
             {:keys [select where] :as parsed} (parse/parse-analytical-query query db)
             {::where/keys [patterns]} where]
         (is (= [{:var '?name}
                 {:var '?age}
-                {:var '?email}] 
+                {:var '?email}]
                (de-recordify-select select)))
         (is (= [[{::where/var '?s}
-                 {::where/val 1003
+                 {::where/val      1003
                   ::where/datatype 7}
-                 {::where/val "Cam"
+                 {::where/val      "Cam"
                   ::where/datatype 1}]
                 [{::where/var '?s}
-                 {::where/val 1009
+                 {::where/val      1009
                   ::where/datatype 7}
                  {::where/var '?f}]
                 [{::where/var '?f}
-                 {::where/val 1003
+                 {::where/val      1003
                   ::where/datatype 7}
                  {::where/var '?name}]
                 [{::where/var '?f}
-                 {::where/val 1005
+                 {::where/val      1005
                   ::where/datatype 7}
                  {::where/var '?age}]
                 [{::where/var '?f}
-                 {::where/val 1008
+                 {::where/val      1008
                   ::where/datatype 7}
                  {::where/var '?email}]]
-              patterns)))
+               patterns)))
       (testing "class, optional"
         (let [optional-q {:select ['?name '?favColor]
                           :where  [['?s :rdf/type :ex/User]
@@ -120,18 +118,18 @@
                  (mapv #(into {} %) select)))
           (is (= [[:class
                    [{::where/var '?s}
-                    {::where/val 200
+                    {::where/val      200
                      ::where/datatype 7}
-                    {::where/val 1002
+                    {::where/val      1002
                      ::where/datatype 0}]]
                   [{::where/var '?s}
-                   {::where/val 1003
+                   {::where/val      1003
                     ::where/datatype 7}
                    {::where/var '?name}]
                   [:optional
                    {::where/patterns
                     [[{::where/var '?s}
-                      {::where/val 1007
+                      {::where/val      1007
                        ::where/datatype 7}
                       {::where/var '?favColor}]]
                     ::where/filters {}}]]
@@ -147,24 +145,24 @@
                  (de-recordify-select select)))
           (is (= [[:class
                    [{::where/var '?s}
-                    {::where/val 200
+                    {::where/val      200
                      ::where/datatype 7}
-                    {::where/val 1002
+                    {::where/val      1002
                      ::where/datatype 0}]]
                   [:union
                    [{::where/patterns
                      [[{::where/var '?s}
-                       {::where/val 1008
+                       {::where/val      1008
                         ::where/datatype 7}
                        {::where/var '?email1}]]
                      ::where/filters {}}
                     {::where/patterns
                      [[{::where/var '?s}
-                       {::where/val 1004
+                       {::where/val      1004
                         ::where/datatype 7}
                        {::where/var '?email2}]]
                      ::where/filters {}}]]]
-              patterns))))
+                 patterns))))
       (testing "class, filters"
         (let [filter-q {:select ['?name '?age]
                         :where  [['?s :rdf/type :ex/User]
@@ -175,18 +173,18 @@
               {::where/keys [patterns filters]} where]
           (is (= [{:var '?name} {:var '?age}]
                  (de-recordify-select select)))
-          (is (= [[:class	  
+          (is (= [[:class
                    [{::where/var '?s}
-                    {::where/val 200
+                    {::where/val      200
                      ::where/datatype 7}
-                    {::where/val 1002
+                    {::where/val      1002
                      ::where/datatype 0}]]
                   [{::where/var '?s}
-                   {::where/val 1005
+                   {::where/val      1005
                     ::where/datatype 7}
                    {::where/var '?age}]
                   [{::where/var '?s}
-                   {::where/val 1003
+                   {::where/val      1003
                     ::where/datatype 7}
                    {::where/var '?name}]]
                  patterns))))
@@ -197,7 +195,7 @@
                      :group-by '?name
                      :order-by '?name}
               {:keys [select where group-by order-by] :as parsed} (parse/parse-analytical-query query db)]
-          (is (= ['?name] 
+          (is (= ['?name]
                  group-by))
-          (is (=  [['?name :asc]]
+          (is (= [['?name :asc]]
                  order-by)))))))

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -13,7 +13,7 @@
           ledger  @(fluree/create conn "query/index-range"
                                   {:context {:ex "http://example.org/ns/"}})
           db      @(fluree/stage
-                     ledger
+                     (fluree/db ledger)
                      [{:id           :ex/brian,
                        :type         :ex/User,
                        :schema/name  "Brian"

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -1,8 +1,7 @@
 (ns fluree.db.query.json-ld-basic-test
   (:require [clojure.test :refer :all]
             [fluree.db.test-utils :as test-utils]
-            [fluree.db.json-ld.api :as fluree]
-            [fluree.db.util.log :as log]))
+            [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration json-ld-basic-query
   (testing "json-ld"
@@ -82,7 +81,7 @@
       (testing "basic analytical RFD type query"
         (let [query-res @(fluree/query db {:select {'?s [:* {:schema/isBasedOn [:*]}]}
                                            :where  [['?s :rdf/type :schema/Movie]]})]
-          (is (= query-res                                  ;; :id is a DID and will be unique per DB so exclude from comparison
+          (is (= query-res ;; :id is a DID and will be unique per DB so exclude from comparison
                  [{:id                               :wiki/Q230552,
                    :rdf/type                         [:schema/Movie],
                    :schema/name                      "Back to the Future Part III",
@@ -115,10 +114,11 @@
     (let [conn   (test-utils/create-conn)
           movies (test-utils/load-movies conn)]
       (testing "define @list container in context"
-        (let [db        @(fluree/stage movies {:context {:ex      "http://example.org/ns#"
-                                                         :ex/list {"@container" "@list"}}
-                                               :id      "list-test"
-                                               :ex/list [42 2 88 1]})
+        (let [db        @(fluree/stage (fluree/db movies)
+                                       {:context {:ex      "http://example.org/ns#"
+                                                  :ex/list {"@container" "@list"}}
+                                        :id      "list-test"
+                                        :ex/list [42 2 88 1]})
               query-res @(fluree/query db {:context   {:ex "http://example.org/ns#"}
                                            :selectOne [:*]
                                            :from      "list-test"})]
@@ -127,9 +127,10 @@
                   :ex/list [42 2 88 1]})
               "Order of query result is different from transaction.")))
       (testing "define @list directly on subject"
-        (let [db        @(fluree/stage movies {:context {:ex "http://example.org/ns#"}
-                                               :id      "list-test2"
-                                               :ex/list {"@list" [42 2 88 1]}})
+        (let [db        @(fluree/stage (fluree/db movies)
+                                       {:context {:ex "http://example.org/ns#"}
+                                        :id      "list-test2"
+                                        :ex/list {"@list" [42 2 88 1]}})
               query-res @(fluree/query db {:context   {:ex "http://example.org/ns#"}
                                            :selectOne [:*]
                                            :from      "list-test2"})]
@@ -142,40 +143,40 @@
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/simple-subject-crawl" {:context {:ex "http://example.org/ns/"}})
         db     @(fluree/stage
-                 ledger
-                 [{:id           :ex/brian,
-                   :type         :ex/User,
-                   :schema/name  "Brian"
-                   :ex/last      "Smith"
-                   :schema/email "brian@example.org"
-                   :schema/age   50
-                   :ex/favColor  "Green"
-                   :ex/favNums   7}
-                  {:id           :ex/alice,
-                   :type         :ex/User,
-                   :schema/name  "Alice"
-                   :ex/last      "Smith"
-                   :schema/email "alice@example.org"
-                   :ex/favColor  "Green"
-                   :schema/age   42
-                   :ex/favNums   [42, 76, 9]}
-                  {:id           :ex/cam,
-                   :type         :ex/User,
-                   :schema/name  "Cam"
-                   :ex/last      "Jones"
-                   :schema/email "cam@example.org"
-                   :schema/age   34
-                   :ex/favColor  "Blue"
-                   :ex/favNums   [5, 10]
-                   :ex/friend    [:ex/brian :ex/alice]}
-                  {:id           :ex/david,
-                   :type         :ex/User,
-                   :schema/name  "David"
-                   :ex/last      "Jones"
-                   :schema/email "david@example.org"
-                   :schema/age   46
-                   :ex/favNums   [15 70]
-                   :ex/friend    [:ex/cam]}])]
+                  (fluree/db ledger)
+                  [{:id           :ex/brian,
+                    :type         :ex/User,
+                    :schema/name  "Brian"
+                    :ex/last      "Smith"
+                    :schema/email "brian@example.org"
+                    :schema/age   50
+                    :ex/favColor  "Green"
+                    :ex/favNums   7}
+                   {:id           :ex/alice,
+                    :type         :ex/User,
+                    :schema/name  "Alice"
+                    :ex/last      "Smith"
+                    :schema/email "alice@example.org"
+                    :ex/favColor  "Green"
+                    :schema/age   42
+                    :ex/favNums   [42, 76, 9]}
+                   {:id           :ex/cam,
+                    :type         :ex/User,
+                    :schema/name  "Cam"
+                    :ex/last      "Jones"
+                    :schema/email "cam@example.org"
+                    :schema/age   34
+                    :ex/favColor  "Blue"
+                    :ex/favNums   [5, 10]
+                    :ex/friend    [:ex/brian :ex/alice]}
+                   {:id           :ex/david,
+                    :type         :ex/User,
+                    :schema/name  "David"
+                    :ex/last      "Jones"
+                    :schema/email "david@example.org"
+                    :schema/age   46
+                    :ex/favNums   [15 70]
+                    :ex/friend    [:ex/cam]}])]
     (testing "using `from`"
       (is (= [{:id           :ex/brian,
                :rdf/type     [:ex/User]
@@ -190,16 +191,16 @@
     (testing "using `where`"
       (testing "id"
         ;;TODO not getting reparsed as ssc
-          (is (= [{:id           :ex/brian,
-                   :rdf/type     [:ex/User]
-                   :schema/name  "Brian"
-                   :ex/last      "Smith"
-                   :schema/email "brian@example.org"
-                   :schema/age   50
-                   :ex/favColor  "Green"
-                   :ex/favNums   7}]
-                 @(fluree/query db {:select {"?s" ["*"]}
-                                    :where  [["?s" :id :ex/brian]]}))))
+        (is (= [{:id           :ex/brian,
+                 :rdf/type     [:ex/User]
+                 :schema/name  "Brian"
+                 :ex/last      "Smith"
+                 :schema/email "brian@example.org"
+                 :schema/age   50
+                 :ex/favColor  "Green"
+                 :ex/favNums   7}]
+               @(fluree/query db {:select {"?s" ["*"]}
+                                  :where  [["?s" :id :ex/brian]]}))))
       ;;TODO not getting reparsed as ssc
       (testing "iri"
         (is (= [{:id           :ex/david
@@ -265,14 +266,14 @@
                  :schema/age   42
                  :ex/favNums   [9 42 76]
                  :ex/favColor  "Green"}
-                {:id :ex/brian,
-                 :rdf/type [:ex/User],
-                 :ex/favNums 7,
-                 :ex/favColor "Green",
-                 :schema/age 50,
-                 :ex/last "Smith",
+                {:id           :ex/brian,
+                 :rdf/type     [:ex/User],
+                 :ex/favNums   7,
+                 :ex/favColor  "Green",
+                 :schema/age   50,
+                 :ex/last      "Smith",
                  :schema/email "brian@example.org",
-                 :schema/name "Brian"}]
+                 :schema/name  "Brian"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :ex/favColor "?color"]]})))
         (is (= [{:id           :ex/alice
@@ -285,14 +286,14 @@
                  :ex/favColor  "Green"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/age 42]]})))
-        (is (= [{:id :ex/alice,	  
-                 :rdf/type [:ex/User],
-                 :ex/favNums [9 42 76],
-                 :ex/favColor "Green",
-                 :schema/age 42,
-                 :ex/last "Smith",
+        (is (= [{:id           :ex/alice,
+                 :rdf/type     [:ex/User],
+                 :ex/favNums   [9 42 76],
+                 :ex/favColor  "Green",
+                 :schema/age   42,
+                 :ex/last      "Smith",
                  :schema/email "alice@example.org",
-                 :schema/name "Alice"}]
+                 :schema/name  "Alice"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/age 42]
                                            ["?s" :ex/favColor "Green"]]})))))))

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -1,17 +1,15 @@
 (ns fluree.db.query.json-ld-compound-test
   (:require
-    [clojure.string :as str]
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
-    [fluree.db.json-ld.api :as fluree]
-    [fluree.db.util.log :as log]))
+    [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration simple-compound-queries
   (testing "Simple compound queries."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/compounda")
           db     @(fluree/stage
-                   ledger
+                   (fluree/db ledger)
                    [{:context      {:ex "http://example.org/ns/"}
                      :id           :ex/brian,
                      :type         :ex/User,

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -1,17 +1,15 @@
 (ns fluree.db.query.misc-queries-test
   (:require
-    [clojure.string :as str]
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
-    [fluree.db.json-ld.api :as fluree]
-    [fluree.db.util.log :as log]))
+    [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration select-sid
   (testing "Select index's subject id in query using special keyword"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/subid" {:context {:ex "http://example.org/ns/"}})
           db     @(fluree/stage
-                    ledger
+                    (fluree/db ledger)
                     {:graph [{:id          :ex/alice,
                               :type        :ex/User,
                               :schema/name "Alice"}
@@ -38,7 +36,7 @@
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/everything" {:context {:ex "http://example.org/ns/"}})
           db     @(fluree/stage
-                    ledger
+                    (fluree/db ledger)
                     {:graph [{:id           :ex/alice,
                               :type         :ex/User,
                               :schema/name  "Alice"

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -11,21 +11,21 @@
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/optional" {:context {:ex "http://example.org/ns/"}})
           db     @(fluree/stage
-                   ledger
-                   [{:id          :ex/brian,
-                     :type        :ex/User,
-                     :schema/name "Brian"
-                     :ex/friend   [:ex/alice]}
-                    {:id          :ex/alice,
-                     :type        :ex/User,
-                     :ex/favColor "Green"
-                     :schema/email "alice@flur.ee"
-                     :schema/name "Alice"}
-                    {:id          :ex/cam,
-                     :type        :ex/User,
-                     :schema/name "Cam"
-                     :schema/email "cam@flur.ee"
-                     :ex/friend   [:ex/brian :ex/alice]}])]
+                    (fluree/db ledger)
+                    [{:id          :ex/brian,
+                      :type        :ex/User,
+                      :schema/name "Brian"
+                      :ex/friend   [:ex/alice]}
+                     {:id          :ex/alice,
+                      :type        :ex/User,
+                      :ex/favColor "Green"
+                      :schema/email "alice@flur.ee"
+                      :schema/name "Alice"}
+                     {:id          :ex/cam,
+                      :type        :ex/User,
+                      :schema/name "Cam"
+                      :schema/email "cam@flur.ee"
+                      :ex/friend   [:ex/brian :ex/alice]}])]
 
       ;; basic single optional statement
       (is (= @(fluree/query db '{:select [?name ?favColor]

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -1,17 +1,15 @@
 (ns fluree.db.query.reverse-query-test
   (:require
-    [clojure.string :as str]
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
-    [fluree.db.json-ld.api :as fluree]
-    [fluree.db.util.log :as log]))
+    [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration context-reverse-test
   (testing "Test that the @reverse context values pulls select values back correctly."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/reverse" {:context {:ex "http://example.org/ns/"}})
           db     @(fluree/stage
-                    ledger
+                    (fluree/db ledger)
                     [{:id           :ex/brian,
                       :type         :ex/User,
                       :schema/name  "Brian"

--- a/test/fluree/db/query/subclass_test.clj
+++ b/test/fluree/db/query/subclass_test.clj
@@ -1,15 +1,14 @@
 (ns fluree.db.query.subclass-test
   (:require [clojure.test :refer :all]
             [fluree.db.test-utils :as test-utils]
-            [fluree.db.json-ld.api :as fluree]
-            [fluree.db.util.log :as log]))
+            [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration subclass-test
   (testing "Subclass queries work."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/subclass")
           db1    @(fluree/stage
-                    ledger
+                    (fluree/db ledger)
                     {"@context"                  "https://schema.org",
                      "id"                        "https://www.wikidata.org/wiki/Q836821",
                      "type"                      ["Movie"],

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -10,28 +10,28 @@
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/parse" {:context {:ex "http://example.org/ns/"}})
         db     @(fluree/stage
-                 ledger
-                 [{:id           :ex/brian,
-                   :type         :ex/User,
-                   :schema/name  "Brian"
-                   :schema/email "brian@example.org"
-                   :schema/age   50
-                   :ex/favColor  "Green"
-                   :ex/favNums   7}
-                  {:id           :ex/alice,
-                   :type         :ex/User,
-                   :schema/name  "Alice"
-                   :schema/email "alice@example.org"
-                   :schema/age   50
-                   :ex/favColor  "Blue"
-                   :ex/favNums   [42, 76, 9]}
-                  {:id           :ex/cam,
-                   :type         :ex/User,
-                   :schema/name  "Cam"
-                   :schema/email "cam@example.org"
-                   :schema/age   34
-                   :ex/favNums   [5, 10]
-                   :ex/friend    [:ex/brian :ex/alice]}])
+                  (fluree/db ledger)
+                  [{:id           :ex/brian,
+                    :type         :ex/User,
+                    :schema/name  "Brian"
+                    :schema/email "brian@example.org"
+                    :schema/age   50
+                    :ex/favColor  "Green"
+                    :ex/favNums   7}
+                   {:id           :ex/alice,
+                    :type         :ex/User,
+                    :schema/name  "Alice"
+                    :schema/email "alice@example.org"
+                    :schema/age   50
+                    :ex/favColor  "Blue"
+                    :ex/favNums   [42, 76, 9]}
+                   {:id           :ex/cam,
+                    :type         :ex/User,
+                    :schema/name  "Cam"
+                    :schema/email "cam@example.org"
+                    :schema/age   34
+                    :ex/favNums   [5, 10]
+                    :ex/friend    [:ex/brian :ex/alice]}])
         ssc-q1-parsed (parse/parse-analytical-query {:select {"?s" ["*"]}
                                                      :where  [["?s" :schema/name "Alice"]]}
                                                     db)

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -51,27 +51,27 @@
                                                   (fn [] start-iso)}
                                    (fn []
                                      (let [db1 @(fluree/stage
-                                                  ledger
+                                                  (fluree/db ledger)
                                                   (first test-utils/movies))]
-                                       @(fluree/commit! db1))))
+                                       @(fluree/commit! ledger db1))))
           _                      (with-redefs-fn {#'util/current-time-millis
                                                   (fn [] three-loaded-millis)
                                                   #'util/current-time-iso
                                                   (fn [] three-loaded-iso)}
                                    (fn []
                                      (let [db2 @(fluree/stage
-                                                  ledger
+                                                  (fluree/db ledger)
                                                   (second test-utils/movies))]
-                                       @(fluree/commit! db2))))
+                                       @(fluree/commit! ledger db2))))
           _                      (with-redefs-fn {#'util/current-time-millis
                                                   (fn [] all-loaded-millis)
                                                   #'util/current-time-iso
                                                   (fn [] all-loaded-iso)}
                                    (fn []
                                      (let [db3 @(fluree/stage
-                                                  ledger
+                                                  (fluree/db ledger)
                                                   (nth test-utils/movies 2))]
-                                       @(fluree/commit! db3))))
+                                       @(fluree/commit! ledger db3))))
           db                     (fluree/db ledger)
           base-query             {:select '{?s [:*]}
                                   :where  '[[?s :rdf/type :schema/Movie]]}

--- a/test/fluree/db/query/union_query_test.clj
+++ b/test/fluree/db/query/union_query_test.clj
@@ -1,17 +1,15 @@
 (ns fluree.db.query.union-query-test
   (:require
-    [clojure.string :as str]
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
-    [fluree.db.json-ld.api :as fluree]
-    [fluree.db.util.log :as log]))
+    [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration union-queries
   (testing "Testing various 'union' query clauses."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/union" {:context {:ex "http://example.org/ns/"}})
           db     @(fluree/stage
-                    ledger
+                    (fluree/db ledger)
                     [{:id           :ex/brian,
                       :type         :ex/User,
                       :schema/name  "Brian"
@@ -69,5 +67,5 @@
              [["Cam" "cam@example.org" nil]
               ["Alice" nil "alice@example.org"]
               ["Brian" nil "brian@example.org"]])
-          "Emails for all 3 users should return using different vars, but also passing through a variable")
-      )))
+          "Emails for all 3 users should return using different vars, but also passing through a variable"))))
+

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -11,7 +11,7 @@
     (let [conn      (test-utils/create-conn)
           ledger    @(fluree/create conn "class/testing")
           db1       @(fluree/stage
-                       ledger
+                       (fluree/db ledger)
                        {:context            {:ex "http://example.org/ns/"}
                         :id                 :ex/MyClass,
                         :schema/description "Just a basic object not used as a class"})
@@ -38,7 +38,7 @@
                         :select  {'?s [:*]}
                         :where   [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
-                          ledger
+                          (fluree/db ledger)
                           {:context        {:ex "http://example.org/ns/"}
                            :id             :ex/UserShape,
                            :type           [:sh/NodeShape],
@@ -96,7 +96,7 @@
                         :select  {'?s [:*]}
                         :where   [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
-                          ledger
+                          (fluree/db ledger)
                           {:context        {:ex "http://example.org/ns/"}
                            :id             :ex/UserShape,
                            :type           [:sh/NodeShape],
@@ -149,7 +149,7 @@
                          :select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]}
           db            @(fluree/stage
-                           ledger
+                           (fluree/db ledger)
                            {:context              {:ex "http://example.org/ns/"}
                             :id                   :ex/UserShape,
                             :type                 [:sh/NodeShape],

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -89,14 +89,15 @@
   [conn]
   (let [ledger @(fluree/create conn "test/movies")]
     (doseq [movie movies]
-      (let [staged @(fluree/stage ledger movie)]
-        @(fluree/commit! staged {:message (str "Commit " (get movie "name"))
-                                 :push? true})))
+      (let [staged @(fluree/stage (fluree/db ledger) movie)]
+        @(fluree/commit! ledger staged
+                         {:message (str "Commit " (get movie "name"))
+                          :push? true})))
     ledger))
 
 (defn load-people
   [conn]
   (let [ledger @(fluree/create conn "test/people")
-        staged @(fluree/stage ledger people)
-        commit @(fluree/commit! staged {:message "Adding people", :push? true})]
+        staged @(fluree/stage (fluree/db ledger) people)]
+    @(fluree/commit! ledger staged {:message "Adding people", :push? true})
     ledger))

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -9,7 +9,7 @@
     (let [conn             (test-utils/create-conn)
           ledger           @(fluree/create conn "tx/delete" {:context {:ex "http://example.org/ns/"}})
           db               @(fluree/stage
-                             ledger
+                             (fluree/db ledger)
                              {:graph [{:id           :ex/alice,
                                        :type         :ex/User,
                                        :schema/name  "Alice"

--- a/test/fluree/db/transact/retraction_test.clj
+++ b/test/fluree/db/transact/retraction_test.clj
@@ -1,15 +1,14 @@
 (ns fluree.db.transact.retraction-test
   (:require [clojure.test :refer :all]
             [fluree.db.test-utils :as test-utils]
-            [fluree.db.json-ld.api :as fluree]
-            [fluree.db.util.log :as log]))
+            [fluree.db.json-ld.api :as fluree]))
 
 (deftest ^:integration retracting-data
   (testing "Retractions of individual properties and entire subjects."
     (let [conn           (test-utils/create-conn)
           ledger         @(fluree/create conn "tx/retract")
           db             @(fluree/stage
-                            ledger
+                            (fluree/db ledger)
                             {:context {:ex "http://example.org/ns/"}
                              :graph   [{:id          :ex/alice,
                                         :type        :ex/User,

--- a/test/nodejs/flureenjs.test.js
+++ b/test/nodejs/flureenjs.test.js
@@ -46,7 +46,9 @@ test("expect conn, ledger, stage, commit, and query to work", async () => {
 
   const ledger = await flureenjs.create(conn, "testledger");
 
-  const db = await flureenjs.stage(ledger, {
+  const db = await flureenjs.db(ledger);
+
+  const db1 = await flureenjs.stage(db, {
     id: "ex:john",
     "@type": "ex:User",
     "schema:name": "John"
@@ -54,7 +56,7 @@ test("expect conn, ledger, stage, commit, and query to work", async () => {
 
 
    const results = await flureenjs.query(
-     db,
+     db1,
      {
        select: { "?s": ["*"] },
        where: [["?s", "rdf:type", "ex:User"]]
@@ -74,7 +76,7 @@ test("expect conn, ledger, stage, commit, and query to work", async () => {
 
    // test providing context works and remaps keys
    const contextResults = await flureenjs.query(
-     db,
+     db1,
      { "@context": {"flhubee": "http://schema.org/name"},
        select: { "?s": ["*"] },
        where: [["?s", "rdf:type", "ex:User"]]


### PR DESCRIPTION
This PR does two things:

- Changes `stage` to only take db's as args (still w/ optional opts arg) b/c under the hood it's a fn of db's.
- Changes `commit!` to only take a ledger and a db as args (i.e. it no longer supports just a ledger or a just a db; still w/ optional opts arg) b/c under the hood it's a fn of ledgers and db's.

The second commit updates all the tests for the new signatures.

Fixes #337 