### PR TITLE
Feature/remove psot

### DIFF
--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -176,7 +176,7 @@
 (defn index-update
   "If provided commit-index is newer than db's commit index, updates db by cleaning novelty.
   If it is not newer, returns original db."
-  [{:keys [ledger commit] :as db} {data-map :data, :keys [spot psot post opst tspo] :as commit-index}]
+  [{:keys [ledger commit] :as db} {data-map :data, :keys [spot post opst tspo] :as commit-index}]
   (let [index-t      (:t data-map)
         newer-index? (and data-map
                           (or (nil? (commit-data/index-t commit))
@@ -186,7 +186,6 @@
           (assoc :commit (assoc commit :index commit-index)
                  :novelty* (idx-proto/-empty-novelty (:indexer ledger) db (- index-t))
                  :spot spot
-                 :psot psot
                  :post post
                  :opst opst
                  :tspo tspo)
@@ -233,7 +232,7 @@
 
 ;; ================ end GraphDB record support fns ============================
 
-(defrecord JsonLdDb [ledger alias branch commit t tt-id stats spot psot post
+(defrecord JsonLdDb [ledger alias branch commit t tt-id stats spot post
                      opst tspo schema comparators novelty policy ecount
                      default-context context-type context-cache new-context?]
   dbproto/IFlureeDb
@@ -308,13 +307,11 @@
   [{:keys [method alias conn] :as ledger} default-context context-type new-context?]
   (let [novelty       (new-novelty-map index/default-comparators)
         {spot-cmp :spot
-         psot-cmp :psot
          post-cmp :post
          opst-cmp :opst
          tspo-cmp :tspo} index/default-comparators
 
         spot          (index/empty-branch alias spot-cmp)
-        psot          (index/empty-branch alias psot-cmp)
         post          (index/empty-branch alias post-cmp)
         opst          (index/empty-branch alias opst-cmp)
         tspo          (index/empty-branch alias tspo-cmp)
@@ -334,7 +331,6 @@
                     :tt-id           nil
                     :stats           stats
                     :spot            spot
-                    :psot            psot
                     :post            post
                     :opst            opst
                     :tspo            tspo

--- a/src/fluree/db/flake.cljc
+++ b/src/fluree/db/flake.cljc
@@ -389,16 +389,6 @@
     (cmp-bool (op f1) (op f2))
     (cmp-meta (m f1) (m f2))))
 
-(defn cmp-flakes-psot [f1 f2]
-  (combine-cmp
-    (cmp-pred (p f1) (p f2))
-    (cmp-subj (s f1) (s f2))
-    (cmp-obj (o f1) (dt f1) (o f2) (dt f2))
-    (cmp-tx (t f1) (t f2))
-    (cmp-bool (op f1) (op f2))
-    (cmp-meta (m f1) (m f2))))
-
-
 (defn cmp-flakes-post [f1 f2]
   (combine-cmp
     (cmp-pred (p f1) (p f2))

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -12,7 +12,6 @@
 (def default-comparators
   "Map of default index comparators for the five index types"
   {:spot flake/cmp-flakes-spot
-   :psot flake/cmp-flakes-psot
    :post flake/cmp-flakes-post
    :opst flake/cmp-flakes-opst
    :tspo flake/cmp-flakes-block})

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -17,7 +17,7 @@
    :tspo flake/cmp-flakes-block})
 
 (def types
-  "The five possible index orderings based on the subject, predicate, object,
+  "The four possible index orderings based on the subject, predicate, object,
   and transaction flake attributes"
   (-> default-comparators keys set))
 
@@ -25,16 +25,19 @@
   [dt]
   (= dt const/$xsd:anyURI))
 
-(defn idx-for
+(defn for-components
+  "Returns the index that should be used to scan for flakes that match the
+  supplied flake components `s` `p` `o` and `o-dt` given when of these supplied
+  components are non-nil."
   [s p o o-dt]
   (cond
-    s         :spot
-    p         :post
-    o         (if (reference? o-dt)
-                :opst
-                (throw (ex-info (str "Illegal reference object value" (::var o))
-                                {:status 400 :error :db/invalid-query})))
-    :else     :spot))
+    s     :spot
+    p     :post
+    o     (if (reference? o-dt)
+            :opst
+            (throw (ex-info (str "Illegal reference object value" (::var o))
+                            {:status 400 :error :db/invalid-query})))
+    :else :spot))
 
 (defn leaf?
   "Returns `true` if `node` is a map for a leaf node"

--- a/src/fluree/db/json_ld/branch.cljc
+++ b/src/fluree/db/json_ld/branch.cljc
@@ -46,7 +46,6 @@
      ;            :db               {}                       ;; db commit-map object of indexed db
      ;            :update-commit-fn nil                      ;; function to call when index is updated to create a new commit with updated index address
      ;            :spot             nil                      ;; top level branch of each index , eliminates file lookup of index root
-     ;            :psot             nil
      ;            :post             nil
      ;            :opst             nil
      ;            :tspo             nil}

--- a/src/fluree/db/json_ld/commit_data.cljc
+++ b/src/fluree/db/json_ld/commit_data.cljc
@@ -50,7 +50,6 @@
                         :flakes  4240000
                         :size    120000}
               :spot    "fluree:ipfs://spot" ;; following 4 items are not recorded in the commit, but used to shortcut updated index retrieval in-process
-              :psot    "fluree:ipfs://psot"
               :post    "fluree:ipfs://post"
               :opst    "fluree:ipfs://opst"
               :tspo    "fluree:ipfs://tspo"}})
@@ -166,7 +165,7 @@
 
 (defn json-ld->map
   "Turns json-ld commit meta into the clojure map structure."
-  [commit-json-ld {:keys [commit-address spot psot post opst tspo]}]
+  [commit-json-ld {:keys [commit-address spot post opst tspo]}]
   (let [{id          :id,
          address     const/iri-address,
          v           const/iri-v,
@@ -218,7 +217,6 @@
                   :address (get-in index [const/iri-address :value]) ;; address to get to index 'root'
                   :data    (db-object (get index const/iri-data))
                   :spot    spot ;; following 4 items are not recorded in the commit, but used to shortcut updated index retrieval in-process
-                  :psot    psot
                   :post    post
                   :opst    opst
                   :tspo    tspo})
@@ -379,7 +377,6 @@
                        rem (- (flake/size-bytes rem)))]
      (-> db
          (update-in [:novelty :spot] flake/revise add rem)
-         (update-in [:novelty :psot] flake/revise add rem)
          (update-in [:novelty :post] flake/revise add rem)
          (update-in [:novelty :opst] flake/revise ref-add ref-rem)
          (update-in [:novelty :tspo] flake/revise add rem)
@@ -412,7 +409,7 @@
   data as its own entity."
   [db]
   (let [tt-id   (random-uuid)
-        indexes [:spot :psot :post :opst :tspo]]
+        indexes [:spot :post :opst :tspo]]
     (-> (reduce
           (fn [db* idx]
             (let [{:keys [children] :as node} (get db* idx)

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -21,8 +21,7 @@
   [s p o o-dt]
   (cond
     s         :spot
-    (and p o) :post
-    p         :psot
+    p         :post
     o         (if (reference? o-dt)
                 :opst
                 (throw (ex-info (str "Illegal reference object value" (::var o))

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -55,7 +55,7 @@
                    [o* o-dt*]  (if-let [o-iri (::iri o-cmp)]
                                  [(<? (dbproto/-subid db o-iri true)) const/$xsd:anyURI]
                                  [(::val o-cmp) (::datatype o-cmp)])
-                   idx         (index/idx-for s* p o* o-dt*)
+                   idx         (index/for-components s* p o* o-dt*)
                    idx-root    (get db idx)
                    novelty     (get-in db [:novelty idx])
                    [o** o-fn*] (augment-object-fn idx s* p o* o-fn)

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -3,6 +3,7 @@
             [clojure.core.async :as async :refer [>! go]]
             [fluree.db.flake :as flake]
             [fluree.db.fuel :as fuel]
+            [fluree.db.index :as index]
             [fluree.db.util.async :refer [<?]]
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.log :as log :include-macros true]
@@ -12,21 +13,6 @@
   #?(:clj (:import (clojure.lang MapEntry))))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-(defn reference?
-  [dt]
-  (= dt const/$xsd:anyURI))
-
-(defn idx-for
-  [s p o o-dt]
-  (cond
-    s         :spot
-    p         :post
-    o         (if (reference? o-dt)
-                :opst
-                (throw (ex-info (str "Illegal reference object value" (::var o))
-                                {:status 400 :error :db/invalid-query})))
-    :else     :spot))
 
 (defn augment-object-fn
   "Returns a pair consisting of an object value and boolean function that will
@@ -69,7 +55,7 @@
                    [o* o-dt*]  (if-let [o-iri (::iri o-cmp)]
                                  [(<? (dbproto/-subid db o-iri true)) const/$xsd:anyURI]
                                  [(::val o-cmp) (::datatype o-cmp)])
-                   idx         (idx-for s* p o* o-dt*)
+                   idx         (index/idx-for s* p o* o-dt*)
                    idx-root    (get db idx)
                    novelty     (get-in db [:novelty idx])
                    [o** o-fn*] (augment-object-fn idx s* p o* o-fn)

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -15,8 +15,7 @@
             [fluree.db.db.json-ld :as jld-db]
             [fluree.db.validation :as v]
             [malli.error :as me]
-            [malli.transform :as mt]
-            [fluree.db.index :as index]))
+            [malli.transform :as mt]))
 
 (def registry
   (merge

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -218,7 +218,7 @@
                    (when p (<? (dbproto/-subid db (jld-db/expand-iri db p context) true)))
                    (when o (jld-db/expand-iri db o context))]
 
-          idx     (index/idx-for s p o nil)
+          idx     (index/for-components s p o nil)
           pattern (case idx
                     :spot [s p o]
                     :post [p o s]

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -40,7 +40,6 @@
   (let [[p1 p2 p3 p4 op m] match]
     (case idx
       :spot [p1 (coerce-predicate db p2) p3 p4 op m]
-      :psot [p2 (coerce-predicate db p1) p3 p4 op m]
       :post [p3 (coerce-predicate db p1) p2 p4 op m]
       :opst [p3 (coerce-predicate db p2) p1 p4 op m]
       :tspo [p2 (coerce-predicate db p3) p4 p1 op m])))
@@ -59,7 +58,6 @@
   [idx]
   (case idx
     :spot subject-min-match
-    :psot pred-min-match
     :post pred-min-match
     :opst subject-min-match
     :tspo txn-min-match))
@@ -70,7 +68,6 @@
   [idx]
   (case idx
     :spot subject-max-match
-    :psot pred-max-match
     :post pred-max-match
     :opst subject-max-match
     :tspo txn-max-match))

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -8,7 +8,6 @@
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.log :as log :include-macros true]
             [fluree.db.query.exec :refer [drop-offset take-limit]]
-            [fluree.db.query.exec.where :as where]
             [fluree.db.query.subject-crawl.common :refer [where-subj-xf result-af
                                                           resolve-ident-vars filter-subject]]
             [fluree.db.permissions-validate :refer [filter-subject-flakes]]
@@ -26,7 +25,7 @@
                         (get vars variable)))
         p*          (:value p)
         o-dt        (:datatype o)
-        idx*        (where/idx-for nil p* o* o-dt)
+        idx*        (index/idx-for nil p* o* o-dt)
         [fflake lflake] (case idx*
                           :post [(flake/create nil p* o* o-dt nil nil util/min-integer)
                                  (flake/create nil p* o* o-dt nil nil util/max-integer)]

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -25,7 +25,7 @@
                         (get vars variable)))
         p*          (:value p)
         o-dt        (:datatype o)
-        idx*        (index/idx-for nil p* o* o-dt)
+        idx*        (index/for-components nil p* o* o-dt)
         [fflake lflake] (case idx*
                           :post [(flake/create nil p* o* o-dt nil nil util/min-integer)
                                  (flake/create nil p* o* o-dt nil nil util/max-integer)])

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -28,14 +28,8 @@
         idx*        (index/idx-for nil p* o* o-dt)
         [fflake lflake] (case idx*
                           :post [(flake/create nil p* o* o-dt nil nil util/min-integer)
-                                 (flake/create nil p* o* o-dt nil nil util/max-integer)]
-                          :psot [(flake/create nil p* nil nil nil nil util/min-integer)
-                                 (flake/create nil p* nil nil nil nil util/max-integer)])
-        filter-fn   (cond
-                      (and o* (= :psot idx*))
-                      #(= o* (flake/o %))
-
-                      (:filter o)
+                                 (flake/create nil p* o* o-dt nil nil util/max-integer)])
+        filter-fn   (when (:filter o)
                       (let [f (filter/extract-combined-filter (:filter o))]
                         #(-> % flake/o f)))
         return-chan (async/chan 10 (comp (map flake/s)
@@ -49,7 +43,6 @@
                                     :start-flake fflake
                                     :end-test    <=
                                     :end-flake   lflake
-                                    ;; if looking for pred + obj, but pred is not indexed, then need to use :psot and filter for 'o' values
                                     :xf          (when filter-fn
                                                    (map (fn [flakes]
                                                           (filter filter-fn flakes))))})

--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -29,11 +29,10 @@
   :ecount will have string keys converted to keywords. Need to re-convert
   them to integer keys."
   [db-root]
-  (let [{:keys [spot psot post opst tspo ecount]} db-root]
+  (let [{:keys [spot post opst tspo ecount]} db-root]
     (assoc db-root
            :ecount (deserialize-ecount ecount)
            :spot   (deserialize-child-node spot)
-           :psot   (deserialize-child-node psot)
            :post   (deserialize-child-node post)
            :opst   (deserialize-child-node opst)
            :tspo   (deserialize-child-node tspo))))
@@ -82,7 +81,7 @@
         (assoc acc (name k)
                    (case k
                      :stats (util/stringify-keys v)
-                     (:spot :psot :post :opst :tspo) (stringify-child v)
+                     (:spot :post :opst :tspo) (stringify-child v)
                      ;; else
                      v)))
       {} db-root))

