### PR TITLE
Feature: allow keywords too in multi-queries

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -1,25 +1,15 @@
 (ns fluree.db.api.query
   "Primary API ns for any user-invoked actions. Wrapped by language & use specific APIS
   that are directly exposed"
-  (:require [clojure.string :as str]
-            [clojure.core.async :as async :refer [go <!]]
+  (:require [clojure.core.async :as async]
             [fluree.db.time-travel :as time-travel]
             [fluree.db.query.fql :as fql]
             [fluree.db.query.fql.parse :as fql-parse]
             [fluree.db.query.history :as history]
             [fluree.db.query.range :as query-range]
-            [fluree.db.dbproto :as dbproto]
-            [fluree.db.flake :as flake]
-            [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
+            [fluree.db.util.core :as util]
             [fluree.db.util.async :as async-util :refer [<? go-try]]
-            [fluree.db.json-ld.credential :as cred]
-            [fluree.db.query.json-ld.response :as json-ld-resp]
-            [fluree.json-ld :as json-ld]
-            [fluree.db.db.json-ld :as jld-db]
-            [malli.core :as m]
-            [fluree.db.util.log :as log]
-            [fluree.db.constants :as const]
-            [fluree.db.datatype :as datatype]))
+            [fluree.db.json-ld.credential :as cred]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -198,7 +198,7 @@
                              [:opts {:optional true} ::opts]
                              [:prettyPrint {:optional true} ::prettyPrint]
                              [:pretty-print {:optional true} ::pretty-print]]
-     ::multi-query          [:map-of :string ::analytical-query]
+     ::multi-query          [:map-of [:or :string :keyword] ::analytical-query]
      ::query                [:orn
                              [:single ::analytical-query]
                              [:multi ::multi-query]]}))

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -53,155 +53,155 @@
     (m/type-schemas)
     (m/sequence-schemas)
     (m/base-schemas)
