### PR TITLE
Feature/nested filters

### DIFF
--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.query.exec.eval
   (:refer-clojure :exclude [compile rand])
-  (:require [fluree.db.query.exec.where :as where]
+  (:require [fluree.db.query.exec.group :as group]
+            [fluree.db.query.exec.where :as where]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :refer [postwalk]])
@@ -185,11 +186,18 @@
                 x))
             code))
 
+
+
 (defn bind-variables
   [soln-sym var-syms]
   (->> var-syms
        (mapcat (fn [v]
-                 [v `(::where/val (get ~soln-sym (quote ~v)))]))
+                 [v `(let [mch# (get ~soln-sym (quote ~v))
+                           val# (::where/val mch#)
+                           dt#  (::where/datatype mch#)]
+                       (cond->> val#
+                         (= dt# ::group/grouping)
+                         (mapv ::where/val)))]))
        (into [])))
 
 (defn compile

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -209,3 +209,12 @@
     (eval `(fn [~soln-sym]
              (let ~bdg
                ~qualified-code)))))
+
+(defn compile-filter
+  [code var]
+  (let [f        (compile code)
+        soln-sym 'solution]
+    (eval `(fn [~soln-sym ~var]
+             (-> ~soln-sym
+                 (assoc (quote ~var) {::where/val ~var})
+                 ~f)))))

--- a/src/fluree/db/query/exec/select.cljc
+++ b/src/fluree/db/query/exec/select.cljc
@@ -67,10 +67,10 @@
                       (>! error-ch e))))))
 
 (defn aggregate-selector
-  "Returns a selector that extracts the grouped value bound to the specified
-  `variable` from a where solution, formats each item in the group, and
-  processes the formatted group with the supplied `agg-function` to generate the
-  final aggregated result for display."
+  "Returns a selector that extracts the grouped values bound to the specified
+  variables referenced in the supplied `agg-function` from a where solution,
+  formats each item in the group, and processes the formatted group with the
+  supplied `agg-function` to generate the final aggregated result for display."
   [agg-function]
   (->AggregateSelector agg-function))
 

--- a/src/fluree/db/query/exec/select.cljc
+++ b/src/fluree/db/query/exec/select.cljc
@@ -57,22 +57,22 @@
   [variable]
   (->VariableSelector variable))
 
-(defrecord AggregateSelector [fmt agg-fn]
+(defrecord AggregateSelector [agg-fn]
   ValueSelector
   (format-value
     [_ db iri-cache compact error-ch solution]
-    (let [agg-ch (chan 1 (map agg-fn))]
-      (-> (format-value fmt db iri-cache compact error-ch solution)
-          (async/pipe agg-ch)))))
+    (go (try* (agg-fn solution)
+              (catch* e
+                      (log/error e "Error applying aggregate selector")
+                      (>! error-ch e))))))
 
 (defn aggregate-selector
   "Returns a selector that extracts the grouped value bound to the specified
   `variable` from a where solution, formats each item in the group, and
   processes the formatted group with the supplied `agg-function` to generate the
   final aggregated result for display."
-  [variable agg-function]
-  (let [var-fmt (variable-selector variable)]
-    (->AggregateSelector var-fmt agg-function)))
+  [agg-function]
+  (->AggregateSelector agg-function))
 
 (defrecord SubgraphSelector [var selection depth spec]
   ValueSelector

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -85,7 +85,7 @@
 
 (defn ->function
   "Build a filter function specification for the variable `var` out of the
-  boolean function `f` with parameters `params`."
+  boolean function `f`."
   [var f]
   (-> var
       ->variable

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -86,11 +86,10 @@
 (defn ->function
   "Build a filter function specification for the variable `var` out of the
   boolean function `f` with parameters `params`."
-  [var params f]
+  [var f]
   (-> var
       ->variable
-      (assoc ::params params
-             ::fn     f)))
+      (assoc ::fn f)))
 
 (defn ->predicate
   "Build a pattern that already matches the explicit predicate value `value`."
@@ -154,6 +153,8 @@
               (assoc component ::val value)
               (let [filter-fn (some->> (get filters variable)
                                        (map ::fn)
+                                       (map (fn [f]
+                                              (partial f solution)))
                                        (apply every-pred))]
                 (assoc component ::fn filter-fn)))
             component))

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -65,6 +65,16 @@
                                          ['?s :schema/name '?name]
                                          ['?s :ex/last '?last]
                                          {:filter ["(> ?age 45)", "(strEnds ?last \"ith\")"]}]}))))
+
+    (testing "nested filters"
+      (is (= [["Brian" 50]]
+             @(fluree/query db '{:context {:ex "http://example.org/ns/"}
+                                 :select [?name ?age]
+                                 :where  [[?s :rdf/type :ex/User]
+                                          [?s :schema/age ?age]
+                                          [?s :schema/name ?name]
+                                          {:filter ["(> ?age (/ (+ ?age 47) 2))"]}]}))))
+
     ;;TODO: simple-subject-crawl does not yet support filters.
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"
@@ -109,4 +119,3 @@
              @(fluree/query db {:select {"?s" ["*"]}
                                 :where  [["?s" :ex/favColor "?color"]
                                          {:filter ["(strStarts ?color \"B\")"]}]}))))))
-

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -35,6 +35,15 @@
                                               [?s :ex/favNums ?favNums]]
                                    :group-by ?name
                                    :having   (>= (count ?favNums) 2)}))
+            "filters results according to the supplied having function code")
+
+        (is (= [["Cam" [5 10]] ["Alice" [9 42 76]] ["Brian" [7]]]
+               @(fluree/query db '{:context  {:ex "http://example.org/ns/"}
+                                   :select   [?name ?favNums]
+                                   :where    [[?s :schema/name ?name]
+                                              [?s :ex/favNums ?favNums]]
+                                   :group-by ?name
+                                   :having   (>= (avg ?favNums) 2)}))
             "filters results according to the supplied having function code")))))
 
 (deftest ^:integration multi-query-test


### PR DESCRIPTION
This patch changes the query processor to execute all query functions (except for those related to simple subject crawl) with the unified query execution namespaces added in #368, and allows arbitrarily nested functions in both user-supplied aggregate and filter code.

I also found a bug with `having` processing that was caused by my forgetfulness in extracting the value from the match map and supplying that to the user supplied function. I supplied the entire match map instead. This bug was not caught in my `having` clause test because I happened to pick the `count` function as my test, which doesn't care what it's actually processing, but just how many of them there are. I have fixed that bug here, and added another test using `avg` for good measure. 

Closes #272