### PR TITLE
Adds ability to update default context, default context APIs

### DIFF
--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -442,6 +442,15 @@
         (vswap! context-cache assoc-in [context-type supplied-context] parsed-ctx)
         parsed-ctx)))
 
+(defn default-context-update
+  "Updates default context, so on next commit it will get written in the commit file."
+  [db default-context]
+  (let [default-context* (-> default-context
+                             (ctx-util/mapify-context (dbproto/-default-context db)) ;; allows 'extending' existing default context using empty string ""
+                             (ctx-util/stringify-context))]
+    (assoc db :default-context default-context*
+              :context-cache (volatile! {})
+              :new-context? true)))
 
 ;; ================ end GraphDB record support fns ============================
 
@@ -486,7 +495,8 @@
   (-context [_] (retrieve-context default-context context-cache nil context-type))
   (-context [_ context] (retrieve-context default-context context-cache context context-type))
   (-context [_ context type] (retrieve-context default-context context-cache context (or type context-type)))
-  (-default-context [_] default-context))
+  (-default-context [_] default-context)
+  (-default-context-update [db default-context] (default-context-update db default-context)))
 
 #?(:cljs
    (extend-type JsonLdDb

--- a/src/fluree/db/dbproto.cljc
+++ b/src/fluree/db/dbproto.cljc
@@ -24,7 +24,8 @@
   (-stage [db tx] [db tx opts] "Stages a database transaction.")
   (-index-update [db commit-index] "Updates db to reflect a new index point described by commit-index metadata")
   (-context [db] [db context] [db context context-type] "Returns parsed context given supplied context. If no context is supplied, returns default context.")
-  (-default-context [db] "Returns the default context the db is configured to use."))
+  (-default-context [db] "Returns the default context the db is configured to use.")
+  (-default-context-update [db new-default] "Updates the default context, so it will get written on out the next commit."))
 
 (defn db?
   [db]

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -4,6 +4,7 @@
             [fluree.db.conn.file :as file-conn]
             [fluree.db.conn.memory :as memory-conn]
             [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.dbproto :as dbproto]
             [fluree.db.platform :as platform]
             [clojure.core.async :as async :refer [go <!]]
             [fluree.db.api.query :as query-api]
@@ -158,6 +159,22 @@
                       (<! (alias->address conn ledger-alias-or-address)))]
         (log/debug "exists? - ledger address:" address)
         (<! (conn-proto/-exists? conn address))))))
+
+(defn default-context
+  "Returns the current default context set on the db."
+  [db]
+  (dbproto/-default-context db))
+
+(defn update-default-context
+  "Updates the default context on a specified ledger.
+  Currently, the updated default context will only be
+  written with a new commit, which requires staging
+  changed data.
+
+  Returns new db updated with new provided default context."
+  [db default-context]
+  (dbproto/-default-context-update db default-context))
+
 
 (defn index
   "Performs indexing operation on the specified ledger"

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -166,12 +166,12 @@
   (dbproto/-default-context db))
 
 (defn update-default-context
-  "Updates the default context on a specified ledger.
+  "Updates the default context on a given database.
   Currently, the updated default context will only be
   written with a new commit, which requires staging
   changed data.
 
-  Returns new db updated with new provided default context."
+  Returns an updated db."
   [db default-context]
   (dbproto/-default-context-update db default-context))
 

--- a/test/fluree/db/transact/default_context_test.clj
+++ b/test/fluree/db/transact/default_context_test.clj
@@ -1,0 +1,85 @@
+(ns fluree.db.transact.default-context-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.util.log :as log]))
+
+
+(deftest ^:integration default-context-update
+  (let [conn            (test-utils/create-conn)
+        ledger          @(fluree/create conn "default-context-update" {:defaultContext ["", {:ex "http://example.org/ns/"}]})
+        db1             @(test-utils/transact ledger [{:id   :ex/foo
+                                                       :ex/x "foo-1"
+                                                       :ex/y "bar-1"}])
+        ledger1-load    @(fluree/load conn "default-context-update")
+        db1-load        (fluree/db ledger1-load)
+
+        ;; change "ex" alias in default context to "ex-new"
+        db-update-ctx   (fluree/update-default-context db1-load (-> (dbproto/-default-context db1-load)
+                                                                    (dissoc "ex")
+                                                                    (assoc "ex-new" "http://example.org/ns/")))
+        db-update-cmt   (->> [{:id       :ex-new/foo2
+                               :ex-new/x "foo-2"
+                               :ex-new/y "bar-2"}]
+                             (fluree/stage db-update-ctx)
+                             deref
+                             (fluree/commit! ledger)
+                             deref)
+
+        db-updated-load @(fluree/load conn "default-context-update")]
+
+    (testing "Default context on db is correct."
+      (is (= {"ex"     "http://example.org/ns/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+              "schema" "http://schema.org/"
+              "sh"     "http://www.w3.org/ns/shacl#"
+              "skos"   "http://www.w3.org/2008/05/skos#"
+              "type"   "@type"
+              "wiki"   "https://www.wikidata.org/wiki/"
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+             (dbproto/-default-context db1))))
+
+    (testing "Default context on original db and loaded db are identical."
+      (is (= (dbproto/-default-context db1-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Default context working as expected with a query.."
+      (is (= [{:ex/x "foo-1"
+               :ex/y "bar-1"
+               :id   :ex/foo}]
+             @(fluree/query db1-load `{:select {?s [:*]}
+                                       :where  [[?s :ex/x nil]]}))))
+
+    (testing "Updated default context is correct"
+      (is (= {"ex-new" "http://example.org/ns/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+              "schema" "http://schema.org/"
+              "sh"     "http://www.w3.org/ns/shacl#"
+              "skos"   "http://www.w3.org/2008/05/skos#"
+              "type"   "@type"
+              "wiki"   "https://www.wikidata.org/wiki/"
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+             (dbproto/-default-context db-update-ctx))))
+
+    (testing "Updated context db loaded is same as one before commit."
+      (is (= (dbproto/-default-context (fluree/db db-updated-load))
+             (dbproto/-default-context db-update-ctx))))
+
+
+    (testing "Updated context commit db has all data expected"
+      (is (= [{:ex-new/x "foo-2"
+               :ex-new/y "bar-2"
+               :id       :ex-new/foo2}
+              {:ex-new/x "foo-1"
+               :ex-new/y "bar-1"
+               :id       :ex-new/foo}]
+             @(fluree/query (fluree/db db-updated-load)
+                            `{:select {?s [:*]}
+                              :where  [[?s :ex-new/x nil]]}))))))


### PR DESCRIPTION
This closes #439
This closes #440

Adds new APIs to both retrieve default context and update default context.

This sits on top of the changes in PR #437 which was designed to accommodate these features fairly easily.

Note that an updated default context is not written into a commit until a subsequent `fluree/commit!`, which today requires a data update via `fluree/stage`. Meaning, there is no way to update only the default context without any data changes. I think we should allow this in a similar way that we allow updated indexes to update commits without data changes, but that approach should be thought through.

This also addresses the naive approach taken in PR #437 that stringifys a CLJ dev's keyword-based context if they chose to use one. This is still not comprehensive, but should accomodate semi-complex keyword-based contexts. CLJ devs always have the ability to use the standard string-based context which supports all features if their needs are sufficiently complex.
 
