### PR TITLE
Fix string context merging

### DIFF
--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -280,8 +280,8 @@
     s))
 
 (defn ledger-defaults
-  [{:keys [context did indexer]}]
-  {:context context
+  [{:keys [context-type context did indexer]}]
+  {:context (util/normalize-context context-type context)
    :did     did
    :indexer (cond
               (fn? indexer)

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -158,7 +158,7 @@
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"
-  [ipfs-endpoint {:keys [ipns context did indexer] :as defaults}]
+  [ipfs-endpoint {:keys [ipns context-type context did indexer] :as defaults}]
   (go-try
     (let [ipns-default-key     (or (:key ipns) "self")
           ipns-default-address (<? (ipfs-keys/address ipfs-endpoint ipns-default-key))
@@ -180,7 +180,7 @@
                         {:status 400 :error :db/ipfs-keys})))
       {:ipns    {:key     ipns-default-key
                  :address ipns-default-address}
-       :context context
+       :context (util/normalize-context context-type context)
        :did     did
        :indexer new-indexer-fn})))
 

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async :refer [go]]
             [fluree.db.storage.core :as storage]
             [fluree.db.index :as index]
+            [fluree.db.util.core :as util]
             [fluree.db.util.log :as log :include-macros true]
             #?(:clj [fluree.db.full-text :as full-text])
             [fluree.db.conn.proto :as conn-proto]
@@ -194,9 +195,9 @@
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"
-  [{:keys [context did] :as _defaults}]
+  [{:keys [context-type context did] :as _defaults}]
   (async/go
-    {:context context
+    {:context (util/normalize-context context-type context)
      :did     did}))
 
 (defn connect

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -150,7 +150,7 @@
   "Creates a new ledger, optionally bootstraps it as permissioned or with default context."
   [conn ledger-alias opts]
   (go-try
-    (let [{:keys [context did branch pub-fn ipns indexer include
+    (let [{:keys [context-type context did branch pub-fn ipns indexer include
                   reindex-min-bytes reindex-max-bytes initial-tx]
            :or   {branch :main}} opts
           did*          (if did
@@ -174,7 +174,9 @@
                                     :reindex-max-bytes reindex-max-bytes})))
           ledger-alias* (normalize-alias ledger-alias)
           address       (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
-          context*      (merge (conn-proto/-context conn) context)
+          context*      (->> context
+                             (util/normalize-context context-type)
+                             (merge (conn-proto/-context conn)))
           method-type   (conn-proto/-method conn)
           ;; map of all branches and where they are branched from
           branches      {branch (branch/new-branch-map nil ledger-alias* branch)}

--- a/src/fluree/db/util/core.cljc
+++ b/src/fluree/db/util/core.cljc
@@ -207,6 +207,14 @@
         (assoc acc k v)))
     {} m))
 
+(defn normalize-context
+  "Keywordizes string contexts so they merge correctly with other keyword
+  contexts."
+  [context-type context]
+  (if (= :string context-type)
+    (keywordize-keys context)
+    context))
+
 (defn str->epoch-ms
   "Takes time as a string and returns epoch millis."
   [time-str]


### PR DESCRIPTION
Fixes https://github.com/fluree/http-api-gateway/issues/20

When passing in contexts w/ string keys (e.g. from a JSON ledger create request) and then merge that w/ a conn default context using keywords, you end up w/ mixed keyword / string keys (and things like both a `:ex` and `"ex"` key).

This normalizes incoming string contexts (for conns and ledgers) to keywords before merging.