### PR TITLE
Feature/value binding

### DIFF
--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -69,11 +69,11 @@
           ::val      x
           ::datatype dt)))
 
-(defn ->value
+(defn anonymous-value
   "Build a pattern that already matches an explicit value."
   ([v]
    (let [dt (datatype/infer v)]
-     (->value v dt)))
+     (anonymous-value v dt)))
   ([v dt]
    (-> (unmatched)
        (match-value v dt))))
@@ -109,7 +109,7 @@
 (defn ->predicate
   "Build a pattern that already matches the explicit predicate value `value`."
   ([value]
-   (->value value))
+   (anonymous-value value))
   ([value recur-n]
    (-> value
        ->predicate

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -35,8 +35,7 @@
 
 (defn parse-variable
   [x]
-  (when-let [var-name (parse-var-name x)]
-    (where/->variable var-name)))
+  (some-> x parse-var-name where/unmatched))
 
 (defn parse-values
   [{:keys [values] :as _q}]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -10,7 +10,6 @@
             [clojure.walk :refer [postwalk]]
             [fluree.json-ld :as json-ld]
             [fluree.db.util.core :as util :refer [try* catch*]]
-            [fluree.db.query.analytical-filter :as filter]
             [fluree.db.util.log :as log :include-macros true]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.constants :as const]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -416,9 +416,9 @@
     (-> q
         (assoc :context context
                :where   where)
-        (cond-> (not-empty values) (assoc :values values)
-                grouping           (assoc :group-by grouping)
-                ordering           (assoc :order-by ordering))
+        (cond-> (seq values) (assoc :values values)
+                grouping     (assoc :group-by grouping)
+                ordering     (assoc :order-by ordering))
         parse-having
         (parse-select db context))))
 
@@ -436,11 +436,11 @@
 (defn parse-delete
   [q db]
   (when (:delete q)
-    (let [context (parse-context q db)
-          values  (parse-values q)
-          where   (parse-where q values db context)]
+    (let [context       (parse-context q db)
+          [vars values] (parse-values q)
+          where         (parse-where q vars db context)]
       (-> q
           (assoc :context context
                  :where   where)
-          (cond-> (not-empty values) (assoc :values  values))
+          (cond-> (seq values) (assoc :values values))
           (update :delete parse-triple db context)))))

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -37,13 +37,13 @@
   (when-let [var-name (parse-var-name x)]
     (where/->variable var-name)))
 
-(defn parse-vars
-  [{:keys [vars] :as _q}]
+(defn parse-values
+  [{:keys [values] :as _q}]
   (reduce-kv (fn [m var val]
                (let [variable (-> (parse-variable var)
                                   (assoc ::where/val val))]
                  (assoc m var variable)))
-             {} vars))
+             {} values))
 
 (def rdf-type-preds #{"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
                       "a"
@@ -390,13 +390,13 @@
 (defn parse-analytical-query*
   [q db]
   (let [context  (parse-context q db)
-        vars     (parse-vars q)
-        where    (parse-where q vars db context)
+        values   (parse-values q)
+        where    (parse-where q values db context)
         grouping (parse-grouping q)
         ordering (parse-ordering q)]
     (-> q
         (assoc :context context
-               :vars    vars
+               :values  values
                :where   where)
         (cond-> grouping (assoc :group-by grouping)
                 ordering (assoc :order-by ordering))
@@ -418,10 +418,10 @@
   [q db]
   (when (:delete q)
     (let [context (parse-context q db)
-          vars    (parse-vars q)
-          where   (parse-where q vars db context)]
+          values  (parse-values q)
+          where   (parse-where q values db context)]
       (-> q
           (assoc :context context
                  :where   where
-                 :vars    vars)
+                 :values  values)
           (update :delete parse-triple db context)))))

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -172,12 +172,12 @@
   [x context]
   (-> x
       (json-ld/expand-iri context)
-      (where/->value const/$xsd:anyURI)))
+      (where/anonymous-value const/$xsd:anyURI)))
 
 (defn parse-sid
   [x]
   (when (syntax/sid? x)
-    (where/->value x)))
+    (where/anonymous-value x)))
 
 (defn parse-subject
   ([x]
@@ -202,7 +202,7 @@
 (defn parse-class-predicate
   [x]
   (when (rdf-type? x)
-    (where/->value const/$rdf:type)))
+    (where/anonymous-value const/$rdf:type)))
 
 (defn parse-iri-predicate
   [x]
@@ -240,7 +240,7 @@
   [x db context]
   (-> x
       (iri->pred-id-strict db context)
-      where/->value))
+      where/anonymous-value))
 
 (defn parse-predicate-pattern
   [p-pat db context]
@@ -254,7 +254,7 @@
 (defn parse-class
   [o-iri db context]
   (if-let [id (iri->pred-id o-iri db context)]
-    (where/->value id const/$xsd:anyURI)
+    (where/anonymous-value id const/$xsd:anyURI)
     (throw (ex-info (str "Undefined RDF type specified: " (json-ld/expand-iri o-iri context))
                     {:status 400 :error :db/invalid-query}))))
 
@@ -262,7 +262,7 @@
   [o-pat]
   (or (parse-variable o-pat)
       (parse-pred-ident o-pat)
-      (where/->value o-pat)))
+      (where/anonymous-value o-pat)))
 
 (defmulti parse-pattern
   (fn [pattern _vars _db _context]
@@ -312,7 +312,7 @@
       (if (= const/$iri (::where/val p))
         (let [o (-> o-pat
                     (json-ld/expand-iri context)
-                    where/->value)]
+                    where/anonymous-value)]
           (where/->pattern :iri [s p o]))
         (let [o (parse-object-pattern o-pat)]
           [s p o])))))

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -27,6 +27,8 @@
   (and (or (string? x) (symbol? x) (keyword? x))
        (-> x name first (= \?))))
 
