### PR TITLE
Fix commit+load after deleting entire subjects

### DIFF
--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -678,4 +678,53 @@
                       "rdf:type" ["sh:NodeShape"],
                       "sh:targetClass" {"id" "schema:Person"},
                       "sh:property" {"id" "_:f211106232532994"}}]
-                    @(fluree/query (fluree/db loaded2) property-query)))))))))
+                    @(fluree/query (fluree/db loaded2) property-query)))))))
+    (testing "can load after deletion of entire subjects"
+       (let [conn              @(fluree/connect
+                                  {:method :memory
+                                   :defaults
+                                   {:context      test-utils/default-context
+                                    :context-type :keyword}})
+             ledger-alias      "tx/delete"
+             ledger            @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+             db1               @(fluree/stage
+                                  (fluree/db ledger)
+                                  {:graph
+                                   [{:id                 :ex/fluree
+                                     :type               :schema/Organization
+                                     :schema/description "We ❤️ Data"}
+                                    {:id                 :ex/w3c
+                                     :type               :schema/Organization
+                                     :schema/description "We ❤️ Internet"}
+                                    {:id                 :ex/mosquitos
+                                     :type               :ex/Monster
+                                     :schema/description "We ❤️ human blood"}
+                                    {:id                 :ex/kittens
+                                     :type               :ex/Animal
+                                     :schema/description "We ❤️ catnip"}]})
+             description-query '{:select {?s [:id]}
+                                 :where  [[?s :schema/description ?description]]}
+             _                 @(fluree/commit! ledger db1)
+             loaded1           @(fluree/load conn ledger-alias)
+             loaded-db1        (fluree/db loaded1)
+             db2               @(fluree/stage
+                                  loaded-db1
+                                  '{:delete [:ex/mosquitos ?p ?o]
+                                    :where  [[:ex/mosquitos ?p ?o]]})
+             _                 @(fluree/commit! ledger db2)
+             loaded2           @(fluree/load conn ledger-alias)
+             loaded-db2        (fluree/db loaded2)]
+         (is (= [{:id :ex/kittens} {:id :ex/w3c} {:id :ex/fluree}]
+                @(fluree/query loaded-db2 description-query))
+             "The id :ex/mosquitos should be removed")
+         (let [db3        @(fluree/stage
+                             loaded-db2
+                             '{:delete [?s ?p ?o]
+                               :where  [[?s :rdf/type :schema/Organization]
+                                        [?s ?p ?o]]})
+               _          @(fluree/commit! ledger db3)
+               loaded3    @(fluree/load conn ledger-alias)
+               loaded-db3 (fluree/db loaded3)]
+           (is (= [{:id :ex/kittens}]
+                  @(fluree/query loaded-db3 description-query))
+               "Only :ex/kittens should be left")))) ))


### PR DESCRIPTION
Closes #473 

We create flakes which map subject ids to iris, to use internally for iri lookup. Prior to this change, our update code was creating retractions for these flakes when subjects got deleted. However, during the commit process, we depend on them to look up iris for the subjects we encounter. When these were retracted, that lookup failed and we fell back to creating invalid blank nodes which could not be loaded.

While it is safe to retract them in some cases (eg if there are no references to that subject), they are for internal use only and they don't _need_ to be deleted.

If we wanted to delete these flakes, we would need to consider:
- only deleting them when no other subjects refer to them (likely requires an index lookup in `opst`)
- to ensure they don't get reintroduced upon load, update our loading pipeline to handle retracting them as well

If so desired, we could do that as future work, as it would save us from having these flakes hanging around when they're not needed.