### PR TITLE
update api to allow credential-wrapped requests

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -79,7 +79,10 @@
   "Return a summary of the changes over time, optionally with the full commit details included."
   [db query-map]
   (go-try
-   (let [coerced-query (try*
+   (let [{query-map :subject, issuer :issuer}
+         (or (<? (cred/verify query-map))
+             {:subject query-map})
+         coerced-query (try*
                         (history/coerce-history-query query-map)
                         (catch* e
                           (throw
@@ -145,7 +148,9 @@
            - errors - map of query alias to their respective error"
   [source flureeQL]
   (go-try
-   (let [global-opts         (:opts flureeQL)
+   (let [{flureeQL :subject, issuer :issuer} (or (<? (cred/verify flureeQL))
+                                                 {:subject flureeQL})
+         global-opts         (:opts flureeQL)
          db                  (if-let [policy-opts (perm/policy-opts global-opts)]
                                (<? (perm/wrap-policy source policy-opts))
                                source)

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -79,7 +79,7 @@
   "Return a summary of the changes over time, optionally with the full commit details included."
   [db query-map]
   (go-try
-   (let [{query-map :subject, issuer :issuer} (or (<? (cred/verify query-map))
+   (let [{query-map :subject, did :did} (or (<? (cred/verify query-map))
                                                   {:subject query-map})
          coerced-query (try*
                          (history/coerce-history-query query-map)
@@ -91,7 +91,7 @@
                                      {:status  400
                                       :message (history/humanize-error e)
                                       :error   :db/invalid-query}))))
-         history-query (cond-> coerced-query issuer (assoc-in [:opts :did] issuer))]
+         history-query (cond-> coerced-query did (assoc-in [:opts :did] did))]
      (<? (history* db history-query)))))
 
 (defn query
@@ -99,12 +99,11 @@
   containing result or exception."
   [db query]
   (go-try
-    (let [{query :subject, issuer :issuer}
-          (or (<? (cred/verify query))
-              {:subject query})
+    (let [{query :subject, did :did} (or (<? (cred/verify query))
+                                         {:subject query})
 
           {:keys [opts t]} query
-          db*              (if-let [policy-opts (perm/policy-opts (cond-> opts issuer (assoc :did issuer)))]
+          db*              (if-let [policy-opts (perm/policy-opts (cond-> opts did (assoc :did did)))]
                              (<? (perm/wrap-policy db policy-opts))
                              db)
           db**             (-> (if t
@@ -112,10 +111,10 @@
                                  db*)
                                (assoc-in [:policy :cache] (atom {})))
           query*           (-> query
-                               (update :opts assoc :issuer issuer)
+                               (update :opts assoc :issuer did)
                                (update :opts dissoc :meta))
           start            #?(:clj  (System/nanoTime)
-                              :cljs (util/current-time-millis)) ]
+                              :cljs (util/current-time-millis))]
       (if (:meta opts)
         (let [fuel-tracker (fuel/tracker)]
           (try* (let [result (<? (fql/query db** fuel-tracker query*))]
@@ -148,9 +147,9 @@
            - errors - map of query alias to their respective error"
   [source flureeQL]
   (go-try
-   (let [{flureeQL :subject, issuer :issuer} (or (<? (cred/verify flureeQL))
-                                                 {:subject flureeQL})
-         global-opts         (cond-> (:opts flureeQL) issuer (assoc :did issuer))
+   (let [{flureeQL :subject, did :did} (or (<? (cred/verify flureeQL))
+                                              {:subject flureeQL})
+         global-opts         (cond-> (:opts flureeQL) did (assoc :did did))
          db                  (if-let [policy-opts (perm/policy-opts global-opts)]
                                (<? (perm/wrap-policy source policy-opts))
                                source)

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -49,6 +49,7 @@
 (def ^:const iri-all-nodes "https://ns.flur.ee/ledger#allNodes")
 (def ^:const iri-view "https://ns.flur.ee/ledger#view")
 (def ^:const iri-modify "https://ns.flur.ee/ledger#modify")
+(def ^:const iri-role "https://ns.flur.ee/ledger#role")
 
 (def ^:const iri-id "@id")
 (def ^:const iri-type "@type")

--- a/src/fluree/db/json_ld/credential.cljc
+++ b/src/fluree/db/json_ld/credential.cljc
@@ -58,26 +58,27 @@
 
 (defn generate
   "Generate a VerifiableCredential given a subject and some issuer opts."
-  ([credential-subject private] (generate credential-subject private
-                                          (did/private->did-map private)))
+  ([credential-subject private]
+   (generate credential-subject private (did/private->did-map private)))
   ([credential-subject private did]
    (go-try
-     (let [proof #?(:clj (create-proof (-> credential-subject
-                                           jld-processor/canonize
-                                           crypto/sha2-256)
-                                       (did/encode-did-key (:public did))
-                                       private)
-                    :cljs (let [canonicalized (<p! (jld-processor/canonize credential-subject))]
-                            (create-proof (crypto/sha2-256 canonicalized)
-                                          (did/encode-did-key (:public did))
-                                          private)))]
+     (let [canonicalized #?(:clj (jld-processor/canonize credential-subject)
+                            :cljs (<p! (jld-processor/canonize credential-subject)))
+
+           ;; TODO: assert this once our credential subjects are proper json-ld
+           ;; _ (when (= "" canonicalized) (throw (ex-info "Unsupported credential subject" {:credential-subject credential-subject})))
+
+           did-key (did/encode-did-key (:public did))
+           proof (create-proof (crypto/sha2-256 canonicalized)
+                               did-key
+                               private)]
        {"@context"          "https://www.w3.org/2018/credentials/v1"
         "id"                ""
         "type"              ["VerifiableCredential" "CommitProof"]
-        "issuer"            (:id did)
+        "issuer"            did-key
         "issuanceDate"      (util/current-time-iso)
         "credentialSubject" credential-subject
-        "proof" proof}))))
+        "proof"             proof}))))
 
 (defn verify
   "Takes a credential and returns the credential subject and issuer id if it verifies. If
@@ -87,16 +88,16 @@
   (go-try
     (when-let [jws (get-in credential ["proof" "jws"])]
       (let [subject (get credential "credentialSubject")
-            issuer  (get credential "issuer")
             {:keys [header signature]} (deserialize-jws jws)
 
-            signing-input #?(:clj (-> (jld-processor/canonize subject)
-                                      (crypto/sha2-256))
+            signing-input #?(:clj (some-> (jld-processor/canonize subject)
+                                          (crypto/sha2-256))
                              :cljs (<p! (-> (jld-processor/canonize subject)
                                             (.then (fn [res] (crypto/sha2-256 res))))))
 
             proof-did     (get-in credential ["proof" "verificationMethod"])
-            pubkey        (did/decode-did-key proof-did)]
+            pubkey        (did/decode-did-key proof-did)
+            id            (crypto/account-id-from-public pubkey)]
         (when (not= jws-header-json header)
           (throw (ex-info "Unsupported jws header in credential."
                           {:error :credential/unknown-signing-algorithm
@@ -107,4 +108,4 @@
         (when (not (crypto/verify-signature pubkey signing-input signature))
           (throw (ex-info "Verification failed." {:error :credential/invalid-signature :credential credential})))
         ;; everything is good
-        {:subject subject :issuer issuer}))))
+        {:subject subject :issuer id}))))

--- a/src/fluree/db/json_ld/credential.cljc
+++ b/src/fluree/db/json_ld/credential.cljc
@@ -81,9 +81,9 @@
         "proof"             proof}))))
 
 (defn verify
-  "Takes a credential and returns the credential subject and issuer id if it verifies. If
-  credential does not have a jws returns the credential without verifying it. If the
-  credential is invalid an exception will be thrown."
+  "Takes a credential and returns the credential subject and signing did if it
+  verifies. If credential does not have a jws returns nil. If the credential is invalid
+  an exception will be thrown."
   [credential]
   (go-try
     (when-let [jws (get-in credential ["proof" "jws"])]

--- a/src/fluree/db/json_ld/credential.cljc
+++ b/src/fluree/db/json_ld/credential.cljc
@@ -109,4 +109,4 @@
         (when (not (crypto/verify-signature pubkey signing-input signature))
           (throw (ex-info "Verification failed." {:error :credential/invalid-signature :credential credential})))
         ;; everything is good
-        {:subject subject :issuer auth-did}))))
+        {:subject subject :did auth-did}))))

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -77,6 +77,7 @@
           "http://www.w3.org/ns/shacl#xone"                     const/$sh:xone
           ;; fluree
           "https://ns.flur.ee/ledger#context"                   const/$fluree:context
+          const/iri-role                                        const/$_role
           const/iri-default-context                             const/$fluree:default-context}))
 
 (def predefined-sids

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -503,12 +503,17 @@
   ;; TODO - not yet paying attention to verifiable credentials that are present
   (go-try
     (cond
-      (or (:ident policy) (:roles policy)) (throw (ex-info (str "Policy already in place for this db. "
-                                                                "Applying policy more than once, via multiple uses of `wrap-policy` and/or supplying an identity via `:opts`, is not supported.")
-                                                           {:status 400
-                                                            :error  :db/policy-exception}))
-      (not role) (throw (ex-info "Applying policy without a role is not yet supported."
-                                 {:status 400
-                                  :error  :db/policy-exception}))
-      :else (assoc db :policy
-                      (<? (policy-map db did role credential))))))
+      (or (:ident policy) (:roles policy))
+      (throw (ex-info (str "Policy already in place for this db. "
+                           "Applying policy more than once, via multiple uses of `wrap-policy` and/or supplying "
+                           "an identity via `:opts`, is not supported.")
+                      {:status 400
+                       :error  :db/policy-exception}))
+
+      (not role)
+      (throw (ex-info "Applying policy without a role is not yet supported."
+                      {:status 400
+                       :error  :db/policy-exception}))
+
+      :else
+      (assoc db :policy (<? (policy-map db did role credential))))))

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -514,7 +514,7 @@
                         {:status 400
                          :error  :db/policy-exception}))
 
