### PR TITLE
Feature: Enforce shacl class constraints

### DIFF
--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -582,7 +582,6 @@
                                                                                  first
                                                                                  flake/o)
                                                                        next-ciris (conj ciris ciri)]
-                                                                   (log/trace "next-ciris:" next-ciris)
                                                                    (if (seq csids)
                                                                      (recur csids next-ciris)
                                                                      next-ciris))))

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -574,20 +574,18 @@
                                              p-shapes*      (update p-shapes path util/conjv property-shape*)
                                              ;; elevate following conditions to top-level custom keys to optimize validations when processing txs
                                              class-iris      (when-let [class-sids (:class property-shape)]
-                                                               (let [id-path (fn [sid] [sid const/iri-id])]
-                                                                 (loop [[csid & csids] class-sids
-                                                                        ciris []]
-                                                                   (let [ciri (->> csid
-                                                                                   id-path
-                                                                                   (query-range/index-range db :spot =)
-                                                                                   <?
-                                                                                   first
-                                                                                   flake/o)
-                                                                         next-ciris (conj ciris ciri)]
-                                                                     (log/trace "next-ciris:" next-ciris)
-                                                                     (if (seq csids)
-                                                                       (recur csids next-ciris)
-                                                                       next-ciris)))))
+                                                               (loop [[csid & csids] class-sids
+                                                                      ciris []]
+                                                                 (let [ciri (->> [csid const/iri-id]
+                                                                                 (query-range/index-range db :spot =)
+                                                                                 <?
+                                                                                 first
+                                                                                 flake/o)
+                                                                       next-ciris (conj ciris ciri)]
+                                                                   (log/trace "next-ciris:" next-ciris)
+                                                                   (if (seq csids)
+                                                                     (recur csids next-ciris)
+                                                                     next-ciris))))
                                              shape*         (cond-> shape
                                                                     (:required? property-shape)
                                                                     (update :required util/conjs (:path property-shape))

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -951,8 +951,9 @@
                                       "sh:minCount" 1
                                       "sh:maxCount" 1
                                       "sh:datatype" {"@id" "xsd:string"}}]}])
