### PR TITLE
Refine default context handling

### DIFF
--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -3,6 +3,7 @@
   (:require [clojure.core.async :as async :refer [go]]
             [clojure.string :as str]
             [fluree.crypto :as crypto]
+            [fluree.db.util.context :as ctx-util]
             [fluree.json-ld :as json-ld]
             [fluree.db.index :as index]
             [fluree.db.conn.proto :as conn-proto]
@@ -243,7 +244,7 @@
   (-method [_] :file)
   (-parallelism [_] parallelism)
   (-id [_] id)
-  (-context [_] (:context ledger-defaults))
+  (-default-context [_] (:context ledger-defaults))
   (-new-indexer [_ opts]
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))
@@ -280,12 +281,13 @@
     s))
 
 (defn ledger-defaults
-  [{:keys [context-type context did indexer]}]
-  {:context (util/normalize-context context-type context)
-   :did     did
-   :indexer (cond
-              (fn? indexer)
-              indexer
+  [{:keys [context context-type did indexer]}]
+  {:context      (ctx-util/stringify-context context)
+   :context-type context-type
+   :did          did
+   :indexer      (cond
+                   (fn? indexer)
+                   indexer
 
               (or (map? indexer) (nil? indexer))
               (fn [opts]

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async :refer [go]]
             [fluree.db.storage.core :as storage]
             [fluree.db.index :as index]
+            [fluree.db.util.context :as ctx-util]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log :include-macros true]
             #?(:clj [fluree.db.full-text :as full-text])
@@ -143,7 +144,7 @@
   (-method [_] :memory)
   (-parallelism [_] parallelism)
   (-id [_] id)
-  (-context [_] (:context ledger-defaults))
+  (-default-context [_] (:context ledger-defaults))
   (-new-indexer [_ opts] (idx-default/create opts)) ;; default new ledger indexer
   (-did [_] (:did ledger-defaults))
   (-msg-in [_ msg] (go-try
@@ -172,10 +173,11 @@
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"
-  [{:keys [context-type context did] :as _defaults}]
+  [{:keys [context did context-type] :as _defaults}]
   (async/go
-    {:context (util/normalize-context context-type context)
-     :did     did}))
+    {:context      (ctx-util/stringify-context context)
+     :context-type context-type
+     :did          did}))
 
 (defn connect
   "Creates a new memory connection."

--- a/src/fluree/db/conn/proto.cljc
+++ b/src/fluree/db/conn/proto.cljc
@@ -9,7 +9,7 @@
   (-method [conn] "Returns connection method type (as keyword)")
   (-parallelism [conn] "Returns parallelism integer to use for running multi-thread operations (1->8)")
   (-id [conn] "Returns internal id for connection object")
-  (-context [conn] "Returns optional default context set at connection level")
+  (-default-context [conn] "Returns optional default context set at connection level")
   (-new-indexer [conn opts] "Returns optional default new indexer object for a new ledger with optional opts.")
   (-did [conn] "Returns optional default did map if set at connection level")
   (-msg-in [conn msg] "Handler for incoming message from connection service")

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -423,7 +423,7 @@
 (defn retrieve-context
   "Returns the parsed context. Caches."
   [default-context context-cache supplied-context context-type]
-  (log/debug "retrieve-context - default: " default-context "supplied:" supplied-context "context-type: " context-type)
+  (log/trace "retrieve-context - default: " default-context "supplied:" supplied-context "context-type: " context-type)
   (or (get-in @context-cache [context-type supplied-context])
       (let [context    (if supplied-context
                          (if (sequential? supplied-context)

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -439,7 +439,7 @@
                            (ctx-util/keywordize-context default-context)
                            default-context))
             parsed-ctx (json-ld/parse-context context)]
-        (vswap! context-cache assoc-in [supplied-context context-type] parsed-ctx)
+        (vswap! context-cache assoc-in [context-type supplied-context] parsed-ctx)
         parsed-ctx)))
 
 

--- a/src/fluree/db/dbproto.cljc
+++ b/src/fluree/db/dbproto.cljc
@@ -22,7 +22,9 @@
   (-add-predicate-to-idx [db pred-id] "Adds predicate to idx, return updated db.")
   (-db-type [db] "Returns db type, e.g. :json-ld, :json")
   (-stage [db tx] [db tx opts] "Stages a database transaction.")
-  (-index-update [db commit-index] "Updates db to reflect a new index point described by commit-index metadata"))
+  (-index-update [db commit-index] "Updates db to reflect a new index point described by commit-index metadata")
+  (-context [db] [db context] [db context context-type] "Returns parsed context given supplied context. If no context is supplied, returns default context.")
+  (-default-context [db] "Returns the default context the db is configured to use."))
 
 (defn db?
   [db]

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -111,13 +111,9 @@
     "
   ([conn] (create conn nil nil))
   ([conn ledger-alias] (create conn ledger-alias nil))
-  ([conn ledger-alias {:keys [context context-type] :as opts}]
-   (let [conn-context (conn-proto/-context conn)
-         ledger-context (->> context
-                             (util/normalize-context context-type)
-                             (clojure.core/merge conn-context))
-         res-ch       (jld-ledger/create conn ledger-alias (assoc opts :context ledger-context))]
-     (promise-wrap res-ch))))
+  ([conn ledger-alias opts]
+   (promise-wrap
+     (jld-ledger/create conn ledger-alias opts))))
 
 (defn load-from-address
   "Loads a ledger defined with a Fluree address, e.g.:

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.json-ld.transact
-  (:require [fluree.json-ld :as json-ld]
+  (:require [fluree.db.dbproto :as db-proto]
+            [fluree.json-ld :as json-ld]
             [fluree.db.constants :as const]
             [fluree.db.flake :as flake]
             [fluree.db.json-ld.vocab :as vocab]
@@ -215,13 +216,13 @@
         last-sid (volatile! (jld-ledger/last-sid db))
         commit-t (-> (ledger-proto/-status ledger branch) branch/latest-commit-t)
         t        (-> commit-t inc -)] ;; commit-t is always positive, need to make negative for internal indexing
-    {:issuer        issuer
-     :db-before     (dbproto/-rootdb db)
-     :policy        policy
-     :bootstrap?    bootstrap?
-     :default-ctx   (if (= :string context-type)
-                      (:context-str schema)
-                      (:context schema))
+    {:issuer      issuer
+     :db-before   (dbproto/-rootdb db)
+     :policy      policy
+     :bootstrap?  bootstrap?
+     :default-ctx (if context-type
+                    (dbproto/-context db nil context-type)
+                    (dbproto/-context db))
      :stage-update? (= t db-t) ;; if a previously staged db is getting updated again before committed
      :refs          (volatile! (or (:refs schema) #{const/$rdf:type}))
      :t             t

--- a/src/fluree/db/json_ld/vocab.cljc
+++ b/src/fluree/db/json_ld/vocab.cljc
@@ -186,8 +186,6 @@
      :refs        #{}
      :coll        coll
      :pred        pred
-     :context     nil
-     :context-str nil
      :shapes      (atom {:class {} ; TODO: Does this need to be an atom?
                          :pred  {}})
      :prefix      {}
@@ -223,8 +221,5 @@
   "Updates the schema map of a db."
   [db]
   (go-try
-    (let [{{:keys [context context-str]} :schema} db
-          _       (log/debug "refresh-schema existing context:" context)
-          schema  (<? (vocab-map db))
-          schema* (assoc schema :context context :context-str context-str)]
-      (assoc db :schema schema*))))
+    (let [schema  (<? (vocab-map db))]
+      (assoc db :schema schema))))

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -147,62 +147,62 @@
   "Creates a new ledger, optionally bootstraps it as permissioned or with default context."
   [conn ledger-alias opts]
   (go-try
-    (let [{:keys [default-context context-type did branch pub-fn ipns indexer include
+    (let [{:keys [defaultContext context-type did branch pub-fn ipns indexer include
                   reindex-min-bytes reindex-max-bytes initial-tx new-context?]
            :or   {branch       :main
                   new-context? true}} opts
-          default-context* (if default-context
-                             (-> default-context
-                                 (ctx-util/mapify-context (conn-proto/-default-context conn))
-                                 (ctx-util/stringify-context))
-                             (conn-proto/-default-context conn))
-          context-type*    (or context-type (-> conn :ledger-defaults :context-type))
-          did*             (if did
-                             (if (map? did)
-                               did
-                               {:id did})
-                             (conn-proto/-did conn))
-          indexer          (cond
-                             (satisfies? idx-proto/iIndex indexer)
-                             indexer
+          default-context (if defaultContext
+                            (-> defaultContext
+                                (ctx-util/mapify-context (conn-proto/-default-context conn))
+                                (ctx-util/stringify-context))
+                            (conn-proto/-default-context conn))
+          context-type*   (or context-type (-> conn :ledger-defaults :context-type))
+          did*            (if did
+                            (if (map? did)
+                              did
+                              {:id did})
+                            (conn-proto/-did conn))
+          indexer         (cond
+                            (satisfies? idx-proto/iIndex indexer)
+                            indexer
 
-                             indexer
-                             (throw (ex-info (str "Ledger indexer provided, but doesn't implement iIndex protocol. "
-                                                  "Provided: " indexer)
-                                             {:status 400 :error :db/invalid-indexer}))
+                            indexer
+                            (throw (ex-info (str "Ledger indexer provided, but doesn't implement iIndex protocol. "
+                                                 "Provided: " indexer)
+                                            {:status 400 :error :db/invalid-indexer}))
 
-                             :else
-                             (conn-proto/-new-indexer
-                               conn (util/without-nils
-                                      {:reindex-min-bytes reindex-min-bytes
-                                       :reindex-max-bytes reindex-max-bytes})))
-          ledger-alias*    (normalize-alias ledger-alias)
-          address          (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
-          method-type      (conn-proto/-method conn)
+                            :else
+                            (conn-proto/-new-indexer
+                              conn (util/without-nils
+                                     {:reindex-min-bytes reindex-min-bytes
+                                      :reindex-max-bytes reindex-max-bytes})))
+          ledger-alias*   (normalize-alias ledger-alias)
+          address         (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
+          method-type     (conn-proto/-method conn)
           ;; map of all branches and where they are branched from
-          branches         {branch (branch/new-branch-map nil ledger-alias* branch)}
-          ledger           (map->JsonLDLedger
-                             {:id      (random-uuid)
-                              :did     did*
-                              :state   (atom {:closed?  false
-                                              :branches branches
-                                              :branch   branch
-                                              :graphs   {}
-                                              :push     {:complete {:t   0
-                                                                    :dag nil}
-                                                         :pending  {:t   0
-                                                                    :dag nil}}})
-                              :alias   ledger-alias
-                              :address address
-                              :method  method-type
-                              :cache   (atom {})
-                              :indexer indexer
-                              :conn    conn})
-          blank-db         (jld-db/create ledger default-context* context-type* new-context?)
-          bootstrap?       (boolean initial-tx)
-          db               (if bootstrap?
-                             (<? (bootstrap/bootstrap blank-db initial-tx))
-                             (bootstrap/blank-db blank-db))]
+          branches        {branch (branch/new-branch-map nil ledger-alias* branch)}
+          ledger          (map->JsonLDLedger
+                            {:id      (random-uuid)
+                             :did     did*
+                             :state   (atom {:closed?  false
+                                             :branches branches
+                                             :branch   branch
+                                             :graphs   {}
+                                             :push     {:complete {:t   0
+                                                                   :dag nil}
+                                                        :pending  {:t   0
+                                                                   :dag nil}}})
+                             :alias   ledger-alias
+                             :address address
+                             :method  method-type
+                             :cache   (atom {})
+                             :indexer indexer
+                             :conn    conn})
+          blank-db        (jld-db/create ledger default-context context-type* new-context?)
+          bootstrap?      (boolean initial-tx)
+          db              (if bootstrap?
+                            (<? (bootstrap/bootstrap blank-db initial-tx))
+                            (bootstrap/blank-db blank-db))]
       ;; place initial 'blank' DB into ledger.
       (ledger-proto/-db-update ledger db)
       (when include
@@ -236,10 +236,10 @@
                            :value
                            (->> (jld-reify/load-default-context conn))
                            <?)
-          ledger       (<? (create conn alias {:branch          branch
-                                               :id              last-commit
-                                               :default-context default-ctx
-                                               :new-context?    false}))
+          ledger       (<? (create conn alias {:branch         branch
+                                               :id             last-commit
+                                               :defaultContext default-ctx
+                                               :new-context?   false}))
           db           (ledger-proto/-db ledger)
           db*          (<? (jld-reify/load-db-idx db commit last-commit false))]
       (ledger-proto/-commit-update ledger branch db*)

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -12,6 +12,7 @@
             [clojure.string :as str]
             [fluree.db.indexer.proto :as idx-proto]
             [fluree.db.util.core :as util]
+            [fluree.db.util.context :as ctx-util]
             [fluree.db.util.log :as log])
   (:refer-clojure :exclude [load]))
 
@@ -19,27 +20,23 @@
 
 (defn branch-meta
   "Retrieves branch metadata from ledger state"
-  [{:keys [state context] :as _ledger} requested-branch]
-  (let [{:keys [branch branches]} @state
-        branch      (if requested-branch
-                      (get branches requested-branch)
-                      ;; default branch
-                      (get branches branch))
-        context-kw  (json-ld/parse-context context)
-        context-str (-> context util/stringify-keys json-ld/parse-context)]
-    (-> branch
-        (assoc-in [:latest-db :schema :context] context-kw)
-        (assoc-in [:latest-db :schema :context-str] context-str))))
+  [{:keys [state] :as _ledger} requested-branch]
+  (let [{:keys [branch branches]} @state]
+    (if requested-branch
+      (get branches requested-branch)
+      ;; default branch
+      (get branches branch))))
 
 ;; TODO - no time travel, only latest db on a branch thus far
 (defn db
-  [ledger {:keys [branch]}]
+  [ledger {:keys [branch context-type]}]
   (let [branch-meta (ledger-proto/-branch ledger branch)]
     ;; if branch is nil, will return default
     (when-not branch-meta
       (throw (ex-info (str "Invalid branch: " branch ". Branch must exist before transacting.")
                       {:status 400 :error :db/invalid-branch})))
-    (branch/latest-db branch-meta)))
+    (cond-> (branch/latest-db branch-meta)
+            context-type (assoc :context-type context-type))))
 
 (defn db-update
   "Updates db, will throw if not next 't' from current db.
@@ -100,7 +97,7 @@
   (reset! state {:closed? true})
   (reset! cache {}))
 
-(defrecord JsonLDLedger [id address alias context did indexer
+(defrecord JsonLDLedger [id address alias did indexer
                          state cache conn method]
   ledger-proto/iCommit
   (-commit! [ledger db] (commit! ledger db nil))
@@ -150,56 +147,62 @@
   "Creates a new ledger, optionally bootstraps it as permissioned or with default context."
   [conn ledger-alias opts]
   (go-try
-    (let [{:keys [context-type context did branch pub-fn ipns indexer include
-                  reindex-min-bytes reindex-max-bytes initial-tx]
-           :or   {branch :main}} opts
-          did*          (if did
-                          (if (map? did)
-                            did
-                            {:id did})
-                          (conn-proto/-did conn))
-          indexer       (cond
-                          (satisfies? idx-proto/iIndex indexer)
-                          indexer
+    (let [{:keys [default-context context-type did branch pub-fn ipns indexer include
+                  reindex-min-bytes reindex-max-bytes initial-tx new-context?]
+           :or   {branch       :main
+                  new-context? true}} opts
+          default-context* (if default-context
+                             (-> default-context
+                                 (ctx-util/mapify-context (conn-proto/-default-context conn))
+                                 (ctx-util/stringify-context))
+                             (conn-proto/-default-context conn))
+          context-type*    (or context-type (-> conn :ledger-defaults :context-type))
+          did*             (if did
+                             (if (map? did)
+                               did
+                               {:id did})
+                             (conn-proto/-did conn))
+          indexer          (cond
+                             (satisfies? idx-proto/iIndex indexer)
+                             indexer
 
-                          indexer
-                          (throw (ex-info (str "Ledger indexer provided, but doesn't implement iIndex protocol. "
-                                               "Provided: " indexer)
-                                          {:status 400 :error :db/invalid-indexer}))
+                             indexer
+                             (throw (ex-info (str "Ledger indexer provided, but doesn't implement iIndex protocol. "
+                                                  "Provided: " indexer)
+                                             {:status 400 :error :db/invalid-indexer}))
 
-                          :else
-                          (conn-proto/-new-indexer
-                            conn (util/without-nils
-                                   {:reindex-min-bytes reindex-min-bytes
-                                    :reindex-max-bytes reindex-max-bytes})))
-          ledger-alias* (normalize-alias ledger-alias)
-          address       (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
-          method-type   (conn-proto/-method conn)
+                             :else
+                             (conn-proto/-new-indexer
+                               conn (util/without-nils
+                                      {:reindex-min-bytes reindex-min-bytes
+                                       :reindex-max-bytes reindex-max-bytes})))
+          ledger-alias*    (normalize-alias ledger-alias)
+          address          (<? (conn-proto/-address conn ledger-alias* (assoc opts :branch branch)))
+          method-type      (conn-proto/-method conn)
           ;; map of all branches and where they are branched from
-          branches      {branch (branch/new-branch-map nil ledger-alias* branch)}
-          ledger        (map->JsonLDLedger
-                          {:id      (random-uuid)
-                           :context context
-                           :did     did*
-                           :state   (atom {:closed?  false
-                                           :branches branches
-                                           :branch   branch
-                                           :graphs   {}
-                                           :push     {:complete {:t   0
-                                                                 :dag nil}
-                                                      :pending  {:t   0
-                                                                 :dag nil}}})
-                           :alias   ledger-alias
-                           :address address
-                           :method  method-type
-                           :cache   (atom {})
-                           :indexer indexer
-                           :conn    conn})
-          blank-db      (jld-db/create ledger)
-          bootstrap?    (boolean initial-tx)
-          db            (if bootstrap?
-                          (<? (bootstrap/bootstrap blank-db initial-tx))
-                          (bootstrap/blank-db blank-db))]
+          branches         {branch (branch/new-branch-map nil ledger-alias* branch)}
+          ledger           (map->JsonLDLedger
+                             {:id      (random-uuid)
+                              :did     did*
+                              :state   (atom {:closed?  false
+                                              :branches branches
+                                              :branch   branch
+                                              :graphs   {}
+                                              :push     {:complete {:t   0
+                                                                    :dag nil}
+                                                         :pending  {:t   0
+                                                                    :dag nil}}})
+                              :alias   ledger-alias
+                              :address address
+                              :method  method-type
+                              :cache   (atom {})
+                              :indexer indexer
+                              :conn    conn})
+          blank-db         (jld-db/create ledger default-context* context-type* new-context?)
+          bootstrap?       (boolean initial-tx)
+          db               (if bootstrap?
+                             (<? (bootstrap/bootstrap blank-db initial-tx))
+                             (bootstrap/blank-db blank-db))]
       ;; place initial 'blank' DB into ledger.
       (ledger-proto/-db-update ledger db)
       (when include
@@ -233,9 +236,10 @@
                            :value
                            (->> (jld-reify/load-default-context conn))
                            <?)
-          ledger       (<? (create conn alias {:branch  branch
-                                               :id      last-commit
-                                               :context default-ctx}))
+          ledger       (<? (create conn alias {:branch          branch
+                                               :id              last-commit
+                                               :default-context default-ctx
+                                               :new-context?    false}))
           db           (ledger-proto/-db ledger)
           db*          (<? (jld-reify/load-db-idx db commit last-commit false))]
       (ledger-proto/-commit-update ledger branch db*)

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -20,13 +20,9 @@
 
 (defn parse-context
   [{:keys [opts] :as q} db]
-  (let [ctx-key (if (= :string (or (:context-type opts)
-                                   (:contextType opts)))
-                  :context-str
-                  :context)
-        db-ctx  (get-in db [:schema ctx-key])
-        q-ctx   (or (:context q) (get q "@context"))]
-    (json-ld/parse-context db-ctx q-ctx)))
+  (dbproto/-context db
+                    (or (:context q) (get q "@context"))
+                    (:context-type opts)))
 
 (defn parse-var-name
   "Returns a `x` as a symbol if `x` is a valid '?variable'."

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -178,7 +178,7 @@
      ::analytical-query     [:map
                              [:where ::where]
                              [:t {:optional true} ::t]
-                             [:context {:optional true} ::context]
+                             [:context {:optional true} :any]
                              [:select {:optional true} ::select]
                              [:selectOne {:optional true} ::selectOne]
                              [:select-one {:optional true} ::select-one]

--- a/src/fluree/db/util/context.cljc
+++ b/src/fluree/db/util/context.cljc
@@ -1,0 +1,105 @@
+(ns fluree.db.util.context
+  (:require [clojure.string :as str]))
+
+;; handles some default context merging.
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn mapify-context
+  "An unparsed context may be a vector of maps or URLs. This merges them together into one large map.
+
+  If a sequence context is used, and an item is an empty string, will substitute a default context."
+  [context default-context]
+  (when context
+    (cond
+
+      (map? context)
+      context
+
+      (sequential? context)
+      (reduce (fn [acc context-item]
+                (cond
+
+                  (map? context-item)
+                  (merge acc context-item)
+
+                  (= "" context-item)
+                  (if default-context
+                    (merge acc default-context)
+                    (throw (ex-info (str "Context uses a default context with empty string (''), "
+                                         "but not default context provided.")
+                                    {:status 400
+                                     :error  :db/invalid-context})))
+
+                  :else
+                  (throw (ex-info (str "Only context maps are supported at the moment, provided: " context-item)
+                                  {:status 400
+                                   :error  :db/invalid-context}))))
+              {} context)
+
+      :else
+      (throw (ex-info (str "Invalid context provided: " context)
+                      {:status 400
+                       :error  :db/invalid-context})))))
+
+
+(defn stringify-context
+  "Ensures mapified context that might use keyword keys is in string format."
+  [context]
+  (when context
+    (if (map? context)
+      (reduce-kv
+        (fn [acc k v]
+          (cond
+            (string? k)
+            (assoc acc k v)
+
+            (keyword? k)
+            (if-let [ns (namespace k)]
+              (assoc acc (str ns ":" (name k)) v)
+              (assoc acc (name k) v))
+
+            :else
+            (throw (ex-info (str "Context key appears to be invalid: " k)
+                            {:status 400
+                             :error  :db/invalid-context}))))
+        {}
+        context)
+      (throw (ex-info (str "stringify-context called on a context that is not a map: " context)
+                      {:status 400
+                       :error  :db/invalid-context})))))
+
+
+(defn keywordize-context
+  "Keywordizes a mapified context. Changes all keys to a keyword, unless they start with '@'
+
+  Throws an exception if context cannot be keywordized (some cannot!)"
+  [context]
+  (when context
+    (if (map? context)
+      (reduce-kv
+        (fn [acc k v]
+          (cond
+            (not (string? k))
+            (throw (ex-info (str "Context key expected to be a string, instead got: " k)
+                            {:status 400
+                             :error  :db/invalid-context}))
+
+            (str/starts-with? k "@")
+            (assoc acc k v)
+
+            (str/includes? k ":")
+            (let [parts (str/split k #":")]
+              (if (not= 2 (count parts))
+                (throw (ex-info (str "Context key appears to be invalid: " k)
+                                {:status 400
+                                 :error  :db/invalid-context}))
+                (assoc acc (keyword (first parts) (second parts)) v)))
+
+            :else
+            (assoc acc (keyword k) v)))
+        {}
+        context)
+      (throw (ex-info (str "keywordize-context called on a context that is not a map: " context)
+                      {:status 400
+                       :error  :db/invalid-context})))))

--- a/src/fluree/db/util/core.cljc
+++ b/src/fluree/db/util/core.cljc
@@ -209,13 +209,6 @@
         (assoc acc k v)))
     {} m))
 
-(defn normalize-context
-  "Keywordizes string contexts so they merge correctly with other keyword
-  contexts."
-  [context-type context]
-  (if (= :keyword context-type)
-    context
-    (keywordize-keys context)))
 
 (defn str->epoch-ms
   "Takes time as a string and returns epoch millis."

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -188,10 +188,6 @@
                full-type-url  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
            (is (= (:t db) (:t loaded-db)))
            (is (= merged-ctx (dbproto/-default-context loaded-db)))
-           (is (= (get-in db [:schema :context])
-                  (get-in loaded-db [:schema :context])))
-           (is (= (get-in db [:schema :context-str])
-                  (get-in loaded-db [:schema :context-str])))
            (is (= [{full-type-url   [:ex/User]
                     :id             :ex/wes
                     :schema/age     42
@@ -270,11 +266,7 @@
                loaded-db      (fluree/db loaded)
                merged-ctx     (merge (ctx-util/stringify-context conn1-context) (ctx-util/stringify-context ledger-context))]
            (is (= (:t db) (:t loaded-db)))
-           (is (= merged-ctx (dbproto/-default-context loaded-db)))
-           (is (= (get-in db [:schema :context])
-                  (get-in loaded-db [:schema :context])))
-           (is (= (get-in db [:schema :context-str])
-                  (get-in loaded-db [:schema :context-str]))))))
+           (is (= merged-ctx (dbproto/-default-context loaded-db))))))
 
      (testing "can load a ledger with `list` values"
        (with-tmp-dir storage-path

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -3,8 +3,10 @@
                :cljs [cljs.test :refer-macros [deftest is testing async]])
             #?@(:cljs [[clojure.core.async :refer [go <!]]
                        [clojure.core.async.interop :refer [<p!]]])
+            [fluree.db.dbproto :as dbproto]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.test-utils :as test-utils]
+            [fluree.db.util.context :as ctx-util]
             [fluree.db.util.core :as util]
             #?(:clj  [test-with-files.tools :refer [with-tmp-dir]
                       :as twf]
@@ -60,11 +62,11 @@
              ledger-context {"ex"  "http://example.com/"
                              "foo" "http://foobar.com/"}
              ledger         @(fluree/create conn ledger-alias
-                                            {:context-type :string
-                                             :context      ledger-context})
-             merged-context (merge test-utils/default-context
-                                   (util/keywordize-keys ledger-context))]
-         (is (= merged-context (:context ledger)))))))
+                                            {:context-type    :string
+                                             :default-context ["" ledger-context]})
+             merged-context (merge (util/stringify-keys test-utils/default-context)
+                                   ledger-context)]
+         (is (= merged-context (dbproto/-default-context (fluree/db ledger))))))))
 
 #?(:clj
    (deftest load-from-file-test
@@ -73,21 +75,20 @@
          (let [conn         @(fluree/connect
                                {:method :file :storage-path storage-path
                                 :defaults
-                                {:context test-utils/default-context}})
+                                {:context test-utils/default-context
+                                 :context-type :keyword}})
                ledger-alias "load-from-file-test-single-card"
-               ledger       @(fluree/create conn ledger-alias)
+               ledger       @(fluree/create conn ledger-alias {:default-context ["" {:ex "http://example.org/ns/"}]})
                db           @(fluree/stage
                                (fluree/db ledger)
-                               [{:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/brian
+                               [{:id           :ex/brian
                                  :type         :ex/User
                                  :schema/name  "Brian"
                                  :schema/email "brian@example.org"
                                  :schema/age   50
                                  :ex/favNums   7}
 
-                                {:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/cam
+                                {:id           :ex/cam
                                  :type         :ex/User
                                  :schema/name  "Cam"
                                  :schema/email "cam@example.org"
@@ -97,10 +98,8 @@
                db           @(fluree/commit! ledger db)
                db           @(fluree/stage
                                db
-                               ;; test a retraction
-                               {:context   {:ex "http://example.org/ns/"}
-                                :f/retract {:id         :ex/brian
-                                            :ex/favNums 7}})
+                               {:id         :ex/brian
+                                :ex/favNums 7})
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                loaded       (test-utils/retry-load conn ledger-alias 100)
@@ -113,29 +112,27 @@
          (let [conn         @(fluree/connect
                                {:method :file :storage-path storage-path
                                 :defaults
-                                {:context test-utils/default-context}})
+                                {:context test-utils/default-context
+                                 :context-type :keyword}})
                ledger-alias "load-from-file-test-multi-card"
-               ledger       @(fluree/create conn ledger-alias)
+               ledger       @(fluree/create conn ledger-alias {:default-context ["" {:ex "http://example.org/ns/"}]})
                db           @(fluree/stage
                                (fluree/db ledger)
-                               [{:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/brian
+                               [{:id           :ex/brian
                                  :type         :ex/User
                                  :schema/name  "Brian"
                                  :schema/email "brian@example.org"
                                  :schema/age   50
                                  :ex/favNums   7}
 
-                                {:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/alice
+                                {:id           :ex/alice
                                  :type         :ex/User
                                  :schema/name  "Alice"
                                  :schema/email "alice@example.org"
                                  :schema/age   50
                                  :ex/favNums   [42 76 9]}
 
-                                {:context      {:ex "http://example.org/ns/"}
-                                 :id           :ex/cam
+                                {:id           :ex/cam
                                  :type         :ex/User
                                  :schema/name  "Cam"
                                  :schema/email "cam@example.org"
@@ -146,15 +143,14 @@
                db           @(fluree/stage
                                db
                                ;; test a multi-cardinality retraction
-                               [{:context   {:ex "http://example.org/ns/"}
-                                 :f/retract {:id         :ex/alice
-                                             :ex/favNums [42 76 9]}}])
+                               [{:id         :ex/alice
+                                 :ex/favNums [42 76 9]}])
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                loaded       (test-utils/retry-load conn ledger-alias 100)
                loaded-db    (fluree/db loaded)]
            (is (= (:t db) (:t loaded-db)))
-           (is (= (:context ledger) (:context loaded))))))
+           (is (= (dbproto/-default-context db) (dbproto/-default-context loaded-db))))))
 
      (testing "can load a file ledger with its own context"
        (with-tmp-dir storage-path #_{::twf/delete-dir false}
@@ -165,10 +161,11 @@
                                :schema "http://schema.org/"}
                conn           @(fluree/connect
                                  {:method   :file :storage-path storage-path
-                                  :defaults {:context conn-context}})
+                                  :defaults {:context conn-context
+                                             :context-type :keyword}})
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn ledger-alias
-                                              {:context ledger-context})
+                                              {:default-context ["" ledger-context]})
                db             @(fluree/stage
                                  (fluree/db ledger)
                                  [{:id             :ex/wes
@@ -184,13 +181,13 @@
                db             @(fluree/commit! ledger db)
                loaded         (test-utils/retry-load conn ledger-alias 100)
                loaded-db      (fluree/db loaded)
-               merged-ctx     (merge conn-context ledger-context)
+               merged-ctx     (merge (ctx-util/stringify-context conn-context) (ctx-util/stringify-context ledger-context))
                query          {:where  '[[?p :schema/email "wes@example.org"]]
                                :select '{?p [:*]}}
                results        @(fluree/query loaded-db query)
                full-type-url  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
            (is (= (:t db) (:t loaded-db)))
-           (is (= merged-ctx (:context loaded)))
+           (is (= merged-ctx (dbproto/-default-context loaded-db)))
            (is (= (get-in db [:schema :context])
                   (get-in loaded-db [:schema :context])))
            (is (= (get-in db [:schema :context-str])
@@ -211,10 +208,11 @@
                                :schema "http://schema.org/"}
                conn           @(fluree/connect
                                  {:method   :file :storage-path storage-path
-                                  :defaults {:context conn-context}})
+                                  :defaults {:context conn-context
+                                             :context-type :keyword}})
                ledger-alias   "load-from-file-query"
                ledger         @(fluree/create conn ledger-alias
-                                              {:context ledger-context})
+                                              {:default-context ["" ledger-context]})
                db             @(fluree/stage
                                  (fluree/db ledger)
                                  [{:id          :ex/Andrew
@@ -242,10 +240,11 @@
                                :schema "http://schema.org/"}
                conn1          @(fluree/connect
                                  {:method   :file, :storage-path storage-path
-                                  :defaults {:context conn1-context}})
+                                  :defaults {:context conn1-context
+                                             :context-type :keyword}})
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn1 ledger-alias
-                                              {:context ledger-context})
+                                              {:default-context ["" ledger-context]})
                db             @(fluree/stage
                                  (fluree/db ledger)
                                  [{:id             :ex/wes
@@ -265,12 +264,13 @@
                                :baz "http://baz.org/"}
                conn2          @(fluree/connect
                                  {:method :file, :storage-path storage-path
-                                  :defaults {:context conn2-context}})
+                                  :defaults {:context conn2-context
+                                             :context-type :keyword}})
                loaded         (test-utils/retry-load conn2 ledger-alias 100)
                loaded-db      (fluree/db loaded)
-               merged-ctx     (merge conn1-context ledger-context)]
+               merged-ctx     (merge (ctx-util/stringify-context conn1-context) (ctx-util/stringify-context ledger-context))]
            (is (= (:t db) (:t loaded-db)))