-        (not (not-empty role-sids))
+        (empty? role-sids)
         (throw (ex-info "Applying policy without a role is not yet supported."
                         {:status 400
                          :error  :db/policy-exception}))

--- a/src/fluree/db/json_ld/policy_validate.cljc
+++ b/src/fluree/db/json_ld/policy_validate.cljc
@@ -47,7 +47,7 @@
             (when (> (count next-res) 1)
               (log/warn (str "f:equals used for identity " ident " and path: " equals-rule
                              " however the query produces more than one result, the first one "
-                             " is being used which can product unpredictable results. "
+                             " is being used which can produce unpredictable results. "
                              "Prefer f:contains when comparing with multiple results.")))
             (recur r next-val))
           (do
@@ -79,11 +79,16 @@
   can be operated on/viewed."
   [rule property-path]
   (if (= const/iri-$identity (first property-path))
-    ;; make certain first element of path is :f/$identity which following fn only considers. Will support other path constructs in the future
-    (let [path-no-identity (rest property-path)             ;; remove :f/$identity - following logic will "substitute" the user's actual identity in its place
+    ;; make certain first element of path is :f/$identity which following fn only
+    ;; considers. Will support other path constructs in the future
+    ;; remove :f/$identity - following logic will "substitute" the user's actual identity in its place
+    (let [path-no-identity (rest property-path)
           f                (fn [db flake]
                              (go-try
-                               ;; because same 'path' is likely used in many flake evaluations, keep a local cache of results so expensive lookup only happens once per query/transaction.
+                               ;; because same 'path' is likely used in many flake
+                               ;; evaluations, keep a local cache of results so
+                               ;; expensive lookup only happens once per
+                               ;; query/transaction.
                                (let [path-val (or (cache-get-value db property-path)
                                                   (->> (async/<! (resolve-equals-rule db path-no-identity rule))
                                                        (cache-store-value db property-path)))]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -413,6 +413,7 @@
   (go-try
     (let [{tx :subject issuer :issuer} (or (<? (cred/verify json-ld))
                                            {:subject json-ld})
+          opts* (cond-> opts issuer (assoc :did issuer))
           db* (if-let [policy-opts (perm/policy-opts opts)]
                 (<? (perm/wrap-policy db policy-opts))
                 db)

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -234,13 +234,13 @@
           [sid (into subj-flakes property-flakes)])))))
 
 (defn ->tx-state
-  [db {:keys [bootstrap? issuer context-type] :as _opts}]
+  [db {:keys [bootstrap? did context-type] :as _opts}]
   (let [{:keys [block schema branch ledger policy], db-t :t} db
         last-pid (volatile! (jld-ledger/last-pid db))
         last-sid (volatile! (jld-ledger/last-sid db))
         commit-t (-> (ledger-proto/-status ledger branch) branch/latest-commit-t)
         t        (-> commit-t inc -)] ;; commit-t is always positive, need to make negative for internal indexing
-    {:issuer      issuer
+    {:did         did
      :db-before   (dbproto/-rootdb db)
      :policy      policy
      :bootstrap?  bootstrap?
@@ -413,13 +413,13 @@
   Returns async channel that will contain updated db or exception."
   [db json-ld opts]
   (go-try
-    (let [{tx :subject did :issuer} (or (<? (cred/verify json-ld))
+    (let [{tx :subject did :did} (or (<? (cred/verify json-ld))
                                         {:subject json-ld})
           opts* (cond-> opts did (assoc :did did))
           db* (if-let [policy-opts (perm/policy-opts opts*)]
                 (<? (perm/wrap-policy db policy-opts))
                 db)
-          tx-state (->tx-state db* (assoc opts* :issuer did))
+          tx-state (->tx-state db* opts*)
           flakes   (if (q-parse/update? tx)
                      (<? (modify db tx tx-state))
                      (<? (insert db tx tx-state)))]

--- a/src/fluree/db/query/exec/update.cljc
+++ b/src/fluree/db/query/exec/update.cljc
@@ -120,11 +120,13 @@
 
 (defn insert?
   [mdfn]
-  (contains? mdfn :insert))
+  (or (contains? mdfn :insert)
+      (contains? mdfn "insert")))
 
 (defn retract?
   [mdfn]
-  (contains? mdfn :delete))
+  (or (contains? mdfn :delete)
+      (contains? mdfn "delete")))
 
 (defn modify
   [db mdfn t fuel-tracker error-ch solution-ch]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -500,7 +500,8 @@
   [x]
   (and (or (update/insert? x)
            (update/retract? x))
-       (contains? x :where)))
+       (or (contains? x :where)
+           (contains? x "where"))))
 
 (defn parse-update-clause
   [clause db context]

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -214,7 +214,7 @@
               (when p (<? (dbproto/-subid db (jld-db/expand-iri db p context) true)))
               (when o (jld-db/expand-iri db o context))]
 
-         [s p o] [(get ids 0) (get ids 1) (get ids 2)]
+         [s p o] ids
          [pattern idx] (cond
                          (not (nil? s))
                          [ids :spot]

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -5,7 +5,8 @@
                :cljs [cljs.test :as t :refer [deftest testing is] :include-macros true])
             [fluree.db.json-ld.api :as fluree]
             [fluree.json-ld :as json-ld]
-            [fluree.db.test-utils :as test-utils]))
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.did :as did]))
 
 (def auth
   {:id "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
@@ -13,7 +14,7 @@
    :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})
 
 (def example-cred-subject {"@context" {"a" "http://a.com/"} "a:foo" "bar"})
-(def example-issuer "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh")
+(def example-issuer (did/encode-did-key (:public auth)))
 
 (def clj-generated-jws
   "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HDBFAiEA80-G5gUH6BT9D1Mc-YyWbjuwbL7nKfWj6BrsHS6whQ0CIAcjzJvo0sW52FIlgvxy0hPBKNWolIwLvoedG_4HQu_V")
@@ -25,7 +26,7 @@
   {"@context"          "https://www.w3.org/2018/credentials/v1"
    "id"                ""
    "type"              ["VerifiableCredential" "CommitProof"]
-   "issuer"            example-issuer
+   "issuer"            (:id auth)
    "issuanceDate"      "1970-01-01T00:00:00.00000Z"
    "credentialSubject" example-cred-subject
    "proof"             {"type"               "EcdsaSecp256k1RecoverySignature2020"

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -8,13 +8,14 @@
             [fluree.db.test-utils :as test-utils]
             [fluree.db.did :as did]))
 
-(def auth
-  {:id "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
-   :public "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
+
+(def kp
+  {:public "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
    :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})
+(def auth (did/private->did-map (:private kp)))
 
 (def example-cred-subject {"@context" {"a" "http://a.com/"} "a:foo" "bar"})
-(def example-issuer (did/encode-did-key (:public auth)))
+(def example-issuer (:id auth))
 
 (def clj-generated-jws
   "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HDBFAiEA80-G5gUH6BT9D1Mc-YyWbjuwbL7nKfWj6BrsHS6whQ0CIAcjzJvo0sW52FIlgvxy0hPBKNWolIwLvoedG_4HQu_V")

--- a/test/fluree/db/policy/parsing_test.clj
+++ b/test/fluree/db/policy/parsing_test.clj
@@ -85,12 +85,12 @@
                                                         :f/equals     {:list [:f/$identity :ex/user]}}]}]}])]
 
       (testing "Policy map for classes and props within classes is properly formed"
-        (let [policy-alice  (-> @(fluree/promise-wrap (policy/policy-map db alice-did :ex/userRole nil))
-                                replace-policy-fns)
-              sid-User      @(fluree/internal-id db :ex/User)
+        (let [sid-User      @(fluree/internal-id db :ex/User)
               sid-ssn       @(fluree/internal-id db :schema/ssn)
               sid-alice-did @(fluree/internal-id db alice-did)
-              sid-userRole  @(fluree/internal-id db :ex/userRole)]
+              sid-userRole  @(fluree/internal-id db :ex/userRole)
+              policy-alice  (-> @(fluree/promise-wrap (policy/policy-map db sid-alice-did #{sid-userRole} nil))
+                                replace-policy-fns)]
           (is (= {const/iri-modify
                   {:class
                    {sid-User {:default {const/iri-equals      [{"@id" const/iri-$identity}
@@ -116,10 +116,10 @@
                  policy-alice)
               "Policies for only :ex/userRole should return")))
       (testing "Root policy contains {:root? true} for each applicable :f/action"
-        (let [policy-root  (-> @(fluree/promise-wrap (policy/policy-map db root-did :ex/rootRole nil))
-                               replace-policy-fns)
-              sid-root-did @(fluree/internal-id db root-did)
-              sid-rootRole @(fluree/internal-id db :ex/rootRole)]
+        (let [sid-root-did @(fluree/internal-id db root-did)
+              sid-rootRole @(fluree/internal-id db :ex/rootRole)
+              policy-root  (-> @(fluree/promise-wrap (policy/policy-map db sid-root-did #{sid-rootRole} nil))
+                               replace-policy-fns)]
           (is (= {"https://ns.flur.ee/ledger#modify" {:root? true}
                   "https://ns.flur.ee/ledger#view"   {:root? true}
                   :ident                             sid-root-did
@@ -141,10 +141,10 @@
                                         "f:targetRole" {"id" "ex:rootRole"}
                                         "f:action"     [{"id" "f:view"} {"id" "f:modify"}]}]}])]
       (testing "Root policy contains {:root? true} for each applicable :f/action"
-        (let [policy-root  (-> @(fluree/promise-wrap (policy/policy-map db root-did :ex/rootRole nil))
-                               replace-policy-fns)
-              sid-root-did @(fluree/internal-id db root-did)
-              sid-rootRole @(fluree/internal-id db :ex/rootRole)]
+        (let [sid-root-did @(fluree/internal-id db root-did)
+              sid-rootRole @(fluree/internal-id db :ex/rootRole)
+              policy-root  (-> @(fluree/promise-wrap (policy/policy-map db sid-root-did #{sid-rootRole} nil))
+                               replace-policy-fns)]
           (is (= {"https://ns.flur.ee/ledger#modify" {:root? true}
                   "https://ns.flur.ee/ledger#view"   {:root? true}
                   :ident                             sid-root-did

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -77,14 +77,13 @@
                                          {:f/path  :schema/name
                                           :f/allow [{:f/targetRole :ex/userRole
                                                      :f/action     [:f/view :f/modify]}]}]}])]
-
       (testing "Policy allowed modification"
         (testing "using role + id"
-          (let [update-name @(fluree/stage db+policy {:id          :ex/alice
-                                                      :schema/email "alice@foo.bar"}
+          (let [update-name @(fluree/stage db+policy
+                                           {:id          :ex/alice
+                                            :schema/email "alice@foo.bar"}
                                            {:did alice-did
                                             :role      :ex/userRole})]
-
             (is (= [{:id :ex/alice,
                      :rdf/type [:ex/User],
                      :schema/name "Alice",
@@ -94,33 +93,36 @@
                      :ex/location {:id nil}}]
                    @(fluree/query update-name
                                   {:select {'?s [:*]}
-                                   :where  [['?s :schema/name "Alice"]]}))
+                                   :where  [['?s :schema/name "Alice"]]
+                                   :opts {:did alice-did}}))
                 "Alice should be allowed to update her own name.")))
         (testing "using role only"
-          (let [update-price @(fluree/stage db+policy {:id          :ex/widget
-                                                       :schema/price 105.99}
-                                            {:role :ex/rootRole})]
+            (let [update-price @(fluree/stage db+policy
+                                              {:id          :ex/widget
+                                               :schema/price 105.99}
+                                              {:role :ex/rootRole})]
 
-            (is (= [{:id :ex/widget,
-                     :rdf/type [:ex/Product],
-                     :schema/name "Widget",
-                     :schema/price 105.99,
-                     :schema/priceCurrency "USD"}]
-                   @(fluree/query update-price
-                                  {:select {'?s [:*]}
-                                   :where  [['?s :rdf/type :ex/Product]]}))
-                "Updated :schema/price should have been allowed, and entire product is visible in query."))
-          (let [update-name @(fluree/stage db+policy {:id          :ex/widget
-                                                      :schema/name "Widget2"}
-                                           {:role :ex/userRole})]
+              (is (= [{:id :ex/widget,
+                       :rdf/type [:ex/Product],
+                       :schema/name "Widget",
+                       :schema/price 105.99,
+                       :schema/priceCurrency "USD"}]
+                     @(fluree/query update-price
+                                    {:select {'?s [:*]}
+                                     :where  [['?s :rdf/type :ex/Product]]}))
+                  "Updated :schema/price should have been allowed, and entire product is visible in query."))
+            (let [update-name @(fluree/stage db+policy
+                                             {:id          :ex/widget
+                                              :schema/name "Widget2"}
+                                             {:role :ex/userRole})]
 
-            (is (= [{:rdf/type    [:ex/Product]
-                     :schema/name "Widget2"}]
-                   @(fluree/query update-name
-                                  {:select {'?s [:*]}
-                                   :where  [['?s :rdf/type :ex/Product]]}))
-                "Updated :schema/name should have been allowed, and only name is visible in query."))))
-
+              (is (= [{:rdf/type    [:ex/Product]
+                       :schema/name "Widget2"}]
+                     @(fluree/query update-name
+                                    {:select {'?s [:*]}
+                                     :where  [['?s :rdf/type :ex/Product]]
+                                     :opts {:role :ex/userRole}}))
+                  "Updated :schema/name should have been allowed, and only name is visible in query."))))
       (testing "Policy doesn't allow a modification"
         (let [update-price @(fluree/stage db+policy {:id           :ex/widget
                                                      :schema/price 42.99}


### PR DESCRIPTION
- stage
- query
- multiquery
- history

In order to handle string requests, we need to understand string when discerning whether we're dealing with an insert or a retract, so there are a couple updates to handle that (fql.parse/update? and update/insert? and update/retract?).

In each case we unwrap the credential subject before parsing. We only use a limited subset of the credential spec internally, but the wide world of credentials has a very large schema and I didn't want to include it in our internal query/transaction schema.

https://github.com/fluree/core/issues/2