### PR TITLE
Fix commit-details lost on load

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          instaparse/instaparse           {:mvn/version "1.4.12"}
          metosin/malli                   {:mvn/version "0.11.0"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :sha     "4c559826e281c7c373bea29b1fc11462740e5398"}
+                                          :git/sha "2be635f2a30b08a5c100a35dd8afb20078d261ac"}
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.2.4"}

--- a/deps.edn
+++ b/deps.edn
@@ -15,8 +15,8 @@
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.2.4"}
-         ch.qos.logback/logback-classic  {:mvn/version "1.4.5"}
-         org.slf4j/slf4j-api             {:mvn/version "2.0.5"}
+         ch.qos.logback/logback-classic  {:mvn/version "1.4.7"}
+         org.slf4j/slf4j-api             {:mvn/version "2.0.7"}
 
          ;; Lucene
          clucie/clucie                   {:mvn/version "0.4.2"}
@@ -43,22 +43,22 @@
 
  :aliases
  {:build
-  {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.5"
-                                               :git/sha "b73ff34"}
-                slipset/deps-deploy           {:mvn/version "0.2.0"}}
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.9.4"
+                                               :git/sha "b0ee58b"}
+                slipset/deps-deploy           {:mvn/version "0.2.1"}}
    :ns-default build}
 
   :dev
   {:extra-paths ["dev" "test" "dev-resources" "src-cljs" "src-nodejs" "src-docs"]
-   :extra-deps  {org.clojure/tools.namespace       {:mvn/version "1.3.0"}
+   :extra-deps  {org.clojure/tools.namespace       {:mvn/version "1.4.4"}
                  criterium/criterium               {:mvn/version "0.4.6"}
                  figwheel-sidecar/figwheel-sidecar {:mvn/version "0.5.20"}
-                 thheller/shadow-cljs              {:mvn/version "2.20.12"}
+                 thheller/shadow-cljs              {:mvn/version "2.23.3"}
                  com.magnars/test-with-files {:mvn/version "2021-02-17"}}}
 
   :cljtest
   {:extra-paths ["test" "dev-resources"]
-   :extra-deps  {lambdaisland/kaocha         {:mvn/version "1.71.1119"}
+   :extra-deps  {lambdaisland/kaocha         {:mvn/version "1.82.1306"}
                  org.clojure/test.check      {:mvn/version "1.1.1"}
                  io.github.cap10morgan/test-with-files {:git/tag "v1.0.0"
                                                         :git/sha "9181a2e"}}
@@ -78,7 +78,7 @@
                 :output-path "docs"}}
 
   :deploy
-  {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.0"}}
+  {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
    :main-opts    ["-m" "deps-deploy.deps-deploy" "deploy"
                   "target/fluree-db.jar"]}
 
@@ -91,7 +91,7 @@
    :main-opts   ["-m" "cloverage.coverage" "-p" "src" "-s" "test" "--output" "scanning_results/coverage"]}
 
   :eastwood
-  {:extra-deps  {jonase/eastwood {:mvn/version "1.3.0"}}
+  {:extra-deps  {jonase/eastwood {:mvn/version "1.4.0"}}
    :main-opts   ["-m" "eastwood.lint"
                  {:source-paths ["src" "src-docs"]
                   :test-paths   ["test"]
@@ -106,5 +106,5 @@
    :main-opts  ["-m" "antq.core"]}
 
   :clj-kondo
-  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.11.02"}}
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.04.14"}}
    :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -26,6 +26,7 @@
 (def ^:const iri-ledger "https://ns.flur.ee/ledger#ledger")
 (def ^:const iri-branch "https://ns.flur.ee/ledger#branch")
 (def ^:const iri-issuer "https://www.w3.org/2018/credentials#issuer")
+(def ^:const iri-cred-subj "https://www.w3.org/2018/credentials#credentialSubject")
 (def ^:const iri-index "https://ns.flur.ee/ledger#index")
 (def ^:const iri-ns "https://ns.flur.ee/ledger#ns")
 (def ^:const iri-time "https://ns.flur.ee/ledger#time")

--- a/src/fluree/db/json_ld/commit_data.cljc
+++ b/src/fluree/db/json_ld/commit_data.cljc
@@ -437,86 +437,92 @@
       add-tt-id
       (update :schema vocab/update-with* -1 commit-schema-flakes)))
 
+(defn commit-metadata-flakes
+  [{:keys [address alias branch data id time v]} t db-sid]
+  (let [{db-id :id db-t :t db-address :address :keys [flakes size]} data]
+    [;; link db to associated commit meta: @id
+     (flake/create t const/$xsd:anyURI id const/$xsd:string t true nil)
+
+     ;; commit flakes
+     ;; address
+     (flake/create t const/$_address address const/$xsd:string t true nil)
+     ;; alias
+     (flake/create t const/$_ledger:alias alias const/$xsd:string t true nil)
+     ;; branch
+     (flake/create t const/$_ledger:branch branch const/$xsd:string t true nil)
+     ;; v
+     (flake/create t const/$_v v const/$xsd:int t true nil)
+     ;; time
+     (flake/create t const/$_commit:time (util/str->epoch-ms time)
+                   const/$xsd:dateTime t true nil) ;; data
+     (flake/create t const/$_commit:data db-sid const/$xsd:anyURI t true nil)
+
+     ;; db flakes
+     ;; @id
+     (flake/create db-sid const/$xsd:anyURI db-id const/$xsd:string t true nil)
+     ;; t
+     (flake/create db-sid const/$_commitdata:t db-t const/$xsd:int t true nil)
+     ;; address
+     (flake/create db-sid const/$_address db-address const/$xsd:string t true nil)
+     ;; size
+     (flake/create db-sid const/$_commitdata:size size const/$xsd:int t true nil)
+     ;; flakes
+     (flake/create db-sid const/$_commitdata:flakes flakes const/$xsd:int t true
+                   nil)]))
+
+
 (defn add-commit-flakes
   "Translate commit metadata into flakes and merge them into novelty."
   [prev-commit {:keys [commit] :as db}]
   (go-try
-    (let [last-sid (volatile! (jld-ledger/last-commit-sid db))
-          next-sid (fn [] (vswap! last-sid inc))
+   (let [last-sid           (volatile! (jld-ledger/last-commit-sid db))
+         next-sid           (fn [] (vswap! last-sid inc))
 
-          {:keys [address alias branch data defaultContext id issuer message time v]} commit
-          {db-id :id db-t :t db-address :address :keys [flakes size]} data
+         {:keys [data defaultContext issuer message]} commit
+         {db-t :t} data
 
-          {previous-id :id prev-data :data} prev-commit
-          prev-data-id                      (:id prev-data)
+         {previous-id :id prev-data :data} prev-commit
+         prev-data-id       (:id prev-data)
 
-          t      (- db-t)
-          db-sid (next-sid)
+         t                  (- db-t)
+         db-sid             (next-sid)
 
-          base-flakes [ ;; link db to associated commit meta: @id
-                       (flake/create t const/$xsd:anyURI id const/$xsd:string t true nil)
+         base-flakes        (commit-metadata-flakes commit t db-sid)
 
-                       ;; commit flakes
-                       ;; address
-                       (flake/create t const/$_address address const/$xsd:string t true nil)
-                       ;; alias
-                       (flake/create t const/$_ledger:alias alias const/$xsd:string t true nil)
-                       ;; branch
-                       (flake/create t const/$_ledger:branch branch const/$xsd:string t true nil)
-                       ;; v
-                       (flake/create t const/$_v v const/$xsd:int t true nil)
-                       ;; time
-                       (flake/create t const/$_commit:time (util/str->epoch-ms time) const/$xsd:dateTime t true nil) ;; data
-                       (flake/create t const/$_commit:data db-sid const/$xsd:anyURI t true nil)
+         prev-commit-flakes (when previous-id
+                              (let [prev-sid (<? (dbproto/-subid db previous-id))]
+                                [(flake/create t const/$_previous prev-sid const/$xsd:anyURI t true nil)]))
 
+         prev-db-flakes     (when prev-data-id
+                              (let [prev-sid (<? (dbproto/-subid db prev-data-id))]
+                                [(flake/create db-sid const/$_previous prev-sid const/$xsd:anyURI t true nil)]))
 
-
-                       ;; db flakes
-                       ;; @id
-                       (flake/create db-sid const/$xsd:anyURI db-id const/$xsd:string t true nil)
-                       ;; t
-                       (flake/create db-sid const/$_commitdata:t db-t const/$xsd:int t true nil)
-                       ;; address
-                       (flake/create db-sid const/$_address db-address const/$xsd:string t true nil)
-                       ;; size
-                       (flake/create db-sid const/$_commitdata:size size const/$xsd:int t true nil)
-                       ;; flakes
-                       (flake/create db-sid const/$_commitdata:flakes flakes const/$xsd:int t true nil)]
-
-          prev-commit-flakes (when previous-id
-                               (let [prev-sid (<? (dbproto/-subid db previous-id))]
-                                 [(flake/create t const/$_previous prev-sid const/$xsd:anyURI t true nil)]))
-
-          prev-db-flakes (when prev-data-id
-                           (let [prev-sid (<? (dbproto/-subid db prev-data-id))]
-                             [(flake/create db-sid const/$_previous prev-sid const/$xsd:anyURI t true nil)]))
-
-          issuer-flakes  (when-let [issuer-iri (:id issuer)]
-                           (if-let [issuer-sid (<? (dbproto/-subid db issuer-iri))]
-                             ;; create reference to existing issuer
-                             [(flake/create t const/$_commit:signer issuer-sid const/$xsd:anyURI t true nil)]
-                             ;; create new issuer flake and a reference to it
-                             (let [new-issuer-sid (next-sid)]
-                               [(flake/create t const/$_commit:signer new-issuer-sid const/$xsd:anyURI t true nil)
-                                (flake/create new-issuer-sid const/$xsd:anyURI issuer-iri const/$xsd:string t true nil)])))
-          message-flakes (when message
-                           [(flake/create t const/$_commit:message message const/$xsd:string t true nil)])
-          default-ctx-flakes (when-let [default-ctx-iri (:id defaultContext)]
-                               (if-let [default-ctx-id (<? (dbproto/-subid db default-ctx-iri))]
-                                 [(flake/create t const/$_ledger:context default-ctx-id const/$xsd:anyURI t true nil)]
-                                 (let [new-default-ctx-id (next-sid)
-                                       address (:address defaultContext)]
-                                   [(flake/create t const/$_ledger:context new-default-ctx-id const/$xsd:anyURI t true nil)
-                                    (flake/create new-default-ctx-id const/$xsd:anyURI default-ctx-iri const/$xsd:string t true nil)
-                                    (flake/create new-default-ctx-id const/$_address address const/$xsd:string t true nil)])))
-          commit-flakes  (cond-> base-flakes
-                           prev-commit-flakes (into prev-commit-flakes)
-                           prev-db-flakes     (into prev-db-flakes)
-                           issuer-flakes      (into issuer-flakes)
-                           message-flakes     (into message-flakes)
-                           default-ctx-flakes (into default-ctx-flakes))]
-      (-> db
-          (assoc-in [:ecount const/$_shard] @last-sid)
-          (cond-> (= 1 db-t) add-commit-schema-flakes)
-          (update-novelty commit-flakes)
-          add-tt-id))))
+         issuer-flakes      (when-let [issuer-iri (:id issuer)]
+                              (if-let [issuer-sid (<? (dbproto/-subid db issuer-iri))]
+                                ;; create reference to existing issuer
+                                [(flake/create t const/$_commit:signer issuer-sid const/$xsd:anyURI t true nil)]
+                                ;; create new issuer flake and a reference to it
+                                (let [new-issuer-sid (next-sid)]
+                                  [(flake/create t const/$_commit:signer new-issuer-sid const/$xsd:anyURI t true nil)
+                                   (flake/create new-issuer-sid const/$xsd:anyURI issuer-iri const/$xsd:string t true nil)])))
+         message-flakes     (when message
+                              [(flake/create t const/$_commit:message message const/$xsd:string t true nil)])
+         default-ctx-flakes (when-let [default-ctx-iri (:id defaultContext)]
+                              (if-let [default-ctx-id (<? (dbproto/-subid db default-ctx-iri))]
+                                [(flake/create t const/$_ledger:context default-ctx-id const/$xsd:anyURI t true nil)]
+                                (let [new-default-ctx-id (next-sid)
+                                      address            (:address defaultContext)]
+                                  [(flake/create t const/$_ledger:context new-default-ctx-id const/$xsd:anyURI t true nil)
+                                   (flake/create new-default-ctx-id const/$xsd:anyURI default-ctx-iri const/$xsd:string t true nil)
+                                   (flake/create new-default-ctx-id const/$_address address const/$xsd:string t true nil)])))
+         commit-flakes      (cond-> base-flakes
+                                    prev-commit-flakes (into prev-commit-flakes)
+                                    prev-db-flakes (into prev-db-flakes)
+                                    issuer-flakes (into issuer-flakes)
+                                    message-flakes (into message-flakes)
+                                    default-ctx-flakes (into default-ctx-flakes))]
+     (-> db
+         (assoc-in [:ecount const/$_shard] @last-sid)
+         (cond-> (= 1 db-t) add-commit-schema-flakes)
+         (update-novelty commit-flakes)
+         add-tt-id))))

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -374,18 +374,19 @@
                                 (into metadata-flakes)
                                 (into retract-flakes)
                                 (into flakes)
