### PR TITLE
Fix index-range bug, add test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -92,10 +92,15 @@
    :main-opts   ["-m" "cloverage.coverage" "-p" "src" "-s" "test" "--output" "scanning_results/coverage"]}
 
   :eastwood
-  {:extra-deps {jonase/eastwood {:mvn/version "1.3.0"}}
-   :main-opts  ["-m" "eastwood.lint"
-                {:source-paths ["src" "src-docs"]
-                 :test-paths   ["test"]}]}
+  {:extra-deps  {jonase/eastwood {:mvn/version "1.3.0"}}
+   :main-opts   ["-m" "eastwood.lint"
+                 {:source-paths ["src" "src-docs"]
+                  :test-paths   ["test"]
+                  ;; TODO: Un-exclude this when it stops triggering false
+                  ;;       positives on "UnsupportedOperationException empty is
+                  ;;       not supported on Flake" when using the #Flake data
+                  ;;       reader - WSM 2023-02-01
+                  :exclude-linters [:implicit-dependencies]}]}
 
   :ancient
   {:extra-deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,0 +1,1 @@
+{Flake fluree.db.flake/parts->Flake}

--- a/test/fluree/db/policy/parsing_test.clj
+++ b/test/fluree/db/policy/parsing_test.clj
@@ -1,4 +1,4 @@
-(ns fluree.db.policy.parsing
+(ns fluree.db.policy.parsing-test
   (:require
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
@@ -99,17 +99,17 @@
                                                                     {:id :ex/user}]
                                                      :f/targetRole {:_id sid-userRole}
                                                      :function     [true
-                                                                    :fluree.db.policy.parsing/replaced-policy-function]
+                                                                    ::replaced-policy-function]
                                                      :id           "_:f211106232533008"}}}}
               :f/view   {:class {sid-User {sid-ssn  {:f/equals     [{:id :f/$identity}
                                                                     {:id :ex/user}]
                                                      :f/targetRole {:_id sid-userRole}
                                                      :function     [true
-                                                                    :fluree.db.policy.parsing/replaced-policy-function]
+                                                                    ::replaced-policy-function]
                                                      :id           :ex/ssnViewRule}
                                            :default {:f/targetRole {:_id sid-userRole}
                                                      :function     [false
-                                                                    :fluree.db.policy.parsing/replaced-policy-function]
+                                                                    ::replaced-policy-function]
                                                      :id           :ex/globalViewAllow}}}}
               :ident    sid-alice
               :roles    #{sid-userRole}}

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -1,0 +1,2 @@
+(ns fluree.db.policy.subj-flakes-test
+  (:require [clojure.test :refer :all]))

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -1,2 +1,0 @@
-(ns fluree.db.policy.subj-flakes-test
-  (:require [clojure.test :refer :all]))

