### PR TITLE
add context tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          instaparse/instaparse           {:mvn/version "1.4.12"}
          metosin/malli                   {:mvn/version "0.9.2"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :sha     "a909330e33196504ef8a5411aaa0409ab72aaa35"}
+                                          :sha     "c6b3aa2c3ef158219f153552238b1865a6422bab"}
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.2.4"}


### PR DESCRIPTION
Fixes #395 

The real work is done in the json-ld library, which allows you to force expansion by compacting with a "null" context. 
https://github.com/fluree/json-ld/pull/14
^needs to be merged first.

Just a note that for queries we don't return json-ld in it's [fully expanded form](https://www.w3.org/TR/json-ld11/#expanded-document-form) if you use a null context, we just expand the properties.