### PR TITLE
load predefined properties and ref retracts

### DIFF
--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -89,7 +89,6 @@
       (let [ref-id (:id v-map)]
         (cond (and ref-id (node? v-map))
               (let [ref-sid (<? (get-iri-sid ref-id db iri-cache))
-                    ;; wrong! need to retract the reference, not the referent
                     acc** (conj acc* (flake/create sid pid ref-sid const/$xsd:anyURI t false nil))]
                 (if (seq r-v-maps)
                   (recur r-v-maps acc**)

--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -207,9 +207,9 @@
       (loop [[type-item & r] type
              acc []]
         (if type-item
-          (let [existing-id (or (<? (get-iri-sid type-item db iris))
-                                (get jld-ledger/predefined-properties type-item))
+          (let [existing-id (<? (get-iri-sid type-item db iris))
                 type-id     (or existing-id
+                                (get jld-ledger/predefined-properties type-item)
                                 (jld-ledger/generate-new-pid type-item iris
                                                              next-pid nil nil))
                 type-flakes (when-not existing-id

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -640,4 +640,28 @@
                                                             {:rdf/type [:_id]}
                                                             {:f/allow [:* {:f/targetRole [:_id]}]}
                                                             {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
-                                               :where  [[?s :rdf/type :f/Policy]]})))))))))
+                                               :where  [[?s :rdf/type :f/Policy]]})))))))
+     (testing "loading predefined properties"
+       (let [conn (test-utils/create-conn {:context test-utils/default-str-context
+                                           :context-type :string})
+             ledger @(fluree/create conn "predefined-props" {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
+             db1 @(test-utils/transact ledger {"@id" "ex:UserShape",
+                                               "@type" ["sh:NodeShape"],
+                                               "sh:targetClass" {"@id" "ex:User"},
+                                               "sh:property" [{"sh:path" {"@id" "schema:name"},
+                                                               "sh:datatype" {"@id" "xsd:string"}}]})
+
+             ledger2 @(fluree/load conn "predefined-props")
+             db2 (fluree/db ledger2)]
+         (is (= [{"id" "ex:UserShape",
+                  "rdf:type" ["sh:NodeShape"],
+                  "sh:targetClass" {"id" "ex:User"},
+                  "sh:property" {"id" "_:f211106232532993"}}]
+                @(fluree/query db1 {:select {"?s" ["*"]},
+                                    :where [["?s", "sh:targetClass", "?property"]]})))
+         (is (= [{"id" "ex:UserShape",
+                  "rdf:type" ["sh:NodeShape"],
+                  "sh:targetClass" {"id" "ex:User"},
+                  "sh:property" {"id" "_:f211106232532993"}}]
+                @(fluree/query db2 {:select {"?s" ["*"]},
+                                    :where [["?s", "sh:targetClass", "?property"]]})))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -644,30 +644,6 @@
      (testing "loading predefined properties"
        (let [conn (test-utils/create-conn {:context test-utils/default-str-context
                                            :context-type :string})
-             ledger @(fluree/create conn "predefined-props" {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-             db1 @(test-utils/transact ledger {"@id" "ex:UserShape",
-                                               "@type" ["sh:NodeShape"],
-                                               "sh:targetClass" {"@id" "ex:User"},
-                                               "sh:property" [{"sh:path" {"@id" "schema:name"},
-                                                               "sh:datatype" {"@id" "xsd:string"}}]})
-
-             ledger2 @(fluree/load conn "predefined-props")
-             db2 (fluree/db ledger2)]
-         (is (= [{"id" "ex:UserShape",
-                  "rdf:type" ["sh:NodeShape"],
-                  "sh:targetClass" {"id" "ex:User"},
-                  "sh:property" {"id" "_:f211106232532993"}}]
-                @(fluree/query db1 {:select {"?s" ["*"]},
-                                    :where [["?s", "sh:targetClass", "?property"]]})))
-         (is (= [{"id" "ex:UserShape",
-                  "rdf:type" ["sh:NodeShape"],
-                  "sh:targetClass" {"id" "ex:User"},
-                  "sh:property" {"id" "_:f211106232532993"}}]
-                @(fluree/query db2 {:select {"?s" ["*"]},
-                                    :where [["?s", "sh:targetClass", "?property"]]})))))
-     (testing "load id only retracts"
-       (let [conn (test-utils/create-conn {:context test-utils/default-str-context
-                                           :context-type :string})
              ledger @(fluree/create conn "shacl/a" {:defaultContext ["" {"ex" "http://example.org/ns/"}]})
 
              db1 @(test-utils/transact ledger
@@ -676,21 +652,30 @@
                                         "sh:property"
                                         [{"sh:path" {"@type" "@id" "@value" "schema:familyName"},
                                           "sh:datatype" {"@type" "@id" "@value" "xsd:string"}}]})
-
-             shape-id (-> @(fluree/query db1 {:select {"?s" ["id"]}, :where [["?s" "sh:property" "?property"]]})
+             property-query {:select {"?s" ["*"]}, :where [["?s" "sh:property" "?property"]]}
+             shape-id (-> @(fluree/query db1 property-query)
                           first
                           (get "id"))
-             loaded1 @(fluree/load conn "shacl/a")
-             db2 @(test-utils/transact loaded1
-                                       {"@id" shape-id
-                                        "sh:property"
-                                        [{"sh:path" {"@type" "@id" "@value" "schema:age"},
-                                          "sh:datatype" {"@type" "@id" "@value" "xsd:string"}}]})
-
-             loaded2 @(fluree/load conn "shacl/a")]
+             loaded1 @(fluree/load conn "shacl/a")]
          (is (= [{"id" shape-id
                   "rdf:type" ["sh:NodeShape"],
                   "sh:targetClass" {"id" "schema:Person"},
-                  "sh:property" {"id" "_:f211106232532994"}}]
-                @(fluree/query (fluree/db loaded2) {:select {"?s" ["*"]},
-                                                    :where [["?s" "sh:property" "?property"]]})))))))
+                  "sh:property" {"id" "_:f211106232532993"}}]
+                @(fluree/query db1 property-query)))
+         (is (= [{"id" shape-id
+                  "rdf:type" ["sh:NodeShape"],
+                  "sh:targetClass" {"id" "schema:Person"},
+                  "sh:property" {"id" "_:f211106232532993"}}]
+                @(fluree/query (fluree/db loaded1) property-query)))
+         (testing "load ref retracts"
+           (let [db2 @(test-utils/transact loaded1
+                                           {"@id" shape-id
+                                            "sh:property"
+                                            [{"sh:path" {"@type" "@id" "@value" "schema:age"},
+                                              "sh:datatype" {"@type" "@id" "@value" "xsd:string"}}]})
+                 loaded2 @(fluree/load conn "shacl/a")]
+             (is (= [{"id" shape-id
+                      "rdf:type" ["sh:NodeShape"],
+                      "sh:targetClass" {"id" "schema:Person"},
+                      "sh:property" {"id" "_:f211106232532994"}}]
+                    @(fluree/query (fluree/db loaded2) property-query)))))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -648,10 +648,10 @@
 
              db1 @(test-utils/transact ledger
                                        {"@type" "sh:NodeShape",
-                                        "sh:targetClass" {"@type" "@id" "@value" "schema:Person"},
+                                        "sh:targetClass" {"id" "schema:Person"}
                                         "sh:property"
-                                        [{"sh:path" {"@type" "@id" "@value" "schema:familyName"},
-                                          "sh:datatype" {"@type" "@id" "@value" "xsd:string"}}]})
+                                        [{"sh:path" {"id" "schema:familyName"}
+                                          "sh:datatype" {"id" "xsd:string"}}]})
              property-query {:select {"?s" ["*"]}, :where [["?s" "sh:property" "?property"]]}
              shape-id (-> @(fluree/query db1 property-query)
                           first
@@ -671,8 +671,8 @@
            (let [db2 @(test-utils/transact loaded1
                                            {"@id" shape-id
                                             "sh:property"
-                                            [{"sh:path" {"@type" "@id" "@value" "schema:age"},
-                                              "sh:datatype" {"@type" "@id" "@value" "xsd:string"}}]})
+                                            [{"sh:path" {"id" "schema:age"}
+                                              "sh:datatype" {"id" "xsd:string"}}]})
                  loaded2 @(fluree/load conn "shacl/a")]
              (is (= [{"id" shape-id
                       "rdf:type" ["sh:NodeShape"],

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -17,6 +17,18 @@
    :wiki   "https://www.wikidata.org/wiki/"
    :f      "https://ns.flur.ee/ledger#"})
 
+(def default-str-context
+  {"id" "@id"
+   "type" "@type"
+   "xsd" "http://www.w3.org/2001/XMLSchema#"
+   "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   "rdfs" "http://www.w3.org/2000/01/rdf-schema#"
+   "sh" "http://www.w3.org/ns/shacl#"
+   "schema" "http://schema.org/"
+   "skos" "http://www.w3.org/2008/05/skos#"
+   "wiki" "https://www.wikidata.org/wiki/"
+   "f" "https://ns.flur.ee/ledger#"})
+
 (def default-private-key
   "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c")
 

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -83,11 +83,12 @@
 (defn create-conn
   ([]
    (create-conn {}))
-  ([{:keys [context did]
+  ([{:keys [context did context-type]
      :or   {context default-context
+            context-type :keyword
             did     (did/private->did-map default-private-key)}}]
    (let [conn-p (fluree/connect-memory {:defaults {:context      context
-                                                   :context-type :keyword
+                                                   :context-type context-type
                                                    :did          did}})]
      #?(:clj @conn-p :cljs (go (<p! conn-p))))))
 


### PR DESCRIPTION
Fixes https://github.com/fluree/core/issues/5, https://github.com/fluree/core/issues/10

When loading a db we use a different process for creating flakes than we do during staging. In this case our reify code was not properly creating flakes for predefined properties ([07c2df5](https://github.com/fluree/db/pull/469/commits/07c2df5bb986c9bc92cfb179033c3245c0c92ca8)) and it wasn't properly retracting flakes with references ([6139ffa](https://github.com/fluree/db/pull/469/commits/6139ffa671f7bc0f85ce7c050bc3923ec7b5b75e)).

The other commits are doing some renames and adding tests, but those two commits are at the heart of it.