--- a/test/fluree/db/query/range_test.clj
+++ b/test/fluree/db/query/range_test.clj
@@ -1,0 +1,73 @@
+(ns fluree.db.query.range-test
+  (:require
+    [clojure.test :refer :all]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.util.log :as log]
+    [fluree.db.dbproto :as dbproto]
+    [clojure.core.async :as async]))
+
+;; tests for index-range calls (just some basic tests for now)
+
+(deftest ^:integration index-range-basic
+  (testing "Index-range calls with various options."
+    (let [conn                 (test-utils/create-conn)
+          ledger               @(fluree/create conn "policy/a" {:context {:ex "http://example.org/ns/"}})
+          ;; get some basic data transacted
+          db                   @(fluree/stage
+                                  (fluree/db ledger)
+                                  [{:id               :ex/alice,
+                                    :type             :ex/User,
+                                    :schema/name      "Alice"
+                                    :schema/email     "alice@flur.ee"
+                                    :schema/birthDate "2022-08-17"
+                                    :schema/ssn       "111-11-1111"
+                                    :ex/location      {:ex/state   "NC"
+                                                       :ex/country "USA"}}
+                                   {:id               :ex/john,
+                                    :type             :ex/User,
+                                    :schema/name      "John"
+                                    :schema/email     "john@flur.ee"
+                                    :schema/birthDate "2021-08-17"
+                                    :schema/ssn       "888-88-8888"}
+                                   {:id                   :ex/widget,
+                                    :type                 :ex/Product,
+                                    :schema/name          "Widget"
+                                    :schema/price         99.99
+                                    :schema/priceCurrency "USD"}])
+          ;; get a group of flakes that we know will have different permissions for different users.
+          john-flakes-compact  @(fluree/range db :spot = [:ex/john])
+          john-flakes-expanded @(fluree/range db :spot = [(fluree/expand-iri db :ex/john)])
+          john-flakes-sid      @(fluree/range db :spot = [(async/<!! (dbproto/-subid db :ex/john))])
+
+          alice-flakes         @(fluree/range db :spot = [:ex/alice])
+          widget-flakes        @(fluree/range db :spot = [:ex/widget])]
+
+
+      (log/warn "john-flakes: \n" john-flakes-expanded)
+      ;(log/warn "alice-flakes: \n" alice-flakes)
+      ;(log/warn "widget-flakes: \n" widget-flakes)
+
+      ;; root can see all user data
+      (is (= john-flakes-compact
+             john-flakes-expanded
+             john-flakes-sid)
+          "query-range should properly expand IRIs")
+
+      (is (= [#Flake [211106232532992 0 "http://example.org/ns/alice" 1 -1 true nil]
+              #Flake [211106232532992 200 1002 0 -1 true nil]
+              #Flake [211106232532992 1003 "Alice" 1 -1 true nil]
+              #Flake [211106232532992 1004 "alice@flur.ee" 1 -1 true nil]
+              #Flake [211106232532992 1005 "2022-08-17" 1 -1 true nil]
+              #Flake [211106232532992 1006 "111-11-1111" 1 -1 true nil]
+              #Flake [211106232532992 1007 211106232532993 0 -1 true nil]]
+             alice-flakes))
+
+
+      (is (= [#Flake [211106232532995 0 "http://example.org/ns/widget" 1 -1 true nil]
+              #Flake [211106232532995 200 1010 0 -1 true nil]
+              #Flake [211106232532995 1003 "Widget" 1 -1 true nil]
+              #Flake [211106232532995 1011 99.99 5 -1 true nil]
+              #Flake [211106232532995 1012 "USD" 1 -1 true nil]]
+             widget-flakes)))))
+

--- a/test/fluree/db/query/range_test.clj
+++ b/test/fluree/db/query/range_test.clj
@@ -3,7 +3,6 @@
     [clojure.test :refer :all]
     [fluree.db.test-utils :as test-utils]
     [fluree.db.json-ld.api :as fluree]
-    [fluree.db.util.log :as log]
     [fluree.db.dbproto :as dbproto]
     [clojure.core.async :as async]))
 
@@ -43,10 +42,6 @@
           alice-flakes         @(fluree/range db :spot = [:ex/alice])
           widget-flakes        @(fluree/range db :spot = [:ex/widget])]
 
-
-      (log/warn "john-flakes: \n" john-flakes-expanded)
-      ;(log/warn "alice-flakes: \n" alice-flakes)
-      ;(log/warn "widget-flakes: \n" widget-flakes)
 
       ;; root can see all user data
       (is (= john-flakes-compact


### PR DESCRIPTION
index-range was still testing for the old predicate-ident two-tuple syntax to determine if it should resolve a subject ID.

Also found a bug where the second flake of an index range was not working correctly.

Lastly did a small optimization for the `=` test, where the first/second flake are identical and it doesn't need to look up the subject id twice.

Adds a simple flake test, and a reader for `#Flake` to make writing flake-output tests easier (or other Flake output data in the REPL).

This closes issue #361.

