### PR TITLE
Update test expecation SHAs and sizes for recent commit change

### DIFF
--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -8,159 +8,159 @@
 (deftest ^:integration history-query
   (let [ts-primeval (util/current-time-iso)
 
-        conn (test-utils/create-conn)
-        ledger @(fluree/create conn "historytest" {:context {:ex "http://example.org/ns/"}})
+        conn        (test-utils/create-conn)
+        ledger      @(fluree/create conn "historytest" {:context {:ex "http://example.org/ns/"}})
 
-        db1 @(test-utils/transact ledger [{:id :ex/dan
-                                           :ex/x "foo-1"
-                                           :ex/y "bar-1"}
-                                          {:id :ex/cat
-                                           :ex/x "foo-1"
-                                           :ex/y "bar-1"}
-                                          {:id :ex/dog
-                                           :ex/x "foo-1"
-                                           :ex/y "bar-1"}])
-        db2 @(test-utils/transact ledger {:id :ex/dan
-                                          :ex/x "foo-2"
-                                          :ex/y "bar-2"})
-        ts2 (-> db2 :commit :time)
-        db3 @(test-utils/transact ledger {:id :ex/dan
-                                          :ex/x "foo-3"
-                                          :ex/y "bar-3"})
+        db1         @(test-utils/transact ledger [{:id   :ex/dan
+                                                   :ex/x "foo-1"
+                                                   :ex/y "bar-1"}
+                                                  {:id   :ex/cat
+                                                   :ex/x "foo-1"
+                                                   :ex/y "bar-1"}
+                                                  {:id   :ex/dog
+                                                   :ex/x "foo-1"
+                                                   :ex/y "bar-1"}])
+        db2         @(test-utils/transact ledger {:id   :ex/dan
+                                                  :ex/x "foo-2"
+                                                  :ex/y "bar-2"})
+        ts2         (-> db2 :commit :time)
+        db3         @(test-utils/transact ledger {:id   :ex/dan
+                                                  :ex/x "foo-3"
+                                                  :ex/y "bar-3"})
 
-        ts3 (-> db3 :commit :time)
-        db4 @(test-utils/transact ledger [{:id :ex/cat
-                                           :ex/x "foo-cat"
-                                           :ex/y "bar-cat"}
-                                          {:id :ex/dog
-                                           :ex/x "foo-dog"
-                                           :ex/y "bar-dog"}])
-        db5 @(test-utils/transact ledger {:id :ex/dan
-                                          :ex/x "foo-cat"
-                                          :ex/y "bar-cat"})]
+        ts3         (-> db3 :commit :time)
+        db4         @(test-utils/transact ledger [{:id   :ex/cat
+                                                   :ex/x "foo-cat"
+                                                   :ex/y "bar-cat"}
+                                                  {:id   :ex/dog
+                                                   :ex/x "foo-dog"
+                                                   :ex/y "bar-dog"}])
+        db5         @(test-utils/transact ledger {:id   :ex/dan
+                                                  :ex/x "foo-cat"
+                                                  :ex/y "bar-cat"})]
     (testing "subject history"
-      (is (= [{:f/t 1
-               :f/assert [{:id :ex/dan :ex/x "foo-1" :ex/y "bar-1"}]
+      (is (= [{:f/t       1
+               :f/assert  [{:id :ex/dan :ex/x "foo-1" :ex/y "bar-1"}]
                :f/retract []}
-              {:f/t 2
-               :f/assert [{:id :ex/dan :ex/x "foo-2" :ex/y "bar-2"}]
+              {:f/t       2
+               :f/assert  [{:id :ex/dan :ex/x "foo-2" :ex/y "bar-2"}]
                :f/retract [{:id :ex/dan :ex/x "foo-1" :ex/y "bar-1"}]}
-              {:f/t 3
-               :f/assert [{:id :ex/dan :ex/x "foo-3" :ex/y "bar-3"}]
+              {:f/t       3
+               :f/assert  [{:id :ex/dan :ex/x "foo-3" :ex/y "bar-3"}]
                :f/retract [{:id :ex/dan :ex/x "foo-2" :ex/y "bar-2"}]}
-              {:f/t 5
-               :f/assert [{:id :ex/dan :ex/x "foo-cat" :ex/y "bar-cat"}]
+              {:f/t       5
+               :f/assert  [{:id :ex/dan :ex/x "foo-cat" :ex/y "bar-cat"}]
                :f/retract [{:id :ex/dan :ex/x "foo-3" :ex/y "bar-3"}]}]
              @(fluree/history ledger {:history :ex/dan :t {:from 1}}))))
     (testing "one-tuple flake history"
-      (is (= [{:f/t 1
-               :f/assert [{:id :ex/dan :ex/x "foo-1" :ex/y "bar-1"}]
+      (is (= [{:f/t       1
+               :f/assert  [{:id :ex/dan :ex/x "foo-1" :ex/y "bar-1"}]
                :f/retract []}
-              {:f/t 2
-               :f/assert [{:ex/x "foo-2" :ex/y "bar-2" :id :ex/dan}]
+              {:f/t       2
+               :f/assert  [{:ex/x "foo-2" :ex/y "bar-2" :id :ex/dan}]
                :f/retract [{:ex/x "foo-1" :ex/y "bar-1" :id :ex/dan}]}
-              {:f/t 3
-               :f/assert [{:ex/x "foo-3" :ex/y "bar-3" :id :ex/dan}]
+              {:f/t       3
+               :f/assert  [{:ex/x "foo-3" :ex/y "bar-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :ex/y "bar-2" :id :ex/dan}]}
-              {:f/t 5
-               :f/assert [{:ex/x "foo-cat" :ex/y "bar-cat" :id :ex/dan}]
+              {:f/t       5
+               :f/assert  [{:ex/x "foo-cat" :ex/y "bar-cat" :id :ex/dan}]
                :f/retract [{:ex/x "foo-3" :ex/y "bar-3" :id :ex/dan}]}]
              @(fluree/history ledger {:history [:ex/dan] :t {:from 1}}))))
     (testing "two-tuple flake history"
       (is (= [{:f/t 1 :f/assert [{:ex/x "foo-1" :id :ex/dan}] :f/retract []}
-              {:f/t 2
-               :f/assert [{:ex/x "foo-2" :id :ex/dan}]
+              {:f/t       2
+               :f/assert  [{:ex/x "foo-2" :id :ex/dan}]
                :f/retract [{:ex/x "foo-1" :id :ex/dan}]}
-              {:f/t 3
-               :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+              {:f/t       3
+               :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}
-              {:f/t 5
-               :f/assert [{:ex/x "foo-cat" :id :ex/dan}]
+              {:f/t       5
+               :f/assert  [{:ex/x "foo-cat" :id :ex/dan}]
                :f/retract [{:ex/x "foo-3" :id :ex/dan}]}]
              @(fluree/history ledger {:history [:ex/dan :ex/x] :t {:from 1}})))
 
-      (is (= [{:f/t 1 :f/assert [{:ex/x "foo-1" :id :ex/dog}
-                                 {:ex/x "foo-1" :id :ex/cat}
-                                 {:ex/x "foo-1" :id :ex/dan}]
+      (is (= [{:f/t       1 :f/assert [{:ex/x "foo-1" :id :ex/dog}
+                                       {:ex/x "foo-1" :id :ex/cat}
+                                       {:ex/x "foo-1" :id :ex/dan}]
                :f/retract []}
-              {:f/t 2
-               :f/assert [{:ex/x "foo-2" :id :ex/dan}]
+              {:f/t       2
+               :f/assert  [{:ex/x "foo-2" :id :ex/dan}]
                :f/retract [{:ex/x "foo-1" :id :ex/dan}]}
-              {:f/t 3
-               :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+              {:f/t       3
+               :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}
-              {:f/t 4
-               :f/assert [{:ex/x "foo-dog" :id :ex/dog}
-                          {:ex/x "foo-cat" :id :ex/cat}]
+              {:f/t       4
+               :f/assert  [{:ex/x "foo-dog" :id :ex/dog}
+                           {:ex/x "foo-cat" :id :ex/cat}]
                :f/retract [{:ex/x "foo-1" :id :ex/dog}
                            {:ex/x "foo-1" :id :ex/cat}]}
-              {:f/t 5
-               :f/assert [{:ex/x "foo-cat" :id :ex/dan}]
+              {:f/t       5
+               :f/assert  [{:ex/x "foo-cat" :id :ex/dan}]
                :f/retract [{:ex/x "foo-3" :id :ex/dan}]}]
              @(fluree/history ledger {:history [nil :ex/x] :t {:from 1}}))))
     (testing "three-tuple flake history"
       (is (= [{:f/t 4 :f/assert [{:ex/x "foo-cat" :id :ex/cat}] :f/retract []}
               {:f/t 5 :f/assert [{:ex/x "foo-cat" :id :ex/dan}] :f/retract []}]
              @(fluree/history ledger {:history [nil :ex/x "foo-cat"] :t {:from 1}})))
-      (is (= [{:f/t 2
-               :f/assert [{:ex/x "foo-2" :id :ex/dan}]
+      (is (= [{:f/t       2
+               :f/assert  [{:ex/x "foo-2" :id :ex/dan}]
                :f/retract []}
-              {:f/t 3
-               :f/assert []
+              {:f/t       3
+               :f/assert  []
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}]
              @(fluree/history ledger {:history [nil :ex/x "foo-2"] :t {:from 1}})))
       (is (= [{:f/t 5 :f/assert [{:ex/x "foo-cat" :id :ex/dan}] :f/retract []}]
              @(fluree/history ledger {:history [:ex/dan :ex/x "foo-cat"] :t {:from 1}}))))
 
     (testing "at-t"
-      (let [expected [{:f/t 3
-                       :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+      (let [expected [{:f/t       3
+                       :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                        :f/retract [{:ex/x "foo-2" :id :ex/dan}]}]]
         (is (= expected
                @(fluree/history ledger {:history [:ex/dan :ex/x] :t {:from 3 :to 3}})))
         (is (= expected
                @(fluree/history ledger {:history [:ex/dan :ex/x] :t {:at 3}})))))
     (testing "from-t"
-      (is (= [{:f/t 3
-               :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+      (is (= [{:f/t       3
+               :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}
-              {:f/t 5
-               :f/assert [{:ex/x "foo-cat" :id :ex/dan}]
+              {:f/t       5
+               :f/assert  [{:ex/x "foo-cat" :id :ex/dan}]
                :f/retract [{:ex/x "foo-3" :id :ex/dan}]}]
              @(fluree/history ledger {:history [:ex/dan :ex/x] :t {:from 3}}))))
     (testing "to-t"
-      (is (= [{:f/t 1
-               :f/assert [{:ex/x "foo-1" :id :ex/dan}]
+      (is (= [{:f/t       1
+               :f/assert  [{:ex/x "foo-1" :id :ex/dan}]
                :f/retract []}
-              {:f/t 2
-               :f/assert [{:ex/x "foo-2" :id :ex/dan}]
+              {:f/t       2
+               :f/assert  [{:ex/x "foo-2" :id :ex/dan}]
                :f/retract [{:ex/x "foo-1" :id :ex/dan}]}
-              {:f/t 3
-               :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+              {:f/t       3
+               :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}]
              @(fluree/history ledger {:history [:ex/dan :ex/x] :t {:to 3}}))))
     (testing "t-range"
-      (is (= [{:f/t 2
-               :f/assert [{:ex/x "foo-2" :id :ex/dan}]
+      (is (= [{:f/t       2
+               :f/assert  [{:ex/x "foo-2" :id :ex/dan}]
                :f/retract [{:ex/x "foo-1" :id :ex/dan}]}
-              {:f/t 3
-               :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+              {:f/t       3
+               :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}
-              {:f/t 4
-               :f/assert [{:ex/x "foo-dog" :id :ex/dog} {:ex/x "foo-cat" :id :ex/cat}]
+              {:f/t       4
+               :f/assert  [{:ex/x "foo-dog" :id :ex/dog} {:ex/x "foo-cat" :id :ex/cat}]
                :f/retract [{:ex/x "foo-1" :id :ex/dog} {:ex/x "foo-1" :id :ex/cat}]}]
              @(fluree/history ledger {:history [nil :ex/x] :t {:from 2 :to 4}}))))
     (testing "datetime-t"
-      (is (= [{:f/t 2
-               :f/assert [{:ex/x "foo-2" :id :ex/dan}]
+      (is (= [{:f/t       2
+               :f/assert  [{:ex/x "foo-2" :id :ex/dan}]
                :f/retract [{:ex/x "foo-1" :id :ex/dan}]}
-              {:f/t 3
-               :f/assert [{:ex/x "foo-3" :id :ex/dan}]
+              {:f/t       3
+               :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}]
              @(fluree/history ledger {:history [nil :ex/x] :t {:from ts2 :to ts3}}))
           "does not include t 1 4 or 5")
-      (is (= [{:f/t 5
-               :f/assert [{:ex/x "foo-cat" :id :ex/dan}]
+      (is (= [{:f/t       5
+               :f/assert  [{:ex/x "foo-cat" :id :ex/dan}]
                :f/retract [{:ex/x "foo-3" :id :ex/dan}]}]
              @(fluree/history ledger {:history [:ex/dan :ex/x] :t {:from (util/current-time-iso)}}))
           "timestamp translates to first t before ts")
@@ -177,357 +177,359 @@
                  :cause))))
 
     (testing "small cache"
-      (let [conn (test-utils/create-conn)
+      (let [conn   (test-utils/create-conn)
             ledger @(fluree/create conn "historycachetest" {:context {:ex "http://example.org/ns/"}})
 
-            db1 @(test-utils/transact ledger [{:id :ex/dan
-                                               :ex/x "foo-1"
-                                               :ex/y "bar-1"}])
-            db2 @(test-utils/transact ledger {:id :ex/dan
-                                              :ex/x "foo-2"
-                                              :ex/y "bar-2"})]
+            db1    @(test-utils/transact ledger [{:id   :ex/dan
+                                                  :ex/x "foo-1"
+                                                  :ex/y "bar-1"}])
+            db2    @(test-utils/transact ledger {:id   :ex/dan
+                                                 :ex/x "foo-2"
+                                                 :ex/y "bar-2"})]
         (testing "no t-range cache collision"
-          (is (= [{:f/t 2
-                   :f/assert [{:ex/x "foo-2" :ex/y "bar-2" :id :ex/dan}]
+          (is (= [{:f/t       2
+                   :f/assert  [{:ex/x "foo-2" :ex/y "bar-2" :id :ex/dan}]
                    :f/retract [{:ex/x "foo-1" :ex/y "bar-1" :id :ex/dan}]}]
                  @(fluree/history ledger {:history [:ex/dan] :t {:from 2}}))))))))
 
 (deftest ^:integration commit-details
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
-    (let [conn (test-utils/create-conn)
+    (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "committest" {:context {:ex "http://example.org/ns/"}})
 
-          db1 @(test-utils/transact ledger {:id :ex/alice
-                                            :ex/x "foo-1"
-                                            :ex/y "bar-1"})
-          db2 @(test-utils/transact ledger {:id :ex/alice
-                                            :ex/x "foo-2"
-                                            :ex/y "bar-2"})
-          db3 @(test-utils/transact ledger {:id :ex/alice
-                                            :ex/x "foo-3"
-                                            :ex/y "bar-3"})
-          db4 @(test-utils/transact ledger {:id :ex/cat
-                                            :ex/x "foo-cat"
-                                            :ex/y "bar-cat"})
-          db5 @(test-utils/transact ledger {:id :ex/alice
-                                            :ex/x "foo-cat"
-                                            :ex/y "bar-cat"}
-                                    {:message "meow"})]
+          db1    @(test-utils/transact ledger {:id   :ex/alice
+                                               :ex/x "foo-1"
+                                               :ex/y "bar-1"})
+          db2    @(test-utils/transact ledger {:id   :ex/alice
+                                               :ex/x "foo-2"
+                                               :ex/y "bar-2"})
+          db3    @(test-utils/transact ledger {:id   :ex/alice
+                                               :ex/x "foo-3"
+                                               :ex/y "bar-3"})
+          db4    @(test-utils/transact ledger {:id   :ex/cat
+                                               :ex/x "foo-cat"
+                                               :ex/y "bar-cat"})
+          db5    @(test-utils/transact ledger {:id   :ex/alice
+                                               :ex/x "foo-cat"
+                                               :ex/y "bar-cat"}
+                                       {:message "meow"})]
       (testing "at time t"
         (is (= [{:f/commit
                  {:f/address
-                  "fluree:memory://2a2436a01df3343870bca46e3a24c6b57df73f28666fe5247c221ca888abba5e",
-                  :f/v 0,
-                  :f/time 720000,
+                  "fluree:memory://3f7ff6df48e007cab36098274fd822ac11c9da4bf8b29762d1de3fdbdd6b6013",
+                  :f/v      0,
+                  :f/time   720000,
                   :id
-                  "fluree:commit:sha256:bb7lpextw2b64rq2k3ilcttpb66he3derz4cvnqtu5znptvzfndev",
+                  "fluree:commit:sha256:bsso2btsgd4gsukmqrlmm4gap4gbmk5fkemiht6hlpjkaxzdgmmk",
                   :f/branch "main",
                   :f/data
                   {:f/address "fluree:memory://5d3ce686baa6fd5cc547b5e03e6aca3d92cbce0328c2320a49c514b01e58b4c2",
-                   :f/flakes 11,
-                   :f/size 996,
-                   :f/t 1,
-                   :f/assert [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}],
+                   :f/flakes  11,
+                   :f/size    996,
+                   :f/t       1,
+                   :f/assert  [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}],
                    :f/retract []},
                   "https://www.w3.org/2018/credentials#issuer"
                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias "committest",
+                  :f/alias  "committest",
                   :f/context
-                  "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
                @(fluree/history ledger {:commit-details true :t {:from 1 :to 1}})))
         (let [commit-5 {:f/commit
                         {:f/address
-                         "fluree:memory://14efe5ef1163589f9ee6fcc5af8e2830c3300a80abbbae0aa82194083e93aebe",
-                         :f/v 0,
+                         "fluree:memory://16d376f6cac29e8125ec3beca7aea6f75fb7a4328d73cbe0d629c6132510621c",
+                         :f/v       0,
                          :f/previous
                          {:id
-                          "fluree:commit:sha256:bbr54svhy4ergg3mmed4eugzljonsl7jlfmadsbcq6b7sr2cs7yyl"},
-                         :f/time 720000,
+                          "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7"},
+                         :f/time    720000,
                          :id
-                         "fluree:commit:sha256:bb3v3rd7q6lojz5w4gsweglna6afhc6ooh5fgfdhxitdtdwquxwgv",
-                         :f/branch "main",
+                         "fluree:commit:sha256:bbgkybvkkdwelzlmj6vei7kitm5hvxecotx6imytpta272jwbiaw7",
+                         :f/branch  "main",
                          :f/message "meow",
                          :f/data
                          {:f/previous
                           {:id
-                           "fluree:db:sha256:bt6d6eup2oo2icrjj7ejcmfoa3wsen45y2l2iomlnbqsuoypizgn"},
+                           "fluree:db:sha256:bbiioffkgezekkxzojudoqrtk3zmjcxeotecprh2ordafskng7hhc"},
                           :f/address
-                          "fluree:memory://a505e939983b4cfa9325ebe0bbd8615865606c3f4ab9343dd00d594ee722cc10",
-                          :f/flakes 102,
-                          :f/size 9408,
-                          :f/t 5,
-                          :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
+                          "fluree:memory://783086c375a712eba5d5a74b18882a98a1f77eccf51bddd9b99e2c625e67a088",
+                          :f/flakes  102,
+                          :f/size    9328,
+                          :f/t       5,
+                          :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
                           :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]},
                          "https://www.w3.org/2018/credentials#issuer"
                          {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                         :f/alias "committest",
+                         :f/alias   "committest",
                          :f/context
-                         "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+                         "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
               commit-4 {:f/commit
                         {:f/address
-                         "fluree:memory://67df776dd7cee2a21b9c2a513224ad044e2dc613e5be5d6de42478ed69ac7b21",
-                         :f/v 0,
+                         "fluree:memory://f0207c4d1d5b3e9abd71622f72149ec36518abda929aa63812c44d21a0b77b5a",
+                         :f/v      0,
                          :f/previous
                          {:id
-                          "fluree:commit:sha256:bzlpatyzpsmdyvr4eywvsa2bctleol5tbupsr35ejxntxnjn7l2q"},
-                         :f/time 720000,
+                          "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd"},
+                         :f/time   720000,
                          :id
-                         "fluree:commit:sha256:bbr54svhy4ergg3mmed4eugzljonsl7jlfmadsbcq6b7sr2cs7yyl",
+                         "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7",
                          :f/branch "main",
                          :f/data
                          {:f/previous
                           {:id
-                           "fluree:db:sha256:blxs4kpvkuwsc76cf2hfgs6housqeoxwvbehect4p47f6ow7fkbb"},
+                           "fluree:db:sha256:bbc26gz36q2kxbrwmdo4ryfq4shvbw5b7aloxqsaje3tzd32issul"},
                           :f/address
-                          "fluree:memory://85e076bdfe8e5c8d53551d290f9e4e716eab86ba8577238d731c51df4f6effba",
-                          :f/flakes 82,
-                          :f/size 7650,
-                          :f/t 4,
-                          :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
+                          "fluree:memory://c3a54a71c8c554c9d583df9e72a57bf572976e7a20c088f0cf536032cfd6d212",
+                          :f/flakes  82,
+                          :f/size    7590,
+                          :f/t       4,
+                          :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
                           :f/retract []},
                          "https://www.w3.org/2018/credentials#issuer"
                          {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                         :f/alias "committest",
+                         :f/alias  "committest",
                          :f/context
-                         "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+                         "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
           (is (= [commit-4 commit-5]
                  @(fluree/history ledger {:commit-details true :t {:from 4 :to 5}})))
           (is (= [commit-5]
                  @(fluree/history ledger {:commit-details true :t {:at :latest}})))))
 
       (testing "time range"
-        (let [[c2 c3 c4 :as response] @(fluree/history ledger {:commit-details true :t {:from 2 :to 4}})]
+        (let [[c2 c3 c4 :as response] @(fluree/history
+                                         ledger
+                                         {:commit-details true
+                                          :t              {:from 2 :to 4}})]
           (testing "all commits in time range are returned"
-            (is (=  3
-                    (count response))))
-          (is (=  {:f/commit
-                   {:f/address
-                    "fluree:memory://67df776dd7cee2a21b9c2a513224ad044e2dc613e5be5d6de42478ed69ac7b21",
-                    :f/v 0,
-                    :f/previous
-                    {:id
-                     "fluree:commit:sha256:bzlpatyzpsmdyvr4eywvsa2bctleol5tbupsr35ejxntxnjn7l2q"},
-                    :f/time 720000,
-                    :id
-                    "fluree:commit:sha256:bbr54svhy4ergg3mmed4eugzljonsl7jlfmadsbcq6b7sr2cs7yyl",
-                    :f/branch "main",
-                    :f/data
-                    {:f/previous
+            (is (= 3 (count response)))
+            (is (= {:f/commit
+                    {:f/address
+                     "fluree:memory://f0207c4d1d5b3e9abd71622f72149ec36518abda929aa63812c44d21a0b77b5a",
+                     :f/v      0,
+                     :f/previous
                      {:id
-                      "fluree:db:sha256:blxs4kpvkuwsc76cf2hfgs6housqeoxwvbehect4p47f6ow7fkbb"},
-                     :f/address
-                     "fluree:memory://85e076bdfe8e5c8d53551d290f9e4e716eab86ba8577238d731c51df4f6effba",
-                     :f/flakes 82,
-                     :f/size 7650,
-                     :f/t 4,
-                     :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
-                     :f/retract []},
-                    "https://www.w3.org/2018/credentials#issuer"
-                    {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                    :f/alias "committest",
-                    :f/context
-                    "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
-                  c4))
+                      "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd"},
+                     :f/time   720000,
+                     :id
+                     "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7",
+                     :f/branch "main",
+                     :f/data
+                     {:f/previous
+                      {:id
+                       "fluree:db:sha256:bbc26gz36q2kxbrwmdo4ryfq4shvbw5b7aloxqsaje3tzd32issul"},
+                      :f/address
+                      "fluree:memory://c3a54a71c8c554c9d583df9e72a57bf572976e7a20c088f0cf536032cfd6d212",
+                      :f/flakes  82,
+                      :f/size    7590,
+                      :f/t       4,
+                      :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
+                      :f/retract []},
+                     "https://www.w3.org/2018/credentials#issuer"
+                     {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
+                     :f/alias  "committest",
+                     :f/context
+                     "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+                   c4)))
           (is (= {:f/commit
                   {:f/address
-                   "fluree:memory://c5aeefb071f0c42cdbc64ff531b54137395e074880ff153b8bd8712004c6554a",
-                   :f/v 0,
+                   "fluree:memory://3529d447998ec5b2c42ed1336009fdab9388bbd987fade075f1208aa8b7ec44b",
+                   :f/v      0,
                    :f/previous
                    {:id
-                    "fluree:commit:sha256:bbn7ggrkec2gqgkdjh4qisbeklzgx6g5xdxcfepi3mbkresckyncp"},
-                   :f/time 720000,
+                    "fluree:commit:sha256:bb42ijix6d6tidq4zzc75uymowpx7hazczwhxkuz2u45c2gcwtwvw"},
+                   :f/time   720000,
                    :id
-                   "fluree:commit:sha256:bzlpatyzpsmdyvr4eywvsa2bctleol5tbupsr35ejxntxnjn7l2q",
+                   "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd",
                    :f/branch "main",
                    :f/data
                    {:f/previous
                     {:id
-                     "fluree:db:sha256:bb3hzx3ibkdumy2qf7qzduwfqsxumucjwc334palggyg6qxhfdszh"},
+                     "fluree:db:sha256:bba364nb2cbanjsgwk7t7l34m5f667efop4yiu5l5lvxscoggqdgg"},
                     :f/address
-                    "fluree:memory://ec0a4c9ec4ce5597425ed8fbfb6fc518918b92b5ec69e3c3c4b05d17f0965590",
-                    :f/flakes 63,
-                    :f/size 5906,
-                    :f/t 3,
-                    :f/assert [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
+                    "fluree:memory://dc0c296d3047963ff807d0f17807c21a582d89ae72faa3d1d3c13d7af3929d22",
+                    :f/flakes  63,
+                    :f/size    5864,
+                    :f/t       3,
+                    :f/assert  [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
                     :f/retract [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}]},
                    "https://www.w3.org/2018/credentials#issuer"
                    {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                   :f/alias "committest",
+                   :f/alias  "committest",
                    :f/context
-                   "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+                   "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
                  c3))
           (is (= {:f/commit
                   {:f/address
-                   "fluree:memory://312ac51a0f0fa28445c482da8f6641f461972d205473bd7cb47804041d66d514",
-                   :f/v 0,
+                   "fluree:memory://08ef0ead00f983ec19d1cabbaa991fe2beba70a8666bda2df6685654a646b332",
+                   :f/v      0,
                    :f/previous
                    {:id
-                    "fluree:commit:sha256:bb7lpextw2b64rq2k3ilcttpb66he3derz4cvnqtu5znptvzfndev"},
-                   :f/time 720000,
+                    "fluree:commit:sha256:bsso2btsgd4gsukmqrlmm4gap4gbmk5fkemiht6hlpjkaxzdgmmk"},
+                   :f/time   720000,
                    :id
-                   "fluree:commit:sha256:bbn7ggrkec2gqgkdjh4qisbeklzgx6g5xdxcfepi3mbkresckyncp",
+                   "fluree:commit:sha256:bb42ijix6d6tidq4zzc75uymowpx7hazczwhxkuz2u45c2gcwtwvw",
                    :f/branch "main",
                    :f/data
                    {:f/previous
                     {:id
                      "fluree:db:sha256:bwogmajjh3rwlkijfihbcdy4h52qjv4kumctu4mhy27pj3zsxtes"},
                     :f/address
-                    "fluree:memory://0a0e8230fe970a87d930511961b05e9e9ab284903ce16967666e7883f04a7b05",
-                    :f/flakes 43,
-                    :f/size 4154,
-                    :f/t 2,
-                    :f/assert [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}],
+                    "fluree:memory://cffe310ce5b609c281342f812771e204e8789d5b9c6f15dcd19a7e74427d0413",
+                    :f/flakes  43,
+                    :f/size    4132,
+                    :f/t       2,
+                    :f/assert  [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}],
                     :f/retract [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}]},
                    "https://www.w3.org/2018/credentials#issuer"
                    {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                   :f/alias "committest",
+                   :f/alias  "committest",
                    :f/context
-                   "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+                   "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
                  c2))))
 
       (testing "time range from"
         (is (= [{:f/commit
                  {:f/address
-                  "fluree:memory://67df776dd7cee2a21b9c2a513224ad044e2dc613e5be5d6de42478ed69ac7b21",
-                  :f/v 0,
+                  "fluree:memory://f0207c4d1d5b3e9abd71622f72149ec36518abda929aa63812c44d21a0b77b5a",
+                  :f/v      0,
                   :f/previous
                   {:id
-                   "fluree:commit:sha256:bzlpatyzpsmdyvr4eywvsa2bctleol5tbupsr35ejxntxnjn7l2q"},
-                  :f/time 720000,
+                   "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd"},
+                  :f/time   720000,
                   :id
-                  "fluree:commit:sha256:bbr54svhy4ergg3mmed4eugzljonsl7jlfmadsbcq6b7sr2cs7yyl",
+                  "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7",
                   :f/branch "main",
                   :f/data
                   {:f/previous
                    {:id
-                    "fluree:db:sha256:blxs4kpvkuwsc76cf2hfgs6housqeoxwvbehect4p47f6ow7fkbb"},
+                    "fluree:db:sha256:bbc26gz36q2kxbrwmdo4ryfq4shvbw5b7aloxqsaje3tzd32issul"},
                    :f/address
-                   "fluree:memory://85e076bdfe8e5c8d53551d290f9e4e716eab86ba8577238d731c51df4f6effba",
-                   :f/flakes 82,
-                   :f/size 7650,
-                   :f/t 4,
-                   :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
+                   "fluree:memory://c3a54a71c8c554c9d583df9e72a57bf572976e7a20c088f0cf536032cfd6d212",
+                   :f/flakes  82,
+                   :f/size    7590,
+                   :f/t       4,
+                   :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
                    :f/retract []},
                   "https://www.w3.org/2018/credentials#issuer"
                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias "committest",
+                  :f/alias  "committest",
                   :f/context
-                  "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
                 {:f/commit
                  {:f/address
-                  "fluree:memory://14efe5ef1163589f9ee6fcc5af8e2830c3300a80abbbae0aa82194083e93aebe",
-                  :f/v 0,
+                  "fluree:memory://16d376f6cac29e8125ec3beca7aea6f75fb7a4328d73cbe0d629c6132510621c",
+                  :f/v       0,
                   :f/previous
                   {:id
-                   "fluree:commit:sha256:bbr54svhy4ergg3mmed4eugzljonsl7jlfmadsbcq6b7sr2cs7yyl"},
-                  :f/time 720000,
+                   "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7"},
+                  :f/time    720000,
                   :id
-                  "fluree:commit:sha256:bb3v3rd7q6lojz5w4gsweglna6afhc6ooh5fgfdhxitdtdwquxwgv",
-                  :f/branch "main",
+                  "fluree:commit:sha256:bbgkybvkkdwelzlmj6vei7kitm5hvxecotx6imytpta272jwbiaw7",
+                  :f/branch  "main",
                   :f/message "meow",
                   :f/data
                   {:f/previous
                    {:id
-                    "fluree:db:sha256:bt6d6eup2oo2icrjj7ejcmfoa3wsen45y2l2iomlnbqsuoypizgn"},
+                    "fluree:db:sha256:bbiioffkgezekkxzojudoqrtk3zmjcxeotecprh2ordafskng7hhc"},
                    :f/address
-                   "fluree:memory://a505e939983b4cfa9325ebe0bbd8615865606c3f4ab9343dd00d594ee722cc10",
-                   :f/flakes 102,
-                   :f/size 9408,
-                   :f/t 5,
-                   :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
+                   "fluree:memory://783086c375a712eba5d5a74b18882a98a1f77eccf51bddd9b99e2c625e67a088",
+                   :f/flakes  102,
+                   :f/size    9328,
+                   :f/t       5,
+                   :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
                    :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]},
                   "https://www.w3.org/2018/credentials#issuer"
                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias "committest",
+                  :f/alias   "committest",
                   :f/context
-                  "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
                @(fluree/history ledger {:commit-details true :t {:from 4}}))))
 
       (testing "time range to"
         (is (= [{:f/commit
                  {:f/address
-                  "fluree:memory://2a2436a01df3343870bca46e3a24c6b57df73f28666fe5247c221ca888abba5e",
-                  :f/v 0,
-                  :f/time 720000,
+                  "fluree:memory://3f7ff6df48e007cab36098274fd822ac11c9da4bf8b29762d1de3fdbdd6b6013",
+                  :f/v      0,
+                  :f/time   720000,
                   :id
-                  "fluree:commit:sha256:bb7lpextw2b64rq2k3ilcttpb66he3derz4cvnqtu5znptvzfndev",
+                  "fluree:commit:sha256:bsso2btsgd4gsukmqrlmm4gap4gbmk5fkemiht6hlpjkaxzdgmmk",
                   :f/branch "main",
                   :f/data
                   {:f/address
                    "fluree:memory://5d3ce686baa6fd5cc547b5e03e6aca3d92cbce0328c2320a49c514b01e58b4c2",
-                   :f/flakes 11,
-                   :f/size 996,
-                   :f/t 1,
-                   :f/assert [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}],
+                   :f/flakes  11,
+                   :f/size    996,
+                   :f/t       1,
+                   :f/assert  [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}],
                    :f/retract []},
                   "https://www.w3.org/2018/credentials#issuer"
                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias "committest",
+                  :f/alias  "committest",
                   :f/context
-                  "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
                @(fluree/history ledger {:commit-details true :t {:to 1}}))))
 
       (testing "history commit details"
-        (is (= [{:f/t 3,
-                 :f/assert [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
+        (is (= [{:f/t       3,
+                 :f/assert  [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
                  :f/retract [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}],
                  :f/commit
                  {:f/address
-                  "fluree:memory://c5aeefb071f0c42cdbc64ff531b54137395e074880ff153b8bd8712004c6554a",
-                  :f/v 0,
+                  "fluree:memory://3529d447998ec5b2c42ed1336009fdab9388bbd987fade075f1208aa8b7ec44b",
+                  :f/v      0,
                   :f/previous
                   {:id
-                   "fluree:commit:sha256:bbn7ggrkec2gqgkdjh4qisbeklzgx6g5xdxcfepi3mbkresckyncp"},
-                  :f/time 720000,
+                   "fluree:commit:sha256:bb42ijix6d6tidq4zzc75uymowpx7hazczwhxkuz2u45c2gcwtwvw"},
+                  :f/time   720000,
                   :id
-                  "fluree:commit:sha256:bzlpatyzpsmdyvr4eywvsa2bctleol5tbupsr35ejxntxnjn7l2q",
+                  "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd",
                   :f/branch "main",
                   :f/data
                   {:f/previous
                    {:id
-                    "fluree:db:sha256:bb3hzx3ibkdumy2qf7qzduwfqsxumucjwc334palggyg6qxhfdszh"},
+                    "fluree:db:sha256:bba364nb2cbanjsgwk7t7l34m5f667efop4yiu5l5lvxscoggqdgg"},
                    :f/address
-                   "fluree:memory://ec0a4c9ec4ce5597425ed8fbfb6fc518918b92b5ec69e3c3c4b05d17f0965590",
-                   :f/flakes 63,
-                   :f/size 5906,
-                   :f/t 3,
-                   :f/assert [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
+                   "fluree:memory://dc0c296d3047963ff807d0f17807c21a582d89ae72faa3d1d3c13d7af3929d22",
+                   :f/flakes  63,
+                   :f/size    5864,
+                   :f/t       3,
+                   :f/assert  [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
                    :f/retract [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}]},
                   "https://www.w3.org/2018/credentials#issuer"
                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias "committest",
+                  :f/alias  "committest",
                   :f/context
-                  "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
-                {:f/t 5,
-                 :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
+                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+                {:f/t       5,
+                 :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
                  :f/commit
                  {:f/address
-                  "fluree:memory://14efe5ef1163589f9ee6fcc5af8e2830c3300a80abbbae0aa82194083e93aebe",
-                  :f/v 0,
+                  "fluree:memory://16d376f6cac29e8125ec3beca7aea6f75fb7a4328d73cbe0d629c6132510621c",
+                  :f/v       0,
                   :f/previous
                   {:id
-                   "fluree:commit:sha256:bbr54svhy4ergg3mmed4eugzljonsl7jlfmadsbcq6b7sr2cs7yyl"},
-                  :f/time 720000,
+                   "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7"},
+                  :f/time    720000,
                   :id
-                  "fluree:commit:sha256:bb3v3rd7q6lojz5w4gsweglna6afhc6ooh5fgfdhxitdtdwquxwgv",
-                  :f/branch "main",
+                  "fluree:commit:sha256:bbgkybvkkdwelzlmj6vei7kitm5hvxecotx6imytpta272jwbiaw7",
+                  :f/branch  "main",
                   :f/message "meow",
                   :f/data
                   {:f/previous
                    {:id
-                    "fluree:db:sha256:bt6d6eup2oo2icrjj7ejcmfoa3wsen45y2l2iomlnbqsuoypizgn"},
+                    "fluree:db:sha256:bbiioffkgezekkxzojudoqrtk3zmjcxeotecprh2ordafskng7hhc"},
                    :f/address
-                   "fluree:memory://a505e939983b4cfa9325ebe0bbd8615865606c3f4ab9343dd00d594ee722cc10",
-                   :f/flakes 102,
-                   :f/size 9408,
-                   :f/t 5,
-                   :f/assert [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
+                   "fluree:memory://783086c375a712eba5d5a74b18882a98a1f77eccf51bddd9b99e2c625e67a088",
+                   :f/flakes  102,
+                   :f/size    9328,
+                   :f/t       5,
+                   :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
                    :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]},
                   "https://www.w3.org/2018/credentials#issuer"
                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias "committest",
+                  :f/alias   "committest",
                   :f/context
-                  "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"},
+                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"},
                  :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]}]
                @(fluree/history ledger {:history :ex/alice :commit-details true :t {:from 3}})))
         (testing "multiple history results"

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -154,88 +154,88 @@
                @(fluree/query db {:select {'?s ["*"]}
                                   :where  [['?s '?p '?o]]}))
             "Every triple should be returned.")
-      (let [db* @(fluree/commit! ledger db)]
-        (is (= [[:ex/jane :id "http://example.org/ns/jane"]
-                [:ex/jane :rdf/type :ex/User]
-                [:ex/jane :schema/name "Jane"]
-                [:ex/jane :schema/email "jane@flur.ee"]
-                [:ex/jane :schema/age 30]
-                [:ex/bob :id "http://example.org/ns/bob"]
-                [:ex/bob :rdf/type :ex/User]
-                [:ex/bob :schema/name "Bob"]
-                [:ex/bob :schema/age 22]
-                [:ex/alice :id "http://example.org/ns/alice"]
-                [:ex/alice :rdf/type :ex/User]
-                [:ex/alice :schema/name "Alice"]
-                [:ex/alice :schema/email "alice@flur.ee"]
-                [:ex/alice :schema/age 42]
-                ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"
-                 :id
-                 "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                 :id
-                 "fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"]
-                ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                 :f/address
-                 "fluree:memory://6fc2d43d2625d61ac668360707681aed4607da79a25dc0fef36acbebf24cb28a"]
-                ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                 :f/flakes
-                 25]
-                ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                 :f/size
-                 1888]
-                ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                 :f/t
-                 1]
-                [:schema/age :id "http://schema.org/age"]
-                [:schema/email :id "http://schema.org/email"]
-                [:schema/name :id "http://schema.org/name"]
-                [:ex/User :id "http://example.org/ns/User"]
-                [:ex/User :rdf/type :rdfs/Class]
-                [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
-                [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
-                [:f/t :id "https://ns.flur.ee/ledger#t"]
-                [:f/size :id "https://ns.flur.ee/ledger#size"]
-                [:f/flakes :id "https://ns.flur.ee/ledger#flakes"]
-                [:f/context :id "https://ns.flur.ee/ledger#context"]
-                [:f/branch :id "https://ns.flur.ee/ledger#branch"]
-                [:f/alias :id "https://ns.flur.ee/ledger#alias"]
-                [:f/data :id "https://ns.flur.ee/ledger#data"]
-                [:f/address :id "https://ns.flur.ee/ledger#address"]
-                [:f/v :id "https://ns.flur.ee/ledger#v"]
-                ["https://www.w3.org/2018/credentials#issuer"
-                 :id
-                 "https://www.w3.org/2018/credentials#issuer"]
-                [:f/time :id "https://ns.flur.ee/ledger#time"]
-                [:f/message :id "https://ns.flur.ee/ledger#message"]
-                [:f/previous :id "https://ns.flur.ee/ledger#previous"]
-                [:id :id "@id"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :id
-                 "fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/time
-                 720000]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 "https://www.w3.org/2018/credentials#issuer"
-                 "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/v
-                 0]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/address
-                 "fluree:memory://aac96d4d42bfecff44a7479259a1c8f3ccecca4df3cf42d177b84f7619b0baae"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/data
-                 "fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/alias
-                 "query/everything"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/branch
-                 "main"]
-                ["fluree:commit:sha256:bs3bcu3rhzlidsdvg3jgvbplhzxxlevvhipxsnqvfk7em4juu2os"
-                 :f/context
-                 "fluree:memory:///contexts/b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"]]
-              @(fluree/query db* {:select ['?s '?p '?o]
-                                  :where  [['?s '?p '?o]]}) )))))))
+        (let [db* @(fluree/commit! ledger db)]
+          (is (= [[:ex/jane :id "http://example.org/ns/jane"]
+                  [:ex/jane :rdf/type :ex/User]
+                  [:ex/jane :schema/name "Jane"]
+                  [:ex/jane :schema/email "jane@flur.ee"]
+                  [:ex/jane :schema/age 30]
+                  [:ex/bob :id "http://example.org/ns/bob"]
+                  [:ex/bob :rdf/type :ex/User]
+                  [:ex/bob :schema/name "Bob"]
+                  [:ex/bob :schema/age 22]
+                  [:ex/alice :id "http://example.org/ns/alice"]
+                  [:ex/alice :rdf/type :ex/User]
+                  [:ex/alice :schema/name "Alice"]
+                  [:ex/alice :schema/email "alice@flur.ee"]
+                  [:ex/alice :schema/age 42]
+                  ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"
+                   :id
+                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
+                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
+                   :id
+                   "fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"]
+                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
+                   :f/address
+                   "fluree:memory://6fc2d43d2625d61ac668360707681aed4607da79a25dc0fef36acbebf24cb28a"]
+                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
+                   :f/flakes
+                   25]
+                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
+                   :f/size
+                   1888]
+                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
+                   :f/t
+                   1]
+                  [:schema/age :id "http://schema.org/age"]
+                  [:schema/email :id "http://schema.org/email"]
+                  [:schema/name :id "http://schema.org/name"]
+                  [:ex/User :id "http://example.org/ns/User"]
+                  [:ex/User :rdf/type :rdfs/Class]
+                  [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
+                  [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+                  [:f/t :id "https://ns.flur.ee/ledger#t"]
+                  [:f/size :id "https://ns.flur.ee/ledger#size"]
+                  [:f/flakes :id "https://ns.flur.ee/ledger#flakes"]
+                  [:f/context :id "https://ns.flur.ee/ledger#context"]
+                  [:f/branch :id "https://ns.flur.ee/ledger#branch"]
+                  [:f/alias :id "https://ns.flur.ee/ledger#alias"]
+                  [:f/data :id "https://ns.flur.ee/ledger#data"]
+                  [:f/address :id "https://ns.flur.ee/ledger#address"]
+                  [:f/v :id "https://ns.flur.ee/ledger#v"]
+                  ["https://www.w3.org/2018/credentials#issuer"
+                   :id
+                   "https://www.w3.org/2018/credentials#issuer"]
+                  [:f/time :id "https://ns.flur.ee/ledger#time"]
+                  [:f/message :id "https://ns.flur.ee/ledger#message"]
+                  [:f/previous :id "https://ns.flur.ee/ledger#previous"]
+                  [:id :id "@id"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :id
+                   "fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/time
+                   720000]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   "https://www.w3.org/2018/credentials#issuer"
+                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/v
+                   0]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/address
+                   "fluree:memory://8a031273bf6fdbecf13c229abb6c23d346a0f8af3344e8bb9f0a1fce1db723bc"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/data
+                   "fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/alias
+                   "query/everything"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/branch
+                   "main"]
+                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
+                   :f/context
+                   "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"]]
+                @(fluree/query db* {:select ['?s '?p '?o]
+                                    :where  [['?s '?p '?o]]}))))))))


### PR DESCRIPTION
There's probably a better way to structure these tests, but for now I'm just copy-pasting the new values.

I _think_ this changed due to this [recent bug fix](https://github.com/fluree/db/commit/d7bb508e7a322bfda5084365aa13d19908d55c0c) but I'm not positive.

Sorry about the whitespace changes. [Here's the "ignore whitespace" view of this PR](https://github.com/fluree/db/pull/392/files?diff=unified&w=1).