### PR TITLE
transaction numeric, string, datetime, and hash functions

### DIFF
--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -10,7 +10,10 @@
             [fluree.db.datatype :as datatype]
             [fluree.crypto :as crypto]
             [fluree.db.constants :as const])
-  #?(:clj (:import (java.time Instant))))
+  #?(:clj (:import (java.time Instant)
+                   (java.time OffsetDateTime LocalDateTime))))
+
+#?(:clj (set! *warn-on-reflection* true))
 
 (defn sum
   [coll]
@@ -169,42 +172,42 @@
 
 (defn year
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     (.getYear datetime)))
 
 (defn month
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     #?(:clj (.getMonthValue datetime)
        :cljs (.getMonth datetime))))
 
 (defn day
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     #?(:clj (.getDayOfMonth datetime)
        :cljs (.getDate datetime))))
 
 (defn hours
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     #?(:clj (.getHour datetime)
        :cljs (.getHours datetime))))
 
 (defn minutes
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     #?(:clj (.getMinute datetime)
        :cljs (.getMinutes datetime))))
 
 (defn seconds
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     #?(:clj (.getSecond datetime)
        :cljs (.getSeconds datetime))))
 
 (defn tz
   [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  (let [datetime ^OffsetDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
     #?(:clj (.toString (.getOffset datetime))
        :cljs (.getTimeZoneOffset datetime))))
 

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -118,10 +118,10 @@
   (str/ends-with? s substr))
 
 (defn subStr
+  ;; The index of the first character in a string is 1.
   ([s start]
-   (subStr s start (count s)))
+   (subs s (dec start)))
   ([s start length]
-   ;; The index of the first character in a string is 1.
    (let [start (dec start)]
      (subs s start (min (+ start length)
                         (count s))))))

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -10,8 +10,7 @@
             [fluree.db.datatype :as datatype]
             [fluree.crypto :as crypto]
             [fluree.db.constants :as const])
-  #?(:clj (:import (java.time Instant)
-                   (java.time OffsetDateTime LocalDateTime))))
+  #?(:clj (:import (java.time Instant OffsetDateTime LocalDateTime))))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -108,7 +107,7 @@
 (defn now
   []
   #?(:clj (str (Instant/now))
-     :cljs (.toISOString (Date.))))
+     :cljs (.toISOString (js/Date.))))
 
 (defn strStarts
   [s substr]
@@ -175,43 +174,44 @@
 
 (defn year
   [datetime-string]
-  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    (.getYear datetime)))
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.getYear ^LocalDateTime datetime)
+       :cljs (.getFullYear datetime))))
 
 (defn month
   [datetime-string]
-  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    #?(:clj (.getMonthValue datetime)
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.getMonthValue ^LocalDateTime datetime)
        :cljs (.getMonth datetime))))
 
 (defn day
   [datetime-string]
-  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    #?(:clj (.getDayOfMonth datetime)
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.getDayOfMonth ^LocalDateTime datetime)
        :cljs (.getDate datetime))))
 
 (defn hours
   [datetime-string]
-  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    #?(:clj (.getHour datetime)
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.getHour ^LocalDateTime datetime)
        :cljs (.getHours datetime))))
 
 (defn minutes
   [datetime-string]
-  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    #?(:clj (.getMinute datetime)
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.getMinute ^LocalDateTime datetime)
        :cljs (.getMinutes datetime))))
 
 (defn seconds
   [datetime-string]
-  (let [datetime ^LocalDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    #?(:clj (.getSecond datetime)
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.getSecond ^LocalDateTime datetime)
        :cljs (.getSeconds datetime))))
 
 (defn tz
   [datetime-string]
-  (let [datetime ^OffsetDateTime (datatype/coerce datetime-string const/$xsd:dateTime)]
-    #?(:clj (.toString (.getOffset datetime))
+  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+    #?(:clj (.toString (.getOffset ^OffsetDateTime datetime))
        :cljs (.getTimeZoneOffset datetime))))
 
 (defn sha256

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -107,7 +107,8 @@
 
 (defn now
   []
-  #?(:clj (str (Instant/now))))
+  #?(:clj (str (Instant/now))
+     :cljs (.toISOString (Date.))))
 
 (defn strStarts
   [s substr]
@@ -221,6 +222,27 @@
   [x]
   (crypto/sha2-512 x))
 
+(defn uuid
+  []
+  (str "urn:uuid:" (random-uuid)))
+
+(defn struuid
+  []
+  (str (random-uuid)))
+
+(defn isNumeric
+  [x]
+  (number? x))
+
+(defn isBlank
+  [x]
+  (and (string? x)
+       (str/starts-with? x "_:")))
+
+(defn sparql-str
+  [x]
+  (str x))
+
 (def allowed-scalar-fns
   '#{ && || ! > < >= <= = + - * / quot and bound coalesce if nil?
      not not= or re-find re-pattern
@@ -231,7 +253,10 @@
      ;; datetime fns
      now year month day hours minutes seconds tz
      ;; hash fns
-     sha256 sha512})
+     sha256 sha512
+     ;; rdf term fns
+     uuid struuid isNumeric isBlank str
+     })
 
 (def allowed-symbols
   (set/union allowed-aggregate-fns allowed-scalar-fns))
