### PR TITLE
make error-formatting work from servers

### DIFF
--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -79,7 +79,7 @@
            (if at
              (not (or from to))
              (or from to)))]
-        [:fn {:error/message "\"from\" value must be less than or equal to \"to\" value,"}
+        [:fn {:error/message "\"from\" value must be less than or equal to \"to\" value"}
          (fn [{:keys [from to]}] (if (and (number? from) (number? to))
                                    (<= from to)
                                    true))]]]]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -160,12 +160,22 @@
           (recur (pop path) (last path) path' p' m')
           (when m [(if (seq in) (mu/path->in schema path') (me/error-path error options)) m' p']))))))
 
+(def top-level-query-keys
+  #{:select
+    :where
+    :group-by
+    :groupBy
+    :order-by
+    :orderBy
+    :commit-details
+    :t
+    :history})
+
 (defn format-error
   [explained error error-opts]
   (let [{:keys [path value]} error
-        top-level-key (when-not (= ::m/extra-key (:type error))
-                        (some->  (first (filter keyword? path))
-                                 name))
+        top-level-key (some-> (first (filter top-level-query-keys path))
+                              name)
         top-level-message (when top-level-key
                             (str "Error in value for \"" top-level-key "\""))
         [_ root-message] (resolve-root-error-for-in


### PR DESCRIPTION
Part of #312 

Small fix to make sure error messages report valid top-level query keys when the error-formatting fn is used in coercion by h-a-g/server.

When querying via h-a-g/server, the query request schema wraps the fql schema in a dispatch (fql vs sparql). So we can't just assume that the first keyword is the actual top-level key of the query.
