### PR TITLE
Add :remote `conn` type to connect to fluree/server

### DIFF
--- a/dev/remote_conn.clj
+++ b/dev/remote_conn.clj
@@ -1,0 +1,20 @@
+(ns remote-conn
+  (:require [clojure.core.async :as async]
+            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.util.xhttp :as xhttp]))
+
+(comment
+
+  (def conn @(fluree/connect {:method   :remote
+                              :servers  "http://localhost:58090"
+                              :defaults {}}))
+
+  (def ledger @(fluree/load conn "my/test"))
+
+  (def db (fluree/db ledger))
+
+  @(fluree/query db {:select {"?s" ["*"]}
+                     :where  [["?s" "ex:name" nil]]})
+
+
+  )

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -198,7 +198,7 @@
   (json/parse (read-address conn context-key) true))
 
 (defrecord FileConnection [id memory state ledger-defaults parallelism msg-in-ch
-                           msg-out-ch lru-cache-atom]
+                           serializer msg-out-ch lru-cache-atom]
 
   conn-proto/iStorage
   (-c-read [conn commit-key] (go (read-commit conn commit-key)))

--- a/src/fluree/db/conn/remote.cljc
+++ b/src/fluree/db/conn/remote.cljc
@@ -1,0 +1,156 @@
+(ns fluree.db.conn.remote
+  (:require [clojure.core.async :as async :refer [go]]
+            [fluree.db.storage :as storage]
+            [fluree.db.index :as index]
+            [fluree.db.util.context :as ctx-util]
+            [fluree.db.util.log :as log :include-macros true]
+            #?(:clj [fluree.db.full-text :as full-text])
+            [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.serde.json :refer [json-serde]]
+            [fluree.db.conn.cache :as conn-cache]
+            [fluree.db.conn.state-machine :as state-machine]
+            [clojure.string :as str]
+            [fluree.db.util.xhttp :as xhttp]))
+
+(defn pick-server
+  "Currently does just a round-robin selection if multiple servers are given.
+  TODO - add re-tries with a different server if fails to connect. Consider keeping stats to select optimal server."
+  [servers]
+  (rand-nth servers))
+
+(defn remote-read
+  "Returns a core async channel with value of remote resource."
+  [state servers commit-key keywordize-keys?]
+  (log/debug "[remote conn] remote read initiated for: " commit-key)
+  (xhttp/post-json (str (pick-server servers) "/fluree/remoteResource")
+                   {:resource commit-key}
+                   {:keywordize-keys keywordize-keys?}))
+
+;; NOTE, below function works in conjunction with message broadcasting (not in current PR)
+#_(defn remote-read
+  "Returns a core async channel with value of remote resource."
+  [state servers commit-key keywordize-keys?]
+  (log/debug "[remote conn] remote read initiated for: " commit-key)
+  (if-let [cached (get-in @state [:resource commit-key])]
+      (go cached)
+      (xhttp/post-json (str (pick-server servers) "/fluree/remoteResource")
+                       {:resource commit-key}
+                       {:keywordize-keys keywordize-keys?})))
+
+(defn remote-lookup
+  [state servers ledger-address]
+  (go-try
+    (let [head-commit  (<? (remote-read state servers ledger-address false))
+          head-address (get head-commit "address")]
+      head-address)))
+
+;; NOTE, below function works in conjunction with message broadcasting (not in current PR)
+#_(defn remote-lookup
+  [state servers ledger-address]
+  (go-try
+    (or (get-in @state [:lookup ledger-address])
+          (let [head-commit  (<? (remote-read state servers ledger-address false))
+                head-address (get head-commit "address")]
+            (swap! state assoc-in [:lookup ledger-address] head-address)
+            (swap! state assoc-in [:resource head-address] head-commit)
+            head-address))))
+
+(defn remote-ledger-exists?
+  [state servers ledger-address]
+  (go-try
+    (boolean
+      (<? (remote-lookup state servers ledger-address)))))
+
+
+(defrecord RemoteConnection [id servers state lru-cache-atom serializer
+                             ledger-defaults parallelism msg-in-ch msg-out-ch]
+
+  conn-proto/iStorage
+  (-c-read [_ commit-key] (remote-read state servers commit-key false))
+  (-ctx-read [_ context-key] (remote-read state servers context-key false))
+  (-index-file-read [_ index-address] (remote-read state servers index-address true))
+
+  conn-proto/iNameService
+  (-pull [this ledger] :TODO)
+  (-subscribe [this ledger] :TODO)
+  (-alias [this address]
+    address)
+  (-lookup [this ledger-alias]
+    (remote-lookup state servers ledger-alias))
+  (-address [_ ledger-alias {:keys [branch] :or {branch :main} :as _opts}]
+    (go (str ledger-alias "/" (name branch) "/head")))
+  (-exists? [_ ledger-address]
+    (remote-ledger-exists? state servers ledger-address))
+
+  conn-proto/iConnection
+  (-close [_]
+    (log/info "Closing memory connection" id)
+    (swap! state assoc :closed? true))
+  (-closed? [_] (boolean (:closed? @state)))
+  (-method [_] :remote)
+  (-parallelism [_] parallelism)
+  (-id [_] id)
+  (-default-context [_] (:context ledger-defaults))
+  (-did [_] (:did ledger-defaults))
+  (-msg-in [_ msg] (go-try
+                     ;; TODO - push into state machine
+                     (log/warn "-msg-in: " msg)
+                     :TODO))
+  (-msg-out [_ msg] (go-try
+                      ;; TODO - register/submit event
+                      (log/warn "-msg-out: " msg)
+                      :TODO))
+  (-state [_] @state)
+  (-state [_ ledger] (get @state ledger))
+
+  index/Resolver
+  (resolve
+    [conn {:keys [id leaf tempid] :as node}]
+    (let [cache-key [::resolve id tempid]]
+      (if (= :empty id)
+        (storage/resolve-empty-node node)
+        (conn-cache/lru-lookup
+          lru-cache-atom
+          cache-key
+          (fn [_]
+            (storage/resolve-index-node conn node
+                                        (fn [] (conn-cache/lru-evict lru-cache-atom cache-key))))))))
+
+  #?@(:clj
+      [full-text/IndexConnection
+       (open-storage [conn network dbid lang]
+         (throw (ex-info "Memory connection does not support full text operations."
+                         {:status 500 :error :db/unexpected-error})))]))
+
+(defn ledger-defaults
+  "Normalizes ledger defaults settings"
+  [{:keys [context did context-type] :as _defaults}]
+  (async/go
+    {:context      (ctx-util/stringify-context context)
+     :context-type context-type
+     :did          did}))
+
+
+(defn connect
+  "Creates a new memory connection."
+  [{:keys [parallelism lru-cache-atom memory defaults servers serializer]
+    :or {serializer (json-serde)}
+    :as opts}]
+  (go-try
+    (let [ledger-defaults (<? (ledger-defaults defaults))
+          servers*        (str/split servers #",")
+          conn-id         (str (random-uuid))
+          state           (state-machine/blank-state)
+          cache-size      (conn-cache/memory->cache-size memory)
+          lru-cache-atom  (or lru-cache-atom (atom (conn-cache/create-lru-cache
+                                                     cache-size)))]
+      (map->RemoteConnection {:id              conn-id
+                              :servers         servers*
+                              :state           state
+                              :lru-cache-atom  lru-cache-atom
+                              :serializer      serializer
+                              :ledger-defaults ledger-defaults
+                              :parallelism     parallelism
+                              :msg-in-ch       (async/chan)
+                              :msg-out-ch      (async/chan)}))))

--- a/src/fluree/db/conn/remote.cljc
+++ b/src/fluree/db/conn/remote.cljc
@@ -85,7 +85,7 @@
 
   conn-proto/iConnection
   (-close [_]
-    (log/info "Closing memory connection" id)
+    (log/info "Closing remote connection" id)
     (swap! state assoc :closed? true))
   (-closed? [_] (boolean (:closed? @state)))
   (-method [_] :remote)
@@ -115,13 +115,7 @@
           cache-key
           (fn [_]
             (storage/resolve-index-node conn node
-                                        (fn [] (conn-cache/lru-evict lru-cache-atom cache-key))))))))
-
-  #?@(:clj
-      [full-text/IndexConnection
-       (open-storage [conn network dbid lang]
-         (throw (ex-info "Memory connection does not support full text operations."
-                         {:status 500 :error :db/unexpected-error})))]))
+                                        (fn [] (conn-cache/lru-evict lru-cache-atom cache-key)))))))))
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -3,6 +3,7 @@
             [fluree.db.conn.ipfs :as ipfs-conn]
             [fluree.db.conn.file :as file-conn]
             [fluree.db.conn.memory :as memory-conn]