+(def value? (complement coll?))
+
 (defn sid?
   [x]
   (int? x))
@@ -76,6 +78,7 @@
                  [:list [:fn fn-list?]]]
      ::wildcard [:fn wildcard?]
      ::var [:fn variable?]
+     ::val [:fn value?]
      ::iri [:orn
             [:keyword keyword?]
             [:string string?]]
@@ -151,7 +154,17 @@
      ::where [:sequential [:orn
                            [:where-map ::where-map]
                            [:tuple ::where-tuple]]]
-     ::values [:map-of ::var :any]
+     ::var-collection [:sequential ::var]
+     ::var-list [:sequential ::var]
+     ::val-list [:sequential ::val]
+     ::single-var-binding [:tuple ::var ::val-list]
+     ::value-binding [:sequential ::val]
+     ::multiple-var-binding [:tuple
+                             ::var-list
+                             [:sequential ::value-binding]]
+     ::values [:orn
+               [:single ::single-var-binding]
+               [:multiple ::multiple-var-binding]]
      ::t [:or :int :string]
      ::delete ::triple
      ::delete-op [:map

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -155,12 +155,11 @@
                            [:where-map ::where-map]
                            [:tuple ::where-tuple]]]
      ::var-collection [:sequential ::var]
-     ::var-list [:sequential ::var]
-     ::val-list [:sequential ::val]
-     ::single-var-binding [:tuple ::var ::val-list]
+     ::val-collection [:sequential ::val]
+     ::single-var-binding [:tuple ::var ::val-collection]
      ::value-binding [:sequential ::val]
      ::multiple-var-binding [:tuple
-                             ::var-list
+                             ::var-collection
                              [:sequential ::value-binding]]
      ::values [:orn
                [:single ::single-var-binding]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -150,12 +150,12 @@
      ::where [:sequential [:orn
                            [:where-map ::where-map]
                            [:tuple ::where-tuple]]]
-     ::vars [:map-of ::var :any]
+     ::values [:map-of ::var :any]
      ::t [:or :int :string]
      ::delete ::triple     ::delete-op [:map
                                         [:delete ::delete]
                                         [:where ::where]
-                                        [:vars {:optional true} ::vars]]
+                                        [:values {:optional true} ::values]]
      ::context [:map-of :any :any]
      ::analytical-query [:map
                          [:where ::where]
@@ -171,7 +171,7 @@
                          [:group-by {:optional true} ::group-by]
                          [:filter {:optional true} ::filter]
                          [:having {:optional true} ::function]
-                         [:vars {:optional true} ::vars]
+                         [:values {:optional true} ::values]
                          [:limit {:optional true} ::limit]
                          [:offset {:optional true} ::offset]
                          [:maxFuel {:optional true} ::maxFuel]

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -54,15 +54,19 @@
                  {::where/val 1002 ::where/datatype 7}
                  {::where/val "Alice" ::where/datatype 1}]]
                patterns)))
