### PR TITLE
Fix context bugs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -60,7 +60,8 @@
   {:extra-paths ["test" "dev-resources"]
    :extra-deps  {lambdaisland/kaocha         {:mvn/version "1.71.1119"}
                  org.clojure/test.check      {:mvn/version "1.1.1"}
-                 com.magnars/test-with-files {:mvn/version "2021-02-17"}}
+                 io.github.cap10morgan/test-with-files {:git/tag "v1.0.0"
+                                                        :git/sha "9181a2e"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {}}
 

--- a/dev/logback.xml
+++ b/dev/logback.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%-5level) %white(%logger{24}) - %msg%n</pattern>
+            <pattern>%highlight(%-5level) %cyan(%logger{24}) - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -35,11 +35,11 @@
   [{:keys [storage-path] :as _conn}]
   (let [abs-path? #?(:clj (.isAbsolute (io/file storage-path))
                      :cljs (path/isAbsolute storage-path))
-        abs-root          (if abs-path?
-                            ""
-                            (str #?(:clj  (.getAbsolutePath (io/file ""))
-                                    :cljs (path/resolve ".")) "/"))
-        path              (str abs-root storage-path "/")]
+        abs-root  (if abs-path?
+                    ""
+                    (str #?(:clj  (.getAbsolutePath (io/file ""))
+                            :cljs (path/resolve ".")) "/"))
+        path      (str abs-root storage-path "/")]
     #?(:clj  (-> path io/file .getCanonicalPath)
        :cljs (path/resolve path))))
 

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -195,8 +195,8 @@
   [conn context-key]
   (json/parse (read-address conn context-key) true))
 
-(defrecord FileConnection [id memory state ledger-defaults push commit
-                           parallelism msg-in-ch msg-out-ch lru-cache-atom]
+(defrecord FileConnection [id memory state ledger-defaults parallelism msg-in-ch
+                           msg-out-ch lru-cache-atom]
 
   conn-proto/iStorage
   (-c-read [conn commit-key] (go (read-commit conn commit-key)))

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -83,12 +83,12 @@
   conn-proto/iStorage
   (-c-read [_ commit-key]
     (ipfs/read ipfs-endpoint commit-key))
-
-  (-c-write [_ commit-data]
-    (ipfs/commit ipfs-endpoint commit-data))
-
   (-c-write [_ _ commit-data]
-    (ipfs/commit ipfs-endpoint commit-data))
+    (ipfs/write ipfs-endpoint commit-data))
+  (-ctx-read [_ context-key]
+    (ipfs/read ipfs-endpoint context-key))
+  (-ctx-write [_ _ context-data]
+    (ipfs/write ipfs-endpoint context-data))
 
   conn-proto/iNameService
   (-push [_ address ledger-data]
@@ -129,7 +129,7 @@
   (read [_ k]
     (ipfs/read ipfs-endpoint k true))
   (write [_ k data]
-    (ipfs/commit ipfs-endpoint data))
+    (ipfs/write ipfs-endpoint data))
   (exists? [conn k]
     (storage/read conn k))
   (rename [_ old-key new-key]

--- a/src/fluree/db/conn/proto.cljc
+++ b/src/fluree/db/conn/proto.cljc
@@ -16,10 +16,11 @@
   (-msg-out [conn msg] "Pushes outgoing messages/commands to connection service")
   (-state [conn] [conn ledger] "Returns internal state-machine information for connection, or specific ledger"))
 
-
 (defprotocol iStorage
   (-c-read [conn commit-key] "Reads a commit from storage")
-  (-c-write [conn commit-data] [conn db commit-data] "Writes a commit to storage"))
+  (-c-write [conn ledger commit-data] "Writes a commit to storage")
+  (-ctx-write [conn ledger context-data] "Writes a context to storage and returns the key. Expects string keys.")
+  (-ctx-read [conn context-key] "Reads a context from storage"))
 
 (defprotocol iNameService
   (-push [conn address commit-data] "Pushes ledger metadata to all name service destinations")

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -423,8 +423,7 @@
 ;; TODO - conn is included here because current index-range query looks for conn on the db
 ;; TODO - this can likely be excluded once index-range is changed to get 'conn' from (:conn ledger) where it also exists
 (defrecord JsonLdDb [ledger conn method alias branch commit block t tt-id stats
-                     spot psot post opst tspo
-                     schema comparators novelty
+                     spot psot post opst tspo schema comparators novelty
                      policy ecount]
   dbproto/IFlureeDb
   (-latest-db [this] (graphdb-latest-db this))

--- a/src/fluree/db/json_ld/bootstrap.cljc
+++ b/src/fluree/db/json_ld/bootstrap.cljc
@@ -135,20 +135,6 @@
                          "Must be a valid JSON context, or a valid context map or array/vector. Provided: " default-ctx)
                     {:status 400 :error :db/invalid-context}))))
 
-
-#_(defn bootstrap-tx
-    [default-ctx]
-    (let [ctx    (when default-ctx
-                   (let [default-ctx* (normalize-default-ctx default-ctx)]
-                     {"@id"     "fluree-default-context"
-                      "@type"   ["Context"]
-                      "context" default-ctx*}))
-          graph (cond-> []
-                        ctx (conj ctx))]
-      (when (seq graph)
-        {"@context" "https://ns.flur.ee/ledger/v1"
-         "@graph"   graph})))
-
 (defn bootstrap
   "Bootstraps a permissioned JSON-LD db. Returns async channel."
   ([blank-db] (bootstrap blank-db nil))

--- a/src/fluree/db/json_ld/bootstrap.cljc
+++ b/src/fluree/db/json_ld/bootstrap.cljc
@@ -1,6 +1,8 @@
 (ns fluree.db.json-ld.bootstrap
   (:require [clojure.string :as str]
+            [clojure.core.async :refer [go]]
             [fluree.crypto :as crypto]
+            [fluree.db.ledger.proto :as ledger-proto]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.json :as json]
             [fluree.json-ld :as json-ld]
@@ -134,26 +136,28 @@
                     {:status 400 :error :db/invalid-context}))))
 
 
-(defn bootstrap-tx
-  [default-ctx]
-  (let [ctx    (when default-ctx
-                 (let [default-ctx* (normalize-default-ctx default-ctx)]
-                   {"@id"     "fluree-default-context"
-                    "@type"   ["Context"]
-                    "context" default-ctx*}))
-        graph (cond-> []
-                      ctx (conj ctx))]
-    (when (seq graph)
-      {"@context" "https://ns.flur.ee/ledger/v1"
-       "@graph"   graph})))
+#_(defn bootstrap-tx
+    [default-ctx]
+    (let [ctx    (when default-ctx
+                   (let [default-ctx* (normalize-default-ctx default-ctx)]
+                     {"@id"     "fluree-default-context"
+                      "@type"   ["Context"]
+                      "context" default-ctx*}))
+          graph (cond-> []
+                        ctx (conj ctx))]
+      (when (seq graph)
+        {"@context" "https://ns.flur.ee/ledger/v1"
+         "@graph"   graph})))
 
 (defn bootstrap
   "Bootstraps a permissioned JSON-LD db. Returns async channel."
-  [blank-db default-ctx]
-  (let [tx (bootstrap-tx default-ctx)]
-    (if tx
-      (db-proto/-stage blank-db tx {:bootstrap? true})
-      blank-db)))
+  ([blank-db] (bootstrap blank-db nil))
+  ([blank-db initial-tx]
+   (if-let [tx (when initial-tx
+                 {"@context" "https://ns.flur.ee/ledger/v1"
+                  "@graph"   initial-tx})]
+     (db-proto/-stage blank-db tx {:bootstrap? true})
+     (go blank-db))))
 
 (defn blank-db
   "When not bootstrapping with a transaction, bootstraps initial base set of flakes required for a db."

--- a/src/fluree/db/json_ld/branch.cljc
+++ b/src/fluree/db/json_ld/branch.cljc
@@ -133,15 +133,11 @@
 
 ;; TODO
 #_(defn branch
-  "Creates, or changes, a ledger's branch"
-  [ledger branch]
-  (let [{:keys [state]} ledger
-        {:keys [branches branch]} @state
-        [branch-t [branch-current branch-commit]] branch
-        branch*     (util/str->keyword branch)
-        new?        (contains? branches branch*)
-        is-current? (= branch)]
-
-    )
-
-  )
+    "Creates, or changes, a ledger's branch"
+    [ledger branch]
+    (let [{:keys [state]} ledger
+          {:keys [branches branch]} @state
+          [branch-t [branch-current branch-commit]] branch
+          branch*     (util/str->keyword branch)
+          new?        (contains? branches branch*)
+          is-current? (= branch)]))