-           (is (= merged-ctx (:context loaded)))
+           (is (= merged-ctx (dbproto/-default-context loaded-db)))
            (is (= (get-in db [:schema :context])
                   (get-in loaded-db [:schema :context])))
            (is (= (get-in db [:schema :context-str])
@@ -283,7 +283,8 @@
                                 :storage-path storage-path
                                 :defaults
                                 {:context (merge test-utils/default-context
-                                                 {:ex "http://example.org/ns/"})}})
+                                                 {:ex "http://example.org/ns/"})
+                                 :context-type :keyword}})
                ledger-alias "load-lists-test"
                ledger       @(fluree/create conn ledger-alias)
                db           @(fluree/stage
@@ -318,7 +319,8 @@
                                   :storage-path storage-path
                                   :defaults
                                   {:context (merge test-utils/default-context
-                                                   {:ex "http://example.org/ns/"})}})
+                                                   {:ex "http://example.org/ns/"})
+                                   :context-type :keyword}})
                  ledger-alias "load-policy-test"
                  ledger       @(fluree/create conn ledger-alias)
                  db           @(fluree/stage

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -63,7 +63,7 @@
                              "foo" "http://foobar.com/"}
              ledger         @(fluree/create conn ledger-alias
                                             {:context-type    :string
-                                             :default-context ["" ledger-context]})
+                                             :defaultContext ["" ledger-context]})
              merged-context (merge (util/stringify-keys test-utils/default-context)
                                    ledger-context)]
          (is (= merged-context (dbproto/-default-context (fluree/db ledger))))))))
