### PR TITLE
Fix multi-cardinality predicates when loading ledgers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ browser-test: out/fluree-browser-sdk.js
 cljstest: cljs-browser-test cljs-node-test
 
 cljtest:
-	clojure -M:cljtest
+	clojure -X:cljtest
 
 test: cljtest cljstest nodejs-test browser-test
 
 eastwood:
-	clojure -M:test:eastwood
+	clojure -M:cljtest:eastwood
 
 ci: test eastwood
 

--- a/deps.edn
+++ b/deps.edn
@@ -60,9 +60,11 @@
 
   :cljtest
   {:extra-paths ["test" "dev-resources"]
-   :extra-deps  {lambdaisland/kaocha    {:mvn/version "1.71.1119"}
-                 org.clojure/test.check {:mvn/version "1.1.1"}}
-   :main-opts   ["-m" "kaocha.runner"]}
+   :extra-deps  {lambdaisland/kaocha         {:mvn/version "1.71.1119"}
+                 org.clojure/test.check      {:mvn/version "1.1.1"}
+                 com.magnars/test-with-files {:mvn/version "2021-02-17"}}
+   :exec-fn     kaocha.runner/exec-fn
+   :exec-args   {}}
 
   :js-deps
   {:extra-deps {com.timetraveltoaster/target-bundle-libs {:mvn/version "RELEASE"}}

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -32,12 +32,12 @@
     (str "fluree:file://" path)))
 
 (defn local-path
-  [conn]
+  [{:keys [storage-path] :as _conn}]
   (let [abs-root #?(:clj (.getAbsolutePath (io/file ""))
                     :cljs (path/resolve "."))
         path (str abs-root
                   "/"
-                  (:storage-path conn)
+                  storage-path
                   "/")]
     #?(:clj  (-> path io/file .getCanonicalPath)
        :cljs (path/resolve path))))

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -33,12 +33,13 @@
 
 (defn local-path
   [{:keys [storage-path] :as _conn}]
-  (let [abs-root #?(:clj (.getAbsolutePath (io/file ""))
-                    :cljs (path/resolve "."))
-        path (str abs-root
-                  "/"
-                  storage-path
-                  "/")]
+  (let [abs-path? #?(:clj  (.isAbsolute (io/file storage-path))
+                     :cljs (path/isAbsolute storage-path))
+        abs-root  (if abs-path?
+                    ""
+                    (str #?(:clj  (.getAbsolutePath (io/file ""))
+                            :cljs (path/resolve ".")) "/"))
+        path      (str abs-root storage-path "/")]
     #?(:clj  (-> path io/file .getCanonicalPath)
        :cljs (path/resolve path))))
 

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.datatype
   (:require [fluree.db.constants :as const]
+            [fluree.db.util.log :as log]
             [clojure.string :as str]
             #?(:clj  [fluree.db.util.clj-const :as uc]
                :cljs [fluree.db.util.cljs-const :as uc]))
@@ -324,6 +325,7 @@
    - numbers in strings
    - the strings 'true' or 'false' to a boolean"
   [value required-type]
+  (log/debug "coerce value:" value "to type:" required-type)
   (uc/case (int required-type)
     const/$xsd:string
     (when (string? value)
@@ -389,6 +391,7 @@
   (let [type-id (if type
                   (get default-data-types type)
                   (infer value))
+        _       (log/debug "from-expanded type:" type-id)
         value*  (coerce value type-id)]
     (cond (and required-type (not= type-id required-type))
           (throw (ex-info (str "Required data type " required-type

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -110,7 +110,7 @@
       (dec (flake/->sid const/$_shard 0))))
 
 (defn generate-new-sid
-  "Generates a new subject ID. If it is know this is a property or class will
+  "Generates a new subject ID. If it is known this is a property or class will
   assign the lower range of subject ids."
   [{:keys [id] :as node} referring-pid iris next-pid next-sid]
   (let [new-sid (or

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -96,7 +96,9 @@
                                                {:status 400 :error
                                                 :db/invalid-commit})))
           context          {:db db, :iris iris, :sid sid, :t t}
-          type-retractions (<? (get-type-retractions context type))
+          type-retractions (if (seq type)
+                             (<? (get-type-retractions context type))
+                             [])
           context*         (assoc context :type-retractions type-retractions)]
       (<? (retract-node* context* node)))))
 
@@ -197,7 +199,9 @@
           context         {:db       db, :iris iris, :id id
                            :next-pid next-pid, :refs refs, :sid sid
                            :next-sid next-sid, :t t}
-          type-assertions (<? (get-type-assertions context type))
+          type-assertions (if (seq type)
+                            (<? (get-type-assertions context type))
+                            [])
           base-flakes     (if existing-sid
                             type-assertions
                             (conj type-assertions

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -65,6 +65,7 @@
                                  :ex/favNums   5
                                  :ex/friend    :ex/brian}])
                _            @(fluree/commit! ledger db)
+               ;; TODO: Replace this w/ :syncTo equivalent once we have it
                _            (Thread/sleep 1000)
                loaded       @(fluree/load conn ledger-alias)]
            (if (instance? Throwable loaded)
@@ -106,6 +107,7 @@
                                  :ex/favNums   [5, 10]
                                  :ex/friend    [:ex/brian :ex/alice]}])
                _            @(fluree/commit! ledger db)
