### PR TITLE
fn intends to check maps, but other data structures are valid

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -498,7 +498,8 @@
 
 (defn update?
   [x]
-  (and (or (update/insert? x)
+  (and (map? x)
+       (or (update/insert? x)
            (update/retract? x))
        (or (contains? x :where)
            (contains? x "where"))))


### PR DESCRIPTION
Tiny fix. This fn assumes it is checking a map, but never constrains the check to a map. Through some unintentional CLJ behavior, a vector still passes - but a list will not and throw an unexpected error.

This just makes sure the data structure is actually a map before proceeding with the other checks.