### PR TITLE
fix history query schema to allow @context key

### DIFF
--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -27,7 +27,6 @@
     ::context ::v/context
     ::history-query
     [:and
-     [:map-of :keyword :any]
      [:map
       [:history {:optional true}
        [:orn


### PR DESCRIPTION
The `[:map-of :keyword :any]` clause was disallowing the string key `"@context"`, which I think we want to allow. Multiquery and current query both allow a string `"@context`.