### PR TITLE
Fix index read error

### DIFF
--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -46,6 +46,7 @@
    "http://www.w3.org/2001/XMLSchema#base64Binary"         const/$xsd:base64Binary
    "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" const/$rdf:langString})
 
+
 (def iso8601-offset-pattern
   "(Z|(?:[+-][0-9]{2}:[0-9]{2}))?")
 
@@ -67,7 +68,7 @@
 (def iso8601-time-pattern
   (str #?(:clj  "([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\\.([0-9]{1,9}))?"
           :cljs "([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\\.([0-9]{1,3}))?")
-       iso8601-offset-pattern))
+        iso8601-offset-pattern))
 
 (def iso8601-time-re
   (re-pattern iso8601-time-pattern))

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -134,18 +134,9 @@
         local timezone according to your device."
   [s]
   (when-let [matches (re-matches iso8601-time-re s)]
-    #?(:clj  (let [time-parts (->> matches rest butlast)
-                   offset     (last matches)
-
-                   [hours minutes seconds second-fraction]
-                   (->> time-parts
-                        (map #(or % "0"))
-                        (map #(Integer/parseInt %)))
-
-                   nanos      (* second-fraction 1000000)]
-               (if offset
-                 (OffsetTime/of hours minutes seconds nanos (ZoneOffset/of ^String offset))
-                 (LocalTime/of hours minutes seconds nanos)))
+    #?(:clj  (if-let [offset     (peek matches)]
+               (OffsetTime/parse s)
+               (LocalTime/parse s))
        :cljs (js/Date. (str "1970-01-01T" s)))))
 
 (defn- parse-iso8601-datetime
@@ -157,20 +148,9 @@
   [s]
   (when-let [matches (re-matches iso8601-datetime-re s)]
     #?(:clj
-       (let [datetime-parts (->> matches rest (take 7))
-             offset         (last matches)
-             [years months days hours minutes seconds second-fraction]
-             (->> datetime-parts
-                  (map #(or % "0"))
-                  (map #(Integer/parseInt %)))
-
-             nanos          (* second-fraction 1000000)]
-         (if offset
-           (OffsetDateTime/of years months days hours minutes seconds nanos
-                              (ZoneOffset/of ^String offset))
-           (LocalDateTime/of ^int years ^int months ^int days ^int hours
-                             ^int minutes ^int seconds ^int nanos)))
-
+       (if-let [offset         (peek matches)]
+         (OffsetDateTime/parse s)
+         (LocalDateTime/parse s))
        :cljs
        (js/Date. s))))
 

--- a/src/fluree/db/json_ld/commit_data.cljc
+++ b/src/fluree/db/json_ld/commit_data.cljc
@@ -442,8 +442,7 @@
      ;; v
      (flake/create t const/$_v v const/$xsd:int t true nil)
      ;; time
-     (flake/create t const/$_commit:time (util/str->epoch-ms time)
-                   const/$xsd:dateTime t true nil) ;; data
+     (flake/create t const/$_commit:time (util/str->epoch-ms time) const/$xsd:long t true nil) ;; data
      (flake/create t const/$_commit:data db-sid const/$xsd:anyURI t true nil)
 
      ;; db flakes

--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -75,7 +75,6 @@
 #?(:clj (def ^DateTimeFormatter xsdTimeFormatter
           (DateTimeFormatter/ofPattern "HH:mm:ss.SSSSSSSSS[XXXXX]")))
 
-;;xsd:date
 #?(:clj (def ^DateTimeFormatter xsdDateFormatter
           (DateTimeFormatter/ofPattern "uuuu-MM-dd[XXXXX]")))
 
@@ -83,20 +82,11 @@
 (defn format-value
   [val dt]
   (uc/case (int dt)
-    const/$xsd:dateTime #?(:clj (cond->> val
-                                  (or (instance? java.time.OffsetDateTime val)
-                                      (instance? java.time.LocalDateTime val))
-                                  (.format xsdDateTimeFormatter))
+    const/$xsd:dateTime #?(:clj (.format xsdDateTimeFormatter val)
                            :cljs (.toJSON val))
-    const/$xsd:date      #?(:clj (cond->> val
-                                   (or (instance? java.time.OffsetDateTime val)
-                                       (instance? java.time.LocalDate val))
-                                   (.format xsdDateFormatter))
+    const/$xsd:date      #?(:clj (.format xsdDateFormatter val)
                             :cljs (.toJSON val))
-    const/$xsd:time #?(:clj (cond->> val
-                              (or (instance? java.time.OffsetTime val)
-                                  (instance? java.time.LocalTime val))
-                              (.format xsdTimeFormatter))
+    const/$xsd:time #?(:clj (.format xsdTimeFormatter val)
                        :cljs (.toJSON val))
     val))
 

