### PR TITLE
Fix/transform where

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
          byte-streams/byte-streams       {:mvn/version "0.2.4"}
          cheshire/cheshire               {:mvn/version "5.11.0"}
          instaparse/instaparse           {:mvn/version "1.4.12"}
-         metosin/malli                   {:mvn/version "0.9.2"}
+         metosin/malli                   {:mvn/version "0.11.0"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
                                           :sha     "a909330e33196504ef8a5411aaa0409ab72aaa35"}
 

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -495,8 +495,9 @@
 
 (defn parse
   [q db]
-  (syntax/validate q)
-  (parse-analytical-query q db))
+  (-> q
+      syntax/coerce
+      (parse-analytical-query db)))
 
 (defn parse-delete
   [q db]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -54,7 +54,9 @@
 
 (defn string->keyword
   [x]
-  (cond-> x (string? x) keyword))
+  (if (string? x)
+    (keyword x)
+    x))
 
 (def registry
   (merge

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.query.fql.syntax
   (:require [fluree.db.constants :as const]
             [fluree.db.util.core :refer [try* catch* pred-ident?]]
+            [fluree.db.util.log :as log]
             [malli.core :as m]
             [malli.transform :as mt]))
 
@@ -122,9 +123,10 @@
                              [:desc [:fn desc?]]]
      ::ordering             [:orn
                              [:scalar ::var]
-                             [:vector [:catn
-                                       [:direction ::direction]
-                                       [:dimension ::var]]]]
+                             [:vector [:and list?
+                                       [:catn
+                                        [:direction ::direction]
+                                        [:dimension ::var]]]]]
      ::orderBy              [:orn
                              [:clause ::ordering]
                              [:collection [:sequential ::ordering]]]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -1,8 +1,8 @@
 (ns fluree.db.query.fql.syntax
   (:require [fluree.db.constants :as const]
             [fluree.db.util.core :refer [try* catch* pred-ident?]]
-            [fluree.db.util.log :as log]
             [malli.core :as m]
+            [malli.error :as me]
             [malli.transform :as mt]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -249,4 +249,4 @@
                 (throw (ex-info "Invalid Query"
                                 {:status  400
                                  :error   :db/invalid-query
-                                 :reasons (m/explain ::query qry {:registry registry})})))))
+                                 :reasons (me/humanize (m/explain ::query qry {:registry registry}))})))))

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -37,6 +37,15 @@
               ["Brian" nil]])
           "Cam, Alice and Brian should all return, but only Alica has a favColor")
 
+      (is (= @(fluree/query db '{:select [?name ?favColor]
+                                 :where  [[?s :rdf/type :ex/User]
+                                          [?s :schema/name ?name]
+                                          {"optional" [?s :ex/favColor ?favColor]}]})
+             [["Cam" nil]
+              ["Alice" "Green"]
+              ["Brian" nil]])
+          "Cam, Alice and Brian should all return, but only Alice has a favColor, even with string 'optional' key")
+
       ;; including another pass-through variable - note Brian doesn't have an email
       (is (= @(fluree/query db '{:select [?name ?favColor ?email]
                                  :where  [[?s :rdf/type :ex/User]


### PR DESCRIPTION
This patch uses malli's built in coercion capabilities to transform any string keys that appear in where clause maps to keywords just before validation to ensure that both validation and further downstream parsing succeeds. 

I also made a small tweak to the ordering spec to ensure that the coerced queries have a list as ordering instead of a vector. In doing this, I realized the name of that particular spec is confusing because it's called vector, but it's supposed to be a vector in the physics sense: with a magnitude and direction. I'm open to better, less ambiguous names if anyone has suggestions.

Fixes https://github.com/fluree/core/issues/14