### PR TITLE
Feature: bind queries

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -2,7 +2,7 @@
   "Primary API ns for any user-invoked actions. Wrapped by language & use specific APIS
   that are directly exposed"
   (:require [clojure.string :as str]
-            [clojure.core.async :as async]
+            [clojure.core.async :as async :refer [go <!]]
             [fluree.db.time-travel :as time-travel]
             [fluree.db.query.fql :as fql]
             [fluree.db.query.fql.parse :as fql-parse]
@@ -68,10 +68,10 @@
 
             (if commit-details
               ;; annotate with commit details
-             (async/alt!
-                (async/into [] (history/add-commit-details db parsed-context error-ch history-results-chan))
-                ([result] result)
-                error-ch ([e] e))
+              (async/alt!
+                 (async/into [] (history/add-commit-details db parsed-context error-ch history-results-chan))
+                 ([result] result)
+                 error-ch ([e] e))
 
               ;; we're already done
               (async/alt!
@@ -88,7 +88,7 @@
 (defn query
   "Execute a query against a database source, or optionally
   additional sources if the query spans multiple data sets.
-  Returns core async channel containing result."
+  Returns core async channel containing result or exception."
   [sources query]
   (go-try
     (let [{query :subject, issuer :issuer}

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -264,8 +264,7 @@
 
 (defn query
   [db query]
-  (let [res-chan (query-api/query db query)]
-    (promise-wrap res-chan)))
+  (promise-wrap (query-api/query db query)))
 
 (defn multi-query
   [db multi-query]

--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -55,16 +55,17 @@
   exception if there was an error."
   [db q]
   (go
-   (let [error-ch  (async/chan)
-         result-ch (->> (where/search db q error-ch)
-                        (group/combine q)
-                        (having/filter q error-ch)
-                        (order/arrange q)
-                        (select/format db q error-ch)
-                        (remove-duplicates q)
-                        (drop-offset q)
-                        (take-limit q)
-                        (collect-results q))]
-     (async/alt!
-       error-ch  ([e] e)
-       result-ch ([result] result)))))
+    (let [error-ch  (async/chan)
+          result-ch (->> (where/search db q error-ch)
+                         #_(log/debug-async->>vals "where/search results:")
+                         (group/combine q)
+                         (having/filter q error-ch)
+                         (order/arrange q)
+                         (select/format db q error-ch)
+                         (remove-duplicates q)
+                         (drop-offset q)
+                         (take-limit q)
+                         (collect-results q))]
+      (async/alt!
+        error-ch  ([e] e)
+        result-ch ([result] result)))))

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -69,7 +69,7 @@
        (take n)
        vec))
 
-(def allowed-aggregates
+(def allowed-aggregate-fns
   '#{abs as avg ceil count count-distinct distinct floor groupconcat
      median max min rand sample stddev str sum variance})
 
@@ -120,12 +120,12 @@
   [s start end]
   (subs s start end))
 
-(def allowed-fns
+(def allowed-scalar-fns
   '#{&& || ! > < >= <= = + - * / quot and bound coalesce if nil?
      not not= now or re-find re-pattern strStarts strEnds subStr})
 
 (def allowed-symbols
-  (set/union allowed-aggregates allowed-fns))
+  (set/union allowed-aggregate-fns allowed-scalar-fns))
 
 (defn variable?
   [sym]

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -70,7 +70,7 @@
        vec))
 
 (def allowed-aggregate-fns
-  '#{as avg ceil count count-distinct distinct floor groupconcat
+  '#{avg ceil count count-distinct distinct floor groupconcat
      median max min rand sample stddev str sum variance})
 
 (defmacro coalesce

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -70,7 +70,7 @@
        vec))
 
 (def allowed-aggregate-fns
-  '#{abs as avg ceil count count-distinct distinct floor groupconcat
+  '#{as avg ceil count count-distinct distinct floor groupconcat
      median max min rand sample stddev str sum variance})
 
 (defmacro coalesce
@@ -121,7 +121,7 @@
   (subs s start end))
 
 (def allowed-scalar-fns
-  '#{&& || ! > < >= <= = + - * / quot and bound coalesce if nil?
+  '#{abs && || ! > < >= <= = + - * / quot and bound coalesce if nil?
      not not= now or re-find re-pattern strStarts strEnds subStr})
 
 (def allowed-symbols

--- a/src/fluree/db/query/exec/select.cljc
+++ b/src/fluree/db/query/exec/select.cljc
@@ -125,6 +125,7 @@
     (async/pipeline-async 1
                           format-ch
                           (fn [solution ch]
+                            (log/debug "select/format solution:" solution)
                             (-> (format-values selectors db iri-cache compact error-ch solution)
                                 (async/pipe ch)))
                           solution-ch)

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -128,9 +128,8 @@
   ([patterns]
    {::patterns patterns})
   ([patterns filters]
-   (-> patterns
-       ->where-clause
-       (assoc ::filters filters))))
+   (cond-> (->where-clause patterns)
+           (seq filters) (assoc ::filters filters))))
 
 (defn pattern-type
   [pattern]

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -346,8 +346,8 @@
 
 (defn add-fn-result-to-solution
   [solution var-name result]
-  (-> solution
-      (assoc var-name {::var var-name ::val result})))
+  (let [dt (datatype/infer result)]
+    (assoc solution var-name {::var var-name ::val result ::datatype dt})))
 
 (defmethod match-pattern :bind
   [_db solution pattern _ error-ch]

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -15,20 +15,20 @@
 (defn idx-for
   [s p o]
   (cond
-    s         :spot
+    s :spot
     (and p o) :post
-    p         :psot
-    o         :opst
-    :else     :spot))
+    p :psot
+    o :opst
+    :else :spot))
 
 (defn resolve-flake-range
   [{:keys [conn t] :as db} error-ch components]
-  (let [out-ch               (async/chan)
-        [s-cmp p-cmp o-cmp]  components
+  (let [out-ch (async/chan)
+        [s-cmp p-cmp o-cmp] components
         {s ::val, s-fn ::fn} s-cmp
         {p ::val, p-fn ::fn} p-cmp
-        {o ::val, o-fn ::fn
-         o-dt ::datatype}    o-cmp]
+        {o    ::val, o-fn ::fn
+         o-dt ::datatype} o-cmp]
     (go
       (try* (let [s*          (if (and s (not (number? s)))
                                 (<? (dbproto/-subid db s true))
@@ -45,17 +45,17 @@
                                        :start-flake start-flake
                                        :end-test    <=
                                        :end-flake   end-flake}
-                                s-fn (assoc :subject-fn s-fn)
-                                p-fn (assoc :predicate-fn p-fn)
-                                o-fn (assoc :object-fn o-fn))]
+                                      s-fn (assoc :subject-fn s-fn)
+                                      p-fn (assoc :predicate-fn p-fn)
+                                      o-fn (assoc :object-fn o-fn))]
               (-> (query-range/resolve-flake-slices conn idx-root novelty
                                                     error-ch opts)
                   (->> (query-range/filter-authorized db start-flake end-flake
                                                       error-ch))
                   (async/pipe out-ch)))
             (catch* e
-                    (log/error e "Error resolving flake range")
-                    (>! error-ch e))))
+              (log/error e "Error resolving flake range")
+              (>! error-ch e))))
     out-ch))
 
 (defn unmatched
@@ -66,8 +66,8 @@
 (defn match-value
   ([m x dt]
    (assoc m
-          ::val      x
-          ::datatype dt)))
+     ::val x
+     ::datatype dt)))
 
 (defn anonymous-value
   "Build a pattern that already matches an explicit value."
@@ -90,7 +90,7 @@
 (defn ->pattern
   "Build a new non-tuple match pattern of type `typ`."
   [typ data]
-  #?(:clj (MapEntry/create typ data)
+  #?(:clj  (MapEntry/create typ data)
      :cljs (MapEntry. typ data nil)))
 
 (defn ->ident
@@ -99,8 +99,8 @@
   {::ident x})
 
 (defn ->function
-  "Build a filter function specification for the variable `var` out of the
-  boolean function `f`."
+  "Build a query function specification for the variable `var` out of the
+  parsed function `f`."
   [var f]
   (-> var
       unmatched
@@ -140,9 +140,9 @@
 
 (defmulti match-pattern
   "Return a channel that will contain all pattern match solutions from flakes in
-  `db` that are compatible with the initial solution `solution` and matches the
-  additional where-clause pattern `pattern`."
-  (fn [db solution pattern filters error-ch]
+   `db` that are compatible with the initial solution `solution` and matches the
+   additional where-clause pattern `pattern`."
+  (fn [_db _solution pattern _filters _error-ch]
     (pattern-type pattern)))
 
 (defn assign-matched-values
@@ -154,9 +154,12 @@
   to the value associated with that variable from the `filter` specification
   map."
   [triple-pattern solution filters]
+  (log/debug "assign-matched-values triple-pattern:" triple-pattern)
+  (log/debug "assign-matched-values solution:" solution)
   (mapv (fn [component]
           (if-let [variable (::var component)]
             (let [match (get solution variable)]
+              (log/debug "assign-matched-values variable:" variable)
               (if-let [value (::val match)]
                 (let [dt (::datatype match)]
                   (match-value component value dt))
@@ -165,6 +168,7 @@
                                          (map (fn [f]
                                                 (partial f solution)))
                                          (apply every-pred))]
+                  (log/debug "assign-matched-values filter-fn:" filter-fn)
                   (assoc component ::fn filter-fn))))
             component))
         triple-pattern))
