### PR TITLE
allow users to clear the default context for queries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          instaparse/instaparse           {:mvn/version "1.4.12"}
          metosin/malli                   {:mvn/version "0.9.2"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :sha     "a909330e33196504ef8a5411aaa0409ab72aaa35"}
+                                          :sha     "010ea42e857eb1845fc390767d649aa539768d6f"}
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.2.4"}

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -25,6 +25,12 @@
 
       (let [{:keys [context history t commit-details] :as _parsed} (history/history-query-parser query-map)
 
+            ;; if context is explicitly nil, preserve it, otherwise fall back to default
+            context (if (or (contains? query-map :context)
+                            (contains? query-map "@context"))
+                      context
+                      {})
+
             ;; from and to are positive ints, need to convert to negative or fill in default values
             {:keys [from to at]} t
             [from-t to-t]        (if at

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -25,7 +25,12 @@
                   :context-str
                   :context)
         db-ctx  (get-in db [:schema ctx-key])
-        q-ctx   (or (:context q) (get q "@context"))]
+        ;; if context is explicitly set to nil, preserve it
+        q-ctx (if (or (contains? q :context)
+                      (contains? q "@context"))
+                (or (:context q) (get q "@context"))
+                ;; otherwise, fall back to db-ctx
+                {})]
     (json-ld/parse-context db-ctx q-ctx)))
 
 (defn parse-var-name


### PR DESCRIPTION
This is a partial fix for #395, allowing users to supply an explicitly `nil` context to clear the default context.

This is just the bare minimum changes necessary to support the new behavior of the json-ld dependency.