### PR TITLE
pass around cache atom instead of cache closure

### DIFF
--- a/src/fluree/db/conn/cache.cljc
+++ b/src/fluree/db/conn/cache.cljc
@@ -6,13 +6,7 @@
              #?@(:clj [:refer [try* catch* exception?]])
              #?@(:cljs [:refer-macros [try* catch*] :refer [exception?]])]))
 
-(defn create-lru-cache
-  "Create a cache that starts holds `cache-size` number of entries, bumping out the least
-  recently used value after the size is exceeded.."
-  [cache-size]
-  (cache/lru-cache-factory {} :threshold cache-size))
-
-(defn lookup
+(defn lookup-or-evict
   [cache-atom k value-fn]
   (if (nil? value-fn)
     (swap! cache-atom cache/evict k)
@@ -20,22 +14,34 @@
       (do (swap! cache-atom cache/hit k)
           v))))
 
-(defn async-cache-fn
-  "Create an async cache lookup function."
-  [memory cache-atom]
-  (let [memory             (or memory 1000000) ; default 1MB memory
-        memory-object-size (quot memory 100000)]
-    (when (< memory-object-size 10)
+(defn create-lru-cache
+  "Create a cache that starts holds `cache-size` number of entries, bumping out the least
+  recently used value after the size is exceeded.."
+  [cache-size]
+  (cache/lru-cache-factory {} :threshold cache-size))
+
+(defn memory->cache-size
+  "Validate system memory is enough to build a usable cache, then derive cache size."
+  [memory]
+  (let [memory      (or memory 1000000)        ; default 1MB memory
+        object-size 100000                     ; estimate 100kb index node size
+        cache-size  (quot memory object-size)] ; number of objects to keep in cache
+    (when (< cache-size 10)
       (throw (ex-info (str "Must allocate at least 1MB of memory for Fluree. You've allocated: " memory " bytes.")
                       {:status 400 :error :db/invalid-configuration})))
+    cache-size))
 
-    (fn [k value-fn]
-      (let [out (async/chan)]
-        (if-let [v (lookup cache-atom k value-fn)]
-          (async/put! out v)
-          (async/go
-            (let [v (async/<! (value-fn k))]
-              (when-not (exception? v)
-                (swap! cache-atom cache/miss k v))
-              (async/put! out v))))
-        out))))
+(defn lru-lookup
+  [cache-atom k value-fn]
+  "Given an LRU cache atom, look up value for `k`. If not found, use `value-fn` (a
+  function that accepts `k` as its only argument) to produce the value and add it to the
+  cache.  If `value-fn` is `nil`, evict the key from the cache."
+  (let [out (async/chan)]
+    (if-let [v (lookup-or-evict cache-atom k value-fn)]
+      (async/put! out v)
+      (async/go
+        (let [v (async/<! (value-fn k))]
+          (when-not (exception? v)
+            (swap! cache-atom cache/miss k v))
+          (async/put! out v))))
+    out))

--- a/src/fluree/db/conn/cache.cljc
+++ b/src/fluree/db/conn/cache.cljc
@@ -2,13 +2,11 @@
   "A simple default connection-level cache."
   (:require [#?(:cljs cljs.cache :clj clojure.core.cache) :as cache]
             [clojure.core.async :as async]
-            [fluree.db.util.core :as util
-             #?@(:clj [:refer [try* catch* exception?]])
-             #?@(:cljs [:refer-macros [try* catch*] :refer [exception?]])]))
+            [fluree.db.util.core :as util :refer [exception?]]))
 
 (defn create-lru-cache
-  "Create a cache that starts holds `cache-size` number of entries, bumping out the least
-  recently used value after the size is exceeded.."
+  "Create a cache that holds `cache-size` number of entries, bumping out the least
+  recently used value after the size is exceeded."
   [cache-size]
   (cache/lru-cache-factory {} :threshold cache-size))
 
@@ -24,10 +22,10 @@
     cache-size))
 
 (defn lru-lookup
-  [cache-atom k value-fn]
   "Given an LRU cache atom, look up value for `k`. If not found, use `value-fn` (a
-  function that accepts `k` as its only argument) to produce the value and add it to the
-  cache."
+  function that accepts `k` as its only argument and returns an async channel) to
+  produce the value and add it to the cache."
+  [cache-atom k value-fn]
   (let [out (async/chan)]
     (if-let [v (get @cache-atom k)]
       (do (swap! cache-atom cache/hit k)

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -288,21 +288,23 @@
   "Create a new file system connection."
   [{:keys [defaults parallelism storage-path async-cache memory] :as opts}]
   (go
-    (let [storage-path   (trim-last-slash storage-path)
-          conn-id        (str (random-uuid))
-          state          (state-machine/blank-state)
-          async-cache-fn (or async-cache
-                             (conn-cache/default-async-cache-fn memory))]
+    (let [storage-path     (trim-last-slash storage-path)
+          conn-id          (str (random-uuid))
+          state            (state-machine/blank-state)
+          async-cache-atom (atom {})
+          async-cache-fn   (or async-cache
+                               (conn-cache/default-async-cache-fn memory async-cache-atom))]
       ;; TODO - need to set up monitor loops for async chans
-      (map->FileConnection {:id              conn-id
-                            :storage-path    storage-path
-                            :ledger-defaults (ledger-defaults defaults)
-                            :serializer      #?(:clj  (avro-serde/avro-serde)
+      (map->FileConnection {:id               conn-id
+                            :storage-path     storage-path
+                            :ledger-defaults  (ledger-defaults defaults)
+                            :serializer       #?(:clj  (avro-serde/avro-serde)
                                                 :cljs (json-serde/json-serde))
-                            :commit          commit
-                            :push            push
-                            :parallelism     parallelism
-                            :msg-in-ch       (async/chan)
-                            :msg-out-ch      (async/chan)
-                            :state           state
-                            :async-cache     async-cache-fn}))))
+                            :commit           commit
+                            :push             push
+                            :parallelism      parallelism
+                            :msg-in-ch        (async/chan)
+                            :msg-out-ch       (async/chan)
+                            :state            state
+                            :async-cache-atom async-cache-atom
+                            :async-cache      async-cache-fn}))))

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -299,7 +299,7 @@
                             :storage-path    storage-path
                             :ledger-defaults (ledger-defaults defaults)
                             :serializer      #?(:clj  (avro-serde/avro-serde)