+            [fluree.db.conn.remote :as remote-conn]
             #?(:clj [fluree.db.conn.s3 :as s3-conn])
             [fluree.db.conn.proto :as conn-proto]
             [fluree.db.dbproto :as dbproto]
@@ -57,12 +58,17 @@
     - commit - (optional) Function to use to write commits. If persistence desired, this must be defined
     - push - (optional) Function(s) in a vector that will attempt to push the commit to naming service(s)
     "
-  [{:keys [method parallelism] :as opts}]
+  [{:keys [method parallelism remote-servers] :as opts}]
   ;; TODO - do some validation
   (promise-wrap
     (let [opts*   (assoc opts :parallelism (or parallelism 4))
-          method* (keyword method)]
+          method* (cond
+                    method (keyword method)
+                    remote-servers :remote
+                    :else (throw (ex-info (str "No Fluree connection method type specified in configuration: " opts)
+                                          {:status 500 :error :db/invalid-configuration})))]
       (case method*
+        :remote (remote-conn/connect opts*)
         :ipfs (ipfs-conn/connect opts*)
         :file (if platform/BROWSER
                 (throw (ex-info "File connection not supported in the browser" opts))

--- a/src/fluree/db/util/xhttp.cljc
+++ b/src/fluree/db/util/xhttp.cljc
@@ -93,7 +93,8 @@
          :or   {request-timeout 5000
                 keywordize-keys true}} opts
         response-chan (async/chan)
-        multipart? (contains? message :multipart)
+        multipart?    (and (map? message)
+                           (contains? message :multipart))
         headers*      (cond-> headers
                         json? (assoc "Content-Type" "application/json")
                         token (assoc "Authorization" (str "Bearer " token)))
@@ -145,7 +146,7 @@
                    (->> (:multipart message)                ;; stringify each :content key of multipart message
                         (mapv #(assoc % :content (json/stringify (:content %))))
                         (assoc message :multipart))
-                   {:body (json/stringify message)})]
+                   (json/stringify message))]
     (post url base-req (assoc opts :json? true))))
 
 


### PR DESCRIPTION
This for #431 this adds a `:remote` conn type that takes a list of `fluree/server` addresses and can execute queries against a remote server network.

This adds core library support, so it can be used in any app using the library, or it is also used by fluree/server to establish a server as an edge query-server.

This PR does not contain the message broadcasting (auto-updating remote dbs), which will be in a separate PR to keep things slim.