### PR TITLE
Exclude queries that require use of equivalentProperty from simple-subject-crawl

### DIFF
--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -115,7 +115,7 @@
 (def ^:const $_predicate:txSpecDoc 25)
 (def ^:const $_predicate:restrictTag 26)
 (def ^:const $_predicate:fullText 27)
-(def ^:const $_predicate:equivalentProperty 28)                          ;; any unique alias for predicate
+(def ^:const $_predicate:equivalentProperty 35)                          ;; any unique alias for predicate
 (def ^:const $_predicate:retractDuplicates 29)             ;; if transaction flake duplicates existing flake, always retract/insert (default behavior ignores new flake)
 ;; TODO - jumping predicate ids - rethink ordering a bit
 (def ^:const $rdf:type 200)

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -487,7 +487,7 @@
 (defn parse-analytical-query
   [q db]
   (let [parsed (parse-analytical-query* q db)]
-    (or (re-parse-as-simple-subj-crawl parsed)
+    (or (re-parse-as-simple-subj-crawl parsed db)
         parsed)))
 
 (defn parse-query

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -66,12 +66,12 @@
       (if where-smt
         (when (and (= :tuple type)
                    (= first-s (clause-subject-var where-smt)))
-          (let [{::where/keys [val var]} o 
+          (let [{::where/keys [val var]} o
                 f (cond
                     val
                     (fn [flake _] (= val (flake/o flake)))
 
-                    ;;TODO: filters are not yet supported 
+                    ;;TODO: filters are not yet supported
                     #_#_filter
                     (let [{:keys [params variable function]} filter]
                       (if (= 1 (count params))
@@ -101,7 +101,7 @@
         [s p o] (if (= :tuple type)
                   pattern
                   (let [[_type-kw tuple] pattern]
-                    tuple)) 
+                    tuple))
         reparse-component (fn [component]
                             (let [{::where/keys [var val]} component]
                               (cond

--- a/src/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/fluree/db/query/subject_crawl/reparse.cljc
@@ -130,10 +130,17 @@
           (assoc parsed-query :where [reparsed-first-clause
                                       {:s-filter subj-filter-map}]
                               :strategy :simple-subject-crawl))))))
+
+(defn has-equivalent-properties?
+  [db pattern]
+  (if-let [p-val (get-in pattern [1 ::where/val])]
+    (some? (where/get-equivalent-properties db p-val))
+    false))
+
 (defn simple-subject-crawl?
   "Simple subject crawl is where the same variable is used in the leading
   position of each where statement."
-  [{:keys [where select vars] :as _parsed-query}]
+  [{:keys [where select vars] :as _parsed-query} db]
   (and (instance? SubgraphSelector select)
        ;;TODO, filtering not supported yet
        (empty? (::where/filters where))
@@ -145,6 +152,7 @@
                      (and (mergeable-where-clause? pattern)
                           (let [pred (second pattern)]
                             (and (= select-var (clause-subject-var pattern))
+                                 (not (has-equivalent-properties? db pattern))
                                  (not (::where/recur pred))
                                  (not (::where/fullText pred)))))) patterns)))))
 
@@ -153,9 +161,9 @@
   e.g.
   {:select {?subjects ['*']}
    :where [...]}"
-  [{:keys [order-by group-by] :as parsed-query}]
+  [{:keys [order-by group-by] :as parsed-query} db]
   (when (and (not group-by)
              (not order-by)
-             (simple-subject-crawl? parsed-query))
+             (simple-subject-crawl? parsed-query db))
     ;; following will return nil if parts of where clause exclude it from being a simple-subject-crawl
     (simple-subject-merge-where parsed-query)))

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -8,10 +8,18 @@
 
 (deftest test-reparse-as-ssc
   (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "query/parse" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+        ledger @(fluree/create conn "query/parse" {:defaultContext ["" {:ex "http://example.org/ns/"
+                                                                        :owl "http://www.w3.org/2002/07/owl#"
+                                                                        :vocab1 "http://vocab1.example.org"
+                                                                        :vocab2 "http://vocab2.example.org"}]})
         db     @(fluree/stage
                  (fluree/db ledger)
-                 [{:id           :ex/brian,
+                 [{:id           :vocab1/credential
+                   :type         :rdf/Property}
+                  {:id           :vocab2/degree
+                   :type         :rdf/Property
+                   :owl/equivalentProperty :vocab1/credential}
+                  {:id           :ex/brian,
                    :type         :ex/User,
                    :schema/name  "Brian"
                    :schema/email "brian@example.org"
@@ -22,6 +30,7 @@
                    :type         :ex/User,
                    :schema/name  "Alice"
                    :schema/email "alice@example.org"
+                   :vocab1/credential "MS"
                    :schema/age   50
                    :ex/favColor  "Blue"
                    :ex/favNums   [42, 76, 9]}
@@ -29,6 +38,7 @@
                    :type         :ex/User,
                    :schema/name  "Cam"
                    :schema/email "cam@example.org"
+                   :vocab2/degree "BA"
                    :schema/age   34
                    :ex/favNums   [5, 10]
                    :ex/friend    [:ex/brian :ex/alice]}])
@@ -66,20 +76,25 @@
         s+p+o3-parsed (parse/parse-analytical-query {:select {'?s ["*"]}
                                                      :where [['?s '?p '?o]
                                                              ['?s :schema/age 50]]}
-                                                    db)]
+                                                    db)
+        equivalent-property-parsed (parse/parse-analytical-query {:select {'?s ["*"]}
+                                                                  :where [['?s :schema/name '?name]
+                                                                          ['?s :vocab1/credential '?credential]]}
+                                                                 db)]
     (testing "simple-subject-crawl?"
       (is (= true
-             (reparse/simple-subject-crawl? ssc-q1-parsed)))
+             (reparse/simple-subject-crawl? ssc-q1-parsed db)))
       (is (= true
-             (reparse/simple-subject-crawl? ssc-q2-parsed)))
-      (is (not (reparse/simple-subject-crawl? vars-query-parsed)))
-      (is (not (reparse/simple-subject-crawl? not-ssc-parsed)))
-      (is (not (reparse/simple-subject-crawl? order-group-parsed)))
-      (is (not (reparse/simple-subject-crawl? s+p+o-parsed)))
-      (is (not (reparse/simple-subject-crawl? s+p+o2-parsed)))
-      (is (not (reparse/simple-subject-crawl? s+p+o3-parsed))))
+             (reparse/simple-subject-crawl? ssc-q2-parsed db)))
+      (is (not (reparse/simple-subject-crawl? vars-query-parsed db)))
+      (is (not (reparse/simple-subject-crawl? not-ssc-parsed db)))
+      (is (not (reparse/simple-subject-crawl? order-group-parsed db)))
+      (is (not (reparse/simple-subject-crawl? s+p+o-parsed db)))
+      (is (not (reparse/simple-subject-crawl? s+p+o2-parsed db)))
+      (is (not (reparse/simple-subject-crawl? s+p+o3-parsed db)))
+      (is (not (reparse/simple-subject-crawl? equivalent-property-parsed db))))
     (testing "reparse"
-      (let [ssc-q1-reparsed (reparse/re-parse-as-simple-subj-crawl ssc-q1-parsed)
+      (let [ssc-q1-reparsed (reparse/re-parse-as-simple-subj-crawl ssc-q1-parsed db)
             {:keys [where context]} ssc-q1-reparsed
             [pattern] where
             {:keys [s p o]} pattern]
@@ -91,7 +106,7 @@
           (is (= "Alice"
                  value))
           (is datatype)))
-      (let [ssc-q2-reparsed (reparse/re-parse-as-simple-subj-crawl ssc-q2-parsed)
+      (let [ssc-q2-reparsed (reparse/re-parse-as-simple-subj-crawl ssc-q2-parsed db)
             {:keys [where context]} ssc-q2-reparsed
             [pattern _s-filter] where
             {:keys [s p o]} pattern]
@@ -104,4 +119,4 @@
                  value))
           (is datatype)))
       (is (nil?
-           (reparse/re-parse-as-simple-subj-crawl not-ssc-parsed))))))
+           (reparse/re-parse-as-simple-subj-crawl not-ssc-parsed db))))))


