### PR TITLE
Ensures default context is carried from loaded commit meta

### DIFF
--- a/src/fluree/db/json_ld/commit_data.cljc
+++ b/src/fluree/db/json_ld/commit_data.cljc
@@ -179,11 +179,13 @@
          issuer      const/iri-issuer
          time        const/iri-time,
          tag         const/iri-tag,
+         ctx-default const/iri-default-context
          message     const/iri-message
          prev-commit const/iri-previous,
          data        const/iri-data,
          ns          const/iri-ns,
          index       const/iri-index} commit-json-ld
+        ctx-key   (keyword const/iri-default-context)
         db-object (fn [{id      :id,
                         t       const/iri-t,
                         address const/iri-address,
@@ -224,7 +226,8 @@
                   :psot    psot
                   :post    post
                   :opst    opst
-                  :tspo    tspo})}))
+                  :tspo    tspo})
+     ctx-key   (:value ctx-default)}))
 
 
 (defn update-commit-id
@@ -359,12 +362,10 @@
   Assumes commit is not yet created (but db is persisted), so
   commit-id and commit-address are added after finalizing and persisting commit."
   [{:keys [old-commit issuer message tag dbid t db-address flakes size]
-    :as commit}]
+    :as   _commit}]
   (let [prev-data   (select-keys (data old-commit) [:id :address])
         data-commit (new-db-commit dbid t db-address prev-data flakes size)
         prev-commit (not-empty (select-keys old-commit [:id :address]))
-        context-key (keyword const/iri-default-context)
-        context     (get commit context-key)
         commit      (-> old-commit
                         (dissoc :id :address :data :issuer :time :message :tag :prev-commit)
                         (assoc :address ""
@@ -374,8 +375,7 @@
             issuer (assoc :issuer {:id issuer})
             prev-commit (assoc :previous prev-commit)
             message (assoc :message message)
-            tag (assoc :tag tag)
-            context (assoc context-key context))))
+            tag (assoc :tag tag))))
 
 (defn update-db
   "Updates the :data portion of the commit map to represent a saved new db update."

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -427,7 +427,7 @@
   [{:keys [ledger] :as db} latest-commit commit-address merged-db?]
   (go-try
     (let [{:keys [conn]} ledger
-          idx-meta   (get latest-commit const/iri-index)
+          idx-meta   (get latest-commit const/iri-index) ;; get persistent index meta if ledger has indexes
           db-base    (if-let [idx-address (get-in idx-meta [const/iri-address :value])]
                        (<? (storage/reify-db conn db idx-address))
                        db)

--- a/test/fluree/db/transact/stable_context_test.clj
+++ b/test/fluree/db/transact/stable_context_test.clj
@@ -8,6 +8,51 @@
 
 ;; ensures default context remains stable across many commits.
 
+(deftest ^:integration default-context-stability-memory-from-load
+  (let [conn     (test-utils/create-conn)
+        ledger   @(fluree/create conn "ctx/stability-mem-ld" {:defaultContext {:id   "@id"
+                                                                               :type "@type"
+                                                                               :ex   "http://example.org/ns/"
+                                                                               :blah "http://blah.me/wow/ns/"}})
+        db1      @(test-utils/transact ledger [{:id      :blah/one
+                                                :ex/name "One"}])
+        db1-load (fluree/db @(fluree/load conn "ctx/stability-mem-ld"))
+
+        db2      (->> @(fluree/stage db1-load [{:id      :blah/two
+                                                :ex/name "Two"}])
+                      (fluree/commit! ledger)
+                      deref)
+        db2-load (fluree/db @(fluree/load conn "ctx/stability-mem-ld"))
+
+        db3      (->> @(fluree/stage db2-load [{:id      :blah/three
+                                                :ex/name "Three"}])
+                      (fluree/commit! ledger)
+                      deref)
+        db3-load (fluree/db @(fluree/load conn "ctx/stability-mem-ld"))]
+
+    (testing "Loaded default context is same as initial db's"
+      (is (= (dbproto/-default-context db1-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Second transaction default context is same as initial db's"
+      (is (= (dbproto/-default-context db2-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Third transaction default context is same as initial db's"
+      (is (= (dbproto/-default-context db3-load)
+             (dbproto/-default-context db1))))
+
+    (testing "Query after the 3rd load is using original default context"
+      (is (= [{:id      :blah/three
+               :ex/name "Three"}
+              {:id      :blah/two
+               :ex/name "Two"}
+              {:id      :blah/one
+               :ex/name "One"}]
+             @(fluree/query db3-load '{:select {?s [:*]}
+                                       :where  [[?s :ex/name nil]]}))))))
+
+
 (deftest ^:integration default-context-stability-memory
   (let [conn     (test-utils/create-conn)
         ledger   @(fluree/create conn "ctx/stability-mem" {:defaultContext {:id   "@id"


### PR DESCRIPTION
This actually addresses the load issue of the default context and adds a test that will break without this fix.
