### PR TITLE
Fix self-referencing nested nodes

### DIFF
--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -141,10 +141,11 @@
            acc* acc]
       (log/debug "assert-v-maps v-map:" v-map)
       (log/debug "assert-v-maps id:" id)
-      (let [acc**
+      (let [ref-id (:id v-map)
+            acc**
             (cond->
-              (if (and id (node? v-map)) ;; is a ref to another IRI
-                (let [existing-sid (<? (get-iri-sid id db iris))
+              (if (and ref-id (node? v-map)) ;; is a ref to another IRI
+                (let [existing-sid (<? (get-iri-sid ref-id db iris))
                       ref-sid      (or existing-sid
                                        (jld-ledger/generate-new-sid
                                          v-map pid iris next-pid next-sid))
@@ -154,7 +155,7 @@
                   (cond-> (conj acc* new-flake)
                           (nil? existing-sid) (conj
                                                 (flake/create ref-sid const/$iri
-                                                              id
+                                                              ref-id
                                                               const/$xsd:string
                                                               t true nil))))
                 (let [[value dt] (datatype/from-expanded v-map nil)


### PR DESCRIPTION
Follow-up fix for issue #380. I accidentally stashed the tests that checked for this part of the fix. So when the whole test suite was passing I thought it wasn't necessary 😆.

Specifically this fixes the issue where nested nodes refer back to the parent node after loading the ledger from storage.