### PR TITLE
Add some tests for load API fn w/ mem conn

### DIFF
--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -484,6 +484,6 @@
                                                             :error  :db/policy-exception}))
       (not role)                           (throw (ex-info "Applying policy without a role is not yet supported."
                                                            {:status 400
-                                                            :error  :db/policy-exception}) )
+                                                            :error  :db/policy-exception}))
       :else                                (assoc db :policy
                                                   (<? (policy-map db did role credential))))))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -365,7 +365,7 @@
         (if (empty? (dissoc node :idx :id))
           (throw (ex-info (str "Invalid transaction, transaction node contains no properties"
                                (some->> (:id node)
-                                        (str " for @id: ") )
+                                        (str " for @id: "))
                                ".")
                           {:status 400 :error :db/invalid-transaction}))
           (let [[_node-sid node-flakes] (<? (json-ld-node->flakes node tx-state nil))]

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -42,17 +42,17 @@
        :cljs
        (async done
          (go
-           (let [conn         (<! (test-utils/create-conn))
-                 ledger-alias "testledger"
-                 ledger       (<p! (fluree/create conn ledger-alias))
-                 db           (<p! (fluree/stage (fluree/db ledger)
-                                                 [{:id           :f/me
-                                                   :type         :schema/Person
-                                                   :schema/fname "Me"}]))]
-             (<p! (fluree/commit! ledger db))
-             (is (test-utils/retry-exists? conn ledger-alias 100))
-             (is (not (<p! (fluree/exists? conn "notaledger"))))
-             (done)))))))
+          (let [conn         (<! (test-utils/create-conn))
+                ledger-alias "testledger"
+                ledger       (<p! (fluree/create conn ledger-alias))
+                db           (<p! (fluree/stage (fluree/db ledger)
+                                                [{:id           :f/me
+                                                  :type         :schema/Person
+                                                  :schema/fname "Me"}]))]
+            (<p! (fluree/commit! ledger db))
+            (is (test-utils/retry-exists? conn ledger-alias 100))
+            (is (not (<p! (fluree/exists? conn "notaledger"))))
+            (done)))))))
 
 (deftest create-test
   (testing "string ledger context gets correctly merged with keyword conn context"
@@ -62,7 +62,7 @@
              ledger-context {"ex"  "http://example.com/"
                              "foo" "http://foobar.com/"}
              ledger         @(fluree/create conn ledger-alias
-                                            {:context-type    :string
+                                            {:context-type   :string
                                              :defaultContext ["" ledger-context]})
              merged-context (merge (util/stringify-keys test-utils/default-context)
                                    ledger-context)]
@@ -73,33 +73,33 @@
      (testing "can load a file ledger with single cardinality predicates"
        (with-tmp-dir storage-path
          (let [conn         @(fluree/connect
-                               {:method :file :storage-path storage-path
-                                :defaults
-                                {:context test-utils/default-context
-                                 :context-type :keyword}})
+                              {:method :file :storage-path storage-path
+                               :defaults
+                               {:context      test-utils/default-context
+                                :context-type :keyword}})
                ledger-alias "load-from-file-test-single-card"
                ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
                db           @(fluree/stage
-                               (fluree/db ledger)
-                               [{:id           :ex/brian
-                                 :type         :ex/User
-                                 :schema/name  "Brian"
-                                 :schema/email "brian@example.org"
-                                 :schema/age   50
-                                 :ex/favNums   7}
+                              (fluree/db ledger)
+                              [{:id           :ex/brian
+                                :type         :ex/User
+                                :schema/name  "Brian"
+                                :schema/email "brian@example.org"
+                                :schema/age   50
+                                :ex/favNums   7}
 
-                                {:id           :ex/cam
-                                 :type         :ex/User
-                                 :schema/name  "Cam"
-                                 :schema/email "cam@example.org"
-                                 :schema/age   34
-                                 :ex/favNums   5
-                                 :ex/friend    :ex/brian}])
+                               {:id           :ex/cam
+                                :type         :ex/User
+                                :schema/name  "Cam"
+                                :schema/email "cam@example.org"
+                                :schema/age   34
+                                :ex/favNums   5
+                                :ex/friend    :ex/brian}])
                db           @(fluree/commit! ledger db)
                db           @(fluree/stage
-                               db
-                               {:id         :ex/brian
-                                :ex/favNums 7})
+                              db
+                              {:id         :ex/brian
+                               :ex/favNums 7})
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                loaded       (test-utils/retry-load conn ledger-alias 100)
@@ -110,41 +110,41 @@
      (testing "can load a file ledger with multi-cardinality predicates"
        (with-tmp-dir storage-path
          (let [conn         @(fluree/connect
-                               {:method :file :storage-path storage-path
-                                :defaults
-                                {:context test-utils/default-context
-                                 :context-type :keyword}})
+                              {:method :file :storage-path storage-path
+                               :defaults
+                               {:context      test-utils/default-context
+                                :context-type :keyword}})
                ledger-alias "load-from-file-test-multi-card"
                ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
                db           @(fluree/stage
-                               (fluree/db ledger)
-                               [{:id           :ex/brian
-                                 :type         :ex/User
-                                 :schema/name  "Brian"
-                                 :schema/email "brian@example.org"
-                                 :schema/age   50
-                                 :ex/favNums   7}
+                              (fluree/db ledger)
+                              [{:id           :ex/brian
+                                :type         :ex/User
+                                :schema/name  "Brian"
+                                :schema/email "brian@example.org"
+                                :schema/age   50
+                                :ex/favNums   7}
 
-                                {:id           :ex/alice
-                                 :type         :ex/User
-                                 :schema/name  "Alice"
-                                 :schema/email "alice@example.org"
-                                 :schema/age   50
-                                 :ex/favNums   [42 76 9]}
+                               {:id           :ex/alice
+                                :type         :ex/User
+                                :schema/name  "Alice"
+                                :schema/email "alice@example.org"
+                                :schema/age   50
+                                :ex/favNums   [42 76 9]}
 
-                                {:id           :ex/cam
-                                 :type         :ex/User
-                                 :schema/name  "Cam"
-                                 :schema/email "cam@example.org"
-                                 :schema/age   34
-                                 :ex/favNums   [5 10]
-                                 :ex/friend    [:ex/brian :ex/alice]}])
+                               {:id           :ex/cam
+                                :type         :ex/User
+                                :schema/name  "Cam"
+                                :schema/email "cam@example.org"
+                                :schema/age   34
+                                :ex/favNums   [5 10]
+                                :ex/friend    [:ex/brian :ex/alice]}])
                db           @(fluree/commit! ledger db)
                db           @(fluree/stage
-                               db
-                               ;; test a multi-cardinality retraction
-                               [{:id         :ex/alice
-                                 :ex/favNums [42 76 9]}])
+                              db
+                              ;; test a multi-cardinality retraction
+                              [{:id         :ex/alice
+                                :ex/favNums [42 76 9]}])
                _            @(fluree/commit! ledger db)
                ;; TODO: Replace this w/ :syncTo equivalent once we have it
                loaded       (test-utils/retry-load conn ledger-alias 100)
@@ -160,24 +160,24 @@
                ledger-context {:ex     "http://example.com/"
                                :schema "http://schema.org/"}
                conn           @(fluree/connect
-                                 {:method   :file :storage-path storage-path
-                                  :defaults {:context conn-context
-                                             :context-type :keyword}})
+                                {:method   :file :storage-path storage-path
+                                 :defaults {:context      conn-context
+                                            :context-type :keyword}})
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn ledger-alias
                                               {:defaultContext ["" ledger-context]})
                db             @(fluree/stage
-                                 (fluree/db ledger)
-                                 [{:id             :ex/wes
-                                   :type           :ex/User
-                                   :schema/name    "Wes"
-                                   :schema/email   "wes@example.org"
-                                   :schema/age     42
-                                   :schema/favNums [1 2 3]
-                                   :ex/friend      {:id           :ex/jake
-                                                    :type         :ex/User
-                                                    :schema/name  "Jake"
-                                                    :schema/email "jake@example.org"}}])
+                                (fluree/db ledger)
+                                [{:id             :ex/wes
+                                  :type           :ex/User
+                                  :schema/name    "Wes"
+                                  :schema/email   "wes@example.org"
+                                  :schema/age     42
+                                  :schema/favNums [1 2 3]
+                                  :ex/friend      {:id           :ex/jake
+                                                   :type         :ex/User
+                                                   :schema/name  "Jake"
+                                                   :schema/email "jake@example.org"}}])
                db             @(fluree/commit! ledger db)
                loaded         (test-utils/retry-load conn ledger-alias 100)
                loaded-db      (fluree/db loaded)
@@ -203,20 +203,20 @@
                ledger-context {:ex     "http://example.com/"
                                :schema "http://schema.org/"}
                conn           @(fluree/connect
-                                 {:method   :file :storage-path storage-path
-                                  :defaults {:context conn-context
-                                             :context-type :keyword}})
+                                {:method   :file :storage-path storage-path
+                                 :defaults {:context      conn-context
+                                            :context-type :keyword}})
                ledger-alias   "load-from-file-query"
                ledger         @(fluree/create conn ledger-alias
                                               {:defaultContext ["" ledger-context]})
                db             @(fluree/stage
-                                 (fluree/db ledger)
-                                 [{:id          :ex/Andrew
-                                   :type        :schema/Person
-                                   :schema/name "Andrew"
-                                   :ex/friend   {:id          :ex/Jonathan
-                                                 :type        :schema/Person
-                                                 :schema/name "Jonathan"}}])
+                                (fluree/db ledger)
+                                [{:id          :ex/Andrew
+                                  :type        :schema/Person
+                                  :schema/name "Andrew"
+                                  :ex/friend   {:id          :ex/Jonathan
+                                                :type        :schema/Person
+                                                :schema/name "Jonathan"}}])
                query          {:select '{?s [:*]}
                                :where  '[[?s :id :ex/Andrew]]}
                res1           @(fluree/query db query)
@@ -235,33 +235,33 @@
                ledger-context {:ex     "http://example.com/"
                                :schema "http://schema.org/"}
                conn1          @(fluree/connect
-                                 {:method   :file, :storage-path storage-path
-                                  :defaults {:context conn1-context
-                                             :context-type :keyword}})
+                                {:method   :file, :storage-path storage-path
+                                 :defaults {:context      conn1-context
+                                            :context-type :keyword}})
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn1 ledger-alias
                                               {:defaultContext ["" ledger-context]})
                db             @(fluree/stage
-                                 (fluree/db ledger)
-                                 [{:id             :ex/wes
-                                   :type           :ex/User
-                                   :schema/name    "Wes"
-                                   :schema/email   "wes@example.org"
-                                   :schema/age     42
-                                   :schema/favNums [1 2 3]
-                                   :ex/friend      {:id           :ex/jake
-                                                    :type         :ex/User
-                                                    :schema/name  "Jake"
-                                                    :schema/email "jake@example.org"}}])
+                                (fluree/db ledger)
+                                [{:id             :ex/wes
+                                  :type           :ex/User
+                                  :schema/name    "Wes"
+                                  :schema/email   "wes@example.org"
+                                  :schema/age     42
+                                  :schema/favNums [1 2 3]
+                                  :ex/friend      {:id           :ex/jake
+                                                   :type         :ex/User
+                                                   :schema/name  "Jake"
+                                                   :schema/email "jake@example.org"}}])
                db             @(fluree/commit! ledger db)