--- a/src/fluree/db/json_ld/commit.cljc
+++ b/src/fluree/db/json_ld/commit.cljc
@@ -1,6 +1,5 @@
 (ns fluree.db.json-ld.commit
-  (:require [clojure.walk :as walk]
-            [fluree.json-ld :as json-ld]
+  (:require [fluree.json-ld :as json-ld]
             [fluree.crypto :as crypto]
             [fluree.db.flake :as flake]
             [fluree.db.constants :as const]
@@ -360,7 +359,7 @@
     (let [context (get commit (keyword const/iri-default-context))
           stringify? (-> context keys first keyword?) ; (too?) simple check if we need to stringify the keys before storing
           context-str (if stringify?
-                        (walk/stringify-keys context)
+                        (util/stringify-keys context)
                         context)
           {:keys [address]} (<? (conn-proto/-ctx-write conn ledger context-str))]
       (assoc commit (keyword const/iri-default-context) address))))

--- a/src/fluree/db/json_ld/commit.cljc
+++ b/src/fluree/db/json_ld/commit.cljc
@@ -1,24 +1,23 @@
 (ns fluree.db.json-ld.commit
-  (:require
-    [clojure.walk :as walk]
-    [fluree.json-ld :as json-ld]
-    [fluree.crypto :as crypto]
-    [fluree.db.flake :as flake]
-    [fluree.db.constants :as const]
-    [fluree.db.json-ld.ledger :as jld-ledger]
-    [fluree.db.util.core :as util :refer [vswap!]]
-    [fluree.db.json-ld.credential :as cred]
-    [fluree.db.conn.proto :as conn-proto]
-    [fluree.db.ledger.proto :as ledger-proto]
-    [fluree.db.json-ld.branch :as branch]
-    [fluree.db.util.async :refer [<? go-try channel?]]
-    #?(:clj  [clojure.core.async :refer [go <!] :as async]
-       :cljs [cljs.core.async :refer [go <! put!] :as async])
-    [fluree.db.indexer.proto :as idx-proto]
-    [fluree.db.json-ld.commit-data :as commit-data]
-    [fluree.db.dbproto :as dbproto]
-    [fluree.db.util.log :as log :include-macros true]
-    [fluree.db.json-ld.vocab :as vocab])
+  (:require [clojure.walk :as walk]
+            [fluree.json-ld :as json-ld]
+            [fluree.crypto :as crypto]
+            [fluree.db.flake :as flake]
+            [fluree.db.constants :as const]
+            [fluree.db.json-ld.ledger :as jld-ledger]
+            [fluree.db.util.core :as util :refer [vswap!]]
+            [fluree.db.json-ld.credential :as cred]
+            [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.ledger.proto :as ledger-proto]
+            [fluree.db.json-ld.branch :as branch]
+            [fluree.db.util.async :refer [<? go-try channel?]]
+            #?(:clj  [clojure.core.async :refer [go <!] :as async]
+               :cljs [cljs.core.async :refer [go <! put!] :as async])
+            [fluree.db.indexer.proto :as idx-proto]
+            [fluree.db.json-ld.commit-data :as commit-data]
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.util.log :as log :include-macros true]
+            [fluree.db.json-ld.vocab :as vocab])
   (:refer-clojure :exclude [vswap!]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/src/fluree/db/json_ld/commit_data.cljc
+++ b/src/fluree/db/json_ld/commit_data.cljc
@@ -13,40 +13,40 @@
   ;; - attached to each DB: to know the last commit state when db was pulled from ledger
   ;; - in the ledger-state: since a db may be operated on asynchronously, it can
   ;;                        see if anything (e.g. an index) has since been updated
-  {:id       "fluree:commit:sha256:ljklj"                   ;; relative from source, source is the 'ledger address'
-   :address  ""                                             ;; commit address, if using something like IPFS this is blank
-   :v        0                                              ;; version of commit format
-   :alias    "mydb"                                         ;; human-readable alias name for ledger
-   :branch   "main"                                         ;; ledger's "branch" - if not included, default of 'main'
-   :time     "2022-08-26T19:51:27.220086Z"                  ;; ISO-8601 timestamp of commit
-   :tag      []                                             ;; optional commit tags
+  {:id       "fluree:commit:sha256:ljklj" ;; relative from source, source is the 'ledger address'
+   :address  "" ;; commit address, if using something like IPFS this is blank
+   :v        0 ;; version of commit format
+   :alias    "mydb" ;; human-readable alias name for ledger
+   :branch   "main" ;; ledger's "branch" - if not included, default of 'main'
+   :time     "2022-08-26T19:51:27.220086Z" ;; ISO-8601 timestamp of commit
+   :tag      [] ;; optional commit tags
    :message  "optional commit message"
-   :issuer   {:id ""}                                       ;; issuer of the commit
+   :issuer   {:id ""} ;; issuer of the commit
    :previous {:id      "fluree:commit:sha256:ljklj"
-              :address "previous commit address"}           ;; previous commit address
+              :address "previous commit address"} ;; previous commit address
    ;; data information commit refers to:
-   :data     {:id       "fluree:db:sha256:lkjlkjlj"         ;; db's unique identifier
+   :data     {:id       "fluree:db:sha256:lkjlkjlj" ;; db's unique identifier
               :t        52
-              :address  "fluree:ipfs://sdfsdfgfdgk"         ;; address to locate data file / db
+              :address  "fluree:ipfs://sdfsdfgfdgk" ;; address to locate data file / db
               :previous {:id      "fluree:db:sha256:lkjlkjlj" ;; previous db
                          :address "fluree:ipfs://sdfsdfgfdgk"}
               :flakes   4242424
               :size     123145
               :source   {:id      "csv:sha256:lkjsdfkljsdf" ;; sha256 of original source (e.g. signed transaction, CSV file)
                          :address "/ipfs/sdfsdfgfdgk"
-                         :issuer  {:id ""}}}                ;; issuer of the commit
+                         :issuer  {:id ""}}} ;; issuer of the commit
    ;; name service(s) used to manage global ledger state
-   :ns       {:id  "fluree:ipns://data.flur.ee/my/db"       ;; one (or more) Name Services that can be consulted for the latest ledger state
-              :foo ""}                                      ;; each name service can contain additional data relevant to it
+   :ns       {:id  "fluree:ipns://data.flur.ee/my/db" ;; one (or more) Name Services that can be consulted for the latest ledger state
+              :foo ""} ;; each name service can contain additional data relevant to it
    ;; latest index (note the index roots below are not recorded into JSON-LD commit file, but short-cut when internally managing transitions)
-   :index    {:id      "fluree:index:sha256:fghfgh"         ;; unique id (hash of root) of index
-              :address "fluree:ipfs://lkjdsflkjsdf"         ;; address to get to index 'root'
+   :index    {:id      "fluree:index:sha256:fghfgh" ;; unique id (hash of root) of index
+              :address "fluree:ipfs://lkjdsflkjsdf" ;; address to get to index 'root'
               :data    {:id      "fluree:db:sha256:lkjlkjlj" ;; db of last index unique identifier
                         :t       42
                         :address "fluree:ipfs://sdfsdfgfdgk" ;; address to locate db
                         :flakes  4240000
                         :size    120000}
-              :spot    "fluree:ipfs://spot"                 ;; following 4 items are not recorded in the commit, but used to shortcut updated index retrieval in-process
+              :spot    "fluree:ipfs://spot" ;; following 4 items are not recorded in the commit, but used to shortcut updated index retrieval in-process
               :psot    "fluree:ipfs://psot"
               :post    "fluree:ipfs://post"
               :opst    "fluree:ipfs://opst"
@@ -66,10 +66,11 @@
    ["time" :time]
    ["tag" :tag]
    ["message" :message]
-   ["previous" :previous]                                   ;; refer to :prev-commit template
-   ["data" :data]                                           ;; refer to :data template
-   ["ns" :ns]                                               ;; refer to :ns template
-   ["index" :index]])                                       ;; refer to :index template
+   ["previous" :previous] ;; refer to :prev-commit template
+   ["data" :data] ;; refer to :data template
+   ["ns" :ns] ;; refer to :ns template
+   ["index" :index] ;; refer to :index template
+   [const/iri-default-context (keyword const/iri-default-context)]])
 
 (def json-ld-prev-commit-template
   "Note, key-val pairs are in vector form to preserve ordering of final commit map"
@@ -125,7 +126,7 @@
         (if (keyword? v)
           (if-let [v* (get m v)]
             (recur r true (-> acc
-                              (conj! k)                     ;; note, CLJS allows multi-arity for conj!, but clj does not
+                              (conj! k) ; note, CLJS allows multi-arity for conj!, but clj does not
                               (conj! v*)))
             (recur r have-value? acc))
           (recur r have-value? (-> acc
@@ -188,20 +189,20 @@
                         address const/iri-address,
                         flakes  const/iri-flakes,
                         size    const/iri-size :as _db-item}]
-                    {:id      id                            ;; db's unique identifier
+                    {:id      id ;; db's unique identifier
                      :t       (:value t)
-                     :address (:value address)              ;; address to locate db
+                     :address (:value address) ;; address to locate db
                      :flakes  (:value flakes)
                      :size    (:value size)})]
     {:id       id
-     :address  (if (empty? (:value address))                ;; commit address, if using something like IPFS this is empty string
+     :address  (if (empty? (:value address)) ;; commit address, if using something like IPFS this is empty string
                  commit-address
                  (:value address))
-     :v        (:value v)                                   ;; version of commit format
-     :alias    (:value alias)                               ;; human-readable alias name for ledger
-     :branch   (:value branch)                              ;; ledger's "branch" - if not included, default of 'main'
+     :v        (:value v) ;; version of commit format
+     :alias    (:value alias) ;; human-readable alias name for ledger
+     :branch   (:value branch) ;; ledger's "branch" - if not included, default of 'main'
      :issuer   (when issuer {:id (:id issuer)})
-     :time     (:value time)                                ;; ISO-8601 timestamp of commit
+     :time     (:value time) ;; ISO-8601 timestamp of commit
      :tag      (mapv :value tag)
      :message  (:value message)
      :previous {:id      (:id prev-commit)
@@ -210,16 +211,16 @@
      :data     (db-object data)
      ;; name service(s) used to manage global ledger state
      ;; TODO - flesh out with final ns data structure
-     :ns       (when ns                                     ;; one (or more) Fluree Name Services that can be consulted for the latest ledger state
+     :ns       (when ns ;; one (or more) Fluree Name Services that can be consulted for the latest ledger state
                  (if (sequential? ns)
                    (mapv (fn [namespace] {:id (:id namespace)}) ns)
                    {:id (:id ns)}))
      ;; latest index (note the index roots below are not recorded into JSON-LD commit file, but short-cut when internally managing transitions)
      :index    (when index
-                 {:id      (:id index)                      ;; unique id (hash of root) of index
+                 {:id      (:id index) ;; unique id (hash of root) of index
                   :address (get-in index [const/iri-address :value]) ;; address to get to index 'root'
                   :data    (db-object (get index const/iri-data))
-                  :spot    spot                             ;; following 4 items are not recorded in the commit, but used to shortcut updated index retrieval in-process
+                  :spot    spot ;; following 4 items are not recorded in the commit, but used to shortcut updated index retrieval in-process
                   :psot    psot
                   :post    post
                   :opst    opst
@@ -335,9 +336,9 @@
 (defn new-db-commit
   "Returns the :data portion of the commit map for a new db commit."
   [dbid t db-address prev-data flakes size]
-  (cond-> {:id      dbid                                    ;; db's unique identifier
+  (cond-> {:id      dbid ;; db's unique identifier
            :t       (- t)
-           :address db-address                              ;; address to locate db
+           :address db-address ;; address to locate db
            :flakes  flakes
            :size    size}
           (not-empty prev-data) (assoc :previous prev-data)))
@@ -357,10 +358,13 @@
   "Returns a commit map with a new db registered.
   Assumes commit is not yet created (but db is persisted), so
   commit-id and commit-address are added after finalizing and persisting commit."
-  [old-commit issuer message tag dbid t db-address flakes size]
+  [{:keys [old-commit issuer message tag dbid t db-address flakes size]
+    :as commit}]
   (let [prev-data   (select-keys (data old-commit) [:id :address])
         data-commit (new-db-commit dbid t db-address prev-data flakes size)
         prev-commit (not-empty (select-keys old-commit [:id :address]))
+        context-key (keyword const/iri-default-context)
+        context     (get commit context-key)
         commit      (-> old-commit
                         (dissoc :id :address :data :issuer :time :message :tag :prev-commit)
                         (assoc :address ""
@@ -370,7 +374,8 @@
             issuer (assoc :issuer {:id issuer})
             prev-commit (assoc :previous prev-commit)
             message (assoc :message message)
-            tag (assoc :tag tag))))
+            tag (assoc :tag tag)
+            context (assoc context-key context))))
 
 (defn update-db
   "Updates the :data portion of the commit map to represent a saved new db update."

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -434,3 +434,13 @@
             (let [new-db (<? (merge-commit conn db* commit merged-db?))]
               (recur r new-db))
             db*))))))
+
+(defn load-default-context
+  "Loads the default context from the given conn's storage using the given key.
+  Returns a core.async channel with the context map."
+  [conn key]
+  (go-try
+    (log/debug "loading default context from storage w/ key:" key)
+    (->> key
+         (conn-proto/-ctx-read conn)
+         <?)))

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -19,6 +19,28 @@
 
 (def ^:const max-vocab-sid (flake/max-subject-id const/$_collection))
 
+(defn node?
+  "Returns true if a nested value is itself another node in the graph.
+  Only need to test maps that have :id - and if they have other properties they
+  are defining then we know it is a node and have additional data to include."
+  [mapx]
+  (cond
+    (contains? mapx :value)
+    false
+
+    (and
+      (contains? mapx :list)
+      (= #{:list :idx} (set (keys mapx))))
+    false
+
+    (and
+      (contains? mapx :set)
+      (= #{:set :idx} (set (keys mapx))))
+    false
+
+    :else
+    true))
+
 (defn get-iri-sid
   "Gets the IRI for any existing subject ID."
   [iri db iris]
@@ -117,24 +139,28 @@
   (go-try
     (loop [[v-map & r-v-maps] v-maps
            acc* acc]
-      (log/debug "assert v-map:" v-map)
+      (log/debug "assert-v-maps v-map:" v-map)
+      (log/debug "assert-v-maps id:" id)
       (let [acc**
             (cond->
-              (if id ;; is a ref to another IRI
+              (if (and id (node? v-map)) ;; is a ref to another IRI
                 (let [existing-sid (<? (get-iri-sid id db iris))
                       ref-sid      (or existing-sid
                                        (jld-ledger/generate-new-sid
-                                         v-map pid iris next-pid next-sid))]
-                  (cond-> (conj acc*
-                                (flake/create sid pid ref-sid const/$xsd:anyURI
-                                              t true nil))
+                                         v-map pid iris next-pid next-sid))
+                      new-flake    (flake/create sid pid ref-sid
+                                                 const/$xsd:anyURI t true nil)]
+                  (log/debug "creating ref flake:" new-flake)
+                  (cond-> (conj acc* new-flake)
                           (nil? existing-sid) (conj
                                                 (flake/create ref-sid const/$iri
                                                               id
                                                               const/$xsd:string
                                                               t true nil))))
-                (let [[value dt] (datatype/from-expanded v-map nil)]
-                  (conj acc* (flake/create sid pid value dt t true nil))))
+                (let [[value dt] (datatype/from-expanded v-map nil)
+                      new-flake  (flake/create sid pid value dt t true nil)]
+                  (log/debug "creating value flake:" new-flake)
+                  (conj acc* new-flake)))
               (nil? existing-pid) (conj (flake/create pid const/$iri k
                                                       const/$xsd:string t true
                                                       nil)))]
@@ -191,6 +217,7 @@
 (defn assert-node
   [db node t iris refs next-pid next-sid]
   (go-try
+    (log/debug "assert-node:" node)
     (let [{:keys [id type]} node
           existing-sid    (<? (get-iri-sid id db iris))
           sid             (or existing-sid
@@ -210,7 +237,6 @@
           context*        (assoc context :base-flakes base-flakes)]
       (<? (assert-node* context* node)))))
 
-
 (defn assert-flakes
   [db assertions t iris refs]
   (go-try
@@ -221,7 +247,8 @@
           flakes   (loop [[node & r] assertions
                           acc []]
                      (if node
-                       (let [assert-flakes (<? (assert-node db node t iris refs next-pid next-sid))]
+                       (let [assert-flakes (<? (assert-node db node t iris refs
+                                                            next-pid next-sid))]
                          (recur r (into acc assert-flakes)))
                        acc))]
       {:flakes flakes
@@ -303,6 +330,7 @@
           refs           (volatile! (-> db :schema :refs))
           db-address     (get-in commit [const/iri-data const/iri-address :value])
           db-data        (<? (read-commit conn db-address))
+          _              (log/debug "merge-commit read commit:" db-data)
           t-new          (- (db-t db-data))
           _              (when (and (not= t-new (dec t))
                                     (not merged-db?)) ;; when including multiple dbs, t values will get reused.
@@ -370,7 +398,6 @@
             (recur commit commit-t commits*)))))))
 
 
-
 (defn load-db
   [{:keys [ledger] :as db} latest-commit merged-db?]
   (go-try
@@ -395,6 +422,7 @@
           commit-map (commit-data/json-ld->map latest-commit
                                                (-> (select-keys db-base index/types)
                                                    (assoc :commit-address commit-address)))
+          _          (log/debug "load-db-idx commit-map:" commit-map)
           db-base*   (assoc db-base :commit commit-map)
           index-t    (commit-data/index-t commit-map)
           commit-t   (commit-data/t commit-map)]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -18,35 +18,13 @@
             [clojure.core.async :as async]
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.policy.enforce-tx :as policy]
-            [fluree.db.dbproto :as dbproto])
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.json-ld.credential :as cred])
   (:refer-clojure :exclude [vswap!]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (declare json-ld-node->flakes)
-
-(defn node?
-  "Returns true if a nested value is itself another node in the graph.
-  Only need to test maps that have :id - and if they have other properties they
-  are defining then we know it is a node and have additional data to include."
-  [mapx]
-  (cond
-    (contains? mapx :value)
-    false
-
-    (and
-      (contains? mapx :list)
-      (= #{:list :idx} (set (keys mapx))))
-    false
-
-    (and
-      (contains? mapx :set)
-      (= #{:set :idx} (set (keys mapx))))
-    false
-
-    :else
-    true))
-
 
 (defn json-ld-type-data
   "Returns two-tuple of [class-subject-ids class-flakes]
@@ -91,7 +69,7 @@
                         {:i (-> v-map :idx last)})
           flakes      (cond
                         ;; a new node's data is contained, process as another node then link to this one
-                        (node? v-map)
+                        (jld-reify/node? v-map)
                         (let [[node-sid node-flakes] (<? (json-ld-node->flakes v-map tx-state pid))]
                           (conj node-flakes (flake/create sid pid node-sid const/$xsd:anyURI t true m)))
 

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -1,20 +1,19 @@
 (ns fluree.db.ledger.json-ld
-  (:require
-    [fluree.db.ledger.proto :as ledger-proto]
-    [fluree.db.conn.proto :as conn-proto]
-    [fluree.db.util.async :refer [<? go-try]]
-    [fluree.db.json-ld.bootstrap :as bootstrap]
-    [fluree.db.json-ld.branch :as branch]
-    [fluree.db.db.json-ld :as jld-db]
-    [fluree.db.json-ld.commit :as jld-commit]
-    [fluree.json-ld :as json-ld]
-    [fluree.db.constants :as const]
-    [fluree.db.json-ld.reify :as jld-reify]
-    [clojure.string :as str]
-    [fluree.db.indexer.proto :as idx-proto]
-    [fluree.db.util.core :as util]
-    [fluree.db.util.log :as log]
-    [clojure.walk :as walk])
+  (:require [fluree.db.ledger.proto :as ledger-proto]
+            [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.json-ld.bootstrap :as bootstrap]
+            [fluree.db.json-ld.branch :as branch]
+            [fluree.db.db.json-ld :as jld-db]
+            [fluree.db.json-ld.commit :as jld-commit]
+            [fluree.json-ld :as json-ld]
+            [fluree.db.constants :as const]
+            [fluree.db.json-ld.reify :as jld-reify]
+            [clojure.string :as str]
+            [fluree.db.indexer.proto :as idx-proto]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.log :as log]
+            [clojure.walk :as walk])
   (:refer-clojure :exclude [load]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -12,8 +12,7 @@
             [clojure.string :as str]
             [fluree.db.indexer.proto :as idx-proto]
             [fluree.db.util.core :as util]
-            [fluree.db.util.log :as log]
-            [clojure.walk :as walk])
+            [fluree.db.util.log :as log])
   (:refer-clojure :exclude [load]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -27,7 +26,7 @@
                       ;; default branch
                       (get branches branch))
         context-kw  (json-ld/parse-context context)
-        context-str (-> context walk/stringify-keys json-ld/parse-context)]
+        context-str (-> context util/stringify-keys json-ld/parse-context)]
     (-> branch
         (assoc-in [:latest-db :schema :context] context-kw)
         (assoc-in [:latest-db :schema :context-str] context-str))))

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -1,29 +1,37 @@
 (ns fluree.db.ledger.json-ld
-  (:require [fluree.db.ledger.proto :as ledger-proto]
-            [fluree.db.conn.proto :as conn-proto]
-            [fluree.db.util.async :refer [<? go-try]]
-            [fluree.db.json-ld.bootstrap :as bootstrap]
-            [fluree.db.json-ld.branch :as branch]
-            [fluree.db.db.json-ld :as jld-db]
-            [fluree.db.json-ld.commit :as jld-commit]
-            [fluree.json-ld :as json-ld]
-            [fluree.db.constants :as const]
-            [fluree.db.json-ld.reify :as jld-reify]
-            [clojure.string :as str]
-            [fluree.db.indexer.proto :as idx-proto]
-            [fluree.db.util.core :as util])
+  (:require
+    [fluree.db.ledger.proto :as ledger-proto]
+    [fluree.db.conn.proto :as conn-proto]
+    [fluree.db.util.async :refer [<? go-try]]
+    [fluree.db.json-ld.bootstrap :as bootstrap]
+    [fluree.db.json-ld.branch :as branch]
+    [fluree.db.db.json-ld :as jld-db]
+    [fluree.db.json-ld.commit :as jld-commit]
+    [fluree.json-ld :as json-ld]
+    [fluree.db.constants :as const]
+    [fluree.db.json-ld.reify :as jld-reify]
+    [clojure.string :as str]
+    [fluree.db.indexer.proto :as idx-proto]
+    [fluree.db.util.core :as util]
+    [fluree.db.util.log :as log]
+    [clojure.walk :as walk])
   (:refer-clojure :exclude [load]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn branch-meta
   "Retrieves branch metadata from ledger state"
-  [{:keys [state] :as _ledger} requested-branch]
-  (let [{:keys [branch branches]} @state]
-    (if requested-branch
-      (get branches requested-branch)
-      ;; default branch
-      (get branches branch))))
+  [{:keys [state context] :as _ledger} requested-branch]
+  (let [{:keys [branch branches]} @state
+        branch      (if requested-branch
+                      (get branches requested-branch)
+                      ;; default branch
+                      (get branches branch))
+        context-kw  (json-ld/parse-context context)
+        context-str (-> context walk/stringify-keys json-ld/parse-context)]
+    (-> branch
+        (assoc-in [:latest-db :schema :context] context-kw)
+        (assoc-in [:latest-db :schema :context-str] context-str))))
 
 ;; TODO - no time travel, only latest db on a branch thus far
 (defn db
@@ -87,7 +95,6 @@
         db*   (or db (ledger-proto/-db ledger (:branch opts*)))]
     (jld-commit/commit ledger db* opts*)))
 
-
 (defn close-ledger
   "Shuts down ledger and resources."
   [{:keys [indexer cache state] :as _ledger}]
@@ -145,8 +152,8 @@
   "Creates a new ledger, optionally bootstraps it as permissioned or with default context."
   [conn ledger-alias opts]
   (go-try
-    (let [{:keys [context did branch pub-fn blank? ipns indexer include
-                  reindex-min-bytes reindex-max-bytes]
+    (let [{:keys [context did branch pub-fn ipns indexer include
+                  reindex-min-bytes reindex-max-bytes initial-tx]
            :or   {branch :main}} opts
           did*          (if did
                           (if (map? did)
@@ -163,9 +170,10 @@
                                           {:status 400 :error :db/invalid-indexer}))
 
                           :else
-                          (conn-proto/-new-indexer conn (util/without-nils
-                                                          {:reindex-min-bytes reindex-min-bytes
-                                                           :reindex-max-bytes reindex-max-bytes})))
+                          (conn-proto/-new-indexer
+                            conn (util/without-nils
+                                   {:reindex-min-bytes reindex-min-bytes
+                                    :reindex-max-bytes reindex-max-bytes})))
           ledger-alias* (normalize-alias ledger-alias)
           address       (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
           context*      (merge (conn-proto/-context conn) context)
@@ -191,9 +199,9 @@
                            :indexer indexer
                            :conn    conn})
           blank-db      (jld-db/create ledger)
-          bootstrap?    (and (not blank?) context*)
+          bootstrap?    (boolean initial-tx)
           db            (if bootstrap?
-                          (<? (bootstrap/bootstrap blank-db context*))
+                          (<? (bootstrap/bootstrap blank-db initial-tx))
                           (bootstrap/blank-db blank-db))]
       ;; place initial 'blank' DB into ledger.
       (ledger-proto/-db-update ledger db)
@@ -219,12 +227,18 @@
           [commit proof] (jld-reify/parse-commit commit-data*)
           _            (when proof
                          (jld-reify/validate-commit db commit proof))
+          _            (log/debug "load commit:" commit)
           alias        (or (get-in commit [const/iri-alias :value])
                            (conn-proto/-alias conn commit-address))
           branch       (keyword (get-in commit [const/iri-branch :value]))
-          ledger       (<? (create conn alias {:branch branch
-                                               :id     last-commit
-                                               :blank? true}))
+          default-ctx  (-> commit
+                           (get const/iri-default-context)
+                           :value
+                           (->> (jld-reify/load-default-context conn))
+                           <?)
+          ledger       (<? (create conn alias {:branch  branch
+                                               :id      last-commit
+                                               :context default-ctx}))
           db           (ledger-proto/-db ledger)
           db*          (<? (jld-reify/load-db-idx db commit last-commit false))]
       (ledger-proto/-commit-update ledger branch db*)

--- a/src/fluree/db/method/ipfs/core.cljc
+++ b/src/fluree/db/method/ipfs/core.cljc
@@ -1,13 +1,12 @@
 (ns fluree.db.method.ipfs.core
   (:refer-clojure :exclude [read])
-  (:require
-    [fluree.db.method.ipfs.xhttp :as ipfs]
-    [fluree.db.util.async :refer [<? go-try]]
-    [clojure.string :as str]
-    [fluree.json-ld :as json-ld]
-    [fluree.db.method.ipfs.directory :as ipfs-dir]
-    [fluree.db.method.ipfs.keys :as ipfs-key]
-    [fluree.db.util.log :as log :include-macros true]))
+  (:require [fluree.db.method.ipfs.xhttp :as ipfs]
+            [fluree.db.util.async :refer [<? go-try]]
+            [clojure.string :as str]
+            [fluree.json-ld :as json-ld]
+            [fluree.db.method.ipfs.directory :as ipfs-dir]
+            [fluree.db.method.ipfs.keys :as ipfs-key]
+            [fluree.db.util.log :as log :include-macros true]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/fluree/db/method/ipfs/xhttp.cljc
+++ b/src/fluree/db/method/ipfs/xhttp.cljc
@@ -131,5 +131,3 @@
   (clojure.core.async/<!!
     (add "http://127.0.0.1:5001/" {:hi "there" :im "blahhere"})))
 
-
-

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -5,7 +5,9 @@
                        [clojure.core.async.interop :refer [<p!]]])
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.test-utils :as test-utils]
-            #?(:clj [test-with-files.tools :refer [with-tmp-dir]])))
+            #?(:clj  [test-with-files.tools :refer [with-tmp-dir]
+                      :as twf]
+               :cljs [test-with-files.tools :as-alias twf])))
 
 (deftest exists?-test
   (testing "returns true after committing data to a ledger"
@@ -127,9 +129,9 @@
            (is (= (:context ledger) (:context loaded))))))
 
      (testing "can load a file ledger with its own context"
-       (with-tmp-dir storage-path
-         (let [conn-context {:id "@id", :type "@type"}
-               ledger-context {:ex "http://example.com/"
+       (with-tmp-dir storage-path #_{::twf/delete-dir false}
+         (let [conn-context   {:id "@id", :type "@type"}
+               ledger-context {:ex     "http://example.com/"
                                :schema "http://schema.org/"}
                conn           @(fluree/connect
                                  {:method :file :storage-path storage-path

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -73,8 +73,10 @@
                                             :ex/favNums 7}})
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
-               loaded       (test-utils/retry-load conn ledger-alias 100)]
-           (is (= (:t db) (:t (fluree/db loaded)))))))
+               loaded       (test-utils/retry-load conn ledger-alias 100)
+               loaded-db    (fluree/db loaded)]
+           (is (= (:t db) (:t loaded-db)))
+           (is (= (:context ledger) (:context loaded))))))
 
      (testing "can load a file ledger with multi-cardinality predicates"
        (with-tmp-dir storage-path
@@ -119,30 +121,37 @@
                                              :ex/favNums [42 76 9]}}])
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
-               loaded       (test-utils/retry-load conn ledger-alias 100)]
-           (is (= (:t db) (:t (fluree/db loaded)))))))
+               loaded       (test-utils/retry-load conn ledger-alias 100)
+               loaded-db    (fluree/db loaded)]
+           (is (= (:t db) (:t loaded-db)))
+           (is (= (:context ledger) (:context loaded))))))
 
      (testing "can load a file ledger with its own context"
        (with-tmp-dir storage-path
          (let [conn-context {:id "@id", :type "@type"}
                ledger-context {:ex "http://example.com/"
                                :schema "http://schema.org/"}
-               conn @(fluree/connect
-                       {:method :file :storage-path storage-path
-                        :defaults {:context conn-context}})
-               ledger-alias "load-from-file-with-context"
-               ledger @(fluree/create conn ledger-alias
-                                      {:context ledger-context})
-               db @(fluree/stage
-                     (fluree/db ledger)
-                     [{:id :ex/wes
-                       :type :ex/User
-                       :schema/name "Wes"
-                       :schema/email "wes@example.org"
-                       :schema/age 42
-                       :schema/favNums [1 2 3]}])
-               db @(fluree/commit! ledger db)
-               loaded (test-utils/retry-load conn ledger-alias 100)]
-           (is (= (:t db) (:t (fluree/db loaded))))
-           (is (= (merge conn-context ledger-context) (:context loaded))))))))
-
+               conn           @(fluree/connect
+                                 {:method :file :storage-path storage-path
+                                  :defaults {:context conn-context}})
+               ledger-alias   "load-from-file-with-context"
+               ledger         @(fluree/create conn ledger-alias
+                                              {:context ledger-context})
+               db             @(fluree/stage
+                                 (fluree/db ledger)
+                                 [{:id :ex/wes
+                                   :type :ex/User
+                                   :schema/name "Wes"
+                                   :schema/email "wes@example.org"
+                                   :schema/age 42
+                                   :schema/favNums [1 2 3]}])
+               db             @(fluree/commit! ledger db)
+               loaded         (test-utils/retry-load conn ledger-alias 100)
+               loaded-db      (fluree/db loaded)
+               merged-ctx     (merge conn-context ledger-context)]
+           (is (= (:t db) (:t loaded-db)))
+           (is (= merged-ctx (:context loaded)))
+           (is (= (get-in db [:schema :context])
+                  (get-in loaded-db [:schema :context])))
+           (is (= (get-in db [:schema :context-str])
+                  (get-in loaded-db [:schema :context-str]))))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -49,16 +49,16 @@
                db           @(fluree/stage
                                (fluree/db ledger)
                                [{:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/brian,
-                                 :type         :ex/User,
+                                 :id           :ex/brian
+                                 :type         :ex/User
                                  :schema/name  "Brian"
                                  :schema/email "brian@example.org"
                                  :schema/age   50
                                  :ex/favNums   7}
 
                                 {:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/cam,
-                                 :type         :ex/User,
+                                 :id           :ex/cam
+                                 :type         :ex/User
                                  :schema/name  "Cam"
                                  :schema/email "cam@example.org"
                                  :schema/age   34
@@ -87,28 +87,28 @@
                db           @(fluree/stage
                                (fluree/db ledger)
                                [{:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/brian,
-                                 :type         :ex/User,
+                                 :id           :ex/brian
+                                 :type         :ex/User
                                  :schema/name  "Brian"
                                  :schema/email "brian@example.org"
                                  :schema/age   50
                                  :ex/favNums   7}
 
                                 {:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/alice,
-                                 :type         :ex/User,
+                                 :id           :ex/alice
+                                 :type         :ex/User
                                  :schema/name  "Alice"
                                  :schema/email "alice@example.org"
                                  :schema/age   50
-                                 :ex/favNums   [42, 76, 9]}
+                                 :ex/favNums   [42 76 9]}
 
                                 {:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/cam,
-                                 :type         :ex/User,
+                                 :id           :ex/cam
+                                 :type         :ex/User
                                  :schema/name  "Cam"
                                  :schema/email "cam@example.org"
                                  :schema/age   34
-                                 :ex/favNums   [5, 10]
+                                 :ex/favNums   [5 10]
                                  :ex/friend    [:ex/brian :ex/alice]}])
                db           @(fluree/commit! ledger db)
                db           @(fluree/stage
@@ -116,7 +116,7 @@
                                ;; test a multi-cardinality retraction
                                [{:context   {:ex "http://example.org/ns/"}
                                  :f/retract {:id         :ex/alice
-                                             :ex/favNums [42, 76, 9]}}])
+                                             :ex/favNums [42 76 9]}}])
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                loaded       (test-utils/retry-load conn ledger-alias 100)]

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -5,7 +5,6 @@
     [fluree.db.json-ld.api :as fluree]
     [fluree.db.did :as did]
     [fluree.db.permissions-validate :as policy-enforce]
