### PR TITLE
Share modification schema between query and transact code

### DIFF
--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -34,12 +34,18 @@
    (m/base-schemas)
    (m/type-schemas)
    v/registry
-   {::txn-leaf-map [:map-of
+   {::triple       ::v/triple
+    ::txn-leaf-map [:map-of
                     [:orn [:string :string] [:keyword :keyword]]
                     :any]
-    ::txn-map      [:orn
-                    [:assert ::txn-leaf-map]
-                    [:retract [:map :retract ::txn-leaf-map]]]
+    ::retract      [:map [:retract ::txn-leaf-map]]
+    ::modification ::v/modification-txn
+    ::txn-map      [:and
+                    [:map-of :keyword :any]
+                    [:orn
+                     [:retract ::retract]
+                     [:modification ::modification]
+                     [:assert ::txn-leaf-map]]]
     ::txn          [:orn
                     [:single-map ::txn-map]
                     [:sequence-of-maps [:sequential ::txn-map]]]}))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -23,7 +23,7 @@
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util :refer [vswap!]]
             [fluree.db.util.log :as log]
-            [fluree.db.util.validation :as v]
+            [fluree.db.validation :as v]
             [fluree.json-ld :as json-ld]
             [malli.core :as m]))
 

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -1,7 +1,7 @@
 (ns fluree.db.query.fql.syntax
   (:require [fluree.db.constants :as const]
             [fluree.db.util.core :refer [try* catch* pred-ident?]]
-            [fluree.db.util.validation :as v]
+            [fluree.db.validation :as v]
             [malli.core :as m]
             [malli.error :as me]
             [malli.transform :as mt]))

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -264,44 +264,31 @@
   [x]
   (triple-validator x))
 
-(def query-validator
-  (m/validator ::query {:registry registry}))
-
-(def query-coercer
+(def coerce-query*
   (m/coercer ::query (mt/transformer {:name :fql}) {:registry registry}))
 
 (def multi-query?
   (m/validator ::multi-query {:registry registry}))
 
-(defn validate-query
-  [qry]
-  (if (query-validator qry)
-    qry
-    (throw (ex-info "Invalid Query"
-                    {:status  400
-                     :error   :db/invalid-query
-                     :reasons (m/explain ::analytical-query qry {:registry registry})}))))
-
 (defn coerce-query
   [qry]
-  (try* (query-coercer qry)
-        (catch* _e
-          (throw (ex-info "Invalid Query"
-                          {:status  400
-                           :error   :db/invalid-query
-                           :reasons (me/humanize (m/explain ::query qry {:registry registry}))})))))
+  (try*
+   (coerce-query* qry)
+   (catch* e
+     (throw (ex-info "Invalid Query"
+                     {:status  400
+                      :error   :db/invalid-query
+                      :reasons (-> e ex-data :data :explain me/humanize)})))))
 
-(def modification-validator
-  (m/validator ::modification {:registry registry}))
-
-(def modification-coercer
+(def coerce-modification*
   (m/coercer ::modification (mt/transformer {:name :fql}) {:registry registry}))
 
 (defn coerce-modification
   [mdfn]
-  (try* (modification-coercer mdfn)
-        (catch* _e
-          (throw (ex-info "Invalid Ledger Modification"
-                          {:status  400
-                           :error   :db/invalid-query
-                           :reasons (me/humanize (m/explain ::modification mdfn {:registry registry}))})))))
+  (try*
+   (coerce-modification* mdfn)
+   (catch* e
+     (throw (ex-info "Invalid Ledger Modification"
+                     {:status  400
+                      :error   :db/invalid-query
+                      :reasons (-> e ex-data :data :explain me/humanize)})))))

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -13,7 +13,7 @@
    [fluree.db.util.log :as log]
    [fluree.db.query.range :as query-range]
    [fluree.db.db.json-ld :as jld-db]
-   [fluree.db.util.validation :as v]
+   [fluree.db.validation :as v]
    [malli.error :as me]
    [malli.transform :as mt]))
 

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -1,5 +1,7 @@
 (ns fluree.db.validation
-  (:require [malli.core :as m]))
+  (:require [fluree.db.util.core :refer [pred-ident?]]
+            [fluree.db.constants :as const]
+            [malli.core :as m]))
 
 (defn iri?
   [v]
@@ -13,11 +15,121 @@
       (keyword v))
     v))
 