-                                (cond-> prev-commit-flakes
-                                  (into prev-commit-flakes))
-                                (cond-> prev-db-flakes
-                                  (into prev-db-flakes))
-                                (cond-> issuer-flakes
-                                  (into issuer-flakes))
-                                (cond-> message-flakes
-                                  (into message-flakes))
-                                (cond-> default-ctx-flakes
-                                  (into default-ctx-flakes))
-                                (cond-> (= -1 t-new)
-                                  (into commit-data/commit-schema-flakes)))
+                                (cond->
+                                 prev-commit-flakes
+                                 (into prev-commit-flakes)
+                                 prev-db-flakes
+                                 (into prev-db-flakes)
+                                 issuer-flakes
+                                 (into issuer-flakes)
+                                 message-flakes
+                                 (into message-flakes)
+                                 default-ctx-flakes
+                                 (into default-ctx-flakes)
+                                 (= -1 t-new)
+                                 (into commit-data/commit-schema-flakes)))
          ecount*            (assoc ecount const/$_predicate pid
                                           const/$_default sid)]
      (when (empty? all-flakes)

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -214,17 +214,15 @@
 (defn load
   [conn db-alias]
   (go-try
-    (let [base-context {:base db-alias}
-          commit-addr  (<? (conn-proto/-lookup conn db-alias))
+    (let [commit-addr  (<? (conn-proto/-lookup conn db-alias))
           _            (when-not commit-addr
                          (throw (ex-info (str "Unable to load. No commit exists for: " db-alias)
                                          {:status 400 :error :db/invalid-commit-address})))
-          commit-data  (<? (conn-proto/-c-read conn commit-addr))
+          commit-data  (<? (jld-reify/read-commit conn commit-addr))
           _            (when-not commit-data
                          (throw (ex-info (str "Unable to load. No commit exists for: " commit-addr)
                                          {:status 400 :error :db/invalid-db})))
-          commit-data* (json-ld/expand commit-data base-context)
-          [commit proof] (jld-reify/parse-commit commit-data*)
+          [commit proof] (jld-reify/parse-commit commit-data)
           _            (when proof
                          (jld-reify/validate-commit db commit proof))
           _            (log/debug "load commit:" commit)

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1,11 +1,12 @@
 (ns fluree.db.query.history-test
   (:require [clojure.test :refer :all]
+            [fluree.db.did :as did]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.util.core :as util]
-            [clojure.string :as str]))
+            [test-with-files.tools :refer [with-tmp-dir]]))
 
-(deftest ^:integration history-query
+(deftest ^:integration history-query-test
   (let [ts-primeval (util/current-time-iso)
 
         conn        (test-utils/create-conn)
@@ -192,7 +193,7 @@
                    :f/retract [{:ex/x "foo-1" :ex/y "bar-1" :id :ex/dan}]}]
                  @(fluree/history ledger {:history [:ex/dan] :t {:from 2}}))))))))
 