--- a/src/fluree/db/storage.cljc
+++ b/src/fluree/db/storage.cljc
@@ -87,8 +87,8 @@
    (write-db-root db nil))
   ([db custom-ecount]
    (go-try
-     (let [{:keys [conn ledger commit t ecount stats spot psot post opst
-                   tspo fork fork-block]} db
+     (let [{:keys [conn ledger commit t ecount stats spot post opst tspo
+                   fork fork-block]} db
            t'          (- t)
            ledger-alias   (:id commit)
            data        {:ledger-alias ledger-alias
@@ -96,7 +96,6 @@
                         :ecount    (or custom-ecount ecount)
                         :stats     (select-keys stats [:flakes :size])
                         :spot      (child-data spot)
-                        :psot      (child-data psot)
                         :post      (child-data post)
                         :opst      (child-data opst)
                         :tspo      (child-data tspo)

--- a/src/fluree/db/util/pprint.clj
+++ b/src/fluree/db/util/pprint.clj
@@ -71,14 +71,10 @@
 
 
 (defn pprint-db
-  [{:keys [conn spot psot post opst tspo]}]
+  [{:keys [conn spot post opst tspo]}]
   (println "spot:")
   (println "-----------")
   (pprint-index conn spot)
-  (println "")
-  (println "psot:")
-  (println "-----------")
-  (pprint-index conn psot)
   (println "")
   (println "post:")
   (println "-----------")

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -715,7 +715,7 @@
              _                 @(fluree/commit! ledger db2)
              loaded2           (test-utils/retry-load conn ledger-alias 100)
              loaded-db2        (fluree/db loaded2)]
-         (is (= [{:id :ex/kittens} {:id :ex/w3c} {:id :ex/fluree}]
+         (is (= [{:id :ex/fluree} {:id :ex/w3c} {:id :ex/kittens}]
                 @(fluree/query loaded-db2 description-query))
              "The id :ex/mosquitos should be removed")
          (let [db3        @(fluree/stage

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -172,7 +172,7 @@
           "Both users should show, but only SSN for Alice")
 
       ;; Alice can only see her allowed data in a non-graph-crawl query too
-      (is (= [["John" nil] ["Alice" "111-11-1111"]]
+      (is (= [["Alice" "111-11-1111"] ["John" nil]]
              @(fluree/query db+policy {:select '[?name ?ssn]
                                        :where  '[[?p :schema/name ?name]
                                                  {:optional [?p :schema/ssn ?ssn]}]

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -15,7 +15,7 @@
                                  [?s :ex/favNums ?favNums]]
                        :group-by ?name}
               subject @(fluree/query db qry)]
-          (is (= [["Liam" 2] ["Cam" 2] ["Alice" 3] ["Brian" 1]]
+          (is (= [["Alice" 3] ["Brian" 1] ["Cam" 2] ["Liam" 2]]
                  subject)
               "aggregates bindings within each group")))
       (testing "with implicit grouping"

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -44,7 +44,7 @@
               "returns grouped results"))
 
         (testing "with having clauses"
-          (is (= [["Liam" [11 42]] ["Cam" [5 10]] ["Alice" [9 42 76]]]
+          (is (= [["Alice" [9 42 76]] ["Cam" [5 10]] ["Liam" [11 42]]]
                  @(fluree/query db '{:select   [?name ?favNums]
                                      :where    [[?s :schema/name ?name]
                                                 [?s :ex/favNums ?favNums]]
@@ -52,7 +52,7 @@
                                      :having   (>= (count ?favNums) 2)}))
               "filters results according to the supplied having function code")
 
-          (is (= [["Liam" [11 42]] ["Alice" [9 42 76]]]
+          (is (= [["Alice" [9 42 76]] ["Liam" [11 42]]]
                  @(fluree/query db '{:select   [?name ?favNums]
                                      :where    [[?s :schema/name ?name]
                                                 [?s :ex/favNums ?favNums]]
@@ -252,8 +252,8 @@
                 :where [[?s "schema:description" ?o]
                         [?s ?p ?o]]}
             subject @(fluree/query db q)]
-        (is (= [["ex:mosquitos" "schema:description" "We ❤️ Human Blood"]
-                ["ex:w3c" "schema:description" "We ❤️ Internet"]
-                ["ex:fluree" "schema:description" "We ❤️ Data"]]
+        (is (= [["ex:fluree" "schema:description" "We ❤️ Data"]
+                ["ex:mosquitos" "schema:description" "We ❤️ Human Blood"]
+                ["ex:w3c" "schema:description" "We ❤️ Internet"]]
                subject)
             "returns all results")))))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -91,8 +91,8 @@
                :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}
               {:f/t       4
-               :f/assert  [{:ex/x "foo-dog" :id :ex/dog}
-                           {:ex/x "foo-cat" :id :ex/cat}]
+               :f/assert  [{:ex/x "foo-cat" :id :ex/cat}
+                           {:ex/x "foo-dog" :id :ex/dog}]
                :f/retract [{:ex/x "foo-1" :id :ex/dog}
                            {:ex/x "foo-1" :id :ex/cat}]}
               {:f/t       5
@@ -148,7 +148,7 @@
                :f/assert  [{:ex/x "foo-3" :id :ex/dan}]
                :f/retract [{:ex/x "foo-2" :id :ex/dan}]}
               {:f/t       4
-               :f/assert  [{:ex/x "foo-dog" :id :ex/dog} {:ex/x "foo-cat" :id :ex/cat}]
+               :f/assert  [{:ex/x "foo-cat" :id :ex/cat} {:ex/x "foo-dog" :id :ex/dog}]
                :f/retract [{:ex/x "foo-1" :id :ex/dog} {:ex/x "foo-1" :id :ex/cat}]}]
              @(fluree/history ledger {:history [nil :ex/x] :t {:from 2 :to 4}}))))
     (testing "datetime-t"

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -87,14 +87,14 @@
       ;; if mixing multi-cardinality results along with single cardinality, there
       ;; should be a result output for every multi-cardinality value and the single
       ;; cardinality values should duplicate
-      (is (= @(fluree/query db {:context {:schema "http://schema.org/"
+      (is (= [["Alice" 9] ["Alice" 42] ["Alice" 76]
+              ["Brian" 7]
+              ["Cam" 5] ["Cam" 10]]
+             @(fluree/query db {:context {:schema "http://schema.org/"
                                           :ex "http://example.org/ns/"}
                                 :select  ['?name '?favNums]
                                 :where   [['?s :schema/name '?name]
-                                          ['?s :ex/favNums '?favNums]]})
-             [["Cam" 5] ["Cam" 10]
-              ["Alice" 9] ["Alice" 42] ["Alice" 76]
-              ["Brian" 7]])
+                                          ['?s :ex/favNums '?favNums]]}))
           "Multi-cardinality values should duplicate non-multicardinality values ")
 
       ;; ordering by a single variable

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -343,10 +343,10 @@
       (is (= [[:ex/User]]
              @(fluree/query db '{:select [?class]
                                  :where  [[:ex/jane :rdf/type ?class]]})))
-      (is (= [[:ex/dave :ex/nonUser]
-              [:ex/jane :ex/User]
+      (is (= [[:ex/jane :ex/User]
               [:ex/bob :ex/User]
-              [:ex/alice :ex/User]]
+              [:ex/alice :ex/User]
+              [:ex/dave :ex/nonUser]]
              @(fluree/query db '{:select [?s ?class]
                                  :where  [[?s :rdf/type ?class]]}))))
     (testing "shacl targetClass"

--- a/test/fluree/db/transact/default_context_test.clj
+++ b/test/fluree/db/transact/default_context_test.clj
@@ -87,12 +87,12 @@
              (dbproto/-default-context db-update-ctx))))
 
     (testing "Updated context commit db has all data expected"
-      (is (= [{:ex-new/x "foo-2"
-               :ex-new/y "bar-2"
-               :id       :ex-new/foo2}
-              {:ex-new/x "foo-1"
+      (is (= [{:ex-new/x "foo-1"
                :ex-new/y "bar-1"
-               :id       :ex-new/foo}]
+               :id       :ex-new/foo}
+              {:ex-new/x "foo-2"
+               :ex-new/y "bar-2"
+               :id       :ex-new/foo2}]
              @(fluree/query (fluree/db ledger-updated-load)
                             '{:select {?s [:*]}
                               :where  [[?s :ex-new/x nil]]}))))

--- a/test/fluree/db/transact/stable_context_test.clj
+++ b/test/fluree/db/transact/stable_context_test.clj
@@ -47,12 +47,12 @@
              (dbproto/-default-context db1))))
 
     (testing "Query after the 3rd load is using original default context"
-      (is (= [{:id      :blah/three
+      (is (= [{:id      :blah/one
+               :ex/name "One"}
+              {:id      :blah/three
                :ex/name "Three"}
               {:id      :blah/two
-               :ex/name "Two"}
-              {:id      :blah/one
-               :ex/name "One"}]
+               :ex/name "Two"}]
              @(fluree/query db3-load '{:select {?s [:*]}
                                        :where  [[?s :ex/name nil]]}))))))
 
@@ -86,12 +86,12 @@
              (dbproto/-default-context db1))))
 
     (testing "Query after the 3rd load is using original default context"
-      (is (= [{:id      :blah/three
+      (is (= [{:id      :blah/one
+               :ex/name "One"}
+              {:id      :blah/three
                :ex/name "Three"}
               {:id      :blah/two
-               :ex/name "Two"}
-              {:id      :blah/one
-               :ex/name "One"}]
+               :ex/name "Two"}]
              @(fluree/query db3-load '{:select {?s [:*]}
                                        :where  [[?s :ex/name nil]]}))))))
 
@@ -130,11 +130,11 @@
                (dbproto/-default-context db1))))
 
       (testing "Query after the 3rd load is using original default context"
-        (is (= [{:id      :blah/three
+        (is (= [{:id      :blah/one
+                 :ex/name "One"}
+                {:id      :blah/three
                  :ex/name "Three"}
                 {:id      :blah/two
-                 :ex/name "Two"}
-                {:id      :blah/one
-                 :ex/name "One"}]
+                 :ex/name "Two"}]
                @(fluree/query db3-load '{:select {?s [:*]}
                                          :where  [[?s :ex/name nil]]})))))))

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -67,7 +67,7 @@
       (is (= @(fluree/query db-subj-delete
                             '{:select ?name
                               :where  [[?s :schema/name ?name]]})
-             ["Jane" "Bob"])
+             ["Bob" "Jane"])
           "Only Jane and Bob should be left in the db.")
 
       (is (= @(fluree/query db-subj-pred-del
@@ -87,7 +87,7 @@
       (is (= @(fluree/query db-age-delete
                             '{:select ?name
                               :where  [[?s :schema/name ?name]]})
-             ["Bob" "Alice"])
+             ["Alice" "Bob"])
           "Only Bob and Alice should be left in the db.")
 
       (testing "Updating property value only if it's current value is a match."

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -418,9 +418,9 @@
                       :where  [[?s "schema:description" ?o]
                                [?s ?p ?o]]}
             subject @(fluree/query db1 q)]
-        (is (= [["ex:mosquitos" "schema:description" "We ❤️ Human Blood"]
-                ["ex:w3c" "schema:description" "We ❤️ Internet"]
-                ["ex:fluree" "schema:description" "We ❤️ Data"]]
+        (is (= [["ex:fluree" "schema:description" "We ❤️ Data"]
+                ["ex:mosquitos" "schema:description" "We ❤️ Human Blood"]
+                ["ex:w3c" "schema:description" "We ❤️ Internet"]]
                subject)
             "returns all results")))
     (testing "after deletion"


### PR DESCRIPTION
This patch removes the psot index. The psot index was only used when scanning for a flake when only the `p` value was known. All the relevant information needed for such a scan is already present in the post index, but in a different order. Since we don't make any guarantees on the order of query results without an explicit `order-by` clause specified, we can use the post index with no performance penalty in all the situations we were currently using the psot index. Removing the psot index should also drop our storage requirements and increase our reindexing performance by ~20%

This patch depends on #539 which itself depends on #536, so please review those first. 