+(defn variable?
+  [x]
+  (and (or (string? x) (symbol? x) (keyword? x))
+       (-> x name first (= \?))))
+
+(def value? (complement coll?))
+
+(defn sid?
+  [x]
+  (int? x))
+
+(defn iri-key?
+  [x]
+  (= const/iri-id x))
+
+(defn where-op [x]
+  (when (map? x)
+    (-> x first key)))
+
+(defn string->keyword
+  [x]
+  (if (string? x)
+    (keyword x)
+    x))
+
+(defn fn-string?
+  [x]
+  (and (string? x)
+       (re-matches #"^\(.+\)$" x)))
+
+(defn fn-list?
+  [x]
+  (and (list? x)
+       (-> x first symbol?)))
+
+(defn query-fn?
+  [x]
+  (or (fn-string? x) (fn-list? x)))
+
 (def registry
   (merge
    (m/base-schemas)
    (m/type-schemas)
-   {::iri             [:or :string :keyword]
-    ::json-ld-keyword [:keyword {:decode/json decode-json-ld-keyword
-                                 :decode/fql  decode-json-ld-keyword}]
-    ::context         :any}))
+   (m/sequence-schemas)
+   {::iri                  [:or :string :keyword]
+    ::iri-key              [:fn iri-key?]
+    ::iri-map              [:map-of {:max 1}
+                            ::iri-key ::iri]
+    ::json-ld-keyword      [:keyword {:decode/json decode-json-ld-keyword
+                                      :decode/fql  decode-json-ld-keyword}]
+    ::var                  [:fn variable?]
+    ::val                  [:fn value?]
+    ::subject              [:orn
+                            [:sid [:fn sid?]]
+                            [:ident [:fn pred-ident?]]
+                            [:iri ::iri]]
+    ::triple               [:catn
+                            [:subject [:orn
+                                       [:var ::var]
+                                       [:val ::subject]]]
+                            [:predicate [:orn
+                                         [:var ::var]
+                                         [:iri ::iri]]]
+                            [:object [:orn
+                                      [:var ::var]
+                                      [:ident [:fn pred-ident?]]
+                                      [:iri-map ::iri-map]
+                                      [:val :any]]]]
+    ::function             [:orn
+                            [:string [:fn fn-string?]]
+                            [:list [:fn fn-list?]]]
+    ::where-pattern        [:orn
+                            [:map ::where-map]
+                            [:tuple ::where-tuple]]
+    ::filter               [:sequential ::function]
+    ::optional             [:orn
+                            [:single ::where-pattern]
+                            [:collection [:sequential ::where-pattern]]]
+    ::union                [:sequential [:sequential ::where-pattern]]
+    ::bind                 [:map-of ::var :any]
+    ::where-op             [:enum {:decode/fql  string->keyword
+                                   :decode/json string->keyword}
+                            :filter :optional :union :bind]
+    ::where-map            [:and
+                            [:map-of {:max 1} ::where-op :any]
+                            [:multi {:dispatch where-op}
+                             [:filter [:map [:filter [:ref ::filter]]]]
+                             [:optional [:map [:optional [:ref ::optional]]]]
+                             [:union [:map [:union [:ref ::union]]]]
+                             [:bind [:map [:bind [:ref ::bind]]]]]]
+    ::where-tuple          [:orn
+                            [:triple ::triple]
+                            [:remote [:sequential {:max 4} :any]]]
+    ::where                [:sequential [:orn
+                                         [:where-map ::where-map]
+                                         [:tuple ::where-tuple]]]
+    ::delete               [:orn
+                            [:single ::triple]
+                            [:collection [:sequential ::triple]]]
+    ::insert               [:orn
+                            [:single ::triple]
+                            [:collection [:sequential ::triple]]]
+    ::single-var-binding   [:tuple ::var [:sequential ::val]]
+    ::multiple-var-binding [:tuple
+                            [:sequential ::var]
+                            [:sequential [:sequential ::val]]]
+    ::values               [:orn
+                            [:single ::single-var-binding]
+                            [:multiple ::multiple-var-binding]]
+    ::modification-txn     [:and
+                            [:map-of ::json-ld-keyword :any]
+                            [:map
+                             [:context {:optional true} ::context]
+                             [:delete ::delete]
+                             [:insert {:optional true} ::insert]
+                             [:where ::where]
+                             [:values {:optional true} ::values]]]
+    ::context              :any}))

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -1,4 +1,4 @@
-(ns fluree.db.util.validation
+(ns fluree.db.validation
   (:require [malli.core :as m]))
 
 (defn iri?


### PR DESCRIPTION
...so we can coerce incoming modification transactions in http-api-gateway.

Should fix https://github.com/fluree/http-api-gateway/issues/55

In the first commit I moved `fluree.db.util.validation` to `fluree.db.validation` because I'm not sure what `util` adds to the meaning of that ns. I'm the one who put it there in the first place, so my bad. So looking at this commit-by-commit is probably best. Let me know if you're not a fan.

- https://github.com/fluree/db/pull/471/commits/551c0835e96585b7451e51a9dbbf713e111a8129 is an opportunistic refactor based on something I learned recently
- https://github.com/fluree/db/pull/471/commits/8ecfb26747a9f002a1a2c2c0e32ed3f5cdf4d07f is the heart of the PR