### PR TITLE
Replace @id w/ f:ledger in transactions

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -14,20 +14,20 @@
   [db json-ld opts]
   (go-try
     (if (:meta opts)
-      (let [start-time   #?(:clj  (System/nanoTime)
-                            :cljs (util/current-time-millis))
-            fuel-tracker (fuel/tracker)]
+      (let [start-time #?(:clj (System/nanoTime)
+                          :cljs (util/current-time-millis))
+            fuel-tracker       (fuel/tracker)]
         (try* (let [result (<? (dbproto/-stage db fuel-tracker json-ld opts))]
                 {:status 200
                  :result result
                  :time   (util/response-time-formatted start-time)
                  :fuel   (fuel/tally fuel-tracker)})
               (catch* e
-                      (throw (ex-info "Error staging database"
-                                      (-> e
-                                          ex-data
-                                          (assoc :time (util/response-time-formatted start-time)
-                                                 :fuel (fuel/tally fuel-tracker))))))))
+                (throw (ex-info "Error staging database"
+                                (-> e
+                                    ex-data
+                                    (assoc :time (util/response-time-formatted start-time)
+                                           :fuel (fuel/tally fuel-tracker))))))))
       (<? (dbproto/-stage db json-ld opts)))))
 
 (defn parse-json-ld-txn
@@ -43,7 +43,7 @@
         parsed-context   (if context
                            (json-ld/parse-context parsed-cdc context)
                            parsed-cdc)
-        {id "@id" graph "@graph" :as parsed-txn}
+        {ledger-id const/iri-ledger graph "@graph" :as parsed-txn}
         (into {}
               (map (fn [[k v]]
                      (let [k* (if (= context-key k)
@@ -54,10 +54,11 @@
                                 v)]
                        [k* v*])))
               json-ld)]
-    (if-not (and id graph)
+    (if-not (and ledger-id graph)
       (throw (ex-info (str "Invalid transaction, missing required keys:"
-                           (when (nil? id)
-                             " @id")
+                           (when (nil? ledger-id)
+                             (str " " (json-ld/compact const/iri-ledger
+                                                       parsed-context)))
                            (when (nil? graph)
                              " @graph")
                            ".")
@@ -68,8 +69,8 @@
   [ledger txn opts]
   (go-try
     (if (:meta opts)
-      (let [start-time   #?(:clj  (System/nanoTime)
-                            :cljs (util/current-time-millis))
+      (let [start-time #?(:clj  (System/nanoTime)
+                          :cljs (util/current-time-millis))
             fuel-tracker (fuel/tracker)]
         (try*
           (let [tx-result (<? (tx/transact! ledger fuel-tracker txn opts))]
@@ -87,19 +88,18 @@
       (<? (tx/transact! ledger txn opts)))))
 
 (defn transact!
-  [conn parsed-json-ld opts]
+  [conn parsed-json-ld]
   (go-try
-    (let [{txn-context "@context"
-           txn "@graph"
-           ledger-id "@id"
-           txn-opts const/iri-opts
+    (let [{txn-context     "@context"
+           txn             "@graph"
+           ledger-id       const/iri-ledger
+           txn-opts        const/iri-opts
            default-context const/iri-default-context} parsed-json-ld
-          address  (<? (conn-proto/-address conn ledger-id nil))]
+          address (<? (conn-proto/-address conn ledger-id nil))]
       (if-not (<? (conn-proto/-exists? conn address))
         (throw (ex-info "Ledger does not exist" {:ledger address}))
         (let [ledger (<? (jld-ledger/load conn address))
-              opts* (cond-> opts
-                      txn-opts        (merge txn-opts)
-                      txn-context     (assoc :txn-context txn-context)
-                      default-context (assoc :defaultContext default-context))]
-          (<? (ledger-transact! ledger txn opts*)))))))
+              opts   (cond-> (or txn-opts {})
+                       txn-context (assoc :txn-context txn-context)
+                       default-context (assoc :defaultContext default-context))]
+          (<? (ledger-transact! ledger txn opts)))))))

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -88,7 +88,7 @@
       (<? (tx/transact! ledger txn opts)))))
 
 (defn transact!
-  [conn parsed-json-ld]
+  [conn parsed-json-ld opts]
   (go-try
     (let [{txn-context     "@context"
            txn             "@graph"
@@ -99,7 +99,8 @@
       (if-not (<? (conn-proto/-exists? conn address))
         (throw (ex-info "Ledger does not exist" {:ledger address}))
         (let [ledger (<? (jld-ledger/load conn address))
-              opts   (cond-> (or txn-opts {})
+              opts   (cond-> opts
+                       txn-opts (merge txn-opts)
                        txn-context (assoc :txn-context txn-context)
                        default-context (assoc :defaultContext default-context))]
           (<? (ledger-transact! ledger txn opts)))))))

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -244,6 +244,7 @@
                                        (if (= :keyword context-type)
                                          (ctx-util/keywordize-context ctx)
                                          ctx)))
+  (-context-type [_] (:context-type ledger-defaults))
   (-new-indexer [_ opts]
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -115,6 +115,7 @@
                                        (if (= :keyword context-type)
                                          (ctx-util/keywordize-context ctx)
                                          ctx)))
