### PR TITLE
Update transact! syntax to be json-ld

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -76,7 +76,7 @@
         (let [ledger (<? (jld-ledger/load conn address))
               opts* (cond-> opts
                       txn-opts        (merge txn-opts)
-                      txn-context     (assoc :top-ctx txn-context)
+                      txn-context     (assoc :txn-context txn-context)
                       default-context (assoc :defaultContext default-context))]
           (if (:meta opts*)
             (let [start-time   #?(:clj  (System/nanoTime)

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -3,6 +3,8 @@
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.async :as async-util :refer [<? go-try]]
             [fluree.db.json-ld.transact :as tx]
+            [fluree.db.ledger.json-ld :as jld-ledger]
+            [fluree.db.conn.proto :as conn-proto]
             [fluree.db.dbproto :as dbproto]))
 
 (defn stage
@@ -26,21 +28,27 @@
       (<? (dbproto/-stage db json-ld opts)))))
 
 (defn transact!
-  [ledger json-ld opts]
+  [conn json-ld opts]
   (go-try
-    (if (:meta opts)
-      (let [start-time   #?(:clj  (System/nanoTime)
-                            :cljs (util/current-time-millis))
-            fuel-tracker (fuel/tracker)]
-        (try* (let [tx-result (<? (tx/transact! ledger fuel-tracker json-ld opts))]
-                {:status 200
-                 :result tx-result
-                 :time   (util/response-time-formatted start-time)
-                 :fuel   (fuel/tally fuel-tracker)})
-              (catch* e
-                      (throw (ex-info "Error updating ledger"
-                                      (-> e
-                                          ex-data
-                                          (assoc :time (util/response-time-formatted start-time)
-                                                 :fuel (fuel/tally fuel-tracker))))))))
-      (<? (tx/transact! ledger json-ld opts)))))
+    (let [{ledger-id :id json-ld :graph top-level-ctx :context} (tx/parse-json-ld-txn json-ld)
+          address  (<? (conn-proto/-address conn ledger-id nil))]
+      (if-not (<? (conn-proto/-exists? conn address))
+        (throw (ex-info "Ledger does not exist" {:ledger address}))
+        (let [ledger (<? (jld-ledger/load conn address))
+              opts* (assoc opts :top-ctx top-level-ctx)]
+          (if (:meta opts*)
+            (let [start-time   #?(:clj  (System/nanoTime)
+                                  :cljs (util/current-time-millis))
+                  fuel-tracker (fuel/tracker)]
+              (try* (let [tx-result (<? (tx/transact! ledger fuel-tracker json-ld opts*))]
+                      {:status 200
+                       :result tx-result
+                       :time   (util/response-time-formatted start-time)
+                       :fuel   (fuel/tally fuel-tracker)})
+                    (catch* e
+                            (throw (ex-info "Error updating ledger"
+                                            (-> e
+                                                ex-data
+                                                (assoc :time (util/response-time-formatted start-time)
+                                                       :fuel (fuel/tally fuel-tracker))))))))
+            (<? (tx/transact! ledger json-ld opts*))))))))

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -45,6 +45,7 @@
 (def ^:const iri-target-objects-of "https://ns.flur.ee/ledger#targetObjectsOf")
 (def ^:const iri-property "https://ns.flur.ee/ledger#property")
 (def ^:const iri-policy "https://ns.flur.ee/ledger#Policy")
+(def ^:const iri-opts "https://ns.flur.ee/ledger#opts")
 (def ^:const iri-path "https://ns.flur.ee/ledger#path")
 (def ^:const iri-action "https://ns.flur.ee/ledger#action")
 (def ^:const iri-all-nodes "https://ns.flur.ee/ledger#allNodes")

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -253,7 +253,7 @@
           [sid (into subj-flakes property-flakes)])))))
 
 (defn ->tx-state
-  [db {:keys [bootstrap? did context-type] :as _opts}]
+  [db {:keys [bootstrap? did context-type top-ctx] :as _opts}]
   (let [{:keys [schema branch ledger policy], db-t :t} db
         last-pid (volatile! (jld-ledger/last-pid db))
         last-sid (volatile! (jld-ledger/last-sid db))
@@ -276,6 +276,7 @@
      :next-sid      (fn [] (vswap! last-sid inc))
      :subj-mods     (atom {}) ;; holds map of subj ids (keys) for modified flakes map with shacl shape and classes
      :iris          (volatile! {})
+     :top-ctx       top-ctx
      :shacl-target-objects-of? (shacl/has-target-objects-of-rule? db-before)}))
 
 (defn final-ecount
@@ -349,25 +350,42 @@
   [db]
   (-> db :t zero?))
 