-      (let [vars-query {:select {"?s" ["*"]}
-                        :where  [["?s" :schema/name '?name]]
-                        :vars   {'?name "Alice"}}
-            {:keys [select where vars] :as parsed} (parse/parse-analytical-query vars-query db)
+
+      (let [values-query {:select {"?s" ["*"]}
+                          :where  [["?s" :schema/name '?name]]
+                          :values {'?name "Alice"}}
+
+            {:keys [select where values] :as parsed}
+            (parse/parse-analytical-query* values-query db)
+
             {::where/keys [patterns]} where]
         (is (= {'?name
                 {::where/var '?name
                  ::where/val "Alice"}}
-               vars))
+               values))
         (is (= {:var       '?s
                 :selection ["*"]
                 :depth     0

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -55,17 +55,18 @@
                  {::where/val "Alice" ::where/datatype 1}]]
                patterns)))
 
-      (let [values-query {:select {"?s" ["*"]}
-                          :where  [["?s" :schema/name '?name]]
-                          :values {'?name "Alice"}}
+      (let [values-query '{:select {"?s" ["*"]}
+                           :where  [["?s" :schema/name ?name]]
+                           :values [?name ["Alice"]]}
 
             {:keys [select where values] :as parsed}
             (parse/parse-analytical-query* values-query db)
 
             {::where/keys [patterns]} where]
-        (is (= {'?name
-                {::where/var '?name
-                 ::where/val "Alice"}}
+        (is (= '[{?name
+                  {::where/var ?name
+                   ::where/val "Alice"
+                   ::where/datatype 1}}]
                values))
         (is (= {:var       '?s
                 :selection ["*"]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -46,6 +46,58 @@
                                    :having   (>= (avg ?favNums) 2)}))
             "filters results according to the supplied having function code")))))
 
+(deftest ^:integration values-test
+  (testing "Queries with pre-specified values"
+    (let [conn   (test-utils/create-conn)
+          people (test-utils/load-people conn)
+          db     (fluree/db people)]
+      (testing "binding a single variable"
+        (testing "with a single value"
+          (let [q '{:context {:ex "http://example.org/ns/"}
+                    :select  [?name ?age]
+                    :where   [[?s :schema/email ?email]
+                              [?s :schema/name ?name]
+                              [?s :schema/age ?age]]
+                    :values [?email ["alice@example.org"]]}]
+            (is (= [["Alice" 50]]
+                   @(fluree/query db q))
+                "returns only the results related to the bound value")))
+        (testing "with multiple values"
+          (let [q '{:context {:ex "http://example.org/ns/"}
+                    :select  [?name ?age]
+                    :where   [[?s :schema/email ?email]
+                              [?s :schema/name ?name]
+                              [?s :schema/age ?age]]
+                    :values [?email ["alice@example.org" "cam@example.org"]]}]
+            (is (= [["Alice" 50] ["Cam" 34]]
+                   @(fluree/query db q))
+                "returns only the results related to the bound values"))))
+      (testing "binding multiple variables"
+        (testing "with multiple values"
+          (let [q '{:context {:ex "http://example.org/ns/"}
+                    :select  [?name ?age]
+                    :where   [[?s :schema/email ?email]
+                              [?s :ex/favNums ?favNum]
+                              [?s :schema/name ?name]
+                              [?s :schema/age ?age]]
+                    :values [[?email ?favNum] [["alice@example.org" 42]
+                                               ["cam@example.org" 10]]]}]
+            (is (= [["Alice" 50] ["Cam" 34]]
+                   @(fluree/query db q))
+                "returns only the results related to the bound values")))
+        (testing "with some values not present"
+          (let [q '{:context {:ex "http://example.org/ns/"}
+                    :select  [?name ?age]
+                    :where   [[?s :schema/email ?email]
+                              [?s :ex/favNums ?favNum]
+                              [?s :schema/name ?name]
+                              [?s :schema/age ?age]]
+                    :values [[?email ?favNum] [["alice@example.org" 42]
+                                               ["cam@example.org" 37]]]}]
+            (is (= [["Alice" 50]]
+                   @(fluree/query db q))
+                "returns only the results related to the existing bound values")))))))
+
 (deftest ^:integration multi-query-test
   (let [conn   (test-utils/create-conn)
         people (test-utils/load-people conn)

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -41,12 +41,12 @@
                                         [?f :schema/age ?age]]})
 
           two-tuple-select-with-crawl+var
-          @(fluree/query db {:context {:ex "http://example.org/ns/"}
-                             :select  ['?age {'?f [:*]}]
-                             :where   [['?s :schema/name '?name]
-                                       ['?s :ex/friend '?f]
-                                       ['?f :schema/age '?age]]
-                             :vars    {'?name "Cam"}})]
+          @(fluree/query db '{:context {:ex "http://example.org/ns/"}
+                              :select  [?age {?f [:*]}]
+                              :where   [[?s :schema/name ?name]
+                                        [?s :ex/friend ?f]
+                                        [?f :schema/age ?age]]
+                              :values  [?name ["Cam"]]})]
 
       (is (= two-tuple-select-with-crawl
              two-tuple-select-with-crawl+var


### PR DESCRIPTION
Implements `:values` bindings in queries in fql according to a Clojurefied version of the [SPARQL values spec](https://www.w3.org/TR/sparql11-query/#inline-data)

I also took the opportunity to refactor some of the where clause matching code so that I could reuse it to create new matches from the supplied values bindings. While I was in there, I gave some things better (I think) names and dried up some code. 

Closes #234