@@ -195,13 +199,14 @@
   [solution triple-pattern flake]
   (let [[s p o] triple-pattern]
     (cond-> solution
-      (unmatched? s) (assoc (::var s) (match-subject s flake))
-      (unmatched? p) (assoc (::var p) (match-predicate p flake))
-      (unmatched? o) (assoc (::var o) (match-object o flake)))))
+            (unmatched? s) (assoc (::var s) (match-subject s flake))
+            (unmatched? p) (assoc (::var p) (match-predicate p flake))
+            (unmatched? o) (assoc (::var o) (match-object o flake)))))
 
 (defmethod match-pattern :tuple
   [db solution pattern filters error-ch]
   (let [cur-vals (assign-matched-values pattern solution filters)
+        _        (log/debug "assign-matched-values returned:" cur-vals)
         flake-ch (resolve-flake-range db error-ch cur-vals)
         match-ch (async/chan 2 (comp cat
                                      (map (fn [flake]
@@ -212,6 +217,7 @@
   [db solution pattern filters error-ch]
   (let [triple   (val pattern)
         cur-vals (assign-matched-values triple solution filters)
+        _        (log/debug "assign-matched-values returned:" cur-vals)
         flake-ch (resolve-flake-range db error-ch cur-vals)
         match-ch (async/chan 2 (comp cat
                                      (map (fn [flake]
@@ -245,7 +251,8 @@
 (defmethod match-pattern :class
   [db solution pattern filters error-ch]
   (let [triple   (val pattern)
-        [s p o]  (assign-matched-values triple solution filters)
+        [s p o] (assign-matched-values triple solution filters)
+        _        (log/debug "assign-matched-values returned:" s p o)
         cls      (::val o)
         classes  (into [cls] (dbproto/-class-prop db :subclasses cls))
         class-ch (async/to-chan! classes)
@@ -257,6 +264,7 @@
                           match-ch
                           (fn [cls ch]
                             (-> (resolve-flake-range db error-ch [s p (assoc o ::val cls)])
+                                (log/debug->val "match-pattern :class pipeline fn flake range:")
                                 (async/pipe ch)))
                           class-ch)
     match-ch))
@@ -283,6 +291,7 @@
         filters    (::filters clause)
         patterns   (::patterns clause)]
     (reduce (fn [solution-ch pattern]
+              (log/debug "calling with-constraint w/ pattern:" pattern)
               (with-constraint db pattern filters error-ch solution-ch))
             initial-ch patterns)))
 
@@ -323,8 +332,8 @@
          (if @solutions?
            (rf result)
            (do (vreset! solutions? true) ; mark that a solution was processed in
-                                         ; case the reducing fn is terminated
-                                         ; again as can happen with buffers.
+               ; case the reducing fn is terminated
+               ; again as can happen with buffers.
                (-> result
                    (rf default-solution)
                    rf))))))))
@@ -335,6 +344,36 @@
         opt-ch (async/chan 2 (with-default solution))]
     (-> (match-clause db solution clause error-ch)
         (async/pipe opt-ch))))
+
+(defn add-fn-result-to-solution
+  [solution var-name result]
+  (-> solution
+      (assoc var-name {::var var-name ::val result})))
+
+(defmethod match-pattern :bind
+  [_db solution pattern _ error-ch]
+  (let [bind     (val pattern)
+        out-ch   (async/chan 2)
+        binds-ch (async/to-chan! (vals bind))]
+    (log/debug "match-pattern :bind bind:" bind)
+    (log/debug "match-pattern :bind solution:" solution)
+    (async/pipeline-async
+      2
+      out-ch
+      (fn [bind ch]
+        (log/debug "pipeline fn bind:" bind)
+        (let [f        (::fn bind)
+              var-name (::var bind)]
+          (go
+            (try*
+              (->> (f solution)
+                   (log/debug->>val "pipeline fn result:")
+                   (add-fn-result-to-solution solution var-name)
+                   (>! ch))
+              (catch* e (>! error-ch e))
+              (finally (async/close! ch))))))
+      binds-ch)
+    out-ch))
 
 (def blank-solution {})
 
@@ -349,7 +388,9 @@
     (async/pipeline-async 2
                           out-ch
                           (fn [initial-solution ch]
+                            (log/debug "search calling match-clause w/ where-clause:" where-clause)
                             (-> (match-clause db initial-solution where-clause error-ch)
+                                #_(log/debug-async->vals "match-clause results:")
                                 (async/pipe ch)))
                           (async/to-chan! initial-solutions))
     out-ch))

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -331,8 +331,8 @@
          (if @solutions?
            (rf result)
            (do (vreset! solutions? true) ; mark that a solution was processed in
-               ; case the reducing fn is terminated
-               ; again as can happen with buffers.
+                                         ; case the reducing fn is terminated
+                                         ; again as can happen with buffers.
                (-> result
                    (rf default-solution)
                    rf))))))))

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -24,8 +24,8 @@
                                    (:contextType opts)))
                   :context-str
                   :context)
