### PR TITLE
Skip pending tests in cljtest alias

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -64,7 +64,7 @@
                  io.github.cap10morgan/test-with-files {:git/tag "v1.0.0"
                                                         :git/sha "9181a2e"}}
    :exec-fn     kaocha.runner/exec-fn
-   :exec-args   {}}
+   :exec-args   {:kaocha.filter/skip-meta [:pending]}}
 
   :cljstest
   {:extra-paths ["test" "dev-resources"]}


### PR DESCRIPTION
This is so we can add tests to drive out new features & fixes before
they pass and PR those new tests by themselves. Motivated by the tiny PR
Graphite workflow.