### PR TITLE
only allow string "latest" instead of keyword for history t

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -33,16 +33,16 @@
             ;; from and to are positive ints, need to convert to negative or fill in default values
             {:keys [from to at]} t
             [from-t to-t]        (if at
-                                   (let [t (cond (= :latest at) (:t db*)
+                                   (let [t (cond (= "latest" at) (:t db*)
                                                  (string? at)   (<? (time-travel/datetime->t db* at))
                                                  (number? at)   (- at))]
                                      [t t])
                                    ;; either (:from or :to)
-                                   [(cond (= :latest from) (:t db*)
+                                   [(cond (= "latest" from) (:t db*)
                                           (string? from)   (<? (time-travel/datetime->t db* from))
                                           (number? from)   (- from)
                                           (nil? from)      -1)
-                                    (cond (= :latest to) (:t db*)
+                                    (cond (= "latest" to) (:t db*)
                                           (string? to)   (<? (time-travel/datetime->t db* to))
                                           (number? to)   (- to)
                                           (nil? to)      (:t db*))])

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -39,15 +39,15 @@
      [:and
       [:map
        [:from {:optional true} [:or
-                                [:enum :latest]
+                                [:enum "latest"]
                                 pos-int?
                                 datatype/iso8601-datetime-re]]
        [:to {:optional true} [:or
-                              [:enum :latest]
+                              [:enum "latest"]
                               pos-int?
                               datatype/iso8601-datetime-re]]
        [:at {:optional true} [:or
-                              [:enum :latest]
+                              [:enum "latest"]
                               pos-int?
                               datatype/iso8601-datetime-re]]]
       [:fn {:error/message "Either \"from\" or \"to\" `t` keys must be provided."}

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -293,7 +293,7 @@
           (is (= [commit-4 commit-5]
                  @(fluree/history ledger {:commit-details true :t {:from 4 :to 5}})))
           (is (= [commit-5]
-                 @(fluree/history ledger {:commit-details true :t {:at :latest}})))))
+                 @(fluree/history ledger {:commit-details true :t {:at "latest"}})))))
 
       (testing "time range"
         (let [[c2 c3 c4 :as response] @(fluree/history


### PR DESCRIPTION
When transforming incoming queries, it is a lot easier if we only have to focus on keys, instead of keys and values. By only using a string we don't have to transform any history query values at all.

Helps fix https://github.com/fluree/http-api-gateway/issues/25