-(defn stage-flakes
-  [{:keys [t] :as db} fuel-tracker tx-state nodes]
+(defn process-node
+  "returns flakes for node"
+  [node* flakes track-fuel tx-state]
+  (go-try
+    (if (empty? (dissoc node* :idx :id))
+      (throw (ex-info (str "Invalid transaction, transaction node contains no properties"
+                           (some->> (:id node*)
+                                    (str " for @id: "))
+                           ".")
+                      {:status 400 :error :db/invalid-transaction}))
+      (let [[_node*-sid node*-flakes] (<? (json-ld-node->flakes node* tx-state nil))
+            flakes* (track-into flakes track-fuel node*-flakes)]
+        flakes*))) )
+
+(defn insert
+  "Performs insert transaction. Returns async chan with resulting flakes."
+  [{:keys [t] :as db} fuel-tracker json-ld {:keys [default-ctx top-ctx] :as tx-state}]
   (go-try
     (let [track-fuel (when fuel-tracker
                        (fuel/track fuel-tracker))
           flakeset   (cond-> (flake/sorted-set-by flake/cmp-flakes-spot)
                              (init-db? db) (track-into track-fuel (base-flakes t)))]
-      (loop [[node & r] nodes
+      (loop [[node & r] (util/sequential json-ld)
              flakes flakeset]
         (if node
-          (if (empty? (dissoc node :idx :id))
-            (throw (ex-info (str "Invalid transaction, transaction node contains no properties"
-                                 (some->> (:id node)
-                                          (str " for @id: "))
-                                 ".")
-                            {:status 400 :error :db/invalid-transaction}))
-            (let [[_node-sid node-flakes] (<? (json-ld-node->flakes node tx-state nil))
-                  flakes* (track-into flakes track-fuel node-flakes)]
-              (recur r flakes*)))
+          (let [node1  {"@context" top-ctx
+                        "@graph" [node]}
+                [node*] (json-ld/expand node1 default-ctx)
+                flakes* (if (map? node*)
+                          (<? (process-node node* flakes track-fuel tx-state))
+                          (loop [[n* & r*] node*
+                                 flakes* flakeset]
+                            (if n*
+                              (recur r* (into flakes* (<? (process-node n* flakes track-fuel tx-state))))
+                              flakes*)))]
+            (recur r flakes*))
           flakes)))))
 
 (defn validate-rules
@@ -405,15 +423,6 @@
                 ;; TODO - PropertyShape class is often not specified for sh:property nodes - direct changes to those would not be caught here!
                 (vocab/reset-shapes (:schema db-after)))
               staged-map)))))))
