### PR TITLE
qualified value node shape

### DIFF
--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -357,9 +357,11 @@
   (go-try
     (let [q-shape-flakes (<? (query-range/index-range db :spot = [qualified-value-shape]))
           node-shape?    (->> q-shape-flakes
-                              (filter #(and (= (flake/p %) const/$rdf:type)
-                                            (= (flake/o %) const/$sh:NodeShape)))
-                              (first))
+                              (reduce (fn [node-shape? f]
+                                        (if (and (= (flake/p f) const/$rdf:type)
+                                                 (= (flake/o f) const/$sh:NodeShape))
+                                          (reduced true)
+                                          false))))
           q-shape        (if node-shape?
                            (<? (build-node-shape db q-shape-flakes))
                            (<? (build-property-shape db const/$sh:qualifiedValueShape q-shape-flakes)))]

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -459,7 +459,9 @@
       (doseq [shape shapes]
         (let [[valid? err-msg] (<? (validate-shape db shape s-flakes pid->p-flakes))]
           (when (not valid?)
-            (throw (ex-info err-msg
+            (throw (ex-info (if (str/starts-with? err-msg "SHACL shape is closed")
+                              err-msg
+                              (str "SHACL PropertyShape exception - " err-msg "."))
                             {:status 400 :error :db/shacl-validation}))))))))
 
 (defn build-property-base-shape

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1413,9 +1413,7 @@
                                            "ex:parent" [{"id" "ex:Bob"}
                                                         {"id" "ex:Zorba"
                                                          "type" "ex:Parent"
-                                                         "ex:gender" "alien"}]}])
-          ]
-      (def valid-kid valid-kid)
+                                                         "ex:gender" "alien"}]}])]
 
       (is (= [{"id" "ex:ValidKid"
                "rdf:type" ["ex:Kid"]


### PR DESCRIPTION
closes #322 

`sh:qualifiedValueShape` can have both a property shape (already supported) or a node shape as its value. This PR adds support for a node shape in that position.

The main value of this PR is refactoring to move validation exceptions up the call stack to `validate-target`, instead of having it inside `validate-shape`. This allows us to call `validate-shape` recursively and decide if we care whether or not data didn't conform (and in the case of `sh:qualifiedValueShape, it's entirely ok to have non-conforming data as long as _enough_ of it conforms).

The test is commented out because we don't support having data that doesn't conform to a node shape that targets it. 
