### PR TITLE
Policy enforcement for non-graph-crawl queries

### DIFF
--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -14,47 +14,50 @@
   "Returns one of:
   (a) exception if there was an error
   (b) truthy value if flake is allowed
-  (c) falsey value if flake not allowed
-
-  Note this should only be called if the db is permissioned, don't call if the root user as the results will
-  not come back correctly."
+  (c) falsey value if flake not allowed"
   [{:keys [permissions] :as db} flake]
   (go-try
-    (let [s         (flake/s flake)
-          p         (flake/p flake)
-          class-ids (or (get @(:cache permissions) s)
-                        (let [classes (<? (dbproto/-class-ids (dbproto/-rootdb db) (flake/s flake)))]
-                          ;; note, classes will return empty list if none found ()
-                          (swap! (:cache permissions) assoc s classes)
-                          classes))
-          fns       (keep #(or (get-in permissions [:view :class % p])
-                               (get-in permissions [:view :class % :default])) class-ids)]
-      (loop [[[async? f] & r] fns]
-        ;; TODO - all fns are currently sync - but that will change. Can check for presence of ch? in response, or ideally pass as meta which fns are sync or async
-        ;; return first truthy response, else false
-        (if f
-          (let [res (if async?
-                      (<? (f db flake))
-                      (f db flake))]
-            (or res
-                (recur r)))
-          false)))))
+    (if (:root? permissions)
+      true
+      (let [s         (flake/s flake)
+            p         (flake/p flake)
+            class-ids (or (get @(:cache permissions) s)
+                          (let [classes (<? (dbproto/-class-ids
+                                              (dbproto/-rootdb db)
+                                              (flake/s flake)))]
+                            ;; note, classes will return empty list if none found ()
+                            (swap! (:cache permissions) assoc s classes)
+                            classes))
+            fns       (keep #(or (get-in permissions [:view :class % p])
+                                 (get-in permissions [:view :class % :default]))
+                            class-ids)]
+        (loop [[[async? f] & r] fns]
+          ;; return first truthy response, else false
+          (if f
+            (let [res (if async?
+                        (<? (f db flake))
+                        (f db flake))]
+              (or res
+                  (recur r)))
+            false))))))
 
 
 (defn allow-flakes?
   "Like allow-flake, but filters a sequence of flakes to only allow those
-  that are whose permissions do not return 'false'."
+  whose permissions do not return 'false'."
   [db flakes]
-  ;; check for root access, in which case we can short-circuit and return true.
   (async/go
-    (loop [[flake & r] flakes
-           acc []]
-      (if flake (if (schema-util/is-schema-flake? flake)    ;; always allow schema flakes
+    (if (get-in db [:permissions :root?])
+      flakes
+      (loop [[flake & r] flakes
+             acc []]
+        (if flake
+          (if (schema-util/is-schema-flake? flake) ;; always allow schema flakes
+            (recur r (conj acc flake))
+            (let [res (async/<! (allow-flake? db flake))]
+              (if (util/exception? res)
+                res
+                (if res
                   (recur r (conj acc flake))
-                  (let [res (async/<! (allow-flake? db flake))]
-                    (if (util/exception? res)
-                      res
-                      (if res
-                        (recur r (conj acc flake))
-                        (recur r acc)))))
-                acc))))
+                  (recur r acc)))))
+          acc)))))

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -48,7 +48,10 @@
                                 s-fn (assoc :subject-fn s-fn)
                                 p-fn (assoc :predicate-fn p-fn)
                                 o-fn (assoc :object-fn o-fn))]
-              (-> (query-range/resolve-flake-slices conn idx-root novelty error-ch opts)
+              (-> (query-range/resolve-flake-slices conn idx-root novelty
+                                                    error-ch opts)
+                  (->> (query-range/filter-authorized db start-flake end-flake
+                                                      error-ch))
                   (async/pipe out-ch)))
             (catch* e
                     (log/error e "Error resolving flake range")

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -68,9 +68,7 @@
                                                     :f/role      :ex/userRole})]
 
       ;; root can see all user data
