### PR TITLE
SHACL property pair constraints

### DIFF
--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -158,6 +158,7 @@
 (def ^:const $sh:equals 242)
 (def ^:const $sh:disjoint 243)
 (def ^:const $sh:lessThan 244)
+(def ^:const $sh:lessThanOrEquals 248)
 
 ;; fluree-specific
 (def ^:const $fluree:context 250)

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -157,6 +157,7 @@
 ;;property pair constraints
 (def ^:const $sh:equals 242)
 (def ^:const $sh:disjoint 243)
+(def ^:const $sh:lessThan 244)
 
 ;; fluree-specific
 (def ^:const $fluree:context 250)

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -154,7 +154,7 @@
 (def ^:const $sh:maxInclusive 241)
 
 
-
+(def ^:const $sh:equals 242)
 
 ;; fluree-specific
 (def ^:const $fluree:context 250)

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -154,7 +154,9 @@
 (def ^:const $sh:maxInclusive 241)
 
 
+;;property pair constraints
 (def ^:const $sh:equals 242)
+(def ^:const $sh:disjoint 243)
 
 ;; fluree-specific
 (def ^:const $fluree:context 250)

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -56,6 +56,7 @@
           "http://www.w3.org/ns/shacl#minLength"                const/$sh:minLength
           "http://www.w3.org/ns/shacl#maxLength"                const/$sh:maxLength
           "http://www.w3.org/ns/shacl#equals"                   const/$sh:equals
+          "http://www.w3.org/ns/shacl#lessThan"                 const/$sh:lessThan
           "http://www.w3.org/ns/shacl#disjoint"                 const/$sh:disjoint
           "http://www.w3.org/ns/shacl#pattern"                  const/$sh:pattern
           "http://www.w3.org/ns/shacl#languageIn"               const/$sh:languageIn
@@ -123,7 +124,8 @@
                              const/$sh:targetClass
                              const/$sh:targetSubjectsOf const/$sh:targetObjectsOf
                              const/$sh:equals
-                             const/$sh:disjoint}
+                             const/$sh:disjoint
+                             const/$sh:lessThan}
                            referring-pid))
                     (next-pid)
                     (next-sid)))]

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -56,6 +56,7 @@
           "http://www.w3.org/ns/shacl#minLength"                const/$sh:minLength
           "http://www.w3.org/ns/shacl#maxLength"                const/$sh:maxLength
           "http://www.w3.org/ns/shacl#equals"                   const/$sh:equals
+          "http://www.w3.org/ns/shacl#disjoint"                 const/$sh:disjoint
           "http://www.w3.org/ns/shacl#pattern"                  const/$sh:pattern
           "http://www.w3.org/ns/shacl#languageIn"               const/$sh:languageIn
           "http://www.w3.org/ns/shacl#uniqueLang"               const/$sh:uniqueLang
@@ -121,7 +122,8 @@
                              const/$sh:path const/$sh:ignoredProperties
                              const/$sh:targetClass
                              const/$sh:targetSubjectsOf const/$sh:targetObjectsOf
-                             const/$sh:equals}
+                             const/$sh:equals
+                             const/$sh:disjoint}
                            referring-pid))
                     (next-pid)
                     (next-sid)))]

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -55,6 +55,7 @@
           "http://www.w3.org/ns/shacl#nodeKind"                 const/$sh:nodeKind
           "http://www.w3.org/ns/shacl#minLength"                const/$sh:minLength
           "http://www.w3.org/ns/shacl#maxLength"                const/$sh:maxLength
+          "http://www.w3.org/ns/shacl#equals"                   const/$sh:equals
           "http://www.w3.org/ns/shacl#pattern"                  const/$sh:pattern
           "http://www.w3.org/ns/shacl#languageIn"               const/$sh:languageIn
           "http://www.w3.org/ns/shacl#uniqueLang"               const/$sh:uniqueLang
