### PR TITLE
Allow object bindings on rdf:type predicates

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -328,7 +328,8 @@
   [[s-pat p-pat o-pat] db context]
   (let [s (parse-subject-pattern s-pat context)
         p (parse-predicate-pattern p-pat db context)]
-    (if (= const/$rdf:type (::where/val p))
+    (if (and (= const/$rdf:type (::where/val p))
+             (not (syntax/variable? o-pat)))
       (let [cls (parse-class o-pat db context)]
         (where/->pattern :class [s p cls]))
       (if (= const/$iri (::where/val p))

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -113,6 +113,20 @@
                   ::where/datatype 8}
                  {::where/var '?email}]]
                patterns)))
+      (testing "not a `:class` pattern if obj is a var"
+        (let [query {:context {:ex "http://example.org/ns/"}
+                     :select  ['?class]
+                     :where   [[:ex/cam :rdf/type '?class]]}
+              {:keys [select where] :as parsed} (parse/parse-analytical-query query db)
+              {::where/keys [patterns]} where]
+          (is (= [{:var '?class}]
+                 (de-recordify-select select)))
+          (is (= [[{::where/val "http://example.org/ns/cam",
+                    ::where/datatype 0}
+                   {::where/val 200,
+                    ::where/datatype 8}
+                   {::where/var '?class}]]
+                 patterns))))
       (testing "class, optional"
         (let [optional-q {:select ['?name '?favColor]
                           :where  [['?s :rdf/type :ex/User]

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -117,16 +117,10 @@
         (let [query {:context {:ex "http://example.org/ns/"}
                      :select  ['?class]
                      :where   [[:ex/cam :rdf/type '?class]]}
-              {:keys [select where] :as parsed} (parse/parse-analytical-query query db)
+              {:keys [where]} (parse/parse-analytical-query query db)
               {::where/keys [patterns]} where]
-          (is (= [{:var '?class}]
-                 (de-recordify-select select)))
-          (is (= [[{::where/val "http://example.org/ns/cam",
-                    ::where/datatype 0}
-                   {::where/val 200,
-                    ::where/datatype 8}
-                   {::where/var '?class}]]
-                 patterns))))
+          (is (= :tuple
+                (where/pattern-type (first patterns))))))
       (testing "class, optional"
         (let [optional-q {:select ['?name '?favColor]
                           :where  [['?s :rdf/type :ex/User]


### PR DESCRIPTION
Fixes #406

Allows queries with clauses like
`[:ex/john :rdf/type ?class]`

where the predicate is `rdf:type` and there is a var in the object position.

This is done by explicitly excluding those patterns from being treated as `:class` patterns (which require the object to be an iri) and processing them as regular tuple patterns instead.