+               ;; TODO: Replace this w/ :syncTo equivalent once we have it
                _            (Thread/sleep 1000)
                loaded       @(fluree/load conn ledger-alias)]
            (if (instance? Throwable loaded)

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -44,7 +44,7 @@
                                {:method :file :storage-path storage-path
                                 :defaults
                                 {:context test-utils/default-context}})
-               ledger-alias "transact-basic-test-single-card"
+               ledger-alias "load-from-file-test-single-card"
                ledger       @(fluree/create conn ledger-alias)
                db           @(fluree/stage
                                (fluree/db ledger)
@@ -73,11 +73,8 @@
                                             :ex/favNums 7}})
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
-               _            (Thread/sleep 1000)
-               loaded       @(fluree/load conn ledger-alias)]
-           (if (instance? Throwable loaded)
-             (throw loaded)
-             (is (= (:t db) (:t (fluree/db loaded))))))))
+               loaded       (test-utils/retry-load conn ledger-alias 100)]
+           (is (= (:t db) (:t (fluree/db loaded)))))))
 
      (testing "can load a file ledger with multi-cardinality predicates"
        (with-tmp-dir storage-path
@@ -85,7 +82,7 @@
                                {:method :file :storage-path storage-path
                                 :defaults
                                 {:context test-utils/default-context}})
-               ledger-alias "transact-basic-test-multi-card"
+               ledger-alias "load-from-file-test-multi-card"
                ledger       @(fluree/create conn ledger-alias)
                db           @(fluree/stage
                                (fluree/db ledger)
@@ -122,8 +119,5 @@
                                              :ex/favNums [42, 76, 9]}}])
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
-               _            (Thread/sleep 1000)
-               loaded       @(fluree/load conn ledger-alias)]
-           (if (instance? Throwable loaded)
-             (throw loaded)
-             (is (= (:t db) (:t (fluree/db loaded))))))))))
+               loaded       (test-utils/retry-load conn ledger-alias 100)]
+           (is (= (:t db) (:t (fluree/db loaded)))))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -4,7 +4,8 @@
             #?@(:cljs [[clojure.core.async :refer [go <!]]
                        [clojure.core.async.interop :refer [<p!]]])
             [fluree.db.json-ld.api :as fluree]
-            [fluree.db.test-utils :as test-utils]))
+            [fluree.db.test-utils :as test-utils]
+            #?(:clj [test-with-files.tools :refer [with-tmp-dir]])))
 
 (deftest exists?-test
   (testing "returns true after committing data to a ledger"
@@ -34,3 +35,79 @@
              (is (<p! (fluree/exists? conn ledger-alias)))
              (is (not (<p! (fluree/exists? conn "notaledger"))))
              (done)))))))
