### PR TITLE
Serialize time objects correctly for commit files

### DIFF
--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -47,35 +47,6 @@
    "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" const/$rdf:langString})
 
 
-(def time-types
-  #{const/$xsd:date
-    const/$xsd:dateTime
-    const/$xsd:time})
-
-#?(:clj (def ^DateTimeFormatter xsdDateTimeFormatter
-          (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS[XXXXX]")))
-
-#?(:clj (def ^DateTimeFormatter xsdTimeFormatter
-          (DateTimeFormatter/ofPattern "HH:mm:ss.SSSSSSSSS[XXXXX]")))
-
-#?(:clj (def ^DateTimeFormatter xsdDateFormatter
-          (DateTimeFormatter/ofPattern "uuuu-MM-dd[XXXXX]")))
-
-(defn serialize-flake-value
-  "Flakes with time types will have time objects as values.
-  We need to serialize these into strings that will be successfully re-coerced into
-  the same objects upon loading."
-  [val dt]
-  (uc/case (int dt)
-    const/$xsd:dateTime #?(:clj (.format xsdDateTimeFormatter val)
-                           :cljs (.toJSON val))
-    const/$xsd:date      #?(:clj (.format xsdDateFormatter val)
-                            :cljs (.toJSON val))
-    const/$xsd:time #?(:clj (.format xsdTimeFormatter val)
-                       :cljs (.toJSON val))
-    val))
-
-
 (def iso8601-offset-pattern
   "(Z|(?:[+-][0-9]{2}:[0-9]{2}))?")
 

--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -47,6 +47,35 @@
    "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" const/$rdf:langString})
 
 
+(def time-types
+  #{const/$xsd:date
+    const/$xsd:dateTime
+    const/$xsd:time})
+
+#?(:clj (def ^DateTimeFormatter xsdDateTimeFormatter
+          (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS[XXXXX]")))
+
+#?(:clj (def ^DateTimeFormatter xsdTimeFormatter
+          (DateTimeFormatter/ofPattern "HH:mm:ss.SSSSSSSSS[XXXXX]")))
+
+#?(:clj (def ^DateTimeFormatter xsdDateFormatter
+          (DateTimeFormatter/ofPattern "uuuu-MM-dd[XXXXX]")))
+
+(defn serialize-flake-value
+  "Flakes with time types will have time objects as values.
+  We need to serialize these into strings that will be successfully re-coerced into
+  the same objects upon loading."
+  [val dt]
+  (uc/case (int dt)
+    const/$xsd:dateTime #?(:clj (.format xsdDateTimeFormatter val)
+                           :cljs (.toJSON val))
+    const/$xsd:date      #?(:clj (.format xsdDateFormatter val)
+                            :cljs (.toJSON val))
+    const/$xsd:time #?(:clj (.format xsdTimeFormatter val)
+                       :cljs (.toJSON val))
+    val))
+
+
 (def iso8601-offset-pattern
   "(Z|(?:[+-][0-9]{2}:[0-9]{2}))?")
 

--- a/src/fluree/db/json_ld/commit.cljc
+++ b/src/fluree/db/json_ld/commit.cljc
@@ -1,7 +1,7 @@
 (ns fluree.db.json-ld.commit
   (:require [fluree.json-ld :as json-ld]
             [fluree.crypto :as crypto]
-            [fluree.db.datatype :as datatype]
+            [fluree.db.serde.json :as serde-json]
             [fluree.db.flake :as flake]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.ledger :as jld-ledger]
@@ -49,12 +49,12 @@
                                                      db iri-map
                                                      compact-fn))}
                                (if (nil? all-refs?) true all-refs?)]
-                              [{"@value" (datatype/serialize-flake-value
+                              [{"@value" (serde-json/serialize-flake-value
                                            (flake/o p-flake)
                                            pdt)} false])
             obj*      (cond-> obj
                         list? (assoc :i (-> p-flake flake/m :i))
-                        (contains? datatype/time-types pdt)
+                        (contains? serde-json/time-types pdt)
                         ;;need to retain the `@type` for times
                         ;;so they will be coerced correctly when loading
                         (assoc "@type"

--- a/src/fluree/db/json_ld/commit.cljc
+++ b/src/fluree/db/json_ld/commit.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.json-ld.commit
   (:require [fluree.json-ld :as json-ld]
             [fluree.crypto :as crypto]
+            [fluree.db.datatype :as datatype]
             [fluree.db.flake :as flake]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.ledger :as jld-ledger]
@@ -48,10 +49,18 @@
                                                      db iri-map
                                                      compact-fn))}
                                (if (nil? all-refs?) true all-refs?)]