-                                                 :cljs (json-serde/json-serde))
+                                                :cljs (json-serde/json-serde))
                             :commit          commit
                             :push            push
                             :parallelism     parallelism

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -187,7 +187,7 @@
     (str (local-path store) "/" ledger "/" "indexes" "/" (str/join "/" r))))
 
 (defrecord FileConnection [id memory state ledger-defaults push commit
-                           parallelism msg-in-ch msg-out-ch async-cache]
+                           parallelism msg-in-ch msg-out-ch lru-cache-atom]
 
   conn-proto/iStorage
   (-c-read [conn commit-key] (go (read-commit conn commit-key)))
@@ -286,25 +286,24 @@
 
 (defn connect
   "Create a new file system connection."
-  [{:keys [defaults parallelism storage-path async-cache memory] :as opts}]
+  [{:keys [defaults parallelism storage-path lru-cache-atom memory] :as opts}]
   (go
-    (let [storage-path     (trim-last-slash storage-path)
-          conn-id          (str (random-uuid))
-          state            (state-machine/blank-state)
-          async-cache-atom (atom {})
-          async-cache-fn   (or async-cache
-                               (conn-cache/async-cache-fn memory async-cache-atom))]
+    (let [storage-path (trim-last-slash storage-path)
+          conn-id      (str (random-uuid))
+          state        (state-machine/blank-state)
+
+          cache-size     (conn-cache/memory->cache-size memory)
+          lru-cache-atom (or lru-cache-atom (atom (conn-cache/create-lru-cache cache-size)))]
       ;; TODO - need to set up monitor loops for async chans
-      (map->FileConnection {:id               conn-id
-                            :storage-path     storage-path
-                            :ledger-defaults  (ledger-defaults defaults)
-                            :serializer       #?(:clj  (avro-serde/avro-serde)
-                                                :cljs (json-serde/json-serde))
-                            :commit           commit
-                            :push             push
-                            :parallelism      parallelism
-                            :msg-in-ch        (async/chan)
-                            :msg-out-ch       (async/chan)
-                            :state            state
-                            :async-cache-atom async-cache-atom
-                            :async-cache      async-cache-fn}))))
+      (map->FileConnection {:id              conn-id
+                            :storage-path    storage-path
+                            :ledger-defaults (ledger-defaults defaults)
+                            :serializer      #?(:clj  (avro-serde/avro-serde)
+                                                 :cljs (json-serde/json-serde))
+                            :commit          commit
+                            :push            push
+                            :parallelism     parallelism
+                            :msg-in-ch       (async/chan)
+                            :msg-out-ch      (async/chan)
+                            :state           state
+                            :lru-cache-atom  lru-cache-atom}))))

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -293,7 +293,7 @@
           state            (state-machine/blank-state)
           async-cache-atom (atom {})
           async-cache-fn   (or async-cache
-                               (conn-cache/default-async-cache-fn memory async-cache-atom))]
+                               (conn-cache/async-cache-fn memory async-cache-atom))]
       ;; TODO - need to set up monitor loops for async chans
       (map->FileConnection {:id               conn-id
                             :storage-path     storage-path

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -201,7 +201,7 @@
 
           default-cache-atom (atom {})
           async-cache-fn     (or async-cache
-                                 (conn-cache/default-async-cache-fn default-cache-atom))]
+                                 (conn-cache/async-cache-fn default-cache-atom))]
       ;; TODO - need to set up monitor loops for async chans
       (map->IPFSConnection {:id               conn-id
                             :ipfs-endpoint    ipfs-endpoint

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -186,7 +186,7 @@
 
           async-cache-atom (atom {})
           async-cache-fn   (or async-cache
-                               (conn-cache/default-async-cache-fn memory async-cache-atom))]
+                               (conn-cache/async-cache-fn memory async-cache-atom))]
       (map->MemoryConnection {:id               conn-id
                               :ledger-defaults  ledger-defaults
                               :data-atom        data-atom

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -179,18 +179,21 @@
   "Creates a new memory connection."
   [{:keys [parallelism async-cache memory defaults]}]
   (go-try
-    (let [ledger-defaults    (<? (ledger-defaults defaults))
-          conn-id            (str (random-uuid))
-          data-atom          (atom {})
-          state              (state-machine/blank-state)
-          async-cache-fn     (or async-cache
-                                 (conn-cache/default-async-cache-fn memory))]
-      (map->MemoryConnection {:id              conn-id
-                              :ledger-defaults ledger-defaults
-                              :data-atom       data-atom
-                              :parallelism     parallelism
-                              :msg-in-ch       (async/chan)
-                              :msg-out-ch      (async/chan)
-                              :memory          true
-                              :state           state
-                              :async-cache     async-cache-fn}))))
+    (let [ledger-defaults (<? (ledger-defaults defaults))
+          conn-id         (str (random-uuid))
+          data-atom       (atom {})
+          state           (state-machine/blank-state)
+
+          async-cache-atom (atom {})
+          async-cache-fn   (or async-cache
+                               (conn-cache/default-async-cache-fn memory async-cache-atom))]
+      (map->MemoryConnection {:id               conn-id
+                              :ledger-defaults  ledger-defaults
+                              :data-atom        data-atom
+                              :parallelism      parallelism
+                              :msg-in-ch        (async/chan)
+                              :msg-out-ch       (async/chan)
+                              :memory           true
+                              :state            state
+                              :async-cache-atom async-cache-atom
+                              :async-cache      async-cache-fn}))))

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -143,9 +143,9 @@
   "Returns a channel that will contain a stream of chunked flake collections that
   contain the flakes between `start-flake` and `end-flake` and are within the
   transaction range starting at `from-t` and ending at `to-t`."
