### PR TITLE
Fix default-context-at-t after load

### DIFF
--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -400,7 +400,8 @@
                                  (= -1 t-new)
                                  (into commit-data/commit-schema-flakes)))
          ecount*            (assoc ecount const/$_predicate pid
-                                          const/$_default sid)]
+                                          const/$_default sid
+                                          const/$_shard @last-sid)]
      (when (empty? all-flakes)
        (commit-error "Commit has neither assertions or retractions!"
                      commit-metadata))

--- a/src/fluree/db/ledger/json_ld.cljc
+++ b/src/fluree/db/ledger/json_ld.cljc
@@ -94,7 +94,8 @@
     (jld-commit/commit ledger db* opts*)))
 
 (defn default-context
-  "Returns default context at t (must be internal negative value)"
+  "Returns default context at t (should be an ISO datetime string or an integer
+  t value)"
   [ledger t]
   (go-try
     (let [latest-db (db ledger nil)

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -680,93 +680,93 @@
   (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:12:00.00000Z")]
     (testing "history commit details on a loaded file ledger"
       (with-tmp-dir storage-path
-                    (let [ledger-name   "loaded-history-file"
-                          conn          @(fluree/connect
-                                          {:method       :file
-                                           :storage-path storage-path
-                                           :defaults
-                                           {:context      test-utils/default-context
-                                            :context-type :keyword
-                                            :did          (did/private->did-map
-                                                           test-utils/default-private-key)}})
-                          ledger        @(fluree/create conn ledger-name
-                                                        {:defaultContext
-                                                         ["" {:ex "http://example.org/ns/"}]})
-                          _             @(test-utils/transact ledger {:id   :ex/alice
-                                                                      :ex/x "foo-1"
-                                                                      :ex/y "bar-1"})
-                          _             @(test-utils/transact ledger {:id   :ex/alice
-                                                                      :ex/x "foo-2"
-                                                                      :ex/y "bar-2"})
-                          _             @(test-utils/transact ledger {:id   :ex/alice
-                                                                      :ex/x "foo-3"
-                                                                      :ex/y "bar-3"})
-                          _             @(test-utils/transact ledger {:id   :ex/cat
-                                                                      :ex/x "foo-cat"
-                                                                      :ex/y "bar-cat"})
-                          _             @(test-utils/transact ledger {:id   :ex/alice
-                                                                      :ex/x "foo-cat"
-                                                                      :ex/y "bar-cat"}
-                                                              {:message "meow"})
-                          loaded-ledger (test-utils/retry-load conn ledger-name 100)]
-                      (is (pred-match?
-                           [#:f{:assert  [{:ex/x "foo-3"
-                                           :ex/y "bar-3"
-                                           :id   :ex/alice}]
-                                :commit  {"https://www.w3.org/2018/credentials#issuer"
-                                          {:id test-utils/did?}
-                                          :f/address        test-utils/address?
-                                          :f/alias          ledger-name
-                                          :f/branch         "main"
-                                          :f/defaultContext {:id test-utils/context-id?}
-                                          :f/data           #:f{:address  test-utils/address?
-                                                                :assert   [{:ex/x "foo-3"
-                                                                            :ex/y "bar-3"
-                                                                            :id   :ex/alice}]
-                                                                :flakes   65
-                                                                :previous {:id test-utils/db-id?}
-                                                                :retract  [{:ex/x "foo-2"
-                                                                            :ex/y "bar-2"
-                                                                            :id   :ex/alice}]
-                                                                :size     pos-int?
-                                                                :t        3}
-                                          :f/previous       {:id test-utils/commit-id?}
-                                          :f/time           720000
-                                          :f/v              0
-                                          :id               test-utils/commit-id?}
-                                :retract [{:ex/x "foo-2"
-                                           :ex/y "bar-2"
-                                           :id   :ex/alice}]
-                                :t       3}
-                            #:f{:assert  [{:ex/x "foo-cat"
-                                           :ex/y "bar-cat"
-                                           :id   :ex/alice}]
-                                :commit  {"https://www.w3.org/2018/credentials#issuer"
-                                          {:id test-utils/did?}
-                                          :f/address        test-utils/address?
-                                          :f/alias          ledger-name
-                                          :f/branch         "main"
-                                          :f/defaultContext {:id test-utils/context-id?}
-                                          :f/data           #:f{:address  test-utils/address?
-                                                                :assert   [{:ex/x "foo-cat"
-                                                                            :ex/y "bar-cat"
-                                                                            :id   :ex/alice}]
-                                                                :flakes   104
-                                                                :previous {:id test-utils/db-id?}
-                                                                :retract  [{:ex/x "foo-3"
-                                                                            :ex/y "bar-3"
-                                                                            :id   :ex/alice}]
-                                                                :size     pos-int?
-                                                                :t        5}
-                                          :f/message        "meow"
-                                          :f/previous       {:id test-utils/commit-id?}
-                                          :f/time           720000
-                                          :f/v              0
-                                          :id               test-utils/commit-id?}
-                                :retract [{:ex/x "foo-3"
-                                           :ex/y "bar-3"
-                                           :id   :ex/alice}]
-                                :t       5}]
-                           @(fluree/history loaded-ledger {:history        :ex/alice
-                                                           :commit-details true
-                                                           :t              {:from 3}}))))))))
+        (let [ledger-name   "loaded-history-file"
+              conn          @(fluree/connect
+                              {:method       :file
+                               :storage-path storage-path
+                               :defaults
+                               {:context      test-utils/default-context
+                                :context-type :keyword
+                                :did          (did/private->did-map
+                                               test-utils/default-private-key)}})
+              ledger        @(fluree/create conn ledger-name
+                                            {:defaultContext
+                                             ["" {:ex "http://example.org/ns/"}]})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-1"
+                                                          :ex/y "bar-1"})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-2"
+                                                          :ex/y "bar-2"})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-3"
+                                                          :ex/y "bar-3"})
+              _             @(test-utils/transact ledger {:id   :ex/cat
+                                                          :ex/x "foo-cat"
+                                                          :ex/y "bar-cat"})
+              _             @(test-utils/transact ledger {:id   :ex/alice
+                                                          :ex/x "foo-cat"
+                                                          :ex/y "bar-cat"}
+                                                  {:message "meow"})
+              loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+          (is (pred-match?
+               [#:f{:assert  [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :commit  {"https://www.w3.org/2018/credentials#issuer"
+                              {:id test-utils/did?}
+                              :f/address        test-utils/address?
+                              :f/alias          ledger-name
+                              :f/branch         "main"
+                              :f/defaultContext {:id test-utils/context-id?}
+                              :f/data           #:f{:address  test-utils/address?
+                                                    :assert   [{:ex/x "foo-3"
+                                                                :ex/y "bar-3"
+                                                                :id   :ex/alice}]
+                                                    :flakes   65
+                                                    :previous {:id test-utils/db-id?}
+                                                    :retract  [{:ex/x "foo-2"
+                                                                :ex/y "bar-2"
+                                                                :id   :ex/alice}]
+                                                    :size     pos-int?
+                                                    :t        3}
+                              :f/previous       {:id test-utils/commit-id?}
+                              :f/time           720000
+                              :f/v              0
+                              :id               test-utils/commit-id?}
+                    :retract [{:ex/x "foo-2"
+                               :ex/y "bar-2"
+                               :id   :ex/alice}]
+                    :t       3}
+                #:f{:assert  [{:ex/x "foo-cat"
+                               :ex/y "bar-cat"
+                               :id   :ex/alice}]
+                    :commit  {"https://www.w3.org/2018/credentials#issuer"
+                              {:id test-utils/did?}
+                              :f/address        test-utils/address?
+                              :f/alias          ledger-name
+                              :f/branch         "main"
+                              :f/defaultContext {:id test-utils/context-id?}
+                              :f/data           #:f{:address  test-utils/address?
+                                                    :assert   [{:ex/x "foo-cat"
+                                                                :ex/y "bar-cat"
+                                                                :id   :ex/alice}]
+                                                    :flakes   104
+                                                    :previous {:id test-utils/db-id?}
+                                                    :retract  [{:ex/x "foo-3"
+                                                                :ex/y "bar-3"
+                                                                :id   :ex/alice}]
+                                                    :size     pos-int?
+                                                    :t        5}
+                              :f/message        "meow"
+                              :f/previous       {:id test-utils/commit-id?}
+                              :f/time           720000
+                              :f/v              0
+                              :id               test-utils/commit-id?}
+                    :retract [{:ex/x "foo-3"
+                               :ex/y "bar-3"
+                               :id   :ex/alice}]
+                    :t       5}]
+               @(fluree/history loaded-ledger {:history        :ex/alice
+                                               :commit-details true
+                                               :t              {:from 3}}))))))))