-(deftest ^:integration commit-details
+(deftest ^:integration commit-details-test
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "committest" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
@@ -216,7 +217,7 @@
       (testing "at time t"
         (is (= [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
                             {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                            :f/address        "fluree:memory://f552d786403cca33da44d3cd26606a787636dc8fae891523b7155609a0065cbe"
+                            :f/address        "fluree:memory://45080eafa6185f468bbb811a570a9bb12449ac402f658f2b8c767f7dd30d0757"
                             :f/alias          "committest"
                             :f/branch         "main"
                             :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee",}
@@ -234,45 +235,45 @@
                @(fluree/history ledger {:commit-details true :t {:from 1 :to 1}})))
         (let [commit-5 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                                    {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                                   :f/address        "fluree:memory://11da6993f6e8c6afa0923faeea8afa113f5f3412af258abf65066a87301a2ed2"
+                                   :f/address        "fluree:memory://63d517697b2e531bb62ac8b8a3eff5e0df137bc289ef473bac622cec0b7cd7f8"
                                    :f/alias          "committest"
                                    :f/branch         "main"
                                    :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee",}
-                                   :f/data           #:f{:address  "fluree:memory://fc07c9e086f121928801fd3b3ca7d995d4183c5b53db9cb63fcb24d1312e593e"
+                                   :f/data           #:f{:address  "fluree:memory://b3eb249d58013e3af179a375ac88f52b2ffd6a887971c23ce8946680456fbc1b"
                                                          :assert   [{:ex/x "foo-cat"
                                                                      :ex/y "bar-cat"
                                                                      :id   :ex/alice}]
                                                          :flakes   104
-                                                         :previous {:id "fluree:db:sha256:bbxuu3o3hbbgkaww5kux2mt2pbzsmfbus3jfg6vp3gt7ur7ews4ib"}
+                                                         :previous {:id "fluree:db:sha256:bbx44tyzom257xbvlpmzriwnkixuwtzaf7gzg5lebuxjarq3lmkji"}
                                                          :retract  [{:ex/x "foo-3"
                                                                      :ex/y "bar-3"
                                                                      :id   :ex/alice}]
-                                                         :size     9136
+                                                         :size     9138
                                                          :t        5}
                                    :f/message        "meow"
-                                   :f/previous       {:id "fluree:commit:sha256:bbtc7emczjpsndhqxaezru3tijpl7j2mqlygiebzcfhof7qnrlyej"}
+                                   :f/previous       {:id "fluree:commit:sha256:biioetuzl6lopu2nef6bvrxdtlab456uqnklpdc54gw3wkny3sdh"}
                                    :f/time           720000
                                    :f/v              0
-                                   :id               "fluree:commit:sha256:bsvdy5ckeo6x62r4eadzckcfkzlyvdewiwwfeyaysvtpbvmejkbq"}}
+                                   :id               "fluree:commit:sha256:bn6hlpssv26lj3gbyvkowopjpmcwymwewtstsggy44i65xnnpn4y"}}
               commit-4 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                                    {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                                   :f/address        "fluree:memory://26b66163e38838e4fd3a3b9747ab62293b0e94e901ec30a04f8681ce78e7f305"
+                                   :f/address        "fluree:memory://248b6ee27610662ce7bef7434b82dfec6822e4075f5cc546a45aae9575210ad9"
                                    :f/alias          "committest"
                                    :f/branch         "main"
                                    :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee",}
-                                   :f/data           #:f{:address  "fluree:memory://9d6208e645a959344da7980e834fac25ca5a48d065cb5ea0eed6b570c71e316d"
+                                   :f/data           #:f{:address  "fluree:memory://0a15a055fc33b54f7d9aec79ba7ff7353f468e6cd17a4617dc5ba96f536ac0f4"
                                                          :assert   [{:ex/x "foo-cat"
                                                                      :ex/y "bar-cat"
                                                                      :id   :ex/cat}]
                                                          :flakes   84
-                                                         :previous {:id "fluree:db:sha256:btltglu2b4trfwzsd4jjn7u7dgg5hkymfcxzbzgfrwep6yli3xxt"}
+                                                         :previous {:id "fluree:db:sha256:bbexo3dfrnt6abi6kpkb27yvnzubxofrncwvqpglnotiu2reidgp5"}
                                                          :retract  []
-                                                         :size     7548
+                                                         :size     7552
                                                          :t        4}
-                                   :f/previous       {:id "fluree:commit:sha256:bbmio7wekwnrf6ixwo22urjlkjx56kkluy6xjet5pihrsx4voapme"}
+                                   :f/previous       {:id "fluree:commit:sha256:bb3dkz4x37v5s23c3u5o6lb3gm2vxj2jhyq3rgemtrhhr35ufaduw"}
                                    :f/time           720000
                                    :f/v              0
-                                   :id               "fluree:commit:sha256:bbtc7emczjpsndhqxaezru3tijpl7j2mqlygiebzcfhof7qnrlyej"}}]
+                                   :id               "fluree:commit:sha256:biioetuzl6lopu2nef6bvrxdtlab456uqnklpdc54gw3wkny3sdh"}}]
           (is (= [commit-4 commit-5]
                  @(fluree/history ledger {:commit-details true :t {:from 4 :to 5}})))
           (is (= [commit-5]
@@ -287,31 +288,31 @@
             (is (= 3 (count response)))
             (is (= {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                                {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                               :f/address        "fluree:memory://26b66163e38838e4fd3a3b9747ab62293b0e94e901ec30a04f8681ce78e7f305"
+                               :f/address        "fluree:memory://248b6ee27610662ce7bef7434b82dfec6822e4075f5cc546a45aae9575210ad9"
                                :f/alias          "committest"
                                :f/branch         "main"
                                :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
-                               :f/data           #:f{:address  "fluree:memory://9d6208e645a959344da7980e834fac25ca5a48d065cb5ea0eed6b570c71e316d"
+                               :f/data           #:f{:address  "fluree:memory://0a15a055fc33b54f7d9aec79ba7ff7353f468e6cd17a4617dc5ba96f536ac0f4"
                                                      :assert   [{:ex/x "foo-cat"
                                                                  :ex/y "bar-cat"
                                                                  :id   :ex/cat}]
                                                      :flakes   84
-                                                     :previous {:id "fluree:db:sha256:btltglu2b4trfwzsd4jjn7u7dgg5hkymfcxzbzgfrwep6yli3xxt"}
+                                                     :previous {:id "fluree:db:sha256:bbexo3dfrnt6abi6kpkb27yvnzubxofrncwvqpglnotiu2reidgp5"}
                                                      :retract  []
-                                                     :size     7548
+                                                     :size     7552
                                                      :t        4}
-                               :f/previous       {:id "fluree:commit:sha256:bbmio7wekwnrf6ixwo22urjlkjx56kkluy6xjet5pihrsx4voapme"}
+                               :f/previous       {:id "fluree:commit:sha256:bb3dkz4x37v5s23c3u5o6lb3gm2vxj2jhyq3rgemtrhhr35ufaduw"}
                                :f/time           720000
                                :f/v              0
-                               :id               "fluree:commit:sha256:bbtc7emczjpsndhqxaezru3tijpl7j2mqlygiebzcfhof7qnrlyej"}}
+                               :id               "fluree:commit:sha256:biioetuzl6lopu2nef6bvrxdtlab456uqnklpdc54gw3wkny3sdh"}}
                    c4)))
           (is (= {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                              {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                             :f/address        "fluree:memory://19356d348b3794d21a4dde576c3fdc8a94f191d75bb8f06b589d4cbe11ead2c0"
+                             :f/address        "fluree:memory://eb82b75843135a0db10ba3d4113e3d2386f94d4f4f9dd3259f3fcec3a9f945e9"
                              :f/alias          "committest"
                              :f/branch         "main"
                              :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
-                             :f/data           #:f{:address  "fluree:memory://6defc84081268ac83403a0f66f89ff775b0d4aaf8b15683a8732a4ba1a3022ba"
+                             :f/data           #:f{:address  "fluree:memory://e970082d077d51cbc40e7616537421aaeb0256a02b91ad316f057088ef9ab6ef"
                                                    :assert   [{:ex/x "foo-3"
                                                                :ex/y "bar-3"
                                                                :id   :ex/alice}]
@@ -320,16 +321,16 @@
                                                    :retract  [{:ex/x "foo-2"
                                                                :ex/y "bar-2"
                                                                :id   :ex/alice}]
-                                                   :size     5974
+                                                   :size     5976
                                                    :t        3}
-                             :f/previous       {:id "fluree:commit:sha256:bu6ul5q7pc4byvmklra7sirndnigjapym523zitymb6vpcyx4mht"}
+                             :f/previous       {:id "fluree:commit:sha256:bbkgoyhm55amgqnxhcdv5fvap7z6cllkn55a3rc67zmgyacqnanpo"}
                              :f/time           720000
                              :f/v              0
-                             :id               "fluree:commit:sha256:bbmio7wekwnrf6ixwo22urjlkjx56kkluy6xjet5pihrsx4voapme"}}
+                             :id               "fluree:commit:sha256:bb3dkz4x37v5s23c3u5o6lb3gm2vxj2jhyq3rgemtrhhr35ufaduw"}}
                  c3))
           (is (= {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                              {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                             :f/address        "fluree:memory://659a8d1976b227e5abc9750786f729dd07a91c6c58f2fe7fa98646e125926123"
+                             :f/address        "fluree:memory://a5c01f9e88548aa840bf8202cc8524301349d3796eede2578299b64af9b22871"
                              :f/alias          "committest"
                              :f/branch         "main"
                              :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
@@ -347,57 +348,57 @@
                              :f/previous       {:id "fluree:commit:sha256:bqach3bavh2jnzepzvpvzsdkhgd5iu6pzs42pcc6lttciaubznqj"}
                              :f/time           720000
                              :f/v              0
-                             :id               "fluree:commit:sha256:bu6ul5q7pc4byvmklra7sirndnigjapym523zitymb6vpcyx4mht"}}
+                             :id               "fluree:commit:sha256:bbkgoyhm55amgqnxhcdv5fvap7z6cllkn55a3rc67zmgyacqnanpo"}}
                  c2))))
 
       (testing "time range from"
         (is (= [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
                             {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                            :f/address        "fluree:memory://26b66163e38838e4fd3a3b9747ab62293b0e94e901ec30a04f8681ce78e7f305"
+                            :f/address        "fluree:memory://248b6ee27610662ce7bef7434b82dfec6822e4075f5cc546a45aae9575210ad9"
                             :f/alias          "committest"
                             :f/branch         "main"
                             :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee",}
-                            :f/data           #:f{:address  "fluree:memory://9d6208e645a959344da7980e834fac25ca5a48d065cb5ea0eed6b570c71e316d"
+                            :f/data           #:f{:address  "fluree:memory://0a15a055fc33b54f7d9aec79ba7ff7353f468e6cd17a4617dc5ba96f536ac0f4"
                                                   :assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/cat}]
                                                   :flakes   84
-                                                  :previous {:id "fluree:db:sha256:btltglu2b4trfwzsd4jjn7u7dgg5hkymfcxzbzgfrwep6yli3xxt"}
+                                                  :previous {:id "fluree:db:sha256:bbexo3dfrnt6abi6kpkb27yvnzubxofrncwvqpglnotiu2reidgp5"}
                                                   :retract  []
-                                                  :size     7548
+                                                  :size     7552
                                                   :t        4}
-                            :f/previous       {:id "fluree:commit:sha256:bbmio7wekwnrf6ixwo22urjlkjx56kkluy6xjet5pihrsx4voapme"}
+                            :f/previous       {:id "fluree:commit:sha256:bb3dkz4x37v5s23c3u5o6lb3gm2vxj2jhyq3rgemtrhhr35ufaduw"}
                             :f/time           720000
                             :f/v              0
-                            :id               "fluree:commit:sha256:bbtc7emczjpsndhqxaezru3tijpl7j2mqlygiebzcfhof7qnrlyej"}}
+                            :id               "fluree:commit:sha256:biioetuzl6lopu2nef6bvrxdtlab456uqnklpdc54gw3wkny3sdh"}}
                 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                             {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                            :f/address        "fluree:memory://11da6993f6e8c6afa0923faeea8afa113f5f3412af258abf65066a87301a2ed2"
+                            :f/address        "fluree:memory://63d517697b2e531bb62ac8b8a3eff5e0df137bc289ef473bac622cec0b7cd7f8"
                             :f/alias          "committest"
                             :f/branch         "main"
                             :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee",}
-                            :f/data           #:f{:address  "fluree:memory://fc07c9e086f121928801fd3b3ca7d995d4183c5b53db9cb63fcb24d1312e593e"
+                            :f/data           #:f{:address  "fluree:memory://b3eb249d58013e3af179a375ac88f52b2ffd6a887971c23ce8946680456fbc1b"
                                                   :assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/alice}]
                                                   :flakes   104
