### PR TITLE
don't wrap single cardinality type values in a vector

### DIFF
--- a/src/fluree/db/query/json_ld/response.cljc
+++ b/src/fluree/db/query/json_ld/response.cljc
@@ -109,7 +109,9 @@
                             (recur rest-types
                                    (conj acc (or (get @cache type-id)
                                                  (<? (cache-sid->iri db cache compact-fn type-id)))))
-                            acc))
+                            (if (= 1 (count acc))
+                              (first acc)
+                              acc)))
 
                         :else                               ;; display all values
                         (loop [[f & r] (if list?

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -193,7 +193,7 @@
                results        @(fluree/query loaded-db query)]
            (is (= target-t (:t loaded-db)))
            (is (= merged-ctx (dbproto/-default-context loaded-db)))
-           (is (= [{:type   [:ex/User]
+           (is (= [{:type   :ex/User
                     :id             :ex/wes
                     :schema/age     42
                     :schema/email   "wes@example.org"
@@ -304,11 +304,11 @@
            (is (= target-t (:t loaded-db)))
            (testing "query returns expected `list` values"
              (is (= [{:id         :ex/cam,
-                      :type   [:ex/User],
+                      :type   :ex/User,
                       :ex/numList [7 8 9 10]}
-                     {:id :ex/john, :type [:ex/User]}
+                     {:id :ex/john, :type :ex/User}
                      {:id         :ex/alice,
-                      :type   [:ex/User],
+                      :type   :ex/User,
                       :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                     @(fluree/query loaded-db '{:select {?s [:*]}
                                                :where  [[?s :type :ex/User]]}))))))
@@ -341,7 +341,7 @@
                  db+policy    @(fluree/stage
                                 db
                                 [{:id            :ex/UserPolicy,
-                                  :type          [:f/Policy],
+                                  :type          :f/Policy,
                                   :f/targetClass :ex/User
                                   :f/allow
                                   [{:id           :ex/globalViewAllow
@@ -363,7 +363,7 @@
              (is (= target-t (:t loaded-db)))
              (testing "query returns expected policy"
                (is (= [{:id            :ex/UserPolicy,
-                        :type      [:f/Policy],
+                        :type      :f/Policy,
                         :f/allow
                         {:id           :ex/globalViewAllow,
                          :f/action     {:id :f/view},
@@ -505,7 +505,7 @@
              results        @(fluree/query loaded-db query)]
          (is (= target-t (:t loaded-db)))
          (is (= merged-ctx (dbproto/-default-context loaded-db)))
-         (is (= [{:type   [:ex/User]
+         (is (= [{:type   :ex/User
                   :id             :ex/wes
                   :schema/age     42
                   :schema/email   "wes@example.org"
@@ -568,11 +568,11 @@
          (is (= target-t (:t loaded-db)))
          (testing "query returns expected `list` values"
            (is (= [{:id         :ex/cam,
-                    :type   [:ex/User],
+                    :type   :ex/User,
                     :ex/numList [7 8 9 10]}
-                   {:id :ex/john, :type [:ex/User]}
+                   {:id :ex/john, :type :ex/User}
                    {:id         :ex/alice,
-                    :type   [:ex/User],
+                    :type   :ex/User,
                     :ex/friends [{:id :ex/john} {:id :ex/cam}]}]
                   @(fluree/query loaded-db '{:select {?s [:*]}
                                              :where  [[?s :type :ex/User]]})))))
@@ -620,7 +620,7 @@
            (is (= target-t (:t loaded-db)))
            (testing "query returns expected policy"
              (is (= [{:id            :ex/UserPolicy,
-                      :type      [:f/Policy],
+                      :type      :f/Policy,
                       :f/allow
                       {:id           :ex/globalViewAllow,
                        :f/action     {:id :f/view},
@@ -657,12 +657,12 @@
                           (get "id"))
              loaded1 (test-utils/retry-load conn ledger-alias 100)]
          (is (= [{"id" shape-id
-                  "type" ["sh:NodeShape"],
+                  "type" "sh:NodeShape",
                   "sh:targetClass" {"id" "schema:Person"},
                   "sh:property" {"id" "_:f211106232532993"}}]
                 @(fluree/query db1 property-query)))
          (is (= [{"id" shape-id
-                  "type" ["sh:NodeShape"],
+                  "type" "sh:NodeShape",
                   "sh:targetClass" {"id" "schema:Person"},
                   "sh:property" {"id" "_:f211106232532993"}}]
                 @(fluree/query (fluree/db loaded1) property-query)))
@@ -674,7 +674,7 @@
                                               "sh:datatype" {"id" "xsd:string"}}]})
                  loaded2 (test-utils/retry-load conn ledger-alias 100)]
              (is (= [{"id" shape-id
-                      "type" ["sh:NodeShape"],
+                      "type" "sh:NodeShape",
                       "sh:targetClass" {"id" "schema:Person"},
                       "sh:property" {"id" "_:f211106232532994"}}]
                     @(fluree/query (fluree/db loaded2) property-query)))))))

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -80,13 +80,13 @@
 
       ;; root can see all user data
       (is (= [{:id               :ex/john,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17",
                :schema/ssn       "888-88-8888"}
               {:id               :ex/alice,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
@@ -101,13 +101,13 @@
           "Both user records + all attributes should show")
 
       (is (= [{:id               :ex/john,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17",
                :schema/ssn       "888-88-8888"}
               {:id               :ex/alice,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
@@ -123,7 +123,7 @@
 
       ;; root role can see all product data, without identity
       (is (= [{:id                   :ex/widget,
-               :type             [:ex/Product],
+               :type             :ex/Product,
                :schema/name          "Widget",
                :schema/price         99.99,
                :schema/priceCurrency "USD"}]
@@ -132,12 +132,12 @@
                                        :opts   {:role :ex/rootRole}}))
           "The product record should show with all attributes")
       (is (= [{:id               :ex/john,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17"}
               {:id               :ex/alice,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17"}]
@@ -155,12 +155,12 @@
 
       ;; Alice can see all users, but can only see SSN for herself, and can't see the nested location
       (is (= [{:id               :ex/john,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "John",
                :schema/email     "john@flur.ee",
                :schema/birthDate "2021-08-17"}
               {:id               :ex/alice,
-               :type         [:ex/User],
+               :type         :ex/User,
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
@@ -199,12 +199,12 @@
                                                           :opts           {:did  alice-did
                                                                            :role :ex/userRole}})
                 commit-details-asserts (get-in history-result [:f/commit :f/data :f/assert])]
-            (is (= [{:type         [:ex/User],
+            (is (= [{:type         :ex/User,
                      :schema/name      "John",
                      :schema/email     "john@flur.ee",
                      :schema/birthDate "2021-08-17",
                      :id               :ex/john}
-                    {:type         [:ex/User],
+                    {:type         :ex/User,
                      :schema/name      "Alice",
                      :schema/email     "alice@flur.ee",
                      :schema/birthDate "2022-08-17",
@@ -219,7 +219,7 @@
                                                                            :role :ex/rootRole}})
                 commit-details-asserts (get-in history-result [:f/commit :f/data :f/assert])]
             (is (contains? (into #{} commit-details-asserts)
-                           {:type         [:ex/User],
+                           {:type         :ex/User,
                             :schema/name      "John",
                             :schema/email     "john@flur.ee",
                             :schema/birthDate "2021-08-17",
@@ -291,8 +291,8 @@
                               [{:id "https://ns.flur.ee/ledger#view"}]
                               "https://ns.flur.ee/ledger#equals"
                               {:list [{:id "https://ns.flur.ee/ledger#$identity"} :ex/user]}}]}]}])]
-      (is (= [{:id :ex/bob, :type [:ex/User], :schema/name "Bob"}
-              {:id          :ex/alice, :type [:ex/User], :ex/secret "alice's secret"
+      (is (= [{:id :ex/bob, :type :ex/User, :schema/name "Bob"}
+              {:id          :ex/alice, :type :ex/User, :ex/secret "alice's secret"
                :schema/name "Alice"}]
              @(fluree/query db {:where  '[[?s :type :ex/User]]
                                 :select '{?s [:*]}

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -85,7 +85,7 @@
                                            {:did alice-did
                                             :role      :ex/userRole})]
             (is (= [{:id :ex/alice,
-                     :type [:ex/User],
+                     :type :ex/User,
                      :schema/name "Alice",
                      :schema/email "alice@foo.bar",
                      :schema/birthDate "2022-08-17",
@@ -103,7 +103,7 @@
                                               {:role :ex/rootRole})]
 
               (is (= [{:id :ex/widget,
-                       :type [:ex/Product],
+                       :type :ex/Product,
                        :schema/name "Widget",
                        :schema/price 105.99,
                        :schema/priceCurrency "USD"}]
@@ -116,7 +116,7 @@
                                               :schema/name "Widget2"}
                                              {:role :ex/userRole})]
 
-              (is (= [{:type    [:ex/Product]
+              (is (= [{:type    :ex/Product
                        :schema/name "Widget2"}]
                      @(fluree/query update-name
                                     {:select {'?s [:*]}

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -31,7 +31,7 @@
                                        :type        :schema/Person
                                        :schema/name 3}])]
         (is (= [{:id          :ex/halie
-                 :type    [:schema/Person]
+                 :type    :schema/Person
                  :schema/name "Halie"}]
                @(fluree/query mixed-db
                               {:context default-context
@@ -45,7 +45,7 @@
                                :where  [['?u :schema/name "a"]]}))
             "does not return results without matching subjects")
         (is (= [{:id :ex/john
-                 :type [:schema/Person]
+                 :type :schema/Person
                  :schema/name 3}]
                @(fluree/query mixed-db
                               {:context default-context

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -78,7 +78,7 @@
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"
       (is (= [{:id :ex/david,
-               :type [:ex/User],
+               :type :ex/User,
                :schema/name "David",
                :ex/last "Jones",
                :schema/email "david@example.org",
@@ -86,7 +86,7 @@
                :ex/favNums [15 70],
                :ex/friend {:id :ex/cam}}
               {:id :ex/brian,
-               :type [:ex/User],
+               :type :ex/User,
                :schema/name "Brian",
                :ex/last "Smith",
                :schema/email "brian@example.org",
@@ -96,7 +96,7 @@
                                 :where  [["?s" :schema/age "?age"]
                                          {:filter ["(> ?age 45)"]}]})))
       (is (= [{:id :ex/david,
-               :type [:ex/User],
+               :type :ex/User,
                :schema/name "David",
                :ex/last "Jones",
                :schema/email "david@example.org",
@@ -106,7 +106,7 @@
              @(fluree/query db {:select {"?s" ["*"]}
                                 :where  [["?s" :schema/age "?age"]
                                          {:filter ["(> ?age 45)", "(< ?age 50)"]}]})))
-      (is (= [{:type [:ex/User]
+      (is (= [{:type :ex/User
                :schema/email "cam@example.org"
                :ex/favNums [5 10]
                :schema/age 34

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -11,67 +11,71 @@
       (testing "basic wildcard single subject query"
         (let [query-res @(fluree/query db '{:select {?s [:*]}
                                             :where [[?s :id :wiki/Q836821]]})]
-          (is (= query-res [{:id                               :wiki/Q836821,
-                             :type                         [:schema/Movie],
-                             :schema/name                      "The Hitchhiker's Guide to the Galaxy",
-                             :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
-                             :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
-                             :schema/isBasedOn                 {:id :wiki/Q3107329}}])
+          (is (= [{:id                               :wiki/Q836821,
+                   :type                         :schema/Movie,
+                   :schema/name                      "The Hitchhiker's Guide to the Galaxy",
+                   :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
+                   :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
+                   :schema/isBasedOn                 {:id :wiki/Q3107329}}]
+                 query-res)
               "Basic select * is working will context normalization")))
       (testing "basic single subject query with explicit field selection"
         (let [query-res @(fluree/query db '{:select {?s [:id :schema/name]}
                                             :where [[?s :id :wiki/Q836821]]})]
-          (is (= query-res [{:id :wiki/Q836821, :schema/name "The Hitchhiker's Guide to the Galaxy"}]))))
+          (is (= [{:id :wiki/Q836821, :schema/name "The Hitchhiker's Guide to the Galaxy"}] query-res))))
       (testing "basic single subject query with selectOne"
         (let [query-res @(fluree/query db '{:selectOne {?s [:id :schema/name]}
                                             :where [[?s :id :wiki/Q836821]]})]
-          (is (= query-res {:id :wiki/Q836821, :schema/name "The Hitchhiker's Guide to the Galaxy"}))))
+          (is (= {:id :wiki/Q836821, :schema/name "The Hitchhiker's Guide to the Galaxy"} query-res))))
       (testing "basic single subject query with graph crawl"
         (let [query-res @(fluree/query db '{:selectOne {?s [:* {:schema/isBasedOn [:*]}]}
                                             :where [[?s :id :wiki/Q836821]]})]
-          (is (= query-res {:id                               :wiki/Q836821,
-                            :type                         [:schema/Movie],
-                            :schema/name                      "The Hitchhiker's Guide to the Galaxy",
-                            :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
-                            :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
-                            :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                               :type      [:schema/Book],
-                                                               :schema/name   "The Hitchhiker's Guide to the Galaxy",
-                                                               :schema/isbn   "0-330-25864-8",
-                                                               :schema/author {:id :wiki/Q42}}}))))
+          (is (= {:id                               :wiki/Q836821,
+                  :type                         :schema/Movie,
+                  :schema/name                      "The Hitchhiker's Guide to the Galaxy",
+                  :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
+                  :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
+                  :schema/isBasedOn                 {:id            :wiki/Q3107329,
+                                                     :type      :schema/Book,
+                                                     :schema/name   "The Hitchhiker's Guide to the Galaxy",
+                                                     :schema/isbn   "0-330-25864-8",
+                                                     :schema/author {:id :wiki/Q42}}}
+                 query-res))))
       (testing "basic single subject query using depth graph crawl"
         (testing "using only wildcard"
           (let [query-res @(fluree/query db '{:selectOne {?s [:*]}
                                               :where [[?s :id :wiki/Q836821]]
                                               :depth 3})]
-            (is (= query-res {:id                               :wiki/Q836821,
-                              :type                         [:schema/Movie],
-                              :schema/name                      "The Hitchhiker's Guide to the Galaxy",
-                              :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
-                              :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
-                              :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                                 :type      [:schema/Book],
-                                                                 :schema/name   "The Hitchhiker's Guide to the Galaxy",
-                                                                 :schema/isbn   "0-330-25864-8",
-                                                                 :schema/author {:id          :wiki/Q42,
-                                                                                 :type    [:schema/Person],
-                                                                                 :schema/name "Douglas Adams"}}}))))
+            (is (= {:id                               :wiki/Q836821,
+                    :type                         :schema/Movie,
+                    :schema/name                      "The Hitchhiker's Guide to the Galaxy",
+                    :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
+                    :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
+                    :schema/isBasedOn                 {:id            :wiki/Q3107329,
+                                                       :type      :schema/Book,
+                                                       :schema/name   "The Hitchhiker's Guide to the Galaxy",
+                                                       :schema/isbn   "0-330-25864-8",
+                                                       :schema/author {:id          :wiki/Q42,
+                                                                       :type    :schema/Person,
+                                                                       :schema/name "Douglas Adams"}}}
+                   query-res))))
         (testing "using graph sub-selection"
           (let [query-res @(fluree/query db '{:selectOne {?s [:* {:schema/isBasedOn [:*]}]}
                                               :where [[?s :id :wiki/Q836821]]
                                               :depth 3})]
-            (is (= query-res {:id                               :wiki/Q836821,
-                              :type                         [:schema/Movie],
-                              :schema/name                      "The Hitchhiker's Guide to the Galaxy",
-                              :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
-                              :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
-                              :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                                 :type      [:schema/Book],
-                                                                 :schema/name   "The Hitchhiker's Guide to the Galaxy",
-                                                                 :schema/isbn   "0-330-25864-8",
-                                                                 :schema/author {:id          :wiki/Q42,
-                                                                                 :type    [:schema/Person],
-                                                                                 :schema/name "Douglas Adams"}}}))))))))
+            (is (= {:id                               :wiki/Q836821,
+                    :type                         :schema/Movie,
+                    :schema/name                      "The Hitchhiker's Guide to the Galaxy",
+                    :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
+                    :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
+                    :schema/isBasedOn                 {:id            :wiki/Q3107329,
+                                                       :type      :schema/Book,
+                                                       :schema/name   "The Hitchhiker's Guide to the Galaxy",
+                                                       :schema/isbn   "0-330-25864-8",
+                                                       :schema/author {:id          :wiki/Q42,
+                                                                       :type    :schema/Person,
+                                                                       :schema/name "Douglas Adams"}}}
+                   query-res))))))))
 
 (deftest ^:integration json-ld-rdf-type-query
   (testing "json-ld rdf type queries"
@@ -82,36 +86,36 @@
         (let [query-res @(fluree/query db '{:select {?s [:* {:schema/isBasedOn [:*]}]}
                                             :where  [[?s :type :schema/Movie]]})]
           (is (= [{:id :wiki/Q2875,
-                   :type [:schema/Movie],
+                   :type :schema/Movie,
                    :schema/disambiguatingDescription "1939 film by Victor Fleming",
                    :schema/isBasedOn {:id :wiki/Q2870,
-                                      :type [:schema/Book],
+                                      :type :schema/Book,
                                       :schema/author {:id :wiki/Q173540},
                                       :schema/isbn "0-582-41805-4",
                                       :schema/name "Gone with the Wind"},
                    :schema/name "Gone with the Wind",
                    :schema/titleEIDR "10.5240/FB0D-0A93-CAD6-8E8D-80C2-4"}
                   {:id                               :wiki/Q230552,
-                   :type                         [:schema/Movie],
+                   :type                         :schema/Movie,
                    :schema/name                      "Back to the Future Part III",
                    :schema/disambiguatingDescription "1990 film by Robert Zemeckis",
                    :schema/titleEIDR                 "10.5240/15F9-F913-FF25-8041-E798-O"}
-                  {:id                :wiki/Q109331, :type [:schema/Movie],
+                  {:id                :wiki/Q109331, :type :schema/Movie,
                    :schema/name       "Back to the Future Part II",
                    :schema/titleEIDR  "10.5240/5DA5-C386-2911-7E2B-1782-L",
                    :schema/followedBy {:id :wiki/Q230552}}
                   {:id                               :wiki/Q91540,
-                   :type                         [:schema/Movie],
+                   :type                         :schema/Movie,
                    :schema/name                      "Back to the Future",
                    :schema/disambiguatingDescription "1985 film by Robert Zemeckis",
                    :schema/titleEIDR                 "10.5240/09A3-1F6E-3538-DF46-5C6F-I",
                    :schema/followedBy                {:id :wiki/Q109331}}
-                  {:id                               :wiki/Q836821, :type [:schema/Movie],
+                  {:id                               :wiki/Q836821, :type :schema/Movie,
                    :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                    :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                    :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                    :schema/isBasedOn                 {:id            :wiki/Q3107329,
-                                                      :type      [:schema/Book],
+                                                      :type      :schema/Book,
                                                       :schema/name   "The Hitchhiker's Guide to the Galaxy",
                                                       :schema/isbn   "0-330-25864-8",
                                                       :schema/author {:id :wiki/Q42}}}]                                  ;; :id is a DID and will be unique per DB so exclude from comparison
@@ -133,9 +137,9 @@
               query-res @(fluree/query db '{:context   ["" {:ex "http://example.org/ns#"}]
                                             :selectOne {?s [:*]},
                                             :where     [[?s :id "list-test"]]})]
-          (is (= query-res
-                 {:id      "list-test"
-                  :ex/list [42 2 88 1]})
+          (is (= {:id      "list-test"
+                  :ex/list [42 2 88 1]}
+                 query-res)
               "Order of query result is different from transaction.")))
       (testing "define @list directly on subject"
         (let [db        @(fluree/stage (fluree/db movies)
@@ -146,9 +150,9 @@
               query-res @(fluree/query db '{:context   ["" {:ex "http://example.org/ns#"}],
                                             :selectOne {?s [:*]},
                                             :where     [[?s :id "list-test2"]]})]
-          (is (= query-res
-                 {:id      "list-test2"
-                  :ex/list [42 2 88 1]})
+          (is (= {:id      "list-test2"
+                  :ex/list [42 2 88 1]}
+                 query-res)
               "Order of query result is different from transaction."))))))
 
 (deftest ^:integration simple-subject-crawl-test
@@ -193,7 +197,7 @@
       (testing "id"
         ;;TODO not getting reparsed as ssc
         (is (= [{:id           :ex/brian,
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "Brian"
                  :ex/last      "Smith"
                  :schema/email "brian@example.org"
@@ -205,14 +209,14 @@
       ;;TODO not getting reparsed as ssc
       (testing "iri"
         (is (= [{:id           :ex/david
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "David"
                  :ex/last      "Jones"
                  :schema/email "david@example.org"
                  :schema/age   46
                  :ex/favNums   [15 70]
                  :ex/friend    {:id :ex/cam}}
-                {:type     [:ex/User]
+                {:type     :ex/User
                  :schema/email "cam@example.org"
                  :ex/favNums   [5 10]
                  :schema/age   34
@@ -222,7 +226,7 @@
                  :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
                  :ex/favColor  "Blue"}
                 {:id           :ex/alice
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -230,7 +234,7 @@
                  :ex/favNums   [9 42 76]
                  :ex/favColor  "Green"}
                 {:id           :ex/brian
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "Brian"
                  :ex/last      "Smith"
                  :schema/email "brian@example.org"
@@ -241,7 +245,7 @@
                                   :where  [["?s" :type :ex/User]]}))))
       (testing "tuple"
         (is (= [{:id           :ex/alice
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -250,7 +254,7 @@
                  :ex/favColor  "Green"}]
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/name "Alice"]]})))
-        (is (= [{:type     [:ex/User]
+        (is (= [{:type     :ex/User
                  :schema/email "cam@example.org"
                  :ex/favNums   [5 10]
                  :schema/age   34
@@ -260,7 +264,7 @@
                  :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
                  :ex/favColor  "Blue"}
                 {:id           :ex/alice
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -268,7 +272,7 @@
                  :ex/favNums   [9 42 76]
                  :ex/favColor  "Green"}
                 {:id           :ex/brian,
-                 :type     [:ex/User],
+                 :type     :ex/User,
                  :ex/favNums   7,
                  :ex/favColor  "Green",
                  :schema/age   50,
@@ -278,7 +282,7 @@
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :ex/favColor "?color"]]})))
         (is (= [{:id           :ex/alice
-                 :type     [:ex/User]
+                 :type     :ex/User
                  :schema/name  "Alice"
                  :ex/last      "Smith"
                  :schema/email "alice@example.org"
@@ -288,7 +292,7 @@
                @(fluree/query db {:select {"?s" ["*"]}
                                   :where  [["?s" :schema/age 42]]})))
         (is (= [{:id           :ex/alice,
-                 :type     [:ex/User],
+                 :type     :ex/User,
                  :ex/favNums   [9 42 76],
                  :ex/favColor  "Green",
                  :schema/age   42,

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -46,13 +46,13 @@
       (is (= two-tuple-select-with-crawl
              two-tuple-select-with-crawl+var
              [[50 {:id           :ex/brian,
-                   :type     [:ex/User],
+                   :type     :ex/User,
                    :schema/name  "Brian",
                    :schema/email "brian@example.org",
                    :schema/age   50,
                    :ex/favNums   7}]
               [50 {:id           :ex/alice,
-                   :type     [:ex/User],
+                   :type     :ex/User,
                    :schema/name  "Alice",
                    :schema/email "alice@example.org",
                    :schema/age   50,
@@ -173,20 +173,20 @@
                               :where   [[?s :ex/friend ?o]
                                         [?o :schema/name "Alice"]]})
              [{:id :ex/cam,
-               :type [:ex/User],
+               :type :ex/User,
                :schema/name "Cam",
                :schema/email "cam@example.org",
                :schema/age 34,
                :ex/favNums [5 10],
                :ex/friend
                [{:id :ex/brian,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Brian",
                  :schema/email "brian@example.org",
                  :schema/age 50,
                  :ex/favNums 7}
                 {:id :ex/alice,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Alice",
                  :schema/email "alice@example.org",
                  :schema/age 50,

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -20,13 +20,13 @@
                                              :schema/name "Picasso"}}]})]
       (is (= [{:_id          211106232532993,
                :id           :ex/bob,
-               :type     [:ex/User],
+               :type     :ex/User,
                :schema/name  "Bob",
                :ex/favArtist {:_id         211106232532994
                               :schema/name "Picasso"}}
               {:_id         211106232532992,
                :id          :ex/alice,
-               :type    [:ex/User],
+               :type    :ex/User,
                :schema/name "Alice"}]
              @(fluree/query db {:select {'?s [:_id :* {:ex/favArtist [:_id :schema/name]}]}
                                 :where  [['?s :type :ex/User]]}))))))
@@ -146,68 +146,68 @@
                                   :where  [['?s '?p '?o]]}))
             "Entire database should be pulled.")
         (is (= [{:id :ex/jane,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/jane,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Jane",
                  :schema/email "jane@flur.ee",
                  :schema/age 30}
                 {:id :ex/bob,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/bob,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/bob,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/bob,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Bob",
                  :schema/age 22}
                 {:id :ex/alice,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
                 {:id :ex/alice,
-                 :type [:ex/User],
+                 :type :ex/User,
                  :schema/name "Alice",
                  :schema/email "alice@flur.ee",
                  :schema/age 42}
@@ -363,13 +363,13 @@
         db3 @(fluree/stage db1 {"@context" ["" {"rdf:type" "@type"}]
                                 "id" "ex:two"
                                 "rdf:type" "ex:Diamond"})]
-    (is (= [{"id" "ex:queen" "type" ["ex:Heart"]}
-            {"id" "ex:king" "type" ["ex:Heart"]}]
+    (is (= [{"id" "ex:queen" "type" "ex:Heart"}
+            {"id" "ex:king" "type" "ex:Heart"}]
            @(fluree/query db1 {"select" {"?s" ["*"]}
                                "where" [["?s" "type" "ex:Heart"]]}))
         "Query with type and type in results")
-    (is (= [{"id" "ex:queen" "type" ["ex:Heart"]}
-            {"id" "ex:king" "type" ["ex:Heart"]}]
+    (is (= [{"id" "ex:queen" "type" "ex:Heart"}
+            {"id" "ex:king" "type" "ex:Heart"}]
            @(fluree/query db1 {"select" {"?s" ["*"]}
                                "where" [["?s" "rdf:type" "ex:Heart"]]}))
         "Query with rdf:type and type in results")
@@ -379,7 +379,7 @@
     (is (= "\"http://www.w3.org/1999/02/22-rdf-syntax-ns#type\" is not a valid predicate IRI. Please use the JSON-LD \"@type\" keyword instead."
            (-> db2 Throwable->map :cause)))
 
-    (is (= [{"id" "ex:two" "type" ["ex:Diamond"]}]
+    (is (= [{"id" "ex:two" "type" "ex:Diamond"}]
            @(fluree/query db3 {"select" {"?s" ["*"]}
                                "where" [["?s" "type" "ex:Diamond"]]}))
         "Can transact with rdf:type aliased to type.")))

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -40,6 +40,6 @@
                                  :where     [[?s :id :ex/brian]]})
              {:schema/name "Brian",
               :friended    {:id           :ex/cam,
-                            :type     [:ex/User],
+                            :type     :ex/User,
                             :schema/name  "Cam",
                             :ex/friend    [{:id :ex/brian} {:id :ex/alice}]}})))))

--- a/test/fluree/db/query/subclass_test.clj
+++ b/test/fluree/db/query/subclass_test.clj
@@ -48,13 +48,13 @@
                             {:select {'?s [:*]}
                              :where  [['?s :type :schema/CreativeWork]]})
              [{:id                               :wiki/Q836821,
-               :type                         [:schema/Movie],
+               :type                         :schema/Movie,
                :schema/name                      "The Hitchhiker's Guide to the Galaxy",
                :schema/disambiguatingDescription "2005 British-American comic science fiction film directed by Garth Jennings",
                :schema/titleEIDR                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
                :schema/isBasedOn                 {:id :wiki/Q3107329}}
               {:id            :wiki/Q3107329,
-               :type      [:schema/Book],
+               :type      :schema/Book,
                :schema/name   "The Hitchhiker's Guide to the Galaxy",
                :schema/isbn   "0-330-25864-8",
                :schema/author {:id :wiki/Q42}}])

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -17,13 +17,13 @@
           db2       @(fluree/stage
                       db1
                       {:id                 :ex/myClassInstance
-                       :type               [:ex/MyClass]
+                       :type               :ex/MyClass
                        :schema/description "Now a new subject uses MyClass as a Class"})
           query-res @(fluree/query db2 '{:select {?s [:*]}
                                          :where  [[?s :id :ex/myClassInstance]]})]
       (is (= query-res
              [{:id                 :ex/myClassInstance
-               :type           [:ex/MyClass]
+               :type           :ex/MyClass
                :schema/description "Now a new subject uses MyClass as a Class"}])))))
 
 
@@ -45,7 +45,7 @@
           db-ok        @(fluree/stage
                          db
                          {:id              :ex/john
-                          :type            [:ex/User]
+                          :type            :ex/User
                           :schema/name     "John"
                           :schema/callSign "j-rock"})
           ; no :schema/name
@@ -53,14 +53,14 @@
                          @(fluree/stage
                            db
                            {:id              :ex/john
-                            :type            [:ex/User]
+                            :type            :ex/User
                             :schema/callSign "j-rock"})
                          (catch Exception e e))
           db-two-names (try
                          @(fluree/stage
                            db
                            {:id              :ex/john
-                            :type            [:ex/User]
+                            :type            :ex/User
                             :schema/name     ["John", "Johnny"]
                             :schema/callSign "j-rock"})
                          (catch Exception e e))]
@@ -73,7 +73,7 @@
       (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
              (ex-message db-two-names)))
       (is (= [{:id              :ex/john,
-               :type        [:ex/User],
+               :type        :ex/User,
                :schema/name     "John",
                :schema/callSign "j-rock"}]
              @(fluree/query db-ok user-query))
@@ -89,28 +89,28 @@
           db           @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/UserShape
-                          :type           [:sh/NodeShape]
+                          :type           :sh/NodeShape
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path     :schema/name
                                             :sh/datatype :xsd/string}]})
           db-ok        @(fluree/stage
                          db
                          {:id          :ex/john
-                          :type        [:ex/User]
+                          :type        :ex/User
                           :schema/name "John"})
           ; no :schema/name
           db-int-name  (try
                          @(fluree/stage
                            db
                            {:id          :ex/john
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name 42})
                          (catch Exception e e))
           db-bool-name (try
                          @(fluree/stage
                            db
                            {:id          :ex/john
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name true})
                          (catch Exception e e))]
       (is (util/exception? db-int-name)
@@ -121,7 +121,7 @@
       (is (str/starts-with? (ex-message db-bool-name) "Data type"))
       (is (= @(fluree/query db-ok user-query)
              [{:id          :ex/john
-               :type    [:ex/User]
+               :type    :ex/User
                :schema/name "John"}])
           "basic rdf:type query response not correct"))))
 
@@ -134,7 +134,7 @@
           db            @(fluree/stage
                           (fluree/db ledger)
                           {:id                   :ex/UserShape
-                           :type                 [:sh/NodeShape]
+                           :type                 :sh/NodeShape
                            :sh/targetClass       :ex/User
                            :sh/property          [{:sh/path     :schema/name
                                                    :sh/datatype :xsd/string}]
@@ -144,14 +144,14 @@
           db-ok         @(fluree/stage
                           db
                           {:id          :ex/john
-                           :type        [:ex/User]
+                           :type        :ex/User
                            :schema/name "John"})
           ; no :schema/name
           db-extra-prop (try
                           @(fluree/stage
                             db
                             {:id           :ex/john
-                             :type         [:ex/User]
+                             :type         :ex/User
                              :schema/name  "John"
                              :schema/email "john@flur.ee"})
                           (catch Exception e e))]
@@ -160,7 +160,7 @@
                             "SHACL shape is closed"))
 
       (is (= [{:id          :ex/john
-               :type    [:ex/User]
+               :type    :ex/User
                :schema/name "John"}]
              @(fluree/query db-ok user-query))
           "basic type query response not correct"))))
@@ -175,14 +175,14 @@
         (let [db           @(fluree/stage
                              (fluree/db ledger)
                              {:id             :ex/EqualNamesShape
-                              :type           [:sh/NodeShape]
+                              :type           :sh/NodeShape
                               :sh/targetClass :ex/User
                               :sh/property    [{:sh/path   :schema/name
                                                 :sh/equals :ex/firstName}]})
               db-ok        @(fluree/stage
                              db
                              {:id           :ex/alice
-                              :type         [:ex/User]
+                              :type         :ex/User
                               :schema/name  "Alice"
                               :ex/firstName "Alice"})
 
@@ -190,7 +190,7 @@
                              @(fluree/stage
                                db
                                {:id           :ex/john
-                                :type         [:ex/User]
+                                :type         :ex/User
                                 :schema/name  "John"
                                 :ex/firstName "Jack"})
                              (catch Exception e e))]
@@ -200,7 +200,7 @@
                                 "SHACL PropertyShape exception - sh:equals"))
 
           (is (= [{:id           :ex/alice
-                   :type     [:ex/User]
+                   :type     :ex/User
                    :schema/name  "Alice"
                    :ex/firstName "Alice"}]
                  @(fluree/query db-ok user-query)))))
@@ -208,14 +208,14 @@
         (let [db            @(fluree/stage
                               (fluree/db ledger)
                               {:id             :ex/EqualNamesShape
-                               :type           [:sh/NodeShape]
+                               :type           :sh/NodeShape
                                :sh/targetClass :ex/User
                                :sh/property    [{:sh/path   :ex/favNums
                                                  :sh/equals :ex/luckyNums}]})
               db-ok         @(fluree/stage
                               db
                               {:id           :ex/alice
-                               :type         [:ex/User]
+                               :type         :ex/User
                                :schema/name  "Alice"
                                :ex/favNums   [11 17]
                                :ex/luckyNums [11 17]})
@@ -223,7 +223,7 @@
               db-ok2        @(fluree/stage
                               db
                               {:id           :ex/alice
-                               :type         [:ex/User]
+                               :type         :ex/User
                                :schema/name  "Alice"
                                :ex/favNums   [11 17]
                                :ex/luckyNums [17 11]})
@@ -232,7 +232,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User]
+                                 :type         :ex/User
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums [13 18]})
@@ -241,7 +241,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User]
+                                 :type         :ex/User
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums [11]})
@@ -250,7 +250,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User]
+                                 :type         :ex/User
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums [11 17 18]})
@@ -259,7 +259,7 @@
                               @(fluree/stage
                                 db
                                 {:id           :ex/brian
-                                 :type         [:ex/User]
+                                 :type         :ex/User
                                  :schema/name  "Brian"
                                  :ex/favNums   [11 17]
                                  :ex/luckyNums ["11" "17"]})
@@ -281,13 +281,13 @@
           (is (str/starts-with? (ex-message db-not-equal4)
                                 "SHACL PropertyShape exception - sh:equals"))
           (is (= [{:id           :ex/alice
-                   :type     [:ex/User]
+                   :type     :ex/User
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums [11 17]}]
                  @(fluree/query db-ok user-query)))
           (is (= [{:id           :ex/alice
-                   :type     [:ex/User]
+                   :type     :ex/User
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums [11 17]}]
@@ -296,14 +296,14 @@
         (let [db               @(fluree/stage
                                  (fluree/db ledger)
                                  {:id             :ex/DisjointShape
-                                  :type           [:sh/NodeShape]
+                                  :type           :sh/NodeShape
                                   :sh/targetClass :ex/User
                                   :sh/property    [{:sh/path     :ex/favNums
                                                     :sh/disjoint :ex/luckyNums}]})
               db-ok            @(fluree/stage
                                  db
                                  {:id           :ex/alice
-                                  :type         [:ex/User]
+                                  :type         :ex/User
                                   :schema/name  "Alice"
                                   :ex/favNums   [11 17]
                                   :ex/luckyNums 1})
@@ -312,7 +312,7 @@
                                  @(fluree/stage
                                    db
                                    {:id           :ex/brian
-                                    :type         [:ex/User]
+                                    :type         :ex/User
                                     :schema/name  "Brian"
                                     :ex/favNums   11
                                     :ex/luckyNums 11})
@@ -321,7 +321,7 @@
                                  @(fluree/stage
                                    db
                                    {:id           :ex/brian
-                                    :type         [:ex/User]
+                                    :type         :ex/User
                                     :schema/name  "Brian"
                                     :ex/favNums   [11 17 31]
                                     :ex/luckyNums 11})
@@ -331,7 +331,7 @@
                                  @(fluree/stage
                                    db
                                    {:id           :ex/brian
-                                    :type         [:ex/User]
+                                    :type         :ex/User
                                     :schema/name  "Brian"
                                     :ex/favNums   [11 17 31]
                                     :ex/luckyNums [13 18 11]})
@@ -353,7 +353,7 @@
                                 "SHACL PropertyShape exception - sh:disjoint"))
 
           (is (= [{:id           :ex/alice
-                   :type     [:ex/User]
+                   :type     :ex/User
                    :schema/name  "Alice"
                    :ex/favNums   [11 17]
                    :ex/luckyNums 1}]
@@ -362,14 +362,14 @@
         (let [db       @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/LessThanShape
-                          :type           [:sh/NodeShape]
+                          :type           :sh/NodeShape
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path     :ex/p1
                                             :sh/lessThan :ex/p2}]})
               db-ok1   @(fluree/stage
                          db
                          {:id          :ex/alice
-                          :type        [:ex/User]
+                          :type        :ex/User
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       [18 19]})
@@ -378,7 +378,7 @@
               db-ok2   @(fluree/stage
                          db
                          {:id          :ex/alice
-                          :type        [:ex/User]
+                          :type        :ex/User
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       [18]})
@@ -387,7 +387,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       17})
@@ -397,7 +397,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       ["18" "19"]})
@@ -408,7 +408,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [12 17]
                             :ex/p2       [10 18]})
@@ -418,7 +418,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       [12 16]})
@@ -426,7 +426,7 @@
               db-iris  (try @(fluree/stage
                               db
                               {:id          :ex/alice
-                               :type        [:ex/User]
+                               :type        :ex/User
                                :schema/name "Alice"
                                :ex/p1       :ex/brian
                                :ex/p2       :ex/john})
@@ -458,13 +458,13 @@
                                 "SHACL PropertyShape exception - sh:lessThan"))
 
           (is (= [{:id          :ex/alice
-                   :type    [:ex/User]
+                   :type    :ex/User
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       [18 19]}]
                  @(fluree/query db-ok1 user-query)))
           (is (= [{:id          :ex/alice
-                   :type    [:ex/User]
+                   :type    :ex/User
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       18}]
@@ -473,14 +473,14 @@
         (let [db       @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/LessThanOrEqualsShape
-                          :type           [:sh/NodeShape]
+                          :type           :sh/NodeShape
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path             :ex/p1
                                             :sh/lessThanOrEquals :ex/p2}]})
               db-ok1   @(fluree/stage
                          db
                          {:id          :ex/alice
-                          :type        [:ex/User]
+                          :type        :ex/User
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       [17 19]})
@@ -489,7 +489,7 @@
               db-ok2   @(fluree/stage
                          db
                          {:id          :ex/alice
-                          :type        [:ex/User]
+                          :type        :ex/User
                           :schema/name "Alice"
                           :ex/p1       [11 17]
                           :ex/p2       17})
@@ -498,7 +498,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       10})
@@ -508,7 +508,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       ["17" "19"]})
@@ -518,7 +518,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [12 17]
                             :ex/p2       [10 17]})
@@ -528,7 +528,7 @@
                          @(fluree/stage
                            db
                            {:id          :ex/alice
-                            :type        [:ex/User]
+                            :type        :ex/User
                             :schema/name "Alice"
                             :ex/p1       [11 17]
                             :ex/p2       [12 16]})
@@ -555,13 +555,13 @@
           (is (str/starts-with? (ex-message db-fail4)
                                 "SHACL PropertyShape exception - sh:lessThanOrEquals"))
           (is (= [{:id          :ex/alice
-                   :type    [:ex/User]
+                   :type    :ex/User
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       [17 19]}]
                  @(fluree/query db-ok1 user-query)))
           (is (= [{:id          :ex/alice
-                   :type    [:ex/User]
+                   :type    :ex/User
                    :schema/name "Alice"
                    :ex/p1       [11 17]
                    :ex/p2       17}]
@@ -577,7 +577,7 @@
         (let [db          @(fluree/stage
                             (fluree/db ledger)
                             {:id             :ex/ExclusiveNumRangeShape
-                             :type           [:sh/NodeShape]
+                             :type           :sh/NodeShape
                              :sh/targetClass :ex/User
                              :sh/property    [{:sh/path         :schema/age
                                                :sh/minExclusive 1
@@ -585,18 +585,18 @@
               db-ok       @(fluree/stage
                             db
                             {:id         :ex/john
-                             :type       [:ex/User]
+                             :type       :ex/User
                              :schema/age 2})
               db-too-low  (try @(fluree/stage
                                  db
                                  {:id         :ex/john
-                                  :type       [:ex/User]
+                                  :type       :ex/User
                                   :schema/age 1})
                                (catch Exception e e))
               db-too-high (try @(fluree/stage
                                  db
                                  {:id         :ex/john
-                                  :type       [:ex/User]
+                                  :type       :ex/User
                                   :schema/age 100})
                                (catch Exception e e))]
           (is (util/exception? db-too-low)
@@ -611,13 +611,13 @@
 
           (is (= @(fluree/query db-ok user-query)
                  [{:id         :ex/john
-                   :type   [:ex/User]
+                   :type   :ex/User
                    :schema/age 2}]))))
       (testing "inclusive constraints"
         (let [db          @(fluree/stage
                             (fluree/db ledger)
                             {:id             :ex/InclusiveNumRangeShape
-                             :type           [:sh/NodeShape]
+                             :type           :sh/NodeShape
                              :sh/targetClass :ex/User
                              :sh/property    [{:sh/path         :schema/age
                                                :sh/minInclusive 1
@@ -625,22 +625,22 @@
               db-ok       @(fluree/stage
                             db
                             {:id         :ex/brian
-                             :type       [:ex/User]
+                             :type       :ex/User
                              :schema/age 1})
               db-ok2      @(fluree/stage
                             db-ok
                             {:id         :ex/alice
-                             :type       [:ex/User]
+                             :type       :ex/User
                              :schema/age 100})
               db-too-low  @(fluree/stage
                             db
                             {:id         :ex/alice
-                             :type       [:ex/User]
+                             :type       :ex/User
                              :schema/age 0})
               db-too-high @(fluree/stage
                             db
                             {:id         :ex/alice
-                             :type       [:ex/User]
+                             :type       :ex/User
                              :schema/age 101})]
           (is (util/exception? db-too-low)
               "Exception, because :schema/age is below the minimum")
@@ -653,29 +653,29 @@
                                 "SHACL PropertyShape exception - sh:maxInclusive: value 101"))
           (is (= @(fluree/query db-ok2 user-query)
                  [{:id         :ex/alice
-                   :type   [:ex/User]
+                   :type   :ex/User
                    :schema/age 100}
                   {:id         :ex/brian
-                   :type   [:ex/User]
+                   :type   :ex/User
                    :schema/age 1}]))))
       (testing "non-numeric values"
         (let [db         @(fluree/stage
                            (fluree/db ledger)
                            {:id             :ex/NumRangeShape
-                            :type           [:sh/NodeShape]
+                            :type           :sh/NodeShape
                             :sh/targetClass :ex/User
                             :sh/property    [{:sh/path         :schema/age
                                               :sh/minExclusive 0}]})
               db-subj-id (try @(fluree/stage
                                 db
                                 {:id         :ex/alice
-                                 :type       [:ex/User]
+                                 :type       :ex/User
                                  :schema/age :ex/brian})
                               (catch Exception e e))
               db-string  (try @(fluree/stage
                                 db
                                 {:id         :ex/alice
-                                 :type       [:ex/User]
+                                 :type       :ex/User
                                  :schema/age "10"})
                               (catch Exception e e))]
           (is (util/exception? db-subj-id)
@@ -699,7 +699,7 @@
           db                  @(fluree/stage
                                 (fluree/db ledger)
                                 {:id             :ex/UserShape
-                                 :type           [:sh/NodeShape]
+                                 :type           :sh/NodeShape
                                  :sh/targetClass :ex/User
                                  :sh/property    [{:sh/path      :schema/name
                                                    :sh/minLength 4
@@ -707,13 +707,13 @@
           db-ok-str           @(fluree/stage
                                 db
                                 {:id          :ex/john
-                                 :type        [:ex/User]
+                                 :type        :ex/User
                                  :schema/name "John"})
 
           db-ok-non-str       @(fluree/stage
                                 db
                                 {:id          :ex/john
-                                 :type        [:ex/User]
+                                 :type        :ex/User
                                  :schema/name 12345})
 
           db-too-short-str    (try
@@ -761,11 +761,11 @@
       (is (str/starts-with? (ex-message db-ref-value)
                             "SHACL PropertyShape exception - sh:maxLength:"))
       (is (= [{:id          :ex/john
-               :type    [:ex/User]
+               :type    :ex/User
                :schema/name "John"}]
              @(fluree/query db-ok-str user-query)))
       (is (= [{:id          :ex/john
-               :type    [:ex/User]
+               :type    :ex/User
                :schema/name 12345}]
              @(fluree/query db-ok-non-str user-query))))))
 
@@ -834,11 +834,11 @@
       (is (str/starts-with? (ex-message db-ref-value)
                             "SHACL PropertyShape exception - sh:pattern:"))
       (is (= [{:id          :ex/brian
-               :type    [:ex/User]
+               :type    :ex/User
                :ex/greeting "hello\nworld!"}]
              @(fluree/query db-ok-greeting user-query)))
       (is (= [{:id           :ex/john
-               :type     [:ex/User]
+               :type     :ex/User
                :ex/birthYear 1984}]
              @(fluree/query db-ok-birthyear user-query))))))
 
@@ -851,7 +851,7 @@
           db           @(fluree/stage
                          (fluree/db ledger)
                          {:id             :ex/UserShape
-                          :type           [:sh/NodeShape]
+                          :type           :sh/NodeShape
                           :sh/targetClass :ex/User
                           :sh/property    [{:sh/path     :schema/name
                                             :sh/datatype :xsd/string
@@ -867,41 +867,41 @@
           db-ok        @(fluree/stage
                          db
                          {:id           :ex/john
-                          :type         [:ex/User]
+                          :type         :ex/User
                           :schema/name  "John"
                           :schema/age   40
                           :schema/email "john@example.org"})
           db-no-name   @(fluree/stage
                          db
                          {:id           :ex/john
-                          :type         [:ex/User]
+                          :type         :ex/User
                           :schema/age   40
                           :schema/email "john@example.org"})
           db-two-names @(fluree/stage
                          db
                          {:id           :ex/john
-                          :type         [:ex/User]
+                          :type         :ex/User
                           :schema/name  ["John" "Billy"]
                           :schema/age   40
                           :schema/email "john@example.org"})
           db-too-old   @(fluree/stage
                          db
                          {:id           :ex/john
-                          :type         [:ex/User]
+                          :type         :ex/User
                           :schema/name  "John"
                           :schema/age   140
                           :schema/email "john@example.org"})
           db-two-ages  @(fluree/stage
                          db
                          {:id           :ex/john
-                          :type         [:ex/User]
+                          :type         :ex/User
                           :schema/name  "John"
                           :schema/age   [40 21]
                           :schema/email "john@example.org"})
           db-num-email @(fluree/stage
                          db
                          {:id           :ex/john
-                          :type         [:ex/User]
+                          :type         :ex/User
                           :schema/name  "John"
                           :schema/age   40
                           :schema/email 42})]
@@ -920,7 +920,7 @@
       (is (util/exception? db-num-email))
       (is (str/starts-with? (ex-message db-num-email) "Data type"))
       (is (= [{:id           :ex/john
-               :type     [:ex/User]
+               :type     :ex/User
                :schema/age   40
                :schema/email "john@example.org"
                :schema/name  "John"}]
@@ -948,7 +948,7 @@
         (is (= [{"id"          "ex:Luke",
                  "schema:name" "Luke",
                  "ex:parent"   {"id"          "ex:Anakin"
-                                "type"    ["ex:Parent"]
+                                "type" "ex:Parent"
                                 "schema:name" "Anakin"}}]
                @(fluree/query valid-parent {"select" {"?s" ["*" {"ex:parent" ["*"]}]}
                                             "where"  [["?s" "id" "ex:Luke"]]})))
@@ -974,7 +974,7 @@
                                             "schema:name" "Darth Vader"
                                             "ex:pal"      {"ex:evil" "has no name"}})]
         (is (= [{"id"          "ex:good-pal",
-                 "type"    ["ex:Pal"]
+                 "type" "ex:Pal"
                  "schema:name" "J.D.",
                  "ex:pal"      [{"schema:name" "Turk"}
                                 {"schema:name" "Rowdy"}]}]
@@ -1003,7 +1003,7 @@
                                                  "ex:child"    {"id"          "ex:Gerb"
                                                                 "type"        "ex:Princess"
                                                                 "schema:name" "Gerb"}})]
-        (is (= [{"id" "ex:Mork", "type" ["ex:Princess"], "schema:name" "Mork"}]
+        (is (= [{"id" "ex:Mork", "type" "ex:Princess", "schema:name" "Mork"}]
                @(fluree/query valid-princess {"select" {"?s" ["*"]}
                                               "where"  [["?s" "id" "ex:Mork"]]})))
 
@@ -1015,14 +1015,14 @@
   (let [conn   @(fluree/connect {:method :memory})
         ledger @(fluree/create conn "classtest" {:defaultContext test-utils/default-str-context})
         db0    (fluree/db ledger)
-        db1    @(fluree/stage db0 [{"@type"          ["sh:NodeShape"]
+        db1    @(fluree/stage db0 [{"@type" "sh:NodeShape"
                                     "sh:targetClass" {"@id" "https://example.com/Country"}
                                     "sh:property"
                                     [{"sh:path"     {"@id" "https://example.com/name"}
                                       "sh:datatype" {"@id" "xsd:string"}
                                       "sh:minCount" 1
                                       "sh:maxCount" 1}]}
-                                   {"@type"          ["sh:NodeShape"]
+                                   {"@type" "sh:NodeShape"
                                     "sh:targetClass" {"@id" "https://example.com/Actor"}
                                     "sh:property"
                                     [{"sh:path"        {"@id" "https://example.com/country"}
@@ -1124,7 +1124,7 @@
 
       (is (not (util/exception? db3)))
       (is (= [{"id"       "ex:PastelPony"
-               "type" ["ex:Pony"]
+               "type" "ex:Pony"
                "ex:color" [{"id" "ex:Pink"} {"id" "ex:Purple"}]}]
              @(fluree/query db3 '{"select" {"?p" ["*"]}
                                   "where"  [["?p" "type" "ex:Pony"]]})))))
@@ -1336,7 +1336,7 @@
                                               "type"       "ex:Person"
                                               "ex:address" {"ex:postalCode" ["12345" "45678"]}}])]
       (is (= [{"id"         "ex:Bob",
-               "type"   ["ex:Person"],
+               "type" "ex:Person",
                "ex:address" {"id" "_:f211106232532997", "ex:postalCode" "12345"}}]
              @(fluree/query valid-person {"select" {"?s" ["*" {"ex:address" ["*"]}]}
                                           "where"  [["?s" "id" "ex:Bob"]]})))
@@ -1372,7 +1372,7 @@
                                                         {"id"        "ex:Zorba"
                                                          "ex:gender" "alien"}]}])]
       (is (= [{"id"        "ex:ValidKid"
-               "type"  ["ex:Kid"]
+               "type" "ex:Kid"
                "ex:parent" [{"id" "ex:Bob"}
                             {"id" "ex:Jane"}]}]
              @(fluree/query valid-kid {"select" {"?s" ["*"]}
@@ -1421,7 +1421,7 @@
                                                         {"ex:name" "Finger"}
                                                         {"ex:name" ["Finger" "Thumb"]}]}])]
       (is (= [{"id"       "ex:ValidHand",
-               "type" ["ex:Hand"],
+               "type" "ex:Hand",
                "ex:digit"
                [{"ex:name" "Thumb"}
                 {"ex:name" "Finger"}

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -67,7 +67,7 @@
       (is (str/starts-with? (ex-message db-callsign-name)
                             "SHACL PropertyShape exception - sh:not sh:equals: [\"Johnny Boy\"] is required to be not equal to [\"Johnny Boy\"]"))
       (is (= [{:id              :ex/john,
-               :type        [:ex/User],
+               :type        :ex/User,
                :schema/name     "John",
                :schema/callSign "j-rock"}]
              ok-results)
@@ -136,7 +136,7 @@
                             ;; could be either problem so just match common prefix
                             "SHACL PropertyShape exception - sh:not "))
       (is (= [{:id              :ex/john,
-               :type        [:ex/User],
+               :type        :ex/User,
                :schema/name     "John",
                :schema/callSign "j-rock"
                :schema/age      42
@@ -206,14 +206,14 @@
       (is (str/starts-with? (ex-message db-greeting-incorrect)
                             "SHACL PropertyShape exception - sh:not sh:pattern: value hello! must not match pattern"))
       (is (= [{:id          :ex/jean-claude
-               :type    [:ex/User],
+               :type    :ex/User,
                :schema/name "Jean-Claude"}]
              @(fluree/query db-ok-name user-query)))
       (is (= [{:id       :ex/al,
-               :type [:ex/User],
+               :type :ex/User,
                :ex/tag   1}]
              @(fluree/query db-ok-tag user-query)))
       (is (= [{:id       :ex/al,
-               :type [:ex/User],
+               :type :ex/User,
                :ex/greeting   "HOWDY"}]
              @(fluree/query db-ok-greeting user-query))))))

--- a/test/fluree/db/transact/retraction_test.clj
+++ b/test/fluree/db/transact/retraction_test.clj
@@ -33,6 +33,6 @@
                               :select {?s [:*]},
                               :where [[?s :id :ex/alice]]})
              [{:id           :ex/alice,
-               :type     [:ex/User],
+               :type     :ex/User,
                :schema/name  "Alice"}])
           "Alice should no longer have an age property"))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -169,8 +169,8 @@
                             (into policy data))
           user-query      '{:select {?s [:*]}
                             :where  [[?s :type :ex/User]]}]
-      (let [users [{:id :ex/john, :type [:ex/User], :schema/name "John"}
-                   {:id :ex/alice, :type [:ex/User], :schema/name "Alice"}]]
+      (let [users [{:id :ex/john, :type :ex/User, :schema/name "John"}
+                   {:id :ex/alice, :type :ex/User, :schema/name "Alice"}]]
         (is (= users
                @(fluree/query db-data-first user-query)))
         (is (= users

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -74,7 +74,7 @@
                             '{:selectOne {?s [:*]}
                               :where     [[?s :id :ex/bob]]})
              {:id          :ex/bob,
-              :type    [:ex/User],
+              :type    :ex/User,
               :schema/name "Bob"})
           "Bob should no longer have an age property.")
 
@@ -92,7 +92,7 @@
 
       (testing "Updating property value only if it's current value is a match."
         (is (= [{:id          :ex/bob,
-                 :type    [:ex/User],
+                 :type    :ex/User,
                  :schema/name "Bob"
                  :schema/age  23}]
                @(fluree/query db-update-bob
@@ -102,7 +102,7 @@
 
       (testing "No update should happen if there is no match."
         (is (= [{:id          :ex/bob,
-                 :type    [:ex/User],
+                 :type    :ex/User,
                  :schema/name "Bob"
                  :schema/age  22}]
                @(fluree/query db-update-bob2
@@ -112,7 +112,7 @@
 
       (testing "Replacing existing property value with new property value."
         (is (= [{:id           :ex/jane,
-                 :type     [:ex/User],
+                 :type     :ex/User,
                  :schema/name  "Jane"
                  :schema/email "jane@flur.ee"
                  :schema/age   31}]

--- a/test/nodejs/flureenjs.test.js
+++ b/test/nodejs/flureenjs.test.js
@@ -75,7 +75,7 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
        [
          {
            id: 'ex:john',
-           type: [ 'ex:User' ],
+           type: 'ex:User',
            'schema:name': "John"
          }
        ]
@@ -94,7 +94,7 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
     [
       {
         id: 'ex:john',
-        type: [ 'ex:User' ],
+        type: 'ex:User',
         flhubee: 'John'
       }
     ]


### PR DESCRIPTION
This is a follow-on to #553 , since I was testing all the test results anyways. This does the same "single cardinality" transformation that other predicates receive, wherein predicates with only a single value are not wrapped in a vector.

We can take it or leave it, I just did it because it's been bugging me and I was there anyways.