-                              [{"@value" (flake/o p-flake)} false])
-            obj*      (if list?
-                        (assoc obj :i (-> p-flake flake/m :i))
-                        obj)
+                              [{"@value" (datatype/serialize-flake-value
+                                           (flake/o p-flake)
+                                           pdt)} false])
+            obj*      (cond-> obj
+                        list? (assoc :i (-> p-flake flake/m :i))
+                        (contains? datatype/time-types pdt)
+                        ;;need to retain the `@type` for times
+                        ;;so they will be coerced correctly when loading
+                        (assoc "@type"
+                               (<? (get-s-iri pdt
+                                              db iri-map
+                                              compact-fn))))
             next-acc' (conj acc' obj*)]
         (if (seq r')
           (recur r' all-refs? next-acc')

--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -1,24 +1,13 @@
 (ns fluree.db.serde.json
-  (:require [fluree.db.constants :as const]
+  (:require [fluree.db.datatype :as datatype]
             [fluree.db.serde.protocol :as serdeproto]
-            [fluree.db.datatype :as datatype]
             [fluree.db.flake :as flake]
-            [fluree.db.util.core :as util]
-            #?(:clj  [fluree.db.util.clj-const :as uc]
-               :cljs [fluree.db.util.cljs-const :as uc]))
-  #?(:clj (:import (java.time OffsetDateTime OffsetTime LocalDate LocalTime
-                              LocalDateTime ZoneOffset)
-                   (java.time.format DateTimeFormatter))))
+            [fluree.db.util.core :as util]))
 #?(:clj (set! *warn-on-reflection* true))
-
-(def time-types
-  #{const/$xsd:date
-    const/$xsd:dateTime
-    const/$xsd:time})
 
 (defn deserialize-flake
   [flake-vec]
-  (if-let [flake-time-dt (time-types (get flake-vec 3))]
+  (if-let [flake-time-dt (datatype/time-types (get flake-vec 3))]
     (-> flake-vec
         (update 2 (fn [val]
                     #?(:clj (datatype/coerce val flake-time-dt)
@@ -69,36 +58,14 @@
   [leaf]
   (assoc leaf :flakes (mapv deserialize-flake (:flakes leaf))))
 
-#?(:clj (def ^DateTimeFormatter xsdDateTimeFormatter
-          (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS[XXXXX]")))
-
-#?(:clj (def ^DateTimeFormatter xsdTimeFormatter
-          (DateTimeFormatter/ofPattern "HH:mm:ss.SSSSSSSSS[XXXXX]")))
-
-#?(:clj (def ^DateTimeFormatter xsdDateFormatter
-          (DateTimeFormatter/ofPattern "uuuu-MM-dd[XXXXX]")))
-
-
-(defn serialize-value
-  [val dt]
-  (uc/case (int dt)
-    const/$xsd:dateTime #?(:clj (.format xsdDateTimeFormatter val)
-                           :cljs (.toJSON val))
-    const/$xsd:date      #?(:clj (.format xsdDateFormatter val)
-                            :cljs (.toJSON val))
-    const/$xsd:time #?(:clj (.format xsdTimeFormatter val)
-                       :cljs (.toJSON val))
-    val))
-
 (defn serialize-flake
-  "Flakes with time types will have time objects as values.
-  We need to serialize these into strings that will be successfully re-coerced into
-  the same objects upon loading.
+  "Serializes flakes into vectors, ensuring values are written such that they will
+  be correctly coerced when loading.
 
   Flakes with an 'm' value need keys converted from keyword keys into strings."
   [flake]
   (-> (vec flake)
-      (update 2 serialize-value (flake/dt flake))
+      (update 2 datatype/serialize-flake-value (flake/dt flake))
       (cond-> (flake/m flake) (assoc 5 (util/stringify-keys (flake/m flake))))))
 
 (defn- deserialize-garbage

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -385,7 +385,39 @@
                                             {:f/property
                                              [:* {:f/allow
                                                   [:* {:f/targetRole [:_id]}]}]}]}
-                                       :where  [[?s :type :f/Policy]]}))))))))))
+                                       :where  [[?s :type :f/Policy]]}))))))))
+
+     (testing "Can load a ledger with time values"
+       (with-tmp-dir storage-path
+         (let [conn @(fluree/connect {:method :file
+                                      :storage-path storage-path
+                                      :defaults
+                                      {:context (merge test-utils/default-str-context
+                                                       {"ex" "http://example.org/ns/"})}})
+               ledger @(fluree/create conn "index/datetimes")
+               db @(fluree/stage
+                     (fluree/db ledger)
+                     [{"@id" "ex:Foo",
+                       "@type" "ex:Bar",
+
+                       "ex:offsetDateTime" {"@type" "xsd:dateTime"
+                                            "@value" "2023-04-01T00:00:00.000Z"}
+                       "ex:localDateTime" {"@type" "xsd:dateTime"
+                                           "@value" "2021-09-24T11:14:32.833"}
+                       "ex:offsetDateTime2" {"@type" "xsd:date"
+                                             "@value" "2022-01-05Z"}
+                       "ex:localDate" {"@type" "xsd:date"
+                                       "@value" "2024-02-02"}
+                       "ex:offsetTime" {"@type" "xsd:time"
+                                        "@value" "12:42:00Z"}
+                       "ex:localTime" {"@type" "xsd:time"
+                                       "@value" "12:42:00"}}])
+               db-commit @(fluree/commit! ledger db)
+               loaded (test-utils/retry-load conn (:alias ledger) 100)
+               q {"select" {"?s" ["*"]}
+                  "where" [["?s" "type" "ex:Bar"]]}]
+           (is (= @(fluree/query (fluree/db loaded) q)
+                  @(fluree/query db q))))))))
 
 #?(:clj
    (deftest load-from-memory-test


### PR DESCRIPTION
Closes #584 

Adds some special handling to commit-writing for flakes that have time objects as values:
- serialize those objects into strings (as in #583)
- ensure we write out the `@type` for these values, so they will be correctly coerced when loading