@@ -78,7 +78,7 @@
                                 {:context test-utils/default-context
                                  :context-type :keyword}})
                ledger-alias "load-from-file-test-single-card"
-               ledger       @(fluree/create conn ledger-alias {:default-context ["" {:ex "http://example.org/ns/"}]})
+               ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
                db           @(fluree/stage
                                (fluree/db ledger)
                                [{:id           :ex/brian
@@ -115,7 +115,7 @@
                                 {:context test-utils/default-context
                                  :context-type :keyword}})
                ledger-alias "load-from-file-test-multi-card"
-               ledger       @(fluree/create conn ledger-alias {:default-context ["" {:ex "http://example.org/ns/"}]})
+               ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
                db           @(fluree/stage
                                (fluree/db ledger)
                                [{:id           :ex/brian
@@ -165,7 +165,7 @@
                                              :context-type :keyword}})
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn ledger-alias
-                                              {:default-context ["" ledger-context]})
+                                              {:defaultContext ["" ledger-context]})
                db             @(fluree/stage
                                  (fluree/db ledger)
                                  [{:id             :ex/wes
@@ -208,7 +208,7 @@
                                              :context-type :keyword}})
                ledger-alias   "load-from-file-query"
                ledger         @(fluree/create conn ledger-alias
-                                              {:default-context ["" ledger-context]})
+                                              {:defaultContext ["" ledger-context]})
                db             @(fluree/stage
                                  (fluree/db ledger)
                                  [{:id          :ex/Andrew
@@ -240,7 +240,7 @@
                                              :context-type :keyword}})
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn1 ledger-alias
-                                              {:default-context ["" ledger-context]})
+                                              {:defaultContext ["" ledger-context]})
                db             @(fluree/stage
                                  (fluree/db ledger)
                                  [{:id             :ex/wes

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -11,7 +11,7 @@
 (deftest ^:integration query-policy-enforcement
   (testing "Testing basic policy enforcement on queries."
     (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "policy/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger    @(fluree/create conn "policy/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db        @(fluree/stage

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -11,7 +11,7 @@
 (deftest ^:integration query-policy-enforcement
   (testing "Testing basic policy enforcement on queries."
     (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "policy/a" {:context {:ex "http://example.org/ns/"}})
+          ledger    @(fluree/create conn "policy/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db        @(fluree/stage

--- a/test/fluree/db/policy/parsing_test.clj
+++ b/test/fluree/db/policy/parsing_test.clj
@@ -46,7 +46,7 @@
 (deftest ^:integration policy-enforcement
   (testing "Testing query policy returns correctly."
     (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "policy-parse/a" {:context {:ex "http://example.org/ns/"}})
+          ledger       @(fluree/create conn "policy-parse/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
           root-did     (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did    (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           customer-did (:id (did/private->did-map "854358f6cb3a78ff81febe0786010d6e22839ea6bd52e03365a728d7b693b5a0"))

--- a/test/fluree/db/policy/parsing_test.clj
+++ b/test/fluree/db/policy/parsing_test.clj
@@ -46,7 +46,7 @@
 (deftest ^:integration policy-enforcement
   (testing "Testing query policy returns correctly."
     (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "policy-parse/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger       @(fluree/create conn "policy-parse/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did     (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did    (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           customer-did (:id (did/private->did-map "854358f6cb3a78ff81febe0786010d6e22839ea6bd52e03365a728d7b693b5a0"))

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -13,7 +13,7 @@
 (deftest ^:integration subject-flakes-policy
   (testing "Policy enforcement for groups of flakes by subject."
     (let [conn            (test-utils/create-conn)
-          ledger          @(fluree/create conn "policy/a" {:context {:ex "http://example.org/ns/"}})
+          ledger          @(fluree/create conn "policy/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
           root-did        (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did       (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db              @(fluree/stage

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -13,7 +13,7 @@
 (deftest ^:integration subject-flakes-policy
   (testing "Policy enforcement for groups of flakes by subject."
     (let [conn            (test-utils/create-conn)
-          ledger          @(fluree/create conn "policy/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger          @(fluree/create conn "policy/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did        (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did       (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db              @(fluree/stage

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -9,7 +9,7 @@
 (deftest ^:integration policy-enforcement
   (testing "Testing basic policy enforcement."
     (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "policy/tx-a" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger    @(fluree/create conn "policy/tx-a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db        @(fluree/stage

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -9,7 +9,7 @@
 (deftest ^:integration policy-enforcement
   (testing "Testing basic policy enforcement."
     (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "policy/tx-a" {:context {:ex "http://example.org/ns/"}})
+          ledger    @(fluree/create conn "policy/tx-a" {:default-context ["" {:ex "http://example.org/ns/"}]})
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db        @(fluree/stage

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -10,8 +10,7 @@
           people (test-utils/load-people conn)
           db     (fluree/db people)]
       (testing "with explicit grouping"
-        (let [qry    '{:context {:ex "http://example.org/ns/"}
-                       :select  [?name (count ?favNums)]
+        (let [qry    '{:select  [?name (count ?favNums)]
                        :where   [[?s :schema/name ?name]
                                  [?s :ex/favNums ?favNums]]
                        :group-by ?name}
@@ -20,8 +19,7 @@
                  subject)
               "aggregates bindings within each group")))
       (testing "with implicit grouping"
-        (let [qry '{:context {:ex "http://example.org/ns/"}
-                    :select  [(count ?name)]
+        (let [qry '{:select  [(count ?name)]
                     :where   [[?s :schema/name ?name]]}
               subject @(fluree/query db qry)]
           (is (= [[4]] subject)

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -6,7 +6,7 @@
 
 (deftest ^:integration filter-test
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/filter" {:context {:ex "http://example.org/ns/"}})
+        ledger @(fluree/create conn "query/filter" {:default-context ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                  [{:id           :ex/brian,
@@ -68,8 +68,7 @@
 
     (testing "nested filters"
       (is (= [["Brian" 50]]
-             @(fluree/query db '{:context {:ex "http://example.org/ns/"}
-                                 :select [?name ?age]
+             @(fluree/query db '{:select [?name ?age]
                                  :where  [[?s :rdf/type :ex/User]
                                           [?s :schema/age ?age]
                                           [?s :schema/name ?name]

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -6,7 +6,7 @@
 
 (deftest ^:integration filter-test
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/filter" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        ledger @(fluree/create conn "query/filter" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                  [{:id           :ex/brian,

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -17,7 +17,7 @@
 (deftest test-parse-query
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/parse"
-                               {:default-context ["" {:ex "http://example.org/ns/"}]})
+                               {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/brian,

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -17,7 +17,7 @@
 (deftest test-parse-query
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/parse"
-                               {:context {:ex "http://example.org/ns/"}})
+                               {:default-context ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/brian,
@@ -78,8 +78,7 @@
                   ::where/datatype 8}
                  {::where/var '?name}]]
                patterns)))
-      (let [query {:context {:ex "http://example.org/ns/"}
-                   :select  ['?name '?age '?email]
+      (let [query {:select  ['?name '?age '?email]
                    :where   [['?s :schema/name "Cam"]
                              ['?s :ex/friend '?f]
                              ['?f :schema/name '?name]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -9,8 +9,7 @@
           people (test-utils/load-people conn)
           db     (fluree/db people)]
       (testing "with a single grouped-by field"
-        (let [qry     '{:context  {:ex "http://example.org/ns/"}
-                        :select   [?name ?email ?age ?favNums]
+        (let [qry     '{:select   [?name ?email ?age ?favNums]
                         :where    [[?s :schema/name ?name]
                                    [?s :schema/email ?email]
                                    [?s :schema/age ?age]
@@ -29,8 +28,7 @@
               "returns grouped results")))
 
       (testing "with multiple grouped-by fields"
-        (let [qry     '{:context  {:ex "http://example.org/ns/"}
-                        :select   [?name ?email ?age ?favNums]
+        (let [qry     '{:select   [?name ?email ?age ?favNums]
                         :where    [[?s :schema/name ?name]
                                    [?s :schema/email ?email]
                                    [?s :schema/age ?age]
@@ -47,8 +45,7 @@
 
         (testing "with having clauses"
           (is (= [["Liam" [11 42]] ["Cam" [5 10]] ["Alice" [9 42 76]]]
-                 @(fluree/query db '{:context  {:ex "http://example.org/ns/"}
-                                     :select   [?name ?favNums]
+                 @(fluree/query db '{:select   [?name ?favNums]
                                      :where    [[?s :schema/name ?name]
                                                 [?s :ex/favNums ?favNums]]
                                      :group-by ?name
@@ -56,8 +53,7 @@
               "filters results according to the supplied having function code")
 
           (is (= [["Liam" [11 42]] ["Alice" [9 42 76]]]
-                 @(fluree/query db '{:context  {:ex "http://example.org/ns/"}
-                                     :select   [?name ?favNums]
+                 @(fluree/query db '{:select   [?name ?favNums]
                                      :where    [[?s :schema/name ?name]
                                                 [?s :ex/favNums ?favNums]]
                                      :group-by ?name
@@ -69,8 +65,7 @@
     (let [conn   (test-utils/create-conn)
           people (test-utils/load-people conn)
           db     (fluree/db people)
-          q      '{:context         {:ex "http://example.org/ns/"}
-                   :select-distinct [?name ?email]
+          q      '{:select-distinct [?name ?email]
                    :where           [[?s :schema/name ?name]
                                      [?s :schema/email ?email]
                                      [?s :ex/favNums ?favNum]]
@@ -89,8 +84,7 @@
           db     (fluree/db people)]
       (testing "binding a single variable"
         (testing "with a single value"
-          (let [q '{:context {:ex "http://example.org/ns/"}
-                    :select  [?name ?age]
+          (let [q '{:select  [?name ?age]
                     :where   [[?s :schema/email ?email]
                               [?s :schema/name ?name]
                               [?s :schema/age ?age]]
@@ -99,8 +93,7 @@
                    @(fluree/query db q))
                 "returns only the results related to the bound value")))
         (testing "with multiple values"
-          (let [q '{:context {:ex "http://example.org/ns/"}
-                    :select  [?name ?age]
+          (let [q '{:select  [?name ?age]
                     :where   [[?s :schema/email ?email]
                               [?s :schema/name ?name]
                               [?s :schema/age ?age]]
@@ -110,8 +103,7 @@
                 "returns only the results related to the bound values"))))
       (testing "binding multiple variables"
         (testing "with multiple values"
-          (let [q '{:context {:ex "http://example.org/ns/"}
-                    :select  [?name ?age]
+          (let [q '{:select  [?name ?age]
                     :where   [[?s :schema/email ?email]
                               [?s :ex/favNums ?favNum]
                               [?s :schema/name ?name]
@@ -122,8 +114,7 @@
                    @(fluree/query db q))
                 "returns only the results related to the bound values")))
         (testing "with some values not present"
-          (let [q '{:context {:ex "http://example.org/ns/"}
-                    :select  [?name ?age]
+          (let [q '{:select  [?name ?age]
                     :where   [[?s :schema/email ?email]
                               [?s :ex/favNums ?favNum]
                               [?s :schema/name ?name]
@@ -139,8 +130,7 @@
         people (test-utils/load-people conn)
         db     (fluree/db people)]
     (testing "with 2 separate fn binds"
-      (let [q   '{:context  {:ex "http://example.org/ns/"}
-                  :select   [?firstLetterOfName ?name ?decadesOld]
+      (let [q   '{:select   [?firstLetterOfName ?name ?decadesOld]
                   :where    [[?s :schema/age ?age]
                              {:bind {?decadesOld (quot ?age 10)}}
                              [?s :schema/name ?name]
@@ -154,8 +144,7 @@
                res))))
 
     (testing "with 2 fn binds in one bind map"
-      (let [q   '{:context  {:ex "http://example.org/ns/"}
-                  :select   [?firstLetterOfName ?name ?canVote]
+      (let [q   '{:select   [?firstLetterOfName ?name ?canVote]
                   :where    [[?s :schema/age ?age]
                              [?s :schema/name ?name]
                              {:bind {?firstLetterOfName (subStr ?name 0 1)
@@ -169,8 +158,7 @@
                res))))
 
     (testing "with invalid aggregate fn"
-      (let [q '{:context  {:ex "http://example.org/ns/"}
-                :select   [?sumFavNums ?name ?canVote]
+      (let [q '{:select   [?sumFavNums ?name ?canVote]
                 :where    [[?s :schema/age ?age]
                            [?s :ex/favNums ?favNums]
                            [?s :schema/name ?name]
@@ -202,19 +190,17 @@
                       "brian" {:select {?s [:*]}
                                :where  [[?s :schema/email "brian@example.org"]]}}
             subject @(fluree/multi-query db q)]
-        (is (= {"alice"
-                [{:id                             "http://example.org/ns/alice",
-                  :rdf/type                       ["http://example.org/ns/User"],
-                  :schema/name                    "Alice",
-                  :schema/email                   "alice@example.org",
-                  :schema/age                     50,
-                  "http://example.org/ns/favNums" [9 42 76]}],
-                "brian"
-                [{:id                             "http://example.org/ns/brian",
-                  :rdf/type                       ["http://example.org/ns/User"],
-                  :schema/name                    "Brian",
-                  :schema/email                   "brian@example.org",
-                  :schema/age                     50,
-                  "http://example.org/ns/favNums" 7}]}
+        (is (= {"alice" [{:id           :ex/alice
+                          :rdf/type     [:ex/User]
+                          :ex/favNums   [9 42 76]
+                          :schema/age   50
+                          :schema/email "alice@example.org"
+                          :schema/name  "Alice"}]
+                "brian" [{:id           :ex/brian
+                          :rdf/type     [:ex/User]
+                          :ex/favNums   7
+                          :schema/age   50
+                          :schema/email "brian@example.org"
+                          :schema/name  "Brian"}]}
                subject)
             "returns all results in a map keyed by alias.")))))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -9,7 +9,7 @@
   (let [ts-primeval (util/current-time-iso)
 
         conn        (test-utils/create-conn)
-        ledger      @(fluree/create conn "historytest" {:context {:ex "http://example.org/ns/"}})
+        ledger      @(fluree/create conn "historytest" {:default-context ["" {:ex "http://example.org/ns/"}]})
 
         db1         @(test-utils/transact ledger [{:id   :ex/dan
                                                    :ex/x "foo-1"
@@ -178,7 +178,7 @@
 
     (testing "small cache"
       (let [conn   (test-utils/create-conn)
-            ledger @(fluree/create conn "historycachetest" {:context {:ex "http://example.org/ns/"}})
+            ledger @(fluree/create conn "historycachetest" {:default-context ["" {:ex "http://example.org/ns/"}]})
 
             db1    @(test-utils/transact ledger [{:id   :ex/dan
                                                   :ex/x "foo-1"
@@ -195,7 +195,7 @@
 (deftest ^:integration commit-details
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "committest" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "committest" {:default-context ["" {:ex "http://example.org/ns/"}]})
 
           db1    @(test-utils/transact ledger {:id   :ex/alice
                                                :ex/x "foo-1"
@@ -214,82 +214,65 @@
                                                :ex/y "bar-cat"}
                                        {:message "meow"})]
       (testing "at time t"
-        (is (= [{:f/commit
-                 {:f/address
-                  "fluree:memory://3f7ff6df48e007cab36098274fd822ac11c9da4bf8b29762d1de3fdbdd6b6013",
-                  :f/v      0,
-                  :f/time   720000,
-                  :id
-                  "fluree:commit:sha256:bsso2btsgd4gsukmqrlmm4gap4gbmk5fkemiht6hlpjkaxzdgmmk",
-                  :f/branch "main",
-                  :f/data
-                  {:f/address "fluree:memory://5d3ce686baa6fd5cc547b5e03e6aca3d92cbce0328c2320a49c514b01e58b4c2",
-                   :f/flakes  11,
-                   :f/size    996,
-                   :f/t       1,
-                   :f/assert  [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}],
-                   :f/retract []},
-                  "https://www.w3.org/2018/credentials#issuer"
-                  {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias  "committest",
-                  :f/context
-                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+        (is (= [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                            {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                            :f/address "fluree:memory://c2e0047d4d75cad2700d5c8d0db0ad3d7dd2bbbbbdf55ba7c28dd4252a557664"
+                            :f/alias   "committest"
+                            :f/branch  "main"
+                            :f/context "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                            :f/data    #:f{:address "fluree:memory://bcb581e731a7c0ceadcfbf432b4ee8cf046de377cc33f047bd05b6c47f9da94d"
+                                           :assert  [{:ex/x "foo-1"
+                                                      :ex/y "bar-1"
+                                                      :id   :ex/alice}]
+                                           :flakes  11
+                                           :retract []
+                                           :size    996
+                                           :t       1}
+                            :f/time    720000
+                            :f/v       0
+                            :id        "fluree:commit:sha256:bn6sykdmktzuxcavgrsa5ejwdzfae6njj4q3lonb5cexlfhauvpc"}}]
                @(fluree/history ledger {:commit-details true :t {:from 1 :to 1}})))
-        (let [commit-5 {:f/commit
-                        {:f/address
-                         "fluree:memory://16d376f6cac29e8125ec3beca7aea6f75fb7a4328d73cbe0d629c6132510621c",
-                         :f/v       0,
-                         :f/previous
-                         {:id
-                          "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7"},
-                         :f/time    720000,
-                         :id
-                         "fluree:commit:sha256:bbgkybvkkdwelzlmj6vei7kitm5hvxecotx6imytpta272jwbiaw7",
-                         :f/branch  "main",
-                         :f/message "meow",
-                         :f/data
-                         {:f/previous
-                          {:id
-                           "fluree:db:sha256:bbiioffkgezekkxzojudoqrtk3zmjcxeotecprh2ordafskng7hhc"},
-                          :f/address
-                          "fluree:memory://783086c375a712eba5d5a74b18882a98a1f77eccf51bddd9b99e2c625e67a088",
-                          :f/flakes  102,
-                          :f/size    9328,
-                          :f/t       5,
-                          :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
-                          :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]},
-                         "https://www.w3.org/2018/credentials#issuer"
-                         {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                         :f/alias   "committest",
-                         :f/context
-                         "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
-              commit-4 {:f/commit
-                        {:f/address
-                         "fluree:memory://f0207c4d1d5b3e9abd71622f72149ec36518abda929aa63812c44d21a0b77b5a",
-                         :f/v      0,
-                         :f/previous
-                         {:id
-                          "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd"},
-                         :f/time   720000,
-                         :id
-                         "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7",
-                         :f/branch "main",
-                         :f/data
-                         {:f/previous
-                          {:id
-                           "fluree:db:sha256:bbc26gz36q2kxbrwmdo4ryfq4shvbw5b7aloxqsaje3tzd32issul"},
-                          :f/address
-                          "fluree:memory://c3a54a71c8c554c9d583df9e72a57bf572976e7a20c088f0cf536032cfd6d212",
-                          :f/flakes  82,
-                          :f/size    7590,
-                          :f/t       4,
-                          :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
-                          :f/retract []},
-                         "https://www.w3.org/2018/credentials#issuer"
-                         {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                         :f/alias  "committest",
-                         :f/context
-                         "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+        (let [commit-5 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                                   :f/address  "fluree:memory://2716b3eaef91b763b32daebab8ba3733a8537de37a864f726c5021464b90277f"
+                                   :f/alias    "committest"
+                                   :f/branch   "main"
+                                   :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                                   :f/data     #:f{:address  "fluree:memory://2b8125a4c996f8612ae62f16cc62b167b762c517b0c5aa7b16fa21dfe47e7b2a"
+                                                   :assert   [{:ex/x "foo-cat"
+                                                               :ex/y "bar-cat"
+                                                               :id   :ex/alice}]
+                                                   :flakes   102
+                                                   :previous {:id "fluree:db:sha256:bbtdwia2mle22abe2z7mmdrs4vufs77yubzxip3chhkmffvfk4npk"}
+                                                   :retract  [{:ex/x "foo-3"
+                                                               :ex/y "bar-3"
+                                                               :id   :ex/alice}]
+                                                   :size     9326
+                                                   :t        5}
+                                   :f/message  "meow"
+                                   :f/previous {:id "fluree:commit:sha256:bhcunj52uwxshi6jws2ypsjiziyncfa5gal4xptfldj5utb54cpf"}
+                                   :f/time     720000
+                                   :f/v        0
+                                   :id         "fluree:commit:sha256:bq4r74wu4sru43z5f4byipe5zzkgyi2kksqxlmwuttdcwcgwpsrn"}}
+              commit-4 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                                   :f/address  "fluree:memory://ffe008a623d3c6920f1d7d7607783893042c8093629f64ffefc8eb8472f542af"
+                                   :f/alias    "committest"
+                                   :f/branch   "main"
+                                   :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                                   :f/data     #:f{:address  "fluree:memory://2cac0ce4036dd82a0c23eb3deca0e7775386ed220411edb271803144b001326c"
+                                                   :assert   [{:ex/x "foo-cat"
+                                                               :ex/y "bar-cat"
+                                                               :id   :ex/cat}]
+                                                   :flakes   82
+                                                   :previous {:id "fluree:db:sha256:bcl3anjpvmxaciox7inzx4za6teagj7ipacuadzlnwg45y6z77ts"}
+                                                   :retract  []
+                                                   :size     7588
+                                                   :t        4}
+                                   :f/previous {:id "fluree:commit:sha256:b5jlses24wzjhcmqywvcdwgxxzmjlmxruh2duqsgxbxy7522utlg"}
+                                   :f/time     720000
+                                   :f/v        0
+                                   :id         "fluree:commit:sha256:bhcunj52uwxshi6jws2ypsjiziyncfa5gal4xptfldj5utb54cpf"}}]
           (is (= [commit-4 commit-5]
                  @(fluree/history ledger {:commit-details true :t {:from 4 :to 5}})))
           (is (= [commit-5]
@@ -302,235 +285,193 @@
                                           :t              {:from 2 :to 4}})]
           (testing "all commits in time range are returned"
             (is (= 3 (count response)))
-            (is (= {:f/commit
-                    {:f/address
-                     "fluree:memory://f0207c4d1d5b3e9abd71622f72149ec36518abda929aa63812c44d21a0b77b5a",
-                     :f/v      0,
-                     :f/previous
-                     {:id
-                      "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd"},
-                     :f/time   720000,
-                     :id
-                     "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7",
-                     :f/branch "main",
-                     :f/data
-                     {:f/previous
-                      {:id
-                       "fluree:db:sha256:bbc26gz36q2kxbrwmdo4ryfq4shvbw5b7aloxqsaje3tzd32issul"},
-                      :f/address
-                      "fluree:memory://c3a54a71c8c554c9d583df9e72a57bf572976e7a20c088f0cf536032cfd6d212",
-                      :f/flakes  82,
-                      :f/size    7590,
-                      :f/t       4,
-                      :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
-                      :f/retract []},
-                     "https://www.w3.org/2018/credentials#issuer"
-                     {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                     :f/alias  "committest",
-                     :f/context
-                     "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+            (is (= {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                               {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                               :f/address  "fluree:memory://ffe008a623d3c6920f1d7d7607783893042c8093629f64ffefc8eb8472f542af"
+                               :f/alias    "committest"
+                               :f/branch   "main"
+                               :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                               :f/data     #:f{:address  "fluree:memory://2cac0ce4036dd82a0c23eb3deca0e7775386ed220411edb271803144b001326c"
+                                               :assert   [{:ex/x "foo-cat"
+                                                           :ex/y "bar-cat"
+                                                           :id   :ex/cat}]
+                                               :flakes   82
+                                               :previous {:id "fluree:db:sha256:bcl3anjpvmxaciox7inzx4za6teagj7ipacuadzlnwg45y6z77ts"}
+                                               :retract  []
+                                               :size     7588
+                                               :t        4}
+                               :f/previous {:id "fluree:commit:sha256:b5jlses24wzjhcmqywvcdwgxxzmjlmxruh2duqsgxbxy7522utlg"}
+                               :f/time     720000
+                               :f/v        0
+                               :id         "fluree:commit:sha256:bhcunj52uwxshi6jws2ypsjiziyncfa5gal4xptfldj5utb54cpf"}}
                    c4)))
-          (is (= {:f/commit
-                  {:f/address
-                   "fluree:memory://3529d447998ec5b2c42ed1336009fdab9388bbd987fade075f1208aa8b7ec44b",
-                   :f/v      0,
-                   :f/previous
-                   {:id
-                    "fluree:commit:sha256:bb42ijix6d6tidq4zzc75uymowpx7hazczwhxkuz2u45c2gcwtwvw"},
-                   :f/time   720000,
-                   :id
-                   "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd",
-                   :f/branch "main",
-                   :f/data
-                   {:f/previous
-                    {:id
-                     "fluree:db:sha256:bba364nb2cbanjsgwk7t7l34m5f667efop4yiu5l5lvxscoggqdgg"},
-                    :f/address
-                    "fluree:memory://dc0c296d3047963ff807d0f17807c21a582d89ae72faa3d1d3c13d7af3929d22",
-                    :f/flakes  63,
-                    :f/size    5864,
-                    :f/t       3,
-                    :f/assert  [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
-                    :f/retract [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}]},
-                   "https://www.w3.org/2018/credentials#issuer"
-                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                   :f/alias  "committest",
-                   :f/context
-                   "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+          (is (= {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                             {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                             :f/address  "fluree:memory://f29bfb686c834d667dc62f8c46af1802f02c62567b400d50c0202428e489d1fe"
+                             :f/alias    "committest"
+                             :f/branch   "main"
+                             :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                             :f/data     #:f{:address  "fluree:memory://cb16fc43954b9ed029be2c96c6f73fa5e34e5ca1607111c5e8f8d6e337b648f6"
+                                             :assert   [{:ex/x "foo-3"
+                                                         :ex/y "bar-3"
+                                                         :id   :ex/alice}]
+                                             :flakes   63
+                                             :previous {:id "fluree:db:sha256:bjufs3dmyea7wzbkrjrh2pzua2mtqgijnl3cqpkktk7wzvy5wlnq"}
+                                             :retract  [{:ex/x "foo-2"
+                                                         :ex/y "bar-2"
+                                                         :id   :ex/alice}]
+                                             :size     5864
+                                             :t        3}
+                             :f/previous {:id "fluree:commit:sha256:bbvotmnlqkm4xkc27au55rctw5klntegd36j4dbh665qfilem42eq"}
+                             :f/time     720000
+                             :f/v        0
+                             :id         "fluree:commit:sha256:b5jlses24wzjhcmqywvcdwgxxzmjlmxruh2duqsgxbxy7522utlg"}}
                  c3))
-          (is (= {:f/commit
-                  {:f/address
-                   "fluree:memory://08ef0ead00f983ec19d1cabbaa991fe2beba70a8666bda2df6685654a646b332",
-                   :f/v      0,
-                   :f/previous
-                   {:id
-                    "fluree:commit:sha256:bsso2btsgd4gsukmqrlmm4gap4gbmk5fkemiht6hlpjkaxzdgmmk"},
-                   :f/time   720000,
-                   :id
-                   "fluree:commit:sha256:bb42ijix6d6tidq4zzc75uymowpx7hazczwhxkuz2u45c2gcwtwvw",
-                   :f/branch "main",
-                   :f/data
-                   {:f/previous
-                    {:id
-                     "fluree:db:sha256:bwogmajjh3rwlkijfihbcdy4h52qjv4kumctu4mhy27pj3zsxtes"},
-                    :f/address
-                    "fluree:memory://cffe310ce5b609c281342f812771e204e8789d5b9c6f15dcd19a7e74427d0413",
-                    :f/flakes  43,
-                    :f/size    4132,
-                    :f/t       2,
-                    :f/assert  [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}],
-                    :f/retract [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}]},
-                   "https://www.w3.org/2018/credentials#issuer"
-                   {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                   :f/alias  "committest",
-                   :f/context
-                   "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
+          (is (= {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                             {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                             :f/address  "fluree:memory://a3f34c963d5724782dc33aae1c9e0d8dc8b1f35092a659cb2431d7204b95288c"
+                             :f/alias    "committest"
+                             :f/branch   "main"
+                             :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                             :f/data     #:f{:address  "fluree:memory://2fb8ce1aa6771837c7986b1d81dcdb42ca8be8927679fe3814b2fb044b903b9d"
+                                             :assert   [{:ex/x "foo-2"
+                                                         :ex/y "bar-2"
+                                                         :id   :ex/alice}]
+                                             :flakes   43
+                                             :previous {:id "fluree:db:sha256:bbbi2zkypmbphdnt7ntmtqxtuvayt5izcbfkjaqfrlq2ixxrj5dcu"}
+                                             :retract  [{:ex/x "foo-1"
+                                                         :ex/y "bar-1"
+                                                         :id   :ex/alice}]
+                                             :size     4134
+                                             :t        2}
+                             :f/previous {:id "fluree:commit:sha256:bn6sykdmktzuxcavgrsa5ejwdzfae6njj4q3lonb5cexlfhauvpc"}
+                             :f/time     720000
+                             :f/v        0
+                             :id         "fluree:commit:sha256:bbvotmnlqkm4xkc27au55rctw5klntegd36j4dbh665qfilem42eq"}}
                  c2))))
 
       (testing "time range from"
-        (is (= [{:f/commit
-                 {:f/address
-                  "fluree:memory://f0207c4d1d5b3e9abd71622f72149ec36518abda929aa63812c44d21a0b77b5a",
-                  :f/v      0,
-                  :f/previous
-                  {:id
-                   "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd"},
-                  :f/time   720000,
-                  :id
-                  "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7",
-                  :f/branch "main",
-                  :f/data
-                  {:f/previous
-                   {:id
-                    "fluree:db:sha256:bbc26gz36q2kxbrwmdo4ryfq4shvbw5b7aloxqsaje3tzd32issul"},
-                   :f/address
-                   "fluree:memory://c3a54a71c8c554c9d583df9e72a57bf572976e7a20c088f0cf536032cfd6d212",
-                   :f/flakes  82,
-                   :f/size    7590,
-                   :f/t       4,
-                   :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/cat}],
-                   :f/retract []},
-                  "https://www.w3.org/2018/credentials#issuer"
-                  {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias  "committest",
-                  :f/context
-                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
-                {:f/commit
-                 {:f/address
-                  "fluree:memory://16d376f6cac29e8125ec3beca7aea6f75fb7a4328d73cbe0d629c6132510621c",
-                  :f/v       0,
-                  :f/previous
-                  {:id
-                   "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7"},
-                  :f/time    720000,
-                  :id
-                  "fluree:commit:sha256:bbgkybvkkdwelzlmj6vei7kitm5hvxecotx6imytpta272jwbiaw7",
-                  :f/branch  "main",
-                  :f/message "meow",
-                  :f/data
-                  {:f/previous
-                   {:id
-                    "fluree:db:sha256:bbiioffkgezekkxzojudoqrtk3zmjcxeotecprh2ordafskng7hhc"},
-                   :f/address
-                   "fluree:memory://783086c375a712eba5d5a74b18882a98a1f77eccf51bddd9b99e2c625e67a088",
-                   :f/flakes  102,
-                   :f/size    9328,
-                   :f/t       5,
-                   :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
-                   :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]},
-                  "https://www.w3.org/2018/credentials#issuer"
-                  {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias   "committest",
-                  :f/context
-                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+        (is (= [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                            {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                            :f/address  "fluree:memory://ffe008a623d3c6920f1d7d7607783893042c8093629f64ffefc8eb8472f542af"
+                            :f/alias    "committest"
+                            :f/branch   "main"
+                            :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                            :f/data     #:f{:address  "fluree:memory://2cac0ce4036dd82a0c23eb3deca0e7775386ed220411edb271803144b001326c"
+                                            :assert   [{:ex/x "foo-cat"
+                                                        :ex/y "bar-cat"
+                                                        :id   :ex/cat}]
+                                            :flakes   82
+                                            :previous {:id "fluree:db:sha256:bcl3anjpvmxaciox7inzx4za6teagj7ipacuadzlnwg45y6z77ts"}
+                                            :retract  []
+                                            :size     7588
+                                            :t        4}
+                            :f/previous {:id "fluree:commit:sha256:b5jlses24wzjhcmqywvcdwgxxzmjlmxruh2duqsgxbxy7522utlg"}
+                            :f/time     720000
+                            :f/v        0
+                            :id         "fluree:commit:sha256:bhcunj52uwxshi6jws2ypsjiziyncfa5gal4xptfldj5utb54cpf"}}
+                {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                            {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                            :f/address  "fluree:memory://2716b3eaef91b763b32daebab8ba3733a8537de37a864f726c5021464b90277f"
+                            :f/alias    "committest"
+                            :f/branch   "main"
+                            :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                            :f/data     #:f{:address  "fluree:memory://2b8125a4c996f8612ae62f16cc62b167b762c517b0c5aa7b16fa21dfe47e7b2a"
+                                            :assert   [{:ex/x "foo-cat"
+                                                        :ex/y "bar-cat"
+                                                        :id   :ex/alice}]
+                                            :flakes   102
+                                            :previous {:id "fluree:db:sha256:bbtdwia2mle22abe2z7mmdrs4vufs77yubzxip3chhkmffvfk4npk"}
+                                            :retract  [{:ex/x "foo-3"
+                                                        :ex/y "bar-3"
+                                                        :id   :ex/alice}]
+                                            :size     9326
+                                            :t        5}
+                            :f/message  "meow"
+                            :f/previous {:id "fluree:commit:sha256:bhcunj52uwxshi6jws2ypsjiziyncfa5gal4xptfldj5utb54cpf"}
+                            :f/time     720000
+                            :f/v        0
+                            :id         "fluree:commit:sha256:bq4r74wu4sru43z5f4byipe5zzkgyi2kksqxlmwuttdcwcgwpsrn"}}]
                @(fluree/history ledger {:commit-details true :t {:from 4}}))))
 
       (testing "time range to"
-        (is (= [{:f/commit
-                 {:f/address
-                  "fluree:memory://3f7ff6df48e007cab36098274fd822ac11c9da4bf8b29762d1de3fdbdd6b6013",
-                  :f/v      0,
-                  :f/time   720000,
-                  :id
-                  "fluree:commit:sha256:bsso2btsgd4gsukmqrlmm4gap4gbmk5fkemiht6hlpjkaxzdgmmk",
-                  :f/branch "main",
-                  :f/data
-                  {:f/address
-                   "fluree:memory://5d3ce686baa6fd5cc547b5e03e6aca3d92cbce0328c2320a49c514b01e58b4c2",
-                   :f/flakes  11,
-                   :f/size    996,
-                   :f/t       1,
-                   :f/assert  [{:ex/x "foo-1", :ex/y "bar-1", :id :ex/alice}],
-                   :f/retract []},
-                  "https://www.w3.org/2018/credentials#issuer"
-                  {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias  "committest",
-                  :f/context
-                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}]
+        (is (= [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                            {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                            :f/address "fluree:memory://c2e0047d4d75cad2700d5c8d0db0ad3d7dd2bbbbbdf55ba7c28dd4252a557664"
+                            :f/alias   "committest"
+                            :f/branch  "main"
+                            :f/context "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                            :f/data    #:f{:address "fluree:memory://bcb581e731a7c0ceadcfbf432b4ee8cf046de377cc33f047bd05b6c47f9da94d"
+                                           :assert  [{:ex/x "foo-1"
+                                                      :ex/y "bar-1"
+                                                      :id   :ex/alice}]
+                                           :flakes  11
+                                           :retract []
+                                           :size    996
+                                           :t       1}
+                            :f/time    720000
+                            :f/v       0
+                            :id        "fluree:commit:sha256:bn6sykdmktzuxcavgrsa5ejwdzfae6njj4q3lonb5cexlfhauvpc"}}]
                @(fluree/history ledger {:commit-details true :t {:to 1}}))))
 
       (testing "history commit details"
-        (is (= [{:f/t       3,
-                 :f/assert  [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
-                 :f/retract [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}],
-                 :f/commit
-                 {:f/address
-                  "fluree:memory://3529d447998ec5b2c42ed1336009fdab9388bbd987fade075f1208aa8b7ec44b",
-                  :f/v      0,
-                  :f/previous
-                  {:id
-                   "fluree:commit:sha256:bb42ijix6d6tidq4zzc75uymowpx7hazczwhxkuz2u45c2gcwtwvw"},
-                  :f/time   720000,
-                  :id
-                  "fluree:commit:sha256:bdsvqh2dyqm7d4y3ou7jteevehp7t6wrfprdhjbuanx43bafyjgd",
-                  :f/branch "main",
-                  :f/data
-                  {:f/previous
-                   {:id
-                    "fluree:db:sha256:bba364nb2cbanjsgwk7t7l34m5f667efop4yiu5l5lvxscoggqdgg"},
-                   :f/address
-                   "fluree:memory://dc0c296d3047963ff807d0f17807c21a582d89ae72faa3d1d3c13d7af3929d22",
-                   :f/flakes  63,
-                   :f/size    5864,
-                   :f/t       3,
-                   :f/assert  [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}],
-                   :f/retract [{:ex/x "foo-2", :ex/y "bar-2", :id :ex/alice}]},
-                  "https://www.w3.org/2018/credentials#issuer"
-                  {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias  "committest",
-                  :f/context
-                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}}
-                {:f/t       5,
-                 :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
-                 :f/commit
-                 {:f/address
-                  "fluree:memory://16d376f6cac29e8125ec3beca7aea6f75fb7a4328d73cbe0d629c6132510621c",
-                  :f/v       0,
-                  :f/previous
-                  {:id
-                   "fluree:commit:sha256:busykqnrg3i2zdhi7wvlbhretnv32e5cyxcqwvgjtazftkjnpup7"},
-                  :f/time    720000,
-                  :id
-                  "fluree:commit:sha256:bbgkybvkkdwelzlmj6vei7kitm5hvxecotx6imytpta272jwbiaw7",
-                  :f/branch  "main",
-                  :f/message "meow",
-                  :f/data
-                  {:f/previous
-                   {:id
-                    "fluree:db:sha256:bbiioffkgezekkxzojudoqrtk3zmjcxeotecprh2ordafskng7hhc"},
-                   :f/address
-                   "fluree:memory://783086c375a712eba5d5a74b18882a98a1f77eccf51bddd9b99e2c625e67a088",
-                   :f/flakes  102,
-                   :f/size    9328,
-                   :f/t       5,
-                   :f/assert  [{:ex/x "foo-cat", :ex/y "bar-cat", :id :ex/alice}],
-                   :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]},
-                  "https://www.w3.org/2018/credentials#issuer"
-                  {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"},
-                  :f/alias   "committest",
-                  :f/context
-                  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"},
-                 :f/retract [{:ex/x "foo-3", :ex/y "bar-3", :id :ex/alice}]}]
+        (is (= [#:f{:assert  [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :commit  {"https://www.w3.org/2018/credentials#issuer"
+                              {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                              :f/address  "fluree:memory://f29bfb686c834d667dc62f8c46af1802f02c62567b400d50c0202428e489d1fe"
+                              :f/alias    "committest"
+                              :f/branch   "main"
+                              :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                              :f/data     #:f{:address  "fluree:memory://cb16fc43954b9ed029be2c96c6f73fa5e34e5ca1607111c5e8f8d6e337b648f6"
+                                              :assert   [{:ex/x "foo-3"
+                                                          :ex/y "bar-3"
+                                                          :id   :ex/alice}]
+                                              :flakes   63
+                                              :previous {:id "fluree:db:sha256:bjufs3dmyea7wzbkrjrh2pzua2mtqgijnl3cqpkktk7wzvy5wlnq"}
+                                              :retract  [{:ex/x "foo-2"
+                                                          :ex/y "bar-2"
+                                                          :id   :ex/alice}]
+                                              :size     5864
+                                              :t        3}
+                              :f/previous {:id "fluree:commit:sha256:bbvotmnlqkm4xkc27au55rctw5klntegd36j4dbh665qfilem42eq"}
+                              :f/time     720000
+                              :f/v        0
+                              :id         "fluree:commit:sha256:b5jlses24wzjhcmqywvcdwgxxzmjlmxruh2duqsgxbxy7522utlg"}
+                    :retract [{:ex/x "foo-2"
+                               :ex/y "bar-2"
+                               :id   :ex/alice}]
+                    :t       3}
+                #:f{:assert  [{:ex/x "foo-cat"
+                               :ex/y "bar-cat"
+                               :id   :ex/alice}]
+                    :commit  {"https://www.w3.org/2018/credentials#issuer"
+                              {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                              :f/address  "fluree:memory://2716b3eaef91b763b32daebab8ba3733a8537de37a864f726c5021464b90277f"
+                              :f/alias    "committest"
+                              :f/branch   "main"
+                              :f/context  "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+                              :f/data     #:f{:address  "fluree:memory://2b8125a4c996f8612ae62f16cc62b167b762c517b0c5aa7b16fa21dfe47e7b2a"
+                                              :assert   [{:ex/x "foo-cat"
+                                                          :ex/y "bar-cat"
+                                                          :id   :ex/alice}]
+                                              :flakes   102
+                                              :previous {:id "fluree:db:sha256:bbtdwia2mle22abe2z7mmdrs4vufs77yubzxip3chhkmffvfk4npk"}
+                                              :retract  [{:ex/x "foo-3"
+                                                          :ex/y "bar-3"
+                                                          :id   :ex/alice}]
+                                              :size     9326
+                                              :t        5}
+                              :f/message  "meow"
+                              :f/previous {:id "fluree:commit:sha256:bhcunj52uwxshi6jws2ypsjiziyncfa5gal4xptfldj5utb54cpf"}
+                              :f/time     720000
+                              :f/v        0
+                              :id         "fluree:commit:sha256:bq4r74wu4sru43z5f4byipe5zzkgyi2kksqxlmwuttdcwcgwpsrn"}
+                    :retract [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :t       5}]
                @(fluree/history ledger {:history :ex/alice :commit-details true :t {:from 3}})))
         (testing "multiple history results"
           (let [history-with-commits @(fluree/history ledger {:history :ex/alice :commit-details true :t {:from 1 :to 5}})]

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -9,7 +9,7 @@
   (let [ts-primeval (util/current-time-iso)
 
         conn        (test-utils/create-conn)
-        ledger      @(fluree/create conn "historytest" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        ledger      @(fluree/create conn "historytest" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
 
         db1         @(test-utils/transact ledger [{:id   :ex/dan
                                                    :ex/x "foo-1"
@@ -178,7 +178,7 @@
 
     (testing "small cache"
       (let [conn   (test-utils/create-conn)
-            ledger @(fluree/create conn "historycachetest" {:default-context ["" {:ex "http://example.org/ns/"}]})
+            ledger @(fluree/create conn "historycachetest" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
 
             db1    @(test-utils/transact ledger [{:id   :ex/dan
                                                   :ex/x "foo-1"
@@ -195,7 +195,7 @@
 (deftest ^:integration commit-details
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "committest" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "committest" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
 
           db1    @(test-utils/transact ledger {:id   :ex/alice
                                                :ex/x "foo-1"

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -11,7 +11,7 @@
   (testing "Various index range scans using the API."
     (let [conn    (test-utils/create-conn)
           ledger  @(fluree/create conn "query/index-range"
-                                  {:default-context ["" {:ex "http://example.org/ns/"}]})
+                                  {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db      @(fluree/stage
                      (fluree/db ledger)
                      [{:id           :ex/brian,

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -11,7 +11,7 @@
   (testing "Various index range scans using the API."
     (let [conn    (test-utils/create-conn)
           ledger  @(fluree/create conn "query/index-range"
-                                  {:context {:ex "http://example.org/ns/"}})
+                                  {:default-context ["" {:ex "http://example.org/ns/"}]})
           db      @(fluree/stage
                      (fluree/db ledger)
                      [{:id           :ex/brian,

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -143,7 +143,7 @@
 
 (deftest ^:integration simple-subject-crawl-test
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/simple-subject-crawl" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        ledger @(fluree/create conn "query/simple-subject-crawl" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/brian,

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -115,25 +115,27 @@
           movies (test-utils/load-movies conn)]
       (testing "define @list container in context"
         (let [db        @(fluree/stage (fluree/db movies)
-                                       {:context {:ex      "http://example.org/ns#"
+                                       {:context {:id      "@id"
+                                                  :ex      "http://example.org/ns#"
                                                   :ex/list {"@container" "@list"}}
                                         :id      "list-test"
                                         :ex/list [42 2 88 1]})
-              query-res @(fluree/query db '{:context {:ex "http://example.org/ns#"},
+              query-res @(fluree/query db '{:context   ["" {:ex "http://example.org/ns#"}]
                                             :selectOne {?s [:*]},
-                                            :where [[?s :id "list-test"]]})]
+                                            :where     [[?s :id "list-test"]]})]
           (is (= query-res
                  {:id      "list-test"
                   :ex/list [42 2 88 1]})
               "Order of query result is different from transaction.")))
       (testing "define @list directly on subject"
         (let [db        @(fluree/stage (fluree/db movies)
-                                       {:context {:ex "http://example.org/ns#"}
+                                       {:context {:id      "@id"
+                                                  :ex      "http://example.org/ns#"}
                                         :id      "list-test2"
                                         :ex/list {"@list" [42 2 88 1]}})
-              query-res @(fluree/query db '{:context {:ex "http://example.org/ns#"},
+              query-res @(fluree/query db '{:context   ["" {:ex "http://example.org/ns#"}],
                                             :selectOne {?s [:*]},
-                                            :where [[?s :id "list-test2"]]})]
+                                            :where     [[?s :id "list-test2"]]})]
           (is (= query-res
                  {:id      "list-test2"
                   :ex/list [42 2 88 1]})
@@ -141,7 +143,7 @@
 
 (deftest ^:integration simple-subject-crawl-test
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/simple-subject-crawl" {:context {:ex "http://example.org/ns/"}})
+        ledger @(fluree/create conn "query/simple-subject-crawl" {:default-context ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/brian,

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -7,25 +7,22 @@
 (deftest ^:integration simple-compound-queries
   (testing "Simple compound queries."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/compounda")
+          ledger @(fluree/create conn "query/compounda" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                    (fluree/db ledger)
-                   [{:context      {:ex "http://example.org/ns/"}
-                     :id           :ex/brian,
+                   [{:id           :ex/brian,
                      :type         :ex/User,
                      :schema/name  "Brian"
                      :schema/email "brian@example.org"
                      :schema/age   50
                      :ex/favNums   7}
-                    {:context      {:ex "http://example.org/ns/"}
-                     :id           :ex/alice,
+                    {:id           :ex/alice,
                      :type         :ex/User,
                      :schema/name  "Alice"
                      :schema/email "alice@example.org"
                      :schema/age   50
                      :ex/favNums   [42, 76, 9]}
-                    {:context      {:ex "http://example.org/ns/"}
-                     :id           :ex/cam,
+                    {:id           :ex/cam,
                      :type         :ex/User,
                      :schema/name  "Cam"
                      :schema/email "cam@example.org"
@@ -34,15 +31,13 @@
                      :ex/friend    [:ex/brian :ex/alice]}])
 
           two-tuple-select-with-crawl
-          @(fluree/query db '{:context {:ex "http://example.org/ns/"}
-                              :select  [?age {?f [:*]}]
+          @(fluree/query db '{:select  [?age {?f [:*]}]
                               :where   [[?s :schema/name "Cam"]
                                         [?s :ex/friend ?f]
                                         [?f :schema/age ?age]]})
 
           two-tuple-select-with-crawl+var
-          @(fluree/query db '{:context {:ex "http://example.org/ns/"}
-                              :select  [?age {?f [:*]}]
+          @(fluree/query db '{:select  [?age {?f [:*]}]
                               :where   [[?s :schema/name ?name]
                                         [?s :ex/friend ?f]
                                         [?f :schema/age ?age]]
@@ -65,7 +60,8 @@
 
       ;; here we have pass-through variables (?name and ?age) which must get "passed through"
       ;; the last where statements into the select statement
-      (is (= @(fluree/query db {:context {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+                                          :ex "http://example.org/ns/"}
                                 :select  ['?name '?age '?email]
                                 :where   [['?s :schema/name "Cam"]
                                           ['?s :ex/friend '?f]
@@ -77,7 +73,8 @@
           "Prior where statement variables may not be passing through to select results")
 
       ;; same as prior query, but using selectOne
-      (is (= @(fluree/query db {:context   {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context   {:schema "http://schema.org/"
+                                            :ex "http://example.org/ns/"}
                                 :selectOne ['?name '?age '?email]
                                 :where     [['?s :schema/name "Cam"]
                                             ['?s :ex/friend '?f]
@@ -90,7 +87,8 @@
       ;; if mixing multi-cardinality results along with single cardinality, there
       ;; should be a result output for every multi-cardinality value and the single
       ;; cardinality values should duplicate
-      (is (= @(fluree/query db {:context {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+                                          :ex "http://example.org/ns/"}
                                 :select  ['?name '?favNums]
                                 :where   [['?s :schema/name '?name]
                                           ['?s :ex/favNums '?favNums]]})
@@ -100,7 +98,8 @@
           "Multi-cardinality values should duplicate non-multicardinality values ")
 
       ;; ordering by a single variable
-      (is (= @(fluree/query db {:context {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+                                          :ex "http://example.org/ns/"}
                                 :select  ['?name '?favNums]
                                 :where   [['?s :schema/name '?name]
                                           ['?s :ex/favNums '?favNums]]
@@ -109,7 +108,8 @@
           "Ordering of favNums not in ascending order.")
 
       ;; ordering by a single variable descending
-      (is (= @(fluree/query db {:context {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+                                          :ex "http://example.org/ns/"}
                                 :select  ['?name '?favNums]
                                 :where   [['?s :schema/name '?name]
                                           ['?s :ex/favNums '?favNums]]
@@ -118,7 +118,8 @@
           "Ordering of favNums not in descending order.")
 
       ;; ordering by multiple variables
-      (is (= @(fluree/query db {:context {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+                                          :ex "http://example.org/ns/"}
                                 :select  ['?name '?favNums]
                                 :where   [['?s :schema/name '?name]
                                           ['?s :ex/favNums '?favNums]]
@@ -127,7 +128,8 @@
           "Ordering of multiple variables not working.")
 
       ;; ordering by multiple variables where some are equal, and not all carried to 'select'
-      (is (= @(fluree/query db {:context {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+                                          :ex "http://example.org/ns/"}
                                 :select  ['?name '?favNums]
                                 :where   [['?s :schema/name '?name]
                                           ['?s :schema/age '?age]
@@ -137,7 +139,8 @@
           "Ordering of multiple variables where some are equal working.")
 
       ;; group-by with a multicardinality value, but not using any aggregate function
-      (is (= @(fluree/query db {:context  {:ex "http://example.org/ns/"}
+      (is (= @(fluree/query db {:context  {:schema "http://schema.org/"
+                                           :ex "http://example.org/ns/"}
                                 :select   ['?name '?favNums]
                                 :where    [['?s :schema/name '?name]
                                            ['?s :ex/favNums '?favNums]]
@@ -150,8 +153,7 @@
 
       ;; checking s, p, o values all pulled correctly and all IRIs are resolved from sid integer & compacted
       (is (= @(fluree/query db
-                            {:context  {:ex "http://example.org/ns/"}
-                             :select  ['?s '?p '?o]
+                            {:select  ['?s '?p '?o]
                              :where   [['?s :schema/age 34]
                                        ['?s '?p '?o]]})
              [[:ex/cam :id "http://example.org/ns/cam"]
@@ -167,8 +169,7 @@
 
       ;; checking object-subject joins
       (is (= @(fluree/query db
-                            '{:context {:ex "http://example.org/ns/"}
-                              :select  {?s ["*" {:ex/friend ["*"]}]}
+                            '{:select  {?s ["*" {:ex/friend ["*"]}]}
                               :where   [[?s :ex/friend ?o]
                                         [?o :schema/name "Alice"]]})
              [{:id :ex/cam,

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration simple-compound-queries
   (testing "Simple compound queries."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/compounda" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "query/compounda" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                    (fluree/db ledger)
                    [{:id           :ex/brian,

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration select-sid
   (testing "Select index's subject id in query using special keyword"
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/subid" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "query/subid" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     {:graph [{:id          :ex/alice,
@@ -33,7 +33,7 @@
 
 (deftest ^:integration result-formatting
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query-context" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        ledger @(fluree/create conn "query-context" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         db     @(test-utils/transact ledger [{:id   :ex/dan
                                               :ex/x 1}])]
     (is (= [{:id    :foo/dan
@@ -60,7 +60,7 @@
 (deftest ^:integration s+p+o-full-db-queries
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/everything" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "query/everything" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                    (fluree/db ledger)
                    {:graph [{:id           :ex/alice,
@@ -258,7 +258,7 @@
 
 (deftest ^:integration class-queries
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/class" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        ledger @(fluree/create conn "query/class" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/alice,

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration select-sid
   (testing "Select index's subject id in query using special keyword"
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/subid" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "query/subid" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     {:graph [{:id          :ex/alice,
@@ -32,35 +32,35 @@
                                 :where  [['?s :type :ex/User]]}))))))
 
 (deftest ^:integration result-formatting
-  (let [conn (test-utils/create-conn)
-        ledger @(fluree/create conn "query-context" {:context {:ex "http://example.org/ns/"}})
-        db @(test-utils/transact ledger [{:id :ex/dan
-                                          :ex/x 1}])]
-    (is (= [{:id :foo/dan
+  (let [conn   (test-utils/create-conn)
+        ledger @(fluree/create conn "query-context" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        db     @(test-utils/transact ledger [{:id   :ex/dan
+                                              :ex/x 1}])]
+    (is (= [{:id    :foo/dan
              :foo/x 1}]
-           @(fluree/query db {"@context" {:foo "http://example.org/ns/"}
-                              :where [['?s :id :foo/dan]]
-                              :select {'?s [:*]}}))
+           @(fluree/query db {"@context" ["" {:foo "http://example.org/ns/"}]
+                              :where     [['?s :id :foo/dan]]
+                              :select    {'?s [:*]}}))
         "default unwrapped objects")
-    (is (= [{:id :foo/dan
+    (is (= [{:id    :foo/dan
              :foo/x [1]}]
-           @(fluree/query db {"@context" {:foo "http://example.org/ns/"
-                                          :foo/x {:container :set}}
-                              :where [['?s :id :foo/dan]]
-                              :select {'?s [:*]}}))
+           @(fluree/query db {"@context" ["" {:foo   "http://example.org/ns/"
+                                              :foo/x {:container :set}}]
+                              :where     [['?s :id :foo/dan]]
+                              :select    {'?s [:*]}}))
         "override unwrapping with :set")
-    (is (= [{:id :ex/dan
+    (is (= [{:id     :ex/dan
              "foo:x" [1]}]
-           @(fluree/query db {"@context" {"foo" "http://example.org/ns/"
-                                          "foo:x" {"@container" "@list"}}
-                              :where [['?s "@id" "foo:dan"]]
-                              :select {'?s ["*"]}}))
+           @(fluree/query db {"@context" ["" {"foo"   "http://example.org/ns/"
+                                              "foo:x" {"@container" "@list"}}]
+                              :where     [['?s "@id" "foo:dan"]]
+                              :select    {'?s ["*"]}}))
         "override unwrapping with @list")))
 
 (deftest ^:integration s+p+o-full-db-queries
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/everything" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "query/everything" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                    (fluree/db ledger)
                    {:graph [{:id           :ex/alice,
@@ -195,24 +195,12 @@
                   [:ex/alice :schema/name "Alice"]
                   [:ex/alice :schema/email "alice@flur.ee"]
                   [:ex/alice :schema/age 42]
-                  ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"
-                   :id
-                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                   :id
-                   "fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"]
-                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                   :f/address
-                   "fluree:memory://6fc2d43d2625d61ac668360707681aed4607da79a25dc0fef36acbebf24cb28a"]
-                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                   :f/flakes
-                   25]
-                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                   :f/size
-                   1888]
-                  ["fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"
-                   :f/t
-                   1]
+                  ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6" :id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
+                  ["fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank" :id "fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank"]
+                  ["fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank" :f/address "fluree:memory://2921503e8e62f47b598d4504f990a25bc7f7b841c11367599d87884d4bf5f0f8"]
+                  ["fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank" :f/flakes 25]
+                  ["fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank" :f/size 1888]
+                  ["fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank" :f/t 1]
                   [:schema/age :id "http://schema.org/age"]
                   [:schema/email :id "http://schema.org/email"]
                   [:schema/name :id "http://schema.org/name"]
@@ -229,40 +217,20 @@
                   [:f/data :id "https://ns.flur.ee/ledger#data"]
                   [:f/address :id "https://ns.flur.ee/ledger#address"]
                   [:f/v :id "https://ns.flur.ee/ledger#v"]
-                  ["https://www.w3.org/2018/credentials#issuer"
-                   :id
-                   "https://www.w3.org/2018/credentials#issuer"]
+                  ["https://www.w3.org/2018/credentials#issuer" :id "https://www.w3.org/2018/credentials#issuer"]
                   [:f/time :id "https://ns.flur.ee/ledger#time"]
                   [:f/message :id "https://ns.flur.ee/ledger#message"]
                   [:f/previous :id "https://ns.flur.ee/ledger#previous"]
                   [:id :id "@id"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :id
-                   "fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/time
-                   720000]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   "https://www.w3.org/2018/credentials#issuer"
-                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/v
-                   0]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/address
-                   "fluree:memory://8a031273bf6fdbecf13c229abb6c23d346a0f8af3344e8bb9f0a1fce1db723bc"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/data
-                   "fluree:db:sha256:bbvrvnmzcotbulq3zo7cdakl3vacysgap6il37m4widvdp7vr353a"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/alias
-                   "query/everything"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/branch
-                   "main"]
-                  ["fluree:commit:sha256:bbstbkfuob2d73ubsc3xvqckbmn7z35esq5k7i3rolj7hed7li2ox"
-                   :f/context
-                   "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"]]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :id "fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3"]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/time 720000]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" "https://www.w3.org/2018/credentials#issuer" "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/v 0]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/address "fluree:memory://1b766e9d594d0afb754aeb7b9bc62158ff319273552a0b7fda9bb77b001e8acb"]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/data "fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank"]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/alias "query/everything"]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/branch "main"]
+                  ["fluree:commit:sha256:bbjjp52yfifntgso6dtpbzynb3qdyjxb3kwiykksiwei45izv2up3" :f/context "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"]]
                  @(fluree/query db* {:select ['?s '?p '?o]
                                      :where  [['?s '?p '?o]]}))))))))
 
@@ -290,7 +258,7 @@
 
 (deftest ^:integration class-queries
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/class" {:context {:ex "http://example.org/ns/"}})
+        ledger @(fluree/create conn "query/class" {:default-context ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                   (fluree/db ledger)
                   [{:id           :ex/alice,
@@ -312,18 +280,16 @@
                     :schema/name "Dave"}])]
     (testing "rdf/type"
       (is (= [[:ex/User]]
-             @(fluree/query db '{:context  {:ex "http://example.org/ns/"}
-                                 :select   [?class]
-                                 :where    [[:ex/jane :rdf/type ?class]]})))
+             @(fluree/query db '{:select [?class]
+                                 :where  [[:ex/jane :rdf/type ?class]]})))
       (is (= [[:ex/dave :ex/nonUser]
               [:ex/jane :ex/User]
               [:ex/bob :ex/User]
               [:ex/alice :ex/User]
               [:ex/nonUser :rdfs/Class]
               [:ex/User :rdfs/Class]]
-             @(fluree/query db '{:context  {:ex "http://example.org/ns/"}
-                                 :select   [?s ?class]
-                                 :where    [[?s :rdf/type ?class]]}))))
+             @(fluree/query db '{:select [?s ?class]
+                                 :where  [[?s :rdf/type ?class]]}))))
     (testing "shacl targetClass"
       (let [shacl-db @(fluree/stage
                         (fluree/db ledger)

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -9,7 +9,7 @@
 (deftest ^:integration optional-queries
   (testing "Testing various 'optional' query clauses."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/optional" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "query/optional" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     [{:id          :ex/brian,

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -9,7 +9,7 @@
 (deftest ^:integration optional-queries
   (testing "Testing various 'optional' query clauses."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/optional" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "query/optional" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     [{:id          :ex/brian,

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration context-reverse-test
   (testing "Test that the @reverse context values pulls select values back correctly."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/reverse" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "query/reverse" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     [{:id           :ex/brian,
@@ -22,22 +22,22 @@
                       :schema/name  "Cam"
                       :ex/friend    [:ex/brian :ex/alice]}])]
 
-      (is (= @(fluree/query db '{:context {:friended {:reverse :ex/friend}}
+      (is (= @(fluree/query db '{:context   ["" {:friended {:reverse :ex/friend}}]
                                  :selectOne {?s [:schema/name :friended]}
-                                 :where [[?s :id :ex/brian]]})
+                                 :where     [[?s :id :ex/brian]]})
              {:schema/name "Brian"
               :friended    :ex/cam}))
 
-      (is (= @(fluree/query db '{:context {:friended {:reverse :ex/friend}},
+      (is (= @(fluree/query db '{:context   ["" {:friended {:reverse :ex/friend}}],
                                  :selectOne {?s [:schema/name :friended]},
-                                 :where [[?s :id :ex/alice]]})
+                                 :where     [[?s :id :ex/alice]]})
              {:schema/name "Alice"
               :friended    [:ex/cam :ex/brian]}))
 
 
-      (is (= @(fluree/query db '{:context {:friended {:reverse :ex/friend}},
+      (is (= @(fluree/query db '{:context   ["" {:friended {:reverse :ex/friend}}],
                                  :selectOne {?s [:schema/name {:friended [:*]}]},
-                                 :where [[?s :id :ex/brian]]})
+                                 :where     [[?s :id :ex/brian]]})
              {:schema/name "Brian",
               :friended    {:id           :ex/cam,
                             :rdf/type     [:ex/User],

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration context-reverse-test
   (testing "Test that the @reverse context values pulls select values back correctly."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/reverse" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "query/reverse" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     [{:id           :ex/brian,

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -8,7 +8,7 @@
 
 (deftest test-reparse-as-ssc
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/parse" {:context {:ex "http://example.org/ns/"}})
+        ledger @(fluree/create conn "query/parse" {:default-context ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                  (fluree/db ledger)
                  [{:id           :ex/brian,
@@ -39,8 +39,7 @@
                                                       :where  [["?s" :schema/age 50]
                                                                ["?s" :ex/favColor "Blue"]]}
                                                      db)
-        not-ssc-parsed (parse/parse-analytical-query* {:context {:ex "http://example.org/ns/"}
-                                                       :select  ['?name '?age '?email]
+        not-ssc-parsed (parse/parse-analytical-query* {:select  ['?name '?age '?email]
                                                        :where   [['?s :schema/name "Cam"]
                                                                  ['?s :ex/friend '?f]
                                                                  ['?f :schema/name '?name]

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -8,7 +8,7 @@
 
 (deftest test-reparse-as-ssc
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/parse" {:default-context ["" {:ex "http://example.org/ns/"}]})
+        ledger @(fluree/create conn "query/parse" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         db     @(fluree/stage
                  (fluree/db ledger)
                  [{:id           :ex/brian,

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -22,8 +22,8 @@
     (let [;conn         (test-utils/create-conn) ; doesn't work see comment below
           conn                   @(fluree/connect {:method :memory
                                                    :defaults
-                                                   {:context
-                                                    test-utils/default-context}})
+                                                   {:context      test-utils/default-context
+                                                    :context-type :keyword}})
           ;; if the :did default below is present on the conn
           ;; (as it is w/ test-utils/create-conn)
           ;; then the tests below fail at the last check

--- a/test/fluree/db/query/union_query_test.clj
+++ b/test/fluree/db/query/union_query_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration union-queries
   (testing "Testing various 'union' query clauses."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/union" {:context {:ex "http://example.org/ns/"}})
+          ledger @(fluree/create conn "query/union" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     [{:id           :ex/brian,

--- a/test/fluree/db/query/union_query_test.clj
+++ b/test/fluree/db/query/union_query_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration union-queries
   (testing "Testing various 'union' query clauses."
     (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "query/union" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger @(fluree/create conn "query/union" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db     @(fluree/stage
                     (fluree/db ledger)
                     [{:id           :ex/brian,

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -9,7 +9,7 @@
 (deftest ^:integration using-pre-defined-types-as-classes
   (testing "Class not used as class initially can still be used as one."
     (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "class/testing" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger    @(fluree/create conn "class/testing" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db1       @(fluree/stage
                        (fluree/db ledger)
                        {:id                 :ex/MyClass,
@@ -30,7 +30,7 @@
 (deftest ^:integration shacl-cardinality-constraints
   (testing "shacl minimum and maximum cardinality"
     (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "shacl/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger       @(fluree/create conn "shacl/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select  {'?s [:*]}
                         :where   [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
@@ -83,7 +83,7 @@
 (deftest ^:integration shacl-datatype-constraints
   (testing "shacl datatype errors"
     (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "shacl/b" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger       @(fluree/create conn "shacl/b" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select  {'?s [:*]}
                         :where   [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
@@ -131,7 +131,7 @@
 (deftest ^:integration shacl-closed-shape
   (testing "shacl closed shape"
     (let [conn          (test-utils/create-conn)
-          ledger        @(fluree/create conn "shacl/c" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger        @(fluree/create conn "shacl/c" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query    {:select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]}
           db            @(fluree/stage
@@ -171,7 +171,7 @@
 (deftest ^:integration shacl-property-pairs
   (testing "shacl property pairs"
     (let [conn          (test-utils/create-conn)
-          ledger        @(fluree/create conn "shacl/pairs" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger        @(fluree/create conn "shacl/pairs" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query    {:select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]} ]
       (testing "single-cardinality equals"
@@ -573,7 +573,7 @@
 (deftest ^:integration shacl-value-range
   (testing "shacl value range constraints"
     (let [conn          (test-utils/create-conn)
-          ledger        @(fluree/create conn "shacl/value-range" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger        @(fluree/create conn "shacl/value-range" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query    {:select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]}]
       (testing "exclusive constraints"

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -9,20 +9,17 @@
 (deftest ^:integration using-pre-defined-types-as-classes
   (testing "Class not used as class initially can still be used as one."
     (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "class/testing")
+          ledger    @(fluree/create conn "class/testing" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db1       @(fluree/stage
                        (fluree/db ledger)
-                       {:context            {:ex "http://example.org/ns/"}
-                        :id                 :ex/MyClass,
+                       {:id                 :ex/MyClass,
                         :schema/description "Just a basic object not used as a class"})
           db2       @(fluree/stage
                        db1
-                       {:context            {:ex "http://example.org/ns/"}
-                        :id                 :ex/myClassInstance,
+                       {:id                 :ex/myClassInstance,
                         :type               [:ex/MyClass]
                         :schema/description "Now a new subject uses MyClass as a Class"})
-          query-res @(fluree/query db2 '{:context {:ex "http://example.org/ns/"},
-                                         :select {?s [:*]},
+          query-res @(fluree/query db2 '{:select {?s [:*]},
                                          :where [[?s :id :ex/myClassInstance]]})]
       (is (= query-res
              [{:id                 :ex/myClassInstance,
@@ -33,14 +30,12 @@
 (deftest ^:integration shacl-cardinality-constraints
   (testing "shacl minimum and maximum cardinality"
     (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "shacl/a")
-          user-query   {:context {:ex "http://example.org/ns/"}
-                        :select  {'?s [:*]}
+          ledger       @(fluree/create conn "shacl/a" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          user-query   {:select  {'?s [:*]}
                         :where   [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
                           (fluree/db ledger)
-                          {:context        {:ex "http://example.org/ns/"}
-                           :id             :ex/UserShape,
+                          {:id             :ex/UserShape,
                            :type           [:sh/NodeShape],
                            :sh/targetClass :ex/User
                            :sh/property    [{:sh/path     :schema/name
@@ -49,8 +44,7 @@
                                              :sh/datatype :xsd/string}]})
           db-ok        @(fluree/stage
                           db
-                          {:context         {:ex "http://example.org/ns/"}
-                           :id              :ex/john,
+                          {:id              :ex/john,
                            :type            [:ex/User],
                            :schema/name     "John"
                            :schema/callSign "j-rock"})
@@ -58,16 +52,14 @@
           db-no-names  (try
                          @(fluree/stage
                             db
-                            {:context         {:ex "http://example.org/ns/"}
-                             :id              :ex/john,
+                            {:id              :ex/john,
                              :type            [:ex/User],
                              :schema/callSign "j-rock"})
                          (catch Exception e e))
           db-two-names (try
                          @(fluree/stage
                             db
-                            {:context         {:ex "http://example.org/ns/"}
-                             :id              :ex/john,
+                            {:id              :ex/john,
                              :type            [:ex/User],
                              :schema/name     ["John", "Johnny"]
                              :schema/callSign "j-rock"})
@@ -91,38 +83,33 @@
 (deftest ^:integration shacl-datatype-constraints
   (testing "shacl datatype errors"
     (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "shacl/b")
-          user-query   {:context {:ex "http://example.org/ns/"}
-                        :select  {'?s [:*]}
+          ledger       @(fluree/create conn "shacl/b" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          user-query   {:select  {'?s [:*]}
                         :where   [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
                           (fluree/db ledger)
-                          {:context        {:ex "http://example.org/ns/"}
-                           :id             :ex/UserShape,
+                          {:id             :ex/UserShape,
                            :type           [:sh/NodeShape],
                            :sh/targetClass :ex/User
                            :sh/property    [{:sh/path     :schema/name
                                              :sh/datatype :xsd/string}]})
           db-ok        @(fluree/stage
                           db
-                          {:context     {:ex "http://example.org/ns/"}
-                           :id          :ex/john,
+                          {:id          :ex/john,
                            :type        [:ex/User],
                            :schema/name "John"})
           ; no :schema/name
           db-int-name  (try
                          @(fluree/stage
                             db
-                            {:context     {:ex "http://example.org/ns/"}
-                             :id          :ex/john,
+                            {:id          :ex/john,
                              :type        [:ex/User],
                              :schema/name 42})
                          (catch Exception e e))
           db-bool-name (try
                          @(fluree/stage
                             db
-                            {:context     {:ex "http://example.org/ns/"}
-                             :id          :ex/john,
+                            {:id          :ex/john,
                              :type        [:ex/User],
                              :schema/name true})
                          (catch Exception e e))]
@@ -144,14 +131,12 @@
 (deftest ^:integration shacl-closed-shape
   (testing "shacl closed shape"
     (let [conn          (test-utils/create-conn)
-          ledger        @(fluree/create conn "shacl/c")
-          user-query    {:context {:ex "http://example.org/ns/"}
-                         :select  {'?s [:*]}
+          ledger        @(fluree/create conn "shacl/c" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          user-query    {:select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]}
           db            @(fluree/stage
                            (fluree/db ledger)
-                           {:context              {:ex "http://example.org/ns/"}
-                            :id                   :ex/UserShape,
+                           {:id                   :ex/UserShape,
                             :type                 [:sh/NodeShape],
                             :sh/targetClass       :ex/User
                             :sh/property          [{:sh/path     :schema/name
@@ -160,16 +145,14 @@
                             :sh/closed            true})
           db-ok         @(fluree/stage
                            db
-                           {:context     {:ex "http://example.org/ns/"}
-                            :id          :ex/john,
+                           {:id          :ex/john,
                             :type        [:ex/User],
                             :schema/name "John"})
           ; no :schema/name
           db-extra-prop (try
                           @(fluree/stage
                              db
-                             {:context      {:ex "http://example.org/ns/"}
-                              :id           :ex/john,
+                             {:id           :ex/john,
                               :type         [:ex/User],
                               :schema/name  "John"
                               :schema/email "john@flur.ee"})
@@ -188,23 +171,20 @@
 (deftest ^:integration shacl-property-pairs
   (testing "shacl property pairs"
     (let [conn          (test-utils/create-conn)
-          ledger        @(fluree/create conn "shacl/pairs")
-          user-query    {:context {:ex "http://example.org/ns/"}
-                         :select  {'?s [:*]}
+          ledger        @(fluree/create conn "shacl/pairs" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          user-query    {:select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]} ]
       (testing "single-cardinality equals"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/EqualNamesShape
+                              {:id                   :ex/EqualNamesShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :schema/name
                                                        :sh/equals   :ex/firstName}]})
               db-ok         @(fluree/stage
                               db
-                              {:context     {:ex "http://example.org/ns/"}
-                               :id          :ex/alice,
+                              {:id          :ex/alice,
                                :type        [:ex/User],
                                :schema/name "Alice"
                                :ex/firstName "Alice"})
@@ -212,8 +192,7 @@
               db-not-equal (try
                              @(fluree/stage
                                db
-                               {:context      {:ex "http://example.org/ns/"}
-                                :id           :ex/john,
+                               {:id           :ex/john,
                                 :type         [:ex/User],
                                 :schema/name  "John"
                                 :ex/firstName "Jack"})
@@ -231,16 +210,14 @@
       (testing "multi-cardinality equals"
           (let [db            @(fluree/stage
                                 (fluree/db ledger)
-                                {:context              {:ex "http://example.org/ns/"}
-                                 :id                   :ex/EqualNamesShape
+                                {:id                   :ex/EqualNamesShape
                                  :type                 [:sh/NodeShape],
                                  :sh/targetClass       :ex/User
                                  :sh/property          [{:sh/path     :ex/favNums
                                                          :sh/equals   :ex/luckyNums}]})
                 db-ok         @(fluree/stage
                                 db
-                                {:context     {:ex "http://example.org/ns/"}
-                                 :id          :ex/alice,
+                                {:id          :ex/alice,
                                  :type        [:ex/User],
                                  :schema/name "Alice"
                                  :ex/favNums   [11 17]
@@ -248,8 +225,7 @@
 
                 db-ok2         @(fluree/stage
                                  db
-                                 {:context     {:ex "http://example.org/ns/"}
-                                  :id          :ex/alice,
+                                 {:id          :ex/alice,
                                   :type        [:ex/User],
                                   :schema/name "Alice"
                                   :ex/favNums   [11 17]
@@ -258,8 +234,7 @@
                 db-not-equal1 (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/brian
+                                  {:id          :ex/brian
                                    :type        [:ex/User],
                                    :schema/name "Brian"
                                    :ex/favNums   [11 17]
@@ -268,8 +243,7 @@
                 db-not-equal2 (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/brian
+                                  {:id          :ex/brian
                                    :type        [:ex/User],
                                    :schema/name "Brian"
                                    :ex/favNums   [11 17]
@@ -278,8 +252,7 @@
                 db-not-equal3 (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/brian
+                                  {:id          :ex/brian
                                    :type        [:ex/User],
                                    :schema/name "Brian"
                                    :ex/favNums   [11 17]
@@ -288,8 +261,7 @@
                 db-not-equal4 (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/brian
+                                  {:id          :ex/brian
                                    :type        [:ex/User],
                                    :schema/name "Brian"
                                    :ex/favNums   [11 17]
@@ -326,16 +298,14 @@
       (testing "disjoint"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/DisjointShape
+                              {:id                   :ex/DisjointShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :ex/favNums
                                                        :sh/disjoint   :ex/luckyNums}]})
               db-ok         @(fluree/stage
                               db
-                              {:context     {:ex "http://example.org/ns/"}
-                               :id          :ex/alice,
+                              {:id          :ex/alice,
                                :type        [:ex/User],
                                :schema/name "Alice"
                                :ex/favNums   [11 17]
@@ -344,8 +314,7 @@
               db-not-disjoint1 (try
                                  @(fluree/stage
                                    db
-                                   {:context     {:ex "http://example.org/ns/"}
-                                    :id          :ex/brian
+                                   {:id          :ex/brian
                                     :type        [:ex/User],
                                     :schema/name "Brian"
                                     :ex/favNums   11
@@ -354,8 +323,7 @@
               db-not-disjoint2 (try
                                  @(fluree/stage
                                    db
-                                   {:context     {:ex "http://example.org/ns/"}
-                                    :id          :ex/brian
+                                   {:id          :ex/brian
                                     :type        [:ex/User],
                                     :schema/name "Brian"
                                     :ex/favNums   [11 17 31]
@@ -365,8 +333,7 @@
               db-not-disjoint3 (try
                                  @(fluree/stage
                                    db
-                                   {:context     {:ex "http://example.org/ns/"}
-                                    :id          :ex/brian
+                                   {:id          :ex/brian
                                     :type        [:ex/User],
                                     :schema/name "Brian"
                                     :ex/favNums   [11 17 31]
@@ -397,16 +364,14 @@
       (testing "lessThan"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/LessThanShape
+                              {:id                   :ex/LessThanShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :ex/p1
                                                        :sh/lessThan :ex/p2}]})
               db-ok1         @(fluree/stage
                                db
-                               {:context     {:ex "http://example.org/ns/"}
-                                :id          :ex/alice,
+                               {:id          :ex/alice,
                                 :type        [:ex/User],
                                 :schema/name "Alice"
                                 :ex/p1   [11 17]
@@ -415,8 +380,7 @@
 
               db-ok2         @(fluree/stage
                                db
-                               {:context     {:ex "http://example.org/ns/"}
-                                :id          :ex/alice,
+                               {:id          :ex/alice,
                                 :type        [:ex/User],
                                 :schema/name "Alice"
                                 :ex/p1   [11 17]
@@ -425,8 +389,7 @@
               db-fail1        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
@@ -436,8 +399,7 @@
               db-fail2        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
@@ -448,8 +410,7 @@
               db-fail3        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [12 17]
@@ -459,8 +420,7 @@
               db-fail4        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
@@ -468,8 +428,7 @@
                                 (catch Exception e e))
               db-iris         (try @(fluree/stage
                                      db
-                                     {:context     {:ex "http://example.org/ns/"}
-                                      :id          :ex/alice,
+                                     {:id          :ex/alice,
                                       :type        [:ex/User],
                                       :schema/name "Alice"
                                       :ex/p1 :ex/brian
@@ -516,16 +475,14 @@
       (testing "lessThanOrEquals"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/LessThanOrEqualsShape
+                              {:id                   :ex/LessThanOrEqualsShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :ex/p1
                                                        :sh/lessThanOrEquals :ex/p2}]})
               db-ok1         @(fluree/stage
                                db
-                               {:context     {:ex "http://example.org/ns/"}
-                                :id          :ex/alice,
+                               {:id          :ex/alice,
                                 :type        [:ex/User],
                                 :schema/name "Alice"
                                 :ex/p1   [11 17]
@@ -534,8 +491,7 @@
 
               db-ok2         @(fluree/stage
                                db
-                               {:context     {:ex "http://example.org/ns/"}
-                                :id          :ex/alice,
+                               {:id          :ex/alice,
                                 :type        [:ex/User],
                                 :schema/name "Alice"
                                 :ex/p1   [11 17]
@@ -544,8 +500,7 @@
               db-fail1        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
@@ -555,8 +510,7 @@
               db-fail2        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
@@ -566,8 +520,7 @@
               db-fail3        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [12 17]
@@ -577,8 +530,7 @@
               db-fail4        (try
                                 @(fluree/stage
                                   db
-                                  {:context     {:ex "http://example.org/ns/"}
-                                   :id          :ex/alice,
+                                  {:id          :ex/alice,
                                    :type        [:ex/User],
                                    :schema/name "Alice"
                                    :ex/p1   [11 17]
@@ -621,15 +573,13 @@
 (deftest ^:integration shacl-value-range
   (testing "shacl value range constraints"
     (let [conn          (test-utils/create-conn)
-          ledger        @(fluree/create conn "shacl/value-range")
-          user-query    {:context {:ex "http://example.org/ns/"}
-                         :select  {'?s [:*]}
+          ledger        @(fluree/create conn "shacl/value-range" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          user-query    {:select  {'?s [:*]}
                          :where   [['?s :rdf/type :ex/User]]}]
       (testing "exclusive constraints"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/ExclusiveNumRangeShape
+                              {:id                   :ex/ExclusiveNumRangeShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :schema/age
@@ -637,21 +587,18 @@
                                                        :sh/maxExclusive 100}]})
               db-ok         @(fluree/stage
                               db
-                              {:context     {:ex "http://example.org/ns/"}
-                               :id          :ex/john,
+                              {:id          :ex/john,
                                :type        [:ex/User],
                                :schema/age  2})
               db-too-low         (try @(fluree/stage
                                         db
-                                        {:context     {:ex "http://example.org/ns/"}
-                                         :id          :ex/john,
+                                        {:id          :ex/john,
                                          :type        [:ex/User],
                                          :schema/age  1})
                                       (catch Exception e e))
               db-too-high         (try @(fluree/stage
                                          db
-                                         {:context     {:ex "http://example.org/ns/"}
-                                          :id          :ex/john,
+                                         {:id          :ex/john,
                                           :type        [:ex/User],
                                           :schema/age  100})
                                        (catch Exception e e))]
@@ -672,8 +619,7 @@
       (testing "inclusive constraints"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/InclusiveNumRangeShape
+                              {:id                   :ex/InclusiveNumRangeShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :schema/age
@@ -681,26 +627,22 @@
                                                        :sh/maxInclusive 100}]})
               db-ok         @(fluree/stage
                               db
-                              {:context     {:ex "http://example.org/ns/"}
-                               :id          :ex/brian
+                              {:id          :ex/brian
                                :type        [:ex/User],
                                :schema/age  1})
               db-ok2        @(fluree/stage
                               db-ok
-                              {:context     {:ex "http://example.org/ns/"}
-                               :id          :ex/alice,
+                              {:id          :ex/alice,
                                :type        [:ex/User],
                                :schema/age  100})
               db-too-low      @(fluree/stage
                                 db
-                                {:context     {:ex "http://example.org/ns/"}
-                                 :id          :ex/alice,
+                                {:id          :ex/alice,
                                  :type        [:ex/User],
                                  :schema/age  0})
               db-too-high      @(fluree/stage
                                  db
-                                 {:context     {:ex "http://example.org/ns/"}
-                                  :id          :ex/alice,
+                                 {:id          :ex/alice,
                                   :type        [:ex/User],
                                   :schema/age  101})]
           (is (util/exception? db-too-low)
@@ -722,23 +664,20 @@
       (testing "non-numeric values"
         (let [db            @(fluree/stage
                               (fluree/db ledger)
-                              {:context              {:ex "http://example.org/ns/"}
-                               :id                   :ex/NumRangeShape
+                              {:id                   :ex/NumRangeShape
                                :type                 [:sh/NodeShape],
                                :sh/targetClass       :ex/User
                                :sh/property          [{:sh/path     :schema/age
                                                        :sh/minExclusive 0}]})
               db-subj-id          (try @(fluree/stage
                                          db
-                                         {:context     {:ex "http://example.org/ns/"}
-                                          :id          :ex/alice,
+                                         {:id          :ex/alice,
                                           :type        [:ex/User],
                                           :schema/age  :ex/brian})
                                        (catch Exception e e))
               db-string      (try @(fluree/stage
                                     db
-                                    {:context     {:ex "http://example.org/ns/"}
-                                     :id          :ex/alice,
+                                    {:id          :ex/alice,
                                      :type        [:ex/User],
                                      :schema/age  "10"})
                                   (catch Exception e e))]

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -103,7 +103,7 @@
 
 (defn load-people
   [conn]
-  (let [ledger @(fluree/create conn "test/people" {:default-context ["" {:ex "http://example.org/ns/"}]})
+  (let [ledger @(fluree/create conn "test/people" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
         staged @(fluree/stage (fluree/db ledger) people)]
     @(fluree/commit! ledger staged {:message "Adding people", :push? true})
     ledger))

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -53,30 +53,26 @@
     "titleEIDR"                 "10.5240/15F9-F913-FF25-8041-E798-O"}])
 
 (def people
-  [{:context      {:ex "http://example.org/ns/"}
-    :id           :ex/brian,
+  [{:id           :ex/brian,
     :type         :ex/User,
     :schema/name  "Brian"
     :schema/email "brian@example.org"
     :schema/age   50
     :ex/favNums   7}
-   {:context      {:ex "http://example.org/ns/"}
-    :id           :ex/alice,
+   {:id           :ex/alice,
     :type         :ex/User,
     :schema/name  "Alice"
     :schema/email "alice@example.org"
     :schema/age   50
     :ex/favNums   [42, 76, 9]}
-   {:context      {:ex "http://example.org/ns/"}
-    :id           :ex/cam,
+   {:id           :ex/cam,
     :type         :ex/User,
     :schema/name  "Cam"
     :schema/email "cam@example.org"
     :schema/age   34
     :ex/favNums   [5, 10]
     :ex/friend    [:ex/brian :ex/alice]}
-   {:context      {:ex "http://example.org/ns/"}
-    :id           :ex/liam
+   {:id           :ex/liam
     :type         :ex/User
     :schema/name  "Liam"
     :schema/email "liam@example.org"
@@ -90,8 +86,9 @@
   ([{:keys [context did]
      :or   {context default-context
             did     (did/private->did-map default-private-key)}}]
-   (let [conn-p (fluree/connect-memory {:defaults {:context context
-                                                   :did     did}})]
+   (let [conn-p (fluree/connect-memory {:defaults {:context      context
+                                                   :context-type :keyword
+                                                   :did          did}})]
      #?(:clj @conn-p :cljs (go (<p! conn-p))))))
 
 (defn load-movies
@@ -101,12 +98,12 @@
       (let [staged @(fluree/stage (fluree/db ledger) movie)]
         @(fluree/commit! ledger staged
                          {:message (str "Commit " (get movie "name"))
-                          :push? true})))
+                          :push?   true})))
     ledger))
 
 (defn load-people
   [conn]
-  (let [ledger @(fluree/create conn "test/people")
+  (let [ledger @(fluree/create conn "test/people" {:default-context ["" {:ex "http://example.org/ns/"}]})
         staged @(fluree/stage (fluree/db ledger) people)]
     @(fluree/commit! ledger staged {:message "Adding people", :push? true})
     ledger))

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration deleting-data
   (testing "Deletions of entire subjects."
     (let [conn             (test-utils/create-conn)
-          ledger           @(fluree/create conn "tx/delete" {:context {:ex "http://example.org/ns/"}})
+          ledger           @(fluree/create conn "tx/delete" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db               @(fluree/stage
                              (fluree/db ledger)
                              {:graph [{:id           :ex/alice,

--- a/test/fluree/db/transact/delete_test.clj
+++ b/test/fluree/db/transact/delete_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration deleting-data
   (testing "Deletions of entire subjects."
     (let [conn             (test-utils/create-conn)
-          ledger           @(fluree/create conn "tx/delete" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger           @(fluree/create conn "tx/delete" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db               @(fluree/stage
                              (fluree/db ledger)
                              {:graph [{:id           :ex/alice,

--- a/test/fluree/db/transact/retraction_test.clj
+++ b/test/fluree/db/transact/retraction_test.clj
@@ -9,7 +9,7 @@
           ledger         @(fluree/create conn "tx/retract")
           db             @(fluree/stage
                             (fluree/db ledger)
-                            {:context {:ex "http://example.org/ns/"}
+                            {:context ["" {:ex "http://example.org/ns/"}]
                              :graph   [{:id          :ex/alice,
                                         :type        :ex/User,
                                         :schema/name "Alice"
@@ -25,11 +25,11 @@
           ;; retract Alice's age attribute by using nil
           db-age-retract @(fluree/stage
                             db
-                            {:context    {:ex "http://example.org/ns/"}
+                            {:context    ["" {:ex "http://example.org/ns/"}]
                              :id         :ex/alice,
                              :schema/age nil})]
       (is (= @(fluree/query db-age-retract
-                            '{:context {:ex "http://example.org/ns/"},
+                            '{:context ["" {:ex "http://example.org/ns/"}],
                               :select {?s [:*]},
                               :where [[?s :id :ex/alice]]})
              [{:id           :ex/alice,

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -8,13 +8,12 @@
 (deftest ^:integration staging-data
   (testing "Disallow staging invalid transactions"
     (let [conn           (test-utils/create-conn )
-          ledger         @(fluree/create conn "tx/disallow")
+          ledger         @(fluree/create conn "tx/disallow" {:default-context ["" {:ex "http://example.org/ns/"}]})
 
           stage-id-only     (try
                               @(fluree/stage
                                 (fluree/db ledger)
-                                {:context {:ex "http://example.org/ns/"}
-                                 :id :ex/alice})
+                                {:id :ex/alice})
                               (catch Exception e e))
           stage-empty-txn   (try
                               @(fluree/stage
@@ -24,15 +23,13 @@
           stage-empty-node   (try
                                @(fluree/stage
                                  (fluree/db ledger)
-                                 [{:context {:ex "http://example.org/ns/"}
-                                   :id :ex/alice
+                                 [{:id :ex/alice
                                    :schema/age 42}
                                   {}])
                                (catch Exception e e))
           db-ok           @(fluree/stage
                             (fluree/db ledger)
-                            {:context {:ex "http://example.org/ns/"}
-                             :id :ex/alice
+                            {:id :ex/alice
                              :schema/age 42})]
       (is (util/exception? stage-id-only))
       (is (str/starts-with? (ex-message stage-id-only)
@@ -49,16 +46,14 @@
               [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
               [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
               [:id :id "@id"]]
-             @(fluree/query db-ok '{:context {:ex "http://example.org/ns/"}
-                                    :select [?s ?p ?o]
+             @(fluree/query db-ok '{:select [?s ?p ?o]
                                     :where  [[?s ?p ?o]]})))))
   (testing "Allow transacting `false` values"
     (let [conn    (test-utils/create-conn)
-          ledger  @(fluree/create conn "tx/bools")
+          ledger  @(fluree/create conn "tx/bools" {:default-context ["" {:ex "http://example.org/ns/"}]})
           db-bool @(fluree/stage
                      (fluree/db ledger)
-                     {:context    {:ex "http://example.org/ns/"}
-                      :id         :ex/alice
+                     {:id         :ex/alice
                       :ex/isCool   false})]
       (is (= [[:ex/alice :id "http://example.org/ns/alice"]
               [:ex/alice :ex/isCool false]
@@ -66,6 +61,5 @@
               [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
               [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
               [:id :id "@id"]]
-             @(fluree/query db-bool '{:context {:ex "http://example.org/ns/"}
-                                      :select  [?s ?p ?o]
+             @(fluree/query db-bool '{:select  [?s ?p ?o]
                                       :where   [[?s ?p ?o]]}))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -8,7 +8,7 @@
 (deftest ^:integration staging-data
   (testing "Disallow staging invalid transactions"
     (let [conn           (test-utils/create-conn )
-          ledger         @(fluree/create conn "tx/disallow" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger         @(fluree/create conn "tx/disallow" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
 
           stage-id-only     (try
                               @(fluree/stage
@@ -50,7 +50,7 @@
                                     :where  [[?s ?p ?o]]})))))
   (testing "Allow transacting `false` values"
     (let [conn    (test-utils/create-conn)
-          ledger  @(fluree/create conn "tx/bools" {:default-context ["" {:ex "http://example.org/ns/"}]})
+          ledger  @(fluree/create conn "tx/bools" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db-bool @(fluree/stage
                      (fluree/db ledger)
                      {:id         :ex/alice

--- a/test/nodejs/flureenjs.test.js
+++ b/test/nodejs/flureenjs.test.js
@@ -77,7 +77,7 @@ test("expect conn, ledger, stage, commit, and query to work", async () => {
    // test providing context works and remaps keys
    const contextResults = await flureenjs.query(
      db1,
-     { "@context": {"flhubee": "http://schema.org/name"},
+     { "@context": ["", {"flhubee": "http://schema.org/name"}],
        select: { "?s": ["*"] },
        where: [["?s", "rdf:type", "ex:User"]]
      }


### PR DESCRIPTION
This fixes default context handling, and modifies how it is handled going forward to make it more explicit and hopefully less confusing. While this work started as looking into Bug #338, that bug is due to incorrect context handling so this became an opportunity to try to address it and related issues.

This likely will address other bugs in the backlog, or least provide a simple foundation to address them.

This also:
a) Provides a simple way for us to add an API to update default context (in another PR)
b) Allows for any query/transaction to set if they are using a keyword-based context or string-based context (but it handles most of this automatically for you)
c) Uses the JSON-LD standard's semantics to merge the default context into an extended context, eg:: `["", {"ex": "http://example.org/ns/"}]`
d) Never attempts to merge default context into a supplied context (unless you are explicit as per (c) above)

This now also makes context always a db-level concern, and adds context operations to the db protocol so there is never a need to reach into other namespaces and 'roll your own' which should reduce future errors. 

When supplying default context now, it is always explicit, e.g. `:default-context` so there is less confusion if that context supplied is a default or not.

Closes #338 

