### PR TITLE
Changes to support replacing spec with malli in http-api-gateway

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -33,16 +33,16 @@
             ;; from and to are positive ints, need to convert to negative or fill in default values
             {:keys [from to at]} t
             [from-t to-t]        (if at
-                                   (let [t (cond (= "latest" at) (:t db*)
+                                   (let [t (cond (= :latest at) (:t db*)
                                                  (string? at)   (<? (time-travel/datetime->t db* at))
                                                  (number? at)   (- at))]
                                      [t t])
                                    ;; either (:from or :to)
-                                   [(cond (= "latest" from) (:t db*)
+                                   [(cond (= :latest from) (:t db*)
                                           (string? from)   (<? (time-travel/datetime->t db* from))
                                           (number? from)   (- from)
                                           (nil? from)      -1)
-                                    (cond (= "latest" to) (:t db*)
+                                    (cond (= :latest to) (:t db*)
                                           (string? to)   (<? (time-travel/datetime->t db* to))
                                           (number? to)   (- to)
                                           (nil? to)      (:t db*))])

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -1,6 +1,8 @@
 (ns fluree.db.query.fql.syntax
   (:require [fluree.db.constants :as const]
+            [fluree.db.util.core :as util]
             [fluree.db.util.core :refer [try* catch* pred-ident?]]
+            [fluree.db.util.validation :as v]
             [malli.core :as m]
             [malli.error :as me]
             [malli.transform :as mt]))
@@ -58,6 +60,10 @@
     (keyword x)
     x))
 
+(defn decode-json
+  [v]
+  (util/keywordize-keys v))
+
 (def registry
   (merge
     (m/predicate-schemas)
@@ -66,6 +72,7 @@
     (m/type-schemas)
     (m/sequence-schemas)
     (m/base-schemas)
+    v/registry
     {::limit                pos-int?
      ::offset               nat-int?
      ::maxFuel              number?
@@ -78,29 +85,33 @@
      ::contextType          [:enum :string :keyword]
      ::context-type         ::contextType
      ::issuer               [:maybe string?]
-     ::opts                 [:map
-                             [:maxFuel {:optional true} ::maxFuel]
-                             [:max-fuel {:optional true} ::maxFuel]
-                             [:parseJSON {:optional true} ::parseJSON]
-                             [:parse-json {:optional true} ::parse-json]
-                             [:prettyPrint {:optional true} ::prettyPrint]
-                             [:pretty-print {:optional true} ::pretty-print]
-                             [:contextType {:optional true} ::contextType]
-                             [:context-type {:optional true} ::contextType]
-                             [:issuer {:optional true} ::issuer]]
+     ::role                 :any
+     ::did                  :any
+     ::opts                 [:and
+                             [:map-of :keyword :any]
+                             [:map
+                              [:maxFuel {:optional true} ::maxFuel]
+                              [:max-fuel {:optional true} ::maxFuel]
+                              [:parseJSON {:optional true} ::parseJSON]
+                              [:parse-json {:optional true} ::parse-json]
+                              [:prettyPrint {:optional true} ::prettyPrint]
+                              [:pretty-print {:optional true} ::pretty-print]
+                              [:contextType {:optional true} ::contextType]
+                              [:context-type {:optional true} ::contextType]
+                              [:issuer {:optional true} ::issuer]
+                              [:role {:optional true} ::role]
+                              [:did {:optional true} ::did]]]
      ::function             [:orn
                              [:string [:fn fn-string?]]
                              [:list [:fn fn-list?]]]
      ::wildcard             [:fn wildcard?]
      ::var                  [:fn variable?]
      ::val                  [:fn value?]
-     ::iri                  [:orn
-                             [:keyword keyword?]
-                             [:string string?]]
+     ::iri                  ::v/iri
      ::subject              [:orn
                              [:sid [:fn sid?]]
-                             [:iri ::iri]
-                             [:ident [:fn pred-ident?]]]
+                             [:ident [:fn pred-ident?]]
+                             [:iri ::iri]]
      ::subselect-map        [:map-of ::iri [:ref ::subselection]]
      ::subselection         [:sequential [:orn
                                           [:wildcard ::wildcard]
@@ -163,10 +174,9 @@
                                        [:val :any]]]]
      ::where-tuple          [:orn
                              [:triple ::triple]
-                             [:binding [:sequential {:max 2} :any]]
                              [:remote [:sequential {:max 4} :any]]]
      ::where-pattern        [:orn
-                             [:where-map ::where-map]
+                             [:map ::where-map]
                              [:tuple ::where-tuple]]
      ::optional             [:orn
                              [:single ::where-pattern]
@@ -188,8 +198,8 @@
                              [:single ::single-var-binding]
                              [:multiple ::multiple-var-binding]]
      ::t                    [:or :int :string]
-     ::context              :any
-     ::analytical-query     [:map
+     ::context              ::v/context
+     ::analytical-query     [:map {:decode/json decode-json}
                              [:where ::where]
                              [:t {:optional true} ::t]
                              [:context {:optional true} ::context]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -274,10 +274,10 @@
   [qry]
   (try* (query-coercer qry)
         (catch* _e
-                (throw (ex-info "Invalid Query"
-                                {:status  400
-                                 :error   :db/invalid-query
-                                 :reasons (me/humanize (m/explain ::query qry {:registry registry}))})))))
+          (throw (ex-info "Invalid Query"
+                          {:status  400
+                           :error   :db/invalid-query
+                           :reasons (me/humanize (m/explain ::query qry {:registry registry}))})))))
 
 (def modification-validator
   (m/validator ::modification {:registry registry}))
@@ -289,7 +289,7 @@
   [mdfn]
   (try* (modification-coercer mdfn)
         (catch* _e
-                (throw (ex-info "Invalid Ledger Modification"
-                                {:status  400
-                                 :error   :db/invalid-query
-                                 :reasons (me/humanize (m/explain ::modification mdfn {:registry registry}))})))))
+          (throw (ex-info "Invalid Ledger Modification"
+                          {:status  400
+                           :error   :db/invalid-query
+                           :reasons (me/humanize (m/explain ::modification mdfn {:registry registry}))})))))

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -51,15 +51,15 @@
         [:map-of :keyword :any]
         [:map
          [:from {:optional true} [:or
-                                  [:= "latest"]
+                                  [:= :latest]
                                   [:int {:min 0}]
                                   [:re datatype/iso8601-datetime-re]]]
          [:to {:optional true} [:or
-                                [:= "latest"]
+                                [:= :latest]
                                 [:int {:min 0}]
                                 [:re datatype/iso8601-datetime-re]]]
          [:at {:optional true} [:or
-                                [:= "latest"]
+                                [:= :latest]
                                 [:int {:min 0}]
                                 [:re datatype/iso8601-datetime-re]]]]
         [:fn {:error/message "Either \"from\" or \"to\" `t` keys must be provided."}
@@ -112,15 +112,15 @@
   [db cache context compact fuel error-ch s-flakes]
   (async/go
     (try*
-      (let [json-chan (json-ld-resp/flakes->res db cache context compact fuel 1000000
-                                                {:wildcard? true, :depth 0}
-                                                0 s-flakes)]
-        (-> (<? json-chan)
-            ;; add the id in case the iri flake isn't present in s-flakes
-            (assoc :id (json-ld/compact (<? (dbproto/-iri db (flake/s (first s-flakes)))) compact))))
-      (catch* e
-              (log/error e "Error transforming s-flakes.")
-              (async/>! error-ch e)))))
+     (let [json-chan (json-ld-resp/flakes->res db cache context compact fuel 1000000
+                                               {:wildcard? true, :depth 0}
+                                               0 s-flakes)]
+       (-> (<? json-chan)
+           ;; add the id in case the iri flake isn't present in s-flakes
+           (assoc :id (json-ld/compact (<? (dbproto/-iri db (flake/s (first s-flakes)))) compact))))
+     (catch* e
+      (log/error e "Error transforming s-flakes."
+       (async/>! error-ch e))))))
 
 (defn t-flakes->json-ld
   "Build a collection of subject maps out of a set of flakes with the same t.
@@ -133,7 +133,7 @@
                          (vals)
                          (async/to-chan!))
 