@@ -278,6 +303,11 @@
     tz          fluree.db.query.exec.eval/tz
     sha256      fluree.db.query.exec.eval/sha256
     sha512      fluree.db.query.exec.eval/sha512
+    uuid        fluree.db.query.exec.eval/uuid
+    struuid     fluree.db.query.exec.eval/struuid
+    isNumeric   fluree.db.query.exec.eval/isNumeric
+    isBlank     fluree.db.query.exec.eval/isBlank
+    str         fluree.db.query.exec.eval/sparql-str
     })
 
 (defn variable?

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -144,15 +144,17 @@
 
 (defn strBefore
   [s substr]
-  (-> (str/split s (re-pattern substr))
-      first
-      str))
+  (let [[before :as split] (str/split s (re-pattern substr))]
+    (if (> (count split) 1)
+      before
+      "")))
 
 (defn strAfter
   [s substr]
-  (-> (str/split s (re-pattern substr))
-      last
-      str))
+  (let [split (str/split s (re-pattern substr))]
+    (if (> (count split) 1)
+      (last split)
+      "")))
 
 (defn concat
   [& strs]

--- a/src/fluree/db/query/exec/update.cljc
+++ b/src/fluree/db/query/exec/update.cljc
@@ -67,16 +67,13 @@
                 p                   (::where/val p-mch)
                 o                   (::where/val o-mch)
                 dt                  (::where/datatype o-mch)]
-            (when (and s p o dt)
+            (when (and (some? s) (some? p) (some? o) (some? dt))
               (let [s* (if-not (number? s)
                          (<? (dbproto/-subid db s true))
                          s)]
-                [(flake/create s* p o dt t true nil)]))) ; wrap created flake in
-                                                         ; a vector so the
-                                                         ; output of this
-                                                         ; function has the same
-                                                         ; shape as the retract
-                                                         ; functions
+                ;; wrap created flake in a vector so the output of this function has the
+                ;; same shape as the retract functions
+                [(flake/create s* p o dt t true nil)])))
           (catch* e
                   (log/error e "Error inserting new triple")
                   (>! error-ch e)))))

--- a/src/fluree/db/query/json_ld/response.cljc
+++ b/src/fluree/db/query/json_ld/response.cljc
@@ -139,7 +139,7 @@
                                      (not (#{:list :set} (-> context (get p-iri) :container))))
                               (first acc)
                               acc))))]
-            (if v
+            (if (some? v)
               (recur r (assoc acc p-iri v))
               (recur r acc)))
           (if reverse

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -146,7 +146,7 @@
                   :where    [[?s :schema/age ?age]
                              {:bind {?decadesOld (quot ?age 10)}}
                              [?s :schema/name ?name]
-                             {:bind {?firstLetterOfName (subStr ?name 0 1)}}]
+                             {:bind {?firstLetterOfName (subStr ?name 1 1)}}]
                   :order-by ?firstLetterOfName}
             res @(fluree/query db q)]
         (is (= [["A" "Alice" 5]
@@ -159,7 +159,7 @@
       (let [q   '{:select   [?firstLetterOfName ?name ?canVote]
                   :where    [[?s :schema/age ?age]
                              [?s :schema/name ?name]
-                             {:bind {?firstLetterOfName (subStr ?name 0 1)
+                             {:bind {?firstLetterOfName (subStr ?name 1 1)
                                      ?canVote           (>= ?age 18)}}]
                   :order-by ?name}
             res @(fluree/query db q)]

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -128,23 +128,23 @@
         db1 (fluree/db ledger)]
 
     (testing "hash functions"
-        (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
-          (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
-                                                 "ex:md5" 0 "ex:sha1" 0 "ex:sha256" 0 "ex:sha384" 0 "ex:sha512" 0}
-                                                {"id" "ex:hash-fns"
-                                                 "ex:message" "abc"}])
-                            (fluree/stage {"delete" []
-                                           "where" [["?s" "id" "ex:hash-fns"]
-                                                    ["?s" "ex:message" "?message"]
-                                                    {"bind" {"?sha256" "(sha256 ?message)"
-                                                             "?sha512" "(sha512 ?message)"}}]
-                                           "insert" [["?s" "ex:sha256" "?sha256"]
-                                                     ["?s" "ex:sha512" "?sha512"]]}))]
-            (is (= {"ex:sha512" "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
-                    "ex:sha256" "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
-                   @(fluree/query @updated {"where" [["?s" "id" "ex:hash-fns"]]
-                                            "selectOne" {"?s" ["ex:sha512"
-                                                               "ex:sha256"]}}))))))
+      (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
+        (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                               "ex:md5" 0 "ex:sha1" 0 "ex:sha256" 0 "ex:sha384" 0 "ex:sha512" 0}
+                                              {"id" "ex:hash-fns"
+                                               "ex:message" "abc"}])
+                          (fluree/stage {"delete" []
+                                         "where" [["?s" "id" "ex:hash-fns"]
+                                                  ["?s" "ex:message" "?message"]
+                                                  {"bind" {"?sha256" "(sha256 ?message)"
+                                                           "?sha512" "(sha512 ?message)"}}]
+                                         "insert" [["?s" "ex:sha256" "?sha256"]
+                                                   ["?s" "ex:sha512" "?sha512"]]}))]
+          (is (= {"ex:sha512" "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+                  "ex:sha256" "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+                 @(fluree/query @updated {"where" [["?s" "id" "ex:hash-fns"]]
+                                          "selectOne" {"?s" ["ex:sha512"
+                                                             "ex:sha256"]}}))))))
     (testing "datetime functions"
       (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
         (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
@@ -325,37 +325,66 @@
                                                              "ex:uuid"
                                                              "ex:struuid"]}}))))))
 
