### PR TITLE
Feature/query iri map

### DIFF
--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -12,7 +12,6 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-
 (defn reference?
   [dt]
   (= dt const/$xsd:anyURI))

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -225,7 +225,7 @@
   (let [match-ch  (async/chan)
         [s p iri] (val pattern)]
     (go (try*
-          (log/info "looking up iri:" iri)
+          (log/trace "looking up iri:" iri)
           (let [sid   (<? (dbproto/-subid db iri true))
                 triple [s p sid]]
             (-> db

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -220,17 +220,6 @@
                                             (match-flake solution pattern flake)))))]
     (async/pipe flake-ch match-ch)))
 
-(defmethod match-pattern :iri
-  [db solution pattern filters error-ch]
-  (let [triple   (val pattern)
-        cur-vals (assign-matched-values triple solution filters)
-        _        (log/debug "assign-matched-values returned:" cur-vals)
-        flake-ch (resolve-flake-range db error-ch cur-vals)
-        match-ch (async/chan 2 (comp cat
-                                     (map (fn [flake]
-                                            (match-flake solution triple flake)))))]
-    (async/pipe flake-ch match-ch)))
-
 (defn with-distinct-subjects
   "Return a transducer that filters a stream of flakes by removing any flakes with
   subject ids repeated from previously processed flakes."

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -35,7 +35,8 @@
         [s-cmp p-cmp o-cmp] components
         {s ::val, s-fn ::fn} s-cmp
         {p ::val, p-fn ::fn} p-cmp
-        {o    ::val, o-fn ::fn
+        {o    ::val
+         o-fn ::fn
          o-dt ::datatype} o-cmp]
     (go
       (try* (let [s*          (if (and s (not (number? s)))
@@ -222,12 +223,13 @@
 
 (defmethod match-pattern :iri-ref
   [db solution pattern filters error-ch]
-  (let [match-ch  (async/chan)
-        [s p iri] (val pattern)]
+  (let [match-ch        (async/chan)
+        [s p iri-match] (val pattern)
+        iri             (::val iri-match)]
     (go (try*
-          (log/trace "looking up iri:" iri)
-          (let [sid   (<? (dbproto/-subid db iri true))
-                triple [s p sid]]
+          (let [sid    (<? (dbproto/-subid db iri true))
+                o      (anonymous-value sid const/$xsd:anyURI)
+                triple [s p o]]
             (-> db
                 (match-pattern solution triple filters error-ch)
                 (async/pipe match-ch)))

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -1,8 +1,7 @@
 (ns fluree.db.query.fql
   (:require [clojure.core.async :as async :refer [<! go]]
-            [fluree.db.util.core :as util]
             [fluree.db.util.log :as log :include-macros true]
-            [fluree.db.util.core #?(:clj :refer :cljs :refer-macros) [try* catch*]]
+            [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.query.subject-crawl.core :refer [simple-subject-crawl]]
             [fluree.db.query.fql.parse :as parse]
             [fluree.db.query.exec :as exec])

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -174,7 +174,7 @@
   (when (util/pred-ident? x)
     (where/->ident x)))
 
-(defn parse-iri
+(defn parse-subject-iri
   [x context]
   (-> x
       (json-ld/expand-iri context)
@@ -193,7 +193,7 @@
    (if-let [parsed (parse-subject x)]
      parsed
      (when context
-       (parse-iri x context)))))
+       (parse-subject-iri x context)))))
 
 (defn parse-subject-pattern
   [s-pat context]
@@ -264,6 +264,12 @@
     (throw (ex-info (str "Undefined RDF type specified: " (json-ld/expand-iri o-iri context))
                     {:status 400 :error :db/invalid-query}))))
 
+(defn parse-object-iri
+  [x context]
+  (-> x
+      (json-ld/expand-iri context)
+      where/anonymous-value))
+
 (defn parse-object-pattern
   [o-pat]
   (or (parse-variable o-pat)
@@ -329,9 +335,7 @@
       (let [cls (parse-class o-pat db context)]
         (where/->pattern :class [s p cls]))
       (if (= const/$xsd:anyURI (::where/val p))
-        (let [o (-> o-pat
-                    (json-ld/expand-iri context)
-                    where/anonymous-value)]
+        (let [o (parse-object-iri o-pat context)]
           [s p o])
         (let [o (parse-object-pattern o-pat)]
           [s p o])))))

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -327,14 +327,18 @@
     (where/->where-clause patterns filters)))
 
 (defn iri-map?
-  [x]
+  [x context]
   (and (map? x)
        (= (count x) 1)
-       (-> x keys first syntax/iri-key?)))
+       (-> x
+           keys
+           first
+           (json-ld/expand-iri context)
+           syntax/iri-key?)))
 
 (defn parse-iri-map
   [x context]
-  (when (iri-map? x)
+  (when (iri-map? x context)
     (-> x
         vals
         first
@@ -351,9 +355,8 @@
       (if (= const/$xsd:anyURI (::where/val p))
         (let [o (parse-object-iri o-pat context)]
           [s p o])
-        (if (iri-map? o-pat)
-          (let [o (parse-iri-map o-pat context)]
-            (where/->pattern :iri-ref [s p o]))
+        (if-let [o (parse-iri-map o-pat context)]
+          (where/->pattern :iri-ref [s p o])
           (let [o (parse-object-pattern o-pat)]
             [s p o]))))))
 

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -332,7 +332,7 @@
         (let [o (-> o-pat
                     (json-ld/expand-iri context)
                     where/anonymous-value)]
-          (where/->pattern :iri [s p o]))
+          [s p o])
         (let [o (parse-object-pattern o-pat)]
           [s p o])))))
 

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -212,7 +212,7 @@
 
 (defn parse-iri-predicate
   [x]
-  (when (= "@id" x)
+  (when (syntax/iri-key? x)
     (where/->predicate const/$xsd:anyURI)))
 
 (defn iri->pred-id

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.query.fql.syntax
-  (:require [malli.core :as m]
-            [fluree.db.util.core :refer [pred-ident?]]))
+  (:require [fluree.db.constants :as const]
+            [fluree.db.util.core :refer [pred-ident?]]
+            [malli.core :as m]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -43,7 +44,7 @@
 
 (defn iri-key?
   [x]
-  (= "@id" x))
+  (= const/iri-id x))
 
 (defn where-op [x]
   (when (map? x)

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -41,6 +41,10 @@
   [x]
   (boolean (#{'desc "desc" :desc} x)))
 
+(defn iri-key?
+  [x]
+  (= "@id" x))
+
 (defn where-op [x]
   (when (map? x)
     (-> x first key)))
@@ -131,6 +135,7 @@
                               [:optional [:map [:optional [:ref ::optional]]]]
                               [:union [:map [:union [:ref ::union]]]]
                               [:bind [:map [:bind [:ref ::bind]]]]]]
+     ::iri-key              [:fn iri-key?]
      ::triple               [:catn
                              [:subject [:orn
                                         [:var ::var]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -136,6 +136,8 @@
                               [:union [:map [:union [:ref ::union]]]]
                               [:bind [:map [:bind [:ref ::bind]]]]]]
      ::iri-key              [:fn iri-key?]
+     ::iri-map              [:map-of {:max 1}
+                             ::iri-key ::iri]
      ::triple               [:catn
                              [:subject [:orn
                                         [:var ::var]
@@ -146,6 +148,7 @@
                              [:object [:orn
                                        [:var ::var]
                                        [:ident [:fn pred-ident?]]
+                                       [:iri-map ::iri-map]
                                        [:val :any]]]]
      ::where-tuple          [:orn
                              [:triple ::triple]

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -25,8 +25,8 @@
                       (when-let [variable (:variable o)]
                         (get vars variable)))
         p*          (:value p)
-        idx*        (where/idx-for nil p* o*)
         o-dt        (:datatype o)
+        idx*        (where/idx-for nil p* o* o-dt)
         [fflake lflake] (case idx*
                           :post [(flake/create nil p* o* o-dt nil nil util/min-integer)
                                  (flake/create nil p* o* o-dt nil nil util/max-integer)]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -175,10 +175,16 @@
         db     (fluree/db movies)]
     (testing "iri queries"
       (let [test-subject @(fluree/query db '{:select [?s]
-                                             :where [[?s :id :wiki/Q836821]]})]
+                                             :where  [[?s :id :wiki/Q836821]]})]
         (is (= [[:wiki/Q836821]]
                test-subject)
-            "Returns the subject with that iri")))))
+            "Returns the subject with that iri")))
+    (testing "iri references"
+      (let [test-subject @(fluree/query db '{:select [?name]
+                                             :where  [[?s :schema/name ?name]
+                                                      [?s :schema/isBasedOn {:id :wiki/Q3107329}]]})]
+        (is (= [["The Hitchhiker's Guide to the Galaxy"]]
+               test-subject))))))
 
 (deftest ^:integration multi-query-test
   (let [conn   (test-utils/create-conn)


### PR DESCRIPTION
This patch allows users to reference subjects with an iri map in the object position containing one entry whose key is "@id" and value is the referenced iri. 

After parsing the iri map, the query executor first looks up the subject id corresponding to the supplied iri and then processes the rest of the query normally.