### PR TITLE
don't treat sh:class constraint as a sh:nodeKind constraint

### DIFF
--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -328,7 +328,7 @@
           ;; Note that multiple values for sh:class are interpreted as a conjunction,
           ;; i.e. the values need to be SHACL instances of all of them.
           const/$sh:class
-          (assoc acc :node-kind o)
+          (assoc acc :class o)
 
           const/$sh:pattern
           (assoc acc :pattern o)


### PR DESCRIPTION
This test isn't very high value, but it fails before and passes now.

The problem was treating a "sh:class" property constraint as a "sh:nodeKind" constraint. When attempting to register the nodekind in our schema cache it would blow up, because the class sid was not one of the 6 supported nodekinds.

Addresses [#458](https://github.com/fluree/db/issues/458)

