### PR TITLE
Fix: txn @context explicit inheritance / merging

### DIFF
--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -26,16 +26,16 @@
                      :schema/age   30}])
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bbevm5b6f2ai7ftqmx3re3y7ovzlfrkpeliqbdgtjgcovrknegejh"
+        (is (= "fluree:commit:sha256:bkbx42yw5xqjhj6qbilvms4gj4bksowxl3k2rwvtlzwfnlhjcjuz"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://a7368fab9c18ebb55b5b01279b417bc2381afb752a0e397a222624816fe6e22d"
+        (is (= "fluree:memory://2f36f5af396fa586ccf126d81e5c0700639f264662e9409f750a9e2806b8373f"
                (get-in db1 [:commit :address]))))
       (testing "stable default context id"
-        (is (= "fluree:context:b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+        (is (= "fluree:context:68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"
                (get-in db1 [:commit :defaultContext :id]))))
       (testing "stable context address"
-        (is (= "fluree:memory://b6dcf8968183239ecc7a664025f247de5b7859ac18cdeaace89aafc421eeddee"
+        (is (= "fluree:memory://68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"
                (get-in db1 [:commit :defaultContext :address]))))
       (testing "stable db id"
         (is (= "fluree:db:sha256:bbeducmbtm7ducvewuufjhl26p2a7v2mb5dasv5ykwdti2uamegm4"

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -9,6 +9,7 @@
 (def default-context
   {:id     "@id"
    :type   "@type"
+   :graph  "@graph"
    :xsd    "http://www.w3.org/2001/XMLSchema#"
    :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    :rdfs   "http://www.w3.org/2000/01/rdf-schema#"
@@ -21,6 +22,7 @@
 (def default-str-context
   {"id"     "@id"
    "type"   "@type"
+   "graph"  "@graph"
    "xsd"    "http://www.w3.org/2001/XMLSchema#"
    "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -3,6 +3,7 @@
             [fluree.db.did :as did]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.util.core :as util :refer [try* catch*]]
+            [fluree.db.util.log :as log]
             #?@(:cljs [[clojure.core.async :refer [go go-loop]]
                        [clojure.core.async.interop :refer [<p!]]])))
 
@@ -211,35 +212,50 @@
 
 (defn did?
   [s]
-  (and (string? s) (re-matches did-regex s)))
+  (let [result (and (string? s) (re-matches did-regex s))]
+    (when-not result
+      (log/trace "did? falsey result from:" s))
+    result))
 
 (def addr-regex
   (re-pattern (str "fluree:(memory|file|ipfs)://.+")))
 
 (defn address?
   [s]
-  (and (string? s) (re-matches addr-regex s)))
+  (let [result (and (string? s) (re-matches addr-regex s))]
+    (when-not result
+      (log/trace "address? falsey result from:" s))
+    result))
 
 (def context-id-regex
   (re-pattern (str "fluree:context:" base64-pattern "{64}")))
 
 (defn context-id?
   [s]
-  (and (string? s) (re-matches context-id-regex s)))
+  (let [result (and (string? s) (re-matches context-id-regex s))]
+    (when-not result
+      (log/trace "context-id? falsey result from:" s))
+    result))
 
 (def db-id-regex
   (re-pattern (str "fluree:db:sha256:" base32-pattern "{52,53}")))
 
 (defn db-id?
   [s]
-  (and (string? s) (re-matches db-id-regex s)))
+  (let [result (and (string? s) (re-matches db-id-regex s))]
+    (when-not result
+      (log/trace "db-id? falsey result from:" s))
+    result))
 
 (def commit-id-regex
   (re-pattern (str "fluree:commit:sha256:" base32-pattern "{52,53}")))
 
 (defn commit-id?
   [s]
-  (and (string? s) (re-matches commit-id-regex s)))
+  (let [result (and (string? s) (re-matches commit-id-regex s))]
+    (when-not result
+      (log/trace "commit-id? falsey result from:" s))
+    result))
 
 (defn pred-match?
   "Does a deep compare of expected and actual map values but any predicate fns

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -248,7 +248,7 @@
     result))
 
 (def commit-id-regex
-  (re-pattern (str "fluree:commit:sha256:" base32-pattern "{52,53}")))
+  (re-pattern (str "fluree:commit:sha256:" base32-pattern "{51,53}")))
 
 (defn commit-id?
   [s]

--- a/test/fluree/db/transact/default_context_test.clj
+++ b/test/fluree/db/transact/default_context_test.clj
@@ -54,7 +54,8 @@
               "skos"   "http://www.w3.org/2008/05/skos#"
               "type"   "@type"
               "wiki"   "https://www.wikidata.org/wiki/"
-              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"
+              "graph"  "@graph"}
              (dbproto/-default-context db1))))
 
     (testing "Default context on original db and loaded db are identical."
@@ -79,7 +80,8 @@
               "skos"   "http://www.w3.org/2008/05/skos#"
               "type"   "@type"
               "wiki"   "https://www.wikidata.org/wiki/"
-              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"
+              "graph"  "@graph"}
              (dbproto/-default-context db-update-ctx))))
 
     (testing "Updated context db loaded is same as one before commit."
@@ -108,7 +110,8 @@
               "skos"   "http://www.w3.org/2008/05/skos#"
               "type"   "@type"
               "wiki"   "https://www.wikidata.org/wiki/"
-              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"
+              "graph"  "@graph"}
              @(fluree/default-context-at-t ledger-updated-load 1)))
 
       (is (= {"ex-new" "http://example.org/ns/"
@@ -121,7 +124,8 @@
               "skos"   "http://www.w3.org/2008/05/skos#"
               "type"   "@type"
               "wiki"   "https://www.wikidata.org/wiki/"
-              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"
+              "graph"  "@graph"}
              @(fluree/default-context-at-t ledger-updated-load 2))))
 
     (testing "Default contexts can be retrieved by ISO datetime"
@@ -135,7 +139,8 @@
               "skos"   "http://www.w3.org/2008/05/skos#"
               "type"   "@type"
               "wiki"   "https://www.wikidata.org/wiki/"
-              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"
+              "graph"  "@graph"}
              @(fluree/default-context-at-t ledger-updated-load "1972-01-01T00:00:00.00000Z")))
 
       (is (= {"ex-new" "http://example.org/ns/"
@@ -148,7 +153,8 @@
               "skos"   "http://www.w3.org/2008/05/skos#"
               "type"   "@type"
               "wiki"   "https://www.wikidata.org/wiki/"
-              "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+              "xsd"    "http://www.w3.org/2001/XMLSchema#"
+              "graph"  "@graph"}
              @(fluree/default-context-at-t ledger-updated-load "1982-01-01T00:00:00.00000Z"))))))
 
 (deftest ^:integration default-context-update-file-storage-test
@@ -205,7 +211,8 @@
                 :skos   "http://www.w3.org/2008/05/skos#"
                 :type   "@type"
                 :wiki   "https://www.wikidata.org/wiki/"
-                :xsd    "http://www.w3.org/2001/XMLSchema#"}
+                :xsd    "http://www.w3.org/2001/XMLSchema#"
+                :graph  "@graph"}
                @(fluree/default-context-at-t ledger-updated-load 1)))
 
         (is (= {:ex-new "http://example.org/ns/"
@@ -218,5 +225,6 @@
                 :skos   "http://www.w3.org/2008/05/skos#"
                 :type   "@type"
                 :wiki   "https://www.wikidata.org/wiki/"
-                :xsd    "http://www.w3.org/2001/XMLSchema#"}
+                :xsd    "http://www.w3.org/2001/XMLSchema#"
+                :graph  "@graph"}
                @(fluree/default-context-at-t ledger-updated-load 2)))))))


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/38

This changes top-level transaction `@context` merging of the conn's default-context into an explicit opt-in (via `["" {...}]` syntax OR by omitting a `@context` altogether like we do elsewhere) instead of always silently merging it.

I was hoping to re-use some existing code for this, but it's at the db level, and we don't even have a ledger yet in this context.