### PR TITLE
Remove avro deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,6 @@
          criterium/criterium             {:mvn/version "0.4.6"}
 
          ;; serialization / compression
-         com.fluree/abracad              {:mvn/version "0.4.19"}
          com.fluree/alphabase            {:mvn/version "3.3.0"}
 
          ;; cryptography

--- a/src/fluree/db/flake.cljc
+++ b/src/fluree/db/flake.cljc
@@ -2,8 +2,7 @@
   (:refer-clojure :exclude [split-at sorted-set-by sorted-map-by take last])
   (:require [clojure.data.avl :as avl]
             [fluree.db.constants :as const]
-            [fluree.db.util.core :as util]
-            #?(:clj [abracad.avro :as avro]))
+            [fluree.db.util.core :as util])
   #?(:cljs (:require-macros [fluree.db.flake :refer [combine-cmp]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -76,12 +75,7 @@
 
 
 (deftype Flake [s p o dt t op m]
-  #?@(:clj  [avro/AvroSerializable
-             (schema-name [_] "fluree.Flake")
-             (field-get [f field] (get f field))
-             (field-list [_] #{:s :p :o :dt :t :op :m})
-
-             clojure.lang.Seqable
+  #?@(:clj  [clojure.lang.Seqable
              (seq [f] (list (.-s f) (.-p f) (.-o f) (.-dt f) (.-t f) (.-op f) (.-m f)))
 
              clojure.lang.Indexed


### PR DESCRIPTION
In PR #427, file-based persistent indexing came back, and I opted for JSON serialization of those index files.

Previously we had used AVRO, which I think is always an option we could re-introduce. The use of IPFS and its more native file type handlers of JSON made sense to use JSON serialization there at least initially

AVRO excels at compression of maps by encoding keys as mostly a byte or two. The bulk of the data we store in an index however is the Flakes, which are already serialized into tuples. While I haven't tested it, my assumption is a gzipped JSON index file would have similar compression characteristics as AVRO - maybe even better - for our use case anyhow.

For now however serialization of index files is not gzipped. I think we should do that, but in these early stages being able to open an index file directly in a code editor is super helpful for debugging.

If we feel AVRO or another serialization format would have substantial advantages over gzipped JSON, we can always explore that in the future.
