### PR TITLE
Ensure objects of `fluree:targetClass` are correctly handled as types, regardless of txn order

### DIFF
--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -179,6 +179,7 @@
 
 ;; fluree-specific
 (def ^:const $fluree:context 250)
+(def ^:const $fluree:targetClass 255)
 
 ;; owl
 (def ^:const $owl:Class 245)

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -78,6 +78,7 @@
           ;; fluree
           "https://ns.flur.ee/ledger#context"                   const/$fluree:context
           const/iri-role                                        const/$_role
+          const/iri-target-class                                const/$fluree:targetClass
           const/iri-default-context                             const/$fluree:default-context}))
 
 (def predefined-sids
@@ -125,6 +126,7 @@
                           (#{const/$rdfs:subClassOf
                              const/$sh:path const/$sh:ignoredProperties
                              const/$sh:targetClass
+                             const/$fluree:targetClass
                              const/$sh:targetSubjectsOf const/$sh:targetObjectsOf
                              const/$sh:equals
                              const/$sh:disjoint

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -63,24 +63,17 @@
            class-sids   #{}
            class-flakes #{}]
       (if class-iri
-        (if-let [existing-type-sid (<? (jld-reify/get-iri-sid class-iri db-before iris))]
-          (let [class-flake (-> (query-range/index-range db-before :spot = [existing-type-sid const/$rdf:type const/$rdfs:Class])
-                               <?
-                               first)]
-            (if class-flake
-              (recur r (conj class-sids existing-type-sid) class-flakes)
-              (recur r
-                     (conj class-sids existing-type-sid)
-                     (conj class-flakes (flake/create existing-type-sid const/$rdf:type const/$rdfs:Class const/$xsd:anyURI t true nil)))))
-          (let [new-type-sid (if-let [predefined-pid (get jld-ledger/predefined-properties class-iri)]
+        (if-let [existing (<? (jld-reify/get-iri-sid class-iri db-before iris))]
+          (recur r (conj class-sids existing) class-flakes)
+          (let [type-sid (if-let [predefined-pid (get jld-ledger/predefined-properties class-iri)]
                            predefined-pid
                            (next-pid))]
-            (vswap! iris assoc class-iri new-type-sid)
+            (vswap! iris assoc class-iri type-sid)
             (recur r
-                   (conj class-sids new-type-sid)
+                   (conj class-sids type-sid)
                    (conj class-flakes
-                         (flake/create new-type-sid const/$xsd:anyURI class-iri const/$xsd:string t true nil)
-                         (flake/create new-type-sid const/$rdf:type const/$rdfs:Class const/$xsd:anyURI t true nil)))))
+                         (flake/create type-sid const/$xsd:anyURI class-iri const/$xsd:string t true nil)
+                         (flake/create type-sid const/$rdf:type const/$rdfs:Class const/$xsd:anyURI t true nil)))))
         [class-sids class-flakes]))))
 
 

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -63,17 +63,24 @@
            class-sids   #{}
            class-flakes #{}]
       (if class-iri
-        (if-let [existing (<? (jld-reify/get-iri-sid class-iri db-before iris))]
-          (recur r (conj class-sids existing) class-flakes)
-          (let [type-sid (if-let [predefined-pid (get jld-ledger/predefined-properties class-iri)]
+        (if-let [existing-type-sid (<? (jld-reify/get-iri-sid class-iri db-before iris))]
+          (let [class-flake (-> (query-range/index-range db-before :spot = [existing-type-sid const/$rdf:type const/$rdfs:Class])
+                               <?
+                               first)]
+            (if class-flake
+              (recur r (conj class-sids existing-type-sid) class-flakes)
+              (recur r
+                     (conj class-sids existing-type-sid)
+                     (conj class-flakes (flake/create existing-type-sid const/$rdf:type const/$rdfs:Class const/$xsd:anyURI t true nil)))))
+          (let [new-type-sid (if-let [predefined-pid (get jld-ledger/predefined-properties class-iri)]
                            predefined-pid
                            (next-pid))]
-            (vswap! iris assoc class-iri type-sid)
+            (vswap! iris assoc class-iri new-type-sid)
             (recur r
-                   (conj class-sids type-sid)
+                   (conj class-sids new-type-sid)
                    (conj class-flakes
-                         (flake/create type-sid const/$xsd:anyURI class-iri const/$xsd:string t true nil)
-                         (flake/create type-sid const/$rdf:type const/$rdfs:Class const/$xsd:anyURI t true nil)))))
+                         (flake/create new-type-sid const/$xsd:anyURI class-iri const/$xsd:string t true nil)
+                         (flake/create new-type-sid const/$rdf:type const/$rdfs:Class const/$xsd:anyURI t true nil)))))
         [class-sids class-flakes]))))
 
 

