### PR TITLE
Enforce policies for transactions

### DIFF
--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -317,9 +317,10 @@
   "Returns list of class-ids for given subject-id"
   [db subject-id]
   (go-try
-    (->>
-      (<? (query-range/index-range db :spot = [subject-id const/$rdf:type]))
-      (map flake/o))))
+    (map flake/o
+         (-> (dbproto/-rootdb db)
+             (query-range/index-range :spot = [subject-id const/$rdf:type])
+             <?))))
 
 (defn iri
   "Returns the iri for a given subject ID"

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -388,12 +388,12 @@
              all-classes #{}]
         (if s-flakes
           (let [sid        (flake/s (first s-flakes))
-                {:keys [new? classes shacl]} (get subj-mods' sid)
-                all-flakes (if new?
-                             s-flakes
-                             (<? (query-range/index-range db-after :spot = [sid])))]
+                {:keys [new? classes shacl]} (get subj-mods' sid)]
             (when shacl
-              (<? (shacl/validate-target db-after shacl all-flakes)))
+              (let [all-flakes (if new?
+                                 s-flakes
+                                 (<? (query-range/index-range db-after :spot = [sid])))]
+                (<? (shacl/validate-target db-after shacl all-flakes))))
             (recur r (into all-classes classes)))
           (let [new-shacl? (or (contains? all-classes const/$sh:NodeShape)
                                (contains? all-classes const/$sh:PropertyShape))]

--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -23,9 +23,7 @@
     (let [s         (flake/s flake)
           p         (flake/p flake)
           class-ids (or (get @(:cache policy) s)
-                        (let [classes (<? (dbproto/-class-ids
-                                            (dbproto/-rootdb db)
-                                            (flake/s flake)))]
+                        (let [classes (<? (dbproto/-class-ids db (flake/s flake)))]
                           ;; note, classes will return empty list if none found ()
                           (swap! (:cache policy) assoc s classes)
                           classes))

--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -40,19 +40,7 @@
           false)))))
 
 
-(defn- group-policy-by-default
-  "Returns map with :default and :property keys, each having k-v tuples of
-  their respective policies."
-  [policy-maps]
-  (->> policy-maps
-       (mapcat identity)
-       (group-by (fn [policy-map]
-                   (if (= :default (key policy-map))
-                     :default
-                     :property)))))
-
-
-(defn- group-property-policies
+(defn group-property-policies
   "Returns a map of property policies grouped by property-id (pid).
   For each pid key, returns a vector containing only the function tuples (not entire policy map) of
   [async? fn]. Note while many will have only one fn per pid, there can be multiple - and the first
@@ -89,35 +77,60 @@
               :else (recur r acc)))
           acc)))))
 
