### PR TITLE
Feature: unify create keys with transact

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -30,10 +30,8 @@
                                                  :fuel (fuel/tally fuel-tracker))))))))
       (<? (dbproto/-stage db json-ld opts)))))
 
-(defn- parse-json-ld-txn
-  "Expands top-level keys and parses any opts in json-ld transaction document,
-  for use by `transact!`.
-
+(defn parse-json-ld-txn
+  "Expands top-level keys and parses any opts in json-ld transaction document.
   Throws if required keys @id or @graph are absent."
   [json-ld]
   (let [context-key (cond
@@ -62,14 +60,36 @@
                         {:status 400 :error :db/invalid-transaction}))
         parsed-txn))))
 
+(defn ledger-transact!
+  [ledger txn opts]
+  (go-try
+    (if (:meta opts)
+      (let [start-time   #?(:clj  (System/nanoTime)
+                            :cljs (util/current-time-millis))
+            fuel-tracker (fuel/tracker)]
+        (try*
+          (let [tx-result (<? (tx/transact! ledger fuel-tracker txn opts))]
+            {:status 200
+             :result tx-result
+             :time   (util/response-time-formatted start-time)
+             :fuel   (fuel/tally fuel-tracker)})
+          (catch* e
+            (throw
+             (ex-info "Error updating ledger"
+                      (-> e
+                          ex-data
+                          (assoc :time (util/response-time-formatted start-time)
+                                 :fuel (fuel/tally fuel-tracker))))))))
+      (<? (tx/transact! ledger txn opts)))))
+
 (defn transact!
-  [conn json-ld opts]
+  [conn parsed-json-ld opts]
   (go-try
     (let [{txn-context "@context"
            txn "@graph"
            ledger-id "@id"
            txn-opts const/iri-opts
-           default-context const/iri-default-context} (parse-json-ld-txn json-ld)
+           default-context const/iri-default-context} parsed-json-ld
           address  (<? (conn-proto/-address conn ledger-id nil))]
       (if-not (<? (conn-proto/-exists? conn address))
         (throw (ex-info "Ledger does not exist" {:ledger address}))
@@ -78,19 +98,4 @@
                       txn-opts        (merge txn-opts)
                       txn-context     (assoc :txn-context txn-context)
                       default-context (assoc :defaultContext default-context))]
-          (if (:meta opts*)
-            (let [start-time   #?(:clj  (System/nanoTime)
-                                  :cljs (util/current-time-millis))
-                  fuel-tracker (fuel/tracker)]
-              (try* (let [tx-result (<? (tx/transact! ledger fuel-tracker txn opts*))]
-                      {:status 200
-                       :result tx-result
-                       :time   (util/response-time-formatted start-time)
-                       :fuel   (fuel/tally fuel-tracker)})
-                    (catch* e
-                      (throw (ex-info "Error updating ledger"
-                                      (-> e
-                                          ex-data
-                                          (assoc :time (util/response-time-formatted start-time)
-                                                 :fuel (fuel/tally fuel-tracker))))))))
-            (<? (tx/transact! ledger txn opts*))))))))
+          (<? (ledger-transact! ledger txn opts*)))))))

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -240,6 +240,10 @@
   (-parallelism [_] parallelism)
   (-id [_] id)
   (-default-context [_] (:context ledger-defaults))
