### PR TITLE
Cancel in-progress GH Actions runs on same non-main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: 13 01 * * *
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   docker-build-cache:
     name: docker build cache


### PR DESCRIPTION
... and same workflow