@@ -119,7 +120,8 @@
                           (#{const/$rdfs:subClassOf
                              const/$sh:path const/$sh:ignoredProperties
                              const/$sh:targetClass
-                             const/$sh:targetSubjectsOf const/$sh:targetObjectsOf}
+                             const/$sh:targetSubjectsOf const/$sh:targetObjectsOf
+                             const/$sh:equals}
                            referring-pid))
                     (next-pid)
                     (next-sid)))]
@@ -175,5 +177,3 @@
      "commit"   commit
      "idx"      idx-map
      "from"     from}))
-
-

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -57,6 +57,7 @@
           "http://www.w3.org/ns/shacl#maxLength"                const/$sh:maxLength
           "http://www.w3.org/ns/shacl#equals"                   const/$sh:equals
           "http://www.w3.org/ns/shacl#lessThan"                 const/$sh:lessThan
+          "http://www.w3.org/ns/shacl#lessThanOrEquals"         const/$sh:lessThanOrEquals
           "http://www.w3.org/ns/shacl#disjoint"                 const/$sh:disjoint
           "http://www.w3.org/ns/shacl#pattern"                  const/$sh:pattern
           "http://www.w3.org/ns/shacl#languageIn"               const/$sh:languageIn
@@ -125,7 +126,8 @@
                              const/$sh:targetSubjectsOf const/$sh:targetObjectsOf
                              const/$sh:equals
                              const/$sh:disjoint
