### PR TITLE
return @type instead of rdf:type

### DIFF
--- a/dev/indexing_test.clj
+++ b/dev/indexing_test.clj
@@ -68,7 +68,7 @@
 
   @(fluree/query (fluree/db ledger)
                  {:select {'?s [:* {:schema/isBasedOn [:*]}]}
-                  :where  [['?s :rdf/type :schema/Movie]]})
+                  :where  [['?s :type :schema/Movie]]})
 
   (def db2 @(fluree/stage
               ledger
@@ -92,7 +92,7 @@
 
   @(fluree/query (fluree/db loaded-ledger)
                  {:select {'?s [:* {:schema/isBasedOn [:*]}]}
-                  :where  [['?s :rdf/type :schema/Movie]]})
+                  :where  [['?s :type :schema/Movie]]})
 
   (-> (fluree/db loaded-ledger)
       :commit)
@@ -105,7 +105,7 @@
 
   @(fluree/query db3
                  {:select {'?s [:* {:schema/isBasedOn [:*]}]}
-                  :where  [['?s :rdf/type :schema/Movie]]})
+                  :where  [['?s :type :schema/Movie]]})
 
   (-> @(fluree/commit! db3 {:message "Third commit, from loaded ledger"
                             :push?   true})

--- a/dev/json_ld.clj
+++ b/dev/json_ld.clj
@@ -77,7 +77,7 @@
 
   @(fluree/query (fluree/db ledger)
                  {:select {'?s [:* {:f/role [:*]}]}
-                  :where  [['?s :rdf/type :f/DID]]})
+                  :where  [['?s :type :f/DID]]})
 
   (def newdb
     @(fluree/stage
@@ -160,7 +160,7 @@
                             :from   :f/Rule})
 
   @(fluree/query latest-db {:select {'?s [:* {:f/role [:*]}]}
-                            :where  [['?s :rdf/type :f/DID]]})
+                            :where  [['?s :type :f/DID]]})
 
 
 

--- a/dev/json_ld.cljc
+++ b/dev/json_ld.cljc
@@ -37,7 +37,7 @@
                             (println "ledger" (pr-str ledger))
                             (-> (fluree/query (fluree/db ledger)
                                               {:select {'?s [:* {:f/role [:*]}]}
-                                               :where [['?s :rdf/type :f/DID]]})
+                                               :where [['?s :type :f/DID]]})
                                 (.then (fn [q0] (println "q0" q0))))
 
 
@@ -95,7 +95,7 @@
 
   @(fluree/query (fluree/db ledger)
                  {:select {'?s [:* {:f/role [:*]}]}
-                  :where  [['?s :rdf/type :f/DID]]})
+                  :where  [['?s :type :f/DID]]})
 
   (def newdb
     @(fluree/stage
@@ -176,7 +176,7 @@
                             :from   :f/Rule})
 
   @(fluree/query latest-db {:select {'?s [:* {:f/role [:*]}]}
-                            :where  [['?s :rdf/type :f/DID]]})
+                            :where  [['?s :type :f/DID]]})
 
 
 

--- a/dev/json_ld/crud.clj
+++ b/dev/json_ld/crud.clj
@@ -51,7 +51,7 @@
                      :from   :ex/alice})
 
   @(fluree/query db {:select {'?s [:*]}
-                     :where  [['?s :rdf/type :ex/User]]})
+                     :where  [['?s :type :ex/User]]})
 
   @(fluree/query db {:select ['?p '?o]
                      :where  [[:ex/alice '?p '?o]]})
@@ -83,7 +83,7 @@
 
   @(fluree/query db-subj-pred-del
                  {:select {'?s [:*]}
-                  :where  [['?s :rdf/type :ex/User]]})
+                  :where  [['?s :type :ex/User]]})
 
   ;;;;;;;;;;;;;;;;
   ;; delete all subjects with a :schema/email predicate

--- a/dev/json_ld/mem_conn.clj
+++ b/dev/json_ld/mem_conn.clj
@@ -23,7 +23,7 @@
 
   @(fluree/query (fluree/db ledger)
                  {:select {'?s [:* {:f/role [:*]}]}
-                  :where  [['?s :rdf/type :f/DID]]})
+                  :where  [['?s :type :f/DID]]})
 
   (def newdb
     @(fluree/stage

--- a/dev/json_ld/policy.clj
+++ b/dev/json_ld/policy.clj
@@ -73,7 +73,7 @@
 
   ;; Note that already, one can query for everything unpermissioned - but either role hasn't been given any permissions so nothing will return
   @(fluree/query db3 {:select {'?s [:* {:ex/location [:*]}]}
-                      :where  [['?s :rdf/type :ex/User]]})
+                      :where  [['?s :type :ex/User]]})
 
   ;; try to get a permissioned DB - but not rules exist yet!
   @(fluree/wrap-policy db3 {:f/$identity (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
@@ -94,7 +94,7 @@
 
   ;; try some queries... default uses no permissions
   @(fluree/query db4 {:select {'?s [:* {:ex/location [:*]}]}
-                      :where  [['?s :rdf/type :ex/User]]})
+                      :where  [['?s :type :ex/User]]})
 
   ;; try with the non-root role
   (def perm-db @(fluree/wrap-policy db4 {:f/$identity (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
@@ -102,7 +102,7 @@
 
   ;; no permissions to :ex/User data
   @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
-                          :where  [['?s :rdf/type :ex/User]]})
+                          :where  [['?s :type :ex/User]]})
 
   ;; try with root role
   (def perm-db @(fluree/wrap-policy db4 {:f/$identity (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
@@ -110,7 +110,7 @@
 
   ;; root can see all
   @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
-                          :where  [['?s :rdf/type :ex/User]]})
+                          :where  [['?s :type :ex/User]]})
 
   (-> perm-db :permissions)
 
@@ -137,11 +137,11 @@
 
   ;; should see users, but only own SSN - and not location in crawl
   @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
-                          :where  [['?s :rdf/type :ex/User]]})
+                          :where  [['?s :type :ex/User]]})
 
   ;; no product permissions
   @(fluree/query perm-db {:select {'?s [:* {:ex/location [:*]}]}
-                          :where  [['?s :rdf/type :ex/Product]]})
+                          :where  [['?s :type :ex/Product]]})
 
   )
 

--- a/dev/json_ld/query.clj
+++ b/dev/json_ld/query.clj
@@ -75,36 +75,36 @@
 
 
   @(fluree/query db {:select ['?name '?email1 '?email2]
-                     :where  [['?s :rdf/type :ex/User]
+                     :where  [['?s :type :ex/User]
                               ['?s :schema/name '?name]
                               {:union [[['?s :ex/email '?email1]]
                                        [['?s :schema/email '?email2]]]}]})
 
   @(fluree/query db {:select ['?s '?email1 '?email2]
-                     :where  [['?s :rdf/type :ex/User]
+                     :where  [['?s :type :ex/User]
                               {:union [[['?s :ex/email '?email1]]
                                        [['?s :schema/email '?email2]]]}]})
 
 
   @(fluree/query db {:select ['?s '?email1 '?email2]
-                     :where  [['?s :rdf/type :ex/User]
+                     :where  [['?s :type :ex/User]
                               {:optional ['?s :ex/email '?email1]}
                               {:optional ['?s :schema/email '?email2]}]})
 
 
   @(fluree/query db {:select ['?email]
-                     :where  [['?s :rdf/type :ex/User]
+                     :where  [['?s :type :ex/User]
                               ;['?s :schema/name '?name]
                               {:union [[['?s :ex/email '?email]]
                                        [['?s :schema/email '?email]]]}]})
 
   @(fluree/query db {:select ['?name '?email]
-                     :where  [['?s :rdf/type :ex/User]
+                     :where  [['?s :type :ex/User]
                               ['?s :schema/name '?name]
                               ['?s :ex/email '?email]]})
 
   @(fluree/query db {:select ['?name '?favColor '?age]
-                     :where  [['?s :rdf/type :ex/User]
+                     :where  [['?s :type :ex/User]
                               ['?s :schema/name '?name]
                               {:optional ['?s :ex/favColor '?favColor]}
                               ['?s :schema/age '?age]]})
@@ -189,5 +189,5 @@
                      :from   :ex/brian})
 
   @(fluree/query db {:select {'?s [:* {:ex/friend [:*]}]}
-                     :where  [['?s :rdf/type :ex/User]]}))
+                     :where  [['?s :type :ex/User]]}))
 

--- a/dev/json_ld/shacl.clj
+++ b/dev/json_ld/shacl.clj
@@ -34,7 +34,7 @@
                                       :sh/minCount 1
                                       :sh/maxCount 1
                                       :sh/datatype :xsd/string}]
-              :sh/ignoredProperties [:rdf/type]
+              :sh/ignoredProperties [:type]
               :sh/closed            true}))
 
   (def db2 @(fluree/stage
@@ -100,16 +100,16 @@
                                 :sh/minCount 1
                                 :sh/maxCount 1
                                 :sh/nodeKind :sh/IRI}]
-        :sh/ignoredProperties [:rdf/type :schema/author]
+        :sh/ignoredProperties [:type :schema/author]
         :sh/closed            true}))
 
 
   @(fluree/query newdb2 {:select {'?s [:* {:sh/property [:*]}]}
-                         :where  [['?s :rdf/type :sh/NodeShape]]})
+                         :where  [['?s :type :sh/NodeShape]]})
 
 
   @(fluree/query newdb2 {:select {'?s [:*]}
-                         :where  [['?s :rdf/type :ex/User]]})
+                         :where  [['?s :type :ex/User]]})
 
   ;; should error - no email
   (def db2
@@ -149,7 +149,7 @@
 
 
   @(fluree/query db2 {:select {'?s [:* {:sh/property [:*]}]}
-                      :where  [['?s :rdf/type :ex/User]]})
+                      :where  [['?s :type :ex/User]]})
 
 
   (-> newdb2 :schema :shapes deref)

--- a/dev/json_ld/subclass.clj
+++ b/dev/json_ld/subclass.clj
@@ -57,7 +57,7 @@
 
   @(fluree/query newdb
                  {:select {'?s [:*]}
-                  :where  [['?s :rdf/type :schema/Book]]})
+                  :where  [['?s :type :schema/Book]]})
 
 
   ;; add CreativeWork class
@@ -87,6 +87,6 @@
   ;; Query for CreativeWork
   @(fluree/query db3
                  {:select {'?s [:*]}
-                  :where  [['?s :rdf/type :schema/CreativeWork]]})
+                  :where  [['?s :type :schema/CreativeWork]]})
 
   )

--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -23,7 +23,7 @@
 (def ^:const predefined-properties
   (merge datatype/default-data-types
          {"http://www.w3.org/1999/02/22-rdf-syntax-ns#Property" const/$rdf:Property
-          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"     const/$rdf:type
+          const/iri-type                                        const/$rdf:type
           ;; rdfs
           "http://www.w3.org/2000/01/rdf-schema#Class"          const/$rdfs:Class
           "http://www.w3.org/2000/01/rdf-schema#subClassOf"     const/$rdfs:subClassOf

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -38,13 +38,13 @@
     ;; TODO - once supported, use context to always return :f/allow and :f/property as vectors so we don't need to coerce downstream
     (<? (fql/query db {:context nil
                        :select {'?s [:*
-                                     {const/iri-rdf-type [:_id]}
+                                     {const/iri-type [:_id]}
                                      {const/iri-allow [:* {const/iri-target-role
                                                            [:_id]}]}
                                      {const/iri-property
                                       [:* {const/iri-allow
                                            [:* {const/iri-target-role [:_id]}]}]}]}
-                       :where [['?s const/iri-rdf-type const/iri-policy]]}))))
+                       :where [['?s const/iri-type const/iri-policy]]}))))
 
 (defn policies-for-roles*
   "Filters all rules into only those that apply to the given roles."

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -444,7 +444,7 @@
             (when (not valid?)
               (throw-property-shape-exception! err-msg))
             (when (and closed? (not-empty unvalidated-properties))
-              (throw (ex-info (str "SHACL shape is closed, extra properties not allowed: " unvalidated-properties)
+              (throw (ex-info (str "SHACL shape is closed, extra properties not allowed: " (vec unvalidated-properties))
                               {:status 400 :error :db/shacl-validation})))
             [res]))))))
 

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -15,7 +15,7 @@
 (comment
  ;; a raw SHACL shape looks something like this:
  {:id             :ex/UserShape,
-  :rdf/type       [:sh/NodeShape],
+  :type       [:sh/NodeShape],
   :sh/targetClass {:id :ex/User},
   :sh/property    [{:id          "_:f211106232533000",
                     :sh/path     {:id :schema/name},

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -210,7 +210,11 @@
              property-flakes type-flakes ;; only used if generating new Class and Property flakes
              subj-flakes     base-flakes]
         (if k
-          (let [list?            (list-value? v)
+          (let [_ (when (= k const/iri-rdf-type)
+                    (throw (ex-info (str (pr-str const/iri-rdf-type) " is not a valid predicate IRI."
+                                         " Please use the JSON-LD \"@type\" keyword instead.")
+                                    {:status 400 :error :db/invalid-predicate})))
+                list?            (list-value? v)
                 retract?         (nil? v)
                 v*               (if list?
                                    (let [list-vals (:list v)]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -282,7 +282,7 @@
 (defn base-flakes
   "Returns base set of flakes needed in any new ledger."
   [t]
-  [(flake/create const/$rdf:type const/$xsd:anyURI const/iri-rdf-type const/$xsd:string t true nil)
+  [(flake/create const/$rdf:type const/$xsd:anyURI const/iri-type const/$xsd:string t true nil)
    (flake/create const/$rdfs:Class const/$xsd:anyURI const/iri-class const/$xsd:string t true nil)
    (flake/create const/$xsd:anyURI const/$xsd:anyURI "@id" const/$xsd:string t true nil)])
 

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -117,7 +117,7 @@
        (= :list (-> v first key))))
 
 (defn get-subject-types
-  "Returns a set of all :rdf/type Class subject ids for the provided subject.
+  "Returns a set of all :type Class subject ids for the provided subject.
   new-types are a set of newly created types in the transaction."
   [db sid added-classes]
   (go-try

--- a/src/fluree/db/json_ld/vocab.cljc
+++ b/src/fluree/db/json_ld/vocab.cljc
@@ -199,10 +199,6 @@
                                 :ref? true
                                 :idx? true
                                 :id   const/$rdf:type}
-                               {:iri  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-                                :ref? true
-                                :idx? true
-                                :id   const/$rdf:type}
                                {:iri  "http://www.w3.org/2000/01/rdf-schema#Class"
                                 :ref? true
                                 :idx? true

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -69,7 +69,10 @@
 (def rdf-type-preds #{"a"
                       :a
                       :type
-                      const/iri-type})
+                      const/iri-type
+                      "rdf:type"
+                      :rdf/type
+                      const/iri-rdf-type})
 
 (defn rdf-type?
   [p]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -66,12 +66,10 @@
                              values)
                         {:status 400 :error :db/invalid-query}))))))
 
-(def rdf-type-preds #{"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-                      "a"
+(def rdf-type-preds #{"a"
                       :a
-                      "rdf:type"
-                      :rdf/type
-                      "@type"})
+                      :type
+                      const/iri-type})
 
 (defn rdf-type?
   [p]

--- a/src/fluree/db/query/sparql_parser.cljc
+++ b/src/fluree/db/query/sparql_parser.cljc
@@ -226,7 +226,7 @@
         (handle-iri (second path-primary))
 
         (= path-primary "a")
-        ["$fdb" "rdf:type"]
+        ["$fdb" "type"]
 
         (= path-primary "!")
         (throw (ex-info (str "! not currently supported as SPARQL predicate.")

--- a/src/fluree/db/query/sql.cljc
+++ b/src/fluree/db/query/sql.cljc
@@ -311,7 +311,7 @@
         field-var (template/build-var pred)]
     (if (some #{"NOT"} parsed)
       (bounce [[template/collection-var pred field-var]])
-      (bounce [[template/collection-var "rdf:type" template/collection]
+      (bounce [[template/collection-var "type" template/collection]
                {:optional [[template/collection-var pred field-var]]}
                {:filter [(template/build-fn-call ["nil?" field-var])]}]))))
 
@@ -369,7 +369,7 @@
   (let [parse-map    (parse-into-map rst)
         from-clause  (->> parse-map :from-clause first)
         where-clause (or (some->> parse-map :where-clause first)
-                         {::where [[template/collection-var  "rdf:type" template/collection]]})
+                         {::where [[template/collection-var  "type" template/collection]]})
         grouping     (->> parse-map :group-by-clause vec)
         from         (-> from-clause ::coll first)]
     (-> (merge-parsed from-clause where-clause)

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -66,7 +66,7 @@
   (log/trace "Running simple subject crawl query:" parsed-query)
   (let [error-ch    (async/chan)
         f-where     (first where)
-        rdf-type?   (= :rdf/type (:type f-where))
+        rdf-type?   (= :type (:type f-where))
         filter-map  (:s-filter (second where))
         cache       (volatile! {})
         fuel-vol    (volatile! 0)

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -190,11 +190,10 @@
                                      (ctx-util/stringify-context ledger-context))
                query          {:where  '[[?p :schema/email "wes@example.org"]]
                                :select '{?p [:*]}}
-               results        @(fluree/query loaded-db query)
-               full-type-url  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+               results        @(fluree/query loaded-db query)]
            (is (= target-t (:t loaded-db)))
            (is (= merged-ctx (dbproto/-default-context loaded-db)))
-           (is (= [{full-type-url   [:ex/User]
+           (is (= [{:type   [:ex/User]
                     :id             :ex/wes
                     :schema/age     42
                     :schema/email   "wes@example.org"
@@ -305,14 +304,14 @@
            (is (= target-t (:t loaded-db)))
            (testing "query returns expected `list` values"
              (is (= [{:id         :ex/cam,
-                      :rdf/type   [:ex/User],
+                      :type   [:ex/User],
                       :ex/numList [7 8 9 10]}
-                     {:id :ex/john, :rdf/type [:ex/User]}
+                     {:id :ex/john, :type [:ex/User]}
                      {:id         :ex/alice,
-                      :rdf/type   [:ex/User],
+                      :type   [:ex/User],
                       :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                     @(fluree/query loaded-db '{:select {?s [:*]}
-                                               :where  [[?s :rdf/type :ex/User]]}))))))
+                                               :where  [[?s :type :ex/User]]}))))))
 
        (testing "can load with policies"
          (with-tmp-dir storage-path
@@ -364,7 +363,7 @@
              (is (= target-t (:t loaded-db)))
              (testing "query returns expected policy"
                (is (= [{:id            :ex/UserPolicy,
-                        :rdf/type      [:f/Policy],
+                        :type      [:f/Policy],
                         :f/allow
                         {:id           :ex/globalViewAllow,
                          :f/action     {:id :f/view},
@@ -381,12 +380,12 @@
                       @(fluree/query loaded-db
                                      '{:select
                                        {?s [:*
-                                            {:rdf/type [:_id]}
+                                            {:type [:_id]}
                                             {:f/allow [:* {:f/targetRole [:_id]}]}
                                             {:f/property
                                              [:* {:f/allow
                                                   [:* {:f/targetRole [:_id]}]}]}]}
-                                       :where  [[?s :rdf/type :f/Policy]]}))))))))))
+                                       :where  [[?s :type :f/Policy]]}))))))))))
 
 #?(:clj
    (deftest load-from-memory-test
@@ -503,11 +502,10 @@
              merged-ctx     (merge (ctx-util/stringify-context conn-context) (ctx-util/stringify-context ledger-context))
              query          {:where  '[[?p :schema/email "wes@example.org"]]
                              :select '{?p [:*]}}
-             results        @(fluree/query loaded-db query)
-             full-type-url  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+             results        @(fluree/query loaded-db query)]
          (is (= target-t (:t loaded-db)))
          (is (= merged-ctx (dbproto/-default-context loaded-db)))
-         (is (= [{full-type-url   [:ex/User]
+         (is (= [{:type   [:ex/User]
                   :id             :ex/wes
                   :schema/age     42
                   :schema/email   "wes@example.org"
@@ -570,14 +568,14 @@
          (is (= target-t (:t loaded-db)))
          (testing "query returns expected `list` values"
            (is (= [{:id         :ex/cam,
-                    :rdf/type   [:ex/User],
+                    :type   [:ex/User],
                     :ex/numList [7 8 9 10]}
-                   {:id :ex/john, :rdf/type [:ex/User]}
+                   {:id :ex/john, :type [:ex/User]}
                    {:id         :ex/alice,
-                    :rdf/type   [:ex/User],
+                    :type   [:ex/User],
                     :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                   @(fluree/query loaded-db '{:select {?s [:*]}
-                                             :where  [[?s :rdf/type :ex/User]]})))))
+                                             :where  [[?s :type :ex/User]]})))))
 
        (testing "can load with policies"
          (let [conn         @(fluree/connect
@@ -622,7 +620,7 @@
            (is (= target-t (:t loaded-db)))
            (testing "query returns expected policy"
              (is (= [{:id            :ex/UserPolicy,
-                      :rdf/type      [:f/Policy],
+                      :type      [:f/Policy],
                       :f/allow
                       {:id           :ex/globalViewAllow,
                        :f/action     {:id :f/view},
@@ -637,10 +635,10 @@
                        :f/path {:id :schema/ssn}},
                       :f/targetClass {:id :ex/User}}]
                     @(fluree/query loaded-db '{:select {?s [:*
-                                                            {:rdf/type [:_id]}
+                                                            {:type [:_id]}
                                                             {:f/allow [:* {:f/targetRole [:_id]}]}
                                                             {:f/property [:* {:f/allow [:* {:f/targetRole [:_id]}]}]}]}
-                                               :where  [[?s :rdf/type :f/Policy]]})))))))
+                                               :where  [[?s :type :f/Policy]]})))))))
      (testing "loading predefined properties"
        (let [conn (test-utils/create-conn {:context test-utils/default-str-context
                                            :context-type :string})
@@ -659,12 +657,12 @@
                           (get "id"))
              loaded1 (test-utils/retry-load conn ledger-alias 100)]
          (is (= [{"id" shape-id
-                  "rdf:type" ["sh:NodeShape"],
+                  "type" ["sh:NodeShape"],
                   "sh:targetClass" {"id" "schema:Person"},
                   "sh:property" {"id" "_:f211106232532993"}}]
                 @(fluree/query db1 property-query)))
          (is (= [{"id" shape-id
-                  "rdf:type" ["sh:NodeShape"],
+                  "type" ["sh:NodeShape"],
                   "sh:targetClass" {"id" "schema:Person"},
                   "sh:property" {"id" "_:f211106232532993"}}]
                 @(fluree/query (fluree/db loaded1) property-query)))
@@ -676,7 +674,7 @@
                                               "sh:datatype" {"id" "xsd:string"}}]})
                  loaded2 (test-utils/retry-load conn ledger-alias 100)]
              (is (= [{"id" shape-id
-                      "rdf:type" ["sh:NodeShape"],
+                      "type" ["sh:NodeShape"],
                       "sh:targetClass" {"id" "schema:Person"},
                       "sh:property" {"id" "_:f211106232532994"}}]
                     @(fluree/query (fluree/db loaded2) property-query)))))))
@@ -721,7 +719,7 @@
          (let [db3        @(fluree/stage
                              loaded-db2
                              '{:delete [?s ?p ?o]
-                               :where  [[?s :rdf/type :schema/Organization]
+                               :where  [[?s :type :schema/Organization]
                                         [?s ?p ?o]]})
                _          @(fluree/commit! ledger db3)
                loaded3  (test-utils/retry-load conn ledger-alias 100)

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -70,7 +70,7 @@
             double-policy-query-result @(fluree/query
                                          root-wrapped-db
                                          {:select {'?s [:* {:ex/location [:*]}]}
-                                          :where  [['?s :rdf/type :ex/User]]
+                                          :where  [['?s :type :ex/User]]
                                           :opts   {:did  root-did
                                                    :role :ex/rootRole}})]
         (is (util/exception? double-policy-query-result)
@@ -80,13 +80,13 @@
 
       ;; root can see all user data
       (is (= [{:id               :ex/john,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17",
                :schema/ssn       "888-88-8888"}
               {:id               :ex/alice,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
@@ -95,19 +95,19 @@
                                   :ex/state   "NC",
                                   :ex/country "USA"}}]
              @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
-                                       :where  [['?s :rdf/type :ex/User]]
+                                       :where  [['?s :type :ex/User]]
                                        :opts   {:did  root-did
                                                 :role :ex/rootRole}}))
           "Both user records + all attributes should show")
 
       (is (= [{:id               :ex/john,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17",
                :schema/ssn       "888-88-8888"}
               {:id               :ex/alice,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
@@ -116,57 +116,57 @@
                                   :ex/state   "NC",
                                   :ex/country "USA"}}]
              @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
-                                       :where  [['?s :rdf/type :ex/User]]
+                                       :where  [['?s :type :ex/User]]
                                        :opts   {:did  root-did
                                                 :role :ex/rootRole}}))
           "Both user records + all attributes should show")
 
       ;; root role can see all product data, without identity
       (is (= [{:id                   :ex/widget,
-               :rdf/type             [:ex/Product],
+               :type             [:ex/Product],
                :schema/name          "Widget",
                :schema/price         99.99,
                :schema/priceCurrency "USD"}]
              @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
-                                       :where  [['?s :rdf/type :ex/Product]]
+                                       :where  [['?s :type :ex/Product]]
                                        :opts   {:role :ex/rootRole}}))
           "The product record should show with all attributes")
       (is (= [{:id               :ex/john,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17"}
               {:id               :ex/alice,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17"}]
              @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
-                                       :where  [['?s :rdf/type :ex/User]]
+                                       :where  [['?s :type :ex/User]]
                                        :opts   {:role :ex/userRole}}))
           "Both users should show, but no SSNs because no identity was provided")
 
       ;; Alice cannot see product data as it was not explicitly allowed
       (is (= []
              @(fluree/query db+policy {:select {'?s [:*]}
-                                       :where  [['?s :rdf/type :ex/Product]]
+                                       :where  [['?s :type :ex/Product]]
                                        :opts   {:did  alice-did
                                                 :role :ex/userRole}})))
 
       ;; Alice can see all users, but can only see SSN for herself, and can't see the nested location
       (is (= [{:id               :ex/john,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17"}
               {:id               :ex/alice,
-               :rdf/type         [:ex/User],
+               :type         [:ex/User],
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
                :schema/ssn       "111-11-1111"}]
              @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
-                                       :where  [['?s :rdf/type :ex/User]]
+                                       :where  [['?s :type :ex/User]]
                                        :opts   {:did  alice-did
                                                 :role :ex/userRole}}))
           "Both users should show, but only SSN for Alice")
@@ -199,12 +199,12 @@
                                                           :opts           {:did  alice-did
                                                                            :role :ex/userRole}})
                 commit-details-asserts (get-in history-result [:f/commit :f/data :f/assert])]
-            (is (= [{:rdf/type         [:ex/User],
+            (is (= [{:type         [:ex/User],
                      :schema/name      "John",
                      :schema/email     "john@flur.ee",
                      :schema/birthDate "2021-08-17",
                      :id               :ex/john}
-                    {:rdf/type         [:ex/User],
+                    {:type         [:ex/User],
                      :schema/name      "Alice",
                      :schema/email     "alice@flur.ee",
                      :schema/birthDate "2022-08-17",
@@ -219,7 +219,7 @@
                                                                            :role :ex/rootRole}})
                 commit-details-asserts (get-in history-result [:f/commit :f/data :f/assert])]
             (is (contains? (into #{} commit-details-asserts)
-                           {:rdf/type         [:ex/User],
+                           {:type         [:ex/User],
                             :schema/name      "John",
                             :schema/email     "john@flur.ee",
                             :schema/birthDate "2021-08-17",
@@ -291,10 +291,10 @@
                               [{:id "https://ns.flur.ee/ledger#view"}]
                               "https://ns.flur.ee/ledger#equals"
                               {:list [{:id "https://ns.flur.ee/ledger#$identity"} :ex/user]}}]}]}])]
-      (is (= [{:id :ex/bob, :rdf/type [:ex/User], :schema/name "Bob"}
-              {:id          :ex/alice, :rdf/type [:ex/User], :ex/secret "alice's secret"
+      (is (= [{:id :ex/bob, :type [:ex/User], :schema/name "Bob"}
+              {:id          :ex/alice, :type [:ex/User], :ex/secret "alice's secret"
                :schema/name "Alice"}]
-             @(fluree/query db {:where  '[[?s :rdf/type :ex/User]]
+             @(fluree/query db {:where  '[[?s :type :ex/User]]
                                 :select '{?s [:*]}
                                 :opts   {:role :ex/userRole
                                          :did  alice-did}}))))))

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -71,7 +71,7 @@
                         {:id            :ex/ProductPolicy,
                          :type          [:f/Policy],
                          :f/targetClass :ex/Product
-                         :f/property    [{:f/path  :rdf/type
+                         :f/property    [{:f/path  :type
                                           :f/allow [{:f/targetRole :ex/userRole
                                                      :f/action     [:f/view]}]}
                                          {:f/path  :schema/name
@@ -85,7 +85,7 @@
                                            {:did alice-did
                                             :role      :ex/userRole})]
             (is (= [{:id :ex/alice,
-                     :rdf/type [:ex/User],
+                     :type [:ex/User],
                      :schema/name "Alice",
                      :schema/email "alice@foo.bar",
                      :schema/birthDate "2022-08-17",
@@ -103,24 +103,24 @@
                                               {:role :ex/rootRole})]
 
               (is (= [{:id :ex/widget,
-                       :rdf/type [:ex/Product],
+                       :type [:ex/Product],
                        :schema/name "Widget",
                        :schema/price 105.99,
                        :schema/priceCurrency "USD"}]
                      @(fluree/query update-price
                                     {:select {'?s [:*]}
-                                     :where  [['?s :rdf/type :ex/Product]]}))
+                                     :where  [['?s :type :ex/Product]]}))
                   "Updated :schema/price should have been allowed, and entire product is visible in query."))
             (let [update-name @(fluree/stage db+policy
                                              {:id          :ex/widget
                                               :schema/name "Widget2"}
                                              {:role :ex/userRole})]
 
-              (is (= [{:rdf/type    [:ex/Product]
+              (is (= [{:type    [:ex/Product]
                        :schema/name "Widget2"}]
                      @(fluree/query update-name
                                     {:select {'?s [:*]}
-                                     :where  [['?s :rdf/type :ex/Product]]
+                                     :where  [['?s :type :ex/Product]]
                                      :opts {:role :ex/userRole}}))
                   "Updated :schema/name should have been allowed, and only name is visible in query."))))
       (testing "Policy doesn't allow a modification"

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -31,7 +31,7 @@
                                        :type        :schema/Person
                                        :schema/name 3}])]
         (is (= [{:id          :ex/halie
-                 :rdf/type    [:schema/Person]
+                 :type    [:schema/Person]
                  :schema/name "Halie"}]
                @(fluree/query mixed-db
                               {:context default-context
@@ -45,7 +45,7 @@
                                :where  [['?u :schema/name "a"]]}))
             "does not return results without matching subjects")
         (is (= [{:id :ex/john
-                 :rdf/type [:schema/Person]
+                 :type [:schema/Person]
                  :schema/name 3}]
                @(fluree/query mixed-db
                               {:context default-context

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -46,21 +46,21 @@
       (is (= [["David" 46]
               ["Brian" 50]]
              @(fluree/query db {:select ['?name '?age]
-                                :where  [['?s :rdf/type :ex/User]
+                                :where  [['?s :type :ex/User]
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
                                          {:filter ["(> ?age 45)"]}]}))))
     (testing "multiple filters on same var"
       (is (= [["David" 46]]
              @(fluree/query db {:select ['?name '?age]
-                                :where  [['?s :rdf/type :ex/User]
+                                :where  [['?s :type :ex/User]
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
                                          {:filter ["(> ?age 45)", "(< ?age 50)"]}]}))))
     (testing "multiple filters, different vars"
       (is (= [["Brian" "Smith"]]
              @(fluree/query db {:select ['?name '?last]
-                                :where  [['?s :rdf/type :ex/User]
+                                :where  [['?s :type :ex/User]
                                          ['?s :schema/age '?age]
                                          ['?s :schema/name '?name]
                                          ['?s :ex/last '?last]
@@ -69,7 +69,7 @@
     (testing "nested filters"
       (is (= [["Brian" 50]]
              @(fluree/query db '{:select [?name ?age]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/age ?age]
                                           [?s :schema/name ?name]
                                           {:filter ["(> ?age (/ (+ ?age 47) 2))"]}]}))))
@@ -78,7 +78,7 @@
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"
       (is (= [{:id :ex/david,
-               :rdf/type [:ex/User],
+               :type [:ex/User],
                :schema/name "David",
                :ex/last "Jones",
                :schema/email "david@example.org",
@@ -86,7 +86,7 @@
                :ex/favNums [15 70],
                :ex/friend {:id :ex/cam}}
               {:id :ex/brian,
-               :rdf/type [:ex/User],
+               :type [:ex/User],
                :schema/name "Brian",
                :ex/last "Smith",
                :schema/email "brian@example.org",
@@ -96,7 +96,7 @@
                                 :where  [["?s" :schema/age "?age"]
                                          {:filter ["(> ?age 45)"]}]})))
       (is (= [{:id :ex/david,
-               :rdf/type [:ex/User],
+               :type [:ex/User],
                :schema/name "David",
                :ex/last "Jones",
                :schema/email "david@example.org",
@@ -106,7 +106,7 @@
              @(fluree/query db {:select {"?s" ["*"]}
                                 :where  [["?s" :schema/age "?age"]
                                          {:filter ["(> ?age 45)", "(< ?age 50)"]}]})))
-      (is (= [{:rdf/type [:ex/User]
+      (is (= [{:type [:ex/User]
                :schema/email "cam@example.org"
                :ex/favNums [5 10]
                :schema/age 34

--- a/test/fluree/db/query/fql_parse_test.clj
+++ b/test/fluree/db/query/fql_parse_test.clj
@@ -115,14 +115,14 @@
       (testing "not a `:class` pattern if obj is a var"
         (let [query {:context {:ex "http://example.org/ns/"}
                      :select  ['?class]
-                     :where   [[:ex/cam :rdf/type '?class]]}
+                     :where   [[:ex/cam :type '?class]]}
               {:keys [where]} (parse/parse-analytical-query query db)
               {::where/keys [patterns]} where]
           (is (= :tuple
                 (where/pattern-type (first patterns))))))
       (testing "class, optional"
         (let [optional-q {:select ['?name '?favColor]
-                          :where  [['?s :rdf/type :ex/User]
+                          :where  [['?s :type :ex/User]
                                    ['?s :schema/name '?name]
                                    {:optional ['?s :ex/favColor '?favColor]}]}
               {:keys [select where] :as parsed} (parse/parse-analytical-query optional-q db)
@@ -148,7 +148,7 @@
                  patterns))))
       (testing "class, union"
         (let [union-q {:select ['?s '?email1 '?email2]
-                       :where  [['?s :rdf/type :ex/User]
+                       :where  [['?s :type :ex/User]
                                 {:union [[['?s :ex/email '?email1]]
                                          [['?s :schema/email '?email2]]]}]}
               {:keys [select where] :as parsed} (parse/parse-analytical-query union-q db)
@@ -175,7 +175,7 @@
                  patterns))))
       (testing "class, filters"
         (let [filter-q {:select ['?name '?age]
-                        :where  [['?s :rdf/type :ex/User]
+                        :where  [['?s :type :ex/User]
                                  ['?s :schema/age '?age]
                                  ['?s :schema/name '?name]
                                  {:filter ["(> ?age 45)", "(< ?age 50)"]}]}

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -12,7 +12,7 @@
         (let [query-res @(fluree/query db '{:select {?s [:*]}
                                             :where [[?s :id :wiki/Q836821]]})]
           (is (= query-res [{:id                               :wiki/Q836821,
-                             :rdf/type                         [:schema/Movie],
+                             :type                         [:schema/Movie],
                              :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                              :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                              :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
@@ -30,12 +30,12 @@
         (let [query-res @(fluree/query db '{:selectOne {?s [:* {:schema/isBasedOn [:*]}]}
                                             :where [[?s :id :wiki/Q836821]]})]
           (is (= query-res {:id                               :wiki/Q836821,
-                            :rdf/type                         [:schema/Movie],
+                            :type                         [:schema/Movie],
                             :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                             :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                             :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                             :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                               :rdf/type      [:schema/Book],
+                                                               :type      [:schema/Book],
                                                                :schema/name   "The Hitchhiker's Guide to the Galaxy",
                                                                :schema/isbn   "0-330-25864-8",
                                                                :schema/author {:id :wiki/Q42}}}))))
@@ -45,32 +45,32 @@
                                               :where [[?s :id :wiki/Q836821]]
                                               :depth 3})]
             (is (= query-res {:id                               :wiki/Q836821,
-                              :rdf/type                         [:schema/Movie],
+                              :type                         [:schema/Movie],
                               :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                               :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                               :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                               :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                                 :rdf/type      [:schema/Book],
+                                                                 :type      [:schema/Book],
                                                                  :schema/name   "The Hitchhiker's Guide to the Galaxy",
                                                                  :schema/isbn   "0-330-25864-8",
                                                                  :schema/author {:id          :wiki/Q42,
-                                                                                 :rdf/type    [:schema/Person],
+                                                                                 :type    [:schema/Person],
                                                                                  :schema/name "Douglas Adams"}}}))))
         (testing "using graph sub-selection"
           (let [query-res @(fluree/query db '{:selectOne {?s [:* {:schema/isBasedOn [:*]}]}
                                               :where [[?s :id :wiki/Q836821]]
                                               :depth 3})]
             (is (= query-res {:id                               :wiki/Q836821,
-                              :rdf/type                         [:schema/Movie],
+                              :type                         [:schema/Movie],
                               :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                               :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                               :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                               :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                                 :rdf/type      [:schema/Book],
+                                                                 :type      [:schema/Book],
                                                                  :schema/name   "The Hitchhiker's Guide to the Galaxy",
                                                                  :schema/isbn   "0-330-25864-8",
                                                                  :schema/author {:id          :wiki/Q42,
-                                                                                 :rdf/type    [:schema/Person],
+                                                                                 :type    [:schema/Person],
                                                                                  :schema/name "Douglas Adams"}}}))))))))
 
 (deftest ^:integration json-ld-rdf-type-query
@@ -80,38 +80,38 @@
           db     (fluree/db movies)]
       (testing "basic analytical RFD type query"
         (let [query-res @(fluree/query db '{:select {?s [:* {:schema/isBasedOn [:*]}]}
-                                            :where  [[?s :rdf/type :schema/Movie]]})]
+                                            :where  [[?s :type :schema/Movie]]})]
           (is (= [{:id :wiki/Q2875,
-                   :rdf/type [:schema/Movie],
+                   :type [:schema/Movie],
                    :schema/disambiguatingDescription "1939 film by Victor Fleming",
                    :schema/isBasedOn {:id :wiki/Q2870,
-                                      :rdf/type [:schema/Book],
+                                      :type [:schema/Book],
                                       :schema/author {:id :wiki/Q173540},
                                       :schema/isbn "0-582-41805-4",
                                       :schema/name "Gone with the Wind"},
                    :schema/name "Gone with the Wind",
                    :schema/titleEIDR "10.5240/FB0D-0A93-CAD6-8E8D-80C2-4"}
                   {:id                               :wiki/Q230552,
-                   :rdf/type                         [:schema/Movie],
+                   :type                         [:schema/Movie],
                    :schema/name                      "Back to the Future Part III",
                    :schema/disambiguatingDescription "1990 film by Robert Zemeckis",
                    :schema/titleEIDR                 "10.5240/15F9-F913-FF25-8041-E798-O"}
-                  {:id                :wiki/Q109331, :rdf/type [:schema/Movie],
+                  {:id                :wiki/Q109331, :type [:schema/Movie],
                    :schema/name       "Back to the Future Part II",
                    :schema/titleEIDR  "10.5240/5DA5-C386-2911-7E2B-1782-L",
                    :schema/followedBy {:id :wiki/Q230552}}
                   {:id                               :wiki/Q91540,
-                   :rdf/type                         [:schema/Movie],
+                   :type                         [:schema/Movie],
                    :schema/name                      "Back to the Future",
                    :schema/disambiguatingDescription "1985 film by Robert Zemeckis",
                    :schema/titleEIDR                 "10.5240/09A3-1F6E-3538-DF46-5C6F-I",
                    :schema/followedBy                {:id :wiki/Q109331}}
-                  {:id                               :wiki/Q836821, :rdf/type [:schema/Movie],
+                  {:id                               :wiki/Q836821, :type [:schema/Movie],
                    :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                    :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                    :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                    :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                      :rdf/type      [:schema/Book],
+                                                      :type      [:schema/Book],
                                                       :schema/name   "The Hitchhiker's Guide to the Galaxy",
                                                       :schema/isbn   "0-330-25864-8",
                                                       :schema/author {:id :wiki/Q42}}}]                                  ;; :id is a DID and will be unique per DB so exclude from comparison
@@ -193,7 +193,7 @@
       (testing "id"
         ;;TODO not getting reparsed as ssc
         (is (= [{:id           :ex/brian,
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "Brian"
                  :ex/last      "Smith"
                  :schema/email "brian@example.org"
@@ -205,14 +205,14 @@
       ;;TODO not getting reparsed as ssc
       (testing "iri"
         (is (= [{:id           :ex/david
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "David"
                  :ex/last      "Jones"
                  :schema/email "david@example.org"
                  :schema/age   46
                  :ex/favNums   [15 70]
                  :ex/friend    {:id :ex/cam}}
-                {:rdf/type     [:ex/User]
+                {:type     [:ex/User]
                  :schema/email "cam@example.org"
                  :ex/favNums   [5 10]
                  :schema/age   34
@@ -222,7 +222,7 @@
                  :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
                  :ex/favColor  "Blue"}
                 {:id           :ex/alice
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -230,7 +230,7 @@
                  :ex/favNums   [9 42 76]
                  :ex/favColor  "Green"}
                 {:id           :ex/brian
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "Brian"
                  :ex/last      "Smith"
                  :schema/email "brian@example.org"
@@ -241,7 +241,7 @@
                                   :where  [["?s" :type :ex/User]]}))))
       (testing "tuple"
         (is (= [{:id           :ex/alice
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -250,7 +250,7 @@
                  :ex/favColor  "Green"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/name "Alice"]]})))
-        (is (= [{:rdf/type     [:ex/User]
+        (is (= [{:type     [:ex/User]
                  :schema/email "cam@example.org"
                  :ex/favNums   [5 10]
                  :schema/age   34
@@ -260,7 +260,7 @@
                  :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
                  :ex/favColor  "Blue"}
                 {:id           :ex/alice
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -268,7 +268,7 @@
                  :ex/favNums   [9 42 76]
                  :ex/favColor  "Green"}
                 {:id           :ex/brian,
-                 :rdf/type     [:ex/User],
+                 :type     [:ex/User],
                  :ex/favNums   7,
                  :ex/favColor  "Green",
                  :schema/age   50,
@@ -278,7 +278,7 @@
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :ex/favColor "?color"]]})))
         (is (= [{:id           :ex/alice
-                 :rdf/type     [:ex/User]
+                 :type     [:ex/User]
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -288,7 +288,7 @@
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/age 42]]})))
         (is (= [{:id           :ex/alice,
-                 :rdf/type     [:ex/User],
+                 :type     [:ex/User],
                  :ex/favNums   [9 42 76],
                  :ex/favColor  "Green",
                  :schema/age   42,

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -46,13 +46,13 @@
       (is (= two-tuple-select-with-crawl
              two-tuple-select-with-crawl+var
              [[50 {:id           :ex/brian,
-                   :rdf/type     [:ex/User],
+                   :type     [:ex/User],
                    :schema/name  "Brian",
                    :schema/email "brian@example.org",
                    :schema/age   50,
                    :ex/favNums   7}]
               [50 {:id           :ex/alice,
-                   :rdf/type     [:ex/User],
+                   :type     [:ex/User],
                    :schema/name  "Alice",
                    :schema/email "alice@example.org",
                    :schema/age   50,
@@ -157,7 +157,7 @@
                              :where   [['?s :schema/age 34]
                                        ['?s '?p '?o]]})
              [[:ex/cam :id "http://example.org/ns/cam"]
-              [:ex/cam :rdf/type :ex/User]
+              [:ex/cam :type :ex/User]
               [:ex/cam :schema/name "Cam"]
               [:ex/cam :schema/email "cam@example.org"]
               [:ex/cam :schema/age 34]
@@ -173,20 +173,20 @@
                               :where   [[?s :ex/friend ?o]
                                         [?o :schema/name "Alice"]]})
              [{:id :ex/cam,
-               :rdf/type [:ex/User],
+               :type [:ex/User],
                :schema/name "Cam",
                :schema/email "cam@example.org",
                :schema/age 34,
                :ex/favNums [5 10],
                :ex/friend
                [{:id :ex/brian,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Brian",
                  :schema/email "brian@example.org",
                  :schema/age 50,
                  :ex/favNums 7}
                 {:id :ex/alice,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Alice",
                  :schema/email "alice@example.org",
                  :schema/age 50,

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -20,13 +20,13 @@
                                              :schema/name "Picasso"}}]})]
       (is (= [{:_id          211106232532993,
                :id           :ex/bob,
-               :rdf/type     [:ex/User],
+               :type     [:ex/User],
                :schema/name  "Bob",
                :ex/favArtist {:_id         211106232532994
                               :schema/name "Picasso"}}
               {:_id         211106232532992,
                :id          :ex/alice,
-               :rdf/type    [:ex/User],
+               :type    [:ex/User],
                :schema/name "Alice"}]
              @(fluree/query db {:select {'?s [:_id :* {:ex/favArtist [:_id :schema/name]}]}
                                 :where  [['?s :type :ex/User]]}))))))
@@ -122,16 +122,16 @@
                              :schema/age   30}]})]
       (testing "Query that pulls entire database."
         (is (= [[:ex/jane :id "http://example.org/ns/jane"]
-                [:ex/jane :rdf/type :ex/User]
+                [:ex/jane :type :ex/User]
                 [:ex/jane :schema/name "Jane"]
                 [:ex/jane :schema/email "jane@flur.ee"]
                 [:ex/jane :schema/age 30]
                 [:ex/bob :id "http://example.org/ns/bob"]
-                [:ex/bob :rdf/type :ex/User]
+                [:ex/bob :type :ex/User]
                 [:ex/bob :schema/name "Bob"]
                 [:ex/bob :schema/age 22]
                 [:ex/alice :id "http://example.org/ns/alice"]
-                [:ex/alice :rdf/type :ex/User]
+                [:ex/alice :type :ex/User]
                 [:ex/alice :schema/name "Alice"]
                 [:ex/alice :schema/email "alice@flur.ee"]
                 [:ex/alice :schema/age 42]
@@ -140,74 +140,74 @@
                 [:schema/name :id "http://schema.org/name"]
                 [:ex/User :id "http://example.org/ns/User"]
                 [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
-                [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+                [:type :id "@type"]
                 [:id :id "@id"]]
                @(fluree/query db {:select ['?s '?p '?o]
                                   :where  [['?s '?p '?o]]}))
             "Entire database should be pulled.")
         (is (= [{:id :ex/jane,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/bob,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/bob,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/bob,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/bob,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/alice,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :rdf/type [:ex/User],
+                 :type [:ex/User],
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
@@ -216,7 +216,7 @@
                 {:id :schema/name}
                 {:id :ex/User}
                 {:id :rdfs/Class}
-                {:id :rdf/type}
+                {:id :type}
                 {:id :id}]
                @(fluree/query db {:select {'?s ["*"]}
                                   :where  [['?s '?p '?o]]}))
@@ -226,16 +226,16 @@
                                          :where  [['?s '?p '?o]]})]
           (is (pred-match?
                [[:ex/jane :id "http://example.org/ns/jane"]
-                [:ex/jane :rdf/type :ex/User]
+                [:ex/jane :type :ex/User]
                 [:ex/jane :schema/name "Jane"]
                 [:ex/jane :schema/email "jane@flur.ee"]
                 [:ex/jane :schema/age 30]
                 [:ex/bob :id "http://example.org/ns/bob"]
-                [:ex/bob :rdf/type :ex/User]
+                [:ex/bob :type :ex/User]
                 [:ex/bob :schema/name "Bob"]
                 [:ex/bob :schema/age 22]
                 [:ex/alice :id "http://example.org/ns/alice"]
-                [:ex/alice :rdf/type :ex/User]
+                [:ex/alice :type :ex/User]
                 [:ex/alice :schema/name "Alice"]
                 [:ex/alice :schema/email "alice@flur.ee"]
                 [:ex/alice :schema/age 42]
@@ -245,14 +245,14 @@
                 [test-utils/db-id? :id test-utils/db-id?]
                 [test-utils/db-id? :f/address test-utils/address?]
                 [test-utils/db-id? :f/flakes 24]
-                [test-utils/db-id? :f/size 1838]
+                [test-utils/db-id? :f/size 1670]
                 [test-utils/db-id? :f/t 1]
                 [:schema/age :id "http://schema.org/age"]
                 [:schema/email :id "http://schema.org/email"]
                 [:schema/name :id "http://schema.org/name"]
                 [:ex/User :id "http://example.org/ns/User"]
                 [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
-                [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+                [:type :id "@type"]
                 [:f/t :id "https://ns.flur.ee/ledger#t"]
                 [:f/size :id "https://ns.flur.ee/ledger#size"]
                 [:f/flakes :id "https://ns.flur.ee/ledger#flakes"]
@@ -323,16 +323,16 @@
                    {:id          :ex/dave
                     :type        :ex/nonUser
                     :schema/name "Dave"}])]
-    (testing "rdf/type"
+    (testing "type"
       (is (= [[:ex/User]]
              @(fluree/query db '{:select [?class]
-                                 :where  [[:ex/jane :rdf/type ?class]]})))
+                                 :where  [[:ex/jane :type ?class]]})))
       (is (= [[:ex/jane :ex/User]
               [:ex/bob :ex/User]
               [:ex/alice :ex/User]
               [:ex/dave :ex/nonUser]]
              @(fluree/query db '{:select [?s ?class]
-                                 :where  [[?s :rdf/type ?class]]}))))
+                                 :where  [[?s :type ?class]]}))))
     (testing "shacl targetClass"
       (let [shacl-db @(fluree/stage
                         (fluree/db ledger)

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -29,7 +29,7 @@
 
       ;; basic single optional statement
       (is (= @(fluree/query db '{:select [?name ?favColor]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           {:optional [?s :ex/favColor ?favColor]}]})
              [["Cam" nil]
@@ -38,7 +38,7 @@
           "Cam, Alice and Brian should all return, but only Alica has a favColor")
 
       (is (= @(fluree/query db '{:select [?name ?favColor]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           {"optional" [?s :ex/favColor ?favColor]}]})
              [["Cam" nil]
@@ -48,7 +48,7 @@
 
       ;; including another pass-through variable - note Brian doesn't have an email
       (is (= @(fluree/query db '{:select [?name ?favColor ?email]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           [?s :schema/email ?email]
                                           {:optional [?s :ex/favColor ?favColor]}]})
@@ -57,7 +57,7 @@
 
       ;; including another pass-through variable, but with 'optional' sandwiched
       (is (= @(fluree/query db '{:select [?name ?favColor ?email]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           {:optional [?s :ex/favColor ?favColor]}
                                           [?s :schema/email ?email]]})
@@ -66,7 +66,7 @@
 
       ;; query with two optionals!
       (is (= @(fluree/query db '{:select [?name ?favColor ?email]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           {:optional [?s :ex/favColor ?favColor]}
                                           {:optional [?s :schema/email ?email]}]})
@@ -76,7 +76,7 @@
 
       ;; optional with unnecessary embedded vector statement
       (is (= @(fluree/query db '{:select [?name ?favColor]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           {:optional [[?s :ex/favColor ?favColor]]}]})
              [["Cam" nil]
@@ -89,7 +89,7 @@
               ["Alice" "Green" "alice@flur.ee"]
               ["Brian" nil nil]]
              @(fluree/query db '{:select [?name ?favColor ?email]
-                                 :where  [[?s :rdf/type :ex/User]
+                                 :where  [[?s :type :ex/User]
                                           [?s :schema/name ?name]
                                           {:optional [[?s :ex/favColor ?favColor]
                                                       [?s :schema/email ?email]]}]}))

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -40,6 +40,6 @@
                                  :where     [[?s :id :ex/brian]]})
              {:schema/name "Brian",
               :friended    {:id           :ex/cam,
-                            :rdf/type     [:ex/User],
+                            :type     [:ex/User],
                             :schema/name  "Cam",
                             :ex/friend    [{:id :ex/brian} {:id :ex/alice}]}})))))

--- a/test/fluree/db/query/sql_test.cljc
+++ b/test/fluree/db/query/sql_test.cljc
@@ -45,7 +45,7 @@
                    (:select subject))
                 "correctly constructs the select clause")
 
-            (is (= [["?person" "rdf:type" "person"]]
+            (is (= [["?person" "type" "person"]]
                    (:where subject))
                 "correctly constructs the where clause"))))
 
@@ -186,7 +186,7 @@
                    (:select subject))
                 "correctly constructs the select clause")
 
-            (is (= [["?person" "rdf:type" "person"]
+            (is (= [["?person" "type" "person"]
                     {:optional [["?person" "person/email" "?personEmail"]]}
                     {:filter ["(nil? ?personEmail)"]}
                     ["?person" "person/name" "?personName"]
@@ -204,7 +204,7 @@
                      (:select subject))
                   "correctly constructs the select clause")
 
-              (is (= [["?person" "rdf:type" "person"]
+              (is (= [["?person" "type" "person"]
                       ["?person" "person/middleName" "?personMiddleName"]]
                      (:where subject))
                   "correctly constructs the where clause"))
@@ -217,7 +217,7 @@
                      (:select subject))
                     "correctly constructs the select clause")
 
-                (is (= [["?person" "rdf:type" "person"]
+                (is (= [["?person" "type" "person"]
                         ["?person" "person/middleName" "?personMiddleName"]]
                        (:where subject))
                     "correctly constructs the where clause")))))))

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -26,10 +26,10 @@
                      :schema/age   30}])
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bkmm63rf3nrz5ghujiw2sy6duhqex5jctfspneashahjyny2jrcm"
+        (is (= "fluree:commit:sha256:bbxggb4sn2r6i73kk6gqeosfloq3dn33fnsdaadmjxrxkmkwxi2ya"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://1c2e42c6bfdfae91c4d441c15e1d7c6c464d39c2e65b72d082244306da402938"
+        (is (= "fluree:memory://fa19452088bf0e41f78668b3619097bc31340908891fdfdd0f3f425ece753981"
                (get-in db1 [:commit :address]))))
       (testing "stable default context id"
         (is (= "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
@@ -38,8 +38,8 @@
         (is (= "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
                (get-in db1 [:commit :defaultContext :address]))))
       (testing "stable db id"
-        (is (= "fluree:db:sha256:bb5xl62nkyxzwyv3ey5zpnikd7k633ch6cjapphrdu75sk7zdgpkr"
+        (is (= "fluree:db:sha256:bbeducmbtm7ducvewuufjhl26p2a7v2mb5dasv5ykwdti2uamegm4"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://88ae1b85a97df6e9df03d08eeaf367b192ff1e2f7edb6ebb7fd0ebbe5f8933a6"
+        (is (= "fluree:memory://2a0a2bcf83cd202649b3f3418116ccffe7857f03b8d3c5432e49907b667d06c0"
                (get-in db1 [:commit :data :address])))))))

--- a/test/fluree/db/query/subclass_test.clj
+++ b/test/fluree/db/query/subclass_test.clj
@@ -46,15 +46,15 @@
 
       (is (= @(fluree/query db3
                             {:select {'?s [:*]}
-                             :where  [['?s :rdf/type :schema/CreativeWork]]})
+                             :where  [['?s :type :schema/CreativeWork]]})
              [{:id                               :wiki/Q836821,
-               :rdf/type                         [:schema/Movie],
+               :type                         [:schema/Movie],
                :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                :schema/isBasedOn                 {:id :wiki/Q3107329}}
               {:id            :wiki/Q3107329,
-               :rdf/type      [:schema/Book],
+               :type      [:schema/Book],
                :schema/name   "The Hitchhiker's Guide to the Galaxy",
                :schema/isbn   "0-330-25864-8",
                :schema/author {:id :wiki/Q42}}])

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -10,7 +10,7 @@
           ledger (test-utils/load-movies conn)
           db     (fluree/db ledger)
           movies @(fluree/query db '{:select {?s [:*]}
-                                     :where  [[?s :rdf/type :schema/Movie]]
+                                     :where  [[?s :type :schema/Movie]]
                                      :t      2})]
       (is (= 3 (count movies)))
       (is (every? #{"The Hitchhiker's Guide to the Galaxy"
@@ -75,7 +75,7 @@
                                        @(fluree/commit! ledger db3))))
           db                     (fluree/db ledger)
           base-query             {:select '{?s [:*]}
-                                  :where  '[[?s :rdf/type :schema/Movie]]}
+                                  :where  '[[?s :type :schema/Movie]]}
           one-movie              @(fluree/query db (assoc base-query
                                                      :t after-one-loaded-iso))
           three-movies           @(fluree/query db (assoc base-query

--- a/test/fluree/db/query/union_query_test.clj
+++ b/test/fluree/db/query/union_query_test.clj
@@ -39,7 +39,7 @@
 
       ;; basic combine :schema/email and :ex/email into same result variable
       (is (= @(fluree/query db {:select ['?name '?email]
-                                :where  [['?s :rdf/type :ex/User]
+                                :where  [['?s :type :ex/User]
                                          ['?s :schema/name '?name]
                                          {:union [[['?s :ex/email '?email]]
                                                   [['?s :schema/email '?email]]]}]})
@@ -50,7 +50,7 @@
 
       ;; basic union that uses different variables for output
       (is (= @(fluree/query db {:select ['?s '?email1 '?email2]
-                                :where  [['?s :rdf/type :ex/User]
+                                :where  [['?s :type :ex/User]
                                          {:union [[['?s :ex/email '?email1]]
                                                   [['?s :schema/email '?email2]]]}]})
              [[:ex/cam "cam@example.org" nil]
@@ -60,7 +60,7 @@
 
       ;; basic union that uses different variables for output and has a passthrough variable
       (is (= @(fluree/query db {:select ['?name '?email1 '?email2]
-                                :where  [['?s :rdf/type :ex/User]
+                                :where  [['?s :type :ex/User]
                                          ['?s :schema/name '?name]
                                          {:union [[['?s :ex/email '?email1]]
                                                   [['?s :schema/email '?email2]]]}]})

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -23,7 +23,7 @@
                                          :where  [[?s :id :ex/myClassInstance]]})]
       (is (= query-res
              [{:id                 :ex/myClassInstance
-               :rdf/type           [:ex/MyClass]
+               :type           [:ex/MyClass]
                :schema/description "Now a new subject uses MyClass as a Class"}])))))
 
 
@@ -32,7 +32,7 @@
     (let [conn         (test-utils/create-conn)
           ledger       @(fluree/create conn "shacl/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
-                        :where  [['?s :rdf/type :ex/User]]}
+                        :where  [['?s :type :ex/User]]}
           db           @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/UserShape
@@ -73,7 +73,7 @@
       (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
              (ex-message db-two-names)))
       (is (= [{:id              :ex/john,
-               :rdf/type        [:ex/User],
+               :type        [:ex/User],
                :schema/name     "John",
                :schema/callSign "j-rock"}]
              @(fluree/query db-ok user-query))
@@ -85,7 +85,7 @@
     (let [conn         (test-utils/create-conn)
           ledger       @(fluree/create conn "shacl/b" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
-                        :where  [['?s :rdf/type :ex/User]]}
+                        :where  [['?s :type :ex/User]]}
           db           @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/UserShape
@@ -121,17 +121,16 @@
       (is (str/starts-with? (ex-message db-bool-name) "Data type"))
       (is (= @(fluree/query db-ok user-query)
              [{:id          :ex/john
-               :rdf/type    [:ex/User]
+               :type    [:ex/User]
                :schema/name "John"}])
           "basic rdf:type query response not correct"))))
-
 
 (deftest ^:integration shacl-closed-shape
   (testing "shacl closed shape"
     (let [conn          (test-utils/create-conn)
           ledger        @(fluree/create conn "shacl/c" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query    {:select {'?s [:*]}
-                         :where  [['?s :rdf/type :ex/User]]}
+                         :where  [['?s :type :ex/User]]}
           db            @(fluree/stage
                           (fluree/db ledger)
                           {:id                   :ex/UserShape
@@ -139,8 +138,9 @@
                            :sh/targetClass       :ex/User
                            :sh/property          [{:sh/path     :schema/name
                                                    :sh/datatype :xsd/string}]
-                           :sh/ignoredProperties [:rdf/type]
-                           :sh/closed            true})
+                           :sh/closed            true
+                           :sh/ignoredProperties [:type]})
+
           db-ok         @(fluree/stage
                           db
                           {:id          :ex/john
@@ -159,18 +159,18 @@
       (is (str/starts-with? (ex-message db-extra-prop)
                             "SHACL shape is closed"))
 
-      (is (= @(fluree/query db-ok user-query)
-             [{:id          :ex/john
-               :rdf/type    [:ex/User]
-               :schema/name "John"}])
-          "basic rdf:type query response not correct"))))
+      (is (= [{:id          :ex/john
+               :type    [:ex/User]
+               :schema/name "John"}]
+             @(fluree/query db-ok user-query))
+          "basic type query response not correct"))))
 
 (deftest ^:integration shacl-property-pairs
   (testing "shacl property pairs"
     (let [conn       (test-utils/create-conn)
           ledger     @(fluree/create conn "shacl/pairs" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query {:select {'?s [:*]}
-                      :where  [['?s :rdf/type :ex/User]]}]
+                      :where  [['?s :type :ex/User]]}]
       (testing "single-cardinality equals"
         (let [db           @(fluree/stage
                              (fluree/db ledger)
@@ -200,7 +200,7 @@
                                 "SHACL PropertyShape exception - sh:equals"))
 
           (is (= [{:id           :ex/alice
-                   :rdf/type     [:ex/User]
+                   :type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/firstName "Alice"}]
                  @(fluree/query db-ok user-query)))))
@@ -281,13 +281,13 @@
           (is (str/starts-with? (ex-message db-not-equal4)
                                 "SHACL PropertyShape exception - sh:equals"))
           (is (= [{:id           :ex/alice
-                   :rdf/type     [:ex/User]
+                   :type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums [11 17]}]
                  @(fluree/query db-ok user-query)))
           (is (= [{:id           :ex/alice
-                   :rdf/type     [:ex/User]
+                   :type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums [11 17]}]
@@ -353,7 +353,7 @@
                                 "SHACL PropertyShape exception - sh:disjoint"))
 
           (is (= [{:id           :ex/alice
-                   :rdf/type     [:ex/User]
+                   :type     [:ex/User]
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums 1}]
@@ -458,13 +458,13 @@
                                 "SHACL PropertyShape exception - sh:lessThan"))
 
           (is (= [{:id          :ex/alice
-                   :rdf/type    [:ex/User]
+                   :type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       [18 19]}]
                  @(fluree/query db-ok1 user-query)))
           (is (= [{:id          :ex/alice
-                   :rdf/type    [:ex/User]
+                   :type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       18}]
@@ -555,13 +555,13 @@
           (is (str/starts-with? (ex-message db-fail4)
                                 "SHACL PropertyShape exception - sh:lessThanOrEquals"))
           (is (= [{:id          :ex/alice
-                   :rdf/type    [:ex/User]
+                   :type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       [17 19]}]
                  @(fluree/query db-ok1 user-query)))
           (is (= [{:id          :ex/alice
-                   :rdf/type    [:ex/User]
+                   :type    [:ex/User]
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       17}]
@@ -572,7 +572,7 @@
     (let [conn       (test-utils/create-conn)
           ledger     @(fluree/create conn "shacl/value-range" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query {:select {'?s [:*]}
-                      :where  [['?s :rdf/type :ex/User]]}]
+                      :where  [['?s :type :ex/User]]}]
       (testing "exclusive constraints"
         (let [db          @(fluree/stage
                             (fluree/db ledger)
@@ -611,7 +611,7 @@
 
           (is (= @(fluree/query db-ok user-query)
                  [{:id         :ex/john
-                   :rdf/type   [:ex/User]
+                   :type   [:ex/User]
                    :schema/age 2}]))))
       (testing "inclusive constraints"
         (let [db          @(fluree/stage
@@ -653,10 +653,10 @@
                                 "SHACL PropertyShape exception - sh:maxInclusive: value 101"))
           (is (= @(fluree/query db-ok2 user-query)
                  [{:id         :ex/alice
-                   :rdf/type   [:ex/User]
+                   :type   [:ex/User]
                    :schema/age 100}
                   {:id         :ex/brian
-                   :rdf/type   [:ex/User]
+                   :type   [:ex/User]
                    :schema/age 1}]))))
       (testing "non-numeric values"
         (let [db         @(fluree/stage
@@ -695,7 +695,7 @@
                                               {:defaultContext
                                                ["" {:ex "http://example.org/ns/"}]})
           user-query          {:select {'?s [:*]}
-                               :where  [['?s :rdf/type :ex/User]]}
+                               :where  [['?s :type :ex/User]]}
           db                  @(fluree/stage
                                 (fluree/db ledger)
                                 {:id             :ex/UserShape
@@ -761,11 +761,11 @@
       (is (str/starts-with? (ex-message db-ref-value)
                             "SHACL PropertyShape exception - sh:maxLength:"))
       (is (= [{:id          :ex/john
-               :rdf/type    [:ex/User]
+               :type    [:ex/User]
                :schema/name "John"}]
              @(fluree/query db-ok-str user-query)))
       (is (= [{:id          :ex/john
-               :rdf/type    [:ex/User]
+               :type    [:ex/User]
                :schema/name 12345}]
              @(fluree/query db-ok-non-str user-query))))))
 
@@ -776,7 +776,7 @@
                                                  {:defaultContext
                                                   ["" {:ex "http://example.org/ns/"}]})
           user-query             {:select {'?s [:*]}
-                                  :where  [['?s :rdf/type :ex/User]]}
+                                  :where  [['?s :type :ex/User]]}
           db                     @(fluree/stage
                                    (fluree/db ledger)
                                    {:id             :ex/UserShape
@@ -834,11 +834,11 @@
       (is (str/starts-with? (ex-message db-ref-value)
                             "SHACL PropertyShape exception - sh:pattern:"))
       (is (= [{:id          :ex/brian
-               :rdf/type    [:ex/User]
+               :type    [:ex/User]
                :ex/greeting "hello\nworld!"}]
              @(fluree/query db-ok-greeting user-query)))
       (is (= [{:id           :ex/john
-               :rdf/type     [:ex/User]
+               :type     [:ex/User]
                :ex/birthYear 1984}]
              @(fluree/query db-ok-birthyear user-query))))))
 
@@ -847,7 +847,7 @@
     (let [conn         (test-utils/create-conn)
           ledger       @(fluree/create conn "shacl/b" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
-                        :where  [['?s :rdf/type :ex/User]]}
+                        :where  [['?s :type :ex/User]]}
           db           @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/UserShape
@@ -920,7 +920,7 @@
       (is (util/exception? db-num-email))
       (is (str/starts-with? (ex-message db-num-email) "Data type"))
       (is (= [{:id           :ex/john
-               :rdf/type     [:ex/User]
+               :type     [:ex/User]
                :schema/age   40
                :schema/email "john@example.org"
                :schema/name  "John"}]
@@ -948,7 +948,7 @@
         (is (= [{"id"          "ex:Luke",
                  "schema:name" "Luke",
                  "ex:parent"   {"id"          "ex:Anakin"
-                                "rdf:type"    ["ex:Parent"]
+                                "type"    ["ex:Parent"]
                                 "schema:name" "Anakin"}}]
                @(fluree/query valid-parent {"select" {"?s" ["*" {"ex:parent" ["*"]}]}
                                             "where"  [["?s" "id" "ex:Luke"]]})))
@@ -974,7 +974,7 @@
                                             "schema:name" "Darth Vader"
                                             "ex:pal"      {"ex:evil" "has no name"}})]
         (is (= [{"id"          "ex:good-pal",
-                 "rdf:type"    ["ex:Pal"]
+                 "type"    ["ex:Pal"]
                  "schema:name" "J.D.",
                  "ex:pal"      [{"schema:name" "Turk"}
                                 {"schema:name" "Rowdy"}]}]
@@ -1003,7 +1003,7 @@
                                                  "ex:child"    {"id"          "ex:Gerb"
                                                                 "type"        "ex:Princess"
                                                                 "schema:name" "Gerb"}})]
-        (is (= [{"id" "ex:Mork", "rdf:type" ["ex:Princess"], "schema:name" "Mork"}]
+        (is (= [{"id" "ex:Mork", "type" ["ex:Princess"], "schema:name" "Mork"}]
                @(fluree/query valid-princess {"select" {"?s" ["*"]}
                                               "where"  [["?s" "id" "ex:Mork"]]})))
 
@@ -1124,7 +1124,7 @@
 
       (is (not (util/exception? db3)))
       (is (= [{"id"       "ex:PastelPony"
-               "rdf:type" ["ex:Pony"]
+               "type" ["ex:Pony"]
                "ex:color" [{"id" "ex:Pink"} {"id" "ex:Purple"}]}]
              @(fluree/query db3 '{"select" {"?p" ["*"]}
                                   "where"  [["?p" "type" "ex:Pony"]]})))))
@@ -1336,7 +1336,7 @@
                                               "type"       "ex:Person"
                                               "ex:address" {"ex:postalCode" ["12345" "45678"]}}])]
       (is (= [{"id"         "ex:Bob",
-               "rdf:type"   ["ex:Person"],
+               "type"   ["ex:Person"],
                "ex:address" {"id" "_:f211106232532997", "ex:postalCode" "12345"}}]
              @(fluree/query valid-person {"select" {"?s" ["*" {"ex:address" ["*"]}]}
                                           "where"  [["?s" "id" "ex:Bob"]]})))
@@ -1372,7 +1372,7 @@
                                                         {"id"        "ex:Zorba"
                                                          "ex:gender" "alien"}]}])]
       (is (= [{"id"        "ex:ValidKid"
-               "rdf:type"  ["ex:Kid"]
+               "type"  ["ex:Kid"]
                "ex:parent" [{"id" "ex:Bob"}
                             {"id" "ex:Jane"}]}]
              @(fluree/query valid-kid {"select" {"?s" ["*"]}
@@ -1421,7 +1421,7 @@
                                                         {"ex:name" "Finger"}
                                                         {"ex:name" ["Finger" "Thumb"]}]}])]
       (is (= [{"id"       "ex:ValidHand",
-               "rdf:type" ["ex:Hand"],
+               "type" ["ex:Hand"],
                "ex:digit"
                [{"ex:name" "Thumb"}
                 {"ex:name" "Finger"}

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -12,7 +12,7 @@
                                            {:defaultContext
                                             ["" {:ex "http://example.org/ns/"}]})
           user-query       {:select {'?s [:*]}
-                            :where  [['?s :rdf/type :ex/User]]}
+                            :where  [['?s :type :ex/User]]}
           db               @(fluree/stage
                              (fluree/db ledger)
                              {:id             :ex/UserShape
@@ -67,7 +67,7 @@
       (is (str/starts-with? (ex-message db-callsign-name)
                             "SHACL PropertyShape exception - sh:not sh:equals: [\"Johnny Boy\"] is required to be not equal to [\"Johnny Boy\"]"))
       (is (= [{:id              :ex/john,
-               :rdf/type        [:ex/User],
+               :type        [:ex/User],
                :schema/name     "John",
                :schema/callSign "j-rock"}]
              ok-results)
@@ -79,7 +79,7 @@
                                        {:defaultContext
                                         ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
-                        :where  [['?s :rdf/type :ex/User]]}
+                        :where  [['?s :type :ex/User]]}
           db           @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/UserShape
@@ -136,7 +136,7 @@
                             ;; could be either problem so just match common prefix
                             "SHACL PropertyShape exception - sh:not "))
       (is (= [{:id              :ex/john,
-               :rdf/type        [:ex/User],
+               :type        [:ex/User],
                :schema/name     "John",
                :schema/callSign "j-rock"
                :schema/age      42
@@ -150,7 +150,7 @@
                                        {:defaultContext
                                         ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
-                        :where  [['?s :rdf/type :ex/User]]}
+                        :where  [['?s :type :ex/User]]}
           db           @(fluree/stage
                           (fluree/db ledger)
                           {:id             :ex/UserShape
@@ -206,14 +206,14 @@
       (is (str/starts-with? (ex-message db-greeting-incorrect)
                             "SHACL PropertyShape exception - sh:not sh:pattern: value hello! must not match pattern"))
       (is (= [{:id          :ex/jean-claude
-               :rdf/type    [:ex/User],
+               :type    [:ex/User],
                :schema/name "Jean-Claude"}]
              @(fluree/query db-ok-name user-query)))
       (is (= [{:id       :ex/al,
-               :rdf/type [:ex/User],
+               :type [:ex/User],
                :ex/tag   1}]
              @(fluree/query db-ok-tag user-query)))
       (is (= [{:id       :ex/al,
-               :rdf/type [:ex/User],
+               :type [:ex/User],
                :ex/greeting   "HOWDY"}]
              @(fluree/query db-ok-greeting user-query))))))

--- a/test/fluree/db/transact/retraction_test.clj
+++ b/test/fluree/db/transact/retraction_test.clj
@@ -33,6 +33,6 @@
                               :select {?s [:*]},
                               :where [[?s :id :ex/alice]]})
              [{:id           :ex/alice,
-               :rdf/type     [:ex/User],
+               :type     [:ex/User],
                :schema/name  "Alice"}])
           "Alice should no longer have an age property"))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -48,7 +48,7 @@
               [:ex/alice :schema/age 42]
               [:schema/age :id "http://schema.org/age"]
               [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
-              [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+              [:type :id "@type"]
               [:id :id "@id"]]
              @(fluree/query db-ok '{:select [?s ?p ?o]
                                     :where  [[?s ?p ?o]]})))))
@@ -64,7 +64,7 @@
               [:ex/alice :ex/isCool false]
               [:ex/isCool :id "http://example.org/ns/isCool"]
               [:rdfs/Class :id "http://www.w3.org/2000/01/rdf-schema#Class"]
-              [:rdf/type :id "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+              [:type :id "@type"]
               [:id :id "@id"]]
              @(fluree/query db-bool '{:select [?s ?p ?o]
                                       :where  [[?s ?p ?o]]})))))
@@ -168,9 +168,9 @@
                             (fluree/db ledger)
                             (into policy data))
           user-query      '{:select {?s [:*]}
-                            :where  [[?s :rdf/type :ex/User]]}]
-      (let [users [{:id :ex/john, :rdf/type [:ex/User], :schema/name "John"}
-                   {:id :ex/alice, :rdf/type [:ex/User], :schema/name "Alice"}]]
+                            :where  [[?s :type :ex/User]]}]
+      (let [users [{:id :ex/john, :type [:ex/User], :schema/name "John"}
+                   {:id :ex/alice, :type [:ex/User], :schema/name "Alice"}]]
         (is (= users
                @(fluree/query db-data-first user-query)))
         (is (= users
@@ -196,7 +196,7 @@
             db2     @(fluree/stage db0 movies)
             _       (assert (not (util/exception? db2)))
             query   {"select" "?title"
-                     "where"  [["?m" "rdf:type" "ex:Movie"]
+                     "where"  [["?m" "type" "ex:Movie"]
                                ["?m" "ex:title" "?title"]]}
             results @(fluree/query db2 query)]
         (is (= 100 (count results)))

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -74,7 +74,7 @@
                             '{:selectOne {?s [:*]}
                               :where     [[?s :id :ex/bob]]})
              {:id          :ex/bob,
-              :rdf/type    [:ex/User],
+              :type    [:ex/User],
               :schema/name "Bob"})
           "Bob should no longer have an age property.")
 
@@ -92,7 +92,7 @@
 
       (testing "Updating property value only if it's current value is a match."
         (is (= [{:id          :ex/bob,
-                 :rdf/type    [:ex/User],
+                 :type    [:ex/User],
                  :schema/name "Bob"
                  :schema/age  23}]
                @(fluree/query db-update-bob
@@ -102,7 +102,7 @@
 
       (testing "No update should happen if there is no match."
         (is (= [{:id          :ex/bob,
-                 :rdf/type    [:ex/User],
+                 :type    [:ex/User],
                  :schema/name "Bob"
                  :schema/age  22}]
                @(fluree/query db-update-bob2
@@ -112,7 +112,7 @@
 
       (testing "Replacing existing property value with new property value."
         (is (= [{:id           :ex/jane,
-                 :rdf/type     [:ex/User],
+                 :type     [:ex/User],
                  :schema/name  "Jane"
                  :schema/email "jane@flur.ee"
                  :schema/age   31}]

--- a/test/nodejs/flureenjs.test.js
+++ b/test/nodejs/flureenjs.test.js
@@ -75,7 +75,7 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
        [
          {
            id: 'ex:john',
-           'rdf:type': [ 'ex:User' ],
+           type: [ 'ex:User' ],
            'schema:name': "John"
          }
        ]
@@ -94,7 +94,7 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
     [
       {
         id: 'ex:john',
-        'rdf:type': [ 'ex:User' ],
+        type: [ 'ex:User' ],
         flhubee: 'John'
       }
     ]

--- a/test/nodejs/flureenjs.test.js
+++ b/test/nodejs/flureenjs.test.js
@@ -66,7 +66,7 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
      db1,
      {
        select: { "?s": ["*"] },
-       where: [["?s", "rdf:type", "ex:User"]]
+       where: [["?s", "type", "ex:User"]]
      }
    );
 
@@ -86,7 +86,7 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
      db1,
      { "@context": ["", {"flhubee": "http://schema.org/name"}],
        select: { "?s": ["*"] },
-       where: [["?s", "rdf:type", "ex:User"]]
+       where: [["?s", "type", "ex:User"]]
      }
    );
 


### PR DESCRIPTION
Fixes https://github.com/fluree/db/issues/551

Uses the json-ld `@type` keyword instead of the rdf `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` IRI.

Also fixes #537 by throwing an error during insert if it comes across the `rdf:type` IRI.