-
-(defn insert
-  "Performs insert transaction. Returns async chan with resulting flakes."
-  [db fuel-tracker json-ld {:keys [default-ctx] :as tx-state}]
-  (log/trace "insert default-ctx:" default-ctx)
-  (let [nodes (-> json-ld
-                  (json-ld/expand default-ctx)
-                  util/sequential)]
-    (stage-flakes db fuel-tracker tx-state nodes)))
 
 (defn into-flakeset
   [fuel-tracker flake-ch]
@@ -476,7 +485,7 @@
   ([ledger json-ld opts]
    (stage-ledger ledger nil json-ld opts))
   ([ledger fuel-tracker json-ld opts]
-   (let [{:keys [:defaultContext]} opts
+   (let [{:keys [defaultContext]} opts
          db (cond-> (ledger-proto/-db ledger)
               defaultContext  (dbproto/-default-context-update
                                 defaultContext))]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -1,7 +1,6 @@
 (ns fluree.db.json-ld.transact
   (:refer-clojure :exclude [vswap!])
   (:require [clojure.core.async :as async :refer [go]]
-            [clojure.walk :refer [keywordize-keys]]
             [fluree.db.constants :as const]
             [fluree.db.datatype :as datatype]
             [fluree.db.dbproto :as dbproto]
@@ -482,23 +481,7 @@
        (log/trace "stage flakes:" flakes)
        (<? (flakes->final-db tx-state flakes))))))
 
-(defn parse-json-ld-txn
-  [json-ld]
-  (let [context-key (cond
-                      (contains? json-ld "@context") "@context"
-                      (contains? json-ld :context) :context)
-        context (get json-ld context-key)]
-    (let [parsed-context (json-ld/parse-context context)]
-      (into {}
-            (map (fn [[k v]]
-                   (let [k* (if (= context-key k)
-                              "@context"
-                              (json-ld/expand-iri k parsed-context))
-                         v* (if (= const/iri-opts k*)
-                              (keywordize-keys v)
-                              v)]
-                     [k* v*])))
-            json-ld))))
+
 
 
 (defn stage-ledger

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -381,7 +381,7 @@
                 flakes* (if (map? node*)
                           (<? (process-node node* flakes track-fuel tx-state))
                           (loop [[n* & r*] node*
-                                 flakes* flakeset]
+                                 flakes* flakes]
                             (if n*
                               (recur r* (into flakes* (<? (process-node n* flakes track-fuel tx-state))))
                               flakes*)))]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -481,9 +481,6 @@
        (log/trace "stage flakes:" flakes)
        (<? (flakes->final-db tx-state flakes))))))
 
