### PR TITLE
Fix datetime coercion

### DIFF
--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -47,14 +47,14 @@
    "http://www.w3.org/2001/XMLSchema#base64Binary"       const/$xsd:base64Binary})
 
 (def iso8601-offset-pattern
-  "(Z|(?:[+-][0-9]{1,2}:[0-9]{2}))?")
+  "(Z|(?:[+-][0-9]{2}:[0-9]{2}))?")
 
 (def iso8601-date-component-pattern
   "This is slightly more forgiving than the xsd:date spec:
   http://books.xmlschemata.org/relaxng/ch19-77041.html
   Note there is no need to be extra strict with the numeric ranges in here as
   the java.time constructors will take care of that for us."
-  "((?:-)?[0-9]{4})-([0-9]{1,2})-([0-9]{1,2})")
+  "((?:-)?[0-9]{4})-([0-9]{2})-([0-9]{2})")
 
 (def iso8601-date-pattern
   "Defines the pattern for dates w/o times where an offset is still allowed on
@@ -69,7 +69,7 @@
   http://books.xmlschemata.org/relaxng/ch19-77311.html
   Note there is no need to be extra strict with the numeric ranges in here as
   the java.time constructors will take care of that for us."
-  (str "([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})(?:\\.([0-9]{1,9}))?" iso8601-offset-pattern))
+  (str "([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\\.([0-9]{1,9}))?" iso8601-offset-pattern))
 
 (def iso8601-time-re
   (re-pattern iso8601-time-pattern))

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -46,6 +46,9 @@
    "http://www.w3.org/2001/XMLSchema#hexBinary"          const/$xsd:hexBinary
    "http://www.w3.org/2001/XMLSchema#base64Binary"       const/$xsd:base64Binary})
 
+(def iso8601-offset-pattern
+  "(Z|(?:[+-][0-9]{1,2}:[0-9]{2}))?")
+
 (def iso8601-date-component-pattern
   "This is slightly more forgiving than the xsd:date spec:
   http://books.xmlschemata.org/relaxng/ch19-77041.html
@@ -56,7 +59,7 @@
 (def iso8601-date-pattern
   "Defines the pattern for dates w/o times where an offset is still allowed on
   the end."
-  (str iso8601-date-component-pattern "(Z|(?:[+-][0-9]{1,2}:[0-9]{2}))?"))
+  (str iso8601-date-component-pattern iso8601-offset-pattern))
 
 (def iso8601-date-re
   (re-pattern iso8601-date-pattern))
@@ -66,7 +69,7 @@
   http://books.xmlschemata.org/relaxng/ch19-77311.html
   Note there is no need to be extra strict with the numeric ranges in here as
   the java.time constructors will take care of that for us."
-  "([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})(Z|(?:[+-][0-9]{1,2}:[0-9]{2}))?")
+  (str "([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})(?:\\.([0-9]{1,9}))?" iso8601-offset-pattern))
 
 (def iso8601-time-re
   (re-pattern iso8601-time-pattern))
@@ -86,11 +89,10 @@
   "Infers a default data type if not otherwise provided."
   [x]
   (cond
-    (string? x) const/$xsd:string
+    (string? x)  const/$xsd:string
     (integer? x) const/$xsd:long ; infer to long to prevent overflow
-    (number? x) const/$xsd:decimal
+    (number? x)  const/$xsd:decimal
     (boolean? x) const/$xsd:boolean))