+(defn group-policies-by-default
+  "Groups policies for the specified action (e.g. :f/view, :f/modify)
+  and provided class subject ids by either :default or :property.
+
+  Returns map with :default and :property keys, each having k-v tuples of
+  their respective policies"
+  [policy action class-ids]
+  (->> class-ids
+       (keep #(get-in policy [action :class %]))
+       (mapcat identity)
+       (group-by (fn [policy-map]
+                   (if (= :default (key policy-map))
+                     :default
+                     :property)))))
+
+(defn default-allow?
+  "Returns true or false if the default policy allows, or denies access
+  to the subject's flakes.
+
+  default-allow-policies is as output by group-policies-by-default which will
+  be a two-tuple where the second position is the default policy map."
+  [db flake default-allow-policies]
+  (go-try
+    (loop [[[async? f] & r] (eduction
+                              (map second) (map :function)
+                              default-allow-policies)]
+      ;; return first truthy response, else false
+      (if f
+        (let [f-res (if async?
+                      (<? (f db flake))
+                      (f db flake))]
+          (if f-res
+            true
+            (recur r)))
+        ;; always default to false! (deny)
+        false))))
+
 
 (defn filter-subject-flakes
   "Takes multiple flakes for the *same* subject and optimizes evaluation
   for the group. Returns the allowed flakes, or an empty vector if none
   are allowed.
 
-  If specific property policies are not defined, a single evaluation for
+  Supply action evaluation is for, e.g. :f/view or :f/modify
+
+  If no property policies are not defined, a single evaluation for
   the subject can be done and each flake does not need to be checked."
   [{:keys [policy] :as db} flakes]
   (go-try
     (let [fflake         (first flakes)
-          class-ids      (<? (dbproto/-class-ids
-                               (dbproto/-rootdb db)
-                               (flake/s fflake)))
-          class-policies (keep #(get-in policy [:f/view :class %]) class-ids)
-          {defaults :default props :property} (group-policy-by-default class-policies)
+          class-ids      (<? (dbproto/-class-ids db (flake/s fflake)))
+          {defaults :default props :property} (group-policies-by-default policy :f/view class-ids)
           ;; default-allow? will be the default for all flakes that don't have a property-specific policy
-          default-allow? (loop [[[async? f] & r] (eduction
-                                                   (map second) (map :function)
-                                                   defaults)]
-                           ;; return first truthy response, else false
-                           (if f
-                             (let [res (if async?
-                                         (<? (f db fflake))
-                                         (f db fflake))]
-                               (or res
-                                   (recur r)))
-                             ;; always default to false! (deny)
-                             false))]
+          default-allow? (<? (default-allow? db fflake defaults))]
       (cond
         props (<? (evaluate-subject-properties db props default-allow? flakes))
         default-allow? flakes

--- a/src/fluree/db/policy/enforce_tx.cljc
+++ b/src/fluree/db/policy/enforce_tx.cljc
@@ -1,9 +1,9 @@
 (ns fluree.db.policy.enforce-tx
   (:require [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.flake :as flake]
-            [fluree.db.permissions-validate :as validate]
-            [fluree.db.util.log :as log]))
+            [fluree.db.permissions-validate :as validate]))
 
+#?(:clj (set! *warn-on-reflection* true))
 
 (defn root?
   "Returns true if policy has root modify permissions."

--- a/src/fluree/db/policy/enforce_tx.cljc
+++ b/src/fluree/db/policy/enforce_tx.cljc
@@ -1,0 +1,70 @@
+(ns fluree.db.policy.enforce-tx
+  (:require [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.flake :as flake]
+            [fluree.db.permissions-validate :as validate]
+            [fluree.db.util.log :as log]))
+
+
+(defn root?
+  "Returns true if policy has root modify permissions."
+  [policy]
+  (= {:root? true} (get policy :f/modify)))
+
+
+(defn- check-property-policies
+  "Checks property policies, if they exist for a given flake's property and
+  will reject entire transaction if any fail. If they don't exist, default to
+  default-allow?, where it will continue if true, else reject entire transaction if false."
+  [db property-policies default-allow? flakes]
+  (go-try
+    (let [policies-by-pid (validate/group-property-policies property-policies)]
+      (loop [[flake & r] flakes]
+        (if flake
+          (if-let [p-policies (->> flake flake/p (get policies-by-pid))]
+            (let [allow? (loop [[[async? f] & r] p-policies]
+                           ;; return first truthy response, else false
+                           (if f
+                             (let [res (if async?
+                                         (<? (f db flake))
+                                         (f db flake))]
+                               (or res
+                                   (recur r)))
+                             ;; always default to false! (deny)
+                             false))]
+              (if allow?
+                (recur r)
+                (throw (ex-info "Policy enforcement prevents modification."
+                                {:status 400 :error :db/policy-exception}))))
+            (if default-allow?
+              (recur r)
+              (throw (ex-info "Policy enforcement prevents modification."
+                              {:status 400 :error :db/policy-exception}))))
+          ;; passed all property policies, allow everything!
+          true)))))
+
+
+(defn allowed?
+  "Returns true if all policy enforcement passes, else exception related to
+  first policy the fails."
+  [{:keys [db-after add]} {:keys [subj-mods] :as _tx-state}]
+  (let [{:keys [policy]} db-after
+        subj-mods' @subj-mods]
+    (go-try
+      (if (root? policy)
+        db-after
+        (loop [[s-flakes & r] (partition-by flake/s add)]
+          (if s-flakes
+            (let [fflake         (first s-flakes)
+                  sid            (flake/s fflake)
+                  {:keys [classes]} (get subj-mods' sid)
+                  {defaults :default props :property} (validate/group-policies-by-default policy :f/modify classes)
+                  default-allow? (<? (validate/default-allow? db-after fflake defaults))
+                  allow?         (if props
+                                   (<? (check-property-policies db-after props default-allow? s-flakes))
+                                   default-allow?)]
+              (if allow?
+                (recur r)
+                (throw (ex-info "Policy enforcement prevents modification."
+                                {:status 400 :error :db/policy-exception}))))
+            ;; all flakes processed and passed! return final db
+            db-after))))))

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -1,0 +1,99 @@
+(ns fluree.db.policy.transact-test
+  (:require
+    [clojure.test :refer :all]
+    [fluree.db.test-utils :as test-utils]
+    [fluree.db.json-ld.api :as fluree]
+    [fluree.db.did :as did]
+    [fluree.db.util.core :as util]))
+
+(deftest ^:integration policy-enforcement
+  (testing "Testing basic policy enforcement."
+    (let [conn      (test-utils/create-conn)
+          ledger    @(fluree/create conn "policy/tx-a" {:context {:ex "http://example.org/ns/"}})
+          root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+          alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+          db        @(fluree/stage
+                       (fluree/db ledger)
+                       [{:id               :ex/alice,
+                         :type             :ex/User,
+                         :schema/name      "Alice"
+                         :schema/email     "alice@flur.ee"
+                         :schema/birthDate "2022-08-17"
+                         :schema/ssn       "111-11-1111"
+                         :ex/location      {:ex/state   "NC"
+                                            :ex/country "USA"}}
+                        {:id               :ex/john,
+                         :type             :ex/User,
+                         :schema/name      "John"
+                         :schema/email     "john@flur.ee"
+                         :schema/birthDate "2021-08-17"
+                         :schema/ssn       "888-88-8888"}
+                        {:id                   :ex/widget,
+                         :type                 :ex/Product,
+                         :schema/name          "Widget"
+                         :schema/price         99.99
+                         :schema/priceCurrency "USD"}
+                        ;; assign root-did to :ex/rootRole
+                        {:id     root-did
+                         :f/role :ex/rootRole}
+                        ;; assign alice-did to :ex/userRole and also link the did to :ex/alice via :ex/user
+                        {:id      alice-did
+                         :ex/user :ex/alice
+                         :f/role  :ex/userRole}])
+
+          db+policy @(fluree/stage
+                       db
+                       ;; add policy targeting :ex/rootRole that can view and modify everything
+                       [{:id           :ex/rootPolicy,
+                         :type         [:f/Policy], ;; must be of type :f/Policy, else it won't be treated as a policy
+                         :f/targetNode :f/allNodes ;; :f/allNodes special keyword meaning every node (everything)
+                         :f/allow      [{:id           :ex/rootAccessAllow
+                                         :f/targetRole :ex/rootRole ;; our name for global / root role
+                                         :f/action     [:f/view :f/modify]}]}
+                        ;; add a policy targeting :ex/userRole that can see all users, but only SSN if belonging to themselves
+                        {:id            :ex/UserPolicy,
+                         :type          [:f/Policy],
+                         :f/targetClass :ex/User
+                         :f/allow       [{:id           :ex/globalViewAllow
+                                          :f/targetRole :ex/userRole ;; our assigned name for standard user's role (given to Alice above)
+                                          :f/action     [:f/view]}]
+                         :f/property    [{:f/path  :schema/ssn
+                                          :f/allow [{:id           :ex/ssnViewRule
+                                                     :f/targetRole :ex/userRole
+                                                     :f/action     [:f/view]
+                                                     :f/equals     {:list [:f/$identity :ex/user]}}]}]}
+                        ;; add a :ex/Product policy allows view & modify for only :schema/name
+                        {:id            :ex/ProductPolicy,
+                         :type          [:f/Policy],
+                         :f/targetClass :ex/Product
+                         :f/property    [{:f/path  :rdf/type
+                                          :f/allow [{:f/targetRole :ex/userRole
+                                                     :f/action     [:f/view]}]}
+                                         {:f/path  :schema/name
+                                          :f/allow [{:f/targetRole :ex/userRole
+                                                     :f/action     [:f/view :f/modify]}]}]}])]
+
+      (testing "Policy allowed modification"
+        (let [alice-db    @(fluree/wrap-policy db+policy {:f/$identity alice-did
+                                                          :f/role      :ex/userRole})
+              update-name @(fluree/stage alice-db {:id          :ex/widget
+                                                   :schema/name "Widget2"})]
+
+          (is (= [{:rdf/type    [:ex/Product]
+                   :schema/name "Widget2"}]
+                 @(fluree/query update-name
+                                {:select {'?s [:*]}
+                                 :where  [['?s :rdf/type :ex/Product]]}))
+              "Updated :schema/name should have been allowed and have updated value.")))
+
+      (testing "Policy doesn't allow a modification"
+        (let [alice-db     @(fluree/wrap-policy db+policy {:f/$identity alice-did
+                                                           :f/role      :ex/userRole})
+              update-price @(fluree/stage alice-db {:id           :ex/widget
+                                                    :schema/price 42.99})]
+          (is (util/exception? update-price)
+              "Attempted update should have thrown an exception")
+
+          (is (= :db/policy-exception
+                 (:error (ex-data update-price)))
+              "Exception should be of type :db/policy-exception"))))))


### PR DESCRIPTION
This closes issue #296. This relies on PR #365 (still waiting approval).

Policy enforcement had been limited to queries. This extends it to now support transactions.

See new tests for a full example. A quick summary is that this policy on products (class `:ex/Prouct`):

```
{:id            :ex/ProductPolicy,
:type          [:f/Policy],
:f/targetClass :ex/Product
:f/property    [{:f/path   :schema/name
                 :f/allow  [{:f/targetRole :ex/userRole
                 :f/action [:f/view :f/modify]}]}]}
```

Would allow a user that is part of`:ex/userRole` to view and modify `:schema/name`  _only_ - they could neither view nor modify anything else.

Therefore, this transaction would succeed:
```
{:id          :ex/widget
 :schema/name "Some Product Name"}
```

And this transaction would fail:
```
{:id           :ex/widget
 :schema/price 42.99}
```