--- a/test/fluree/db/transact/default_context_test.clj
+++ b/test/fluree/db/transact/default_context_test.clj
@@ -1,18 +1,19 @@
 (ns fluree.db.transact.default-context-test
   (:require [clojure.test :refer :all]
             [fluree.db.dbproto :as dbproto]
+            [fluree.db.json-ld.ledger :as jld-ledger]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.util.core :as util]
+            [test-with-files.tools :as twf :refer [with-tmp-dir]]
             [fluree.db.util.log :as log]))
 
-
-(deftest ^:integration default-context-update
+(deftest ^:integration default-context-update-test
   (let [conn                (test-utils/create-conn)
         ledger              @(fluree/create conn "default-context-update"
                                             {:defaultContext
                                              ["" {:ex "http://example.org/ns/"}]})
-        
+
         db1                 (with-redefs
                              [util/current-time-iso
                               (constantly "1971-01-01T00:00:00.00000Z")]
@@ -38,6 +39,7 @@
                                   deref
                                   (fluree/commit! ledger)
                                   deref))
+
 
         ledger-updated-load @(fluree/load conn "default-context-update")]
 
@@ -96,55 +98,125 @@
                               :where  [[?s :ex-new/x nil]]}))))
 
     (testing "All default contexts can be retrieved by t"
-      (is (= {"ex" "http://example.org/ns/",
-              "f" "https://ns.flur.ee/ledger#",
-              "id" "@id",
-              "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-              "rdfs" "http://www.w3.org/2000/01/rdf-schema#",
-              "schema" "http://schema.org/",
-              "sh" "http://www.w3.org/ns/shacl#",
-              "skos" "http://www.w3.org/2008/05/skos#",
-              "type" "@type",
-              "wiki" "https://www.wikidata.org/wiki/",
-              "xsd" "http://www.w3.org/2001/XMLSchema#"}
+      (is (= {"ex"     "http://example.org/ns/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+              "schema" "http://schema.org/"
+              "sh"     "http://www.w3.org/ns/shacl#"
+              "skos"   "http://www.w3.org/2008/05/skos#"
+              "type"   "@type"
+              "wiki"   "https://www.wikidata.org/wiki/"
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
              @(fluree/default-context-at-t ledger-updated-load 1)))
 
-      (is (= {"ex-new" "http://example.org/ns/",
-              "f" "https://ns.flur.ee/ledger#",
-              "id" "@id",
-              "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-              "rdfs" "http://www.w3.org/2000/01/rdf-schema#",
-              "schema" "http://schema.org/",
-              "sh" "http://www.w3.org/ns/shacl#",
-              "skos" "http://www.w3.org/2008/05/skos#",
-              "type" "@type",
-              "wiki" "https://www.wikidata.org/wiki/",
-              "xsd" "http://www.w3.org/2001/XMLSchema#"}
+      (is (= {"ex-new" "http://example.org/ns/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+              "schema" "http://schema.org/"
+              "sh"     "http://www.w3.org/ns/shacl#"
+              "skos"   "http://www.w3.org/2008/05/skos#"
+              "type"   "@type"
+              "wiki"   "https://www.wikidata.org/wiki/"
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
              @(fluree/default-context-at-t ledger-updated-load 2))))
 
     (testing "Default contexts can be retrieved by ISO datetime"
-      (is (= {"ex" "http://example.org/ns/",
-              "f" "https://ns.flur.ee/ledger#",
-              "id" "@id",
-              "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-              "rdfs" "http://www.w3.org/2000/01/rdf-schema#",
-              "schema" "http://schema.org/",
-              "sh" "http://www.w3.org/ns/shacl#",
-              "skos" "http://www.w3.org/2008/05/skos#",
-              "type" "@type",
-              "wiki" "https://www.wikidata.org/wiki/",
-              "xsd" "http://www.w3.org/2001/XMLSchema#"}
+      (is (= {"ex"     "http://example.org/ns/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+              "schema" "http://schema.org/"
+              "sh"     "http://www.w3.org/ns/shacl#"
+              "skos"   "http://www.w3.org/2008/05/skos#"
+              "type"   "@type"
+              "wiki"   "https://www.wikidata.org/wiki/"
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
              @(fluree/default-context-at-t ledger-updated-load "1972-01-01T00:00:00.00000Z")))
 
-      (is (= {"ex-new" "http://example.org/ns/",
-              "f" "https://ns.flur.ee/ledger#",
-              "id" "@id",
-              "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-              "rdfs" "http://www.w3.org/2000/01/rdf-schema#",
-              "schema" "http://schema.org/",
-              "sh" "http://www.w3.org/ns/shacl#",
-              "skos" "http://www.w3.org/2008/05/skos#",
-              "type" "@type",
-              "wiki" "https://www.wikidata.org/wiki/",
-              "xsd" "http://www.w3.org/2001/XMLSchema#"}
+      (is (= {"ex-new" "http://example.org/ns/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+              "schema" "http://schema.org/"
+              "sh"     "http://www.w3.org/ns/shacl#"
+              "skos"   "http://www.w3.org/2008/05/skos#"
+              "type"   "@type"
+              "wiki"   "https://www.wikidata.org/wiki/"
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
              @(fluree/default-context-at-t ledger-updated-load "1982-01-01T00:00:00.00000Z"))))))
+
+(deftest ^:integration default-context-update-file-storage-test
+  (testing "All default contexts can be retrieved by t w/ file storage"
+    (with-tmp-dir storage-path
+      (let [conn                @(fluree/connect
+                                  {:method       :file
+                                   :storage-path storage-path
+                                   :defaults
+                                   {:context      test-utils/default-context
+                                    :context-type :keyword}})
+            ledger              @(fluree/create conn "default-context-update"
+                                                {:defaultContext
+                                                 ["" {:ex "http://example.org/ns/"}]})
+
+            db1                 (with-redefs
+                                 [util/current-time-iso
+                                  (constantly "1971-01-01T00:00:00.00000Z")]
+                                 @(test-utils/transact ledger [{:id   :ex/foo
+                                                                :ex/x "foo-1"
+                                                                :ex/y "bar-1"}]))
+            _                   (fluree/default-context-at-t ledger 1)
+
+            ledger1-load        (test-utils/retry-load
+                                 conn "default-context-update" 100)
+            db1-load            (fluree/db ledger1-load)
+
+            ;; change "ex" alias in default context to "ex-new"
+            db-update-ctx       (fluree/update-default-context
+                                 db1-load (-> (dbproto/-default-context db1-load)
+                                              (dissoc "ex")
+                                              (assoc "ex-new" "http://example.org/ns/")))
+
+            db-update-cmt       (with-redefs
+                                 [util/current-time-iso
+                                  (constantly "1981-01-01T00:00:00.00000Z")]
+                                 (->> [{:id       :ex-new/foo2
+                                        :ex-new/x "foo-2"
+                                        :ex-new/y "bar-2"}]
+                                      (fluree/stage db-update-ctx)
+                                      deref
+                                      (fluree/commit! ledger)
+                                      deref))
+
+            ledger-updated-load (test-utils/retry-load
+                                 conn "default-context-update" 100)]
+        (is (= {:ex     "http://example.org/ns/"
+                :f      "https://ns.flur.ee/ledger#"
+                :id     "@id"
+                :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                :rdfs   "http://www.w3.org/2000/01/rdf-schema#"
+                :schema "http://schema.org/"
+                :sh     "http://www.w3.org/ns/shacl#"
+                :skos   "http://www.w3.org/2008/05/skos#"
+                :type   "@type"
+                :wiki   "https://www.wikidata.org/wiki/"
+                :xsd    "http://www.w3.org/2001/XMLSchema#"}
+               @(fluree/default-context-at-t ledger-updated-load 1)))
+
+        (is (= {:ex-new "http://example.org/ns/"
+                :f      "https://ns.flur.ee/ledger#"
+                :id     "@id"
+                :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                :rdfs   "http://www.w3.org/2000/01/rdf-schema#"
+                :schema "http://schema.org/"
+                :sh     "http://www.w3.org/ns/shacl#"
+                :skos   "http://www.w3.org/2008/05/skos#"
+                :type   "@type"
+                :wiki   "https://www.wikidata.org/wiki/"
+                :xsd    "http://www.w3.org/2001/XMLSchema#"}
+               @(fluree/default-context-at-t ledger-updated-load 2)))))))


### PR DESCRIPTION
Tests that use default-context-at-t w/ file storage are in 9e512e732ed9147880182ebe345505920508ef73. Given the fix, I'm not sure why this worked in mem conns before, but this seems necessary either way.

Fix is in 3197523e584b536cea0ae9983320405ef0e6e6b9. This value is the basis of the "what was the last sid in this db?" calculation, so not setting it on load was causing us to reuse existing sids and then every `t` would point at the same default-context b/c its sid was reused.

As a result this is needed for default-context-at-t to work in http-api-gateway.