+  (-context-type [_] (:context-type ledger-defaults))
   (-new-indexer [_ opts] ;; default new ledger indexer
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -148,6 +148,7 @@
                                        (if (= :keyword context-type)
                                          (ctx-util/keywordize-context ctx)
                                          ctx)))
+  (-context-type [_] (:context-type ledger-defaults))
   (-new-indexer [_ opts] (idx-default/create opts)) ;; default new ledger indexer
   (-did [_] (:did ledger-defaults))
   (-msg-in [_ msg] (go-try

--- a/src/fluree/db/conn/proto.cljc
+++ b/src/fluree/db/conn/proto.cljc
@@ -10,6 +10,7 @@
   (-parallelism [conn] "Returns parallelism integer to use for running multi-thread operations (1->8)")
   (-id [conn] "Returns internal id for connection object")
   (-default-context [conn] [conn context-type] "Returns optional default context set at connection level")
+  (-context-type [conn] "Returns the context-type for the default-context")
   (-new-indexer [conn opts] "Returns optional default new indexer object for a new ledger with optional opts.")
   (-did [conn] "Returns optional default did map if set at connection level")
   (-msg-in [conn msg] "Handler for incoming message from connection service")

--- a/src/fluree/db/conn/remote.cljc
+++ b/src/fluree/db/conn/remote.cljc
@@ -47,9 +47,9 @@
 
 ;; NOTE, below function works in conjunction with message broadcasting (not in current PR)
 #_(defn remote-lookup
-  [state servers ledger-address]
-  (go-try
-    (or (get-in @state [:lookup ledger-address])
+    [state servers ledger-address]
+    (go-try
+      (or (get-in @state [:lookup ledger-address])
           (let [head-commit  (<? (remote-read state servers ledger-address false))
                 head-address (get head-commit "address")]
             (swap! state assoc-in [:lookup ledger-address] head-address)
@@ -96,6 +96,7 @@
                                        (if (= :keyword context-type)
                                          (ctx-util/keywordize-context ctx)
                                          ctx)))
+  (-context-type [_] (:context-type ledger-defaults))
   (-did [_] (:did ledger-defaults))
   (-msg-in [_ msg] (go-try
                      ;; TODO - push into state machine

--- a/src/fluree/db/conn/s3.clj
+++ b/src/fluree/db/conn/s3.clj
@@ -215,6 +215,7 @@
                                        (if (= :keyword context-type)
                                          (ctx-util/keywordize-context ctx)
                                          ctx)))
+  (-context-type [_] (:context-type ledger-defaults))
   (-new-indexer [_ opts]
     (let [indexer-fn (:indexer ledger-defaults)]
       (indexer-fn opts)))

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -253,8 +253,9 @@
   call `load` on the ledger alias."
   [conn json-ld opts]
   (promise-wrap
-   (let [context-type (conn-proto/-context-type conn)
+   (let [context-type (or (:context-type opts) (conn-proto/-context-type conn))
          parsed-txn   (transact-api/parse-json-ld-txn conn context-type json-ld)]
+     (log/trace "transact! context-type:" context-type)
      (log/trace "transact! parsed-txn:" parsed-txn)
      (transact-api/transact! conn parsed-txn opts))))
 
@@ -266,7 +267,7 @@
   ([conn txn opts]
    (log/trace "create-with-txn txn:" txn)
    (log/trace "create-with-txn opts:" opts)
-   (let [context-type   (get opts :context-type :string)
+   (let [context-type   (or (:context-type opts) (conn-proto/-context-type conn))
          {ledger-id       const/iri-ledger
           txn-context     "@context"
           txn-opts        const/iri-opts

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -251,12 +251,12 @@
   Note: Loading the ledger results in a new ledger object, so references to existing
   ledger objects will be rendered stale. To obtain a ledger with the new changes,
   call `load` on the ledger alias."
-  [conn json-ld]
+  [conn json-ld opts]
   (promise-wrap
    (let [context-type (conn-proto/-context-type conn)
          parsed-txn   (transact-api/parse-json-ld-txn conn context-type json-ld)]
      (log/trace "transact! parsed-txn:" parsed-txn)
-     (transact-api/transact! conn parsed-txn))))
+     (transact-api/transact! conn parsed-txn opts))))
 
 (defn create-with-txn
   "Creates a new ledger named by the @id key (or its context alias) in txn if it

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -242,21 +242,21 @@
 
 (defn transact!
   "Expects a conn and json-ld document containing at least the following keys:
-  `@id`: the id of the ledger to transact to
+  `https://ns.flur.ee/ledger#ledger`: the id of the ledger to transact to
   `@graph`: the data to be transacted
 
-  Loads the specified ledger and peforms stage and commit! operations.
+  Loads the specified ledger and performs stage and commit! operations.
   Returns the new db.
 
   Note: Loading the ledger results in a new ledger object, so references to existing
   ledger objects will be rendered stale. To obtain a ledger with the new changes,
   call `load` on the ledger alias."
-  [conn json-ld opts]
+  [conn json-ld]
   (promise-wrap
-   (let [context-type (get opts :context-type :string)
+   (let [context-type (conn-proto/-context-type conn)
          parsed-txn   (transact-api/parse-json-ld-txn conn context-type json-ld)]
      (log/trace "transact! parsed-txn:" parsed-txn)
-     (transact-api/transact! conn parsed-txn opts))))
+     (transact-api/transact! conn parsed-txn))))
 
 (defn create-with-txn
   "Creates a new ledger named by the @id key (or its context alias) in txn if it
@@ -267,7 +267,7 @@
    (log/trace "create-with-txn txn:" txn)
    (log/trace "create-with-txn opts:" opts)
    (let [context-type   (get opts :context-type :string)
-         {ledger-id       "@id"
+         {ledger-id       const/iri-ledger
           txn-context     "@context"
           txn-opts        const/iri-opts
           default-context const/iri-default-context

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -4,7 +4,6 @@
             #?(:clj [clojure.test :as t :refer [deftest testing is]]
                :cljs [cljs.test :as t :refer [deftest testing is] :include-macros true])
             [fluree.db.json-ld.api :as fluree]
-            [fluree.json-ld :as json-ld]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.did :as did]))
 

--- a/test/fluree/db/query/property_test.clj
+++ b/test/fluree/db/query/property_test.clj
@@ -165,7 +165,8 @@
                            "ex:preds" {"@list" [{"@id" "ex:cool"
                                                  "@type" "rdf:Property"}
                                                 {"@id" "ex:fool"
-                                                 "@type" "rdf:Property"}]}}]})
+                                                 "@type" "rdf:Property"}]}}]}
+                   nil)
           _ (Thread/sleep 100)
           db2    @(fluree/transact!
                    conn {"f:ledger" ledger-id
@@ -176,7 +177,8 @@
                                       "ex:givenName" "Dan"}
                                      {"@id" "ex:other"
                                       "ex:fool" false
-                                      "ex:cool" true}]})
+                                      "ex:cool" true}]}
+                   nil)
           loaded @(fluree/load conn ledger-id)
           dbl    (fluree/db loaded)]
       (testing "before load"

--- a/test/fluree/db/query/property_test.clj
+++ b/test/fluree/db/query/property_test.clj
@@ -132,7 +132,7 @@
                 "ex:new-pred"       {"id" "ex:nested"}
                 "ex:unlabeled-pred" "unlabeled"}}]
              @(fluree/query db2 {"@context" ["" {"ex:reversed-pred" {"@reverse" "ex:new-pred"}}]
-                                 "select"   {"?s" ["id" {"ex:reversed-pred" ["*"]} ]}
+                                 "select"   {"?s" ["id" {"ex:reversed-pred" ["*"]}]}
                                  "where"    [["?s" "@id" "ex:nested"]]}))
           "via reverse crawl")
       (is (= [{"id" "ex:nested", "ex:reversed-pred" "ex:subject-as-predicate"}]
@@ -143,35 +143,40 @@
 
 (deftest nested-properties
   (with-tmp-dir storage-path
-    (let [conn   @(fluree/connect {:method :file :storage-path storage-path})
+    (let [conn   @(fluree/connect {:method :file, :storage-path storage-path
+                                   :defaults {:context test-utils/default-str-context}})
           ledger-id "bugproperty-iri"
-          ledger @(fluree/create conn ledger-id {:defaultContext [test-utils/default-str-context
-                                                                  {"ex" "http://example.com/"
-                                                                   "owl" "http://www.w3.org/2002/07/owl#"}]})
+          ledger @(fluree/create conn ledger-id
+                                 {:defaultContext
+                                  ["" {"ex" "http://example.com/"
+                                       "owl" "http://www.w3.org/2002/07/owl#"}]})
           db0      (->> @(fluree/stage (fluree/db ledger) {"ex:new" true})
                         (fluree/commit! ledger)
                         (deref))
 
           _ (Thread/sleep 100)
-          db1    @(fluree/transact! conn {"@id" ledger-id
-                                          "@graph" [{"@id" "ex:givenName"
-                                                     "@type" "rdf:Property"
-                                                     "owl:equivalentProperty" {"@id" "ex:firstName"
-                                                                               "@type" "rdf:Property"}
-                                                     "ex:preds" {"@list" [{"@id" "ex:cool"
-                                                                           "@type" "rdf:Property"}
-                                                                          {"@id" "ex:fool"
-                                                                           "@type" "rdf:Property"}]}}]} {})
+          db1    @(fluree/transact!
+                   conn {"f:ledger" ledger-id
+                         "@graph"
+                         [{"@id" "ex:givenName"
+                           "@type" "rdf:Property"
+                           "owl:equivalentProperty" {"@id" "ex:firstName"
+                                                     "@type" "rdf:Property"}
+                           "ex:preds" {"@list" [{"@id" "ex:cool"
+                                                 "@type" "rdf:Property"}
+                                                {"@id" "ex:fool"
+                                                 "@type" "rdf:Property"}]}}]})
           _ (Thread/sleep 100)
-          db2    @(fluree/transact! conn {"@id" ledger-id
-                                          "@graph" [{"@id" "ex:andrew"
-                                                     "ex:firstName" "Andrew"
-                                                     "ex:age" 35}
-                                                    {"@id" "ex:dan"
-                                                     "ex:givenName" "Dan"}
-                                                    {"@id" "ex:other"
-                                                     "ex:fool" false
-                                                     "ex:cool" true}]} {})
+          db2    @(fluree/transact!
+                   conn {"f:ledger" ledger-id
+                         "@graph"   [{"@id" "ex:andrew"
+                                      "ex:firstName" "Andrew"
+                                      "ex:age" 35}
+                                     {"@id" "ex:dan"
+                                      "ex:givenName" "Dan"}
+                                     {"@id" "ex:other"
+                                      "ex:fool" false
+                                      "ex:cool" true}]})
           loaded @(fluree/load conn ledger-id)
           dbl    (fluree/db loaded)]
       (testing "before load"

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -232,7 +232,7 @@
                              :type        :ex/User
                              :foo/baz     "baz"
                              :schema/name "Bob"}]}
-            db  @(fluree/transact! conn txn)]
+            db  @(fluree/transact! conn txn nil)]
         (is (= [{:id          :ex/bob,
                  :type        :ex/User,
                  :schema/name "Bob",
@@ -249,7 +249,7 @@
                  :f/ledger    ledger-name
                  :graph-alias {:id-alias    :ex/alice
                                :schema/givenName "Alicia"}}
-            db  @(fluree/transact! conn txn)]
+            db  @(fluree/transact! conn txn nil)]
         (is (= [{:id          :ex/bob,
                  :type        :ex/User,
                  :schema/name "Bob",
@@ -267,7 +267,7 @@
                         "@graph"  [{:context    {:quux "http://quux.com/"}
                                     :id         :ex/alice
                                     :quux/corge "grault"}]}
-            db @(fluree/transact! conn txn)]
+            db @(fluree/transact! conn txn nil)]
         (is (= [{:id          :ex/bob,
                  :type        :ex/User,
                  :schema/name "Bob",
@@ -286,7 +286,7 @@
       (let [txn        {"@graph" [{:context    {:quux "http://quux.com/"}
                                    :id         :ex/cam
                                    :quux/corge "grault"}]}
-            db (try @(fluree/transact! conn txn)
+            db (try @(fluree/transact! conn txn nil)
                     (catch Exception e e))]
         (is (util/exception? db))
         (is (str/starts-with? (ex-message db)

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -55,7 +55,9 @@
 
   (testing "Allow transacting `false` values"
     (let [conn    (test-utils/create-conn)
-          ledger  @(fluree/create conn "tx/bools" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+          ledger  @(fluree/create conn "tx/bools"
+                                  {:defaultContext
+                                   ["" {:ex "http://example.org/ns/"}]})
           db-bool @(fluree/stage
                     (fluree/db ledger)
                     {:id        :ex/alice
@@ -207,7 +209,9 @@
 (deftest ^:integration transact-api-test
   (let [conn        (test-utils/create-conn)
         ledger-name "example-ledger"
-        ledger      @(fluree/create conn ledger-name {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+        ledger      @(fluree/create conn ledger-name
+                                    {:defaultContext
+                                     ["" {:ex "http://example.org/ns/"}]})
         ;; can't `transact!` until ledger can be loaded (ie has at least one commit)
         db          @(fluree/stage (fluree/db ledger)
                                    {:id   :ex/firstTransaction
@@ -216,19 +220,19 @@
         user-query  '{:select {?s [:*]}
                       :where  [[?s :type :ex/User]]}]
     (testing "Top-level context is used for transaction nodes"
-      (let [txn {:id      ledger-name
-                 :context {:foo "http://foo.com/"
-                           :id  "@id"
-                           :graph "@graph"}
-                 :graph   [{:id          :ex/alice
-                            :type        :ex/User
-                            :foo/bar     "foo"
-                            :schema/name "Alice"}
-                           {:id          :ex/bob
-                            :type        :ex/User
-                            :foo/baz     "baz"
-                            :schema/name "Bob"}]}
-            db  @(fluree/transact! conn txn {})]
+      (let [txn {:f/ledger ledger-name
+                 :context  {:foo "http://foo.com/"
+                            :id  "@id"
+                            :graph "@graph"}
+                 :graph    [{:id          :ex/alice
+                             :type        :ex/User
+                             :foo/bar     "foo"
+                             :schema/name "Alice"}
+                            {:id          :ex/bob
+                             :type        :ex/User
+                             :foo/baz     "baz"
+                             :schema/name "Bob"}]}
+            db  @(fluree/transact! conn txn)]
         (is (= [{:id          :ex/bob,
                  :type        :ex/User,
                  :schema/name "Bob",
@@ -242,10 +246,10 @@
     (testing "Aliased @id, @graph are correctly identified"
       (let [txn {:context     {:id-alias    "@id"
                                :graph-alias "@graph"}
-                 :id-alias    ledger-name
+                 :f/ledger    ledger-name
                  :graph-alias {:id-alias    :ex/alice
                                :schema/givenName "Alicia"}}
-            db  @(fluree/transact! conn txn {})]
+            db  @(fluree/transact! conn txn)]
         (is (= [{:id          :ex/bob,
                  :type        :ex/User,
                  :schema/name "Bob",
@@ -259,11 +263,11 @@
                                         :context ["" {:foo "http://foo.com/"
                                                       :bar "http://bar.com/"}]))))))
     (testing "@context inside node is correctly handled"
-      (let [txn        {"@id"    ledger-name
-                        "@graph" [{:context    {:quux "http://quux.com/"}
-                                 :id         :ex/alice
-                                 :quux/corge "grault"}]}
-            db @(fluree/transact! conn txn {})]
+      (let [txn        {:f/ledger ledger-name
+                        "@graph"  [{:context    {:quux "http://quux.com/"}
+                                    :id         :ex/alice
+                                    :quux/corge "grault"}]}
+            db @(fluree/transact! conn txn)]
         (is (= [{:id          :ex/bob,
                  :type        :ex/User,
                  :schema/name "Bob",
@@ -282,8 +286,8 @@
       (let [txn        {"@graph" [{:context    {:quux "http://quux.com/"}
                                    :id         :ex/cam
                                    :quux/corge "grault"}]}
-            db (try @(fluree/transact! conn txn {})
+            db (try @(fluree/transact! conn txn)
                     (catch Exception e e))]
         (is (util/exception? db))
         (is (str/starts-with? (ex-message db)
-                              "Invalid transaction, missing required keys: @id"))))))
+                              "Invalid transaction, missing required keys: :f/ledger"))))))

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -278,10 +278,10 @@
                     fluree.db.query.exec.eval/struuid (fn [] "34bdb25f-9fae-419b-9c50-203b5f306e47")]
         (let [updated  (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
                                                 "ex:isBlank" 0 "ex:isNumeric" 0 "ex:str" 0 "ex:uuid" 0
-                                                "ex:struuid" 0 "ex:isNotNumeric" 0 "ex:isNotBlank" 0
+                                                "ex:struuid" 0 "ex:isNotNumeric" 0 "ex:isNotBlank" 0}
                                                 ;; "ex:isIRI" 0 "ex:isURI" 0 "ex:isLiteral" 0 "ex:lang" 0 "ex:IRI" 0
                                                 ;; "ex:datatype" 0 "ex:bnode" 0 "ex:strdt" 0 "ex:strLang" 0
-                                                }
+
                                                {"id" "ex:rdf-term-fns"
                                                 "ex:text" "Abcdefg"
                                                 "ex:number" 1
@@ -425,14 +425,13 @@
                subject)
             "returns all results")))
     (testing "after deletion"
-      @(fluree/transact!  conn
-                          {:context {:id "@id"
-                                     :graph "@graph"}
-                           :id ledger-id
-                           :graph {:delete '[?s ?p ?o]
-                                   :where  '[[?s "schema:description" ?o]
-                                             [?s ?p ?o]]}}
-                          {})
+      @(fluree/transact! conn
+                         {:context  {:id "@id", :graph "@graph",
+                                     :f  "https://ns.flur.ee/ledger#"}
+                          :f/ledger ledger-id
+                          :graph    {:delete '[?s ?p ?o]
+                                     :where  '[[?s "schema:description" ?o]
+                                               [?s ?p ?o]]}})
       (let [db2   (fluree/db @(fluree/load conn ledger-id))
             q       '{:select [?s ?p ?o]
                       :where  [[?s "schema:description" ?o]

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -431,7 +431,7 @@
                           :f/ledger ledger-id
                           :graph    {:delete '[?s ?p ?o]
                                      :where  '[[?s "schema:description" ?o]
-                                               [?s ?p ?o]]}})
+                                               [?s ?p ?o]]}} nil)
       (let [db2   (fluree/db @(fluree/load conn ledger-id))
             q       '{:select [?s ?p ?o]
                       :where  [[?s "schema:description" ?o]


### PR DESCRIPTION
...for identifying the ledger. This is more semantically correct and fixes an issue with these not necessarily being IRIs which broke credential verification.

Also adds context-type to connection protocol and looks it up from there in transact instead of making it an opt passed separately and redundantly.

Upcoming server & http-api-gateway PRs will adapt them to this change.

Part of https://github.com/fluree/core/issues/32