-    [fluree.db.util.log :as log]
     [clojure.core.async :as async]))
 
 ;; tests for the optimized policy filtering for groups of flakes of the same subject
@@ -78,32 +77,31 @@
           ;; john's flakes filtered using alice's policy-enforced db
           alice-db-john   (->> john-flakes
                                (policy-enforce/filter-subject-flakes alice-db)
-                               (async/<!!))
+                               async/<!!)
           ;; alice's flakes filtered using alice's policy-enforced db
           alice-db-alice  (->> alice-flakes
                                (policy-enforce/filter-subject-flakes alice-db)
-                               (async/<!!))
+                               async/<!!)
           ;; widget flakes filtered using alice's policy-enforced db
           alice-db-widget (->> widget-flakes
                                (policy-enforce/filter-subject-flakes alice-db)
-                               (async/<!!))]
-
+                               async/<!!)]
 
       (is (= [#Flake [211106232532994 0 "http://example.org/ns/john" 1 -1 true nil]
-              #Flake [211106232532994 200 1002 0 -1 true nil]
-              #Flake [211106232532994 1003 "John" 1 -1 true nil]
-              #Flake [211106232532994 1004 "john@flur.ee" 1 -1 true nil]
-              #Flake [211106232532994 1005 "2021-08-17" 1 -1 true nil]]
+              #Flake [211106232532994 200 1001 0 -1 true nil]
+              #Flake [211106232532994 1002 "John" 1 -1 true nil]
+              #Flake [211106232532994 1003 "john@flur.ee" 1 -1 true nil]
+              #Flake [211106232532994 1004 "2021-08-17" 1 -1 true nil]]
              alice-db-john)
           "Alice cannot see John's ssn, but can see everything else.")
 
       (is (= [#Flake [211106232532992 0 "http://example.org/ns/alice" 1 -1 true nil]
-              #Flake [211106232532992 200 1002 0 -1 true nil]
-              #Flake [211106232532992 1003 "Alice" 1 -1 true nil]
-              #Flake [211106232532992 1004 "alice@flur.ee" 1 -1 true nil]
-              #Flake [211106232532992 1005 "2022-08-17" 1 -1 true nil]
-              #Flake [211106232532992 1006 "111-11-1111" 1 -1 true nil]
-              #Flake [211106232532992 1007 211106232532993 0 -1 true nil]]
+              #Flake [211106232532992 200 1001 0 -1 true nil]
+              #Flake [211106232532992 1002 "Alice" 1 -1 true nil]
+              #Flake [211106232532992 1003 "alice@flur.ee" 1 -1 true nil]
+              #Flake [211106232532992 1004 "2022-08-17" 1 -1 true nil]
+              #Flake [211106232532992 1005 "111-11-1111" 1 -1 true nil]
+              #Flake [211106232532992 1006 211106232532993 0 -1 true nil]]
              alice-db-alice)
           "Alice can see all flakes for herself, including her ssn.")
 

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -16,7 +16,8 @@
 
 (deftest test-parse-query
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/parse" {:context {:ex "http://example.org/ns/"}})
+        ledger @(fluree/create conn "query/parse"
+                               {:context {:ex "http://example.org/ns/"}})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/brian,
@@ -50,7 +51,7 @@
                 :spec      {:depth 0 :wildcard? true}}
                (de-recordify-select select)))
         (is (= [[{::where/var '?s}
-                 {::where/val 1003 ::where/datatype 7}
+                 {::where/val 1002 ::where/datatype 7}
                  {::where/val "Alice" ::where/datatype 1}]]
                patterns)))
       (let [vars-query {:select {"?s" ["*"]}
@@ -68,7 +69,7 @@
                 :spec      {:depth 0 :wildcard? true}}
                (de-recordify-select select)))
         (is (= [[{::where/var '?s}
-                 {::where/val      1003
+                 {::where/val      1002
                   ::where/datatype 7}
                  {::where/var '?name}]]
                patterns)))
@@ -86,24 +87,24 @@
                 {:var '?email}]
                (de-recordify-select select)))
         (is (= [[{::where/var '?s}
-                 {::where/val      1003
+                 {::where/val      1002
                   ::where/datatype 7}
                  {::where/val      "Cam"
                   ::where/datatype 1}]
                 [{::where/var '?s}
-                 {::where/val      1009
+                 {::where/val      1008
                   ::where/datatype 7}
                  {::where/var '?f}]
                 [{::where/var '?f}
-                 {::where/val      1003
+                 {::where/val      1002
                   ::where/datatype 7}
                  {::where/var '?name}]
                 [{::where/var '?f}
-                 {::where/val      1005
+                 {::where/val      1004
                   ::where/datatype 7}
                  {::where/var '?age}]
                 [{::where/var '?f}
-                 {::where/val      1008
+                 {::where/val      1007
                   ::where/datatype 7}
                  {::where/var '?email}]]
                patterns)))
@@ -120,16 +121,16 @@
                    [{::where/var '?s}
                     {::where/val      200
                      ::where/datatype 7}
-                    {::where/val      1002
+                    {::where/val      1001
                      ::where/datatype 0}]]
                   [{::where/var '?s}
-                   {::where/val      1003
+                   {::where/val      1002
                     ::where/datatype 7}
                    {::where/var '?name}]
                   [:optional
                    {::where/patterns
                     [[{::where/var '?s}
-                      {::where/val      1007
+                      {::where/val      1006
                        ::where/datatype 7}
                       {::where/var '?favColor}]]
                     ::where/filters {}}]]
@@ -147,18 +148,18 @@
                    [{::where/var '?s}
                     {::where/val      200
                      ::where/datatype 7}
-                    {::where/val      1002
+                    {::where/val      1001
                      ::where/datatype 0}]]
                   [:union
                    [{::where/patterns
                      [[{::where/var '?s}
-                       {::where/val      1008
+                       {::where/val      1007
                         ::where/datatype 7}
                        {::where/var '?email1}]]
                      ::where/filters {}}
                     {::where/patterns
                      [[{::where/var '?s}
-                       {::where/val      1004
+                       {::where/val      1003
                         ::where/datatype 7}
                        {::where/var '?email2}]]
                      ::where/filters {}}]]]
@@ -177,14 +178,14 @@
                    [{::where/var '?s}
                     {::where/val      200
                      ::where/datatype 7}
-                    {::where/val      1002
+                    {::where/val      1001
                      ::where/datatype 0}]]
                   [{::where/var '?s}
-                   {::where/val      1005
+                   {::where/val      1004
                     ::where/datatype 7}
                    {::where/var '?age}]
                   [{::where/var '?s}
-                   {::where/val      1003
+                   {::where/val      1002
                     ::where/datatype 7}
                    {::where/var '?name}]]
                  patterns))))

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -45,50 +45,50 @@
       (testing "Slice operations"
         (testing "Slice for subject id only"
           (let [alice-sid @(fluree/internal-id db :ex/alice)]
-            (is (= (->> @(fluree/slice db :spot [alice-sid])
-                        (mapv flake/Flake->parts))
-                   [[alice-sid 0 "http://example.org/ns/alice" 1 -1 true nil]
-                    [alice-sid 200 1002 0 -1 true nil]
-                    [alice-sid 1003 "Alice" 1 -1 true nil]
-                    [alice-sid 1004 "alice@example.org" 1 -1 true nil]
-                    [alice-sid 1005 50 7 -1 true nil]
-                    [alice-sid 1006 9 7 -1 true nil]
-                    [alice-sid 1006 42 7 -1 true nil]
-                    [alice-sid 1006 76 7 -1 true nil]])
+            (is (= [[alice-sid 0 "http://example.org/ns/alice" 1 -1 true nil]
+                    [alice-sid 200 1001 0 -1 true nil]
+                    [alice-sid 1002 "Alice" 1 -1 true nil]
+                    [alice-sid 1003 "alice@example.org" 1 -1 true nil]
+                    [alice-sid 1004 50 7 -1 true nil]
+                    [alice-sid 1005 9 7 -1 true nil]
+                    [alice-sid 1005 42 7 -1 true nil]
+                    [alice-sid 1005 76 7 -1 true nil]]
+                   (->> @(fluree/slice db :spot [alice-sid])
+                        (mapv flake/Flake->parts)))
                 "Slice should return a vector of flakes for only Alice")))
 
         (testing "Slice for subject + predicate"
           (let [alice-sid   @(fluree/internal-id db :ex/alice)
                 favNums-pid @(fluree/internal-id db :ex/favNums)]
-            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid])
-                        (mapv flake/Flake->parts))
-                   [[alice-sid favNums-pid 9 7 -1 true nil]
+            (is (= [[alice-sid favNums-pid 9 7 -1 true nil]
                     [alice-sid favNums-pid 42 7 -1 true nil]
-                    [alice-sid favNums-pid 76 7 -1 true nil]])
+                    [alice-sid favNums-pid 76 7 -1 true nil]]
+                   (->> @(fluree/slice db :spot [alice-sid favNums-pid])
+                        (mapv flake/Flake->parts)))
                 "Slice should only return Alice's favNums (multi-cardinality)")))
 
         (testing "Slice for subject + predicate + value"
           (let [alice-sid   @(fluree/internal-id db :ex/alice)
                 favNums-pid @(fluree/internal-id db :ex/favNums)]
-            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid 42])
-                        (mapv flake/Flake->parts))
-                   [[alice-sid favNums-pid 42 7 -1 true nil]])
+            (is (= [[alice-sid favNums-pid 42 7 -1 true nil]]
+                   (->> @(fluree/slice db :spot [alice-sid favNums-pid 42])
+                        (mapv flake/Flake->parts)))
                 "Slice should only return the specified favNum value")))
 
         (testing "Slice for subject + predicate + value + datatype"
           (let [alice-sid   @(fluree/internal-id db :ex/alice)
                 favNums-pid @(fluree/internal-id db :ex/favNums)]
-            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 7]])
-                        (mapv flake/Flake->parts))
-                   [[alice-sid favNums-pid 42 7 -1 true nil]])
+            (is (= [[alice-sid favNums-pid 42 7 -1 true nil]]
+                   (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 7]])
+                        (mapv flake/Flake->parts)))
                 "Slice should only return the specified favNum value with matching datatype")))
 
         (testing "Slice for subject + predicate + value + mismatch datatype"
           (let [alice-sid   @(fluree/internal-id db :ex/alice)
                 favNums-pid @(fluree/internal-id db :ex/favNums)]
-            (is (= (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 8]])
-                        (mapv flake/Flake->parts))
-                   [])
+            (is (= []
+                   (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 8]])
+                        (mapv flake/Flake->parts)))
                 "We specify a different datatype for the value, nothing should be returned")))
 
 

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -18,9 +18,7 @@
                               :schema/name  "Bob"
                               :ex/favArtist {:id          :ex/picasso
                                              :schema/name "Picasso"}}]})]
-      (is (= @(fluree/query db {:select {'?s [:_id :* {:ex/favArtist [:_id :schema/name]}]}
-                                :where  [['?s :type :ex/User]]})
-             [{:_id          211106232532993,
+      (is (= [{:_id          211106232532993,
                :id           :ex/bob,
                :rdf/type     [:ex/User],
                :schema/name  "Bob",
@@ -29,7 +27,9 @@
               {:_id         211106232532992,
                :id          :ex/alice,
                :rdf/type    [:ex/User],
-               :schema/name "Alice"}])))))
+               :schema/name "Alice"}]
+             @(fluree/query db {:select {'?s [:_id :* {:ex/favArtist [:_id :schema/name]}]}
+                                :where  [['?s :type :ex/User]]}))))))
 
 (deftest ^:integration s+p+o-full-db-queries
   (testing "Query that pulls entire database."
@@ -52,9 +52,7 @@
                               :schema/email "jane@flur.ee"
                               :schema/age   30}]})]
 
-      (is (= @(fluree/query db {:select ['?s '?p '?o]
-                                :where  [['?s '?p '?o]]})
-             [[:ex/jane :id "http://example.org/ns/jane"]
+      (is (= [[:ex/jane :id "http://example.org/ns/jane"]
               [:ex/jane :rdf/type :ex/User]
               [:ex/jane :schema/name "Jane"]
               [:ex/jane :schema/email "jane@flur.ee"]
@@ -73,13 +71,9 @@
               [:schema/name :id "http://schema.org/name"]
               [:ex/User :id "http://example.org/ns/User"]
               [:ex/User :rdf/type :rdfs/Class]
-              [:f/Context :id "https://ns.flur.ee/ledger#Context"]
-              [:f/Context :rdf/type :rdfs/Class]
-              [:f/context :id "https://ns.flur.ee/ledger#context"]
               [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
               [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
-              ["fluree-default-context" :id "fluree-default-context"]
-              ["fluree-default-context" :rdf/type :f/Context]
-              ["fluree-default-context" :f/context "{\"schema\":\"http://schema.org/\",\"wiki\":\"https://www.wikidata.org/wiki/\",\"xsd\":\"http://www.w3.org/2001/XMLSchema#\",\"type\":\"@type\",\"rdfs\":\"http://www.w3.org/2000/01/rdf-schema#\",\"ex\":\"http://example.org/ns/\",\"id\":\"@id\",\"f\":\"https://ns.flur.ee/ledger#\",\"sh\":\"http://www.w3.org/ns/shacl#\",\"skos\":\"http://www.w3.org/2008/05/skos#\",\"rdf\":\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"}"]
-              [:id :id "@id"]])
+              [:id :id "@id"]]
+             @(fluree/query db {:select ['?s '?p '?o]
+                                :where  [['?s '?p '?o]]}))
           "Entire database should be pulled."))))

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -113,7 +113,10 @@
   [conn ledger-alias max-attempts]
   (loop [attempt 0]
     (let [ledger (try
-                   @(fluree/load conn ledger-alias)
+                   (let [res @(fluree/load conn ledger-alias)]
+                     (if (instance? Throwable res)
+                       (throw res)
+                       res))
                    (catch Exception e
                      (when (= (inc attempt) max-attempts)
                        (throw e)

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -8,6 +8,7 @@
   (testing "Deletions of entire subjects."
     (let [conn             (test-utils/create-conn)
           ledger           @(fluree/create conn "tx/delete" {:context {:ex "http://example.org/ns/"}})
+          _                (println "TEST LEDGER CONTEXT:" (pr-str (:context ledger)))
           db               @(fluree/stage
                              (fluree/db ledger)
                              {:graph [{:id           :ex/alice,

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -8,7 +8,6 @@
   (testing "Deletions of entire subjects."
     (let [conn             (test-utils/create-conn)
           ledger           @(fluree/create conn "tx/delete" {:context {:ex "http://example.org/ns/"}})
-          _                (println "TEST LEDGER CONTEXT:" (pr-str (:context ledger)))
           db               @(fluree/stage
                              (fluree/db ledger)
                              {:graph [{:id           :ex/alice,


### PR DESCRIPTION
Fixes #370 & #371.

This is definitely a "simplest possible thing that could work" approach to #371, and specifically the implementation we decided on of moving the context from db flakes into the commits. So, for example, it leaves it in `(-> db :schema :context)` and `(-> db :schema :context-str)` which feels kind of like the wrong place now (there's a few hacks to make sure the vocab-flakes don't clobber it).

Also the imminent PR for #342 is going to conflict with this in some important ways, but I've promised to lead the effort to clean that up.

I also deleted some files that were deleted in the merge of #372 rather than update them to work with the changes in here.