### PR TITLE
Adds tests to ensure context remains "stable" through multiple reloads

### DIFF
--- a/test/fluree/db/transact/stable_context_test.clj
+++ b/test/fluree/db/transact/stable_context_test.clj
@@ -11,9 +11,9 @@
 (deftest ^:integration default-context-stability-memory
   (let [conn     (test-utils/create-conn)
         ledger   @(fluree/create conn "ctx/stability-mem" {:defaultContext {:id   "@id"
-                                                                        :type "@type"
-                                                                        :ex   "http://example.org/ns/"
-                                                                        :blah "http://blah.me/wow/ns/"}})
+                                                                            :type "@type"
+                                                                            :ex   "http://example.org/ns/"
+                                                                            :blah "http://blah.me/wow/ns/"}})
         db1      @(test-utils/transact ledger [{:id      :blah/one
                                                 :ex/name "One"}])
         db1-load (fluree/db @(fluree/load conn "ctx/stability-mem"))
@@ -49,43 +49,43 @@
 
 (deftest ^:integration default-context-stability-file
   (with-tmp-dir storage-path
-                (let [conn     @(fluree/connect
-                                  {:method :file :storage-path storage-path
-                                   :defaults
-                                   {:context      test-utils/default-context
-                                    :context-type :keyword}})
-                      ledger   @(fluree/create conn "ctx/stability" {:defaultContext {:id   "@id"
-                                                                                      :type "@type"
-                                                                                      :ex   "http://example.org/ns/"
-                                                                                      :blah "http://blah.me/wow/ns/"}})
-                      db1      @(test-utils/transact ledger [{:id      :blah/one
-                                                              :ex/name "One"}])
-                      db1-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))
-                      db2      @(test-utils/transact ledger [{:id      :blah/two
-                                                              :ex/name "Two"}])
-                      db2-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))
-                      db3      @(test-utils/transact ledger [{:id      :blah/three
-                                                              :ex/name "Three"}])
-                      db3-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))]
+    (let [conn     @(fluree/connect
+                      {:method :file :storage-path storage-path
+                       :defaults
+                       {:context      test-utils/default-context
+                        :context-type :keyword}})
+          ledger   @(fluree/create conn "ctx/stability" {:defaultContext {:id   "@id"
+                                                                          :type "@type"
+                                                                          :ex   "http://example.org/ns/"
+                                                                          :blah "http://blah.me/wow/ns/"}})
+          db1      @(test-utils/transact ledger [{:id      :blah/one
+                                                  :ex/name "One"}])
+          db1-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))
+          db2      @(test-utils/transact ledger [{:id      :blah/two
+                                                  :ex/name "Two"}])
+          db2-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))
+          db3      @(test-utils/transact ledger [{:id      :blah/three
+                                                  :ex/name "Three"}])
+          db3-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))]
 
-                  (testing "Loaded default context is same as initial db's"
-                    (is (= (dbproto/-default-context db1-load)
-                           (dbproto/-default-context db1))))
+      (testing "Loaded default context is same as initial db's"
+        (is (= (dbproto/-default-context db1-load)
+               (dbproto/-default-context db1))))
 
-                  (testing "Second transaction default context is same as initial db's"
-                    (is (= (dbproto/-default-context db2-load)
-                           (dbproto/-default-context db1))))
+      (testing "Second transaction default context is same as initial db's"
+        (is (= (dbproto/-default-context db2-load)
+               (dbproto/-default-context db1))))
 
-                  (testing "Third transaction default context is same as initial db's"
-                    (is (= (dbproto/-default-context db3-load)
-                           (dbproto/-default-context db1))))
+      (testing "Third transaction default context is same as initial db's"
+        (is (= (dbproto/-default-context db3-load)
+               (dbproto/-default-context db1))))
 
-                  (testing "Query after the 3rd load is using original default context"
-                    (is (= [{:id      :blah/three
-                             :ex/name "Three"}
-                            {:id      :blah/two
-                             :ex/name "Two"}
-                            {:id      :blah/one
-                             :ex/name "One"}]
-                           @(fluree/query db3-load '{:select {?s [:*]}
-                                                     :where  [[?s :ex/name nil]]})))))))
+      (testing "Query after the 3rd load is using original default context"
+        (is (= [{:id      :blah/three
+                 :ex/name "Three"}
+                {:id      :blah/two
+                 :ex/name "Two"}
+                {:id      :blah/one
+                 :ex/name "One"}]
+               @(fluree/query db3-load '{:select {?s [:*]}
+                                         :where  [[?s :ex/name nil]]})))))))