-                             const/$sh:lessThan}
+                             const/$sh:lessThan
+                             const/$sh:lessThanOrEquals}
                            referring-pid))
                     (next-pid)
                     (next-sid)))]

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -85,10 +85,10 @@
   (loop [[p-flakes & r] (vals flakes-by-p)
          required (:required shape)]
     (if p-flakes
-      (let [pid      (flake/p (first p-flakes)) ;;validate by predicate
-            p-shapes (get property pid) ;;look up pid in :property part of shape
+      (let [pid      (flake/p (first p-flakes))
+            p-shapes (get property pid)
             error?   (some (fn [p-shape]
-                             (if-let [pair (:pair? p-shape)]
+                             (if-let [pair (:pair-property p-shape)]
                                (let [pair-flake (-> flakes-by-p (get pair) first)]
                                  (validate-pair-property p-shape pair-flake p-flakes))
                                (validate-property p-shape p-flakes)))
@@ -180,7 +180,7 @@
           (assoc acc :max-inclusive o)
 
           const/$sh:equals
-          (assoc acc :equals o :pair? o)
+          (assoc acc :equals o :pair-property o)
 
           ;; else
           acc)))
@@ -322,7 +322,7 @@
                                                                   (build-property-shape))
                                              ;; we key the property shapes map with the property subj id (sh:path)
                                              p-shapes*      (cond-> (update p-shapes path util/conjv property-shape)
-                                                              equals (update equals util/conjv {:path equals :equals path :pair? path}))
+                                                              equals (update equals util/conjv {:path equals :equals path :pair-property path}))
                                              ;; elevate following conditions to top-level custom keys to optimize validations when processing txs
                                              shape*         (cond-> shape
                                                                     (:required? property-shape)

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -68,17 +68,12 @@
   (doall
    (map
     (fn [l-flake r-flake]
-      (cond
-        (let [comp-result (flake/cmp-obj (flake/o l-flake) (flake/dt l-flake)
-                                         (flake/o r-flake) (flake/dt r-flake))]
-          (when-not (contains? #{0 true} comp-result)
-            (throw (ex-info (str "SHACL PropertyShape exception - sh:equals. " (mapv flake/o lhs-flakes)
-                                 " not equal to " (mapv flake/o rhs-flakes) ".")
-                            {:status 400 :error :db/shacl-validation}))))
-
-        (throw (ex-info (str "SHACL PropertyShape exception - sh:equals. " (mapv flake/o lhs-flakes)
-                             " not equal to " (mapv flake/o rhs-flakes) ".")
-                        {:status 400 :error :db/shacl-validation}))))
+      (let [comp-result (flake/cmp-obj (flake/o l-flake) (flake/dt l-flake)
+                                       (flake/o r-flake) (flake/dt r-flake))]
+        (when-not (contains? #{0 true} comp-result)
+          (throw (ex-info (str "SHACL PropertyShape exception - sh:equals. " (mapv flake/o lhs-flakes)
+                               " not equal to " (mapv flake/o rhs-flakes) ".")
+                          {:status 400 :error :db/shacl-validation})))))
     lhs-flakes
     rhs-flakes)))
 
@@ -332,11 +327,10 @@
                                    (let [p (flake/p flake)
                                          o (flake/o flake)]
                                      (if (= const/$sh:property p)
-                                       (let [{:keys [equals path] :as property-shape} (-> (<? (query-range/index-range db :spot = [o]))
+                                       (let [{:keys [path] :as property-shape} (-> (<? (query-range/index-range db :spot = [o]))
                                                                   (build-property-shape))
                                              ;; we key the property shapes map with the property subj id (sh:path)
-                                             p-shapes*      (cond-> (update p-shapes path util/conjv property-shape)
-                                                              equals (update equals util/conjv {:path equals :equals path :pair-property path}))
+                                             p-shapes*      (update p-shapes path util/conjv property-shape)
                                              ;; elevate following conditions to top-level custom keys to optimize validations when processing txs
                                              shape*         (cond-> shape
                                                                     (:required? property-shape)

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -101,15 +101,15 @@
                                                 r-flake-o))))))))
 
 (defn validate-shape
-  [{:keys [property closed-props] :as shape} p-flakes all-flakes]
-  (loop [[p-flakes & r] p-flakes
+  [{:keys [property closed-props] :as shape} flake-p-partitions all-flakes]
+  (loop [[p-flakes & r] flake-p-partitions
          required (:required shape)]
     (if p-flakes
       (let [pid      (flake/p (first p-flakes))
             p-shapes (get property pid)
             error?   (some (fn [p-shape]
-                             (if-let [pair-property (:rhs-property p-shape)]
-                               (let [rhs-flakes (filter #(= pair-property (flake/p %)) all-flakes)]
+                             (if-let [rhs-property (:rhs-property p-shape)]
+                               (let [rhs-flakes (filter #(= rhs-property (flake/p %)) all-flakes)]
                                  (validate-pair-property p-shape p-flakes rhs-flakes))
                                (validate-property p-shape p-flakes)))
                            p-shapes)]
@@ -128,9 +128,9 @@
   "Some new flakes don't need extra validation."
   [db {:keys [shapes datatype] :as shape-map} all-flakes]
   (go-try
-   (let [p-flakes (partition-by flake/p all-flakes)]
+   (let [flake-p-partitions (partition-by flake/p all-flakes)]
      (doseq [shape shapes]
-       (validate-shape shape p-flakes all-flakes)))))
+       (validate-shape shape flake-p-partitions all-flakes)))))
 
 (defn build-property-shape
   "Builds map out of values from a SHACL propertyShape (target of sh:property)"

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -406,15 +406,14 @@
   or nil if none exist."
   [{:keys [schema] :as db} type-sids]
   (go-try
-   (let [shapes-atom (:shapes schema)
-         cached-shapes @shapes-atom]
+    (let [shapes-cache (:shapes schema)]
       (loop [[type-sid & r] type-sids
              shape-maps nil]
         (if type-sid
-          (let [shape-map (if-let [cached (get-in cached-shapes [:class type-sid])]
-                            cached
+          (let [shape-map (if (contains? (:class @shapes-cache) type-sid)
+                            (get-in @shapes-cache [:class type-sid])
                             (let [shapes (<? (build-class-shapes db type-sid))]
-                              (swap! shapes-atom assoc-in [:class type-sid] shapes)
+                              (swap! shapes-cache assoc-in [:class type-sid] shapes)
                               shapes))]
             (recur r (if shape-map
                        (conj shape-maps shape-map)

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -377,14 +377,15 @@
   or nil if none exist."
   [{:keys [schema] :as db} type-sids]
   (go-try
-    (let [shapes-cache (:shapes schema)]
+   (let [shapes-atom (:shapes schema)
+         cached-shapes @shapes-atom]
       (loop [[type-sid & r] type-sids
              shape-maps nil]
         (if type-sid
-          (let [shape-map (if (contains? (:class @shapes-cache) type-sid)
-                            (get-in @shapes-cache [:class type-sid])
+          (let [shape-map (if-let [cached (get-in cached-shapes [:class type-sid])]
+                            cached
                             (let [shapes (<? (build-class-shapes db type-sid))]
-                              (swap! shapes-cache assoc-in [:class type-sid] shapes)
+                              (swap! shapes-atom assoc-in [:class type-sid] shapes)
                               shapes))]
             (recur r (if shape-map
                        (conj shape-maps shape-map)

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -93,7 +93,7 @@
                 (throw (ex-info error-msg
                                 {:status 400 :error :db/shacl-validation}))
                 (cmp-flake-pairs lhs-flakes rhs-flakes (fn [cmp-result]
-                                                         (not (contains? #{0 true} cmp-result)))
+                                                         (not= 0 cmp-result))
                                  error-msg)))
 
     :disjoint (let [error-msg (str "SHACL PropertyShape exception - sh:disjoint. " (mapv flake/o lhs-flakes)

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -465,8 +465,16 @@
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
                                    :ex/p2 [12 16]})
-                                (catch Exception e e))]
-
+                                (catch Exception e e))
+              db-iris         (try @(fluree/stage
+                                     db
+                                     {:context     {:ex "http://example.org/ns/"}
+                                      :id          :ex/alice,
+                                      :type        [:ex/User],
+                                      :schema/name "Alice"
+                                      :ex/p1 :ex/brian
+                                      :ex/p2 :ex/john})
+                                   (catch Exception e e))]
           (is (util/exception? db-fail1)
               "Exception, because :ex/p1 is not less than :ex/p2")
           (is (str/starts-with? (ex-message db-fail1)
@@ -487,6 +495,12 @@
               "Exception, because :ex/p1 is not less than :ex/p2")
           (is (str/starts-with? (ex-message db-fail4)
                                 "SHACL PropertyShape exception - sh:lessThan"))
+
+          (is (util/exception? db-iris)
+              "Exception, because :ex/p1 and :ex/p2 are iris, and not valid for comparison")
+          (is (str/starts-with? (ex-message db-iris)
+                                "SHACL PropertyShape exception - sh:lessThan"))
+
           (is (= [{:id          :ex/alice,
                    :rdf/type        [:ex/User],
                    :schema/name "Alice"

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -88,7 +88,7 @@
           "basic rdf:type query response not correct"))))
 
 
-(deftest ^:integration shacl-datatype-constraings
+(deftest ^:integration shacl-datatype-constraints
   (testing "shacl datatype errors"
     (let [conn         (test-utils/create-conn)
           ledger       @(fluree/create conn "shacl/b")
@@ -298,7 +298,7 @@
         (let [db            @(fluree/stage
                               (fluree/db ledger)
                               {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/EqualNames
+                               :id                   :ex/DisjointNums
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :ex/favNums


### PR DESCRIPTION
Closes #319

This PR implements [SHACL property pair constraints](https://www.w3.org/TR/shacl/#core-components-property-pairs):
- `sh:equals`
- `sh:disjoint`
- `sh:lessThan`
- `sh:lessThanOrEquals`

As with the existing SHACL rule implementations, the validation for these constraints uses the flakes that have been pulled from [the `index-range` call in the `transact` ns](https://github.com/fluree/db/blob/main/src/fluree/db/json_ld/transact.cljc#L380), rather than with a fresh query. This allows us to leverage an optimization in which we pull thosse flakes out once, and only for new subjects, and reuse them for any shapes that apply to that subject.

This works fine for now, since we don't yet support property paths (https://www.w3.org/TR/shacl/#property-paths), and all rules are just defined on a single predicate.  However, once we do https://github.com/fluree/db/issues/324 we'll need to revisit this (and all the other SHACL rules) to allow them to use property paths in the shape. This may or may not require full queries.

Also, at some point I'd like to see if we can try to do this validation with protocols.  Instead of building maps to store the data needed to enforce a rule and then inspecting those maps during validation, we would build instances of records that implement that protocol and let those records handle it. However, it felt too early to try that now.