-    ;; errors: undefined symbol, type error, mismatching parens
     (testing "functional forms"
-        (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
-                                               "ex:bound" 0
-                                               "ex:if" 0
-                                               "ex:coalesce" 0
-                                               "ex:not-exists" 0
-                                               "ex:exists" 0
-                                               "ex:logical-or" 0
-                                               "ex:logical-and" 0
-                                               "ex:rdfterm-equal" 0
-                                               "ex:sameTerm" 0
-                                               "ex:in" 0
-                                               "ex:not-in" 0}
-                                              {"id" "ex:functional-fns"
-                                               "ex:text" "Abcdefg"}])
-                          (fluree/stage {"delete" []
-                                         "where" [["?s" "id" "ex:functional-fns"]
-                                                  ["?s" "ex:text" "?text"]
-                                                  {"bind" {"?bound" "(bound ?text)"}}]
-                                         "insert" [["?s" "ex:bound" "?bound"]]}))]
-          (is (= {"ex:bound" true}
-                 @(fluree/query @updated {"where" [["?s" "id" "ex:functional-fns"]]
-                                          "selectOne" {"?s" ["ex:bound"
-                                                             "ex:if"
-                                                             "ex:coalesce"
-                                                             "ex:not-exists"
-                                                             "ex:exists"
-                                                             "ex:logical-or"
-                                                             "ex:logical-and"
-                                                             "ex:rdfterm-equal"
-                                                             "ex:sameTerm"
-                                                             "ex:in"
-                                                             "ex:not-in"]}})))))))
+      (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                             "ex:bound" 0
+                                             "ex:if" 0
+                                             "ex:coalesce" 0
+                                             "ex:not-exists" 0
+                                             "ex:exists" 0
+                                             "ex:logical-or" 0
+                                             "ex:logical-and" 0
+                                             "ex:rdfterm-equal" 0
+                                             "ex:sameTerm" 0
+                                             "ex:in" 0
+                                             "ex:not-in" 0}
+                                            {"id" "ex:functional-fns"
+                                             "ex:text" "Abcdefg"}])
+                        (fluree/stage {"delete" []
+                                       "where" [["?s" "id" "ex:functional-fns"]
+                                                ["?s" "ex:text" "?text"]
+                                                {"bind" {"?bound" "(bound ?text)"}}]
+                                       "insert" [["?s" "ex:bound" "?bound"]]}))]
+        (is (= {"ex:bound" true}
+               @(fluree/query @updated {"where" [["?s" "id" "ex:functional-fns"]]
+                                        "selectOne" {"?s" ["ex:bound"
+                                                           "ex:if"
+                                                           "ex:coalesce"
+                                                           "ex:not-exists"
+                                                           "ex:exists"
+                                                           "ex:logical-or"
+                                                           "ex:logical-and"
+                                                           "ex:rdfterm-equal"
+                                                           "ex:sameTerm"
+                                                           "ex:in"
+                                                           "ex:not-in"]}})))))
+    (testing "error handling"
+      (let [db2 @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                     "ex:text" 0
+                                     "ex:error" 0}
+                                    {"id" "ex:error"
+                                     "ex:text" "Abcdefg"}])
+            parse-err @(fluree/stage db2 {"delete" []
+                                          "where" [["?s" "id" "ex:error"]
+                                                   ["?s" "ex:text" "?text"]
+                                                   {"bind" {"?err" "(foo ?text)"}}]
+                                          "insert" [["?s" "ex:text" "?err"]]})
+
+            run-err   @(fluree/stage db2 {"delete" []
+                                          "where" [["?s" "id" "ex:error"]
+                                                   ["?s" "ex:text" "?text"]
+                                                   {"bind" {"?err" "(abs ?text)"}}]
+                                          "insert" [["?s" "ex:error" "?err"]]})]
+        (is (= "Query function references illegal symbol: foo"
+               (-> parse-err
+                   Throwable->map
+                   :cause))
+            "mdfn parse error")
+        (is (= "Query function references illegal symbol: foo"
+               (-> @(fluree/query db2 {"where" [["?s" "id" "ex:error"]
+                                                ["?s" "ex:text" "?text"]
+                                                {"bind" {"?err" "(foo ?text)"}}]
+                                       "select" "?err"})
+                   Throwable->map
+                   :cause))
+            "query parse error")))))

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -125,50 +125,14 @@
   (let [conn @(fluree/connect {:method :memory})
         ledger @(fluree/create conn "functions" {:defaultContext [test-utils/default-str-context
                                                                   {"ex" "http://example.com/"}]})
-        db0 (fluree/db ledger)
-        db1 @(fluree/stage db0 [{"id" "ex:create-predicates"
-                                 ;; string functions
-                                 "ex:strLen" 0
-                                 "ex:subStr" 0
-                                 "ex:ucase" 0
-                                 "ex:lcase" 0
-                                 "ex:strStarts" 0
-                                 "ex:strEnds" 0
-                                 "ex:contains" 0
-                                 "ex:strBefore" 0
-                                 "ex:strAfter" 0
-                                 "ex:encodeForUri" 0
-                                 "ex:concat" 0
-                                 "ex:langMatches" 0
-                                 "ex:regex" 0
-                                 "ex:replace" 0
-                                 ;; numeric functions
-                                 "ex:abs" 0
-                                 "ex:round" 0
-                                 "ex:ceil" 0
-                                 "ex:floor" 0
-                                 "ex:rand" 0
-                                 ;; date/time functions
-                                 "ex:now" 0
-                                 "ex:year" 0
-                                 "ex:month" 0
-                                 "ex:day" 0
-                                 "ex:hours" 0
-                                 "ex:minutes" 0
-                                 "ex:seconds" 0
-                                 "ex:timezone" 0
-                                 "ex:tz" 0
-                                 ;; hash functions
-                                 "ex:md5" 0
-                                 "ex:sha1" 0
-                                 "ex:sha256" 0
-                                 "ex:sha384" 0
-                                 "ex:sha512" 0}])]
+        db1 (fluree/db ledger)]
 
     (testing "hash functions"
       (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
-        (let [updated (-> @(fluree/stage db1 {"id" "ex:hash-fns"
-                                              "ex:message" "abc"})
+        (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                               "ex:md5" 0 "ex:sha1" 0 "ex:sha256" 0 "ex:sha384" 0 "ex:sha512" 0}
+                                              {"id" "ex:hash-fns"
+                                               "ex:message" "abc"}])
                           (fluree/stage {"delete" []
                                          "where" [["?s" "id" "ex:hash-fns"]
                                                   ["?s" "ex:message" "?message"]
@@ -183,10 +147,13 @@
                                                              "ex:sha256"]}}))))))
     (testing "datetime functions"
       (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
-        (let [updated (-> @(fluree/stage db1 {"id" "ex:datetime-fns"
-                                              "ex:localdatetime" "2023-06-13T14:17:22.435"
-                                              "ex:offsetdatetime" "2023-06-13T14:17:22.435-05:00"
-                                              "ex:utcdatetime" "2023-06-13T14:17:22.435Z"})
+        (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                               "ex:now" 0 "ex:year" 0 "ex:month" 0 "ex:day" 0 "ex:hours" 0
+                                               "ex:minutes" 0 "ex:seconds" 0 "ex:timezone" 0 "ex:tz" 0}
+                                              {"id" "ex:datetime-fns"
+                                               "ex:localdatetime" "2023-06-13T14:17:22.435"
+                                               "ex:offsetdatetime" "2023-06-13T14:17:22.435-05:00"
+                                               "ex:utcdatetime" "2023-06-13T14:17:22.435Z"}])
                           (fluree/stage {"delete" []
                                          "where" [["?s" "id" "ex:datetime-fns"]
                                                   ["?s" "ex:localdatetime" "?localdatetime"]
@@ -219,20 +186,16 @@
                   "ex:seconds" 22
                   "ex:tz" ["-05:00" "Z"]}
                  @(fluree/query @updated {"where" [["?s" "id" "ex:datetime-fns"]]
-                                          "selectOne" {"?s" ["ex:now"
-                                                             "ex:year"
-                                                             "ex:month"
-                                                             "ex:day"
-                                                             "ex:hours"
-                                                             "ex:minutes"
-                                                             "ex:seconds"
+                                          "selectOne" {"?s" ["ex:now" "ex:year" "ex:month" "ex:day" "ex:hours" "ex:minutes" "ex:seconds"
                                                              "ex:tz"]}}))))))
 
     (testing "numeric functions"
-      (let [updated (-> @(fluree/stage db1 {"id" "ex:numeric-fns"
-                                            "ex:pos-int" 2
-                                            "ex:neg-int" -2
-                                            "ex:decimal" 1.4})
+      (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                             "ex:abs" 0 "ex:round" 0 "ex:ceil" 0 "ex:floor" 0 "ex:rand" 0}
+                                            {"id" "ex:numeric-fns"
+                                             "ex:pos-int" 2
+                                             "ex:neg-int" -2
+                                             "ex:decimal" 1.4}])
                         (fluree/stage {"delete" []
                                        "where" [["?s" "id" "ex:numeric-fns"]
                                                 ["?s" "ex:pos-int" "?pos-int"]
@@ -262,7 +225,12 @@
                                            "selectOne" "?rand"})))))
 
     (testing "string functions"
-      (let [updated  (-> @(fluree/stage db1 {"id" "ex:string-fns" "ex:text" "Abcdefg"})
+      (let [updated  (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                              "ex:strLen" 0 "ex:subStr" 0 "ex:ucase" 0 "ex:lcase" 0 "ex:strStarts" 0 "ex:strEnds" 0
+                                              "ex:contains" 0 "ex:strBefore" 0 "ex:strAfter" 0 "ex:encodeForUri" 0 "ex:concat" 0
+                                              "ex:langMatches" 0 "ex:regex" 0 "ex:replace" 0}
+                                             {"id" "ex:string-fns"
+                                              "ex:text" "Abcdefg"}])
                          (fluree/stage {"delete" []
                                         "where" [["?s" "id" "ex:string-fns"]
                                                  ["?s" "ex:text" "?text"]
@@ -302,20 +270,9 @@
                 "ex:strAfter" "efg"
                 "ex:concat" "Abcdefg STR1 STR2"}
                @(fluree/query @updated {"where" [["?s" "id" "ex:string-fns"]]
-                                        "selectOne" {"?s" ["ex:strLen"
-                                                           "ex:subStr"
-                                                           "ex:ucase"
-                                                           "ex:lcase"
-                                                           "ex:strStarts"
-                                                           "ex:strEnds"
-                                                           "ex:contains"
-                                                           "ex:strBefore"
-                                                           "ex:strAfter"
-                                                           "ex:encodeForUri"
-                                                           "ex:concat"
-                                                           "ex:langMatches"
-                                                           "ex:regex"
-                                                           "ex:replace"]}})))))
+                                        "selectOne" {"?s" ["ex:strLen" "ex:subStr" "ex:ucase" "ex:lcase" "ex:strStarts" "ex:strEnds"
+                                                           "ex:contains" "ex:strBefore" "ex:strAfter" "ex:encodeForUri" "ex:concat"
+                                                           "ex:langMatches" "ex:regex" "ex:replace"]}})))))
 
     #_(testing "functional forms")
     #_(testing "scalar functions")))

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -128,23 +128,23 @@
         db1 (fluree/db ledger)]
 
     (testing "hash functions"
-      (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
-        (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
-                                               "ex:md5" 0 "ex:sha1" 0 "ex:sha256" 0 "ex:sha384" 0 "ex:sha512" 0}
-                                              {"id" "ex:hash-fns"
-                                               "ex:message" "abc"}])
-                          (fluree/stage {"delete" []
-                                         "where" [["?s" "id" "ex:hash-fns"]
-                                                  ["?s" "ex:message" "?message"]
-                                                  {"bind" {"?sha256" "(sha256 ?message)"}}
-                                                  {"bind" {"?sha512" "(sha512 ?message)"}}]
-                                         "insert" [["?s" "ex:sha256" "?sha256"]
-                                                   ["?s" "ex:sha512" "?sha512"]]}))]
-          (is (= {"ex:sha512" "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
-                  "ex:sha256" "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
-                 @(fluree/query @updated {"where" [["?s" "id" "ex:hash-fns"]]
-                                          "selectOne" {"?s" ["ex:sha512"
-                                                             "ex:sha256"]}}))))))
+        (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
+          (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
+                                                 "ex:md5" 0 "ex:sha1" 0 "ex:sha256" 0 "ex:sha384" 0 "ex:sha512" 0}
+                                                {"id" "ex:hash-fns"
+                                                 "ex:message" "abc"}])
+                            (fluree/stage {"delete" []
+                                           "where" [["?s" "id" "ex:hash-fns"]
+                                                    ["?s" "ex:message" "?message"]
+                                                    {"bind" {"?sha256" "(sha256 ?message)"
+                                                             "?sha512" "(sha512 ?message)"}}]
+                                           "insert" [["?s" "ex:sha256" "?sha256"]
+                                                     ["?s" "ex:sha512" "?sha512"]]}))]
+            (is (= {"ex:sha512" "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+                    "ex:sha256" "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+                   @(fluree/query @updated {"where" [["?s" "id" "ex:hash-fns"]]
+                                            "selectOne" {"?s" ["ex:sha512"
+                                                               "ex:sha256"]}}))))))
     (testing "datetime functions"
       (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
         (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
@@ -159,15 +159,15 @@
                                                   ["?s" "ex:localdatetime" "?localdatetime"]
                                                   ["?s" "ex:offsetdatetime" "?offsetdatetime"]
                                                   ["?s" "ex:utcdatetime" "?utcdatetime"]
-                                                  {"bind" {"?now" "(now)"}}
-                                                  {"bind" {"?year" "(year ?localdatetime)"}}
-                                                  {"bind" {"?month" "(month ?localdatetime)"}}
-                                                  {"bind" {"?day" "(day ?localdatetime)"}}
-                                                  {"bind" {"?hours" "(hours ?localdatetime)"}}
-                                                  {"bind" {"?minutes" "(minutes ?localdatetime)"}}
-                                                  {"bind" {"?seconds" "(seconds ?localdatetime)"}}
-                                                  {"bind" {"?tz1" "(tz ?utcdatetime)"}}
-                                                  {"bind" {"?tz2" "(tz ?offsetdatetime)"}}]
+                                                  {"bind" {"?now" "(now)"
+                                                           "?year" "(year ?localdatetime)"
+                                                           "?month" "(month ?localdatetime)"
+                                                           "?day" "(day ?localdatetime)"
+                                                           "?hours" "(hours ?localdatetime)"
+                                                           "?minutes" "(minutes ?localdatetime)"
+                                                           "?seconds" "(seconds ?localdatetime)"
+                                                           "?tz1" "(tz ?utcdatetime)"
+                                                           "?tz2" "(tz ?offsetdatetime)"}}]
                                          "insert" [["?s" "ex:now" "?now"]
                                                    ["?s" "ex:year" "?year"]
                                                    ["?s" "ex:month" "?month"]
@@ -201,11 +201,11 @@
                                                 ["?s" "ex:pos-int" "?pos-int"]
                                                 ["?s" "ex:neg-int" "?neg-int"]
                                                 ["?s" "ex:decimal" "?decimal"]
-                                                {"bind" {"?abs" "(abs ?neg-int)"}}
-                                                {"bind" {"?round" "(round ?decimal)"}}
-                                                {"bind" {"?ceil" "(ceil ?decimal)"}}
-                                                {"bind" {"?floor" "(floor ?decimal)"}}
-                                                {"bind" {"?rand" "(rand)"}}]
+                                                {"bind" {"?abs" "(abs ?neg-int)"
+                                                         "?round" "(round ?decimal)"
+                                                         "?ceil" "(ceil ?decimal)"
+                                                         "?floor" "(floor ?decimal)"
+                                                         "?rand" "(rand)"}}]
                                        "insert" [["?s" "ex:abs" "?abs"]
                                                  ["?s" "ex:round" "?round"]
                                                  ["?s" "ex:ceil" "?ceil"]
@@ -234,18 +234,18 @@
                          (fluree/stage {"delete" []
                                         "where" [["?s" "id" "ex:string-fns"]
                                                  ["?s" "ex:text" "?text"]
-                                                 {"bind" {"?strlen" "(strLen ?text)"}}
-                                                 {"bind" {"?sub1" "(subStr ?text 5)"}}
-                                                 {"bind" {"?sub2" "(subStr ?text 1 4)"}}
-                                                 {"bind" {"?upcased" "(ucase ?text)"}}
-                                                 {"bind" {"?downcased" "(lcase ?text)"}}
-                                                 {"bind" {"?a-start" "(strStarts ?text \"x\")"}}
-                                                 {"bind" {"?a-end" "(strEnds ?text \"x\")"}}
-                                                 {"bind" {"?contains" "(contains ?text \"x\")"}}
-                                                 {"bind" {"?strBefore" "(strBefore ?text \"bcd\")"}}
-                                                 {"bind" {"?strAfter" "(strAfter ?text \"bcd\")"}}
-                                                 {"bind" {"?concatted" "(concat ?text \" \" \"STR1 \" \"STR2\")"}}
-                                                 {"bind" {"?matched" "(regex ?text \"^Abc\")"}}]
+                                                 {"bind" {"?strlen" "(strLen ?text)"
+                                                          "?sub1" "(subStr ?text 5)"
+                                                          "?sub2" "(subStr ?text 1 4)"
+                                                          "?upcased" "(ucase ?text)"
+                                                          "?downcased" "(lcase ?text)"
+                                                          "?a-start" "(strStarts ?text \"x\")"
+                                                          "?a-end" "(strEnds ?text \"x\")"
+                                                          "?contains" "(contains ?text \"x\")"
+                                                          "?strBefore" "(strBefore ?text \"bcd\")"
+                                                          "?strAfter" "(strAfter ?text \"bcd\")"
+                                                          "?concatted" "(concat ?text \" \" \"STR1 \" \"STR2\")"
+                                                          "?matched" "(regex ?text \"^Abc\")"}}]
                                         "insert" [["?s" "ex:strStarts" "?a-start"]
                                                   ["?s" "ex:strEnds" "?a-end"]
                                                   ["?s" "ex:subStr" "?sub1"]

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -120,3 +120,202 @@
                               '{:select {?s [:*]}
                                 :where  [[?s :id :ex/jane]]}))
             "Jane's age should now be updated to 31 (from 30).")))))
