### PR TITLE
short circuit validation

### DIFF
--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -398,9 +398,10 @@
   type. Value coercion is only attempted when a required-type is supplied."
   [{:keys [type value] :as _value-map} required-type]
   (let [type-id (if type (get default-data-types type) (infer value))
-        to-type (if required-type required-type type-id)]
-    (if-let [value* (coerce value to-type)]
-      [value* to-type]
+        to-type (if required-type required-type type-id)
+        value* (coerce value to-type)]
+    (if (nil? value*)
       (throw (ex-info (str "Data type " to-type
                            " cannot be coerced from provided value: " value ".")
-                      {:status 400 :error, :db/shacl-value-coercion})))))
+                      {:status 400 :error, :db/shacl-value-coercion}))
+      [value* to-type])))

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -406,4 +406,4 @@
                            " cannot be coerced from provided value: " value ".")
                       {:status 400 :error, :db/shacl-value-coercion}))
 
-      :else [value to-type])))
+      :else [value* to-type])))

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -398,12 +398,9 @@
   type. Value coercion is only attempted when a required-type is supplied."
   [{:keys [type value] :as _value-map} required-type]
   (let [type-id (if type (get default-data-types type) (infer value))
-        to-type (if required-type required-type type-id)
-        value*  (coerce value to-type)]
-    (cond
-      (nil? value*)
+        to-type (if required-type required-type type-id)]
+    (if-let [value* (coerce value to-type)]
+      [value* to-type]
       (throw (ex-info (str "Data type " to-type
                            " cannot be coerced from provided value: " value ".")
-                      {:status 400 :error, :db/shacl-value-coercion}))
-
-      :else [value* to-type])))
+                      {:status 400 :error, :db/shacl-value-coercion})))))

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -825,7 +825,8 @@
   (boolean (:target-class shape)))
 
 (defn add-advanced-validation-lookup
-  "Constructs a map "
+  "Constructs a map to facilitate the retrieval of advanced-validation p-shapes during
+  property additions."
   [shape advanced-eligible-p-shapes]
   (let [pid->shape->p-shapes (reduce (fn [pid->shape->p-shapes p-shape]
                                        (update-in pid->shape->p-shapes [(-> p-shape :path ffirst) (:id shape)]

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -798,11 +798,6 @@
     :flags
 
     :datatype
-    :in
-    :has-value
-
-    :min-count
-    :max-count
 
     :min-exclusive
     :min-inclusive

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -186,8 +186,8 @@
   [{:keys [in has-value datatype nodekind logical-constraint] :as _p-shape} p-flakes]
   (let [in-results (when in
                      (if (every? #(contains? (set in) (flake/o %)) p-flakes)
-                       [true (str "sh:not sh:in: value " val " must not be one of " in)]
-                       [false (str "sh:in: value " val " must be one of " in)]))
+                       [true (str "sh:not sh:in: value must not be one of " in)]
+                       [false (str "sh:in: value must be one of " in)]))
         has-value-results (when has-value
                             (if (some #(= (flake/o %) has-value) p-flakes)
                               [true (str "sh:not sh:hasValue: none of the values can be " has-value)]

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -554,8 +554,7 @@
          (assoc acc :datatype o)
 
          const/$sh:minCount
-         (cond-> (assoc acc :min-count o)
-           (>= o 1) (assoc :required? true)) ; min-count >= 1 means property is required
+         (assoc acc :min-count o)
 
          const/$sh:maxCount
          (assoc acc :max-count o)
@@ -788,7 +787,7 @@
           base*    (<? (resolve-path-types base db))]
       (cond-> base*
         (:pattern base) (build-pattern)
-        (= p const/$sh:not) (assoc :logical-constraint :not, :required? false)))))
+        (= p const/$sh:not) (assoc :logical-constraint :not)))))
 
 (def optimzable-property-constraints
   #{:min-length
@@ -807,7 +806,7 @@
   [p-shape]
   (let [[[_ path-type] :as tagged-path] (:path p-shape)
         constraints (-> p-shape
-                        (dissoc :path :required? :id)
+                        (dissoc :path :id)
                         (keys)
                         (set))]
     (boolean

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -546,6 +546,8 @@
    (fn [acc property-flake]
      (let [o (flake/o property-flake)]
        (condp = (flake/p property-flake)
+         const/$xsd:anyURI
+         (assoc acc :id o)
          const/$sh:path
          (update acc :path (fnil conj []) o)
 
@@ -808,7 +810,7 @@
   [p-shape]
   (let [[[_ path-type] :as tagged-path] (:path p-shape)
         constraints (-> p-shape
-                        (dissoc :path :required?)
+                        (dissoc :path :required? :id)
                         (keys)
                         (set))]
     (boolean

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -111,7 +111,7 @@
                                                      (shacl/validate-simple-property-constraints p-shape flakes))
                                                    p-shapes)))
                                    shape->p-shapes))]
-      (when (not valid?)
+      (when-not valid?
         (shacl/throw-shacl-exception err-msg))
       (into flakes retractions))))
 

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -125,7 +125,7 @@
       (is (= [{:id                   :ex/widget,
                :type             :ex/Product,
                :schema/name          "Widget",
-               :schema/price         99.99,
+               :schema/price         99.99M,
                :schema/priceCurrency "USD"}]
              @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
                                        :where  [['?s :type :ex/Product]]

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -105,7 +105,7 @@
               (is (= [{:id :ex/widget,
                        :type :ex/Product,
                        :schema/name "Widget",
-                       :schema/price 105.99,
+                       :schema/price 105.99M,
                        :schema/priceCurrency "USD"}]
                      @(fluree/query update-price
                                     {:select {'?s [:*]}

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -115,10 +115,12 @@
                          (catch Exception e e))]
       (is (util/exception? db-int-name)
           "Exception, because :schema/name is an integer and not a string.")
-      (is (str/starts-with? (ex-message db-int-name) "Data type"))
+      (is (= "Data type 1 cannot be coerced from provided value: 42."
+             (ex-message db-int-name)))
       (is (util/exception? db-bool-name)
           "Exception, because :schema/name is a boolean and not a string.")
-      (is (str/starts-with? (ex-message db-bool-name) "Data type"))
+      (is (= "Data type 1 cannot be coerced from provided value: true."
+             (ex-message db-bool-name)))
       (is (= @(fluree/query db-ok user-query)
              [{:id          :ex/john
                :type    :ex/User
@@ -156,8 +158,8 @@
                              :schema/email "john@flur.ee"})
                           (catch Exception e e))]
       (is (util/exception? db-extra-prop))
-      (is (str/starts-with? (ex-message db-extra-prop)
-                            "SHACL shape is closed"))
+      (is (= "SHACL shape is closed, extra properties not allowed: [1003]"
+             (ex-message db-extra-prop)))
 
       (is (= [{:id          :ex/john
                :type    :ex/User
@@ -196,8 +198,8 @@
                              (catch Exception e e))]
           (is (util/exception? db-not-equal)
               "Exception, because :schema/name does not equal :ex/firstName")
-          (is (str/starts-with? (ex-message db-not-equal)
-                                "SHACL PropertyShape exception - sh:equals"))
+          (is (= "SHACL PropertyShape exception - sh:equals: [\"John\"] not equal to [\"Jack\"]."
+                 (ex-message db-not-equal)))
 
           (is (= [{:id           :ex/alice
                    :type     :ex/User
@@ -266,20 +268,20 @@
                               (catch Exception e e))]
           (is (util/exception? db-not-equal1)
               "Exception, because :ex/favNums does not equal :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-equal1)
-                                "SHACL PropertyShape exception - sh:equals"))
+          (is (= (ex-message db-not-equal1)
+                 "SHACL PropertyShape exception - sh:equals: [11 17] not equal to [13 18]."))
           (is (util/exception? db-not-equal2)
               "Exception, because :ex/favNums does not equal :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-equal2)
-                                "SHACL PropertyShape exception - sh:equals"))
+          (is (= "SHACL PropertyShape exception - sh:equals: [11 17] not equal to [11]."
+                 (ex-message db-not-equal2)))
           (is (util/exception? db-not-equal3)
               "Exception, because :ex/favNums does not equal :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-equal3)
-                                "SHACL PropertyShape exception - sh:equals"))
+          (is (= "SHACL PropertyShape exception - sh:equals: [11 17] not equal to [11 17 18]."
+                 (ex-message db-not-equal3)))
           (is (util/exception? db-not-equal4)
               "Exception, because :ex/favNums does not equal :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-equal4)
-                                "SHACL PropertyShape exception - sh:equals"))
+          (is (= "SHACL PropertyShape exception - sh:equals: [11 17] not equal to [\"11\" \"17\"]."
+                 (ex-message db-not-equal4)))
           (is (= [{:id           :ex/alice
                    :type     :ex/User
                    :schema/name  "Alice"
@@ -338,19 +340,19 @@
                                  (catch Exception e e))]
           (is (util/exception? db-not-disjoint1)
               "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-disjoint1)
-                                "SHACL PropertyShape exception - sh:disjoint"))
+          (is (= "SHACL PropertyShape exception - sh:disjoint: [11] not disjoint from [11]."
+                 (ex-message db-not-disjoint1)))
 
           (is (util/exception? db-not-disjoint2)
               "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-disjoint2)
-                                "SHACL PropertyShape exception - sh:disjoint"))
+          (is (= "SHACL PropertyShape exception - sh:disjoint: [11 17 31] not disjoint from [11]."
+                 (ex-message db-not-disjoint2)))
 
 
           (is (util/exception? db-not-disjoint3)
               "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")
-          (is (str/starts-with? (ex-message db-not-disjoint3)
-                                "SHACL PropertyShape exception - sh:disjoint"))
+          (is (= "SHACL PropertyShape exception - sh:disjoint: [11 17 31] not disjoint from [11 13 18]."
+                 (ex-message db-not-disjoint3)))
 
           (is (= [{:id           :ex/alice
                    :type     :ex/User
@@ -433,29 +435,29 @@
                             (catch Exception e e))]
           (is (util/exception? db-fail1)
               "Exception, because :ex/p1 is not less than :ex/p2")
-          (is (str/starts-with? (ex-message db-fail1)
-                                "SHACL PropertyShape exception - sh:lessThan"))
+          (is (= "SHACL PropertyShape exception - sh:lessThan: 17 not less than 17, or values are not valid for comparison."
+                 (ex-message db-fail1)))
 
 
           (is (util/exception? db-fail2)
               "Exception, because :ex/p1 is not less than :ex/p2")
-          (is (str/starts-with? (ex-message db-fail2)
-                                "SHACL PropertyShape exception - sh:lessThan"))
+          (is (= "SHACL PropertyShape exception - sh:lessThan: 17 not less than 19, or values are not valid for comparison; sh:lessThan: 17 not less than 18, or values are not valid for comparison; sh:lessThan: 11 not less than 19, or values are not valid for comparison; sh:lessThan: 11 not less than 18, or values are not valid for comparison."
+                 (ex-message db-fail2)))
 
           (is (util/exception? db-fail3)
               "Exception, because :ex/p1 is not less than :ex/p2")
-          (is (str/starts-with? (ex-message db-fail3)
-                                "SHACL PropertyShape exception - sh:lessThan"))
+          (is (= "SHACL PropertyShape exception - sh:lessThan: 17 not less than 10, or values are not valid for comparison; sh:lessThan: 12 not less than 10, or values are not valid for comparison."
+                 (ex-message db-fail3)))
 
           (is (util/exception? db-fail4)
               "Exception, because :ex/p1 is not less than :ex/p2")
-          (is (str/starts-with? (ex-message db-fail4)
-                                "SHACL PropertyShape exception - sh:lessThan"))
+          (is (= "SHACL PropertyShape exception - sh:lessThan: 17 not less than 16, or values are not valid for comparison; sh:lessThan: 17 not less than 12, or values are not valid for comparison."
+                 (ex-message db-fail4)))
 
           (is (util/exception? db-iris)
               "Exception, because :ex/p1 and :ex/p2 are iris, and not valid for comparison")
-          (is (str/starts-with? (ex-message db-iris)
-                                "SHACL PropertyShape exception - sh:lessThan"))
+          (is (= "SHACL PropertyShape exception - sh:lessThan: 211106232532995 not less than 211106232532996, or values are not valid for comparison."
+                 (ex-message db-iris)))
 
           (is (= [{:id          :ex/alice
                    :type    :ex/User
@@ -536,24 +538,24 @@
 
           (is (util/exception? db-fail1)
               "Exception, because :ex/p1 is not less than or equal to :ex/p2")
-          (is (str/starts-with? (ex-message db-fail1)
-                                "SHACL PropertyShape exception - sh:lessThanOrEquals"))
+          (is (= "SHACL PropertyShape exception - sh:lessThanOrEquals: 17 not less than or equal to 10, or values are not valid for comparison; sh:lessThanOrEquals: 11 not less than or equal to 10, or values are not valid for comparison."
+                 (ex-message db-fail1)))
 
 
           (is (util/exception? db-fail2)
               "Exception, because :ex/p1 is not less than or equal to :ex/p2")
-          (is (str/starts-with? (ex-message db-fail2)
-                                "SHACL PropertyShape exception - sh:lessThanOrEquals"))
+          (is (= "SHACL PropertyShape exception - sh:lessThanOrEquals: 17 not less than or equal to 19, or values are not valid for comparison; sh:lessThanOrEquals: 17 not less than or equal to 17, or values are not valid for comparison; sh:lessThanOrEquals: 11 not less than or equal to 19, or values are not valid for comparison; sh:lessThanOrEquals: 11 not less than or equal to 17, or values are not valid for comparison."
+                 (ex-message db-fail2)))
 
           (is (util/exception? db-fail3)
               "Exception, because :ex/p1 is not less than or equal to :ex/p2")
-          (is (str/starts-with? (ex-message db-fail3)
-                                "SHACL PropertyShape exception - sh:lessThanOrEquals"))
+          (is (= "SHACL PropertyShape exception - sh:lessThanOrEquals: 17 not less than or equal to 10, or values are not valid for comparison; sh:lessThanOrEquals: 12 not less than or equal to 10, or values are not valid for comparison."
+                 (ex-message db-fail3)))
 
           (is (util/exception? db-fail4)
               "Exception, because :ex/p1 is not less than or equal to :ex/p2")
-          (is (str/starts-with? (ex-message db-fail4)
-                                "SHACL PropertyShape exception - sh:lessThanOrEquals"))
+          (is (= "SHACL PropertyShape exception - sh:lessThanOrEquals: 17 not less than or equal to 16, or values are not valid for comparison; sh:lessThanOrEquals: 17 not less than or equal to 12, or values are not valid for comparison."
+                 (ex-message db-fail4)))
           (is (= [{:id          :ex/alice
                    :type    :ex/User
                    :schema/name "Alice"
@@ -601,13 +603,13 @@
                                (catch Exception e e))]
           (is (util/exception? db-too-low)
               "Exception, because :schema/age is below the minimum")
-          (is (str/starts-with? (ex-message db-too-low)
-                                "SHACL PropertyShape exception - sh:minExclusive: value 1"))
+          (is (= "SHACL PropertyShape exception - sh:minExclusive: value 1 is either non-numeric or lower than exclusive minimum of 1."
+                 (ex-message db-too-low)))
 
           (is (util/exception? db-too-high)
               "Exception, because :schema/age is above the maximum")
-          (is (str/starts-with? (ex-message db-too-high)
-                                "SHACL PropertyShape exception - sh:maxExclusive: value 100"))
+          (is (= "SHACL PropertyShape exception - sh:maxExclusive: value 100 is either non-numeric or higher than exclusive maximum of 100."
+                 (ex-message db-too-high)))
 
           (is (= @(fluree/query db-ok user-query)
                  [{:id         :ex/john
@@ -644,13 +646,13 @@
                              :schema/age 101})]
           (is (util/exception? db-too-low)
               "Exception, because :schema/age is below the minimum")
-          (is (str/starts-with? (ex-message db-too-low)
-                                "SHACL PropertyShape exception - sh:minInclusive: value 0"))
+          (is (= "SHACL PropertyShape exception - sh:minInclusive: value 0 is either non-numeric or lower than minimum of 1."
+                 (ex-message db-too-low)))
 
           (is (util/exception? db-too-high)
               "Exception, because :schema/age is above the maximum")
-          (is (str/starts-with? (ex-message db-too-high)
-                                "SHACL PropertyShape exception - sh:maxInclusive: value 101"))
+          (is (= "SHACL PropertyShape exception - sh:maxInclusive: value 101 is either non-numeric or higher than maximum of 100."
+                 (ex-message db-too-high)))
           (is (= @(fluree/query db-ok2 user-query)
                  [{:id         :ex/alice
                    :type   :ex/User
@@ -680,13 +682,13 @@
                               (catch Exception e e))]
           (is (util/exception? db-subj-id)
               "Exception, because :schema/age is not a number")
-          (is (str/starts-with? (ex-message db-string)
-                                "SHACL PropertyShape exception - sh:minExclusive"))
+          (is (= "SHACL PropertyShape exception - sh:minExclusive: value 10 is either non-numeric or lower than exclusive minimum of 0."
+                 (ex-message db-string)))
 
           (is (util/exception? db-string)
               "Exception, because :schema/age is not a number")
-          (is (str/starts-with? (ex-message db-string)
-                                "SHACL PropertyShape exception - sh:minExclusive: value 10")))))))
+          (is (= "SHACL PropertyShape exception - sh:minExclusive: value 10 is either non-numeric or lower than exclusive minimum of 0."
+                 (ex-message db-string))))))))
 
 (deftest ^:integration shacl-string-length-constraints
   (testing "shacl string length constraint errors"
@@ -746,20 +748,20 @@
                                 (catch Exception e e))]
       (is (util/exception? db-too-short-str)
           "Exception, because :schema/name is shorter than minimum string length")
-      (is (str/starts-with? (ex-message db-too-short-str)
-                            "SHACL PropertyShape exception - sh:minLength"))
+      (is (= "SHACL PropertyShape exception - sh:minLength: value Al has string length smaller than minimum: 4 or it is not a literal value."
+             (ex-message db-too-short-str)))
       (is (util/exception? db-too-long-str)
           "Exception, because :schema/name is longer than maximum string length")
-      (is (str/starts-with? (ex-message db-too-long-str)
-                            "SHACL PropertyShape exception - sh:maxLength"))
+      (is (= "SHACL PropertyShape exception - sh:maxLength: value Jean-Claudehas string length larger than 10 or it is not a literal value."
+             (ex-message db-too-long-str)))
       (is (util/exception? db-too-long-non-str)
           "Exception, because :schema/name is longer than maximum string length")
-      (is (str/starts-with? (ex-message db-too-long-non-str)
-                            "SHACL PropertyShape exception - sh:maxLength"))
+      (is (= "SHACL PropertyShape exception - sh:maxLength: value 12345678910has string length larger than 10 or it is not a literal value."
+             (ex-message db-too-long-non-str)))
       (is (util/exception? db-ref-value)
           "Exception, because :schema/name is not a literal value")
-      (is (str/starts-with? (ex-message db-ref-value)
-                            "SHACL PropertyShape exception - sh:maxLength:"))
+      (is (= "SHACL PropertyShape exception - sh:maxLength: value 211106232532995has string length larger than 10 or it is not a literal value; sh:minLength: value 211106232532995 has string length smaller than minimum: 4 or it is not a literal value."
+             (ex-message db-ref-value)))
       (is (= [{:id          :ex/john
                :type    :ex/User
                :schema/name "John"}]
@@ -821,18 +823,20 @@
                                    (catch Exception e e))]
       (is (util/exception? db-wrong-case-greeting)
           "Exception, because :ex/greeting does not match pattern")
-      (is (str/starts-with? (ex-message db-wrong-case-greeting)
-                            "SHACL PropertyShape exception - sh:pattern"))
-      (is (str/includes? (ex-message db-wrong-case-greeting)
-                         "with provided sh:flags: [\"s\" \"x\"]"))
+      (is (= "SHACL PropertyShape exception - sh:pattern: value HELLO
+WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"s\" \"x\"] or it is not a literal value."
+             (ex-message db-wrong-case-greeting)))
+      (is (= "SHACL PropertyShape exception - sh:pattern: value HELLO
+WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"s\" \"x\"] or it is not a literal value."
+             (ex-message db-wrong-case-greeting)))
       (is (util/exception? db-wrong-birth-year)
           "Exception, because :ex/birthYear does not match pattern")
-      (is (str/starts-with? (ex-message db-wrong-birth-year)
-                            "SHACL PropertyShape exception - sh:pattern"))
+      (is (= "SHACL PropertyShape exception - sh:pattern: value 1776 does not match pattern \"(19|20)[0-9][0-9]\" or it is not a literal value."
+             (ex-message db-wrong-birth-year)))
       (is (util/exception? db-ref-value)
           "Exception, because :schema/name is not a literal value")
-      (is (str/starts-with? (ex-message db-ref-value)
-                            "SHACL PropertyShape exception - sh:pattern:"))
+      (is (= "SHACL PropertyShape exception - sh:pattern: value 211106232532996 does not match pattern \"(19|20)[0-9][0-9]\" or it is not a literal value."
+             (ex-message db-ref-value)))
       (is (= [{:id          :ex/brian
                :type    :ex/User
                :ex/greeting "hello\nworld!"}]
@@ -918,7 +922,8 @@
       (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
              (ex-message db-two-ages)))
       (is (util/exception? db-num-email))
-      (is (str/starts-with? (ex-message db-num-email) "Data type"))
+      (is (= "Data type 1 cannot be coerced from provided value: 42."
+             (ex-message db-num-email)))
       (is (= [{:id           :ex/john
                :type     :ex/User
                :schema/age   40
@@ -1073,9 +1078,11 @@
     (is (not (util/exception? db2)))
     (is (not (util/exception? db3)))
     (is (util/exception? db4))
-    (is (str/starts-with? (ex-message db4) "SHACL PropertyShape exception - sh:class"))
+    (is (= "SHACL PropertyShape exception - sh:class: class(es) #{1001} must be same set as #{1006}."
+           (ex-message db4)))
     (is (util/exception? db5))
-    (is (str/starts-with? (ex-message db5) "SHACL PropertyShape exception - sh:class"))))
+    (is (= "SHACL PropertyShape exception - sh:class: class(es) #{1001} must be same set as #{1006}."
+           (ex-message db5)))))
 
 (deftest ^:integration shacl-in-test
   (testing "value nodes"
@@ -1093,7 +1100,8 @@
                                      "type"     "ex:Pony"
                                      "ex:color" "yellow"})]
       (is (util/exception? db2))
-      (is (str/includes? (ex-message db2) "sh:in"))))
+      (is (= "SHACL PropertyShape exception - sh:in: value clojure.core$val@54162b6a must be one of [\"cyan\" \"magenta\"]."
+             (ex-message db2)))))
   (testing "node refs"
     (let [conn   @(fluree/connect {:method :memory
                                    :defaults
@@ -1120,7 +1128,8 @@
                                       "ex:color" [{"id" "ex:Pink"}
                                                   {"id" "ex:Purple"}]}])]
       (is (util/exception? db2))
-      (is (str/includes? (ex-message db2) "sh:in"))
+      (is (= "SHACL PropertyShape exception - sh:in: value clojure.core$val@54162b6a must be one of [211106232532994 211106232532995]."
+             (ex-message db2)))
 
       (is (not (util/exception? db3)))
       (is (= [{"id"       "ex:PastelPony"
@@ -1145,7 +1154,8 @@
                                       "ex:color" [{"id" "ex:Pink"}
                                                   {"id" "ex:Green"}]}])]
       (is (util/exception? db2))
-      (is (str/includes? (ex-message db2) "sh:in")))))
+      (is (= "SHACL PropertyShape exception - sh:in: value clojure.core$val@54162b6a must be one of [211106232532994 211106232532995 \"green\"]."
+             (ex-message db2))))))
 
 (deftest ^:integration shacl-targetobjectsof-test
   (testing "subject and object of constrained predicate in the same txn"
@@ -1170,7 +1180,8 @@
                                                 "ex:name" 123
                                                 "type"    "ex:User"}])]
         (is (util/exception? db-bad-friend-name))
