### PR TITLE
fix: no conn context on load

### DIFF
--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -111,8 +111,12 @@
     "
   ([conn] (create conn nil nil))
   ([conn ledger-alias] (create conn ledger-alias nil))
-  ([conn ledger-alias opts]
-   (let [res-ch (jld-ledger/create conn ledger-alias opts)]
+  ([conn ledger-alias {:keys [context context-type] :as opts}]
+   (let [conn-context (conn-proto/-context conn)
+         ledger-context (->> context
+                             (util/normalize-context context-type)
+                             (clojure.core/merge conn-context))
+         res-ch       (jld-ledger/create conn ledger-alias (assoc opts :context ledger-context))]
      (promise-wrap res-ch))))
 
 (defn load-from-address

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -174,18 +174,12 @@
                                     :reindex-max-bytes reindex-max-bytes})))
           ledger-alias* (normalize-alias ledger-alias)
           address       (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
-          conn-context  (conn-proto/-context conn)
-          _             (log/debug "create conn-context:" conn-context)
-          context*      (->> context
-                             (util/normalize-context context-type)
-                             (merge conn-context))
-          _             (log/debug "create merged context*:" context*)
           method-type   (conn-proto/-method conn)
           ;; map of all branches and where they are branched from
           branches      {branch (branch/new-branch-map nil ledger-alias* branch)}
           ledger        (map->JsonLDLedger
                           {:id      (random-uuid)
-                           :context context*
+                           :context context
                            :did     did*
                            :state   (atom {:closed?  false
                                            :branches branches


### PR DESCRIPTION
Fixes #413

The conn only holds a default context for creating new ledgers, it's pure syntactic sugar to make that task easier. After ledger creation, a ledger should never again interact with the conn default context.

This PR makes it so.

The actual change is to move any changing of the context out of the ledger `create` function - now it just stores the context it has been given with no additional processing. Now `fluree/create` builds its own ledger context and passes it along, while `fluree/load` recovers the ledger context from the commit and passes that along.