-        db-ctx (get-in db [:schema ctx-key])
-        q-ctx  (or (:context q) (get q "@context"))]
+        db-ctx  (get-in db [:schema ctx-key])
+        q-ctx   (or (:context q) (get q "@context"))]
     (json-ld/parse-context db-ctx q-ctx)))
 
 (defn parse-var-name
@@ -51,9 +51,9 @@
   [q]
   (when-let [values (:values q)]
     (let [[vars vals] values
-          vars*       (util/sequential vars)
-          vals*       (mapv util/sequential vals)
-          var-count   (count vars*)]
+          vars*     (util/sequential vars)
+          vals*     (mapv util/sequential vals)
+          var-count (count vars*)]
       (if (every? (fn [bdg]
                     (= (count bdg) var-count))
                   vals*)
@@ -88,9 +88,9 @@
                         {:status 400 :error :db/invalid-query})))
       code)
     (catch* e
-            (log/warn e "Invalid query function attempted: " code-str)
-            (throw (ex-info (str "Invalid query function: " code-str)
-                            {:status 400 :error :db/invalid-query})))))
+      (log/warn e "Invalid query function attempted: " code-str)
+      (throw (ex-info (str "Invalid query function: " code-str)
+                      {:status 400 :error :db/invalid-query})))))
 
 (defn variables
   "Returns the set of items within the arbitrary data structure `data` that
@@ -129,12 +129,13 @@
 
 (defn parse-code
   [x]
+  (log/debug "parse-code:" x)
   (if (list? x)
     x
     (safe-read x)))
 
 (defn parse-filter-function
-  "Evals, and returns query function."
+  "Evals and returns filter function."
   [fltr vars]
   (let [code      (parse-code fltr)
         code-vars (or (not-empty (variables code))
@@ -142,6 +143,15 @@
                                       {:status 400 :error :db/invalid-query})))
         var-name  (find-filtered-var code-vars vars)
         f         (eval/compile-filter code var-name)]
+    (where/->function var-name f)))
+
+(defn parse-bind-function
+  "Evals and returns bind function."
+  [var-name fn-code]
+  (let [code (parse-code fn-code)
+        _    (log/debug "parse-bind-function code:" code)
+        f    (eval/compile code)]
+    (log/debug "parse-bind-function f:" f)
     (where/->function var-name f)))
 
 (def ^:const default-recursion-depth 100)
