### PR TITLE
Fix decimal coercion w/ file conn loading

### DIFF
--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -6,8 +6,7 @@
                :cljs [fluree.db.util.cljs-const :as uc]))
   #?(:clj (:import (java.time OffsetDateTime OffsetTime LocalDate LocalTime
                               LocalDateTime ZoneOffset)
-                   (java.time.format DateTimeFormatter)
-                   (java.math BigDecimal))))
+                   (java.time.format DateTimeFormatter))))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -190,16 +189,20 @@
   [value]
   (cond
     (string? value)
-    #?(:clj  (try (BigDecimal. ^String value) (catch Exception _ nil))
+    #?(:clj  (try (bigdec value) (catch Exception _ nil))
        :cljs (let [n (js/parseFloat value)] (if (js/Number.isNaN n) nil n)))
 
     (integer? value)
-    #?(:clj  (BigDecimal. ^int value)
+    #?(:clj  (bigdec value)
        :cljs value)
 
     (float? value)
     ;; convert to string first to keep float precision explosion at bay
-    #?(:clj  (BigDecimal. ^String (Float/toString value))
+    #?(:clj  (bigdec (Float/toString value))
+       :cljs value)
+
+    (number? value)
+    #?(:clj  (bigdec value)
        :cljs value)
 
     :else nil))

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -90,11 +90,11 @@
     (is (= nil (coerce "foo" const/$xsd:dateTime))))
 
   (testing "decimal"
-    (is (= #?(:clj (BigDecimal. "3.14") :cljs 3.14)
+    (is (= #?(:clj (bigdec "3.14") :cljs 3.14)
            (coerce 3.14 const/$xsd:decimal)))
-    (is (= #?(:clj (BigDecimal. "3.14") :cljs 3.14)
+    (is (= #?(:clj (bigdec "3.14") :cljs 3.14)
            (coerce "3.14" const/$xsd:decimal)))
-    (is (= #?(:clj (BigDecimal. "42.0") :cljs 42)
+    (is (= #?(:clj (bigdec "42.0") :cljs 42)
            (coerce 42 const/$xsd:decimal)))
     (is (= #?(:clj (bigdec 99.99) :cljs 99.99)
            (coerce #?(:clj (bigdec 99.99) :cljs 99.99) const/$xsd:decimal)))

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -96,6 +96,8 @@
            (coerce "3.14" const/$xsd:decimal)))
     (is (= #?(:clj (BigDecimal. "42.0") :cljs 42)
            (coerce 42 const/$xsd:decimal)))
+    (is (= #?(:clj (bigdec 99.99) :cljs 99.99)
+           (coerce #?(:clj (bigdec 99.99) :cljs 99.99) const/$xsd:decimal)))
     (is (= nil
            (coerce "foo" const/$xsd:decimal))))
 

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -86,7 +86,8 @@
                                 :schema/name  "Brian"
                                 :schema/email "brian@example.org"
                                 :schema/age   50
-                                :ex/favNums   7}
+                                :ex/favNums   7
+                                :ex/height    6.2}
 
                                {:id           :ex/cam
                                 :type         :ex/User


### PR DESCRIPTION
Fixes #436 and adds tests for it. The values were already BigDecimals there (which is what the `M` suffix designates), so this catches those. I suppose it could also test for that first, but it's not a thing in JS and this should catch additional cases that should probably work anyway.