-
 
 #?(:cljs
    (defn- left-pad
@@ -132,15 +134,19 @@
         local timezone according to your device."
   [s]
   (when-let [matches (re-matches iso8601-time-re s)]
-    (let [time   (->> matches rest butlast)
-          offset (last matches)
-          [hour min sec] (map #?(:clj  #(Integer/parseInt %)
-                                 :cljs #(left-pad % "0" 2))
-                              time)]
-      #?(:clj  (if offset
-                 (OffsetTime/of hour min sec 0 (ZoneOffset/of ^String offset))
-                 (LocalTime/of hour min sec))
-         :cljs (js/Date. (str "1970-01-01T" hour ":" min ":" sec offset))))))
+    #?(:clj (let [time-parts (->> matches rest butlast)
+                  offset     (last matches)
+
+                  [hours minutes seconds second-fraction]
+                  (->> time-parts
+                       (map #(or % "0"))
+                       (map #(Integer/parseInt %)))
+
+                  nanos (* second-fraction 1000000)]
+              (if offset
+                (OffsetTime/of hours minutes seconds nanos (ZoneOffset/of ^String offset))
+                (LocalTime/of hours minutes seconds nanos)))
+       :cljs (js/Date. (str "1970-01-01T" s)))))
 
 (defn- parse-iso8601-datetime
   "Parses string s into one of the following:
@@ -150,18 +156,23 @@
         assume it's in your current, local timezone according to your device."
   [s]
   (when-let [matches (re-matches iso8601-datetime-re s)]
-    (let [datetime (->> matches rest (take 6))
-          offset   (last matches)
-          [year month day hour min sec] (map #?(:clj  #(Integer/parseInt %)
-                                                :cljs #(left-pad % "0" 2))
-                                             datetime)]
-      #?(:clj  (if offset
-                 (OffsetDateTime/of year month day hour min sec 0
-                                    (ZoneOffset/of ^String offset))
-                 (LocalDateTime/of ^int year ^int month ^int day ^int hour
-                                   ^int min ^int sec))
-         :cljs (js/Date. (str year "-" month "-" day "T" hour ":" min ":" sec
-                              offset))))))
+    #?(:clj
+       (let [datetime-parts (->> matches rest (take 7))
+             offset   (last matches)
+             [years months days hours minutes seconds second-fraction]
+             (->> datetime-parts
+                  (map #(or % "0"))
+                  (map #(Integer/parseInt %)))
+
+             nanos (* second-fraction 1000000)]
+         (if offset
+           (OffsetDateTime/of years months days hours minutes seconds nanos
+                              (ZoneOffset/of ^String offset))
+           (LocalDateTime/of ^int years ^int months ^int days ^int hours
+                             ^int minutes ^int seconds ^int nanos)))
+
+       :cljs
+       (js/Date. s))))
 
 (defn- coerce-boolean
   [value]

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -65,21 +65,16 @@
   (re-pattern iso8601-date-pattern))
 
 (def iso8601-time-pattern
-  "This is slightly more forgiving than the xsd:time spec:
-  http://books.xmlschemata.org/relaxng/ch19-77311.html
-  Note there is no need to be extra strict with the numeric ranges in here as
-  the java.time constructors will take care of that for us."
-  (str "([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\\.([0-9]{1,9}))?" iso8601-offset-pattern))
+  (str #?(:clj  "([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\\.([0-9]{1,9}))?"
+          :cljs "([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\\.([0-9]{1,3}))?")
+       iso8601-offset-pattern))
 
 (def iso8601-time-re
   (re-pattern iso8601-time-pattern))
 
 (def iso8601-datetime-pattern
-  "This is slightly more forgiving than the xsd:dateTime spec:
-  http://books.xmlschemata.org/relaxng/ch19-77049.html
-
-  Note there is no need to be extra strict with the numeric ranges in here as
-  the java.time constructors will take care of that for us."
+  "JS: https://tc39.es/ecma262/#sec-date-time-string-format simplified ISO8601 HH:mm:ss.sssZ
+   JVM: ISO8601 that supports nanosecond resolution."
   (str iso8601-date-component-pattern "T" iso8601-time-pattern))
 
 (def iso8601-datetime-re

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -1,258 +1,270 @@
 (ns fluree.db.datatype-test
-  (:require #?(:clj  [clojure.test :refer [deftest are]]
-               :cljs [cljs.test :refer-macros [deftest are]])
+  (:require [clojure.test :refer [deftest testing are is]]
             [fluree.db.constants :as const]
             [fluree.db.datatype :refer [coerce]])
   #?(:clj (:import (java.time LocalDate LocalTime OffsetDateTime OffsetTime
                               ZoneOffset))))
 
 (deftest coerce-test
-  (are [coerced-value value datatype]
-    (= coerced-value (coerce value datatype))
+  (testing "strings"
+    (is (= "foo" (coerce "foo" const/$xsd:string)))
+    (is (= nil (coerce 42 const/$xsd:string))))
 
-    ;; test format:
-    ;; expected input const/$xsd:type
+  (testing "anyURI"
+    (is (= "foo" (coerce "foo" const/$xsd:anyURI)))
+    (is (= nil (coerce 42 const/$xsd:anyURI))))
+  (testing "boolean"
+    (is (= true (coerce "true" const/$xsd:boolean)))
+    (is (= false (coerce "false" const/$xsd:boolean)))
+    (is (= true (coerce true const/$xsd:boolean)))
+    (is (= false (coerce false const/$xsd:boolean)))
+    (is (= nil (coerce "foo" const/$xsd:boolean))))
 
-    ;; string
-    "foo" "foo" const/$xsd:string
-    nil 42 const/$xsd:string
+  (testing "date"
+    (is (= #?(:clj
+              (OffsetDateTime/of 1980 10 5 0 0 0 0 (ZoneOffset/of "Z"))
+              :cljs
+              #inst "1980-10-05T00:00:00.000-00:00")
+           (coerce "1980-10-5Z" const/$xsd:date)))
+    (is (= #?(:clj
+              (LocalDate/of 1980 10 5)
+              :cljs
+              (js/Date. "1980-10-05T00:00:00"))
+           (coerce "1980-10-5" const/$xsd:date)))
+    (is (= #?(:clj
+              (OffsetDateTime/of 2022 1 5 0 0 0 0 (ZoneOffset/of "Z"))
+              :cljs
+              #inst "2022-01-05T00:00:00.000-00:00")
+           (coerce "2022-01-05Z" const/$xsd:date)))
 
-    ;; anyURI
-    "foo" "foo" const/$xsd:anyURI
-    nil 42 const/$xsd:anyURI
+    (is (= #?(:clj
+              (LocalDate/of 2022 1 5)
+              :cljs
+              (js/Date. "2022-01-05T00:00:00"))
+           (coerce "2022-01-05" const/$xsd:date)))
 
-    ;; boolean
-    true "true" const/$xsd:boolean
-    false "false" const/$xsd:boolean
-    true true const/$xsd:boolean
-    false false const/$xsd:boolean
-    nil "foo" const/$xsd:boolean
+    (is (= nil
+           (coerce "foo" const/$xsd:date))))
 