### PR DESCRIPTION
Closes #482 

This bug was caused by the fact that the offending query was being processed by simple-subject-crawl, and that query mechanism did not utilize the schema where equivalent properties are stored.

This PR updates query reparsing to reject equivalentProperty queries from using simple-subject-crawl, processing them via the main query mechanism instead.  

The simple-subject-crawl strategy is meant for cases where we can do a single retrieval of flakes that match the first clause, and then filter through them using the combination of subsequent clauses. Finding equivalent properties would require additional flake retrievals.

The issue with the commit files containing the wrong iri for `equivalentProperty` was unrelated, but I did update the constant we use for  `$_predicate:equivalentProperty` to be unique, to fix it. The commit now looks like:

```json
{
  "@context": {
    "f": "https://ns.flur.ee/ledger#",
    "f:assert": {
      "@container": "@graph"
    },
    "http://www.w3.org/2002/07/owl#equivalentProperty": {
      "@type": "@id"
    }
  },
  "@id": "fluree:db:sha256:bzdcxxka4xspxxh2sz6x4wvzrgpzj3zmmf4t4lnp2wpsyvcfet2",
  "@type": [
    "f:DB"
  ],
  "f:assert": [
    {
      "@id": "http://vocab1.example.org/givenName",
      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
    },
    {
      "@id": "http://vocab2.example.org/firstName",
      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
      "http://www.w3.org/2002/07/owl#equivalentProperty": "http://vocab1.example.org/givenName"
    },
    {
      "@id": "http://vocab3.example.fr/prenom",
      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
      "http://www.w3.org/2002/07/owl#equivalentProperty": "http://vocab2.example.org/firstName"
    }
  ],
  "f:flakes": 17,
  "f:size": 1530,
  "f:t": 1,
  "f:v": 0
}
```

We have a _lot_ of duplicate constants in the `constants.clj` file, which may cause other similar issues. 

