### PR TITLE
Fix txn schema to allow just asserts again

### DIFF
--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -38,14 +38,14 @@
     ::txn-leaf-map [:map-of
                     [:orn [:string :string] [:keyword :keyword]]
                     :any]
-    ::retract      [:map [:retract ::txn-leaf-map]]
-    ::modification ::v/modification-txn
-    ::txn-map      [:and
+    ::retract      [:and
                     [:map-of :keyword :any]
-                    [:orn
-                     [:retract ::retract]
-                     [:modification ::modification]
-                     [:assert ::txn-leaf-map]]]
+                    [:map [:retract ::txn-leaf-map]]]
+    ::modification ::v/modification-txn
+    ::txn-map      [:orn
+                    [:retract ::retract]
+                    [:modification ::modification]
+                    [:assert ::txn-leaf-map]]
     ::txn          [:orn
                     [:single-map ::txn-map]
                     [:sequence-of-maps [:sequential ::txn-map]]]}))


### PR DESCRIPTION
In #471 I accidentally added a requirement that transaction maps always use keyword keys (and I guess every transaction in db's test suite does? that's surprising). But of course they don't / can't always, and this fixes that.

Should hopefully really fix https://github.com/fluree/http-api-gateway/issues/55 along w/ an upcoming PR to http-api-gateway to have it actually use the txn schema in here 😆.