-        (is (str/includes? (ex-message db-bad-friend-name) "Data type"))))
+        (is (= "Data type 1 cannot be coerced from provided value: 123."
+               (ex-message db-bad-friend-name)))))
     (testing "maxCount"
       (let [conn          @(fluree/connect {:method :memory
                                             :defaults
@@ -1193,7 +1204,8 @@
                                                      "222-22-2222"]
                                            "type"   "ex:User"}])]
         (is (util/exception? db-excess-ssn))
-        (is (str/includes? (ex-message db-excess-ssn) "sh:maxCount"))))
+        (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
+               (ex-message db-excess-ssn)))))
     (testing "required properties"
       (let [conn          @(fluree/connect {:method :memory
                                             :defaults
@@ -1212,7 +1224,8 @@
                                            "type"      "ex:User"
                                            "ex:friend" {"@id" "ex:Bob"}}])]
         (is (util/exception? db-just-alice))
-        (is (str/includes? (ex-message db-just-alice) "sh:minCount"))))
+        (is (= "SHACL PropertyShape exception - sh:minCount of 1 higher than actual count of 0."
+               (ex-message db-just-alice)))))
     (testing "combined with `sh:targetClass`"
       (let [conn          @(fluree/connect {:method :memory
                                             :defaults
@@ -1239,7 +1252,8 @@
                                                "ex:ssn"  "111-11-1111"
                                                "type"    "ex:User"}])]
         (is (util/exception? db-bad-friend))
-        (is (str/includes? (ex-message db-bad-friend) "sh:maxCount")))))
+        (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
+               (ex-message db-bad-friend))))))
   (testing "separate txns"
     (testing "maxCount"
       (let [conn                   @(fluree/connect {:method :memory
@@ -1262,7 +1276,8 @@
                                                    "type"      "ex:User"
                                                    "ex:friend" {"@id" "ex:Bob"}})]
         (is (util/exception? db-db-forbidden-friend))
-        (is (str/includes? (ex-message db-db-forbidden-friend) "sh:maxCount")))
+        (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
+               (ex-message db-db-forbidden-friend))))
       (let [conn          @(fluree/connect {:method :memory
                                             :defaults
                                             {:context test-utils/default-str-context}})
@@ -1287,7 +1302,8 @@
                                           "ex:ssn" ["111-11-1111"
                                                     "222-22-2222"]})]
         (is (util/exception? db-excess-ssn))