-  [{:keys [async-cache] :as conn} root novelty error-ch
+  [{:keys [lru-cache-atom] :as conn} root novelty error-ch
    {:keys [from-t to-t start-flake end-flake] :as opts}]
-  (let [resolver  (index/->CachedTRangeResolver conn novelty from-t to-t async-cache)
+  (let [resolver  (index/->CachedTRangeResolver conn novelty from-t to-t lru-cache-atom)
         cmp       (:comparator root)
         range-set (flake/sorted-set-by cmp start-flake end-flake)
         in-range? (fn [node]
@@ -284,7 +284,7 @@
          novelty  (get-in db [:novelty idx])
 
          ;; resolve-flake-slices
-         resolver  (index/->CachedHistoryRangeResolver conn novelty from-t to-t (:async-cache conn))
+         resolver  (index/->CachedHistoryRangeResolver conn novelty from-t to-t (:lru-cache-atom conn))
          cmp       (:comparator idx-root)
          range-set (flake/sorted-set-by cmp start-flake end-flake)
          in-range? (fn [node] (intersects-range? node range-set))

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -25,7 +25,7 @@
                       (when-let [variable (:variable o)]
                         (get vars variable)))
         p*          (:value p)
-        idx*        (where/idx-for nil p* o*) 
+        idx*        (where/idx-for nil p* o*)
         o-dt        (:datatype o)
         [fflake lflake] (case idx*
                           :post [(flake/create nil p* o* o-dt nil nil util/min-integer)
@@ -54,7 +54,7 @@
                                     :xf          (when filter-fn
                                                    (map (fn [flakes]
                                                           (filter filter-fn flakes))))})
-          resolver  (index/->CachedTRangeResolver conn (get novelty idx*) t t (:async-cache conn))
+          resolver  (index/->CachedTRangeResolver conn (get novelty idx*) t t (:lru-cache-atom conn))
           tree-chan (index/tree-chan resolver idx-root in-range? query-range/resolved-leaf? 1 query-xf error-ch)]
       (async/go-loop []
         (let [next-chunk (<! tree-chan)]


### PR DESCRIPTION
This is a quick refactor that should make cache introspection a lot simpler. Instead of carrying the cache atom around in a closure, just pass the cache atom and call the lookup/evict functions directly.