### PR TITLE
Feature/equal list items

### DIFF
--- a/src/fluree/db/flake.cljc
+++ b/src/fluree/db/flake.cljc
@@ -308,13 +308,19 @@
     #?(:clj (Boolean/compare b1 b2) :cljs (compare b1 b2))
     0))
 
+(defn hash-meta
+  [m]
+  (if (int? m)
+    m
+    (hash m)))
+
 (defn cmp-meta
   "Meta will always be a map or nil, but can be searched using an integer to
   perform effective range scans if needed. i.e. (Integer/MIN_VALUE)
   to (Integer/MAX_VALUE) will always include all meta values."
   [m1 m2]
-  (let [m1h (if (int? m1) m1 (hash m1))
-        m2h (if (int? m2) m2 (hash m2))]
+  (let [m1h (hash-meta m1)
+        m2h (hash-meta m2)]
     #?(:clj (Integer/compare m1h m2h) :cljs (- m1h m2h))))
 
 

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -212,21 +212,23 @@
   (juxt flake/s flake/p flake/o flake/dt meta-hash))
 
 (defn stale-by
-  "Returns a sequence of flakes from the sorted set `flakes` that are out of date
-  by the transaction `from-t` because `flakes` contains another flake with the same
-  subject and predicate and a t-value later than that flake but on or before `from-t`."
+  "Returns a vector of flakes from the sorted set `flakes` that are out of date by
+  the transaction `from-t` because `flakes` contains another flake with the same
+  subject and predicate and a t-value later than that flake but on or before
+  `from-t`."
   [from-t flakes]
-  (->> flakes
-       (remove (partial after-t? from-t))
-       (partition-by fact-content)
-       (mapcat (fn [flakes]
-                 ;; if the last flake for a subject/predicate/object combo is an assert,
-                 ;; then everything before that is stale (object is necessary for
-                 ;; multicardinality flakes)
-                 (let [last-flake (last flakes)]
-                   (if (flake/op last-flake)
-                     (butlast flakes)
-                     flakes))))))
+  (let [stale-xf (comp (remove (partial after-t? from-t))
+                       (partition-by fact-content)
+                       (mapcat (fn [flakes]
+                                 ;; if the last flake pertaining to a unique
+                                 ;; fact is an assert, then every flake before
+                                 ;; that is stale. If that item is a retract,
+                                 ;; then all the flakes are stale.
+                                 (let [last-flake (last flakes)]
+                                   (if (flake/op last-flake)
+                                     (butlast flakes)
+                                     flakes)))))]
+    (into [] stale-xf flakes)))
 
 (defn t-range
   "Returns a sorted set of flakes that are not out of date between the

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -204,6 +204,13 @@
                    novelty)]
     (flakes-through through-t subrange)))
 
+(def meta-hash
+  (comp flake/hash-meta flake/m))
+
+(def fact-content
+  "Function to extract the content being asserted or retracted by a flake."
+  (juxt flake/s flake/p flake/o flake/dt meta-hash))
+
 (defn stale-by
   "Returns a sequence of flakes from the sorted set `flakes` that are out of date
   by the transaction `from-t` because `flakes` contains another flake with the same
@@ -211,7 +218,7 @@
   [from-t flakes]
   (->> flakes
        (remove (partial after-t? from-t))
-       (partition-by (juxt flake/s flake/p flake/o))
+       (partition-by fact-content)
        (mapcat (fn [flakes]
                  ;; if the last flake for a subject/predicate/object combo is an assert,
                  ;; then everything before that is stale (object is necessary for

--- a/src/fluree/db/index.cljc
+++ b/src/fluree/db/index.cljc
@@ -217,18 +217,18 @@
   subject and predicate and a t-value later than that flake but on or before
   `from-t`."
   [from-t flakes]
-  (let [stale-xf (comp (remove (partial after-t? from-t))
-                       (partition-by fact-content)
-                       (mapcat (fn [flakes]
-                                 ;; if the last flake pertaining to a unique
-                                 ;; fact is an assert, then every flake before
-                                 ;; that is stale. If that item is a retract,
-                                 ;; then all the flakes are stale.
-                                 (let [last-flake (last flakes)]
-                                   (if (flake/op last-flake)
-                                     (butlast flakes)
-                                     flakes)))))]
-    (into [] stale-xf flakes)))
+  (->> flakes
+       (flake/remove (partial after-t? from-t))
+       (flake/partition-by fact-content)
+       (mapcat (fn [flakes]
+                 ;; if the last flake pertaining to a unique
+                 ;; fact is an assert, then every flake before
+                 ;; that is stale. If that item is a retract,
+                 ;; then all the flakes are stale.
+                 (let [last-flake (flake/last flakes)]
+                   (if (flake/op last-flake)
+                     (disj flakes last-flake)
+                     flakes))))))
 
 (defn t-range
   "Returns a sorted set of flakes that are not out of date between the

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -121,8 +121,9 @@
   new-types are a set of newly created types in the transaction."
   [db sid added-classes]
   (go-try
-    (let [type-sids (->> (<? (query-range/index-range db :spot = [sid const/$rdf:type]))
-                         (map flake/o))]
+    (let [type-sids (<? (query-range/index-range db
+                                                 :spot = [sid const/$rdf:type]
+                                                 {:flake-xf (map flake/o)}))]
       (if (seq type-sids)
         (into added-classes type-sids)
         added-classes))))
@@ -239,8 +240,9 @@
                 ;; check-retracts? - a new subject or property don't require checking for flake retractions
                 check-retracts?  (or (not new-subj?) existing-pid)
                 flakes*          (if retract?
-                                   (->> (<? (query-range/index-range db-before :spot = [sid pid]))
-                                        (map #(flake/flip-flake % t)))
+                                   (<? (query-range/index-range db-before
+                                                                :spot = [sid pid]
+                                                                {:flake-xf (map #(flake/flip-flake % t))}))
                                    (loop [[v' & r] v*
                                           flakes* subj-flakes]
                                      (if v'


### PR DESCRIPTION
When filtering out flakes representing the same fact that were out of date, we only took into account the subject, predicate, and object to determine the fact represented by a flake. This means that fact content stored in flake metadata (like "@list" index or language tag) were ignored and multiple equal items in a list or equal items of different languages were filtered out. This patch also considers the hash of the flake metadata (the hash is for performance reasons) to disambiguate items with different metadata. 

I also added a few utility functions mirroring some clojure.core sequence functions that return sorted sets instead of seqs to make the filtering code more efficient. The different implementations have the same performance on small inputs, but I expect the sorted set returning functions to be much faster as input sizes grow due to the logarithmic vs linear complexity of the two data structures. 

Closes #235