-    ;; date
-    #?(:clj
-       (OffsetDateTime/of 1980 10 5 0 0 0 0
-                          (ZoneOffset/of "Z"))
-       :cljs
-       #inst "1980-10-05T00:00:00.000-00:00") "1980-10-5Z" const/$xsd:date
-    #?(:clj
-       (LocalDate/of 1980 10 5)
-       :cljs
-       (js/Date. "1980-10-05T00:00:00")) "1980-10-5" const/$xsd:date
-    #?(:clj
-       (OffsetDateTime/of 2022 1 5 0 0 0 0
-                          (ZoneOffset/of "Z"))
-       :cljs
-       #inst "2022-01-05T00:00:00.000-00:00") "2022-01-05Z" const/$xsd:date
-    #?(:clj
-       (LocalDate/of 2022 1 5)
-       :cljs
-       (js/Date. "2022-01-05T00:00:00")) "2022-01-05" const/$xsd:date
+  (testing "time"
+    (is (= #?(:clj
+              (LocalTime/of 12 42 0)
+              :cljs
+              (js/Date. "1970-01-01T12:42:00"))
+           (coerce "12:42:00" const/$xsd:time)))
+    (is (=
+          #?(:clj
+             (OffsetTime/of 12 42 0 0 (ZoneOffset/of "Z"))
+             :cljs
+             #inst "1970-01-01T12:42:00.000-00:00")
+          (coerce "12:42:00Z" const/$xsd:time)))
+    (is (=
+          #?(:clj
+             (LocalTime/of 12 42 5)
+             :cljs
+             (js/Date. "1970-01-01T12:42:05"))
+          (coerce "12:42:5" const/$xsd:time)))
+    (is (=
+          #?(:clj
+             (OffsetTime/of 12 42 5 0 (ZoneOffset/of "Z"))
+             :cljs
+             #inst "1970-01-01T12:42:05.000-00:00")
+          (coerce "12:42:5Z" const/$xsd:time)))
+    (is (= nil (coerce "foo" const/$xsd:time))))
 
-    nil "foo" const/$xsd:date
+  (testing "datetime"
+    (is (= #?(:clj
+              (OffsetDateTime/of 1980 10 5 11 23 0 0
+                                 (ZoneOffset/of "Z"))
+              :cljs
+              #inst "1980-10-05T11:23:00.000-00:00")
+           (coerce "1980-10-5T11:23:00Z" const/$xsd:dateTime)))
 
-    ;; time
-    #?(:clj
-       (LocalTime/of 12 42 0)
-       :cljs
-       (js/Date. "1970-01-01T12:42:00")) "12:42:00" const/$xsd:time
+    (is (= nil (coerce "foo" const/$xsd:dateTime))))
 
-    #?(:clj
-       (OffsetTime/of 12 42 0 0
-                      (ZoneOffset/of "Z"))
-       :cljs
-       #inst "1970-01-01T12:42:00.000-00:00") "12:42:00Z" const/$xsd:time
+  (testing "decimal"
+    (is (= #?(:clj (BigDecimal. "3.14") :cljs 3.14)
+           (coerce 3.14 const/$xsd:decimal)))
+    (is (= #?(:clj (BigDecimal. "3.14") :cljs 3.14)
+           (coerce "3.14" const/$xsd:decimal)))
+    (is (= #?(:clj (BigDecimal. "42.0") :cljs 42)
+           (coerce 42 const/$xsd:decimal)))
+    (is (= nil
+           (coerce "foo" const/$xsd:decimal))))
 
-    #?(:clj
-       (LocalTime/of 12 42 5)
-       :cljs
-       (js/Date. "1970-01-01T12:42:05")) "12:42:5" const/$xsd:time
+  (testing "double"
+    (is (= #?(:clj Double/POSITIVE_INFINITY
+              :cljs js/Number.POSITIVE_INFINITY)
+           (coerce "INF" const/$xsd:double)))
+    (is (= #?(:clj Double/NEGATIVE_INFINITY
+              :cljs js/Number.NEGATIVE_INFINITY)
+           (coerce "-INF" const/$xsd:double)))
+    (is (= 3.14
+           (coerce 3.14 const/$xsd:double)))
+    (is (= 3.0
+           (coerce 3 const/$xsd:double)))
+    (is (= nil
+           (coerce "foo" const/$xsd:double))))
 
-    #?(:clj
-       (OffsetTime/of 12 42 5 0
-                      (ZoneOffset/of "Z"))
-       :cljs
-       #inst "1970-01-01T12:42:05.000-00:00") "12:42:5Z" const/$xsd:time
+  (testing "float"
+    (is (= #?(:clj Float/POSITIVE_INFINITY
+              :cljs js/Number.POSITIVE_INFINITY)
+           (coerce "INF" const/$xsd:float)))
+    (is (= #?(:clj Float/NEGATIVE_INFINITY
+              :cljs js/Number.NEGATIVE_INFINITY)
+           (coerce "-INF" const/$xsd:float)))
+    (is (= 3.14
+           (coerce 3.14 const/$xsd:float)))
+    (is (= 3.0
+           (coerce 3 const/$xsd:float)))
+    (is (= nil
+           (coerce "foo" const/$xsd:float))))
 