-               conn2-context  {:id "@id", :type "@type"
+               conn2-context  {:id  "@id", :type "@type"
                                :xsd "http://www.w3.org/2001/XMLSchema#"
                                :foo "http://foobar.com/"
                                :baz "http://baz.org/"}
                conn2          @(fluree/connect
-                                 {:method :file, :storage-path storage-path
-                                  :defaults {:context conn2-context
-                                             :context-type :keyword}})
+                                {:method   :file, :storage-path storage-path
+                                 :defaults {:context      conn2-context
+                                            :context-type :keyword}})
                loaded         (test-utils/retry-load conn2 ledger-alias 100)
                loaded-db      (fluree/db loaded)
                merged-ctx     (merge (ctx-util/stringify-context conn1-context) (ctx-util/stringify-context ledger-context))]
@@ -271,35 +271,35 @@
      (testing "can load a ledger with `list` values"
        (with-tmp-dir storage-path
          (let [conn         @(fluree/connect
-                               {:method       :file
-                                :storage-path storage-path
-                                :defaults
-                                {:context (merge test-utils/default-context
-                                                 {:ex "http://example.org/ns/"})
-                                 :context-type :keyword}})
+                              {:method       :file
+                               :storage-path storage-path
+                               :defaults
+                               {:context      (merge test-utils/default-context
+                                                     {:ex "http://example.org/ns/"})
+                                :context-type :keyword}})
                ledger-alias "load-lists-test"
                ledger       @(fluree/create conn ledger-alias)
                db           @(fluree/stage
-                               (fluree/db ledger)
-                               [{:id         :ex/alice,
-                                 :type       :ex/User,
-                                 :ex/friends {:list [:ex/john :ex/cam]}}
-                                {:id   :ex/cam,
-                                 :type :ex/User
-                                 :ex/numList {:list [7 8 9 10]}}
-                                {:id   :ex/john,
-                                 :type :ex/User}])
+                              (fluree/db ledger)
+                              [{:id         :ex/alice,
+                                :type       :ex/User,
+                                :ex/friends {:list [:ex/john :ex/cam]}}
+                               {:id         :ex/cam,
+                                :type       :ex/User
+                                :ex/numList {:list [7 8 9 10]}}
+                               {:id   :ex/john,
+                                :type :ex/User}])
                db           @(fluree/commit! ledger db)
                loaded       (test-utils/retry-load conn ledger-alias 100)
                loaded-db    (fluree/db loaded)]
            (is (= (:t db) (:t loaded-db)))
            (testing "query returns expected `list` values"
-             (is (= [{:id :ex/cam,
-                      :rdf/type [:ex/User],
+             (is (= [{:id         :ex/cam,
+                      :rdf/type   [:ex/User],
                       :ex/numList [7 8 9 10]}
                      {:id :ex/john, :rdf/type [:ex/User]}
-                     {:id :ex/alice,
-                      :rdf/type [:ex/User],
+                     {:id         :ex/alice,
+                      :rdf/type   [:ex/User],
                       :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                     @(fluree/query loaded-db '{:select {?s [:*]}
                                                :where  [[?s :rdf/type :ex/User]]}))))))
@@ -307,66 +307,66 @@
        (testing "can load with policies"
          (with-tmp-dir storage-path
            (let [conn         @(fluree/connect
-                                 {:method       :file
-                                  :storage-path storage-path
-                                  :defaults
-                                  {:context (merge test-utils/default-context
-                                                   {:ex "http://example.org/ns/"})
-                                   :context-type :keyword}})
+                                {:method       :file
+                                 :storage-path storage-path
+                                 :defaults
+                                 {:context      (merge test-utils/default-context
+                                                       {:ex "http://example.org/ns/"})
+                                  :context-type :keyword}})
                  ledger-alias "load-policy-test"
                  ledger       @(fluree/create conn ledger-alias)
                  db           @(fluree/stage
-                                 (fluree/db ledger)
-                                 [{:id          :ex/alice,
-                                   :type        :ex/User,
-                                   :schema/name "Alice"
-                                   :schema/ssn  "111-11-1111"
-                                   :ex/friend   :ex/john}
-                                  {:id          :ex/john,
-                                   :schema/name "John"
-                                   :type        :ex/User,
-                                   :schema/ssn  "888-88-8888"}
-                                  {:id      "did:fluree:123"
-                                   :ex/user :ex/alice
-                                   :f/role  :ex/userRole}])
+                                (fluree/db ledger)
+                                [{:id          :ex/alice,
+                                  :type        :ex/User,
+                                  :schema/name "Alice"
+                                  :schema/ssn  "111-11-1111"
+                                  :ex/friend   :ex/john}
+                                 {:id          :ex/john,
+                                  :schema/name "John"
+                                  :type        :ex/User,
+                                  :schema/ssn  "888-88-8888"}
+                                 {:id      "did:fluree:123"
+                                  :ex/user :ex/alice
+                                  :f/role  :ex/userRole}])
                  db+policy    @(fluree/stage
-                                 db
-                                 [{:id            :ex/UserPolicy,
-                                   :type          [:f/Policy],
-                                   :f/targetClass :ex/User
-                                   :f/allow       [{:id           :ex/globalViewAllow
-                                                    :f/targetRole :ex/userRole
-                                                    :f/action     [:f/view]}]
-                                   :f/property    [{:f/path  :schema/ssn
-                                                    :f/allow [{:id           :ex/ssnViewRule
-                                                               :f/targetRole :ex/userRole
-                                                               :f/action     [:f/view]
-                                                               :f/equals     {:list [:f/$identity :ex/user]}}]}]}])
+                                db
+                                [{:id            :ex/UserPolicy,
+                                  :type          [:f/Policy],
+                                  :f/targetClass :ex/User
+                                  :f/allow       [{:id           :ex/globalViewAllow
+                                                   :f/targetRole :ex/userRole
+                                                   :f/action     [:f/view]}]
+                                  :f/property    [{:f/path  :schema/ssn
+                                                   :f/allow [{:id           :ex/ssnViewRule
+                                                              :f/targetRole :ex/userRole
+                                                              :f/action     [:f/view]
+                                                              :f/equals     {:list [:f/$identity :ex/user]}}]}]}])
                  db+policy    @(fluree/commit! ledger db+policy)
                  loaded       (test-utils/retry-load conn ledger-alias 100)
                  loaded-db    (fluree/db loaded)]
              (is (= (:t db) (:t loaded-db)))
              (testing "query returns expected policy"
-               (is (= [{:id :ex/UserPolicy,
-                        :rdf/type [:f/Policy],
+               (is (= [{:id            :ex/UserPolicy,
+                        :rdf/type      [:f/Policy],
                         :f/allow
-                        {:id :ex/globalViewAllow,
-                         :f/action {:id :f/view},
+                        {:id           :ex/globalViewAllow,
+                         :f/action     {:id :f/view},
                          :f/targetRole {:_id 211106232532995}},
                         :f/property
-                        {:id "_:f211106232532999",
+                        {:id     "_:f211106232532999",
                          :f/allow
-                         {:id :ex/ssnViewRule,
-                          :f/action {:id :f/view},
+                         {:id           :ex/ssnViewRule,
+                          :f/action     {:id :f/view},
                           :f/targetRole {:_id 211106232532995},
-                          :f/equals [{:id :f/$identity} {:id :ex/user}]},
+                          :f/equals     [{:id :f/$identity} {:id :ex/user}]},
                          :f/path {:id :schema/ssn}},
                         :f/targetClass {:id :ex/User}}]
                       @(fluree/query loaded-db '{:select {?s [:*
                                                               {:rdf/type [:_id]}
                                                               {:f/allow [:* {:f/targetRole [:_id]}]}
                                                               {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
-                                                 :where  [[?s :rdf/type :f/Policy]]})))))))))
+                                                 :where  [[?s :rdf/type :f/Policy]]}))))))))))
 
 #?(:clj
    (deftest load-from-memory-test
@@ -374,7 +374,7 @@
        (let [conn         @(fluree/connect
                             {:method :memory
                              :defaults
-                             {:context test-utils/default-context
+                             {:context      test-utils/default-context
                               :context-type :keyword}})
              ledger-alias "load-from-memory-test-single-card"
              ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
@@ -410,7 +410,7 @@
        (let [conn         @(fluree/connect
                             {:method :memory
                              :defaults
-                             {:context test-utils/default-context
+                             {:context      test-utils/default-context
                               :context-type :keyword}})
              ledger-alias "load-from-memory-test-multi-card"
              ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
@@ -457,7 +457,7 @@
                              :schema "http://schema.org/"}
              conn           @(fluree/connect
                               {:method   :memory
-                               :defaults {:context conn-context
+                               :defaults {:context      conn-context
                                           :context-type :keyword}})
              ledger-alias   "load-from-memory-with-context"
              ledger         @(fluree/create conn ledger-alias
@@ -499,7 +499,7 @@
                              :schema "http://schema.org/"}
              conn           @(fluree/connect
                               {:method   :memory
-                               :defaults {:context conn-context
+                               :defaults {:context      conn-context
                                           :context-type :keyword}})
              ledger-alias   "load-from-memory-query"
              ledger         @(fluree/create conn ledger-alias
@@ -523,10 +523,10 @@
 
      (testing "can load a ledger with `list` values"
        (let [conn         @(fluree/connect
-                            {:method       :memory
+                            {:method :memory
                              :defaults
-                             {:context (merge test-utils/default-context
-                                              {:ex "http://example.org/ns/"})
+                             {:context      (merge test-utils/default-context
+                                                   {:ex "http://example.org/ns/"})
                               :context-type :keyword}})
              ledger-alias "load-lists-test"
              ledger       @(fluree/create conn ledger-alias)
@@ -535,8 +535,8 @@
                             [{:id         :ex/alice,
                               :type       :ex/User,
                               :ex/friends {:list [:ex/john :ex/cam]}}
-                             {:id   :ex/cam,
-                              :type :ex/User
+                             {:id         :ex/cam,
+                              :type       :ex/User
                               :ex/numList {:list [7 8 9 10]}}
                              {:id   :ex/john,
                               :type :ex/User}])
@@ -545,22 +545,22 @@
              loaded-db    (fluree/db loaded)]
          (is (= (:t db) (:t loaded-db)))
          (testing "query returns expected `list` values"
-           (is (= [{:id :ex/cam,
-                    :rdf/type [:ex/User],
+           (is (= [{:id         :ex/cam,
+                    :rdf/type   [:ex/User],
                     :ex/numList [7 8 9 10]}
                    {:id :ex/john, :rdf/type [:ex/User]}
-                   {:id :ex/alice,
-                    :rdf/type [:ex/User],
+                   {:id         :ex/alice,
+                    :rdf/type   [:ex/User],
                     :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                   @(fluree/query loaded-db '{:select {?s [:*]}
                                              :where  [[?s :rdf/type :ex/User]]})))))
 
        (testing "can load with policies"
          (let [conn         @(fluree/connect
-                              {:method       :memory
+                              {:method :memory
                                :defaults
-                               {:context (merge test-utils/default-context
-                                                {:ex "http://example.org/ns/"})
+                               {:context      (merge test-utils/default-context
+                                                     {:ex "http://example.org/ns/"})
                                 :context-type :keyword}})
                ledger-alias "load-policy-test"
                ledger       @(fluree/create conn ledger-alias)
@@ -596,19 +596,19 @@
                loaded-db    (fluree/db loaded)]
            (is (= (:t db) (:t loaded-db)))
            (testing "query returns expected policy"
-             (is (= [{:id :ex/UserPolicy,
-                      :rdf/type [:f/Policy],
+             (is (= [{:id            :ex/UserPolicy,
+                      :rdf/type      [:f/Policy],
                       :f/allow
-                      {:id :ex/globalViewAllow,
-                       :f/action {:id :f/view},
+                      {:id           :ex/globalViewAllow,
+                       :f/action     {:id :f/view},
                        :f/targetRole {:_id 211106232532995}},
                       :f/property
-                      {:id "_:f211106232532999",
+                      {:id     "_:f211106232532999",
                        :f/allow
-                       {:id :ex/ssnViewRule,
-                        :f/action {:id :f/view},
+                       {:id           :ex/ssnViewRule,
+                        :f/action     {:id :f/view},
                         :f/targetRole {:_id 211106232532995},
-                        :f/equals [{:id :f/$identity} {:id :ex/user}]},
+                        :f/equals     [{:id :f/$identity} {:id :ex/user}]},
                        :f/path {:id :schema/ssn}},
                       :f/targetClass {:id :ex/User}}]
                     @(fluree/query loaded-db '{:select {?s [:*

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -368,6 +368,7 @@
                                                               {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
                                                  :where  [[?s :rdf/type :f/Policy]]})))))))))
 
+#?(:clj
    (deftest load-from-memory-test
      (testing "can load a memory ledger with single cardinality predicates"
        (let [conn         @(fluree/connect

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -366,4 +366,292 @@
                                                               {:rdf/type [:_id]}
                                                               {:f/allow [:* {:f/targetRole [:_id]}]}
                                                               {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
-                                                 :where  [[?s :rdf/type :f/Policy]]}))))))))))
+                                                 :where  [[?s :rdf/type :f/Policy]]})))))))))
+
+   (deftest load-from-memory-test
+     (testing "can load a memory ledger with single cardinality predicates"
+       (let [conn         @(fluree/connect
+                            {:method :memory
+                             :defaults
+                             {:context test-utils/default-context
+                              :context-type :keyword}})
+             ledger-alias "load-from-memory-test-single-card"
+             ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+             db           @(fluree/stage
+                            (fluree/db ledger)
+                            [{:id           :ex/brian
+                              :type         :ex/User
+                              :schema/name  "Brian"
+                              :schema/email "brian@example.org"
+                              :schema/age   50
+                              :ex/favNums   7}
+
+                             {:id           :ex/cam
+                              :type         :ex/User
+                              :schema/name  "Cam"
+                              :schema/email "cam@example.org"
+                              :schema/age   34
+                              :ex/favNums   5
+                              :ex/friend    :ex/brian}])
+             db           @(fluree/commit! ledger db)
+             db           @(fluree/stage
+                            db
+                            {:id         :ex/brian
+                             :ex/favNums 7})
+             _            @(fluree/commit! ledger db)
+             ;; TODO: Replace this w/ :syncTo equivalent once we have it
+             loaded       (test-utils/retry-load conn ledger-alias 100)
+             loaded-db    (fluree/db loaded)]
+         (is (= (:t db) (:t loaded-db)))
+         (is (= (:context ledger) (:context loaded)))))
+
+     (testing "can load a memory ledger with multi-cardinality predicates"
+       (let [conn         @(fluree/connect
+                            {:method :memory
+                             :defaults
+                             {:context test-utils/default-context
+                              :context-type :keyword}})
+             ledger-alias "load-from-memory-test-multi-card"
+             ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+             db           @(fluree/stage
+                            (fluree/db ledger)
+                            [{:id           :ex/brian
+                              :type         :ex/User
+                              :schema/name  "Brian"
+                              :schema/email "brian@example.org"
+                              :schema/age   50
+                              :ex/favNums   7}
+
+                             {:id           :ex/alice
+                              :type         :ex/User
+                              :schema/name  "Alice"
+                              :schema/email "alice@example.org"
+                              :schema/age   50
+                              :ex/favNums   [42 76 9]}
+
+                             {:id           :ex/cam
+                              :type         :ex/User
+                              :schema/name  "Cam"
+                              :schema/email "cam@example.org"
+                              :schema/age   34
+                              :ex/favNums   [5 10]
+                              :ex/friend    [:ex/brian :ex/alice]}])
+             db           @(fluree/commit! ledger db)
+             db           @(fluree/stage
+                            db
+                            ;; test a multi-cardinality retraction
+                            [{:id         :ex/alice
+                              :ex/favNums [42 76 9]}])
+             _            @(fluree/commit! ledger db)
+             ;; TODO: Replace this w/ :syncTo equivalent once we have it
+             loaded       (test-utils/retry-load conn ledger-alias 100)
+             loaded-db    (fluree/db loaded)]
+         (is (= (:t db) (:t loaded-db)))
+         (is (= (dbproto/-default-context db) (dbproto/-default-context loaded-db)))))
+
+     (testing "can load a memory ledger with its own context"
+       (let [conn-context   {:id  "@id", :type "@type"
+                             :xsd "http://www.w3.org/2001/XMLSchema#"}
+             ledger-context {:ex     "http://example.com/"
+                             :schema "http://schema.org/"}
+             conn           @(fluree/connect
+                              {:method   :memory
+                               :defaults {:context conn-context
+                                          :context-type :keyword}})
+             ledger-alias   "load-from-memory-with-context"
+             ledger         @(fluree/create conn ledger-alias
+                                            {:defaultContext ["" ledger-context]})
+             db             @(fluree/stage
+                              (fluree/db ledger)
+                              [{:id             :ex/wes
+                                :type           :ex/User
+                                :schema/name    "Wes"
+                                :schema/email   "wes@example.org"
+                                :schema/age     42
+                                :schema/favNums [1 2 3]
+                                :ex/friend      {:id           :ex/jake
+                                                 :type         :ex/User
+                                                 :schema/name  "Jake"
+                                                 :schema/email "jake@example.org"}}])
+             db             @(fluree/commit! ledger db)
+             loaded         (test-utils/retry-load conn ledger-alias 100)
+             loaded-db      (fluree/db loaded)
+             merged-ctx     (merge (ctx-util/stringify-context conn-context) (ctx-util/stringify-context ledger-context))
+             query          {:where  '[[?p :schema/email "wes@example.org"]]
+                             :select '{?p [:*]}}
+             results        @(fluree/query loaded-db query)
+             full-type-url  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+         (is (= (:t db) (:t loaded-db)))
+         (is (= merged-ctx (dbproto/-default-context loaded-db)))
+         (is (= [{full-type-url   [:ex/User]
+                  :id             :ex/wes
+                  :schema/age     42
+                  :schema/email   "wes@example.org"
+                  :schema/favNums [1 2 3]
+                  :schema/name    "Wes"
+                  :ex/friend      {:id :ex/jake}}]
+                results))))
+
+     (testing "query returns the correct results from a loaded ledger"
+       (let [conn-context   {:id "@id", :type "@type"}
+             ledger-context {:ex     "http://example.com/"
+                             :schema "http://schema.org/"}
+             conn           @(fluree/connect
+                              {:method   :memory
+                               :defaults {:context conn-context
+                                          :context-type :keyword}})
+             ledger-alias   "load-from-memory-query"
+             ledger         @(fluree/create conn ledger-alias
+                                            {:defaultContext ["" ledger-context]})
+             db             @(fluree/stage
+                              (fluree/db ledger)
+                              [{:id          :ex/Andrew
+                                :type        :schema/Person
+                                :schema/name "Andrew"
+                                :ex/friend   {:id          :ex/Jonathan
+                                              :type        :schema/Person
+                                              :schema/name "Jonathan"}}])
+             query          {:select '{?s [:*]}
+                             :where  '[[?s :id :ex/Andrew]]}
+             res1           @(fluree/query db query)
+             _              @(fluree/commit! ledger db)
+             loaded         (test-utils/retry-load conn ledger-alias 100)
+             loaded-db      (fluree/db loaded)
+             res2           @(fluree/query loaded-db query)]
+         (is (= res1 res2))))
+
+     (testing "conn context is not merged into ledger's on load"
+       (let [conn1-context  {:id  "@id", :type "@type"
+                             :xsd "http://www.w3.org/2001/XMLSchema#"
+                             :foo "http://foo.com/"}
+             ledger-context {:ex     "http://example.com/"
+                             :schema "http://schema.org/"}
+             conn1          @(fluree/connect
+                              {:method   :memory
+                               :defaults {:context conn1-context
+                                          :context-type :keyword}})
+             ledger-alias   "load-from-memory-with-context"
+             ledger         @(fluree/create conn1 ledger-alias
+                                            {:defaultContext ["" ledger-context]})
+             db             @(fluree/stage
+                              (fluree/db ledger)
+                              [{:id             :ex/wes
+                                :type           :ex/User
+                                :schema/name    "Wes"
+                                :schema/email   "wes@example.org"
+                                :schema/age     42
+                                :schema/favNums [1 2 3]
+                                :ex/friend      {:id           :ex/jake
+                                                 :type         :ex/User
+                                                 :schema/name  "Jake"
+                                                 :schema/email "jake@example.org"}}])
+             db             @(fluree/commit! ledger db)
+             conn2-context  {:id "@id", :type "@type"
+                             :xsd "http://www.w3.org/2001/XMLSchema#"
+                             :foo "http://foobar.com/"
+                             :baz "http://baz.org/"}
+             conn2          @(fluree/connect
+                              {:method :file, :storage-path storage-path
+                               :defaults {:context conn2-context
+                                          :context-type :keyword}})
+             loaded         (test-utils/retry-load conn2 ledger-alias 100)
+             loaded-db      (fluree/db loaded)
+             merged-ctx     (merge (ctx-util/stringify-context conn1-context) (ctx-util/stringify-context ledger-context))]
+         (is (= (:t db) (:t loaded-db)))
+         (is (= merged-ctx (dbproto/-default-context loaded-db)))))
+
+     (testing "can load a ledger with `list` values"
+       (let [conn         @(fluree/connect
+                            {:method       :memory
+                             :defaults
+                             {:context (merge test-utils/default-context
+                                              {:ex "http://example.org/ns/"})
+                              :context-type :keyword}})
+             ledger-alias "load-lists-test"
+             ledger       @(fluree/create conn ledger-alias)
+             db           @(fluree/stage
+                            (fluree/db ledger)
+                            [{:id         :ex/alice,
+                              :type       :ex/User,
+                              :ex/friends {:list [:ex/john :ex/cam]}}
+                             {:id   :ex/cam,
+                              :type :ex/User
+                              :ex/numList {:list [7 8 9 10]}}
+                             {:id   :ex/john,
+                              :type :ex/User}])
+             db           @(fluree/commit! ledger db)
+             loaded       (test-utils/retry-load conn ledger-alias 100)
+             loaded-db    (fluree/db loaded)]
+         (is (= (:t db) (:t loaded-db)))
+         (testing "query returns expected `list` values"
+           (is (= [{:id :ex/cam,
+                    :rdf/type [:ex/User],
+                    :ex/numList [7 8 9 10]}
+                   {:id :ex/john, :rdf/type [:ex/User]}
+                   {:id :ex/alice,
+                    :rdf/type [:ex/User],
+                    :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
+                  @(fluree/query loaded-db '{:select {?s [:*]}
+                                             :where  [[?s :rdf/type :ex/User]]})))))
+
+       (testing "can load with policies"
+         (let [conn         @(fluree/connect
+                              {:method       :memory
+                               :defaults
+                               {:context (merge test-utils/default-context
+                                                {:ex "http://example.org/ns/"})
+                                :context-type :keyword}})
+               ledger-alias "load-policy-test"
+               ledger       @(fluree/create conn ledger-alias)
+               db           @(fluree/stage
+                              (fluree/db ledger)
+                              [{:id          :ex/alice,
+                                :type        :ex/User,
+                                :schema/name "Alice"
+                                :schema/ssn  "111-11-1111"
+                                :ex/friend   :ex/john}
+                               {:id          :ex/john,
+                                :schema/name "John"
+                                :type        :ex/User,
+                                :schema/ssn  "888-88-8888"}
+                               {:id      "did:fluree:123"
+                                :ex/user :ex/alice
+                                :f/role  :ex/userRole}])
+               db+policy    @(fluree/stage
+                              db
+                              [{:id            :ex/UserPolicy,
+                                :type          [:f/Policy],
+                                :f/targetClass :ex/User
+                                :f/allow       [{:id           :ex/globalViewAllow
+                                                 :f/targetRole :ex/userRole
+                                                 :f/action     [:f/view]}]
+                                :f/property    [{:f/path  :schema/ssn
+                                                 :f/allow [{:id           :ex/ssnViewRule
+                                                            :f/targetRole :ex/userRole
+                                                            :f/action     [:f/view]
+                                                            :f/equals     {:list [:f/$identity :ex/user]}}]}]}])
+               db+policy    @(fluree/commit! ledger db+policy)
+               loaded       (test-utils/retry-load conn ledger-alias 100)
+               loaded-db    (fluree/db loaded)]
+           (is (= (:t db) (:t loaded-db)))
+           (testing "query returns expected policy"
+             (is (= [{:id :ex/UserPolicy,
+                      :rdf/type [:f/Policy],
+                      :f/allow
+                      {:id :ex/globalViewAllow,
+                       :f/action {:id :f/view},
+                       :f/targetRole {:_id 211106232532995}},
+                      :f/property
+                      {:id "_:f211106232532999",
+                       :f/allow
+                       {:id :ex/ssnViewRule,
+                        :f/action {:id :f/view},
+                        :f/targetRole {:_id 211106232532995},
+                        :f/equals [{:id :f/$identity} {:id :ex/user}]},
+                       :f/path {:id :schema/ssn}},
+                      :f/targetClass {:id :ex/User}}]
+                    @(fluree/query loaded-db '{:select {?s [:*
+                                                            {:rdf/type [:_id]}
+                                                            {:f/allow [:* {:f/targetRole [:_id]}]}
+                                                            {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
+                                               :where  [[?s :rdf/type :f/Policy]]})))))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -521,46 +521,6 @@
              res2           @(fluree/query loaded-db query)]
          (is (= res1 res2))))
 
-     (testing "conn context is not merged into ledger's on load"
-       (let [conn1-context  {:id  "@id", :type "@type"
-                             :xsd "http://www.w3.org/2001/XMLSchema#"
-                             :foo "http://foo.com/"}
-             ledger-context {:ex     "http://example.com/"
-                             :schema "http://schema.org/"}
-             conn1          @(fluree/connect
-                              {:method   :memory
-                               :defaults {:context conn1-context
-                                          :context-type :keyword}})
-             ledger-alias   "load-from-memory-with-context"
-             ledger         @(fluree/create conn1 ledger-alias
-                                            {:defaultContext ["" ledger-context]})
-             db             @(fluree/stage
-                              (fluree/db ledger)
-                              [{:id             :ex/wes
-                                :type           :ex/User
-                                :schema/name    "Wes"
-                                :schema/email   "wes@example.org"
-                                :schema/age     42
-                                :schema/favNums [1 2 3]
-                                :ex/friend      {:id           :ex/jake
-                                                 :type         :ex/User
-                                                 :schema/name  "Jake"
-                                                 :schema/email "jake@example.org"}}])
-             db             @(fluree/commit! ledger db)
-             conn2-context  {:id "@id", :type "@type"
-                             :xsd "http://www.w3.org/2001/XMLSchema#"
-                             :foo "http://foobar.com/"
-                             :baz "http://baz.org/"}
-             conn2          @(fluree/connect
-                              {:method :file, :storage-path storage-path
-                               :defaults {:context conn2-context
-                                          :context-type :keyword}})
-             loaded         (test-utils/retry-load conn2 ledger-alias 100)
-             loaded-db      (fluree/db loaded)
-             merged-ctx     (merge (ctx-util/stringify-context conn1-context) (ctx-util/stringify-context ledger-context))]
-         (is (= (:t db) (:t loaded-db)))
-         (is (= merged-ctx (dbproto/-default-context loaded-db)))))
-
      (testing "can load a ledger with `list` values"
        (let [conn         @(fluree/connect
                             {:method       :memory


### PR DESCRIPTION
This is mostly used by other tests, but it's nice to know it's working when those other tests are failing (so you can start elsewhere in your search for the failure cause).

I copy-pasted these from the file conn `load` tests b/c I was worried that this was why an http-api-gateway test was failing (i.e. that `load` had issues w/ mem conns that it didn't have w/ file conns). Luckily that wasn't it, but these tests seemed nice to have anyway.