@@ -266,14 +276,19 @@
 
 (defmulti parse-pattern
   (fn [pattern _vars _db _context]
-    (if (map? pattern)
-      (->> pattern keys first)
-      :triple)))
+    (log/debug "parse-pattern pattern:" pattern)
+    (cond
+      (map? pattern) (->> pattern keys first)
+      (map-entry? pattern) :binding
+      :else :triple)))
 
-(defn filter-pattern?
-  [x]
+(defn type-pattern?
+  [typ x]
   (and (map? x)
-       (-> x keys first (= :filter))))
+       (-> x keys first (= typ))))
+
+(def filter-pattern?
+  (partial type-pattern? :filter))
 
 (defn parse-filter-maps
   [vars filters]
@@ -291,15 +306,22 @@
                                               (conj fltr))))))
                  {}))))
 
+(defn parse-bind-map
+  [bind]
+  (reduce (fn [m k] (update m k #(parse-bind-function k %)))
+          bind (keys bind)))
+
 (defn parse-where-clause
   [clause vars db context]
   (let [patterns (->> clause
                       (remove filter-pattern?)
+                      (log/debug->>val "patterns to parse:")
                       (mapv (fn [pattern]
                               (parse-pattern pattern vars db context))))
         filters  (->> clause
                       (filter filter-pattern?)
                       (parse-filter-maps vars))]
+    (log/debug "parse-where-clause patterns:" patterns)
     (where/->where-clause patterns filters)))
 
 (defn parse-triple
@@ -319,6 +341,7 @@
 
 (defmethod parse-pattern :triple
   [triple _ db context]
+  (log/debug "parse-triple:" triple)
   (parse-triple triple db context))
 
 (defmethod parse-pattern :union
@@ -336,6 +359,19 @@
         parsed (parse-where-clause clause vars db context)]
     (where/->pattern :optional parsed)))
 
+(defmethod parse-pattern :bind
+  [{:keys [bind]} _vars _db _context]
+  (let [parsed (parse-bind-map bind)
+        _ (log/debug "parsed bind map:" parsed)
+        pattern (where/->pattern :bind parsed)]
+    (log/debug "parse-pattern :bind pattern:" pattern)
+    pattern))
+
+(defmethod parse-pattern :binding
+  [[v f] _vars _db _context]
+  (log/debug "parse-pattern binding v:" v "- f:" f)
+  (where/->pattern :binding [v f]))
+
 (defn parse-where
   [q vars db context]
   (when-let [where (:where q)]
@@ -346,9 +382,9 @@
   (cond
     (syntax/variable? s) (-> s parse-var-name select/variable-selector)
     (syntax/query-fn? s) (-> s parse-code eval/compile select/aggregate-selector)
-    (select-map? s)      (let [{:keys [variable selection depth spec]}
-                               (parse-subselection db context s depth)]
-                           (select/subgraph-selector variable selection depth spec))))
+    (select-map? s) (let [{:keys [variable selection depth spec]}
+                          (parse-subselection db context s depth)]
+                      (select/subgraph-selector variable selection depth spec))))
 
 (defn parse-select-clause
   [clause db context depth]
@@ -364,21 +400,21 @@
                            (when (contains? q k) k))
                          [:select :selectOne :select-one
                           :selectDistinct :select-distinct])
