### PR TITLE
Rename js? opt -> :context-type [:string|:keyword]

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,3 @@
 {:paths ["script"]
  :tasks {sync-package-json {:requires ([sync-package-json :as spj])
                             :task (apply spj/run *command-line-args*)}}}
-

--- a/build.clj
+++ b/build.clj
@@ -55,3 +55,6 @@
                                (str target) node-arg])]
     (println "cmd args:" (pr-str cmd-args))
     (b/process {:command-args cmd-args})))
+
+(defn print-version [_]
+  (println (pr-str {:version version})))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -209,7 +209,7 @@
           [sid (into subj-flakes property-flakes)])))))
 
 (defn ->tx-state
-  [db {:keys [bootstrap? issuer js?] :as _opts}]
+  [db {:keys [bootstrap? issuer context-type] :as _opts}]
   (let [{:keys [block ecount schema branch ledger policy], db-t :t} db
         last-pid (volatile! (jld-ledger/last-pid db))
         last-sid (volatile! (jld-ledger/last-sid db))
@@ -219,7 +219,9 @@
      :db-before     (dbproto/-rootdb db)
      :policy        policy
      :bootstrap?    bootstrap?
-     :default-ctx   (if js? (:context-str schema) (:context schema))
+     :default-ctx   (if (= :string context-type)
+                      (:context-str schema)
+                      (:context schema))
      :stage-update? (= t db-t) ;; if a previously staged db is getting updated again before committed
      :refs          (volatile! (or (:refs schema) #{const/$rdf:type}))
      :t             t
@@ -404,7 +406,7 @@
 ;; TODO - delete passes the error-ch but doesn't monitor for it at the top level here to properly throw exceptions
 (defn delete
   "Executes a delete statement"
-  [db max-fuel json-ld {:keys [t] :as tx-state}]
+  [db max-fuel json-ld {:keys [t] :as _tx-state}]
   (go-try
     (let [{:keys [delete] :as parsed-query}
           (-> json-ld

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -19,8 +19,9 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn parse-context
-  [q db]
-  (let [ctx-key (if (-> q :opts :js?)
+  [{:keys [opts] :as q} db]
+  (let [ctx-key (if (= :string (or (:context-type opts)
+                                   (:contextType opts)))
                   :context-str
                   :context)
         db-ctx (get-in db [:schema ctx-key])

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -60,7 +60,8 @@
      ::pretty-print ::prettyPrint
      ::parseJSON boolean?
      ::parse-json ::parseJSON
-     ::js? boolean?
+     ::contextType [:enum :string :keyword]
+     ::context-type ::contextType
      ::opts [:map
              [:maxFuel {:optional true} ::maxFuel]
              [:max-fuel {:optional true} ::maxFuel]
@@ -68,7 +69,8 @@
              [:parse-json {:optional true} ::parse-json]
              [:prettyPrint {:optional true} ::prettyPrint]
              [:pretty-print {:optional true} ::pretty-print]
-             [:js {:optional true} ::js?]]
+             [:contextType {:optional true} ::contextType]
+             [:context-type {:optional true} ::contextType]]
      ::function [:orn
                  [:string [:fn fn-string?]]
                  [:list [:fn fn-list?]]]

--- a/src/fluree/sdk/browser.cljs
+++ b/src/fluree/sdk/browser.cljs
@@ -41,10 +41,11 @@
 
 (defn ^:export stage
   ([db-or-ledger json-ld]
-   (fluree/stage db-or-ledger (js->clj json-ld) {:js? true}))
+   (fluree/stage db-or-ledger (js->clj json-ld) {:context-type :string}))
   ([db-or-ledger json-ld opts]
-   (fluree/stage db-or-ledger (js->clj json-ld) (-> (js->clj opts :keywordize-keys true)
-                                                    (assoc :js? true)))))
+   (fluree/stage db-or-ledger (js->clj json-ld)
+                 (-> (js->clj opts :keywordize-keys true)
+                     (assoc :context-type :string)))))
 
 (defn ^:export commit
   ([ledger db] (.then (fluree/commit! ledger db)
@@ -67,7 +68,7 @@
                     (reduce-kv (fn [acc k v]
                                  (assoc acc (keyword k) v))
                                {}))]
-    (.then (fluree/query db (assoc-in query* [:opts :js?] true))
+    (.then (fluree/query db (assoc-in query* [:opts :context-type] :string))
            (fn [result] (clj->js result)))))
 
 

--- a/src/fluree/sdk/browser.cljs
+++ b/src/fluree/sdk/browser.cljs
@@ -1,12 +1,12 @@
 (ns fluree.sdk.browser
   (:require [fluree.db.json-ld.api :as fluree]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.sdk.version :refer [version]]))
 
 (enable-console-print!)
 
 ;; define your app data so that it doesn't get over-written on reload
-(defonce app-state (atom {:product "FlureeDB APIs"
-                          :version "v0.17.0"}))
+(defonce app-state (atom (assoc (version) :product "Fluree browser SDK")))
 
 (println (:product @app-state) (:version @app-state))
 

--- a/src/fluree/sdk/node.cljs
+++ b/src/fluree/sdk/node.cljs
@@ -13,7 +13,8 @@
 (defn ^:export create
   ([conn] (fluree/create conn))
   ([conn ledger-alias] (fluree/create conn ledger-alias))
-  ([conn ledger-alias opts] (fluree/create conn ledger-alias (js->clj opts :keywordize-keys true))))
+  ([conn ledger-alias opts] (fluree/create conn ledger-alias
+                                           (js->clj opts :keywordize-keys true))))
 
 (defn ^:export exists
   [conn alias-or-address]
@@ -29,10 +30,12 @@
 
 (defn ^:export stage
   ([db-or-ledger json-ld]
-   (fluree/stage db-or-ledger (js->clj json-ld) {:js? true}))
+   (fluree/stage db-or-ledger (js->clj json-ld) {:context-type :string}))
   ([db-or-ledger json-ld opts]
-   (fluree/stage db-or-ledger (js->clj json-ld) (-> (js->clj opts :keywordize-keys true)
-                                                    (assoc :js? true)))))
+   (fluree/stage db-or-ledger (js->clj json-ld)
+                 (-> opts
+                     (js->clj :keywordize-keys true)
+                     (assoc :context-type :string)))))
 
 (defn ^:export commit
   ([ledger db] (fluree/commit! ledger db))
@@ -55,7 +58,7 @@
                                               k
                                               (keyword k)) v))
                                {}))]
-    (.then (fluree/query db (assoc-in query* [:opts :js?] true))
+    (.then (fluree/query db (assoc-in query* [:opts :context-type] :string))
            (fn [result] (clj->js result)))))
 
 (log/set-level! :warning)

--- a/src/fluree/sdk/version.cljc
+++ b/src/fluree/sdk/version.cljc
@@ -1,0 +1,13 @@
+(ns fluree.sdk.version
+  #?(:clj  (:require [clojure.java.shell :refer [sh]]
+                     [clojure.edn :as edn])
+     :cljs (:require-macros [fluree.sdk.version :refer [version]])))
+
+
+(defmacro version
+  "Compiles in the current version in CLJS code. Returns a map like:
+  {:version \"1.2.3\"}"
+  []
+  (-> (sh "clojure" "-T:build" "print-version")
+      :out
+      edn/read-string))


### PR DESCRIPTION
Renames the `:js? true` opt to `:context-type :string` or `"contextType": "string"` for JSON. Also accepts `:context-type :keyword` which is still the default.

This is just my proposal for a better name for the `js?` opt. I'm happy to tweak the details.

Oh, also snuck in 15b4a49167ecfd29d1e80c4dbe622b704d43bdb9 which I have had lying around in local working dirs forever and just want to finally get onto main. Let me know if you'd rather I split it out.