### PR TITLE
update `stage` args to be just `db` in sdk namespaces

### DIFF
--- a/src/fluree/sdk/browser.cljs
+++ b/src/fluree/sdk/browser.cljs
@@ -40,10 +40,10 @@
   ([conn ledger-alias] (fluree/load conn ledger-alias)))
 
 (defn ^:export stage
-  ([db-or-ledger json-ld]
-   (fluree/stage db-or-ledger (js->clj json-ld) {:context-type :string}))
-  ([db-or-ledger json-ld opts]
-   (fluree/stage db-or-ledger (js->clj json-ld)
+  ([db json-ld]
+   (fluree/stage db (js->clj json-ld) {:context-type :string}))
+  ([db json-ld opts]
+   (fluree/stage db (js->clj json-ld)
                  (-> (js->clj opts :keywordize-keys true)
                      (assoc :context-type :string)))))
 

--- a/src/fluree/sdk/node.cljs
+++ b/src/fluree/sdk/node.cljs
@@ -29,10 +29,10 @@
   (fluree/load conn ledger-alias))
 
 (defn ^:export stage
-  ([db-or-ledger json-ld]
-   (fluree/stage db-or-ledger (js->clj json-ld) {:context-type :string}))
-  ([db-or-ledger json-ld opts]
-   (fluree/stage db-or-ledger (js->clj json-ld)
+  ([db json-ld]
+   (fluree/stage db (js->clj json-ld) {:context-type :string}))
+  ([db json-ld opts]
+   (fluree/stage db (js->clj json-ld)
                  (-> opts
                      (js->clj :keywordize-keys true)
                      (assoc :context-type :string)))))


### PR DESCRIPTION
This is a no-op change, but the old `db-or-ledger` arg name has already caused unnecessary confusion (see https://github.com/fluree/db/issues/412#issuecomment-1467012288)