-    nil "foo" const/$xsd:time
+  (testing "integer"
+    (is (= 42 (coerce 42 const/$xsd:integer)))
+    (is (= 42 (coerce "42" const/$xsd:integer)))
+    (is (= -42 (coerce -42 const/$xsd:integer)))
+    (is (= 0 (coerce 0 const/$xsd:integer)))
+    (is (= nil (coerce 3.14 const/$xsd:integer)))
+    (is (= nil (coerce "3.14" const/$xsd:integer))))
 
-    ;; datetime
-    #?(:clj
-       (OffsetDateTime/of 1980 10 5 11 23 0 0
-                          (ZoneOffset/of "Z"))
-       :cljs
-       #inst "1980-10-05T11:23:00.000-00:00") "1980-10-5T11:23:00Z" const/$xsd:dateTime
+  (testing "int"
+    (is (= 42 (coerce 42 const/$xsd:int)))
+    (is (= 42 (coerce "42" const/$xsd:int)))
+    (is (= -42 (coerce -42 const/$xsd:int)))
+    (is (= 0 (coerce 0 const/$xsd:int)))
+    (is (= nil (coerce 3.14 const/$xsd:int)))
+    (is (= nil (coerce "3.14" const/$xsd:int)))
+    (is (= #?(:clj nil :cljs 2147483648) (coerce 2147483648 const/$xsd:int)))
+    (is (= #?(:clj nil :cljs 2147483648) (coerce "2147483648" const/$xsd:int)))
+    (is (= #?(:clj nil :cljs -2147483649) (coerce -2147483649 const/$xsd:int)))
+    (is (= #?(:clj nil :cljs -2147483649) (coerce "-2147483649" const/$xsd:int))))
 
-    nil "foo" const/$xsd:dateTime
+  (testing "unsignedInt"
+    (is (= 42 (coerce 42 const/$xsd:unsignedInt)))
+    (is (= 0 (coerce 0 const/$xsd:unsignedInt)))
+    (is (= 42 (coerce "42" const/$xsd:unsignedInt)))
+    (is (= nil (coerce -42 const/$xsd:unsignedInt)))
+    (is (= nil (coerce "-42" const/$xsd:unsignedInt)))
+    (is (= nil (coerce 3.14 const/$xsd:unsignedInt)))
+    (is (= nil (coerce "3.14" const/$xsd:unsignedInt))))
 
-    ;; decimal
-    #?(:clj (BigDecimal. "3.14") :cljs 3.14) 3.14 const/$xsd:decimal
-    #?(:clj (BigDecimal. "3.14") :cljs 3.14) "3.14" const/$xsd:decimal
-    #?(:clj (BigDecimal. "42.0") :cljs 42) 42 const/$xsd:decimal
-    nil "foo" const/$xsd:decimal
+  (testing "natural integer"
+    (is (= 42 (coerce 42 const/$xsd:nonNegativeInteger)))
+    (is (= 0 (coerce 0 const/$xsd:nonNegativeInteger)))
+    (is (= 42 (coerce "42" const/$xsd:nonNegativeInteger)))
+    (is (= 0 (coerce "0" const/$xsd:nonNegativeInteger)))
+    (is (= nil (coerce -42 const/$xsd:nonNegativeInteger)))
+    (is (= nil (coerce "-42" const/$xsd:nonNegativeInteger)))
+    (is (= nil (coerce 3.14 const/$xsd:nonNegativeInteger)))
+    (is (= nil (coerce "3.14" const/$xsd:nonNegativeInteger))))
 
-    ;; double
-    #?(:clj Double/POSITIVE_INFINITY
-       :cljs js/Number.POSITIVE_INFINITY) "INF" const/$xsd:double
-    #?(:clj Double/NEGATIVE_INFINITY
-       :cljs js/Number.NEGATIVE_INFINITY) "-INF" const/$xsd:double
-    3.14 3.14 const/$xsd:double
-    3.0 3 const/$xsd:double
-    nil "foo" const/$xsd:double
+  (testing "positive integer"
+    (is (= 42 (coerce 42 const/$xsd:positiveInteger)))
+    (is (= 42 (coerce "42" const/$xsd:positiveInteger)))
+    (is (= nil (coerce 0 const/$xsd:positiveInteger)))
+    (is (= nil (coerce "0" const/$xsd:positiveInteger)))
+    (is (= nil (coerce -42 const/$xsd:positiveInteger)))
+    (is (= nil (coerce "-42" const/$xsd:positiveInteger)))
+    (is (= nil (coerce 3.14 const/$xsd:positiveInteger)))
+    (is (= nil (coerce "3.14" const/$xsd:positiveInteger))))
 
-    ;; float
-    #?(:clj Float/POSITIVE_INFINITY
-       :cljs js/Number.POSITIVE_INFINITY) "INF" const/$xsd:float
-    #?(:clj Float/NEGATIVE_INFINITY
-       :cljs js/Number.NEGATIVE_INFINITY) "-INF" const/$xsd:float
-    3.14 3.14 const/$xsd:float
-    3.0 3 const/$xsd:float
-    nil "foo" const/$xsd:float
+  (testing "negative integer"
+    (is (= nil (coerce 42 const/$xsd:negativeInteger)))
+    (is (= nil (coerce "42" const/$xsd:negativeInteger)))
+    (is (= nil (coerce 0 const/$xsd:negativeInteger)))
+    (is (= nil (coerce "0" const/$xsd:negativeInteger)))
+    (is (= -42 (coerce -42 const/$xsd:negativeInteger)))
+    (is (= -42 (coerce "-42" const/$xsd:negativeInteger)))
+    (is (= nil (coerce -3.14 const/$xsd:negativeInteger)))
+    (is (= nil (coerce "-3.14" const/$xsd:negativeInteger))))
 
-    ;; integer / int / unsignedInt / etc.
-    42 42 const/$xsd:integer
-    42 "42" const/$xsd:integer
-    -42 -42 const/$xsd:integer
-    0 0 const/$xsd:integer
-    nil 3.14 const/$xsd:integer
-    nil "3.14" const/$xsd:integer
+  (testing "non-positive integer"
+    (is (= nil (coerce 42 const/$xsd:nonPositiveInteger)))
+    (is (= nil (coerce "42" const/$xsd:nonPositiveInteger)))
+    (is (= 0 (coerce 0 const/$xsd:nonPositiveInteger)))
+    (is (= 0 (coerce "0" const/$xsd:nonPositiveInteger)))
+    (is (= -42 (coerce -42 const/$xsd:nonPositiveInteger)))
+    (is (= -42 (coerce "-42" const/$xsd:nonPositiveInteger)))
+    (is (= nil (coerce -3.14 const/$xsd:nonPositiveInteger)))
+    (is (= nil (coerce "-3.14" const/$xsd:nonPositiveInteger))))
 
-    42 42 const/$xsd:int
-    42 "42" const/$xsd:int
-    -42 -42 const/$xsd:int
-    0 0 const/$xsd:int
-    nil 3.14 const/$xsd:int
-    nil "3.14" const/$xsd:int
-    #?(:clj nil :cljs 2147483648) 2147483648 const/$xsd:int
-    #?(:clj nil :cljs 2147483648) "2147483648" const/$xsd:int
-    #?(:clj nil :cljs -2147483649) -2147483649 const/$xsd:int
-    #?(:clj nil :cljs -2147483649) "-2147483649" const/$xsd:int
+  (testing "long"
+    (is (= 42 (coerce 42 const/$xsd:long)))
+    (is (= 42 (coerce "42" const/$xsd:long)))
+    (is (= -42 (coerce -42 const/$xsd:long)))
+    (is (= -42 (coerce "-42" const/$xsd:long)))
+    (is (= nil (coerce 3.14 const/$xsd:long)))
+    (is (= nil (coerce "3.14" const/$xsd:long))))
 
-    42 42 const/$xsd:unsignedInt
-    0 0 const/$xsd:unsignedInt
-    42 "42" const/$xsd:unsignedInt
-    nil -42 const/$xsd:unsignedInt
-    nil "-42" const/$xsd:unsignedInt
-    nil 3.14 const/$xsd:unsignedInt
-    nil "3.14" const/$xsd:unsignedInt
+  (testing "unsigned long"
+    (is (= 42 (coerce 42 const/$xsd:unsignedLong)))
+    (is (= 42 (coerce "42" const/$xsd:unsignedLong)))
+    (is (= nil (coerce -42 const/$xsd:unsignedLong)))
+    (is (= nil (coerce "-42" const/$xsd:unsignedLong)))
+    (is (= nil (coerce 3.14 const/$xsd:unsignedLong)))
+    (is (= nil (coerce "3.14" const/$xsd:unsignedLong))))
 
-    42 42 const/$xsd:nonNegativeInteger
-    0 0 const/$xsd:nonNegativeInteger
-    42 "42" const/$xsd:nonNegativeInteger
-    0 "0" const/$xsd:nonNegativeInteger
-    nil -42 const/$xsd:nonNegativeInteger
-    nil "-42" const/$xsd:nonNegativeInteger
-    nil 3.14 const/$xsd:nonNegativeInteger
-    nil "3.14" const/$xsd:nonNegativeInteger
+  (testing "short"
+    (is (= 42 (coerce 42 const/$xsd:short)))
+    (is (= 42 (coerce "42" const/$xsd:short)))
+    (is (= -42 (coerce -42 const/$xsd:short)))
+    (is (= -42 (coerce "-42" const/$xsd:short)))
+    (is (= nil (coerce 3.14 const/$xsd:short)))
+    (is (= nil (coerce "3.14" const/$xsd:short)))
+    (is (= #?(:clj nil :cljs 32768) (coerce "32768" const/$xsd:short)))
+    (is (= #?(:clj nil :cljs 32768) (coerce 32768 const/$xsd:short)))
+    (is (= #?(:clj nil :cljs -32769) (coerce "-32769" const/$xsd:short)))
+    (is (= #?(:clj nil :cljs -32769) (coerce -32769 const/$xsd:short))))
 
-    42 42 const/$xsd:positiveInteger
-    42 "42" const/$xsd:positiveInteger
-    nil 0 const/$xsd:positiveInteger
-    nil "0" const/$xsd:positiveInteger
-    nil -42 const/$xsd:positiveInteger
-    nil "-42" const/$xsd:positiveInteger
-    nil 3.14 const/$xsd:positiveInteger
-    nil "3.14" const/$xsd:positiveInteger
+  (testing "unsigned short"
+    (is (= 42 (coerce 42 const/$xsd:unsignedShort)))
+    (is (= 42 (coerce "42" const/$xsd:unsignedShort)))
+    (is (= nil (coerce -42 const/$xsd:unsignedShort)))
+    (is (= nil (coerce "-42" const/$xsd:unsignedShort)))
+    (is (= nil (coerce 3.14 const/$xsd:unsignedShort)))
+    (is (= nil (coerce "3.14" const/$xsd:unsignedShort)))
+    (is (= #?(:clj nil :cljs 32768) (coerce 32768 const/$xsd:unsignedShort)))
+    (is (= #?(:clj nil :cljs 32768) (coerce "32768" const/$xsd:unsignedShort))))
 
-    nil 42 const/$xsd:negativeInteger
-    nil "42" const/$xsd:negativeInteger
-    nil 0 const/$xsd:negativeInteger
-    nil "0" const/$xsd:negativeInteger
-    -42 -42 const/$xsd:negativeInteger
-    -42 "-42" const/$xsd:negativeInteger
-    nil -3.14 const/$xsd:negativeInteger
-    nil "-3.14" const/$xsd:negativeInteger
+  (testing "byte"
+    (is (= 42 (coerce 42 const/$xsd:byte)))
+    (is (= 42 (coerce "42" const/$xsd:byte)))
+    (is (= -42 (coerce -42 const/$xsd:byte)))
+    (is (= -42 (coerce "-42" const/$xsd:byte)))
+    (is (= nil (coerce 3.14 const/$xsd:byte)))
+    (is (= nil (coerce "3.14" const/$xsd:byte)))
+    (is (= #?(:clj nil :cljs 128) (coerce 128 const/$xsd:byte)))
+    (is (= #?(:clj nil :cljs 128) (coerce "128" const/$xsd:byte)))
+    (is (= #?(:clj nil :cljs -129) (coerce -129 const/$xsd:byte)))
+    (is (= #?(:clj nil :cljs -129) (coerce "-129" const/$xsd:byte))))
 
-    nil 42 const/$xsd:nonPositiveInteger
-    nil "42" const/$xsd:nonPositiveInteger
-    0 0 const/$xsd:nonPositiveInteger
-    0 "0" const/$xsd:nonPositiveInteger
-    -42 -42 const/$xsd:nonPositiveInteger
-    -42 "-42" const/$xsd:nonPositiveInteger
-    nil -3.14 const/$xsd:nonPositiveInteger
-    nil "-3.14" const/$xsd:nonPositiveInteger
+  (testing "unsigned byte"
+    (is (= 42 (coerce 42 const/$xsd:unsignedByte)))
+    (is (= 42 (coerce "42" const/$xsd:unsignedByte)))
+    (is (= nil (coerce -42 const/$xsd:unsignedByte)))
+    (is (= nil (coerce "-42" const/$xsd:unsignedByte)))
+    (is (= nil (coerce 3.14 const/$xsd:unsignedByte)))
+    (is (= nil (coerce "3.14" const/$xsd:unsignedByte)))
+    (is (= #?(:clj nil :cljs 32768) (coerce 32768 const/$xsd:unsignedByte)))
+    (is (= #?(:clj nil :cljs 32768) (coerce "32768" const/$xsd:unsignedByte))))
 
-    nil -42 const/$xsd:nonNegativeInteger
-    nil "-42" const/$xsd:nonNegativeInteger
-    0 0 const/$xsd:nonNegativeInteger
-    0 "0" const/$xsd:nonNegativeInteger
-    42 42 const/$xsd:nonNegativeInteger
-    42 "42" const/$xsd:nonNegativeInteger
-    nil 3.14 const/$xsd:nonNegativeInteger
-    nil "3.14" const/$xsd:nonNegativeInteger
+  (testing "normalized string"
+    (is (= "foo  bar  baz" (coerce "foo  bar \tbaz" const/$xsd:normalizedString)))
+    (is (= "foo     bar     baz" (coerce "foo
+    bar     baz" const/$xsd:normalizedString)))
+    (is (= " foo   bar  baz " (coerce " foo   bar  baz " const/$xsd:normalizedString))))
 
-    ;; long & unsignedLong
-    42 42 const/$xsd:long
-    42 "42" const/$xsd:long
-    -42 -42 const/$xsd:long
-    -42 "-42" const/$xsd:long
-    nil 3.14 const/$xsd:long
-    nil "3.14" const/$xsd:long
+  (testing "token"
+    (is (= "foo bar baz" (coerce "  foo    bar \t\t\t baz    " const/$xsd:token)))
+    (is (= "foo bar baz" (coerce "foo
+    bar          baz" const/$xsd:token))))
 
-    42 42 const/$xsd:unsignedLong
-    42 "42" const/$xsd:unsignedLong
-    nil -42 const/$xsd:unsignedLong
-    nil "-42" const/$xsd:unsignedLong
-    nil 3.14 const/$xsd:unsignedLong
-    nil "3.14" const/$xsd:unsignedLong
+  (testing "language"
+    (is (= "en" (coerce "en " const/$xsd:language)))
+    (is (= "en-US" (coerce " en-US" const/$xsd:language)))
+    (is (= "es-MX" (coerce "\tes-MX" const/$xsd:language))))
 
-    ;; short & unsignedShort
-    42 42 const/$xsd:short
-    42 "42" const/$xsd:short
-    -42 -42 const/$xsd:short
-    -42 "-42" const/$xsd:short
-    nil 3.14 const/$xsd:short
-    nil "3.14" const/$xsd:short
-    #?(:clj nil :cljs 32768) "32768" const/$xsd:short
-    #?(:clj nil :cljs 32768) 32768 const/$xsd:short
-    #?(:clj nil :cljs -32769) "-32769" const/$xsd:short
-    #?(:clj nil :cljs -32769) -32769 const/$xsd:short
-
-    42 42 const/$xsd:unsignedShort
-    42 "42" const/$xsd:unsignedShort
-    nil -42 const/$xsd:unsignedShort
-    nil "-42" const/$xsd:unsignedShort
-    nil 3.14 const/$xsd:unsignedShort
-    nil "3.14" const/$xsd:unsignedShort
-    #?(:clj nil :cljs 32768) 32768 const/$xsd:unsignedShort
-    #?(:clj nil :cljs 32768) "32768" const/$xsd:unsignedShort
-
-    ;; byte & unsignedByte
-    42 42 const/$xsd:byte
-    42 "42" const/$xsd:byte
-    -42 -42 const/$xsd:byte
-    -42 "-42" const/$xsd:byte
-    nil 3.14 const/$xsd:byte
-    nil "3.14" const/$xsd:byte
-    #?(:clj nil :cljs 128) 128 const/$xsd:byte
-    #?(:clj nil :cljs 128) "128" const/$xsd:byte
-    #?(:clj nil :cljs -129) -129 const/$xsd:byte
-    #?(:clj nil :cljs -129) "-129" const/$xsd:byte
-
-    42 42 const/$xsd:unsignedByte
-    42 "42" const/$xsd:unsignedByte
-    nil -42 const/$xsd:unsignedByte
-    nil "-42" const/$xsd:unsignedByte
-    nil 3.14 const/$xsd:unsignedByte
-    nil "3.14" const/$xsd:unsignedByte
-    #?(:clj nil :cljs 32768) 32768 const/$xsd:unsignedByte
-    #?(:clj nil :cljs 32768) "32768" const/$xsd:unsignedByte
-
-    ;; normalizedString
-    "foo  bar  baz" "foo  bar \tbaz" const/$xsd:normalizedString
-    "foo     bar     baz" "foo
-    bar     baz" const/$xsd:normalizedString
-    " foo   bar  baz " " foo   bar  baz " const/$xsd:normalizedString
-
-    ;; token
-    "foo bar baz" "  foo    bar \t\t\t baz    " const/$xsd:token
-    "foo bar baz" "foo
-    bar          baz" const/$xsd:token
-
-    ;; language
-    "en" "en " const/$xsd:language
-    "en-US" " en-US" const/$xsd:language
-    "es-MX" "\tes-MX" const/$xsd:language
-
-    ;; non-coerced datatypes
-    "whatever" "whatever" const/$xsd:hexBinary
-    "thingy" "thingy" const/$xsd:duration))
+  (testing "non-coerced datatypes"
+    (is (= "whatever" (coerce "whatever" const/$xsd:hexBinary)))
+    (is (= "thingy" (coerce "thingy" const/$xsd:duration)))))

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -52,33 +52,49 @@
               :cljs
               (js/Date. "1970-01-01T12:42:00"))
            (coerce "12:42:00" const/$xsd:time)))
-    (is (=
-          #?(:clj
-             (OffsetTime/of 12 42 0 0 (ZoneOffset/of "Z"))
-             :cljs
-             #inst "1970-01-01T12:42:00.000-00:00")
-          (coerce "12:42:00Z" const/$xsd:time)))
-    (is (=
-          #?(:clj
-             (LocalTime/of 12 42 5)
-             :cljs
-             (js/Date. "1970-01-01T12:42:05"))
-          (coerce "12:42:5" const/$xsd:time)))
-    (is (=
-          #?(:clj
-             (OffsetTime/of 12 42 5 0 (ZoneOffset/of "Z"))
-             :cljs
-             #inst "1970-01-01T12:42:05.000-00:00")
-          (coerce "12:42:5Z" const/$xsd:time)))
+    (is (= #?(:clj
+              (OffsetTime/of 12 42 0 0 (ZoneOffset/of "Z"))
+              :cljs
+              #inst "1970-01-01T12:42:00.000-00:00")
+           (coerce "12:42:00Z" const/$xsd:time)))
+    (is (= #?(:clj
+              (OffsetTime/of 9 30 10 0 (ZoneOffset/of "-06:00"))
+              :cljs
+              #inst "1970-01-01T09:30:10.000-06:00")
+          (coerce "09:30:10-06:00" const/$xsd:time)))
+    (is (= #?(:clj
+              (LocalTime/of 12 42 5)
+              :cljs
+              (js/Date. "1970-01-01T12:42:05"))
+           (coerce "12:42:5" const/$xsd:time)))
+    (is (= #?(:clj
+              (OffsetTime/of 12 42 5 0 (ZoneOffset/of "Z"))
+              :cljs
+              #inst "1970-01-01T12:42:05.000-00:00")
+           (coerce "12:42:5Z" const/$xsd:time)))
+    (is (= #?(:clj
+              (OffsetTime/of 11 14 32 833000000 (ZoneOffset/of "Z"))
+              :cljs
+              #inst "1970-01-01T11:14:32.833-00:00")
+           (coerce "11:14:32.833Z" const/$xsd:time)))
     (is (= nil (coerce "foo" const/$xsd:time))))
 
   (testing "datetime"
     (is (= #?(:clj
-              (OffsetDateTime/of 1980 10 5 11 23 0 0
-                                 (ZoneOffset/of "Z"))
+              (OffsetDateTime/of 1980 10 5 11 23 0 0 (ZoneOffset/of "Z"))
               :cljs
               #inst "1980-10-05T11:23:00.000-00:00")
-           (coerce "1980-10-5T11:23:00Z" const/$xsd:dateTime)))
+           (coerce "1980-10-5T11:23:00Z" const/$xsd:dateTime))
+        "utc")
+    (is (= #?(:clj
+              (OffsetDateTime/of 1980 10 5 11 23 0 0 (ZoneOffset/of "-06:00"))
+              :cljs
+              #inst "1980-10-05T11:23:00.000-00:00")
+           (coerce "1980-10-5T11:23:00-06:00" const/$xsd:dateTime))
+        "offset")
+    (is (= #?(:clj (OffsetDateTime/of 2021 9 24 11 14 32 833000000 (ZoneOffset/of "Z")))
+           (coerce "2021-09-24T11:14:32.833Z" const/$xsd:dateTime))
+        "with nanoseconds")
 
     (is (= nil (coerce "foo" const/$xsd:dateTime))))
 

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -21,15 +21,9 @@
     (is (= nil (coerce "foo" const/$xsd:boolean))))
 
   (testing "date"
-    (is (= #?(:clj
-              (OffsetDateTime/of 1980 10 5 0 0 0 0 (ZoneOffset/of "Z"))
-              :cljs
-              #inst "1980-10-05T00:00:00.000-00:00")
+    (is (= nil
            (coerce "1980-10-5Z" const/$xsd:date)))
-    (is (= #?(:clj
-              (LocalDate/of 1980 10 5)
-              :cljs
-              (js/Date. "1980-10-05T00:00:00"))
+    (is (= nil
            (coerce "1980-10-5" const/$xsd:date)))
     (is (= #?(:clj
               (OffsetDateTime/of 2022 1 5 0 0 0 0 (ZoneOffset/of "Z"))
@@ -62,15 +56,9 @@
               :cljs
               #inst "1970-01-01T09:30:10.000-06:00")
           (coerce "09:30:10-06:00" const/$xsd:time)))
-    (is (= #?(:clj
-              (LocalTime/of 12 42 5)
-              :cljs
-              (js/Date. "1970-01-01T12:42:05"))
+    (is (= nil
            (coerce "12:42:5" const/$xsd:time)))
-    (is (= #?(:clj
-              (OffsetTime/of 12 42 5 0 (ZoneOffset/of "Z"))
-              :cljs
-              #inst "1970-01-01T12:42:05.000-00:00")
+    (is (= nil
            (coerce "12:42:5Z" const/$xsd:time)))
     (is (= #?(:clj
               (OffsetTime/of 11 14 32 833000000 (ZoneOffset/of "Z"))
@@ -80,18 +68,21 @@
     (is (= nil (coerce "foo" const/$xsd:time))))
 
   (testing "datetime"
+    (is (= nil
+           (coerce "1980-10-5T11:23:00Z" const/$xsd:dateTime))
+        "don't accept non-8601 timestamps")
+    (is (= #?(:clj
+              (OffsetDateTime/of 1980 10 5 11 23 0 0 (ZoneOffset/of "-06:00"))
+              :cljs
+              #inst "1980-10-05T17:23:00.000-00:00")
+           (coerce "1980-10-05T11:23:00-06:00" const/$xsd:dateTime))
+        "offset")
     (is (= #?(:clj
               (OffsetDateTime/of 1980 10 5 11 23 0 0 (ZoneOffset/of "Z"))
               :cljs
               #inst "1980-10-05T11:23:00.000-00:00")
-           (coerce "1980-10-5T11:23:00Z" const/$xsd:dateTime))
-        "utc")
-    (is (= #?(:clj
-              (OffsetDateTime/of 1980 10 5 11 23 0 0 (ZoneOffset/of "-06:00"))
-              :cljs
-              #inst "1980-10-05T11:23:00.000-00:00")
-           (coerce "1980-10-5T11:23:00-06:00" const/$xsd:dateTime))
-        "offset")
+           (coerce "1980-10-05T11:23:00Z" const/$xsd:dateTime))
+        "z")
     (is (= #?(:clj (OffsetDateTime/of 2021 9 24 11 14 32 833000000 (ZoneOffset/of "Z")))
            (coerce "2021-09-24T11:14:32.833Z" const/$xsd:dateTime))
         "with nanoseconds")


### PR DESCRIPTION
Fixes #420 

This is a stricter approach than we had before, only accepting iso 8601 compliant date/time strings. But now we handle subsecond resolution, according to platform support.