+  (-default-context [_ context-type] (let [ctx (:context ledger-defaults)]
+                                       (if (= :keyword context-type)
+                                         (ctx-util/keywordize-context ctx)
+                                         ctx)))
   (-new-indexer [_ opts]
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -111,6 +111,10 @@
   (-parallelism [_] parallelism)
   (-id [_] id)
   (-default-context [_] (:context ledger-defaults))
+  (-default-context [_ context-type] (let [ctx (:context ledger-defaults)]
+                                       (if (= :keyword context-type)
+                                         (ctx-util/keywordize-context ctx)
+                                         ctx)))
   (-new-indexer [_ opts] ;; default new ledger indexer
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -3,7 +3,6 @@
             [fluree.db.storage :as storage]
             [fluree.db.index :as index]
             [fluree.db.util.context :as ctx-util]
-            [fluree.db.util.core :as util]
             [fluree.db.util.log :as log :include-macros true]
             #?(:clj [fluree.db.full-text :as full-text])
             [fluree.db.conn.proto :as conn-proto]
@@ -145,6 +144,10 @@
   (-parallelism [_] parallelism)
   (-id [_] id)
   (-default-context [_] (:context ledger-defaults))
+  (-default-context [_ context-type] (let [ctx (:context ledger-defaults)]
+                                       (if (= :keyword context-type)
+                                         (ctx-util/keywordize-context ctx)
+                                         ctx)))
   (-new-indexer [_ opts] (idx-default/create opts)) ;; default new ledger indexer
   (-did [_] (:did ledger-defaults))
   (-msg-in [_ msg] (go-try

--- a/src/fluree/db/conn/proto.cljc
+++ b/src/fluree/db/conn/proto.cljc
@@ -9,7 +9,7 @@
   (-method [conn] "Returns connection method type (as keyword)")
   (-parallelism [conn] "Returns parallelism integer to use for running multi-thread operations (1->8)")
   (-id [conn] "Returns internal id for connection object")
-  (-default-context [conn] "Returns optional default context set at connection level")
+  (-default-context [conn] [conn context-type] "Returns optional default context set at connection level")
   (-new-indexer [conn opts] "Returns optional default new indexer object for a new ledger with optional opts.")
   (-did [conn] "Returns optional default did map if set at connection level")
   (-msg-in [conn msg] "Handler for incoming message from connection service")

--- a/src/fluree/db/conn/remote.cljc
+++ b/src/fluree/db/conn/remote.cljc
@@ -92,6 +92,10 @@
   (-parallelism [_] parallelism)
   (-id [_] id)
   (-default-context [_] (:context ledger-defaults))
+  (-default-context [_ context-type] (let [ctx (:context ledger-defaults)]
+                                       (if (= :keyword context-type)
+                                         (ctx-util/keywordize-context ctx)
+                                         ctx)))
   (-did [_] (:did ledger-defaults))
   (-msg-in [_ msg] (go-try
                      ;; TODO - push into state machine

--- a/src/fluree/db/conn/s3.clj
+++ b/src/fluree/db/conn/s3.clj
@@ -211,6 +211,10 @@
   (-parallelism [_] parallelism)
   (-id [_] id)
   (-default-context [_] (:context ledger-defaults))
+  (-default-context [_ context-type] (let [ctx (:context ledger-defaults)]
+                                       (if (= :keyword context-type)
+                                         (ctx-util/keywordize-context ctx)
+                                         ctx)))
   (-new-indexer [_ opts]
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -6,6 +6,7 @@
             [fluree.db.conn.remote :as remote-conn]
             #?(:clj [fluree.db.conn.s3 :as s3-conn])
             [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.constants :as const]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.platform :as platform]
             [clojure.core.async :as async :refer [go <!]]
@@ -119,13 +120,14 @@
 
   Options map (opts) can include:
   - did - DiD information to use, if storing blocks as verifiable credentials
-  - context - Default @context map to use for ledgers formed with this connection
-    "
+  - defaultContext - Default @context map to use for ledgers formed with this connection"
   ([conn] (create conn nil nil))
   ([conn ledger-alias] (create conn ledger-alias nil))
   ([conn ledger-alias opts]
    (promise-wrap
-     (jld-ledger/create conn ledger-alias opts))))
+    (do
+      (log/info "Creating ledger" ledger-alias)
+      (jld-ledger/create conn ledger-alias opts)))))
 
 (defn load-from-address
   "Loads a ledger defined with a Fluree address, e.g.:
@@ -251,7 +253,28 @@
   call `load` on the ledger alias."
   [conn json-ld opts]
   (promise-wrap
-    (transact-api/transact! conn json-ld opts)))
+   (let [parsed-txn (transact-api/parse-json-ld-txn json-ld)]
+     (transact-api/transact! conn parsed-txn opts))))
+
+(defn create-with-txn
+  "Creates a new ledger named by the @id key (or its context alias) in txn if it
+  doesn't exist and transacts the data in txn's @graph (or its context alias)
+  into it. Returns a promise with the transaction result (a db value)."
+  ([conn txn] (create-with-txn conn txn nil))
+  ([conn txn opts]
+   (let [{ledger-id "@id" :as parsed-txn} (transact-api/parse-json-ld-txn txn)
+         ledger-exists? @(exists? conn ledger-id)]
+     (if ledger-exists?
+       (let [err-message (str "Ledger " ledger-id " already exists")]
+         (throw (ex-info err-message
+                         {:status 409
+                          :error  :db/ledger-exists})))
+       (let [create-promise (create conn ledger-id opts)
+             ledger @create-promise]
+         (if (util/exception? ledger)
+           create-promise
+           (promise-wrap
+            (transact-api/ledger-transact! ledger parsed-txn opts))))))))
 
 (defn status
   "Returns current status of ledger branch."
@@ -327,7 +350,7 @@
   that produced the changes."
   [ledger query]
   (let [latest-db (ledger-proto/-db ledger)
-        res-chan (query-api/history latest-db query)]
+        res-chan  (query-api/history latest-db query)]
     (promise-wrap res-chan)))
 
 (defn range


### PR DESCRIPTION
Adds a new `create-with-txn` API fn to do create & transact into a new ledger. Supports the new `/create` endpoint in h-a-g (and soon server) that works more like `/transact`.

It also uses the conn's default context in both `create-with-txn` and `transact!` so that those top-level keys can be aliased in the default context too. This seemed more intuitive and consistent.