### PR TITLE
allow transacting `false` values

### DIFF
--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -76,7 +76,7 @@
                           (conj node-flakes (flake/create sid pid node-sid const/$xsd:anyURI t true m)))
 
                         ;; a literal value
-                        (and value (not= shacl-dt const/$xsd:anyURI))
+                        (and (some? value) (not= shacl-dt const/$xsd:anyURI))
                         (let [[value* dt] (datatype/from-expanded v-map shacl-dt)]
                           (if validate-fn
                             (or (validate-fn value*)

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -51,4 +51,21 @@
               [:id :id "@id"]]
              @(fluree/query db-ok '{:context {:ex "http://example.org/ns/"}
                                     :select [?s ?p ?o]
-                                    :where  [[?s ?p ?o]]}))))))
+                                    :where  [[?s ?p ?o]]})))))
+  (testing "Allow transacting `false` values"
+    (let [conn    (test-utils/create-conn)
+          ledger  @(fluree/create conn "tx/bools")
+          db-bool @(fluree/stage
+                     (fluree/db ledger)
+                     {:context    {:ex "http://example.org/ns/"}
+                      :id         :ex/alice
+                      :ex/isCool   false})]
+      (is (= [[:ex/alice :id "http://example.org/ns/alice"]
+              [:ex/alice :ex/isCool false]
+              [:ex/isCool :id "http://example.org/ns/isCool"]
+              [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
+              [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+              [:id :id "@id"]]
+             @(fluree/query db-bool '{:context {:ex "http://example.org/ns/"}
+                                      :select  [?s ?p ?o]
+                                      :where   [[?s ?p ?o]]}))))))


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/13

Updates transact pipeline to restrict its error condition to `nil` values, rather than all falsey values, so we can transact `false`.