-        s-out-ch (async/chan)]
+        s-out-ch    (async/chan)]
     (async/pipeline-async 2
                           s-out-ch
                           (fn [assert-flakes ch]
@@ -149,12 +149,12 @@
   [{:id :ex/foo :f/assert [{},,,} :f/retract [{},,,]]}]
   "
   [db context error-ch flakes]
-  (let [fuel  (volatile! 0)
-        cache (volatile! {})
+  (let [fuel        (volatile! 0)
+        cache       (volatile! {})
 
-        compact (json-ld/compact-fn context)
+        compact     (json-ld/compact-fn context)
 
-        out-ch   (async/chan)
+        out-ch      (async/chan)
 
         t-flakes-ch (->> flakes
                          (sort-by flake/t >)
@@ -170,24 +170,24 @@
                           (fn [t-flakes ch]
                             (-> (async/go
                                   (try*
-                                    (let [{assert-flakes true
-                                           retract-flakes false} (group-by flake/op t-flakes)
+                                   (let [{assert-flakes  true
+                                          retract-flakes false} (group-by flake/op t-flakes)
 
-                                          t (- (flake/t (first t-flakes)))
+                                         t        (- (flake/t (first t-flakes)))
 
-                                          asserts (->> (t-flakes->json-ld db context compact cache fuel error-ch assert-flakes)
+                                         asserts  (->> (t-flakes->json-ld db context compact cache fuel error-ch assert-flakes)
                                                        (async/into [])
                                                        (async/<!))
 
-                                          retracts (->> (t-flakes->json-ld db context compact cache fuel error-ch retract-flakes)
-                                                        (async/into [])
-                                                        (async/<!))]
-                                      {t-key t
-                                       assert-key asserts
-                                       retract-key retracts})
-                                    (catch* e
-                                            (log/error e "Error converting history flakes.")
-                                            (async/>! error-ch e))))
+                                         retracts (->> (t-flakes->json-ld db context compact cache fuel error-ch retract-flakes)
+                                                       (async/into [])
+                                                       (async/<!))]
+                                     {t-key       t
+                                      assert-key  asserts
+                                      retract-key retracts})
+                                   (catch* e
+                                    (log/error e "Error converting history flakes."
+                                     (async/>! error-ch e)))))
 
                                 (async/pipe ch)))
                           t-flakes-ch)
@@ -198,28 +198,28 @@
   to subject ids and return the best index to query against."
   [db context query]
   (go-try
-    (let [ ;; parses to [:subject <:id>] or [:flake {:s <> :p <> :o <>}]}
-          [query-type parsed-query] query
+   (let [;; parses to [:subject <:id>] or [:flake {:s <> :p <> :o <>}]}
+         [query-type parsed-query] query
 
-          {:keys [s p o]} (if (= :subject query-type)
-                            {:s parsed-query}
-                            parsed-query)
+         {:keys [s p o]} (if (= :subject query-type)
+                           {:s parsed-query}
+                           parsed-query)
 
-          ids [(when s (<? (dbproto/-subid db (jld-db/expand-iri db s context) true)))
-               (when p (<? (dbproto/-subid db (jld-db/expand-iri db p context) true)))
-               (when o (jld-db/expand-iri db o context))]
+         ids [(when s (<? (dbproto/-subid db (jld-db/expand-iri db s context) true)))
+              (when p (<? (dbproto/-subid db (jld-db/expand-iri db p context) true)))
+              (when o (jld-db/expand-iri db o context))]
 
-          [s p o] [(get ids 0) (get ids 1) (get ids 2)]
-          [pattern idx] (cond
-                          (not (nil? s))
-                          [ids :spot]
+         [s p o] [(get ids 0) (get ids 1) (get ids 2)]
+         [pattern idx] (cond
+                         (not (nil? s))
+                         [ids :spot]
 
-                          (and (nil? s) (not (nil? p)) (nil? o))
-                          [[p s o] :psot]
+                         (and (nil? s) (not (nil? p)) (nil? o))
+                         [[p s o] :psot]
 
-                          (and (nil? s) (not (nil? p)) (not (nil? o)))
-                          [[p o s] :post])]
-      [pattern idx])))
+                         (and (nil? s) (not (nil? p)) (not (nil? o)))
+                         [[p o s] :post])]
+     [pattern idx])))
 
 (defn commit-wrapper-flake?
   "Returns `true` for a flake that represents
@@ -256,10 +256,10 @@
   [db context compact cache fuel error-ch t-flakes]
   (async/go
     (try*
-     (let [default-ctx-sid (some #(when (= const/$_ledger:context (flake/p %))
-                                    (flake/o %))
-                                 t-flakes)
-           commit-meta?    (partial commit-metadata-flake? default-ctx-sid)
+     (let [default-ctx-sid     (some #(when (= const/$_ledger:context (flake/p %))
+                                        (flake/o %))
+                                     t-flakes)
+           commit-meta?        (partial commit-metadata-flake? default-ctx-sid)
            {commit-wrapper-flakes :commit-wrapper
             commit-meta-flakes    :commit-meta
             assert-flakes         :assert-flakes
@@ -306,12 +306,12 @@
 (defn commit-flakes->json-ld
   "Create a collection of commit maps."
   [db context error-ch flake-slice-ch]
-  (let [fuel    (volatile! 0)
-        cache   (volatile! {})
-        compact (json-ld/compact-fn context)
+  (let [fuel        (volatile! 0)
+        cache       (volatile! {})
+        compact     (json-ld/compact-fn context)
 
         t-flakes-ch (async/chan 1 (comp cat (partition-by flake/t)))
-        out-ch     (async/chan)]
+        out-ch      (async/chan)]
 
     (async/pipe flake-slice-ch t-flakes-ch)
     (async/pipeline-async 2
@@ -326,10 +326,10 @@
   "Return a transducer that processes a stream of history results
   and chunk together results with consecutive `t`s. "
   [t-key]
-  (let [last-t (volatile! nil)
+  (let [last-t             (volatile! nil)
         last-partition-val (volatile! true)]
     (partition-by (fn [result]
-                    (let [result-t (get result t-key)
+                    (let [result-t     (get result t-key)
                           chunk-last-t @last-t]
                       (vreset! last-t result-t)
                       (if (or (nil? chunk-last-t)
@@ -345,17 +345,17 @@
   Chunks together history results with consecutive `t`s to reduce `time-range`
   calls. "
   [db context error-ch history-results-ch]
-  (let [t-key (json-ld/compact const/iri-t context)
-        out-ch (async/chan 2 cat)
+  (let [t-key      (json-ld/compact const/iri-t context)
+        out-ch     (async/chan 2 cat)
         chunked-ch (async/chan 2 (with-consecutive-ts t-key))]
     (async/pipe history-results-ch chunked-ch)
     (async/pipeline-async 2
                           out-ch
                           (fn [chunk ch]
                             (async/pipe (async/go
-                                          (let [to-t  (- (-> chunk peek (get t-key)))
-                                                from-t  (- (-> chunk (nth 0) (get t-key)))
-                                                flake-slices-ch (query-range/time-range db :tspo = [] {:from-t from-t :to-t to-t})
+                                          (let [to-t                       (- (-> chunk peek (get t-key)))
+                                                from-t                     (- (-> chunk (nth 0) (get t-key)))
+                                                flake-slices-ch            (query-range/time-range db :tspo = [] {:from-t from-t :to-t to-t})
                                                 consecutive-commit-details (<? (async/into [] (commit-flakes->json-ld db context error-ch flake-slices-ch)))]
                                             (map into chunk consecutive-commit-details)))
                                         ch))

--- a/src/fluree/db/util/validation.cljc
+++ b/src/fluree/db/util/validation.cljc
@@ -1,0 +1,14 @@
+(ns fluree.db.util.validation
+  (:require [malli.core :as m]))
+
+(defn iri?
+  [v]
+  (or (keyword? v) (string? v)))
+
+(def registry
+  (merge
+   (m/type-schemas)
+   {::iri     [:orn
+               [:string :string]
+               [:keyword :keyword]]
+    ::context :any}))

--- a/src/fluree/db/util/validation.cljc
+++ b/src/fluree/db/util/validation.cljc
@@ -8,7 +8,5 @@
 (def registry
   (merge
    (m/type-schemas)
-   {::iri     [:orn
-               [:string :string]
-               [:keyword :keyword]]
+   {::iri     [:or :string :keyword]
     ::context :any}))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -276,7 +276,7 @@
           (is (= [commit-4 commit-5]
                  @(fluree/history ledger {:commit-details true :t {:from 4 :to 5}})))
           (is (= [commit-5]
-                 @(fluree/history ledger {:commit-details true :t {:at "latest"}})))))
+                 @(fluree/history ledger {:commit-details true :t {:at :latest}})))))
 
       (testing "time range"
         (let [[c2 c3 c4 :as response] @(fluree/history


### PR DESCRIPTION
Part of https://github.com/fluree/http-api-gateway/issues/12

The primary changes are in 340ba17ec49c7eb3328c4423da77f5bba73dc35c and ae531db50f5a307ca248488fb4f0bcdaadbc3bde.

The rest are small improvements that I'm happy to split out if desired.

Of special note is d7189b6494b3c8b7b0d37dd10b9e69a1e2813004 which reverts https://github.com/fluree/db/pull/425 because it's easy to support a keyword for `:latest` now w/ malli coercion everywhere. Let me know if this is still undesirable for some reason.

There will be an http-api-gateway companion PR shortly.