### PR TITLE
Enable policy opts via http-api

### DIFF
--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -37,7 +37,9 @@
                                  {:rdf/type [:_id]}
                                  {:f/allow [:* {:f/targetRole [:_id]}]}
                                  {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
-                   :where  [['?s :rdf/type :f/Policy]]}))))
+                   :where  [['?s :rdf/type :f/Policy]]
+                   :opts {:context-type :keyword}}))))
+
 
 
 (defn policies-for-roles*

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -336,7 +336,9 @@
            async/merge
            (async/reduce
              (fn [acc result]
-               (into acc result)) [])
+               (if (instance? Throwable result)
+                 (reduced result)
+                 (into acc result))) [])
            <?))))
 
 ;; TODO - exceptions in here won't be caught!
@@ -351,7 +353,9 @@
          async/merge
          (async/reduce
            (fn [acc result]
-             (into acc result)) [])
+             (if (instance? Throwable result)
+               (reduced result)
+               (into acc result))) [])
          <?)))
 
 
@@ -429,8 +433,9 @@
        (map #(compile-policy db %))
        async/merge
        (async/reduce (fn [acc compiled-policy]
-                       (into acc compiled-policy)) [])))
-
+                       (if (instance? Throwable compiled-policy)
+                         (reduced compiled-policy)
+                         (into acc compiled-policy))) [])))
 
 (defn policy-map
   "perm-action is a set of the action(s) being filtered for."
@@ -443,7 +448,7 @@
             role-sids         (if (sequential? role)
                                 (->> (<? (subids db role))
                                      (into #{}))
-                                #{(<? (dbproto/-subid db role))})
+                                #{(<? (dbproto/-subid db role ))})
             policies          {:ident ident-sid
                                :roles role-sids
                                :cache (atom {})}


### PR DESCRIPTION
Required for https://github.com/fluree/http-api-gateway/issues/38

This PR enables the use of policy opts via http-api. 

The only _required_ change here was https://github.com/fluree/db/commit/56e770de95ca55fb6ef8e334f47897fb01980850.


I also added a change to how we deal with errors when compiling policies (f394d7867dee564b66943c17f3227d79787eb49c). Prior to this change, if there was an error in that codepath, we would fail to enforce any policy at all, silently failing open to root access.  

We _should_  do something smarter with those errors (they are still not surfaced correctly, so I have left the `TODO`s intact), but this was a minimal change that ensures that we at least fail closed when policy compilation fails.

I encountered this earlier in this work, where due to some bugs I was getting errors during the policy compilation process. Since those got fixed I'm no longer getting those errors, and I couldn't readily think of a way to set up a test for this that would demonstrate this. So, we can take it or leave it, since it's untested.