+
+(deftest transaction-functions
+  (let [conn @(fluree/connect {:method :memory})
+        ledger @(fluree/create conn "functions" {:defaultContext [test-utils/default-str-context
+                                                                  {"ex" "http://example.com/"}]})
+        db0 (fluree/db ledger)
+        db1 @(fluree/stage db0 [{"id" "ex:create-predicates"
+                                 ;; string functions
+                                 "ex:strLen" 0
+                                 "ex:subStr" 0
+                                 "ex:ucase" 0
+                                 "ex:lcase" 0
+                                 "ex:strStarts" 0
+                                 "ex:strEnds" 0
+                                 "ex:contains" 0
+                                 "ex:strBefore" 0
+                                 "ex:strAfter" 0
+                                 "ex:encodeForUri" 0
+                                 "ex:concat" 0
+                                 "ex:langMatches" 0
+                                 "ex:regex" 0
+                                 "ex:replace" 0
+                                 ;; numeric functions
+                                 "ex:abs" 0
+                                 "ex:round" 0
+                                 "ex:ceil" 0
+                                 "ex:floor" 0
+                                 "ex:rand" 0
+                                 ;; date/time functions
+                                 "ex:now" 0
+                                 "ex:year" 0
+                                 "ex:month" 0
+                                 "ex:day" 0
+                                 "ex:hours" 0
+                                 "ex:minutes" 0
+                                 "ex:seconds" 0
+                                 "ex:timezone" 0
+                                 "ex:tz" 0
+                                 ;; hash functions
+                                 "ex:md5" 0
+                                 "ex:sha1" 0
+                                 "ex:sha256" 0
+                                 "ex:sha384" 0
+                                 "ex:sha512" 0}])]
+
+    (testing "hash functions"
+      (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
+        (let [updated (-> @(fluree/stage db1 {"id" "ex:hash-fns"
+                                              "ex:message" "abc"})
+                          (fluree/stage {"delete" []
+                                         "where" [["?s" "id" "ex:hash-fns"]
+                                                  ["?s" "ex:message" "?message"]
+                                                  {"bind" {"?sha256" "(sha256 ?message)"}}
+                                                  {"bind" {"?sha512" "(sha512 ?message)"}}]
+                                         "insert" [["?s" "ex:sha256" "?sha256"]
+                                                   ["?s" "ex:sha512" "?sha512"]]}))]
+          (is (= {"ex:sha512" "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+                  "ex:sha256" "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+                 @(fluree/query @updated {"where" [["?s" "id" "ex:hash-fns"]]
+                                          "selectOne" {"?s" ["ex:sha512"
+                                                             "ex:sha256"]}}))))))
+    (testing "datetime functions"
+      (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
+        (let [updated (-> @(fluree/stage db1 {"id" "ex:datetime-fns"
+                                              "ex:localdatetime" "2023-06-13T14:17:22.435"
+                                              "ex:offsetdatetime" "2023-06-13T14:17:22.435-05:00"
+                                              "ex:utcdatetime" "2023-06-13T14:17:22.435Z"})
+                          (fluree/stage {"delete" []
+                                         "where" [["?s" "id" "ex:datetime-fns"]
+                                                  ["?s" "ex:localdatetime" "?localdatetime"]
+                                                  ["?s" "ex:offsetdatetime" "?offsetdatetime"]
+                                                  ["?s" "ex:utcdatetime" "?utcdatetime"]
+                                                  {"bind" {"?now" "(now)"}}
+                                                  {"bind" {"?year" "(year ?localdatetime)"}}
+                                                  {"bind" {"?month" "(month ?localdatetime)"}}
+                                                  {"bind" {"?day" "(day ?localdatetime)"}}
+                                                  {"bind" {"?hours" "(hours ?localdatetime)"}}
+                                                  {"bind" {"?minutes" "(minutes ?localdatetime)"}}
+                                                  {"bind" {"?seconds" "(seconds ?localdatetime)"}}
+                                                  {"bind" {"?tz1" "(tz ?utcdatetime)"}}
+                                                  {"bind" {"?tz2" "(tz ?offsetdatetime)"}}]
+                                         "insert" [["?s" "ex:now" "?now"]
+                                                   ["?s" "ex:year" "?year"]
+                                                   ["?s" "ex:month" "?month"]
+                                                   ["?s" "ex:day" "?day"]
+                                                   ["?s" "ex:hours" "?hours"]
+                                                   ["?s" "ex:minutes" "?minutes"]
+                                                   ["?s" "ex:seconds" "?seconds"]
+                                                   ["?s" "ex:tz" "?tz1"]
+                                                   ["?s" "ex:tz" "?tz2"]]}))]
+          (is (= {"ex:now" "2023-06-13T19:53:57.234345Z"
+                  "ex:year" 2023
+                  "ex:month" 6
+                  "ex:day" 13
+                  "ex:hours" 14
+                  "ex:minutes" 17
+                  "ex:seconds" 22
+                  "ex:tz" ["-05:00" "Z"]}
+                 @(fluree/query @updated {"where" [["?s" "id" "ex:datetime-fns"]]
+                                          "selectOne" {"?s" ["ex:now"
+                                                             "ex:year"
+                                                             "ex:month"
+                                                             "ex:day"
+                                                             "ex:hours"
+                                                             "ex:minutes"
+                                                             "ex:seconds"
+                                                             "ex:tz"]}}))))))
+
+    (testing "numeric functions"
+      (let [updated (-> @(fluree/stage db1 {"id" "ex:numeric-fns"
+                                            "ex:pos-int" 2
+                                            "ex:neg-int" -2
+                                            "ex:decimal" 1.4})
+                        (fluree/stage {"delete" []
+                                       "where" [["?s" "id" "ex:numeric-fns"]
+                                                ["?s" "ex:pos-int" "?pos-int"]
+                                                ["?s" "ex:neg-int" "?neg-int"]
+                                                ["?s" "ex:decimal" "?decimal"]
+                                                {"bind" {"?abs" "(abs ?neg-int)"}}
+                                                {"bind" {"?round" "(round ?decimal)"}}
+                                                {"bind" {"?ceil" "(ceil ?decimal)"}}
+                                                {"bind" {"?floor" "(floor ?decimal)"}}
+                                                {"bind" {"?rand" "(rand)"}}]
+                                       "insert" [["?s" "ex:abs" "?abs"]
+                                                 ["?s" "ex:round" "?round"]
+                                                 ["?s" "ex:ceil" "?ceil"]
+                                                 ["?s" "ex:floor" "?floor"]
+                                                 ["?s" "ex:rand" "?rand"]]}))]
+        (is (= {"ex:abs" 2
+                "ex:round" 1
+                "ex:ceil" 2
+                "ex:floor" 1}
+               @(fluree/query @updated {"where" [["?s" "id" "ex:numeric-fns"]]
+                                        "selectOne" {"?s" ["ex:abs"
+                                                           "ex:round"
+                                                           "ex:ceil"
+                                                           "ex:floor"]}})))
+        (is (pos? @(fluree/query @updated {"where" [["?s" "id" "ex:numeric-fns"]
+                                                    ["?s" "ex:rand" "?rand"]]
+                                           "selectOne" "?rand"})))))
+
+    (testing "string functions"
+      (let [updated  (-> @(fluree/stage db1 {"id" "ex:string-fns" "ex:text" "Abcdefg"})
+                         (fluree/stage {"delete" []
+                                        "where" [["?s" "id" "ex:string-fns"]
+                                                 ["?s" "ex:text" "?text"]
+                                                 {"bind" {"?strlen" "(strLen ?text)"}}
+                                                 {"bind" {"?sub1" "(subStr ?text 5)"}}
+                                                 {"bind" {"?sub2" "(subStr ?text 1 4)"}}
+                                                 {"bind" {"?upcased" "(ucase ?text)"}}
+                                                 {"bind" {"?downcased" "(lcase ?text)"}}
+                                                 {"bind" {"?a-start" "(strStarts ?text \"x\")"}}
+                                                 {"bind" {"?a-end" "(strEnds ?text \"x\")"}}
+                                                 {"bind" {"?contains" "(contains ?text \"x\")"}}
+                                                 {"bind" {"?strBefore" "(strBefore ?text \"bcd\")"}}
+                                                 {"bind" {"?strAfter" "(strAfter ?text \"bcd\")"}}
+                                                 {"bind" {"?concatted" "(concat ?text \" \" \"STR1 \" \"STR2\")"}}
+                                                 {"bind" {"?matched" "(regex ?text \"^Abc\")"}}]
+                                        "insert" [["?s" "ex:strStarts" "?a-start"]
+                                                  ["?s" "ex:strEnds" "?a-end"]
+                                                  ["?s" "ex:subStr" "?sub1"]
+                                                  ["?s" "ex:subStr" "?sub2"]
+                                                  ["?s" "ex:strLen" "?strlen"]
+                                                  ["?s" "ex:ucase" "?upcased"]
+                                                  ["?s" "ex:lcase" "?downcased"]
+                                                  ["?s" "ex:contains" "?contains"]
+                                                  ["?s" "ex:strBefore" "?strBefore"]
+                                                  ["?s" "ex:strAfter" "?strAfter"]
+                                                  ["?s" "ex:concat" "?concatted"]
+                                                  ["?s" "ex:regex" "?matched"]]}))]
+        (is (= {"ex:strEnds" false
+                "ex:strStarts" false
+                "ex:contains" false
+                "ex:regex" true
+                "ex:subStr" ["Abcd" "efg"]
+                "ex:strLen" 7
+                "ex:ucase" "ABCDEFG"
+                "ex:lcase" "abcdefg"
+                "ex:strBefore" "A"
+                "ex:strAfter" "efg"
+                "ex:concat" "Abcdefg STR1 STR2"}
+               @(fluree/query @updated {"where" [["?s" "id" "ex:string-fns"]]
+                                        "selectOne" {"?s" ["ex:strLen"
+                                                           "ex:subStr"
+                                                           "ex:ucase"
+                                                           "ex:lcase"
+                                                           "ex:strStarts"
+                                                           "ex:strEnds"
+                                                           "ex:contains"
+                                                           "ex:strBefore"
+                                                           "ex:strAfter"
+                                                           "ex:encodeForUri"
+                                                           "ex:concat"
+                                                           "ex:langMatches"
+                                                           "ex:regex"
+                                                           "ex:replace"]}})))))
+
+    #_(testing "functional forms")
+    #_(testing "scalar functions")))


### PR DESCRIPTION
This is the easy part of https://github.com/fluree/db/issues/232

implements numeric, string, datetime, and hash functions

https://www.w3.org/TR/sparql11-query/#SparqlOps :17.4.3, 17.4.4, 17.4.5, 17.4.6

Also includes a fix for #522 


These had existing implementations that needed to be changed to comply:
- rand:
before it selected a random element from a collection, now returns a random
number between 0 and 1.
- now:
before it returned an integer epoch milliseconds, now returns an ISO8601 datetime string
- subStr
before it took a start and optionally an end arg, now it takes a start and optionally a
length arg

These haven't been implemented:
- md5, sha1, sha386:
We don't have implementations for these and I didn't want to add a dependency for
them. Figure we can add later at user request.
- encode-for-uri:
This seems more complex and I want to see if there's a straightforward way to get it
without manually implementing https://www.ietf.org/rfc/rfc3986.txt
- langMatches
We don't currently support language tags

Outstanding work:
The datetime functions currently only work on datetime strings - not date strings, not time strings.

The functional forms (17.4.1) and functions on RDF terms (17.4.2) sections are a bit trickier. A lot of it already is implemented but the stuff that isn't requires additional context beyond just the value (subject, predicate, object).

Also, error handling is really subpar currently, I'd like to have very nice and helpful error messages when a function blows up.