-        (is (str/includes? (ex-message db-excess-ssn) "sh:maxCount"))))
+        (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
+               (ex-message db-excess-ssn)))))
     ;;TODO: this will not pass until we can enforce datatype constraints
     ;;on triples that have already been created.
     #_(testing "datatype"
@@ -1310,7 +1326,8 @@
                                                   "type"      "ex:User"
                                                   "ex:friend" {"@id" "ex:Bob"}})]
           (is (util/exception? db-forbidden-friend))
-          (is (str/includes? (ex-message db-forbidden-friend) "data type"))))))
+          (is (= "data type"
+                 (ex-message db-forbidden-friend)))))))
 
 (deftest ^:integration shape-based-constraints
   (testing "sh:node"

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1394,7 +1394,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
       (is (util/exception? invalid-kid))
       (is (= "SHACL PropertyShape exception - path [[1002 :predicate]] conformed to sh:qualifiedValueShape fewer than sh:qualifiedMinCount times."
              (ex-message invalid-kid)))))
-  #_(testing "sh:qualifiedValueShape node shape"
+  (testing "sh:qualifiedValueShape node shape"
     (let [conn   @(fluree/connect {:method :memory})
           ledger @(fluree/create conn "shape-constaints" {:defaultContext [test-utils/default-str-context
                                                                            {"ex" "http://example.com/"}]})
@@ -1430,13 +1430,13 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                          "ex:gender" "alien"}]}])]
 
       (is (= [{"id" "ex:ValidKid"
-               "rdf:type" ["ex:Kid"]
+               "type" "ex:Kid"
                "ex:parent" [{"id" "ex:Mom"}
                             {"id" "ex:Dad"}]}]
              @(fluree/query valid-kid {"select" {"?s" ["*"]}
                                        "where" [["?s" "id" "ex:ValidKid"]]})))
       (is (util/exception? invalid-kid))