-
-
-
 (defn stage-ledger
   ([ledger json-ld opts]
    (stage-ledger ledger nil json-ld opts))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -476,9 +476,11 @@
   ([ledger json-ld opts]
    (stage-ledger ledger nil json-ld opts))
   ([ledger fuel-tracker json-ld opts]
-   (-> ledger
-       ledger-proto/-db
-       (stage fuel-tracker json-ld opts))))
+   (let [{:keys [:defaultContext]} opts
+         db (cond-> (ledger-proto/-db ledger)
+              defaultContext  (dbproto/-default-context-update
+                                defaultContext))]
+     (stage db fuel-tracker json-ld opts))))
 
 (defn transact!
   ([ledger json-ld opts]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -208,20 +208,18 @@
                                                                 "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
                                                                 "schema" "http://schema.org/",
                                                                 "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
-        love (let [ledger @(fluree/create conn "test/love")]
-               @(fluree/transact! ledger
-                                  [{"@id"                "ex:fluree",
-                                    "@type"              "schema:Organization",
-                                    "schema:description" "We ❤️ Data"}
-                                   {"@id"                "ex:w3c",
-                                    "@type"              "schema:Organization",
-                                    "schema:description" "We ❤️ Internet"}
-                                   {"@id"                "ex:mosquitos",
-                                    "@type"              "ex:Monster",
-                                    "schema:description" "We ❤️ Human Blood"}]
-                                  {})
-               ledger)
-        db   (fluree/db love)]
+        ledger @(fluree/create conn "test/love")
+        db @(fluree/stage     (fluree/db ledger)
+                              [{"@id"                "ex:fluree",
+                                "@type"              "schema:Organization",
+                                "schema:description" "We ❤️ Data"}
+                               {"@id"                "ex:w3c",
+                                "@type"              "schema:Organization",
+                                "schema:description" "We ❤️ Internet"}
+                               {"@id"                "ex:mosquitos",
+                                "@type"              "ex:Monster",
+                                "schema:description" "We ❤️ Human Blood"}]
+                              {})]
     (testing "subject-object scans"
       (let [q '{:select [?s ?p ?o]
                 :where [[?s "schema:description" ?o]

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -277,4 +277,13 @@
                @(fluree/query db (assoc user-query
                                         :context ["" {:foo "http://foo.com/"
                                                       :bar "http://bar.com/"
-                                                      :quux "http://quux.com/"}]))))))))
+                                                      :quux "http://quux.com/"}]))))))
+    (testing "Throws on invalid txn"
+      (let [txn        {"@graph" [{:context    {:quux "http://quux.com/"}
+                                   :id         :ex/cam
+                                   :quux/corge "grault"}]}
+            db (try @(fluree/transact! conn txn {})
+                    (catch Exception e e))]
+        (is (util/exception? db))
+        (is (str/starts-with? (ex-message db)
+                              "Invalid transaction, missing required keys: @id"))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -273,36 +273,4 @@
                  :schema/name "Alice",
                  :foo/bar "baz"}]
                @(fluree/query db (assoc user-query
-                                        :context ["" {:foo "http://foo.com/"}]))))))
-      (let [txn1        {:id    ledger-name
-                         :graph [{:graph
-                                  [{:id          :ex/alice
-                                    :type        :ex/User
-                                    :schema/name "Alice"}]}
-                                 {:id          :ex/bob
-                                  :type        :ex/User
-                                  :schema/name "Bob"}]}
-            invalid-db1 (try
-                          @(fluree/transact! conn txn1 {})
-                          (catch Exception e e))
-
-            txn2        {:context     {:graph-alias "@graph"}
-                         :id          ledger-name
-                         :graph-alias [{:graph-alias
-                                        [{:id          :ex/alice
-                                          :type        :ex/User
-                                          :schema/name "Alice"}]}
-                                       {:id          :ex/bob
-                                        :type        :ex/User
-                                        :schema/name "Bob"}]}
-            invalid-db2 (try
-                          @(fluree/transact! conn txn2 {})
-                          (catch Exception e e))]
-        (is (util/exception? invalid-db1))
-        (is (= "Invalid transaction, node contains unsupported keys: (:graph)"
-               (ex-message invalid-db1)))
-        (is (util/exception? invalid-db2))
-        (is (= "Invalid transaction, node contains unsupported keys: (:graph)"
-              (ex-message invalid-db2)))))))
-
-
+                                        :context ["" {:foo "http://foo.com/"}]))))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -217,7 +217,9 @@
                       :where  [[?s :type :ex/User]]}]
     (testing "Top-level context is used for transaction nodes"
       (let [txn {:id      ledger-name
-                 :context {:foo "http://foo.com/"}
+                 :context {:foo "http://foo.com/"
+                           :id  "@id"
+                           :graph "@graph"}
                  :graph   [{:id          :ex/alice
                             :type        :ex/User
                             :foo/bar     "foo"
@@ -257,8 +259,8 @@
                                         :context ["" {:foo "http://foo.com/"
                                                       :bar "http://bar.com/"}]))))))
     (testing "@context inside node is correctly handled"
-      (let [txn        {:id    ledger-name
-                        :graph [{:context    {:quux "http://quux.com/"}
+      (let [txn        {"@id"    ledger-name
+                        "@graph" [{:context    {:quux "http://quux.com/"}
                                  :id         :ex/alice
                                  :quux/corge "grault"}]}
             db @(fluree/transact! conn txn {})]

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -390,15 +390,16 @@
             "query parse error")))))
 
 (deftest ^:integration subject-object-scan-deletions
-  (let [conn (test-utils/create-conn {:defaults {:context-type :string
-                                                 :context      {"id"     "@id",
-                                                                "type"   "@type",
-                                                                "ex"     "http://example.org/",
-                                                                "f"      "https://ns.flur.ee/ledger#",
-                                                                "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                                                                "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
-                                                                "schema" "http://schema.org/",
-                                                                "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
+  (let [conn @(fluree/connect {:method :memory
+                               :defaults {:context-type :string
+                                          :context      {"id"     "@id",
+                                                         "type"   "@type",
+                                                         "ex"     "http://example.org/",
+                                                         "f"      "https://ns.flur.ee/ledger#",
+                                                         "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                                                         "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
+                                                         "schema" "http://schema.org/",
+                                                         "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
         ledger-id  "test/love"
         ledger @(fluree/create conn ledger-id)
         love @(fluree/stage (fluree/db ledger)
@@ -430,7 +431,7 @@
                                    :where  '[[?s "schema:description" ?o]
                                              [?s ?p ?o]]}}
                           {})
-      (let [db2   (fluree/db ledger)
+      (let [db2   (fluree/db @(fluree/load conn ledger-id))
             q       '{:select [?s ?p ?o]
                       :where  [[?s "schema:description" ?o]
                                [?s ?p ?o]]}

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -426,7 +426,9 @@
             "returns all results")))
     (testing "after deletion"
       @(fluree/transact!  conn
-                          {:id ledger-id
+                          {:context {:id "@id"
+                                     :graph "@graph"}
+                           :id ledger-id
                            :graph {:delete '[?s ?p ?o]
                                    :where  '[[?s "schema:description" ?o]
                                              [?s ?p ?o]]}}

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -399,20 +399,20 @@
                                                                 "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
                                                                 "schema" "http://schema.org/",
                                                                 "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
-        love (let [ledger @(fluree/create conn "test/love")]
-               @(fluree/transact! ledger
-                                  [{"@id"                "ex:fluree",
-                                    "@type"              "schema:Organization",
-                                    "schema:description" "We ❤️ Data"}
-                                   {"@id"                "ex:w3c",
-                                    "@type"              "schema:Organization",
-                                    "schema:description" "We ❤️ Internet"}
-                                   {"@id"                "ex:mosquitos",
-                                    "@type"              "ex:Monster",
-                                    "schema:description" "We ❤️ Human Blood"}]
-                                  {})
-               ledger)
-        db1  (fluree/db love)]
+        ledger-id  "test/love"
+        ledger @(fluree/create conn ledger-id)
+        love @(fluree/stage (fluree/db ledger)
+                            [{"@id"                "ex:fluree",
+                              "@type"              "schema:Organization",
+                              "schema:description" "We ❤️ Data"}
+                             {"@id"                "ex:w3c",
+                              "@type"              "schema:Organization",
+                              "schema:description" "We ❤️ Internet"}
+                             {"@id"                "ex:mosquitos",
+                              "@type"              "ex:Monster",
+                              "schema:description" "We ❤️ Human Blood"}]
+                            {})
+        db1 @(fluree/commit! ledger love)]
     (testing "before deletion"
       (let [q       '{:select [?s ?p ?o]
                       :where  [[?s "schema:description" ?o]
@@ -424,12 +424,13 @@
                subject)
             "returns all results")))
     (testing "after deletion"
-      @(fluree/transact! love
-                         '{:delete [?s ?p ?o]
-                           :where  [[?s "schema:description" ?o]
-                                    [?s ?p ?o]]}
-                         {})
-      (let [db2     (fluree/db love)
+      @(fluree/transact!  conn
+                          {:id ledger-id
+                           :graph {:delete '[?s ?p ?o]
+                                   :where  '[[?s "schema:description" ?o]
+                                             [?s ?p ?o]]}}
+                          {})
+      (let [db2   (fluree/db ledger)
             q       '{:select [?s ?p ?o]
                       :where  [[?s "schema:description" ?o]
                                [?s ?p ?o]]}


### PR DESCRIPTION
Part of https://github.com/fluree/core/issues/20

This PR updates the `transact!` api fn to expect a json-ld document with the following keys:
- `"@id"` (required): the ledger to transact to
- `"@graph"` (required) : the transaction data
- `"@context"` (optional): the context to be used for all nodes in the transaction, as well as the txn document itself
- `"https://ns.flur.ee/ledger#opts"` (optional): any opts for the transaction, eg policy maps
- `"https://ns.flur.ee/ledger#defaultContext"` (optional): for updates to the default context

Because the keys we need may be aliased in the context, we do a tiny bit of expansion before looking for the keys we need. Rather than expand the whole transaction, we just `expand-iri` the top-level keys.

With this change, `transact!` now expects a conn, and will load the ledger described in the request. It does not create ledgers, so it will throw an error if the ledger does not yet have any commits and therefore cannot be loaded. This means you must `stage` and then `commit!` at least once before you can use `transact!`. 

Right now, if you want to use compacted versions of any of the top-level keys, you have to supply aliases in the `@context` of the transaction document itself. I think an argument could be made to also use the conn's default-context, but this PR doesn't include that functionality. 

Also, we don't explicitly disallow `@context`s in the children of the top `@graph` -- any such contexts will just be used alongside any top-level context in the node expansion. 