### PR TITLE
Fix :spot error on query

### DIFF
--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -77,6 +77,83 @@
                @(fluree/query db {:select ['?s '?p '?o]
                                   :where  [['?s '?p '?o]]}))
             "Entire database should be pulled.")
+        (is (= [{:id :ex/jane,
+                 :rdf/type [:ex/User],
+                 :schema/name "Jane",
+                 :schema/email "jane@flur.ee",
+                 :schema/age 30}
+                {:id :ex/jane,
+                 :rdf/type [:ex/User],
+                 :schema/name "Jane",
+                 :schema/email "jane@flur.ee",
+                 :schema/age 30}
+                {:id :ex/jane,
+                 :rdf/type [:ex/User],
+                 :schema/name "Jane",
+                 :schema/email "jane@flur.ee",
+                 :schema/age 30}
+                {:id :ex/jane,
+                 :rdf/type [:ex/User],
+                 :schema/name "Jane",
+                 :schema/email "jane@flur.ee",
+                 :schema/age 30}
+                {:id :ex/jane,
+                 :rdf/type [:ex/User],
+                 :schema/name "Jane",
+                 :schema/email "jane@flur.ee",
+                 :schema/age 30}
+                {:id :ex/bob,
+                 :rdf/type [:ex/User],
+                 :schema/name "Bob",
+                 :schema/age 22}
+                {:id :ex/bob,
+                 :rdf/type [:ex/User],
+                 :schema/name "Bob",
+                 :schema/age 22}
+                {:id :ex/bob,
+                 :rdf/type [:ex/User],
+                 :schema/name "Bob",
+                 :schema/age 22}
+                {:id :ex/bob,
+                 :rdf/type [:ex/User],
+                 :schema/name "Bob",
+                 :schema/age 22}
+                {:id :ex/alice,
+                 :rdf/type [:ex/User],
+                 :schema/name "Alice",
+                 :schema/email "alice@flur.ee",
+                 :schema/age 42}
+                {:id :ex/alice,
+                 :rdf/type [:ex/User],
+                 :schema/name "Alice",
+                 :schema/email "alice@flur.ee",
+                 :schema/age 42}
+                {:id :ex/alice,
+                 :rdf/type [:ex/User],
+                 :schema/name "Alice",
+                 :schema/email "alice@flur.ee",
+                 :schema/age 42}
+                {:id :ex/alice,
+                 :rdf/type [:ex/User],
+                 :schema/name "Alice",
+                 :schema/email "alice@flur.ee",
+                 :schema/age 42}
+                {:id :ex/alice,
+                 :rdf/type [:ex/User],
+                 :schema/name "Alice",
+                 :schema/email "alice@flur.ee",
+                 :schema/age 42}
+                {:id :schema/age}
+                {:id :schema/email}
+                {:id :schema/name}
+                {:id :ex/User, :rdf/type [:rdfs/Class]}
+                {:id :ex/User, :rdf/type [:rdfs/Class]}
+                {:id :rdfs/Class}
+                {:id :rdf/type}
+                {:id :id}]
+               @(fluree/query db {:select {'?s ["*"]}
+                                  :where  [['?s '?p '?o]]}))
+            "Every triple should be returned.")
       (let [db* @(fluree/commit! ledger db)]
         (is (= [[:ex/jane :id "http://example.org/ns/jane"]
                 [:ex/jane :rdf/type :ex/User]

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -35,7 +35,6 @@
         ssc-q1-parsed (parse/parse-analytical-query* {:select {"?s" ["*"]}
                                                       :where  [["?s" :schema/name "Alice"]]}
                                                      db)
-
         ssc-q2-parsed (parse/parse-analytical-query* {:select {"?s" ["*"]}
                                                       :where  [["?s" :schema/age 50]
                                                                ["?s" :ex/favColor "Blue"]]}
@@ -57,7 +56,10 @@
         vars-query-parsed (parse/parse-analytical-query* {:select {"?s" ["*"]}
                                                           :where  [["?s" :schema/name '?name]]
                                                           :vars {'?name "Alice"}}
-                                                         db)]
+                                                         db)
+        s+p+o-parsed (parse/parse-analytical-query {:select {"?s" [:*]}
+                                                    :where  [["?s" "?p" "?o"]]}
+                                                   db)]
     (testing "simple-subject-crawl?"
       (is (= true
              (reparse/simple-subject-crawl? ssc-q1-parsed)))
@@ -65,7 +67,8 @@
              (reparse/simple-subject-crawl? ssc-q2-parsed)))
       (is (not (reparse/simple-subject-crawl? vars-query-parsed)))
       (is (not (reparse/simple-subject-crawl? not-ssc-parsed)))
-      (is (not (reparse/simple-subject-crawl? order-group-parsed))))
+      (is (not (reparse/simple-subject-crawl? order-group-parsed)))
+      (is (not (reparse/simple-subject-crawl? s+p+o-parsed))))
     (testing "reparse"
       (let [ssc-q1-reparsed (reparse/re-parse-as-simple-subj-crawl ssc-q1-parsed)
             {:keys [where context]} ssc-q1-reparsed

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -59,7 +59,15 @@
                                                          db)
         s+p+o-parsed (parse/parse-analytical-query {:select {"?s" [:*]}
                                                     :where  [["?s" "?p" "?o"]]}
-                                                   db)]
+                                                   db)
+        s+p+o2-parsed (parse/parse-analytical-query {:select {'?s ["*"]}
+                                                     :where [['?s :schema/age 50]
+                                                             ['?s '?p '?o]]}
+                                                    db)
+        s+p+o3-parsed (parse/parse-analytical-query {:select {'?s ["*"]}
+                                                     :where [['?s '?p '?o]
+                                                             ['?s :schema/age 50]]}
+                                                    db)]
     (testing "simple-subject-crawl?"
       (is (= true
              (reparse/simple-subject-crawl? ssc-q1-parsed)))
@@ -68,7 +76,9 @@
       (is (not (reparse/simple-subject-crawl? vars-query-parsed)))
       (is (not (reparse/simple-subject-crawl? not-ssc-parsed)))
       (is (not (reparse/simple-subject-crawl? order-group-parsed)))
-      (is (not (reparse/simple-subject-crawl? s+p+o-parsed))))
+      (is (not (reparse/simple-subject-crawl? s+p+o-parsed)))
+      (is (not (reparse/simple-subject-crawl? s+p+o2-parsed)))
+      (is (not (reparse/simple-subject-crawl? s+p+o3-parsed))))
     (testing "reparse"
       (let [ssc-q1-reparsed (reparse/re-parse-as-simple-subj-crawl ssc-q1-parsed)
             {:keys [where context]} ssc-q1-reparsed


### PR DESCRIPTION
Fixes #356 

This error was being caused by the fact that it was going through the simple-subject-crawl pipeline, which is not meant for this type of query.

This PR updates the SSC reparsing logic to reject this query, so it's processed by the main query pipeline instead.

Also adds a test for the expected output of this query. I originally thought this output was a bug, and opened https://github.com/fluree/db/issues/384 to address it, but it may not in fact be a bug.
 
~~If this output is actually correct, we can close #384~~ 