-                                                  :previous {:id "fluree:db:sha256:bbxuu3o3hbbgkaww5kux2mt2pbzsmfbus3jfg6vp3gt7ur7ews4ib"}
+                                                  :previous {:id "fluree:db:sha256:bbx44tyzom257xbvlpmzriwnkixuwtzaf7gzg5lebuxjarq3lmkji"}
                                                   :retract  [{:ex/x "foo-3"
                                                               :ex/y "bar-3"
                                                               :id   :ex/alice}]
-                                                  :size     9136
+                                                  :size     9138
                                                   :t        5}
                             :f/message        "meow"
-                            :f/previous       {:id "fluree:commit:sha256:bbtc7emczjpsndhqxaezru3tijpl7j2mqlygiebzcfhof7qnrlyej"}
+                            :f/previous       {:id "fluree:commit:sha256:biioetuzl6lopu2nef6bvrxdtlab456uqnklpdc54gw3wkny3sdh"}
                             :f/time           720000
                             :f/v              0
-                            :id               "fluree:commit:sha256:bsvdy5ckeo6x62r4eadzckcfkzlyvdewiwwfeyaysvtpbvmejkbq"}}]
+                            :id               "fluree:commit:sha256:bn6hlpssv26lj3gbyvkowopjpmcwymwewtstsggy44i65xnnpn4y"}}]
                @(fluree/history ledger {:commit-details true :t {:from 4}}))))
 
       (testing "time range to"
         (is (= [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
                             {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                            :f/address        "fluree:memory://f552d786403cca33da44d3cd26606a787636dc8fae891523b7155609a0065cbe"
+                            :f/address        "fluree:memory://45080eafa6185f468bbb811a570a9bb12449ac402f658f2b8c767f7dd30d0757"
                             :f/alias          "committest"
                             :f/branch         "main"
                             :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
@@ -420,11 +421,11 @@
                                :id   :ex/alice}]
                     :commit  {"https://www.w3.org/2018/credentials#issuer"
                               {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                              :f/address        "fluree:memory://19356d348b3794d21a4dde576c3fdc8a94f191d75bb8f06b589d4cbe11ead2c0"
+                              :f/address        "fluree:memory://eb82b75843135a0db10ba3d4113e3d2386f94d4f4f9dd3259f3fcec3a9f945e9"
                               :f/alias          "committest"
                               :f/branch         "main"
                               :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
-                              :f/data           #:f{:address  "fluree:memory://6defc84081268ac83403a0f66f89ff775b0d4aaf8b15683a8732a4ba1a3022ba"
+                              :f/data           #:f{:address  "fluree:memory://e970082d077d51cbc40e7616537421aaeb0256a02b91ad316f057088ef9ab6ef"
                                                     :assert   [{:ex/x "foo-3"
                                                                 :ex/y "bar-3"
                                                                 :id   :ex/alice}]
@@ -433,12 +434,12 @@
                                                     :retract  [{:ex/x "foo-2"
                                                                 :ex/y "bar-2"
                                                                 :id   :ex/alice}]
-                                                    :size     5974
+                                                    :size     5976
                                                     :t        3}
-                              :f/previous       {:id "fluree:commit:sha256:bu6ul5q7pc4byvmklra7sirndnigjapym523zitymb6vpcyx4mht"}
+                              :f/previous       {:id "fluree:commit:sha256:bbkgoyhm55amgqnxhcdv5fvap7z6cllkn55a3rc67zmgyacqnanpo"}
                               :f/time           720000
                               :f/v              0
-                              :id               "fluree:commit:sha256:bbmio7wekwnrf6ixwo22urjlkjx56kkluy6xjet5pihrsx4voapme"}
+                              :id               "fluree:commit:sha256:bb3dkz4x37v5s23c3u5o6lb3gm2vxj2jhyq3rgemtrhhr35ufaduw"}
                     :retract [{:ex/x "foo-2"
                                :ex/y "bar-2"
                                :id   :ex/alice}]
@@ -448,39 +449,311 @@
                                :id   :ex/alice}]
                     :commit  {"https://www.w3.org/2018/credentials#issuer"
                               {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
-                              :f/address        "fluree:memory://11da6993f6e8c6afa0923faeea8afa113f5f3412af258abf65066a87301a2ed2"
+                              :f/address        "fluree:memory://63d517697b2e531bb62ac8b8a3eff5e0df137bc289ef473bac622cec0b7cd7f8"
                               :f/alias          "committest"
                               :f/branch         "main"
                               :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
-                              :f/data           #:f{:address  "fluree:memory://fc07c9e086f121928801fd3b3ca7d995d4183c5b53db9cb63fcb24d1312e593e"
+                              :f/data           #:f{:address  "fluree:memory://b3eb249d58013e3af179a375ac88f52b2ffd6a887971c23ce8946680456fbc1b"
                                                     :assert   [{:ex/x "foo-cat"
                                                                 :ex/y "bar-cat"
                                                                 :id   :ex/alice}]
                                                     :flakes   104
-                                                    :previous {:id "fluree:db:sha256:bbxuu3o3hbbgkaww5kux2mt2pbzsmfbus3jfg6vp3gt7ur7ews4ib"}
+                                                    :previous {:id "fluree:db:sha256:bbx44tyzom257xbvlpmzriwnkixuwtzaf7gzg5lebuxjarq3lmkji"}
                                                     :retract  [{:ex/x "foo-3"
                                                                 :ex/y "bar-3"
                                                                 :id   :ex/alice}]
-                                                    :size     9136
+                                                    :size     9138
                                                     :t        5}
                               :f/message        "meow"
-                              :f/previous       {:id "fluree:commit:sha256:bbtc7emczjpsndhqxaezru3tijpl7j2mqlygiebzcfhof7qnrlyej"}
+                              :f/previous       {:id "fluree:commit:sha256:biioetuzl6lopu2nef6bvrxdtlab456uqnklpdc54gw3wkny3sdh"}
                               :f/time           720000
                               :f/v              0
-                              :id               "fluree:commit:sha256:bsvdy5ckeo6x62r4eadzckcfkzlyvdewiwwfeyaysvtpbvmejkbq"}
+                              :id               "fluree:commit:sha256:bn6hlpssv26lj3gbyvkowopjpmcwymwewtstsggy44i65xnnpn4y"}
                     :retract [{:ex/x "foo-3"
                                :ex/y "bar-3"
                                :id   :ex/alice}]
                     :t       5}]