-      (is (= "SHACL PropertyShape exception - path [[1002 :predicate]] conformed to sh:qualifiedValueShape fewer than sh:qualifiedMinCount times."
+      (is (= "SHACL PropertyShape exception - sh:pattern: value alien does not match pattern \"female\" or it is not a literal value."
              (ex-message invalid-kid)))))
   (testing "sh:qualifiedValueShapesDisjoint"
     (let [conn         @(fluree/connect {:method :memory})

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1301,8 +1301,6 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
         (is (util/exception? db-excess-ssn))
         (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
                (ex-message db-excess-ssn)))))
-    ;;TODO: this will not pass until we can enforce datatype constraints
-    ;;on triples that have already been created.
     (testing "datatype"
       (let [conn @(fluree/connect {:method :memory
                                    :defaults

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -115,11 +115,11 @@
                          (catch Exception e e))]
       (is (util/exception? db-int-name)
           "Exception, because :schema/name is an integer and not a string.")
-      (is (= "Data type 1 cannot be coerced from provided value: 42."
+      (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
              (ex-message db-int-name)))
       (is (util/exception? db-bool-name)
           "Exception, because :schema/name is a boolean and not a string.")
-      (is (= "Data type 1 cannot be coerced from provided value: true."
+      (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
              (ex-message db-bool-name)))
       (is (= @(fluree/query db-ok user-query)
              [{:id          :ex/john
@@ -922,7 +922,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
       (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
              (ex-message db-two-ages)))
       (is (util/exception? db-num-email))
-      (is (= "Data type 1 cannot be coerced from provided value: 42."
+      (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
              (ex-message db-num-email)))
       (is (= [{:id           :ex/john
                :type     :ex/User
@@ -1180,7 +1180,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                 "ex:name" 123
                                                 "type"    "ex:User"}])]
         (is (util/exception? db-bad-friend-name))
-        (is (= "Data type 1 cannot be coerced from provided value: 123."
+        (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
                (ex-message db-bad-friend-name)))))
     (testing "maxCount"
       (let [conn          @(fluree/connect {:method :memory

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1100,7 +1100,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                      "type"     "ex:Pony"
                                      "ex:color" "yellow"})]
       (is (util/exception? db2))
-      (is (= "SHACL PropertyShape exception - sh:in: value clojure.core$val@54162b6a must be one of [\"cyan\" \"magenta\"]."
+      (is (= "SHACL PropertyShape exception - sh:in: value must be one of [\"cyan\" \"magenta\"]."
              (ex-message db2)))))
   (testing "node refs"
     (let [conn   @(fluree/connect {:method :memory
@@ -1128,7 +1128,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                       "ex:color" [{"id" "ex:Pink"}
                                                   {"id" "ex:Purple"}]}])]
       (is (util/exception? db2))
-      (is (= "SHACL PropertyShape exception - sh:in: value clojure.core$val@54162b6a must be one of [211106232532994 211106232532995]."
+      (is (= "SHACL PropertyShape exception - sh:in: value must be one of [211106232532994 211106232532995]."
              (ex-message db2)))
 
       (is (not (util/exception? db3)))
@@ -1154,7 +1154,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                       "ex:color" [{"id" "ex:Pink"}
                                                   {"id" "ex:Green"}]}])]
       (is (util/exception? db2))
-      (is (= "SHACL PropertyShape exception - sh:in: value clojure.core$val@54162b6a must be one of [211106232532994 211106232532995 \"green\"]."
+      (is (= "SHACL PropertyShape exception - sh:in: value must be one of [211106232532994 211106232532995 \"green\"]."
              (ex-message db2))))))
 
 (deftest ^:integration shacl-targetobjectsof-test

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -58,14 +58,14 @@
                              (catch Exception e e))
           ok-results       @(fluree/query db-ok user-query)]
       (is (util/exception? db-company-name))
-      (is (str/starts-with? (ex-message db-company-name)
-                            "SHACL PropertyShape exception - sh:not sh:minCount of 1 requires lower count but actual count was 1"))
+      (is (= "SHACL PropertyShape exception - sh:not sh:minCount of 1 requires lower count but actual count was 1."
+             (ex-message db-company-name)))
       (is (util/exception? db-two-names))
-      (is (str/starts-with? (ex-message db-two-names)
-                            "SHACL PropertyShape exception - sh:not sh:minCount of 1 requires lower count but actual count was 2"))
+      (is (= "SHACL PropertyShape exception - sh:not sh:minCount of 1 requires lower count but actual count was 2."
+             (ex-message db-two-names)))
       (is (util/exception? db-callsign-name))
-      (is (str/starts-with? (ex-message db-callsign-name)
-                            "SHACL PropertyShape exception - sh:not sh:equals: [\"Johnny Boy\"] is required to be not equal to [\"Johnny Boy\"]"))
+      (is (= "SHACL PropertyShape exception - sh:not sh:equals: [\"Johnny Boy\"] is required to be not equal to [\"Johnny Boy\"]."
+             (ex-message db-callsign-name)))
       (is (= [{:id              :ex/john,
                :type        :ex/User,
                :schema/name     "John",
@@ -126,11 +126,11 @@
                            :schema/favNums  [4 8 15 16 23 42]})
           ok-results   @(fluree/query db-ok user-query)]
       (is (util/exception? db-too-old))
-      (is (str/starts-with? (ex-message db-too-old)
-                            "SHACL PropertyShape exception - sh:not sh:minInclusive: value 131 must be less than 130"))
+      (is (= "SHACL PropertyShape exception - sh:not sh:minInclusive: value 131 must be less than 130."
+             (ex-message db-too-old)))
       (is (util/exception? db-too-low))
-      (is (str/starts-with? (ex-message db-too-low)
-                            "SHACL PropertyShape exception - sh:not sh:maxExclusive: value 42 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 23 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 16 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 15 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 8 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 4 must be greater than or equal to 9000"))
+      (is (= "SHACL PropertyShape exception - sh:not sh:maxExclusive: value 42 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 23 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 16 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 15 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 8 must be greater than or equal to 9000; sh:not sh:maxExclusive: value 4 must be greater than or equal to 9000."
+             (ex-message db-too-low)))
       (is (util/exception? db-two-probs))
       (is (str/starts-with? (ex-message db-two-probs)
                             ;; could be either problem so just match common prefix
@@ -203,8 +203,8 @@
       (is (= "SHACL PropertyShape exception - sh:not sh:minLength: value 12345 must have string length less than 4."
              (ex-message db-tag-too-long)))
       (is (util/exception? db-greeting-incorrect))
-      (is (str/starts-with? (ex-message db-greeting-incorrect)
-                            "SHACL PropertyShape exception - sh:not sh:pattern: value hello! must not match pattern"))
+      (is (= "SHACL PropertyShape exception - sh:not sh:pattern: value hello! must not match pattern \"hello.*\"."
+             (ex-message db-greeting-incorrect)))
       (is (= [{:id          :ex/jean-claude
                :type    :ex/User,
                :schema/name "Jean-Claude"}]


### PR DESCRIPTION
This adds support for doing some property shape validation during property creation. We can only validate a subset of the constraints before the db-after is created, and these changes allow us to validate them and short circuit transaction processing if they fail.

This refactor uncovered some other problems that get addressed here as well:
- we weren't using coerced datatypes in flake creation (54fde687e0893768d1b21f574d7857c4e5ba4412)
- some validation error messages were garbled and unintelligible, but our tests were only examining hardcoded subsets of the error messages 

These improvements are follow-on changes for [#557](https://github.com/fluree/db/pull/557)