-                                   "https://example.com/country"   {"@id" "https://example.com/Country/AU"},
         db2    @(fluree/stage db1 {"@id"                           "https://example.com/Actor/65731"
+                                   "https://example.com/country"   {"@id"                      "https://example.com/Country/AU"
+                                                                    "https://example.com/name" "Oz"}
                                    "https://example.com/gender"    "Male"
                                    "https://example.com/character" ["Jake Sully" "Marcus Wright"]
                                    "https://example.com/movie"     [{"@id" "https://example.com/Movie/19995"}

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -12,18 +12,18 @@
           ledger    @(fluree/create conn "class/testing" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db1       @(fluree/stage
                       (fluree/db ledger)
-                      {:id                 :ex/MyClass,
+                      {:id                 :ex/MyClass
                        :schema/description "Just a basic object not used as a class"})
           db2       @(fluree/stage
                       db1
-                      {:id                 :ex/myClassInstance,
+                      {:id                 :ex/myClassInstance
                        :type               [:ex/MyClass]
                        :schema/description "Now a new subject uses MyClass as a Class"})
-          query-res @(fluree/query db2 '{:select {?s [:*]},
+          query-res @(fluree/query db2 '{:select {?s [:*]}
                                          :where  [[?s :id :ex/myClassInstance]]})]
       (is (= query-res
-             [{:id                 :ex/myClassInstance,
-               :rdf/type           [:ex/MyClass],
+             [{:id                 :ex/myClassInstance
+               :rdf/type           [:ex/MyClass]
                :schema/description "Now a new subject uses MyClass as a Class"}])))))
 
 
@@ -35,8 +35,8 @@
                         :where  [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
                          (fluree/db ledger)
-                         {:id             :ex/UserShape,
-                          :type           [:sh/NodeShape],
+                         {:id             :ex/UserShape
+                          :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path     :schema/name
                                             :sh/minCount 1
@@ -44,23 +44,23 @@
                                             :sh/datatype :xsd/string}]})
           db-ok        @(fluree/stage
                          db
-                         {:id              :ex/john,
-                          :type            [:ex/User],
+                         {:id              :ex/john
+                          :type            [:ex/User]
                           :schema/name     "John"
                           :schema/callSign "j-rock"})
           ; no :schema/name
           db-no-names  (try
                          @(fluree/stage
                            db
-                           {:id              :ex/john,
-                            :type            [:ex/User],
+                           {:id              :ex/john
+                            :type            [:ex/User]
                             :schema/callSign "j-rock"})
                          (catch Exception e e))
           db-two-names (try
                          @(fluree/stage
                            db
-                           {:id              :ex/john,
-                            :type            [:ex/User],
+                           {:id              :ex/john
+                            :type            [:ex/User]
                             :schema/name     ["John", "Johnny"]
                             :schema/callSign "j-rock"})
                          (catch Exception e e))]
@@ -73,9 +73,9 @@
       (is (= (ex-message db-two-names)
              "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."))
       (is (= @(fluree/query db-ok user-query)
-             [{:id              :ex/john,
-               :rdf/type        [:ex/User],
-               :schema/name     "John",
+             [{:id              :ex/john
+               :rdf/type        [:ex/User]
+               :schema/name     "John"
                :schema/callSign "j-rock"}])
           "basic rdf:type query response not correct"))))
 
@@ -88,29 +88,29 @@
                         :where  [['?s :rdf/type :ex/User]]}
           db           @(fluree/stage
                          (fluree/db ledger)
-                         {:id             :ex/UserShape,
-                          :type           [:sh/NodeShape],
+                         {:id             :ex/UserShape
+                          :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path     :schema/name
                                             :sh/datatype :xsd/string}]})
           db-ok        @(fluree/stage
                          db
-                         {:id          :ex/john,
-                          :type        [:ex/User],
+                         {:id          :ex/john
+                          :type        [:ex/User]
                           :schema/name "John"})
           ; no :schema/name
           db-int-name  (try
                          @(fluree/stage
                            db
-                           {:id          :ex/john,
-                            :type        [:ex/User],
+                           {:id          :ex/john
+                            :type        [:ex/User]
                             :schema/name 42})
                          (catch Exception e e))
           db-bool-name (try
                          @(fluree/stage
                            db
-                           {:id          :ex/john,
-                            :type        [:ex/User],
+                           {:id          :ex/john
+                            :type        [:ex/User]
                             :schema/name true})
                          (catch Exception e e))]
       (is (util/exception? db-int-name)
@@ -122,8 +122,8 @@
       (is (str/starts-with? (ex-message db-bool-name)
                             "Required data type"))
       (is (= @(fluree/query db-ok user-query)
-             [{:id          :ex/john,
-               :rdf/type    [:ex/User],
+             [{:id          :ex/john
+               :rdf/type    [:ex/User]
                :schema/name "John"}])
           "basic rdf:type query response not correct"))))
 
@@ -136,8 +136,8 @@
                          :where  [['?s :rdf/type :ex/User]]}
           db            @(fluree/stage
                           (fluree/db ledger)
-                          {:id                   :ex/UserShape,
-                           :type                 [:sh/NodeShape],
+                          {:id                   :ex/UserShape
+                           :type                 [:sh/NodeShape]
                            :sh/targetClass       :ex/User
                            :sh/property          [{:sh/path     :schema/name
                                                    :sh/datatype :xsd/string}]
@@ -145,15 +145,15 @@
                            :sh/closed            true})
           db-ok         @(fluree/stage
                           db
-                          {:id          :ex/john,
-                           :type        [:ex/User],
+                          {:id          :ex/john
+                           :type        [:ex/User]
                            :schema/name "John"})
           ; no :schema/name
           db-extra-prop (try
                           @(fluree/stage
                             db
-                            {:id           :ex/john,
-                             :type         [:ex/User],
+                            {:id           :ex/john
+                             :type         [:ex/User]
                              :schema/name  "John"
                              :schema/email "john@flur.ee"})
                           (catch Exception e e))]
@@ -162,8 +162,8 @@
                             "SHACL shape is closed"))
 
       (is (= @(fluree/query db-ok user-query)
-             [{:id          :ex/john,
-               :rdf/type    [:ex/User],
+             [{:id          :ex/john
+               :rdf/type    [:ex/User]
                :schema/name "John"}])
           "basic rdf:type query response not correct"))))
 
@@ -177,22 +177,22 @@
         (let [db           @(fluree/stage
                              (fluree/db ledger)
                              {:id             :ex/EqualNamesShape
-                              :type           [:sh/NodeShape],
+                              :type           [:sh/NodeShape]
                               :sh/targetClass :ex/User
                               :sh/property    [{:sh/path   :schema/name
                                                 :sh/equals :ex/firstName}]})
               db-ok        @(fluree/stage
                              db
-                             {:id           :ex/alice,
-                              :type         [:ex/User],
+                             {:id           :ex/alice
+                              :type         [:ex/User]
                               :schema/name  "Alice"
                               :ex/firstName "Alice"})
 
               db-not-equal (try
                              @(fluree/stage
                                db
-                               {:id           :ex/john,
-                                :type         [:ex/User],
+                               {:id           :ex/john
+                                :type         [:ex/User]
                                 :schema/name  "John"
                                 :ex/firstName "Jack"})
                              (catch Exception e e))]
@@ -201,8 +201,8 @@
           (is (str/starts-with? (ex-message db-not-equal)
                                 "SHACL PropertyShape exception - sh:equals"))
 
-          (is (= [{:id           :ex/alice,
-                   :rdf/type     [:ex/User],
+          (is (= [{:id           :ex/alice
+                   :rdf/type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/firstName "Alice"}]
                  @(fluree/query db-ok user-query)))))
@@ -210,22 +210,22 @@
         (let [db            @(fluree/stage
                               (fluree/db ledger)
                               {:id             :ex/EqualNamesShape
-                               :type           [:sh/NodeShape],
+                               :type           [:sh/NodeShape]
                                :sh/targetClass :ex/User
                                :sh/property    [{:sh/path   :ex/favNums
                                                  :sh/equals :ex/luckyNums}]})
               db-ok         @(fluree/stage
                               db
-                              {:id           :ex/alice,
-                               :type         [:ex/User],
+                              {:id           :ex/alice
+                               :type         [:ex/User]
                                :schema/name  "Alice"
                                :ex/favNums   [11 17]
                                :ex/luckyNums [11 17]})
 
               db-ok2        @(fluree/stage
                               db
-                              {:id           :ex/alice,
-                               :type         [:ex/User],
+                              {:id           :ex/alice
+                               :type         [:ex/User]
                                :schema/name  "Alice"
                                :ex/favNums   [11 17]
                                :ex/luckyNums [17 11]})
@@ -234,7 +234,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User],
+                                 :type         [:ex/User]
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums [13 18]})
@@ -243,7 +243,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User],
+                                 :type         [:ex/User]
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums [11]})
@@ -252,7 +252,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User],
+                                 :type         [:ex/User]
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums [11 17 18]})
@@ -261,7 +261,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User],
+                                 :type         [:ex/User]
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums ["11" "17"]})
@@ -282,14 +282,14 @@
               "Exception, because :ex/favNums does not equal :ex/luckyNums")
           (is (str/starts-with? (ex-message db-not-equal4)
                                 "SHACL PropertyShape exception - sh:equals"))
-          (is (= [{:id           :ex/alice,
-                   :rdf/type     [:ex/User],
+          (is (= [{:id           :ex/alice
+                   :rdf/type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums [11 17]}]
                  @(fluree/query db-ok user-query)))
-          (is (= [{:id           :ex/alice,
-                   :rdf/type     [:ex/User],
+          (is (= [{:id           :ex/alice
+                   :rdf/type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums [11 17]}]
@@ -298,14 +298,14 @@
         (let [db               @(fluree/stage
                                  (fluree/db ledger)
                                  {:id             :ex/DisjointShape
-                                  :type           [:sh/NodeShape],
+                                  :type           [:sh/NodeShape]
                                   :sh/targetClass :ex/User
                                   :sh/property    [{:sh/path     :ex/favNums
                                                     :sh/disjoint :ex/luckyNums}]})
               db-ok            @(fluree/stage
                                  db
-                                 {:id           :ex/alice,
-                                  :type         [:ex/User],
+                                 {:id           :ex/alice
+                                  :type         [:ex/User]
                                   :schema/name  "Alice"
                                   :ex/favNums   [11 17]
                                   :ex/luckyNums 1})
@@ -314,7 +314,7 @@
                                  @(fluree/stage
                                    db
                                    {:id           :ex/brian
-                                    :type         [:ex/User],
+                                    :type         [:ex/User]
                                     :schema/name  "Brian"
                                     :ex/favNums   11
                                     :ex/luckyNums 11})
@@ -323,7 +323,7 @@
                                  @(fluree/stage
                                    db
                                    {:id           :ex/brian
-                                    :type         [:ex/User],
+                                    :type         [:ex/User]
                                     :schema/name  "Brian"
                                     :ex/favNums   [11 17 31]
                                     :ex/luckyNums 11})
@@ -333,7 +333,7 @@
                                  @(fluree/stage
                                    db
                                    {:id           :ex/brian
-                                    :type         [:ex/User],
+                                    :type         [:ex/User]
                                     :schema/name  "Brian"
                                     :ex/favNums   [11 17 31]
                                     :ex/luckyNums [13 18 11]})
@@ -354,8 +354,8 @@
           (is (str/starts-with? (ex-message db-not-disjoint3)
                                 "SHACL PropertyShape exception - sh:disjoint"))
 
-          (is (= [{:id           :ex/alice,
-                   :rdf/type     [:ex/User],
+          (is (= [{:id           :ex/alice
+                   :rdf/type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums 1}]
@@ -364,14 +364,14 @@
         (let [db       @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/LessThanShape
-                          :type           [:sh/NodeShape],
+                          :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path     :ex/p1
                                             :sh/lessThan :ex/p2}]})
               db-ok1   @(fluree/stage
                          db
-                         {:id          :ex/alice,
-                          :type        [:ex/User],
+                         {:id          :ex/alice
+                          :type        [:ex/User]
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       [18 19]})
@@ -379,8 +379,8 @@
 
               db-ok2   @(fluree/stage
                          db
-                         {:id          :ex/alice,
-                          :type        [:ex/User],
+                         {:id          :ex/alice
+                          :type        [:ex/User]
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       [18]})
@@ -388,8 +388,8 @@
               db-fail1 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       17})
@@ -398,8 +398,8 @@
               db-fail2 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       ["18" "19"]})
@@ -409,8 +409,8 @@
               db-fail3 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [12 17]
                             :ex/p2       [10 18]})
@@ -419,16 +419,16 @@
               db-fail4 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       [12 16]})
                          (catch Exception e e))
               db-iris  (try @(fluree/stage
                               db
-                              {:id          :ex/alice,
-                               :type        [:ex/User],
+                              {:id          :ex/alice
+                               :type        [:ex/User]
                                :schema/name "Alice"
                                :ex/p1       :ex/brian
                                :ex/p2       :ex/john})
@@ -459,14 +459,14 @@
           (is (str/starts-with? (ex-message db-iris)
                                 "SHACL PropertyShape exception - sh:lessThan"))
 
-          (is (= [{:id          :ex/alice,
-                   :rdf/type    [:ex/User],
+          (is (= [{:id          :ex/alice
+                   :rdf/type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       [18 19]}]
                  @(fluree/query db-ok1 user-query)))
-          (is (= [{:id          :ex/alice,
-                   :rdf/type    [:ex/User],
+          (is (= [{:id          :ex/alice
+                   :rdf/type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       18}]
@@ -475,14 +475,14 @@
         (let [db       @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/LessThanOrEqualsShape
-                          :type           [:sh/NodeShape],
+                          :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path             :ex/p1
                                             :sh/lessThanOrEquals :ex/p2}]})
               db-ok1   @(fluree/stage
                          db
-                         {:id          :ex/alice,
-                          :type        [:ex/User],
+                         {:id          :ex/alice
+                          :type        [:ex/User]
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       [17 19]})
@@ -490,8 +490,8 @@
 
               db-ok2   @(fluree/stage
                          db
-                         {:id          :ex/alice,
-                          :type        [:ex/User],
+                         {:id          :ex/alice
+                          :type        [:ex/User]
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       17})
@@ -499,8 +499,8 @@
               db-fail1 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       10})
@@ -509,8 +509,8 @@
               db-fail2 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       ["17" "19"]})
@@ -519,8 +519,8 @@
               db-fail3 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [12 17]
                             :ex/p2       [10 17]})
@@ -529,8 +529,8 @@
               db-fail4 (try
                          @(fluree/stage
                            db
-                           {:id          :ex/alice,
-                            :type        [:ex/User],
+                           {:id          :ex/alice
+                            :type        [:ex/User]
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       [12 16]})
@@ -556,14 +556,14 @@
               "Exception, because :ex/p1 is not less than or equal to :ex/p2")
           (is (str/starts-with? (ex-message db-fail4)
                                 "SHACL PropertyShape exception - sh:lessThanOrEquals"))
-          (is (= [{:id          :ex/alice,
-                   :rdf/type    [:ex/User],
+          (is (= [{:id          :ex/alice
+                   :rdf/type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       [17 19]}]
                  @(fluree/query db-ok1 user-query)))
-          (is (= [{:id          :ex/alice,
-                   :rdf/type    [:ex/User],
+          (is (= [{:id          :ex/alice
+                   :rdf/type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       17}]
@@ -579,26 +579,26 @@
         (let [db          @(fluree/stage
                             (fluree/db ledger)
                             {:id             :ex/ExclusiveNumRangeShape
-                             :type           [:sh/NodeShape],
+                             :type           [:sh/NodeShape]
                              :sh/targetClass :ex/User
                              :sh/property    [{:sh/path         :schema/age
                                                :sh/minExclusive 1
                                                :sh/maxExclusive 100}]})
               db-ok       @(fluree/stage
                             db
-                            {:id         :ex/john,
-                             :type       [:ex/User],
+                            {:id         :ex/john
+                             :type       [:ex/User]
                              :schema/age 2})
               db-too-low  (try @(fluree/stage
                                  db
-                                 {:id         :ex/john,
-                                  :type       [:ex/User],
+                                 {:id         :ex/john
+                                  :type       [:ex/User]
                                   :schema/age 1})
                                (catch Exception e e))
               db-too-high (try @(fluree/stage
                                  db
-                                 {:id         :ex/john,
-                                  :type       [:ex/User],
+                                 {:id         :ex/john
+                                  :type       [:ex/User]
                                   :schema/age 100})
                                (catch Exception e e))]
           (is (util/exception? db-too-low)
@@ -612,14 +612,14 @@
                                 "SHACL PropertyShape exception - sh:maxExclusive: value 100"))
 
           (is (= @(fluree/query db-ok user-query)
-                 [{:id         :ex/john,
-                   :rdf/type   [:ex/User],
+                 [{:id         :ex/john
+                   :rdf/type   [:ex/User]
                    :schema/age 2}]))))
       (testing "inclusive constraints"
         (let [db          @(fluree/stage
                             (fluree/db ledger)
                             {:id             :ex/InclusiveNumRangeShape
-                             :type           [:sh/NodeShape],
+                             :type           [:sh/NodeShape]
                              :sh/targetClass :ex/User
                              :sh/property    [{:sh/path         :schema/age
                                                :sh/minInclusive 1
@@ -627,22 +627,22 @@
               db-ok       @(fluree/stage
                             db
                             {:id         :ex/brian
-                             :type       [:ex/User],
+                             :type       [:ex/User]
                              :schema/age 1})
               db-ok2      @(fluree/stage
                             db-ok
-                            {:id         :ex/alice,
-                             :type       [:ex/User],
+                            {:id         :ex/alice
+                             :type       [:ex/User]
                              :schema/age 100})
               db-too-low  @(fluree/stage
                             db
-                            {:id         :ex/alice,
-                             :type       [:ex/User],
+                            {:id         :ex/alice
+                             :type       [:ex/User]
                              :schema/age 0})
               db-too-high @(fluree/stage
                             db
-                            {:id         :ex/alice,
-                             :type       [:ex/User],
+                            {:id         :ex/alice
+                             :type       [:ex/User]
                              :schema/age 101})]
           (is (util/exception? db-too-low)
               "Exception, because :schema/age is below the minimum")
@@ -664,20 +664,20 @@
         (let [db         @(fluree/stage
                            (fluree/db ledger)
                            {:id             :ex/NumRangeShape
-                            :type           [:sh/NodeShape],
+                            :type           [:sh/NodeShape]
                             :sh/targetClass :ex/User
                             :sh/property    [{:sh/path         :schema/age
                                               :sh/minExclusive 0}]})
               db-subj-id (try @(fluree/stage
                                 db
-                                {:id         :ex/alice,
-                                 :type       [:ex/User],
+                                {:id         :ex/alice
+                                 :type       [:ex/User]
                                  :schema/age :ex/brian})
                               (catch Exception e e))
               db-string  (try @(fluree/stage
                                 db
-                                {:id         :ex/alice,
-                                 :type       [:ex/User],
+                                {:id         :ex/alice
+                                 :type       [:ex/User]
                                  :schema/age "10"})
                               (catch Exception e e))]
           (is (util/exception? db-subj-id)
@@ -721,22 +721,22 @@
           db-too-short-str    (try
                                 @(fluree/stage
                                   db
-                                  {:id          :ex/al,
-                                   :type        :ex/User,
+                                  {:id          :ex/al
+                                   :type        :ex/User
                                    :schema/name "Al"})
                                 (catch Exception e e))
           db-too-long-str     (try
                                 @(fluree/stage
                                   db
                                   {:id          :ex/jean-claude
-                                   :type        :ex/User,
+                                   :type        :ex/User
                                    :schema/name "Jean-Claude"})
                                 (catch Exception e e))
           db-too-long-non-str (try
                                 @(fluree/stage
                                   db
                                   {:id          :ex/john
-                                   :type        :ex/User,
+                                   :type        :ex/User
                                    :schema/name 12345678910})
                                 (catch Exception e e))
           db-ref-value        (try
@@ -762,12 +762,12 @@
           "Exception, because :schema/name is not a literal value")
       (is (str/starts-with? (ex-message db-ref-value)
                             "SHACL PropertyShape exception - sh:maxLength:"))
-      (is (= [{:id          :ex/john,
-               :rdf/type    [:ex/User],
+      (is (= [{:id          :ex/john
+               :rdf/type    [:ex/User]
                :schema/name "John"}]
              @(fluree/query db-ok-str user-query)))
-      (is (= [{:id          :ex/john,
-               :rdf/type    [:ex/User],
+      (is (= [{:id          :ex/john
+               :rdf/type    [:ex/User]
                :schema/name 12345}]
              @(fluree/query db-ok-non-str user-query))))))
 
@@ -797,8 +797,8 @@
 
           db-ok-birthyear        @(fluree/stage
                                    db
-                                   {:id           :ex/john,
-                                    :type         :ex/User,
+                                   {:id           :ex/john
+                                    :type         :ex/User
                                     :ex/birthYear 1984})
           db-wrong-case-greeting (try
                                    @(fluree/stage
@@ -835,12 +835,12 @@
           "Exception, because :schema/name is not a literal value")
       (is (str/starts-with? (ex-message db-ref-value)
                             "SHACL PropertyShape exception - sh:pattern:"))
-      (is (= [{:id          :ex/brian,
-               :rdf/type    [:ex/User],
+      (is (= [{:id          :ex/brian
+               :rdf/type    [:ex/User]
                :ex/greeting "hello\nworld!"}]
              @(fluree/query db-ok-greeting user-query)))
       (is (= [{:id           :ex/john
-               :rdf/type     [:ex/User],
+               :rdf/type     [:ex/User]
                :ex/birthYear 1984}]
              @(fluree/query db-ok-birthyear user-query))))))
 
@@ -933,31 +933,31 @@
   (let [conn   @(fluree/connect {:method :memory})
         ledger @(fluree/create conn "classtest" {:defaultContext test-utils/default-str-context})
         db0    (fluree/db ledger)
-        db1    @(fluree/stage db0 [{"@type"          ["sh:NodeShape"],
-                                    "sh:targetClass" {"@id" "https://example.com/Country"},
+        db1    @(fluree/stage db0 [{"@type"          ["sh:NodeShape"]
+                                    "sh:targetClass" {"@id" "https://example.com/Country"}
                                     "sh:property"
-                                    [{"sh:path"     {"@id" "https://example.com/name"},
-                                      "sh:datatype" {"@id" "xsd:string"},
-                                      "sh:minCount" 1,
+                                    [{"sh:path"     {"@id" "https://example.com/name"}
+                                      "sh:datatype" {"@id" "xsd:string"}
+                                      "sh:minCount" 1
                                       "sh:maxCount" 1}]}
-                                   {"@type"          ["sh:NodeShape"],
-                                    "sh:targetClass" {"@id" "https://example.com/Actor"},
+                                   {"@type"          ["sh:NodeShape"]
+                                    "sh:targetClass" {"@id" "https://example.com/Actor"}
                                     "sh:property"
-                                    [{"sh:path"        {"@id" "https://example.com/country"},
-                                      "sh:class"       {"@id" "https://example.com/Country"},
-                                      "sh:maxCount"    1,
+                                    [{"sh:path"        {"@id" "https://example.com/country"}
+                                      "sh:class"       {"@id" "https://example.com/Country"}
+                                      "sh:maxCount"    1
                                       "sh:description" "Birth country"}
-                                     {"sh:path"     {"@id" "https://example.com/name"},
-                                      "sh:minCount" 1,
-                                      "sh:maxCount" 1,
+                                     {"sh:path"     {"@id" "https://example.com/name"}
+                                      "sh:minCount" 1
+                                      "sh:maxCount" 1
                                       "sh:datatype" {"@id" "xsd:string"}}]}])
-        db2    @(fluree/stage db1 {"@id"                           "https://example.com/Actor/65731",
                                    "https://example.com/country"   {"@id" "https://example.com/Country/AU"},
-                                   "https://example.com/gender"    "Male",
-                                   "https://example.com/character" ["Jake Sully" "Marcus Wright"],
+        db2    @(fluree/stage db1 {"@id"                           "https://example.com/Actor/65731"
+                                   "https://example.com/gender"    "Male"
+                                   "https://example.com/character" ["Jake Sully" "Marcus Wright"]
                                    "https://example.com/movie"     [{"@id" "https://example.com/Movie/19995"}
-                                                                    {"@id" "https://example.com/Movie/534"}],
-                                   "@type"                         "https://example.com/Actor",
+                                                                    {"@id" "https://example.com/Movie/534"}]
+                                   "@type"                         "https://example.com/Actor"
                                    "https://example.com/name"      "Sam Worthington"})]
     (is (not (util/exception? db2)))))
 
@@ -1007,7 +1007,7 @@
       (is (str/includes? (ex-message db2) "sh:in"))
 
       (is (not (util/exception? db3)))
-      (is (= [{"id" "ex:PastelPony"
+      (is (= [{"id"       "ex:PastelPony"
                "rdf:type" ["ex:Pony"]
                "ex:color" [{"id" "ex:Pink"} {"id" "ex:Purple"}]}]
              @(fluree/query db3 '{"select" {"?p" ["*"]}

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -953,6 +953,7 @@
                                       "sh:datatype" {"@id" "xsd:string"}}]}])
         db2    @(fluree/stage db1 {"@id"                           "https://example.com/Actor/65731"
                                    "https://example.com/country"   {"@id"                      "https://example.com/Country/AU"
+                                                                    "@type"                    "https://example.com/Country"
                                                                     "https://example.com/name" "Oz"}
                                    "https://example.com/gender"    "Male"
                                    "https://example.com/character" ["Jake Sully" "Marcus Wright"]


### PR DESCRIPTION
Closes #316 

Feel free to ignore 8b1580d650779a1e6e6ad90e7a1be53734dcb7e5 when reviewing. It's a find & replace to remove all of the trailing commas in the test data in shacl-basic-test.