### PR TITLE
handle string variables in values clause

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -53,11 +53,11 @@
   [q]
   (when-let [values (:values q)]
     (let [[vars vals] values
-          vars*     (util/sequential vars)
-          vals*     (mapv util/sequential vals)
-          var-count (count vars*)]
-      (if (every? (fn [bdg]
-                    (= (count bdg) var-count))
+          vars*       (keep parse-var-name (util/sequential vars))
+          vals*       (mapv util/sequential vals)
+          var-count   (count vars*)]
+      (if (every? (fn [binding]
+                    (= (count binding) var-count))
                   vals*)
         [vars* (mapv (partial parse-value-binding vars*)
                      vals*)]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -123,7 +123,19 @@
                                                 ["cam@example.org" 37]]]}]
             (is (= [["Alice" 50]]
                    @(fluree/query db q))
-                "returns only the results related to the existing bound values")))))))
+                "returns only the results related to the existing bound values"))))
+      (testing "with string vars"
+        (let [q {:select  ["?name" "?age"]
+                 :where   [["?s" :schema/email "?email"]
+                           ["?s" :schema/name "?name"]
+                           ["?s" :schema/age "?age"]]
+                 :values  ["?age" [13]]}]
+          (is (= [["Liam" 13]]
+                 @(fluree/query db q))
+              "returns only the results related to the bound values"))))))
+
+
+
 
 (deftest ^:integration bind-query-test
   (let [conn   (test-utils/create-conn)


### PR DESCRIPTION
If you use a string variable binding in the values clause, it was never parsed as a variable when being used as a key in the solution map. However, it was parsed as a variable when creating where patterns. The consequence of this is that when we called `fluree.db.query.exec.where/assign-matched-values`, the existing solution didn't match up with the where clause and the values weren't being used.

This commit makes sure to parse the variables in a values clause so that we are always dealing with symbol variables internally.

Fixes #474