-    {::limit pos-int?
-     ::offset nat-int?
-     ::maxFuel number?
-     ::max-fuel ::maxFuel
-     ::depth nat-int?
-     ::prettyPrint boolean?
-     ::pretty-print ::prettyPrint
-     ::parseJSON boolean?
-     ::parse-json ::parseJSON
-     ::contextType [:enum :string :keyword]
-     ::context-type ::contextType
-     ::opts [:map
-             [:maxFuel {:optional true} ::maxFuel]
-             [:max-fuel {:optional true} ::maxFuel]
-             [:parseJSON {:optional true} ::parseJSON]
-             [:parse-json {:optional true} ::parse-json]
-             [:prettyPrint {:optional true} ::prettyPrint]
-             [:pretty-print {:optional true} ::pretty-print]
-             [:contextType {:optional true} ::contextType]
-             [:context-type {:optional true} ::contextType]]
-     ::function [:orn
-                 [:string [:fn fn-string?]]
-                 [:list [:fn fn-list?]]]
-     ::wildcard [:fn wildcard?]
-     ::var [:fn variable?]
-     ::val [:fn value?]
-     ::iri [:orn
-            [:keyword keyword?]
-            [:string string?]]
-     ::subject [:orn
-                [:sid [:fn sid?]]
-                [:iri ::iri]
-                [:ident [:fn pred-ident?]]]
-     ::subselect-map [:map-of ::iri [:ref ::subselection]]
-     ::subselection [:sequential [:orn
-                                  [:wildcard ::wildcard]
-                                  [:predicate ::iri]
-                                  [:subselect-map [:ref ::subselect-map]]]]
-     ::select-map [:map-of {:max 1}
-                   ::var ::subselection]
-     ::selector [:orn
-                 [:var ::var]
-                 [:pred ::iri]
-                 [:aggregate ::function]
-                 [:select-map ::select-map]]
-     ::select [:orn
-               [:selector ::selector]
-               [:collection [:sequential ::selector]]]
-     ::selectOne ::select
-     ::select-one ::selectOne
-     ::select-distinct ::select
-     ::selectDistinct ::select-distinct
-     ::direction [:orn
-                  [:asc [:fn asc?]]
-                  [:desc [:fn desc?]]]
-     ::ordering [:orn
-                 [:scalar ::var]
-                 [:vector [:catn
-                           [:direction ::direction]
-                           [:dimension ::var]]]]
-     ::orderBy [:orn
-                [:clause ::ordering]
-                [:collection [:sequential ::ordering]]]
-     ::order-by ::orderBy
-     ::groupBy [:orn
-                [:clause ::var]
-                [:collection [:sequential ::var]]]
-     ::group-by ::groupBy
-     ::where-op [:enum :filter :optional :union :bind]
-     ::where-map [:and
-                  [:map-of {:max 1} ::where-op :any]
-                  [:multi {:dispatch where-op}
-                   [:filter [:map [:filter [:ref ::filter]]]]
-                   [:optional [:map [:optional [:ref ::optional]]]]
-                   [:union [:map [:union [:ref ::union]]]]
-                   [:bind [:map [:bind [:ref ::bind]]]]]]
-     ::triple [:catn
-               [:subject [:orn
-                          [:var ::var]
-                          [:val ::subject]]]
-               [:predicate [:orn
-                            [:var ::var]
-                            [:iri ::iri]]]
-               [:object [:orn
-                         [:var ::var]
-                         [:ident [:fn pred-ident?]]
-                         [:val :any]]]]
-     ::where-tuple [:orn
-                    [:triple ::triple]
-                    [:binding [:sequential {:max 2} :any]]
-                    [:remote [:sequential {:max 4} :any]]]
-     ::where-pattern [:orn
-                      [:where-map ::where-map]
-                      [:tuple ::where-tuple]]
-     ::optional [:orn
-                 [:single ::where-pattern]
-                 [:collection [:sequential ::where-pattern]]]
-     ::filter [:sequential ::function]
-     ::union [:sequential [:sequential ::where-pattern]]
-     ::bind [:map-of ::var :any]
-     ::where [:sequential [:orn
-                           [:where-map ::where-map]
-                           [:tuple ::where-tuple]]]
-     ::var-collection [:sequential ::var]
-     ::val-collection [:sequential ::val]
-     ::single-var-binding [:tuple ::var ::val-collection]
-     ::value-binding [:sequential ::val]
+    {::limit                pos-int?
+     ::offset               nat-int?
+     ::maxFuel              number?
+     ::max-fuel             ::maxFuel
+     ::depth                nat-int?
+     ::prettyPrint          boolean?
+     ::pretty-print         ::prettyPrint
+     ::parseJSON            boolean?
+     ::parse-json           ::parseJSON
+     ::contextType          [:enum :string :keyword]
+     ::context-type         ::contextType
+     ::opts                 [:map
+                             [:maxFuel {:optional true} ::maxFuel]
+                             [:max-fuel {:optional true} ::maxFuel]
+                             [:parseJSON {:optional true} ::parseJSON]
+                             [:parse-json {:optional true} ::parse-json]
+                             [:prettyPrint {:optional true} ::prettyPrint]
+                             [:pretty-print {:optional true} ::pretty-print]
+                             [:contextType {:optional true} ::contextType]
+                             [:context-type {:optional true} ::contextType]]
+     ::function             [:orn
+                             [:string [:fn fn-string?]]
+                             [:list [:fn fn-list?]]]
+     ::wildcard             [:fn wildcard?]
+     ::var                  [:fn variable?]
+     ::val                  [:fn value?]
+     ::iri                  [:orn
+                             [:keyword keyword?]
+                             [:string string?]]
+     ::subject              [:orn
+                             [:sid [:fn sid?]]
+                             [:iri ::iri]
+                             [:ident [:fn pred-ident?]]]
+     ::subselect-map        [:map-of ::iri [:ref ::subselection]]
+     ::subselection         [:sequential [:orn
+                                          [:wildcard ::wildcard]
+                                          [:predicate ::iri]
+                                          [:subselect-map [:ref ::subselect-map]]]]
+     ::select-map           [:map-of {:max 1}
+                             ::var ::subselection]
+     ::selector             [:orn
+                             [:var ::var]
+                             [:pred ::iri]
+                             [:aggregate ::function]
+                             [:select-map ::select-map]]
+     ::select               [:orn
+                             [:selector ::selector]
+                             [:collection [:sequential ::selector]]]
+     ::selectOne            ::select
+     ::select-one           ::selectOne
+     ::select-distinct      ::select
+     ::selectDistinct       ::select-distinct
+     ::direction            [:orn
+                             [:asc [:fn asc?]]
+                             [:desc [:fn desc?]]]
+     ::ordering             [:orn
+                             [:scalar ::var]
+                             [:vector [:catn
+                                       [:direction ::direction]
+                                       [:dimension ::var]]]]
+     ::orderBy              [:orn
+                             [:clause ::ordering]
+                             [:collection [:sequential ::ordering]]]
+     ::order-by             ::orderBy
+     ::groupBy              [:orn
+                             [:clause ::var]
+                             [:collection [:sequential ::var]]]
+     ::group-by             ::groupBy
+     ::where-op             [:enum :filter :optional :union :bind]
+     ::where-map            [:and
+                             [:map-of {:max 1} ::where-op :any]
+                             [:multi {:dispatch where-op}
+                              [:filter [:map [:filter [:ref ::filter]]]]
+                              [:optional [:map [:optional [:ref ::optional]]]]
+                              [:union [:map [:union [:ref ::union]]]]
+                              [:bind [:map [:bind [:ref ::bind]]]]]]
+     ::triple               [:catn
+                             [:subject [:orn
+                                        [:var ::var]
+                                        [:val ::subject]]]
+                             [:predicate [:orn
+                                          [:var ::var]
+                                          [:iri ::iri]]]
+                             [:object [:orn
+                                       [:var ::var]
+                                       [:ident [:fn pred-ident?]]
+                                       [:val :any]]]]
+     ::where-tuple          [:orn
+                             [:triple ::triple]
+                             [:binding [:sequential {:max 2} :any]]
+                             [:remote [:sequential {:max 4} :any]]]
+     ::where-pattern        [:orn
+                             [:where-map ::where-map]
+                             [:tuple ::where-tuple]]
+     ::optional             [:orn
+                             [:single ::where-pattern]
+                             [:collection [:sequential ::where-pattern]]]
+     ::filter               [:sequential ::function]
+     ::union                [:sequential [:sequential ::where-pattern]]
+     ::bind                 [:map-of ::var :any]
+     ::where                [:sequential [:orn
+                                          [:where-map ::where-map]
+                                          [:tuple ::where-tuple]]]
+     ::var-collection       [:sequential ::var]
+     ::val-collection       [:sequential ::val]
+     ::single-var-binding   [:tuple ::var ::val-collection]
+     ::value-binding        [:sequential ::val]
      ::multiple-var-binding [:tuple
                              ::var-collection
                              [:sequential ::value-binding]]
-     ::values [:orn
-               [:single ::single-var-binding]
-               [:multiple ::multiple-var-binding]]
-     ::t [:or :int :string]
-     ::delete ::triple
-     ::delete-op [:map
-                  [:delete ::delete]
-                  [:where ::where]
-                  [:values {:optional true} ::values]]
-     ::context [:map-of :any :any]
-     ::analytical-query [:map
-                         [:where ::where]
-                         [:t {:optional true} ::t]
-                         [:context {:optional true} ::context]
-                         [:select {:optional true} ::select]
-                         [:selectOne {:optional true} ::selectOne]
-                         [:select-one {:optional true} ::select-one]
-                         [:selectDistinct {:optional true} ::selectDistinct]
-                         [:select-distinct {:optional true} ::select-distinct]
-                         [:delete {:optional true} ::delete]
-                         [:orderBy {:optional true} ::orderBy]
-                         [:order-by {:optional true} ::order-by]
-                         [:groupBy {:optional true} ::groupBy]
-                         [:group-by {:optional true} ::group-by]
-                         [:filter {:optional true} ::filter]
-                         [:having {:optional true} ::function]
-                         [:values {:optional true} ::values]
-                         [:limit {:optional true} ::limit]
-                         [:offset {:optional true} ::offset]
-                         [:maxFuel {:optional true} ::maxFuel]
-                         [:max-fuel {:optional true} ::max-fuel]
-                         [:depth {:optional true} ::depth]
-                         [:opts {:optional true} ::opts]
-                         [:prettyPrint {:optional true} ::prettyPrint]
-                         [:pretty-print {:optional true} ::pretty-print]]
-     ::multi-query [:map-of :string ::analytical-query]
-     ::query [:orn
-              [:single ::analytical-query]
-              [:multi ::multi-query]]}))
+     ::values               [:orn
+                             [:single ::single-var-binding]
+                             [:multiple ::multiple-var-binding]]
+     ::t                    [:or :int :string]
+     ::delete               ::triple
+     ::delete-op            [:map
+                             [:delete ::delete]
+                             [:where ::where]
+                             [:values {:optional true} ::values]]
+     ::context              [:map-of :any :any]
+     ::analytical-query     [:map
+                             [:where ::where]
+                             [:t {:optional true} ::t]
+                             [:context {:optional true} ::context]
+                             [:select {:optional true} ::select]
+                             [:selectOne {:optional true} ::selectOne]
+                             [:select-one {:optional true} ::select-one]
+                             [:selectDistinct {:optional true} ::selectDistinct]
+                             [:select-distinct {:optional true} ::select-distinct]
+                             [:delete {:optional true} ::delete]
+                             [:orderBy {:optional true} ::orderBy]
+                             [:order-by {:optional true} ::order-by]
+                             [:groupBy {:optional true} ::groupBy]
+                             [:group-by {:optional true} ::group-by]
+                             [:filter {:optional true} ::filter]
+                             [:having {:optional true} ::function]
+                             [:values {:optional true} ::values]
+                             [:limit {:optional true} ::limit]
+                             [:offset {:optional true} ::offset]
+                             [:maxFuel {:optional true} ::maxFuel]
+                             [:max-fuel {:optional true} ::max-fuel]
+                             [:depth {:optional true} ::depth]
+                             [:opts {:optional true} ::opts]
+                             [:prettyPrint {:optional true} ::prettyPrint]
+                             [:pretty-print {:optional true} ::pretty-print]]
+     ::multi-query          [:map-of :string ::analytical-query]
+     ::query                [:orn
+                             [:single ::analytical-query]
+                             [:multi ::multi-query]]}))
 
 (def query-validator
   (m/validator ::query {:registry registry}))


### PR DESCRIPTION
...but still allow strings too. This is in the "query labels" top-level keys that are used to associate the responses with their respective queries.

This feels more idiomatic when using this from Clojure or w/ EDN requests in http-api-gateway. Strings are still allowed too.

Fairly small thing either way. Any reason not to allow this?

I ran into this when writing multi-query endpoint tests in http-api-gateway.

I threw a couple other small things I noticed while I was in here too, but let me know if you think anything should be reverted or split out of this PR.