-               @(fluree/history ledger {:history :ex/alice :commit-details true :t {:from 3}})))
-        (testing "multiple history results"
-          (let [history-with-commits @(fluree/history ledger {:history :ex/alice :commit-details true :t {:from 1 :to 5}})]
-            (testing "all `t`s with changes to subject are returned"
-              (is (= [1 2 3 5]
-                     (mapv :f/t history-with-commits))))
-            (testing "all expected commits are present and associated with the correct results"
-              (is (= [[1 1] [2 2] [3 3] [5 5]]
-                     (map (fn [history-map]
-                            (let [commit-t (get-in history-map [:f/commit :f/data :f/t])]
-                              (vector (:f/t history-map) commit-t)))
-                          history-with-commits))))))))))
+               @(fluree/history ledger {:history        :ex/alice
+                                        :commit-details true
+                                        :t              {:from 3}}))))
+      (testing "multiple history results"
+        (let [history-with-commits @(fluree/history ledger {:history :ex/alice :commit-details true :t {:from 1 :to 5}})]
+          (testing "all `t`s with changes to subject are returned"
+            (is (= [1 2 3 5]
+                   (mapv :f/t history-with-commits))))
+          (testing "all expected commits are present and associated with the correct results"
+            (is (= [[1 1] [2 2] [3 3] [5 5]]
+                   (map (fn [history-map]
+                          (let [commit-t (get-in history-map [:f/commit :f/data :f/t])]
+                            (vector (:f/t history-map) commit-t)))
+                        history-with-commits)))))))))
+
+(deftest loaded-mem-ledger-history-test
+  (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:12:00.00000Z")]
+    (testing "history commit details on a loaded memory ledger"
+      (let [ledger-name   "loaded-history-mem"
+            conn          @(fluree/connect
+                            {:method :memory
+                             :defaults
+                             {:context      test-utils/default-context
+                              :context-type :keyword}})
+            ledger        @(fluree/create conn ledger-name
+                                          {:defaultContext
+                                           ["" {:ex "http://example.org/ns/"}]})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-1"
+                                                        :ex/y "bar-1"})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-2"
+                                                        :ex/y "bar-2"})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-3"
+                                                        :ex/y "bar-3"})
+            _             @(test-utils/transact ledger {:id   :ex/cat
+                                                        :ex/x "foo-cat"
+                                                        :ex/y "bar-cat"})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-cat"
+                                                        :ex/y "bar-cat"}
+                                                {:message "meow"})
+            loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+        (is (= [#:f{:assert  [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :commit  {:f/address        "fluree:memory://79fb3db274b3ac8b04df827f0a7897a9c899f175555081b9a8dc81bedc83491b"
+                              :f/alias          ledger-name
+                              :f/branch         "main"
+                              :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
+                              :f/data           #:f{:address  "fluree:memory://ca839a056f6d1e401c3dbfd2c97cd30d0f95b148596ebe7b06fc54c0ce76558b"
+                                                    :assert   [{:ex/x "foo-3"
+                                                                :ex/y "bar-3"
+                                                                :id   :ex/alice}]
+                                                    :flakes   62
+                                                    :previous {:id "fluree:db:sha256:b7pvwgol6v6y7j2pak5ptdmt6l64esaguo3maevh346utpnj7jxh"}
+                                                    :retract  [{:ex/x "foo-2"
+                                                                :ex/y "bar-2"
+                                                                :id   :ex/alice}]
+                                                    :size     5772
+                                                    :t        3}
+                              :f/previous       {:id "fluree:commit:sha256:b45eltgynxrale2dfzktbnpgb7nzra5knnxq3ahqhq4x63xokbdc"}
+                              :f/time           720000
+                              :f/v              0
+                              :id               "fluree:commit:sha256:bbpzonorhttcrdtfi2ud5ghxgh5p7ikoekq3u3biuarhug3lt4jb7"}
+                    :retract [{:ex/x "foo-2"
+                               :ex/y "bar-2"
+                               :id   :ex/alice}]
+                    :t       3}
+                #:f{:assert  [{:ex/x "foo-cat"
+                               :ex/y "bar-cat"
+                               :id   :ex/alice}]
+                    :commit  {:f/address        "fluree:memory://b3b6897ce701fa66ed4645d40877f1736ea6d8ab6478a8edc62b00c7ebdc1c50"
+                              :f/alias          ledger-name
+                              :f/branch         "main"
+                              :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
+                              :f/data           #:f{:address  "fluree:memory://776ab0c891828a05964716d3630c0fac8b43b9a3c98ea12343318b56931fb81d"
+                                                    :assert   [{:ex/x "foo-cat"
+                                                                :ex/y "bar-cat"
+                                                                :id   :ex/alice}]
+                                                    :flakes   99
+                                                    :previous {:id "fluree:db:sha256:b7pvwgol6v6y7j2pak5ptdmt6l64esaguo3maevh346utpnj7jxh"}
+                                                    :retract  [{:ex/x "foo-3"
+                                                                :ex/y "bar-3"
+                                                                :id   :ex/alice}]
+                                                    :size     8864
+                                                    :t        5}
+                              :f/message        "meow"
+                              :f/previous       {:id "fluree:commit:sha256:bk7i7k5cqddb4quw7ygn75kuprgq2birq4nx6v65dwm7mainv46l"}
+                              :f/time           720000
+                              :f/v              0
+                              :id               "fluree:commit:sha256:brqtcmae4xpty2qtivx4a5csnf5qoqngb7rrgv6ydw6wm7lhjdun"}
+                    :retract [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :t       5}]
+               @(fluree/history loaded-ledger {:history        :ex/alice
+                                               :commit-details true
+                                               :t              {:from 3}})))))
+
+    (testing "history commit details on a loaded memory ledger w/ issuer"
+      (let [ledger-name   "loaded-history-mem-issuer"
+            conn          @(fluree/connect
+                            {:method :memory
+                             :defaults
+                             {:context      test-utils/default-context
+                              :context-type :keyword
+                              :did          (did/private->did-map
+                                             test-utils/default-private-key)}})
+            ledger        @(fluree/create conn ledger-name
+                                          {:defaultContext
+                                           ["" {:ex "http://example.org/ns/"}]})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-1"
+                                                        :ex/y "bar-1"})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-2"
+                                                        :ex/y "bar-2"})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-3"
+                                                        :ex/y "bar-3"})
+            _             @(test-utils/transact ledger {:id   :ex/cat
+                                                        :ex/x "foo-cat"
+                                                        :ex/y "bar-cat"})
+            _             @(test-utils/transact ledger {:id   :ex/alice
+                                                        :ex/x "foo-cat"
+                                                        :ex/y "bar-cat"}
+                                                {:message "meow"})
+            loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+        (is (= [#:f{:assert  [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :commit  {"https://www.w3.org/2018/credentials#issuer"
+                              {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                              :f/address        "fluree:memory://a2819e5d9465f67139009752db02680f77c314f180cd9a1d2864ece508531a3a"
+                              :f/alias          ledger-name
+                              :f/branch         "main"
+                              :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
+                              :f/data           #:f{:address  "fluree:memory://b5afa93eb5b3e164128a26f141be03599934408566a0ff23ed901eb5b5adcc56"
+                                                    :assert   [{:ex/x "foo-3"
+                                                                :ex/y "bar-3"
+                                                                :id   :ex/alice}]
+                                                    :flakes   65
+                                                    :previous {:id "fluree:db:sha256:b2sfdas2an3z5u4zunpr77ok64nl4k25xhtc4l22ezgsjhrsipfo"}
+                                                    :retract  [{:ex/x "foo-2"
+                                                                :ex/y "bar-2"
+                                                                :id   :ex/alice}]
+                                                    :size     6034
+                                                    :t        3}
+                              :f/previous       {:id "fluree:commit:sha256:blew52zwjdyhqom6feg7cf2sc4nsv5cqam6azic2jhjvtl6xrw2t"}
+                              :f/time           720000
+                              :f/v              0
+                              :id               "fluree:commit:sha256:bfghczklj2v5bba2zka2rxe2itjhri6xvwkxxqlj42bpx2o72t6c"}
+                    :retract [{:ex/x "foo-2"
+                               :ex/y "bar-2"
+                               :id   :ex/alice}]
+                    :t       3}
+                #:f{:assert  [{:ex/x "foo-cat"
+                               :ex/y "bar-cat"
+                               :id   :ex/alice}]
+                    :commit  {"https://www.w3.org/2018/credentials#issuer"
+                              {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                              :f/address        "fluree:memory://d2d4c0d0f7383376ef8a28a41918bf0c5d0b70d30d7e989344dbb15b2975dc85"
+                              :f/alias          ledger-name
+                              :f/branch         "main"
+                              :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
+                              :f/data           #:f{:address  "fluree:memory://9f2ccfa86bfe998c7b4534d8e4ebb7ba11e60c50ce583e6524dd73db3c78dcf6"
+                                                    :assert   [{:ex/x "foo-cat"
+                                                                :ex/y "bar-cat"
+                                                                :id   :ex/alice}]
+                                                    :flakes   104
+                                                    :previous {:id "fluree:db:sha256:b2sfdas2an3z5u4zunpr77ok64nl4k25xhtc4l22ezgsjhrsipfo"}
+                                                    :retract  [{:ex/x "foo-3"
+                                                                :ex/y "bar-3"
+                                                                :id   :ex/alice}]
+                                                    :size     9252
+                                                    :t        5}
+                              :f/message        "meow"
+                              :f/previous       {:id "fluree:commit:sha256:btfmwl6q3hlfwiu376jw6v3mxriq3qbfpj2x32n6gwhv6zbengnt"}
+                              :f/time           720000
+                              :f/v              0
+                              :id               "fluree:commit:sha256:bkxqf3zgxih4ykd5li323es4ghtwshumbn4wnwk6mqyuwap44hoe"}
+                    :retract [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :t       5}]
+               @(fluree/history loaded-ledger {:history        :ex/alice
+                                               :commit-details true
+                                               :t              {:from 3}})))))))
+
+(deftest loaded-file-ledger-history-test
+  (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:12:00.00000Z")]
+    (testing "history commit details on a loaded file ledger"
+      (with-tmp-dir storage-path
+        (let [ledger-name   "loaded-history-file"
+              conn          @(fluree/connect
+                              {:method       :file
+                               :storage-path storage-path
+                               :defaults
+                               {:context      test-utils/default-context
+                                :context-type :keyword
+                                :did          (did/private->did-map
+                                               test-utils/default-private-key)}})
+              ledger        @(fluree/create conn ledger-name
+                                            {:defaultContext
+                                             ["" {:ex "http://example.org/ns/"}]})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-1"
+                                                          :ex/y "bar-1"})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-2"
+                                                          :ex/y "bar-2"})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-3"
+                                                          :ex/y "bar-3"})
+              _             @(test-utils/transact ledger {:id   :ex/cat
+                                                          :ex/x "foo-cat"
+                                                          :ex/y "bar-cat"})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-cat"
+                                                          :ex/y "bar-cat"}
+                                                  {:message "meow"})
+              loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+          (is (= [#:f{:assert  [{:ex/x "foo-3"
+                                 :ex/y "bar-3"
+                                 :id   :ex/alice}]
+                      :commit  {"https://www.w3.org/2018/credentials#issuer"
+                                {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                                :f/address        "fluree:file://loaded-history-file/main/commit/4aa2c05dfb15383c1985789bd2fc25a50c1d0ce43ef7604329f30fb75407fbd6.json"
+                                :f/alias          ledger-name
+                                :f/branch         "main"
+                                :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
+                                :f/data           #:f{:address  "fluree:file://loaded-history-file/main/commit/bc064cb4f2a50977b599a2efd2ad45a4a05782fd841d91148942ecf2bec57bc5.json"
+                                                      :assert   [{:ex/x "foo-3"
+                                                                  :ex/y "bar-3"
+                                                                  :id   :ex/alice}]
+                                                      :flakes   65
+                                                      :previous {:id "fluree:db:sha256:bb2rkmq5eokfvv46sjjfwg6tifoyspl5kcmwx6skzpubxfvhgr37i"}
+                                                      :retract  [{:ex/x "foo-2"
+                                                                  :ex/y "bar-2"
+                                                                  :id   :ex/alice}]
+                                                      :size     6368
+                                                      :t        3}
+                                :f/previous       {:id "fluree:commit:sha256:bbv5nfjt45alrffunszqz2ztvn6hoq4nkulmggsqieryqvxryncss"}
+                                :f/time           720000
+                                :f/v              0
+                                :id               "fluree:commit:sha256:b4sxvlmkflbevjtva3ytcfa4eght7ocnlocachek777g3srhnbbu"}
+                      :retract [{:ex/x "foo-2"
+                                 :ex/y "bar-2"
+                                 :id   :ex/alice}]
+                      :t       3}
+                  #:f{:assert  [{:ex/x "foo-cat"
+                                 :ex/y "bar-cat"
+                                 :id   :ex/alice}]
+                      :commit  {"https://www.w3.org/2018/credentials#issuer"
+                                {:id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"}
+                                :f/address        "fluree:file://loaded-history-file/main/commit/f527d87439243b2c40fbc61af462d9e58d57865bf4dcc597c983ad723447de4d.json"
+                                :f/alias          ledger-name
+                                :f/branch         "main"
+                                :f/defaultContext {:id "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"}
+                                :f/data           #:f{:address  "fluree:file://loaded-history-file/main/commit/0a48a60e06eb506999a1eac39f95d1cb2c1f19606894f415099c012413f52264.json"
+                                                      :assert   [{:ex/x "foo-cat"
+                                                                  :ex/y "bar-cat"
+                                                                  :id   :ex/alice}]
+                                                      :flakes   104
+                                                      :previous {:id "fluree:db:sha256:bb2rkmq5eokfvv46sjjfwg6tifoyspl5kcmwx6skzpubxfvhgr37i"}
+                                                      :retract  [{:ex/x "foo-3"
+                                                                  :ex/y "bar-3"
+                                                                  :id   :ex/alice}]
+                                                      :size     9846
+                                                      :t        5}
+                                :f/message        "meow"
+                                :f/previous       {:id "fluree:commit:sha256:bbri3m3j4whifm5t6dnyt2qio23ueczghvzmxjmosvauxcsyioykp"}
+                                :f/time           720000
+                                :f/v              0
+                                :id               "fluree:commit:sha256:bb3ozqwbbsvtvhaeu2w5jtxmzrhyucmuk75ou2bhd5c3din727cub"}
+                      :retract [{:ex/x "foo-3"
+                                 :ex/y "bar-3"
+                                 :id   :ex/alice}]
+                      :t       5}]
+                 @(fluree/history loaded-ledger {:history        :ex/alice
+                                                 :commit-details true
+                                                 :t              {:from 3}}))))))))

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -228,7 +228,7 @@
                   ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/time 720000]
                   ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" "https://www.w3.org/2018/credentials#issuer" "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
                   ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/v 0]
-                  ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/address "fluree:memory://f041fc993c5ea8b9acf871497307ba1fece95fc6e2ea85ea11fd35463d3dfa94"]
+                  ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/address "fluree:memory://5655d063e0961148c89150ab65bd03c205cdc8b7153f9aa079d8c461a5b291a7"]
                   ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/data "fluree:db:sha256:beh3as6tvb6shyvxs5w4zdt4gbpaa7xterlvqe42sc7r6u625ank"]
                   ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/alias "query/everything"]
                   ["fluree:commit:sha256:bbgqwgdkhagy6rhdhk7aungz5fnbischldoqohyzvrluwetkhyrfk" :f/branch "main"]


### PR DESCRIPTION
Fixes #451 

We weren't creating the commit details flakes on reification like we were on commits to in-memory ledger values. This refactors that code and then reuses it for reification and fixes some related issues with having access to the necessary values (e.g. commit addresses) to hydrate these flakes on load.