+
+#?(:clj
+   (deftest load-from-file-test
+     (testing "can load a file ledger with single cardinality predicates"
+       (with-tmp-dir storage-path
+         (let [conn         @(fluree/connect
+                               {:method :file :storage-path storage-path
+                                :defaults
+                                {:context test-utils/default-context}})
+               ledger-alias "transact-basic-test-single-card"
+               ledger       @(fluree/create conn ledger-alias)
+               db           @(fluree/stage
+                               (fluree/db ledger)
+                               [{:context      {:ex "http://example.org/ns/"}
+                                 :id           :ex/brian,
+                                 :type         :ex/User,
+                                 :schema/name  "Brian"
+                                 :schema/email "brian@example.org"
+                                 :schema/age   50
+                                 :ex/favNums   7}
+
+                                {:context      {:ex "http://example.org/ns/"}
+                                 :id           :ex/cam,
+                                 :type         :ex/User,
+                                 :schema/name  "Cam"
+                                 :schema/email "cam@example.org"
+                                 :schema/age   34
+                                 :ex/favNums   5
+                                 :ex/friend    :ex/brian}])
+               _            @(fluree/commit! ledger db)
+               _            (Thread/sleep 1000)
+               loaded       @(fluree/load conn ledger-alias)]
+           (if (instance? Throwable loaded)
+             (throw loaded)
+             (is (= (:t db) (:t (fluree/db loaded))))))))
+
+     (testing "can load a file ledger with multi-cardinality predicates"
+       (with-tmp-dir storage-path
+         (let [conn         @(fluree/connect
+                               {:method :file :storage-path storage-path
+                                :defaults
+                                {:context test-utils/default-context}})
+               ledger-alias "transact-basic-test-multi-card"
+               ledger       @(fluree/create conn ledger-alias)
+               db           @(fluree/stage
+                               (fluree/db ledger)
+                               [{:context      {:ex "http://example.org/ns/"}
+                                 :id           :ex/brian,
+                                 :type         :ex/User,
+                                 :schema/name  "Brian"
+                                 :schema/email "brian@example.org"
+                                 :schema/age   50
+                                 :ex/favNums   7}
+
+                                {:context      {:ex "http://example.org/ns/"}
+                                 :id           :ex/alice,
+                                 :type         :ex/User,
+                                 :schema/name  "Alice"
+                                 :schema/email "alice@example.org"
+                                 :schema/age   50
+                                 :ex/favNums   [42, 76, 9]}
+
+                                {:context      {:ex "http://example.org/ns/"}
+                                 :id           :ex/cam,
+                                 :type         :ex/User,
+                                 :schema/name  "Cam"
+                                 :schema/email "cam@example.org"
+                                 :schema/age   34
+                                 :ex/favNums   [5, 10]
+                                 :ex/friend    [:ex/brian :ex/alice]}])
+               _            @(fluree/commit! ledger db)
+               _            (Thread/sleep 1000)
+               loaded       @(fluree/load conn ledger-alias)]
+           (if (instance? Throwable loaded)
+             (throw loaded)
+             (is (= (:t db) (:t (fluree/db loaded))))))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -64,6 +64,13 @@
                                  :schema/age   34
                                  :ex/favNums   5
                                  :ex/friend    :ex/brian}])
+               db           @(fluree/commit! ledger db)
+               db           @(fluree/stage
+                               db
+                               ;; test a retraction
+                               {:context   {:ex "http://example.org/ns/"}
+                                :f/retract {:id         :ex/brian
+                                            :ex/favNums 7}})
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                _            (Thread/sleep 1000)
@@ -106,6 +113,13 @@
                                  :schema/age   34
                                  :ex/favNums   [5, 10]
                                  :ex/friend    [:ex/brian :ex/alice]}])
+               db           @(fluree/commit! ledger db)
+               db           @(fluree/stage
+                               db
+                               ;; test a multi-cardinality retraction
+                               [{:context   {:ex "http://example.org/ns/"}
+                                 :f/retract {:id         :ex/alice
+                                             :ex/favNums [42, 76, 9]}}])
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                _            (Thread/sleep 1000)

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -121,4 +121,3 @@
       (if ledger
         ledger
         (recur (inc attempt))))))
->>>>>>> 94e93ef (Improve ledger loading in file conn api tests)

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -106,3 +106,19 @@
   [ledger data]
   (->> @(fluree/stage (fluree/db ledger) data)
        (fluree/commit! ledger)))
+
+(defn retry-load
+  "Retry loading a ledger until max-attempts. Hopefully not needed once JSON-LD
+  code has an equivalent to :syncTo"
+  [conn ledger-alias max-attempts]
+  (loop [attempt 0]
+    (let [ledger (try
+                   @(fluree/load conn ledger-alias)
+                   (catch Exception e
+                     (when (= (inc attempt) max-attempts)
+                       (throw e)
+                       (Thread/sleep 100))))]
+      (if ledger
+        ledger
+        (recur (inc attempt))))))
+>>>>>>> 94e93ef (Improve ledger loading in file conn api tests)


### PR DESCRIPTION
Fixes #344 

assert-node and retract-node were assuming single-cardinality predicates when loading a ledger. Now they loop over any number of values.

I had to pull a fair amount of code out into separate fns because the go macro was not happy with in-place modifications due to the existing complexity of the old code (and the need to take from a channel inside the per-value code means it's awkward to use map and friends since once you're inside the anonymous fn you're no longer in a go block; and nested `loop`s are awkward too).

Since loading a ledger doesn't really make sense in a memory conn (unless we made it work just for testing), I added a library for the `:cljtest` alias only that creates a temp dir at the start of a test and deletes it after. That allows me to test this with a file conn.

The important fixes are in d69fb6dd0b1afefb396981ff81ee125abc4422c1 and 22e64711badd74b61227f84dd9e72cfbdb211e52.