### PR TITLE
Fix loading `@list`s

### DIFF
--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -182,7 +182,6 @@
       (log/debug "assert-v-maps v-map:" v-map)
       (log/debug "assert-v-maps id:" id)
       (let [ref-id (:id v-map)
-            list? (list-value? v-map)
             acc**
             (cond->
                 (cond

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -335,7 +335,6 @@
                                   {:id      "did:fluree:123"
                                    :ex/user :ex/alice
                                    :f/role  :ex/userRole}])
-
                  db+policy    @(fluree/stage
                                  db
                                  [{:id            :ex/UserPolicy,

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -292,7 +292,8 @@
                                  :type       :ex/User,
                                  :ex/friends {:list [:ex/john :ex/cam]}}
                                 {:id   :ex/cam,
-                                 :type :ex/User}
+                                 :type :ex/User
+                                 :ex/numList {:list [7 8 9 10]}}
                                 {:id   :ex/john,
                                  :type :ex/User}])
                db           @(fluree/commit! ledger db)
@@ -300,7 +301,9 @@
                loaded-db    (fluree/db loaded)]
            (is (= (:t db) (:t loaded-db)))
            (testing "query returns expected `list` values"
-             (is (= [{:id :ex/cam, :rdf/type [:ex/User]}
+             (is (= [{:id :ex/cam,
+                      :rdf/type [:ex/User],
+                      :ex/numList [7 8 9 10]}
                      {:id :ex/john, :rdf/type [:ex/User]}
                      {:id :ex/alice,
                       :rdf/type [:ex/User],

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -306,4 +306,68 @@
                       :rdf/type [:ex/User],
                       :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                     @(fluree/query loaded-db '{:select {?s [:*]}
-                                               :where  [[?s :rdf/type :ex/User]]})))))))))
+                                               :where  [[?s :rdf/type :ex/User]]}))))))
+
+       (testing "can load with policies"
+         (with-tmp-dir storage-path
+           (let [conn         @(fluree/connect
+                                 {:method       :file
+                                  :storage-path storage-path
+                                  :defaults
+                                  {:context (merge test-utils/default-context
+                                                   {:ex "http://example.org/ns/"})}})
+                 ledger-alias "load-policy-test"
+                 ledger       @(fluree/create conn ledger-alias)
+                 db           @(fluree/stage
+                                 (fluree/db ledger)
+                                 [{:id          :ex/alice,
+                                   :type        :ex/User,
+                                   :schema/name "Alice"
+                                   :schema/ssn  "111-11-1111"
+                                   :ex/friend   :ex/john}
+                                  {:id          :ex/john,
+                                   :schema/name "John"
+                                   :type        :ex/User,
+                                   :schema/ssn  "888-88-8888"}
+                                  {:id      "did:fluree:123"
+                                   :ex/user :ex/alice
+                                   :f/role  :ex/userRole}])
+
+                 db+policy    @(fluree/stage
+                                 db
+                                 [{:id            :ex/UserPolicy,
+                                   :type          [:f/Policy],
+                                   :f/targetClass :ex/User
+                                   :f/allow       [{:id           :ex/globalViewAllow
+                                                    :f/targetRole :ex/userRole
+                                                    :f/action     [:f/view]}]
+                                   :f/property    [{:f/path  :schema/ssn
+                                                    :f/allow [{:id           :ex/ssnViewRule
+                                                               :f/targetRole :ex/userRole
+                                                               :f/action     [:f/view]
+                                                               :f/equals     {:list [:f/$identity :ex/user]}}]}]}])
+                 db+policy    @(fluree/commit! ledger db+policy)
+                 loaded       (test-utils/retry-load conn ledger-alias 100)
+                 loaded-db    (fluree/db loaded)]
+             (is (= (:t db) (:t loaded-db)))
+             (testing "query returns expected policy"
+               (is (= [{:id :ex/UserPolicy,
+                        :rdf/type [:f/Policy],
+                        :f/allow
+                        {:id :ex/globalViewAllow,
+                         :f/action {:id :f/view},
+                         :f/targetRole {:_id 211106232532995}},
+                        :f/property
+                        {:id "_:f211106232532999",
+                         :f/allow
+                         {:id :ex/ssnViewRule,
+                          :f/action {:id :f/view},
+                          :f/targetRole {:_id 211106232532995},
+                          :f/equals [{:id :f/$identity} {:id :ex/user}]},
+                         :f/path {:id :schema/ssn}},
+                        :f/targetClass {:id :ex/User}}]
+                      @(fluree/query loaded-db '{:select {?s [:*
+                                                              {:rdf/type [:_id]}
+                                                              {:f/allow [:* {:f/targetRole [:_id]}]}
+                                                              {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
+                                                 :where  [[?s :rdf/type :f/Policy]]}))))))))))


### PR DESCRIPTION
Closes https://github.com/fluree/db/issues/430

The issue with loading policies was not actually specific to policies after all. It was just that we had not yet implemented the logic to load `@list` values in general. This PR adds that functionality.

FWIW this was the smallest, most straightforward change to get this to work and unblock the other work. I held off on some possible improvements because know @zonotope is working in a similar area of the codebase right now, so it seemed best to keep the footprint small and avoid doing potentially unnecessary work. 