--- a/test/fluree/db/policy/parsing_test.clj
+++ b/test/fluree/db/policy/parsing_test.clj
@@ -98,7 +98,7 @@
                                         const/iri-target-role {:_id sid-userRole}
                                         :function             [true
                                                                ::replaced-policy-function]
-                                        "@id"                 "_:f211106232533008"}}}}
+                                        "@id"                 "_:f211106232533007"}}}}
                   const/iri-view
                   {:class
                    {sid-User {sid-ssn  {const/iri-equals      [{"@id" const/iri-$identity}

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -101,10 +101,4 @@
         (is (= users
                @(fluree/query db-data-first user-query)))
         (is (= users
-               @(fluree/query db-policy-first user-query))))
-      (let [types [{:id :f/Policy, :rdf/type [:rdfs/Class]}
-                   {:id :ex/User, :rdf/type [:rdfs/Class]}]]
-        (is (= (into #{} types)
-               (into #{} @(fluree/query db-data-first class-query))))
-        (is (= (into #{} types)
-               (into #{} @(fluree/query db-policy-first class-query))))))))
+               @(fluree/query db-policy-first user-query)))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -1,5 +1,6 @@
 (ns fluree.db.transact.transact-test
   (:require [clojure.test :refer :all]
+            [fluree.db.did :as did]
             [fluree.db.util.core :as util]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.json-ld.api :as fluree]
@@ -63,3 +64,47 @@
               [:id :id "@id"]]
              @(fluree/query db-bool '{:select  [?s ?p ?o]
                                       :where   [[?s ?p ?o]]}))))))
+
+
+(deftest policy-ordering-test
+  (testing "transaction order does not affect query results"
+    (let [conn            (test-utils/create-conn)
+          ledger          @(fluree/create conn "tx/policy-order" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+          alice-did       (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+          data            [{:id          :ex/alice,
+                            :type        :ex/User,
+                            :schema/name "Alice"}
+                           {:id          :ex/john,
+                            :type        :ex/User,
+                            :schema/name "John"}
+                           {:id      alice-did
+                            :ex/user :ex/alice
+                            :f/role  :ex/userRole}]
+          policy          [{:id            :ex/UserPolicy,
+                            :type          [:f/Policy],
+                            :f/targetClass :ex/User
+                            :f/allow       [{:id           :ex/globalViewAllow
+                                             :f/targetRole :ex/userRole
+                                             :f/action     [:f/view]}]}]
+          db-data-first   @(fluree/stage
+                             (fluree/db ledger)
+                             (into data policy))
+          db-policy-first @(fluree/stage
+                             (fluree/db ledger)
+                             (into policy data))
+          user-query      '{:select {?s [:*]}
+                            :where  [[?s :rdf/type :ex/User]]}
+          class-query     '{:select {?type [:*]}
+                            :where  [[?type :rdf/type :rdfs/Class]]}]
+      (let [users [{:id :ex/john, :rdf/type [:ex/User], :schema/name "John"}
+                   {:id :ex/alice, :rdf/type [:ex/User], :schema/name "Alice"}]]
+        (is (= users
+               @(fluree/query db-data-first user-query)))
+        (is (= users
+               @(fluree/query db-policy-first user-query))))
+      (let [types [{:id :f/Policy, :rdf/type [:rdfs/Class]}
+                   {:id :ex/User, :rdf/type [:rdfs/Class]}]]
+        (is (= (into #{} types)
+               (into #{} @(fluree/query db-data-first class-query))))
+        (is (= (into #{} types)
+               (into #{} @(fluree/query db-policy-first class-query))))))))


### PR DESCRIPTION
Closes #435 

1. Adds `fluree:targetClass` to the list of predefined properties 

    This fixes queries with clauses like `[?s :rdf/type :ex/User]`, where `:ex/User` appeared first as a `fluree:targetClass`.

4. When transacting, we go through the types we see and only create flakes for "new" types. However, previously we just checked if a subject id for a given type already existed, and if so, did not create any flakes for it. 

     But in the case where a type first appears as the object of `fluree:targetClass`[*], we would create _only_ an "iri flake". This would mean we had a subject id, and with previous logic, we would consider this type already-created and would not make any flakes for it. However, we would end up missing the flake assigning it to type `rdfs:Class`. With this change, we create this additional flake if necessary.

    This fixes queries with clauses like `[?s :rdf/type :rdfs:Class]`, ensuring the `fluree:targetClass` appears in the results.


[*] I did not check, but I suspect the same would have happened with types that first appeared under `sh:targetClass` as well