### PR TITLE
Add pending-tests alias and make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all deps jar install deploy nodejs browser webworker cljtest \
         cljs-browser-test cljs-node-test cljstest test eastwood ci clean \
         js-packages sync-package-json publish-nodejs publish-browser \
-        publish-webworker publish-js
+        publish-webworker publish-js pending-tests pt
 
 DOCS_MARKDOWN := $(shell find docs -name '*.md')
 DOCS_TARGETS := $(DOCS_MARKDOWN:docs/%.md=docs/%.html)
@@ -110,6 +110,11 @@ cljstest: cljs-browser-test cljs-node-test
 
 cljtest:
 	clojure -X:dev:cljtest
+
+pending-tests:
+	clojure -X:dev:pending-tests
+
+pt: pending-tests
 
 test: cljtest cljstest nodejs-test browser-test
 

--- a/deps.edn
+++ b/deps.edn
@@ -66,6 +66,15 @@
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/skip-meta [:pending]}}
 
+  :pending-tests
+  {:extra-paths ["test" "dev-resources" "test-resources"]
+   :extra-deps  {lambdaisland/kaocha                   {:mvn/version "1.87.1366"}
+                 org.clojure/test.check                {:mvn/version "1.1.1"}
+                 io.github.cap10morgan/test-with-files {:git/tag "v1.0.0"
+                                                        :git/sha "9181a2e"}}
+   :exec-fn     kaocha.runner/exec-fn
+   :exec-args   {:kaocha.filter/focus-meta [:pending]}}
+
   :cljstest
   {:extra-paths ["test" "dev-resources"]}
 


### PR DESCRIPTION
Allows running pending tests only w/ `make pending-tests` or `make pt`
for short. If no pending tests, runs all CLJ tests.