-        select (-> q
-                   (get select-key)
-                   (parse-select-clause db context depth))]
+        select     (-> q
+                       (get select-key)
+                       (parse-select-clause db context depth))]
     (case select-key
       (:select
        :select-one
        :select-distinct) (assoc q select-key select)
 
-      :selectOne         (-> q
-                             (dissoc :selectOne)
-                             (assoc :select-one select))
+      :selectOne (-> q
+                     (dissoc :selectOne)
+                     (assoc :select-one select))
 
-      :selectDistinct    (-> q
-                             (dissoc :selectDistinct)
-                             (assoc :select-distinct select)))))
+      :selectDistinct (-> q
+                          (dissoc :selectDistinct)
+                          (assoc :select-distinct select)))))
 
 (defn ensure-vector
   [x]
@@ -402,7 +438,7 @@
                    (if-let [v (parse-var-name ord)]
                      [v :asc]
                      (let [[dir dim] ord
-                           v         (parse-var-name dim)]
+                           v (parse-var-name dim)]
                        (if (syntax/asc? dir)
                          [v :asc]
                          [v :desc])))))))
@@ -415,17 +451,18 @@
 
 (defn parse-analytical-query*
   [q db]
-  (let [context       (parse-context q db)
+  (let [context  (parse-context q db)
         [vars values] (parse-values q)
-        where         (parse-where q vars db context)
-        grouping      (parse-grouping q)
-        ordering      (parse-ordering q)]
+        _        (log/debug "parse-analytical-query*:" q)
+        where    (parse-where q vars db context)
+        grouping (parse-grouping q)
+        ordering (parse-ordering q)]
     (-> q
         (assoc :context context
-               :where   where)
+               :where where)
         (cond-> (seq values) (assoc :values values)
-                grouping     (assoc :group-by grouping)
-                ordering     (assoc :order-by ordering))
+                grouping (assoc :group-by grouping)
+                ordering (assoc :order-by ordering))
         parse-having
         (parse-select db context))))
 