--- a/test/fluree/db/transact/stable_context_test.clj
+++ b/test/fluree/db/transact/stable_context_test.clj
@@ -1,0 +1,91 @@
+(ns fluree.db.transact.stable-context-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.json-ld.api :as fluree]
+            [test-with-files.tools :refer [with-tmp-dir] :as twf]))
+
+
+;; ensures default context remains stable across many commits.
+
+(deftest ^:integration default-context-stability-memory
+  (let [conn     (test-utils/create-conn)
+        ledger   @(fluree/create conn "ctx/stability-mem" {:defaultContext {:id   "@id"
+                                                                        :type "@type"
+                                                                        :ex   "http://example.org/ns/"
+                                                                        :blah "http://blah.me/wow/ns/"}})
+        db1      @(test-utils/transact ledger [{:id      :blah/one
+                                                :ex/name "One"}])
+        db1-load (fluree/db @(fluree/load conn "ctx/stability-mem"))
+        db2      @(test-utils/transact ledger [{:id      :blah/two
+                                                :ex/name "Two"}])
+        db2-load (fluree/db @(fluree/load conn "ctx/stability-mem"))
+        db3      @(test-utils/transact ledger [{:id      :blah/three
+                                                :ex/name "Three"}])
+        db3-load (fluree/db @(fluree/load conn "ctx/stability-mem"))]
+
+    (testing "Loaded default context is same as initial db's"
+      (is (= (dbproto/-default-context db1-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Second transaction default context is same as initial db's"
+      (is (= (dbproto/-default-context db2-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Third transaction default context is same as initial db's"
+      (is (= (dbproto/-default-context db3-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Query after the 3rd load is using original default context"
+      (is (= [{:id      :blah/three
+               :ex/name "Three"}
+              {:id      :blah/two
+               :ex/name "Two"}
+              {:id      :blah/one
+               :ex/name "One"}]
+             @(fluree/query db3-load '{:select {?s [:*]}
+                                       :where  [[?s :ex/name nil]]}))))))
+
+
+(deftest ^:integration default-context-stability-file
+  (with-tmp-dir storage-path
+                (let [conn     @(fluree/connect
+                                  {:method :file :storage-path storage-path
+                                   :defaults
+                                   {:context      test-utils/default-context
+                                    :context-type :keyword}})
+                      ledger   @(fluree/create conn "ctx/stability" {:defaultContext {:id   "@id"
+                                                                                      :type "@type"
+                                                                                      :ex   "http://example.org/ns/"
+                                                                                      :blah "http://blah.me/wow/ns/"}})
+                      db1      @(test-utils/transact ledger [{:id      :blah/one
+                                                              :ex/name "One"}])
+                      db1-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))
+                      db2      @(test-utils/transact ledger [{:id      :blah/two
+                                                              :ex/name "Two"}])
+                      db2-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))
+                      db3      @(test-utils/transact ledger [{:id      :blah/three
+                                                              :ex/name "Three"}])
+                      db3-load (fluree/db (test-utils/retry-load conn "ctx/stability" 100))]
+
+                  (testing "Loaded default context is same as initial db's"
+                    (is (= (dbproto/-default-context db1-load)
+                           (dbproto/-default-context db1))))
+
+                  (testing "Second transaction default context is same as initial db's"
+                    (is (= (dbproto/-default-context db2-load)
+                           (dbproto/-default-context db1))))
+
+                  (testing "Third transaction default context is same as initial db's"
+                    (is (= (dbproto/-default-context db3-load)
+                           (dbproto/-default-context db1))))
+
+                  (testing "Query after the 3rd load is using original default context"
+                    (is (= [{:id      :blah/three
+                             :ex/name "Three"}
+                            {:id      :blah/two
+                             :ex/name "Two"}
+                            {:id      :blah/one
+                             :ex/name "One"}]
+                           @(fluree/query db3-load '{:select {?s [:*]}
+                                                     :where  [[?s :ex/name nil]]})))))))


### PR DESCRIPTION
@aaj3f was investigating an issue via http-api-gateway where after multiple transactions the default context seemed to revert back to the connection default.

We confirmed this behavior looking at the commit files written, and they do in fact loose all reference to the default context file.

I threw together these tests to attempt to replicate the issue, but they all pass. I figured they are good tests to have regardless.