-      (is (= @(fluree/query root-db {:select {'?s [:* {:ex/location [:*]}]}
-                                     :where  [['?s :rdf/type :ex/User]]})
-             [{:id               :ex/john,
+      (is (= [{:id               :ex/john,
                :rdf/type         [:ex/User],
                :schema/name      "John",
                :schema/email     "john@flur.ee",
@@ -84,28 +82,28 @@
                :schema/ssn       "111-11-1111",
                :ex/location      {:id         "_:f211106232532993",
                                   :ex/state   "NC",
-                                  :ex/country "USA"}}])
+                                  :ex/country "USA"}}]
+             @(fluree/query root-db {:select {'?s [:* {:ex/location [:*]}]}
+                                     :where  [['?s :rdf/type :ex/User]]}))
           "Both user records + all attributes should show")
 
       ;; root can see all product data
-      (is (= @(fluree/query root-db {:select {'?s [:* {:ex/location [:*]}]}
-                                     :where  [['?s :rdf/type :ex/Product]]})
-             [{:id                   :ex/widget,
+      (is (= [{:id                   :ex/widget,
                :rdf/type             [:ex/Product],
                :schema/name          "Widget",
                :schema/price         99.99,
-               :schema/priceCurrency "USD"}])
+               :schema/priceCurrency "USD"}]
+             @(fluree/query root-db {:select {'?s [:* {:ex/location [:*]}]}
+                                     :where  [['?s :rdf/type :ex/Product]]}))
           "The product record should show with all attributes")
 
       ;; Alice cannot see product data as it was not explicitly allowed
-      (is (= @(fluree/query alice-db {:select {'?s [:*]}
-                                      :where  [['?s :rdf/type :ex/Product]]})
-             []))
+      (is (= []
+             @(fluree/query alice-db {:select {'?s [:*]}
+                                      :where  [['?s :rdf/type :ex/Product]]})))
 
       ;; Alice can see all users, but can only see SSN for herself, and can't see the nested location
-      (is (= @(fluree/query alice-db {:select {'?s [:* {:ex/location [:*]}]}
-                                      :where  [['?s :rdf/type :ex/User]]})
-             [{:id               :ex/john,
+      (is (= [{:id               :ex/john,
                :rdf/type         [:ex/User],
                :schema/name      "John",
                :schema/email     "john@flur.ee",
@@ -115,5 +113,7 @@
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
-               :schema/ssn       "111-11-1111"}])
-          "Both users should show, but only SSN for Alice"))))
+               :schema/ssn       "111-11-1111"}]
+             @(fluree/query alice-db {:select {'?s [:* {:ex/location [:*]}]}
+                                      :where  [['?s :rdf/type :ex/User]]}))
+          "Both users should show, but only SSN for Alice")

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -117,3 +117,11 @@
              @(fluree/query alice-db {:select {'?s [:* {:ex/location [:*]}]}
                                       :where  [['?s :rdf/type :ex/User]]}))
           "Both users should show, but only SSN for Alice")
+
+      ;; Alice can only see her allowed data in a non-graph-crawl query too
+      (is (= [["John" nil] ["Alice" "111-11-1111"]]
+             @(fluree/query alice-db {:select '[?name ?ssn]
+                                      :where  '[[?p :schema/name ?name]
+                                                {:optional [?p :schema/ssn ?ssn]}]}))
+          "Both user names should show, but only SSN for Alice"))))
+


### PR DESCRIPTION
Closes #300

Tests are in 9d5a43e15f007b18713cfbd4c85895ff701e8bb5, implementation is in 4936714eb8360304aa640fe5fe6513c88f186a6d.

Let me know if cc6b4885d05fba7e5d7a7e745443a9d92798c406 isn't actually desired. There was a comment that made it sound like it was planned but not yet implemented, and it was simple enough that I just threw it in.