@@ -443,11 +480,11 @@
 (defn parse-delete
   [q db]
   (when (:delete q)
-    (let [context       (parse-context q db)
+    (let [context (parse-context q db)
           [vars values] (parse-values q)
-          where         (parse-where q vars db context)]
+          where   (parse-where q vars db context)]
       (-> q
           (assoc :context context
-                 :where   where)
+                 :where where)
           (cond-> (seq values) (assoc :values values))
           (update :delete parse-triple db context)))))

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -150,7 +150,7 @@
   [var-name fn-code]
   (let [code (parse-code fn-code)
         _    (log/debug "parse-bind-function code:" code)
-        f    (eval/compile code)]
+        f    (eval/compile code false)]
     (log/debug "parse-bind-function f:" f)
     (where/->function var-name f)))
 

--- a/src/fluree/db/util/async.cljc
+++ b/src/fluree/db/util/async.cljc
@@ -1,8 +1,10 @@
 (ns fluree.db.util.async
   (:require
-   [fluree.db.util.core #?(:clj :refer :cljs :refer-macros) [try* catch*]]
-   [clojure.core.async :refer [go <!] :as async]
-   [clojure.core.async.impl.protocols :as async-protocols])
+    [fluree.db.util.core :as util]
+    [fluree.db.util.log :as log]
+    [fluree.db.util.core #?(:clj :refer :cljs :refer-macros) [try* catch*]]
+    [clojure.core.async :refer [go <!] :as async]
+    [clojure.core.async.impl.protocols :as async-protocols])
   #?(:cljs (:require-macros [fluree.db.util.async :refer [<? go-try]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -23,7 +25,8 @@
      (if (cljs-env? &env) then else)))
 
 (defn throw-err [e]
-  (when (instance? #?(:clj Throwable :cljs js/Error) e) (throw e))
+  (when (util/exception? e)
+    (throw e))
   e)
 
 #?(:clj

--- a/src/fluree/db/util/core.cljc
+++ b/src/fluree/db/util/core.cljc
@@ -49,10 +49,12 @@
 
 #?(:clj
    (defmacro try*
-     "Like try but supports catch*. catch* is like catch but supports CLJ/CLJS with
-  less boilerplate. In CLJ it catches `Exception`. In CLJS it catches `:default`.
-  Use it like this: `(try* ... (catch* err (handle-err err)))`.
-  Also supports an optional finally clause."
+     "Like try but supports catch*. catch* is like catch but supports CLJ/CLJS
+     with less boilerplate. In CLJ it catches `Exception`. In CLJS it catches
+     `:default`.
+
+     Use it like this: `(try* ... (catch* err (handle-err err)))`.
+     Also supports an optional finally clause."
      [& body]
      `(if-cljs
         (cljs-exceptions/try* ~@body)
@@ -269,7 +271,7 @@
 
 
 (defn exception?
-  "x-platform, returns true if is an execption"
+  "x-platform, returns true if is an exception"
   [x]
   (instance? #?(:clj Throwable :cljs js/Error) x))
 
@@ -325,17 +327,17 @@
 #?(:clj
    (defmacro condps
      "Takes an expression and a set of clauses.
-  Each clause can take the form of either:
+     Each clause can take the form of either:
 
-  unary-predicate-fn? result-expr
-  (unary-predicate-fn?-1 ... unary-predicate-fn?-N) result-expr
+     unary-predicate-fn? result-expr
+     (unary-predicate-fn?-1 ... unary-predicate-fn?-N) result-expr
 
-  For each clause, (unary-predicate-fn? expr) is evalated (for each
-  unary-predicate-fn? in the clause when >1 is given). If it returns logical
-  true, the clause is a match.
+     For each clause, (unary-predicate-fn? expr) is evalated (for each
+     unary-predicate-fn? in the clause when >1 is given). If it returns logical
+     true, the clause is a match.
 
-  Similar to condp but takes unary predicates instead of binary and allows
-  multiple predicates to be supplied in a list similar to case."
+     Similar to condp but takes unary predicates instead of binary and allows
+     multiple predicates to be supplied in a list similar to case."
      [expr & clauses]
      (let [gexpr (gensym "expr__")
            emit  (fn emit [expr args]

--- a/src/fluree/db/util/log.cljc
+++ b/src/fluree/db/util/log.cljc
@@ -103,16 +103,18 @@
      "Logs a ->> threaded value w/ msg (at debug level) and then returns the
      value so it can continue being threaded."
      [msg v]
-     `(log/debug ~msg ~v)
-     v))
+     `(do
+        (debug ~msg ~v)
+        ~v)))
 
 #?(:clj
    (defmacro debug->val
      "Logs a -> threaded value w/ msg (at debug level) and then returns the
      value so it can continue being threaded."
      [v msg]
-     `(log/debug ~msg ~v)
-     v))
+     `(do
+        (debug ~msg ~v)
+        ~v)))
 
 #?(:clj
    (defmacro debug-async->vals

--- a/src/fluree/db/util/log.cljc
+++ b/src/fluree/db/util/log.cljc
@@ -1,8 +1,12 @@
 (ns fluree.db.util.log
-  (:require #?@(:clj  [[clojure.tools.logging.readable :as log] ; readable variants use pr-str automatically
+  (:require #?@(:clj  [[clojure.core.async :as async]
+                       [clojure.tools.logging.readable :as log] ; readable variants use pr-str automatically
                        [fluree.db.util.core :refer [if-cljs]]]
                 :cljs [[goog.log :as glog]
-                       [fluree.db.util.core :refer-macros [if-cljs]]]))
+                       [fluree.db.util.core :refer-macros [if-cljs]]
+                       [fluree.db.util.log :refer-macros
+                        [debug->val debug->>val debug-async->>vals
+                         debug-async->vals]]]))
   #?(:cljs (:import [goog.debug Console]
                     [goog.log Level])))
 
@@ -93,3 +97,40 @@
 
 #?(:cljs
    (log-to-console!))
+
+#?(:clj
+   (defmacro debug->>val
+     "Logs a ->> threaded value w/ msg (at debug level) and then returns the
+     value so it can continue being threaded."
+     [msg v]
+     `(log/debug ~msg ~v)
+     v))
+
+#?(:clj
+   (defmacro debug->val
+     "Logs a -> threaded value w/ msg (at debug level) and then returns the
+     value so it can continue being threaded."
+     [v msg]
+     `(log/debug ~msg ~v)
+     v))
+
+#?(:clj
+   (defmacro debug-async->vals
+     "Logs value(s) taken from chan c w/ msg (at debug level) and then returns a
+     new channel with the values on it so further async thread ops can consume
+     them."
+     [c msg]
+     `(let [out-ch# (async/chan 100)]
+        (async/pipeline-blocking 1 out-ch#
+                                 (map (fn [v#] (debug->val v# ~msg))) ~c)
+        out-ch#)))
+
+#?(:clj
+   (defmacro debug-async->>vals
+     "Logs value(s) taken from chan c w/ msg (at debug level) and then returns a
+     new channel with the values on it so further async thread ops can consume
+     them."
+     [msg c]
+     `(debug-async->vals ~c ~msg)))
+
+

--- a/src/fluree/db/util/log.cljc
+++ b/src/fluree/db/util/log.cljc
@@ -3,10 +3,10 @@
                        [clojure.tools.logging.readable :as log] ; readable variants use pr-str automatically
                        [fluree.db.util.core :refer [if-cljs]]]
                 :cljs [[goog.log :as glog]
-                       [fluree.db.util.core :refer-macros [if-cljs]]
-                       [fluree.db.util.log :refer-macros
-                        [debug->val debug->>val debug-async->>vals
-                         debug-async->vals]]]))
+                       [fluree.db.util.core :refer-macros [if-cljs]]]))
+  #?(:cljs (:require-macros [fluree.db.util.log :refer
+                             [debug->val debug->>val debug-async->vals
+                              debug-async->>vals]]))
   #?(:cljs (:import [goog.debug Console]
                     [goog.log Level])))
 

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -16,7 +16,7 @@
                                  [?s :ex/favNums ?favNums]]
                        :group-by ?name}
               subject @(fluree/query db qry)]
-          (is (= [["Cam" 2] ["Alice" 3] ["Brian" 1]]
+          (is (= [["Liam" 2] ["Cam" 2] ["Alice" 3] ["Brian" 1]]
                  subject)
               "aggregates bindings within each group")))
       (testing "with implicit grouping"
@@ -24,5 +24,5 @@
                     :select  [(count ?name)]
                     :where   [[?s :schema/name ?name]]}
               subject @(fluree/query db qry)]
-          (is (= [[3]] subject)
+          (is (= [[4]] subject)
               "aggregates bindings for all results"))))))

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -137,8 +137,7 @@
                     [[{::where/var '?s}
                       {::where/val      1006
                        ::where/datatype 8}
-                      {::where/var '?favColor}]]
-                    ::where/filters {}}]]
+                      {::where/var '?favColor}]]}]]
                  patterns))))
       (testing "class, union"
         (let [union-q {:select ['?s '?email1 '?email2]
@@ -160,14 +159,12 @@
                      [[{::where/var '?s}
                        {::where/val      1007
                         ::where/datatype 8}
-                       {::where/var '?email1}]]
-                     ::where/filters {}}
+                       {::where/var '?email1}]]}
                     {::where/patterns
                      [[{::where/var '?s}
                        {::where/val      1003
                         ::where/datatype 8}
-                       {::where/var '?email2}]]
-                     ::where/filters {}}]]]
+                       {::where/var '?email2}]]}]]]
                  patterns))))
       (testing "class, filters"
         (let [filter-q {:select ['?name '?age]

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -1,7 +1,7 @@
 (ns fluree.db.test-utils
   (:require [fluree.db.did :as did]
             [fluree.db.json-ld.api :as fluree]
-            [fluree.db.util.core :refer [try* catch*]]
+            [fluree.db.util.core :as util :refer [try* catch*]]
             #?@(:cljs [[clojure.core.async :refer [go go-loop]]
                        [clojure.core.async.interop :refer [<p!]]])))
 
@@ -116,18 +116,17 @@
   do it for you. In CLJS it will not retry and will return a core.async chan."
   [pwrapped max-attempts & [retry-on-false?]]
   (#?(:clj loop :cljs go-loop) [attempt 0]
-    (let [error? #(instance? #?(:clj Throwable :cljs js/Error) %)
-          res' (try*
+    (let [res' (try*
                  (let [res (#?(:clj deref :cljs <p!) (pwrapped))]
-                   (if (error? res)
+                   (if (util/exception? res)
                      (throw res)
                      res))
                  (catch* e e))]
       (if (= (inc attempt) max-attempts)
-        (if (error? res')
+        (if (util/exception? res')
           (throw res')
           res')
-        (if (or (error? res')
+        (if (or (util/exception? res')
                 (and retry-on-false? (false? res')))
           (do
             #?(:clj (Thread/sleep 100))

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -74,7 +74,15 @@
     :schema/email "cam@example.org"
     :schema/age   34
     :ex/favNums   [5, 10]
-    :ex/friend    [:ex/brian :ex/alice]}])
+    :ex/friend    [:ex/brian :ex/alice]}
+   {:context      {:ex "http://example.org/ns/"}
+    :id           :ex/liam
+    :type         :ex/User
+    :schema/name  "Liam"
+    :schema/email "liam@example.org"
+    :schema/age   13
+    :ex/favNums   [42, 11]
+    :ex/friend    [:ex/brian :ex/alice :ex/cam]}])
 
 (defn create-conn
   ([]


### PR DESCRIPTION
Closes #314 

Adds support for bind maps (only; it does implement the old bind tuple format) that only work on individual results, not aggregates across all results (to better align with the SPARQL spec).

Also adds a couple of useful query fns: `quot` and `subStr` for integer division and indexed substring support, respectively.

I left in a couple of commented-out usages of `log/debug-async->vals` and `log/debug-async->>vals` to demonstrate how they're used. But there are probably runtime perf considerations with how those work even if you're log level is higher than `DEBUG`, hence the commenting-out.