### PR TITLE
Disallow inserting nodes that contain no properties

### DIFF
--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -360,8 +360,14 @@
     (loop [[node & r] nodes
            flakes* flakeset]
       (if node
-        (let [[_node-sid node-flakes] (<? (json-ld-node->flakes node tx-state nil))]
-          (recur r (into flakes* node-flakes)))
+        (if (empty? (dissoc node :idx :id))
+          (throw (ex-info (str "Invalid transaction, transaction node contains no properties"
+                               (some->> (:id node)
+                                        (str " for @id: ") )
+                               ".")
+                          {:status 400 :error :db/invalid-transaction}))
+          (let [[_node-sid node-flakes] (<? (json-ld-node->flakes node tx-state nil))]
+            (recur r (into flakes* node-flakes))))
         flakes*))))
 
 (defn validate-rules

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -1,0 +1,47 @@
+(ns fluree.db.transact.transact-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.util.core :as util]
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.json-ld.api :as fluree]
+            [clojure.string :as str]))
+
+(deftest ^:integration staging-data
+  (testing "Disallow staging invalid transactions"
+    (let [conn           (test-utils/create-conn )
+          ledger         @(fluree/create conn "tx/disallow")
+
+          stage-id-only     (try
+                              @(fluree/stage
+                                (fluree/db ledger)
+                                {:context {:ex "http://example.org/ns/"}
+                                 :id :ex/alice})
+                              (catch Exception e e))
+
+          stage-empty-txn   (try
+                              @(fluree/stage
+                                (fluree/db ledger)
+                                {})
+                              (catch Exception e e))
+
+          db-ok           @(fluree/stage
+                            (fluree/db ledger)
+                            {:context {:ex "http://example.org/ns/"}
+                             :id :ex/alice
+                             :schema/age 42})]
+      (is (util/exception? stage-id-only))
+      (is (str/starts-with? (ex-message stage-id-only)
+                            "Invalid transaction, transaction node contains no properties for @id:" ))
+
+      (is (util/exception? stage-empty-txn))
+      (is (str/starts-with? (ex-message stage-empty-txn)
+                            "Invalid transaction, transaction node contains no properties" ))
+
+      (is (= [[:ex/alice :id "http://example.org/ns/alice"]
+              [:ex/alice :schema/age 42]
+              [:schema/age :id "http://schema.org/age"]
+              [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
+              [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+              [:id :id "@id"]]
+             @(fluree/query db-ok '{:context {:ex "http://example.org/ns/"}
+                                    :select [?s ?p ?o]
+                                    :where  [[?s ?p ?o]]}))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -16,14 +16,11 @@
                                 {:context {:ex "http://example.org/ns/"}
                                  :id :ex/alice})
                               (catch Exception e e))
-
           stage-empty-txn   (try
                               @(fluree/stage
                                 (fluree/db ledger)
                                 {})
                               (catch Exception e e))
-
-
           stage-empty-node   (try
                                @(fluree/stage
                                  (fluree/db ledger)
@@ -32,7 +29,6 @@
                                    :schema/age 42}
                                   {}])
                                (catch Exception e e))
-
           db-ok           @(fluree/stage
                             (fluree/db ledger)
                             {:context {:ex "http://example.org/ns/"}
@@ -41,15 +37,12 @@
       (is (util/exception? stage-id-only))
       (is (str/starts-with? (ex-message stage-id-only)
                             "Invalid transaction, transaction node contains no properties for @id:" ))
-
       (is (util/exception? stage-empty-txn))
-      (is (str/starts-with? (ex-message stage-empty-txn)
-                            "Invalid transaction, transaction node contains no properties" ))
-
+      (is (= (ex-message stage-empty-txn)
+             "Invalid transaction, transaction node contains no properties." ))
       (is (util/exception? stage-empty-node))
-      (is (str/starts-with? (ex-message stage-empty-node)
-                            "Invalid transaction, transaction node contains no properties" ))
-
+      (is (= (ex-message stage-empty-node)
+             "Invalid transaction, transaction node contains no properties." ))
       (is (= [[:ex/alice :id "http://example.org/ns/alice"]
               [:ex/alice :schema/age 42]
               [:schema/age :id "http://schema.org/age"]

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -23,6 +23,16 @@
                                 {})
                               (catch Exception e e))
 
+
+          stage-empty-node   (try
+                               @(fluree/stage
+                                 (fluree/db ledger)
+                                 [{:context {:ex "http://example.org/ns/"}
+                                   :id :ex/alice
+                                   :schema/age 42}
+                                  {}])
+                               (catch Exception e e))
+
           db-ok           @(fluree/stage
                             (fluree/db ledger)
                             {:context {:ex "http://example.org/ns/"}
@@ -34,6 +44,10 @@
 
       (is (util/exception? stage-empty-txn))
       (is (str/starts-with? (ex-message stage-empty-txn)
+                            "Invalid transaction, transaction node contains no properties" ))
+
+      (is (util/exception? stage-empty-node))
+      (is (str/starts-with? (ex-message stage-empty-node)
                             "Invalid transaction, transaction node contains no properties" ))
 
       (is (= [[:ex/alice :id "http://example.org/ns/alice"]


### PR DESCRIPTION
Closes #402 

Updates staging pipeline to throw an error when it sees a node that is either empty, or contains only an `@id`, eg:
```
"Invalid transaction, transaction node contains no properties for @id: http://example.org/ns/alice."
```

I tried to inspect the nodes for validity as early as was feasible without introducing an extra traversal over them, which afaict was in `stage-flakes`, so the error message will show the expanded id.

If it's important that the error show the compacted id (per the example in [this comment on the original issue](https://github.com/fluree/db/issues/402#issuecomment-1448676701)), I can try to revise the approach.
