### PR TITLE
fix vocab flake filter

### DIFF
--- a/src/fluree/db/json_ld/ledger.cljc
+++ b/src/fluree/db/json_ld/ledger.cljc
@@ -130,6 +130,7 @@
 (def predicate-refs
   "The following predicates have objects that are refs to other predicates."
   #{const/$fluree:targetClass
+    const/$_predicate:equivalentProperty
     const/$rdfs:Class
     const/$rdfs:subClassOf
     const/$sh:alternativePath

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -973,7 +973,22 @@
                                                                          "f:equals" {"@list" [{"@id" "f:$identity"}
                                                                                               {"@id" "ex:user"}]}}}}]}})
 
-           committed @(fluree/commit! ledger db5)
+           db6 @(fluree/stage2 db5 {"@context" "https://ns.flur.ee",
+                                    "insert" [{"@id" "schema:givenName", "@type" "rdf:Property"}
+                                              {"@id" "ex:firstName",
+                                               "@type" "rdf:Property",
+                                               "owl:equivalentProperty" {"@id" "schema:givenName"}}
+                                              {"@id" "foaf:name",
+                                               "@type" "rdf:Property",
+                                               "owl:equivalentProperty" {"@id" "ex:firstName"}}]})
+
+           db7 @(fluree/stage2 db6 {"@context" "https://ns.flur.ee",
+                                    "insert" [{"@id" "ex:andrew", "schema:givenName" "Andrew"}
+                                              {"@id" "ex:freddy", "foaf:name" "Freddy"}
+                                              {"@id" "ex:letty", "ex:firstName" "Leticia"}
+                                              {"@id" "ex:betty", "ex:firstName" "Betty"}]})
+
+           committed @(fluree/commit! ledger db7)
            loaded    @(fluree/load conn ledger-id)]
        (is (= ["AP" "Dan" "KP" "NP"]
               @(fluree/query db1 {"where" [["?s" "ex:name" "?name"]]
@@ -1026,13 +1041,18 @@
                                   :opts {:did alice-did :role "ex:userRole"}}))
            "userRole user can see all ex:Users but only their own ssn")
 
-       (is (= 132
+       (is (= #{"Freddy" "Betty" "Leticia" "Andrew"}
+              (set @(fluree/query db7 {"selectDistinct" "?name",
+                                       "where" [["?s" "schema:givenName" "?name"]]})))
+           "equivalentProperty annotations work")
+
+       (is (= 150
               (-> @(fluree/history ledger {:commit-details true :t {:from :latest}})
                   (first)
                   (get "f:commit")
                   (get "f:data")
                   (get "f:flakes"))))
-       (is (= 132
+       (is (= 150
               (-> @(fluree/history loaded {:commit-details true :t {:from :latest}})
                   (first)
                   (get "f:commit")

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -24,6 +24,8 @@
   {"id"     "@id"
    "type"   "@type"
    "graph"  "@graph"
+   "foaf"   "http://xmlns.com/foaf/0.1/"
+   "owl"    "http://www.w3.org/2002/07/owl#"
    "xsd"    "http://www.w3.org/2001/XMLSchema#"
    "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"


### PR DESCRIPTION
In the `hydrate-schema` function we need to extract all of the predicate sids from a sequence of new flakes. The old code used a `cond` wrongly presumed that the cases were mutually exclusive, when in fact each condition always needs to be checked. This commit removes the cond and instead always checks if the subject and the object of a flake could be a predicate id.

Fixes #599