### PR TITLE
Feature/having

### DIFF
--- a/src/fluree/db/query/analytical_filter.cljc
+++ b/src/fluree/db/query/analytical_filter.cljc
@@ -148,32 +148,6 @@
                   {:status 400
                    :error  :db/invalid-query})))
 
-(defn get-filters
-  ;; TODO - refactor now that optional filters can also be non-labelled filters inside optional map
-  "optional? indicates we are looking for optional filters. "
-  [filters optional?]
-  (reduce (fn [acc fil]
-            (cond (string? fil) (if optional? acc (conj acc fil))
-
-                  (and (vector? fil) optional?
-                       (= "optional" (str/lower-case (first fil)))) (conj acc (second fil))
-
-                  (and (map? fil)
-                       (= "clojure" (str/lower-case (:language fil)))
-                       (if optional?
-                         (:optional fil)
-                         (not (true? (:optional fil))))
-                       (contains? fil :code)) (conj acc (:code fil))
-
-                  (and (map? fil)
-                       (= "sparql" (str/lower-case (:language fil)))
-                       (if optional?
-                         (:optional fil)
-                         (not (true? (:optional fil))))
-                       (contains? fil :code)) (conj acc (SPARQL-filter-parser fil))
-
-                  :else acc)) [] filters))
-
 (defn extract-combined-filter
   [filter-maps]
   (some->> filter-maps

--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -51,10 +51,10 @@
    (let [error-ch  (async/chan)
          result-ch (->> (where/search db q error-ch)
                         (group/combine q)
+                        (having/filter q error-ch)
                         (order/arrange q)
                         (drop-offset q)
                         (take-limit q)
-                        (having/filter q error-ch)
                         (select/format db q error-ch)
                         (collect-results q))]
      (async/alt!

--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -5,6 +5,7 @@
             [fluree.db.query.exec.where :as where]
             [fluree.db.query.exec.group :as group]
             [fluree.db.query.exec.order :as order]
+            [fluree.db.query.exec.having :as having]
             [fluree.db.util.log :as log :include-macros true]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -53,6 +54,7 @@
                         (order/arrange q)
                         (drop-offset q)
                         (take-limit q)
+                        (having/filter q error-ch)
                         (select/format db q error-ch)
                         (collect-results q))]
      (async/alt!

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -141,33 +141,33 @@
 
 (defn variables
   "Returns the set of items within the arbitrary data structure `code` that
-  are variables ."
+  are variables."
   [code]
   (->> code
        symbols
        (filter variable?)))
 
 (def qualified-symbols
-  {'abs         'fluree.db.query.exec.eval/abs
-   'avg         'fluree.db.query.exec.eval/avg
-   'bound       'fluree.db.query.exec.eval/bound
-   'ceil        'fluree.db.query.exec.eval/ceil
-   'coalesce    'fluree.db.query.exec.eval/coalesce
-   'count       'fluree.db.query.exec.eval/count-distinct
-   'floor       'fluree.db.query.exec.eval/floor
-   'groupconcat 'fluree.db.query.exec.eval/groupconcat
-   'median      'fluree.db.query.exec.eval/median
-   'now         'fluree.db.query.exec.eval/now
-   'rand        'fluree.db.query.exec.eval/rand
-   'sample      'fluree.db.query.exec.eval/sample
-   'stddev      'fluree.db.query.exec.eval/stddev
-   'strStarts   'fluree.db.query.exec.eval/strStarts
-   'strEnds     'fluree.db.query.exec.eval/strEnds
-   'sum         'fluree.db.query.exec.eval/sum
-   'variance    'fluree.db.query.exec.eval/variance
-   '!           'fluree.db.query.exec.eval/!
-   '&&          'fluree.db.query.exec.eval/&&
-   '||          'fluree.db.query.exec.eval/||})
+  '{abs         fluree.db.query.exec.eval/abs
+    avg         fluree.db.query.exec.eval/avg
+    bound       fluree.db.query.exec.eval/bound
+    ceil        fluree.db.query.exec.eval/ceil
+    coalesce    fluree.db.query.exec.eval/coalesce
+    count       fluree.db.query.exec.eval/count-distinct
+    floor       fluree.db.query.exec.eval/floor
+    groupconcat fluree.db.query.exec.eval/groupconcat
+    median      fluree.db.query.exec.eval/median
+    now         fluree.db.query.exec.eval/now
+    rand        fluree.db.query.exec.eval/rand
+    sample      fluree.db.query.exec.eval/sample
+    stddev      fluree.db.query.exec.eval/stddev
+    strStarts   fluree.db.query.exec.eval/strStarts
+    strEnds     fluree.db.query.exec.eval/strEnds
+    sum         fluree.db.query.exec.eval/sum
+    variance    fluree.db.query.exec.eval/variance
+    !           fluree.db.query.exec.eval/!
+    &&          fluree.db.query.exec.eval/&&
+    ||          fluree.db.query.exec.eval/||})
 
 (defn qualify
   [sym]

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -1,0 +1,203 @@
+(ns fluree.db.query.exec.eval
+  (:refer-clojure :exclude [compile rand])
+  (:require [fluree.db.query.exec.where :as where]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.walk :refer [postwalk]])
+  #?(:clj (:import (java.time Instant))))
+
+(defn sum
+  [coll]
+  (reduce + 0 coll))
+
+(defn avg
+  [coll]
+  (/ (sum coll)
+     (count coll)))
+
+(defn median
+  [coll]
+  (let [terms (sort coll)
+        size  (count coll)
+        med   (bit-shift-right size 1)]
+    (cond-> (nth terms med)
+      (even? size)
+      (-> (+ (nth terms (dec med)))
+          (/ 2)))))
+
+(defn variance
+  [coll]
+  (let [mean (avg coll)
+        sum  (sum (for [x coll
+                        :let [delta (- x mean)]]
+                    (* delta delta)))]
+    (/ sum (count coll))))
+
+(defn stddev
+  [coll]
+  (Math/sqrt (variance coll)))
+
+(defn ceil
+  [n]
+  (cond (= n (int n)) n
+        (> n 0) (-> n int inc)
+        (< n 0) (-> n int)))
+
+(def count-distinct
+  (comp count distinct))
+
+(defn floor
+  [n]
+  (cond (= n (int n)) n
+        (> n 0) (-> n int)
+        (< n 0) (-> n int dec)))
+
+(def groupconcat concat)
+
+(defn rand
+  ([coll]
+   (rand-nth coll))
+  ([n coll]
+   (vec (repeatedly n #(rand-nth coll)))))
+
+(defn sample
+  [n coll]
+  (->> coll
+       shuffle
+       (take n)
+       vec))
+
+(def allowed-aggregates
+  '#{abs as avg ceil count count-distinct distinct floor groupconcat
+     median max min rand sample stddev str sum variance})
+
+(defmacro coalesce
+  "Evaluates args in order. The result of the first arg not to return error gets returned."
+  ([] (throw (ex-info "COALESCE evaluation failed on all forms." {:status 400 :error :db/invalid-query})))
+  ([arg] `(let [res# (try ~arg (catch Exception e# nil))]
+            (if (nil? res#)
+              (throw (ex-info "Coalesce evaluation failed on all forms." {:status 400 :error :db/invalid-query})) res#)))
+  ([arg & args]
+   `(let [res# (try ~arg (catch Exception e# nil))]
+      (if (nil? res#)
+        (coalesce ~@args) res#))))
+
+(def bound some?)
+
+(def ! not)
+
+(defmacro &&
+  "Equivalent to and"
+  ([] true)
+  ([x] x)
+  ([x & next]
+   `(let [and# ~x]
+      (if and# (and ~@next) and#))))
+
+(defmacro ||
+  "Equivalent to or"
+  ([] nil)
+  ([x] x)
+  ([x & next]
+   `(let [or# ~x]
+      (if or# or# (or ~@next)))))
+
+(defn now
+  []
+  #?(:clj (.toEpochMilli (Instant/now))))
+
+(defn strStarts
+  [s substr]
+  (str/starts-with? s substr))
+
+(defn strEnds
+  [s substr]
+  (str/ends-with? s substr))
+
+(def allowed-filters
+  '#{&& || ! > < >= <= = + - * / and bound coalesce if nil?
+     not not= now or re-find re-pattern strStarts strEnds})
+
+(def allowed-symbols
+  (set/union allowed-aggregates allowed-filters))
+
+(defn variable?
+  [sym]
+  (and (symbol? sym)
+       (-> sym
+           name
+           first
+           (= \?))))
+
+(defn symbols
+  [code]
+  (postwalk (fn [x]
+              (if (coll? x)
+                (apply set/union x)
+                (if (symbol? x)
+                  #{x}
+                  #{})))
+            code))
+
+(defn variables
+  "Returns the set of items within the arbitrary data structure `code` that
+  are variables ."
+  [code]
+  (->> code
+       symbols
+       (filter variable?)))
+
+(def qualified-symbols
+  {'abs         'fluree.db.query.exec.eval/abs
+   'avg         'fluree.db.query.exec.eval/avg
+   'bound       'fluree.db.query.exec.eval/bound
+   'ceil        'fluree.db.query.exec.eval/ceil
+   'coalesce    'fluree.db.query.exec.eval/coalesce
+   'count       'fluree.db.query.exec.eval/count-distinct
+   'floor       'fluree.db.query.exec.eval/floor
+   'groupconcat 'fluree.db.query.exec.eval/groupconcat
+   'median      'fluree.db.query.exec.eval/median
+   'now         'fluree.db.query.exec.eval/now
+   'rand        'fluree.db.query.exec.eval/rand
+   'sample      'fluree.db.query.exec.eval/sample
+   'stddev      'fluree.db.query.exec.eval/stddev
+   'strStarts   'fluree.db.query.exec.eval/strStarts
+   'strEnds     'fluree.db.query.exec.eval/strEnds
+   'sum         'fluree.db.query.exec.eval/sum
+   'variance    'fluree.db.query.exec.eval/variance
+   '!           'fluree.db.query.exec.eval/!
+   '&&          'fluree.db.query.exec.eval/&&
+   '||          'fluree.db.query.exec.eval/||})
+
+(defn qualify
+  [sym]
+  (if (contains? allowed-symbols sym)
+    (get qualified-symbols sym sym)
+    (throw (ex-info (str "Query function references illegal symbol: " sym)
+                    {:status 400, :error :db/invalid-query}))))
+
+(defn coerce
+  [code]
+  (postwalk (fn [x]
+              (if (and (symbol? x)
+                       (not (variable? x)))
+                (qualify x)
+                x))
+            code))
+
+(defn bind-variables
+  [soln-sym var-syms]
+  (->> var-syms
+       (mapcat (fn [v]
+                 [v `(::where/val (get ~soln-sym (quote ~v)))]))
+       (into [])))
+
+(defn compile
+  [code]
+  (let [qualified-code (coerce code)
+        vars           (variables qualified-code)
+        soln-sym       'solution
+        bdg            (bind-variables soln-sym vars)]
+    (eval `(fn [~soln-sym]
+             (let ~bdg
+               ~qualified-code)))))

--- a/src/fluree/db/query/exec/having.cljc
+++ b/src/fluree/db/query/exec/having.cljc
@@ -1,0 +1,22 @@
+(ns fluree.db.query.exec.having
+  (:require [fluree.db.util.core :as util :refer [try* catch*]]
+            [fluree.db.util.log :as log :include-macros true]
+            [clojure.core.async :as async :refer [>! go]])
+  (:refer-clojure :exclude [filter]))
+
+(defn filter
+  [q error-ch solution-ch]
+  (if-let [filter-fn (:having q)]
+    (let [filtered-ch (async/chan)]
+      (async/pipeline-async 2
+                            filtered-ch
+                            (fn [solution ch]
+                              (go (try* (when (filter-fn solution)
+                                          (>! ch solution))
+                                        (async/close! ch)
+                                        (catch* e
+                                                (log/error e "Error applying having function")
+                                                (>! error-ch e)))))
+                            solution-ch)
+      filtered-ch)
+    solution-ch))

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -170,6 +170,7 @@
                          [:groupBy {:optional true} ::groupBy]
                          [:group-by {:optional true} ::group-by]
                          [:filter {:optional true} ::filter]
+                         [:having {:optional true} ::function]
                          [:vars {:optional true} ::vars]
                          [:limit {:optional true} ::limit]
                          [:offset {:optional true} ::offset]

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -34,11 +34,11 @@
                      :ex/friend    [:ex/brian :ex/alice]}])
 
           two-tuple-select-with-crawl
-          @(fluree/query db {:context {:ex "http://example.org/ns/"}
-                             :select  ['?age {'?f [:*]}]
-                             :where   [['?s :schema/name "Cam"]
-                                       ['?s :ex/friend '?f]
-                                       ['?f :schema/age '?age]]})
+          @(fluree/query db '{:context {:ex "http://example.org/ns/"}
+                              :select  [?age {?f [:*]}]
+                              :where   [[?s :schema/name "Cam"]
+                                        [?s :ex/friend ?f]
+                                        [?f :schema/age ?age]]})
 
           two-tuple-select-with-crawl+var
           @(fluree/query db {:context {:ex "http://example.org/ns/"}


### PR DESCRIPTION
Implements `:having` clauses by creating an `eval` namespace that compiles user-supplied code into clojure functions after validating that it only references a pre-specified list of functions. 

I think we should convert the aggregate and filter processing code to use the eval namespace because it is both more flexible and general, but those changes will come in another pull request (probably the one for #272). 

Closes #313