--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -4,7 +4,8 @@
             [fluree.db.datatype :as datatype]
             [fluree.db.flake :as flake]
             [fluree.db.util.core :as util]
-            #?(:clj [fluree.db.util.clj-const :as uc]))
+            #?(:clj  [fluree.db.util.clj-const :as uc]
+               :cljs [fluree.db.util.cljs-const :as uc]))
   #?(:clj (:import (java.time OffsetDateTime OffsetTime LocalDate LocalTime
                               LocalDateTime ZoneOffset)
                    (java.time.format DateTimeFormatter))))

--- a/test/fluree/db/indexer/default_test.clj
+++ b/test/fluree/db/indexer/default_test.clj
@@ -23,8 +23,19 @@
                   (fluree/db ledger)
                   [{"@id" "ex:Foo",
                     "@type" "ex:Bar",
-                    "ex:createdDate" {"@type" "xsd:dateTime"
-                                      "@value" "2023-04-01T00:00:00.000Z"}}])
+
+                    "ex:offsetDateTime" {"@type" "xsd:dateTime"
+                                         "@value" "2023-04-01T00:00:00.000Z"}
+                    "ex:localDateTime" {"@type" "xsd:dateTime"
+                                        "@value" "2021-09-24T11:14:32.833"}
+                    "ex:offsetDateTime2" {"@type" "xsd:date"
+                                          "@value" "2022-01-05Z"}
+                    "ex:localDate" {"@type" "xsd:date"
+                                    "@value" "2024-02-02"}
+                    "ex:offsetTime" {"@type" "xsd:time"
+                                     "@value" "12:42:00Z"}
+                    "ex:localTime" {"@type" "xsd:time"
+                                    "@value" "12:42:00"}}])
             db-commit @(fluree/commit! ledger db)
             loaded (test-utils/retry-load conn (:alias ledger) 100)
             q {"select" {"?s" ["*"]}

--- a/test/fluree/db/indexer/default_test.clj
+++ b/test/fluree/db/indexer/default_test.clj
@@ -1,0 +1,33 @@
+(ns fluree.db.indexer.default-test
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [fluree.db.did :as did]
+            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.util.core :as util]
+            [jsonista.core :as json]
+            [test-with-files.tools :refer [with-tmp-dir]]))
+
+(deftest ^:integration index-datetimes-test
+  (testing "Serialize and reread flakes with time types"
+    (with-tmp-dir storage-path
+      (let [conn @(fluree/connect {:method :file
+                                   :storage-path storage-path
+                                   :defaults
+                                   { :indexer {:reindex-min-bytes 12
+                                               :reindex-max-bytes 10000000}
+                                    :context (merge test-utils/default-str-context {"ex" "http://example.org/ns/"})}})
+            ledger @(fluree/create conn "index/datetimes")
+            db @(fluree/stage
+                  (fluree/db ledger)
+                  [{"@id" "ex:Foo",
+                    "@type" "ex:Bar",
+                    "ex:createdDate" {"@type" "xsd:dateTime"
+                                      "@value" "2023-04-01T00:00:00.000Z"}}])
+            db-commit @(fluree/commit! ledger db)
+            loaded (test-utils/retry-load conn (:alias ledger) 100)
+            q {"select" {"?s" ["*"]}
+               "where" [["?s" "type" "ex:Bar"]]}]
+        (is (= @(fluree/query (fluree/db loaded) q)
+               @(fluree/query db q)))))))


### PR DESCRIPTION
Fixes https://github.com/fluree/core/issues/31
Fixes #580

When creating flakes with time-typed values (`xsd:dateTime`, `xsd:date`, `xsd:time`), we coerce the values into `java.time`/`js/Date` objects. This index-reading bug was caused by not serializing those values correctly, resulting in unreadable index files. This PR introduces special serialization/deserialization logic for these types .

We were writing out flakes with unreadable tagged literals, eg:
```
[211106232533902,1038,#object[java.time.OffsetDateTime 0x3d76199b "2023-04-01T00:00Z"],4,-2,true,null]
```

Which was causing parsing errors:
```
Exception in thread "async-thread-macro-1" com.fasterxml.jackson.core.JsonParseException: Unexpected character ('#' (code 35)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
```

Custom formatters are used during serialization to ensure that our existing `datatype/coerce` code can be reused to deserialize these values upon load. This is because the default `str`/ `.toString()` behavior will trim off trailing zeros, which produces values that are not valid for the given datatype. This is a simple initial implementation, we can potentially optimize in the future with more clever formatters and/or a separate coercion path for deserialization.

For #580, I switched coercion for `xsd:time` and `xsd:dateTime` in clj to use the java parsing functions directly. Our hard-coded multiplication of nanoseconds was causing errors/incorrect values, whereas the built-in parsing fns will do the correct thing with those values. I'm not sure if there was a reason to not use these parsing fns in the first place, if there's a significant downside I wasn't aware of then we should discuss other alternatives.