### PR TITLE
immutable db

### DIFF
--- a/src/fluree/db/json_ld/reify.cljc
+++ b/src/fluree/db/json_ld/reify.cljc
@@ -457,10 +457,9 @@
 
 
 (defn load-db
-  [{:keys [ledger] :as db} latest-commit merged-db?]
+  [{:keys [conn] :as db} latest-commit merged-db?]
   (go-try
-    (let [{:keys [conn]} ledger
-          commits (<? (trace-commits conn latest-commit 1))]
+    (let [commits (<? (trace-commits conn latest-commit 1))]
       (loop [[commit & r] commits
              db* db]
         (if commit
@@ -470,10 +469,9 @@
 
 
 (defn load-db-idx
-  [{:keys [ledger] :as db} latest-commit commit-address merged-db?]
+  [{:keys [conn] :as db} latest-commit commit-address merged-db?]
   (go-try
-    (let [{:keys [conn]} ledger
-          idx-meta   (get latest-commit const/iri-index) ;; get persistent index meta if ledger has indexes
+    (let [idx-meta   (get latest-commit const/iri-index) ;; get persistent index meta if ledger has indexes
           db-base    (if-let [idx-address (get-in idx-meta [const/iri-address :value])]
                        (<? (storage/reify-db conn db idx-address))
                        db)

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -209,11 +209,10 @@
 (defn index-range*
   "Return a channel that will eventually hold a sorted vector of the range of
   flakes from `db` that meet the criteria specified in the `opts` map."
-  [{:keys [ledger] :as db}
+  [{:keys [conn] :as db}
    error-ch
    {:keys [idx start-flake end-flake limit offset flake-limit] :as opts}]
-  (let [{:keys [conn]} ledger
-        idx-root       (get db idx)
+  (let [idx-root       (get db idx)
         novelty        (get-in db [:novelty idx])]
     (->> (resolve-flake-slices conn idx-root novelty error-ch opts)
          (filter-authorized db start-flake end-flake error-ch)


### PR DESCRIPTION
This is a quick refactor that capitalizes on an api change we made a while ago.

Before, `commit` took a db and used the `:ledger` key on the db to update the branch pointer to include a reference to the latest db.

Now, `commit` takes a ledger and a db.

Since we are getting the ledger on its own, we no longer need to mutate the ledger state within the db. This commit just pushes the ledger arg of `commit` down to wherever we used the db's `:ledger` key.

There are also a few places where we used the db's `:ledger` just to get the ledger's `:conn` key. Well, db also has a `:conn` key, so we don't need to look at the ledger to get it.

There are a few remaining places where a ledger from a db is required: when we use the `conn` to persist data, some conn methods require a `ledger`. As far as I can tell, they only need a ledger to read the ledger alias and to read the current branch. A future refactor that changes those methods to accept only the data they require instead of the full ledger would allow us to remove the `:ledger` key from the db entirely.

As it stands, after this PR the `:ledger` on the db becomes read-only - no more mutation of the db! But we still need the key because some places read from it, and updating those will require a more invasive refactor.