### PR TITLE
preserve txn context for txn clause expansion

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -9,6 +9,7 @@
             [fluree.db.nameservice.core :as nameservice]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util :refer [catch* try*]]
+            [fluree.db.util.context :as ctx-util]
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]
             [fluree.db.json-ld.credential :as cred]))
@@ -45,9 +46,13 @@
   (go-try
     (let [{txn :subject did :did} (or (<? (cred/verify txn))
                                       {:subject txn})
+          txn-context             (ctx-util/txn-context txn)
           expanded                (json-ld/expand txn)
           opts                    (util/get-first-value expanded const/iri-opts)
-          parsed-opts             (cond-> parsed-opts did (assoc :did did))
+          parsed-opts             (cond-> parsed-opts
+                                    did (assoc :did did)
+                                    txn-context (assoc :context txn-context))
+
           {:keys [maxFuel meta] :as parsed-opts*} (parse-opts opts parsed-opts)]
       (if (or maxFuel meta)
         (let [start-time   #?(:clj  (System/nanoTime)

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -32,9 +32,7 @@
   "Returns subject id or nil if no match."
   [db iri]
   (go-try
-    (some-> (<? (query-range/index-range db :post = [const/$xsd:anyURI iri]))
-            first
-            flake/s)))
+    (first (<? (query-range/index-range db :post = [const/$xsd:anyURI iri] {:flake-xf (map flake/s)})))))
 
 (defn expand-iri
   "Expands an IRI from the db's context."

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -32,7 +32,9 @@
   "Returns subject id or nil if no match."
   [db iri]
   (go-try
-    (first (<? (query-range/index-range db :post = [const/$xsd:anyURI iri] {:flake-xf (map flake/s)})))))
+    (some-> (<? (query-range/index-range db :post = [const/$xsd:anyURI iri]))
+            first
+            flake/s)))
 
 (defn expand-iri
   "Expands an IRI from the db's context."

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -681,8 +681,9 @@
                  (<? (perm/wrap-policy db policy-opts))
                  db)
            tx-state      (->tx-state2 db*)
-           context       (ctx-util/extract db* txn parsed-opts)
-           parsed-txn    (q-parse/parse-txn txn context)
+
+           txn-context   (dbproto/-context db* (:context parsed-opts))
+           parsed-txn    (q-parse/parse-txn txn txn-context db*)
            flakes-ch     (generate-flakes db fuel-tracker parsed-txn tx-state)
            fuel-error-ch (:error-ch fuel-tracker)
            chans         (remove nil? [fuel-error-ch flakes-ch])

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -683,7 +683,7 @@
            tx-state      (->tx-state2 db*)
 
            txn-context   (dbproto/-context db* (:context parsed-opts))
-           parsed-txn    (q-parse/parse-txn txn txn-context db*)
+           parsed-txn    (q-parse/parse-txn txn txn-context)
            flakes-ch     (generate-flakes db fuel-tracker parsed-txn tx-state)
            fuel-error-ch (:error-ch fuel-tracker)
            chans         (remove nil? [fuel-error-ch flakes-ch])

--- a/src/fluree/db/query/exec/update.cljc
+++ b/src/fluree/db/query/exec/update.cljc
@@ -146,15 +146,15 @@
               [s-mch p-mch o-mch] (where/assign-matched-values triple solution nil)
 
               s-cmp  (if (string? (::where/val s-mch))
-                       (assoc s-mch ::where/val (<? (dbproto/-subid db (::where/val s-mch) true)))
+                       (assoc s-mch ::where/val (<? (dbproto/-subid db (::where/val s-mch) {:expand? false})))
                        s-mch)
 
               p-cmp  (if (string? (::where/val p-mch))
-                       (assoc p-mch ::where/val (<? (dbproto/-subid db (::where/val p-mch) true)))
+                       (assoc p-mch ::where/val (<? (dbproto/-subid db (::where/val p-mch) {:expand? false})))
                        p-mch)
               o-cmp  (if (and (= const/$xsd:anyURI (::where/val o-mch))
                               (string? (::where/val o-mch)))
-                       (assoc o-mch ::where/val (<? (dbproto/-subid db (::where/val o-mch) true)))
+                       (assoc o-mch ::where/val (<? (dbproto/-subid db (::where/val o-mch) {:expand? false})))
                        o-mch)]
           (async/pipe (where/resolve-flake-range db fuel-tracker retract-xf error-ch [s-cmp p-cmp o-cmp])
                       retract-flakes-ch))
@@ -215,25 +215,25 @@
             dt (::where/datatype o-mch)
             m  (::where/m o-mch)
 
-            existing-sid   (<? (dbproto/-subid db s))
+            existing-sid   (<? (dbproto/-subid db s {:expand? false}))
             [sid s-iri]    (if (temp-bnode? s)
                              (let [bnode-sid (next-sid s)]
                                [bnode-sid (bnode-id bnode-sid)])
                              [(or existing-sid (get jld-ledger/predefined-properties s) (next-sid s)) s])
             new-subj-flake (when-not existing-sid (create-id-flake sid s-iri t))
 
-            existing-pid   (<? (dbproto/-subid db p))
+            existing-pid   (<? (dbproto/-subid db p {:expand? false}))
             pid            (or existing-pid (get jld-ledger/predefined-properties p) (next-pid p))
             new-pred-flake (when-not existing-pid (create-id-flake pid p t))
 
-            existing-dt  (when dt (<? (dbproto/-subid db dt)))
+            existing-dt  (when dt (<? (dbproto/-subid db dt {:expand? false})))
             dt-sid       (cond existing-dt  existing-dt
                                (string? dt) (or (get jld-ledger/predefined-properties dt) (next-pid dt))
                                :else        (datatype/infer o (:lang m)))
             new-dt-flake (when (and (not existing-dt) (string? dt)) (create-id-flake dt-sid dt t))
 
             ref?             (= dt const/iri-id)
-            existing-ref-sid (when ref? (<? (dbproto/-subid db o)))
+            existing-ref-sid (when ref? (<? (dbproto/-subid db o {:expand? false})))
             ref-sid          (when ref?
                                (if existing-ref-sid
                                  existing-ref-sid

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -229,8 +229,8 @@
                             {:s parsed-query}
                             parsed-query)
 
-          [s p o] [(when s (<? (dbproto/-subid db (jld-db/expand-iri db s context) true)))
-                   (when p (<? (dbproto/-subid db (jld-db/expand-iri db p context) true)))
+          [s p o] [(when s (<? (dbproto/-subid db (jld-db/expand-iri db s context) {:strict? true})))
+                   (when p (<? (dbproto/-subid db (jld-db/expand-iri db p context) {:strict? true})))
                    (when o (jld-db/expand-iri db o context))]
 
           idx     (index/for-components s p o nil)

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -1054,3 +1054,48 @@
                   (get "f:commit")
                   (get "f:data")
                   (get "f:flakes")))))))
+
+(deftest context-handling
+  (let [conn      @(fluree/connect {:method :memory})
+        ledger-id "update-syntax"
+        ledger    @(fluree/create conn ledger-id {:defaultContext [test-utils/default-str-context
+                                                                   {"ex" "http://example.com/"}]})
+        db0       (fluree/db ledger)]
+    (testing "use default context"
+      (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+                                     "insert"   {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
+
+        (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
+               @(fluree/query db1 {"@context"  nil
+                                   "where"     [["?s" "@id" "http://example.com/t1"]
+                                                ["?s" "@type" "my:ContextTest"]]
+                                   "selectOne" {"?s" ["*"]}}))
+            "default context was used to expand")))
+
+    (testing "use instead of default context"
+      (let [db2 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {"ex" "DEFAULTOVERRIDEN:ns/"}]
+                                     "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
+        (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
+               @(fluree/query db2 {"@context"  nil
+                                   "where"     [["?s" "@id" "DEFAULTOVERRIDEN:ns/t2"]]
+                                   "selectOne" {"?s" ["*"]}}))
+            "supplied context used, default context not used")))
+
+    (testing "use with default context"
+      (let [db3 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" "" {"foo" "ns:foo/"}]
+                                     "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
+        (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
+               @(fluree/query db3 {"@context"  nil
+                                   "where"     [["?s" "@id" "http://example.com/t3"]]
+                                   "selectOne" {"?s" ["*"]}}))
+            "default context used, supplemented by supplied context")))
+
+    (testing "use no context"
+      ;; clearing context with nil produces an error because `insert` can't be found
+      (let [db4 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {}]
+                                     "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
+        (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
+               @(fluree/query db4 {"@context"  nil
+                                   "where"     [["?s" "@id" "ex:t4"]]
+                                   "selectOne" {"?s" ["*"]}}))
+            "no default context was used")))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -1055,42 +1055,43 @@
                   (get "f:data")
                   (get "f:flakes")))))))
 
-(deftest context-handling
-  (let [conn      @(fluree/connect {:method :memory})
-        ledger-id "update-syntax"
-        ledger    @(fluree/create conn ledger-id {:defaultContext [test-utils/default-str-context
-                                                                   {"ex" "http://example.com/"}]})
-        db0       (fluree/db ledger)]
-    (testing "use default context"
-      (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
-                                     "insert"   {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
+#?(:clj
+   (deftest context-handling
+     (let [conn      @(fluree/connect {:method :memory})
+           ledger-id "update-syntax"
+           ledger    @(fluree/create conn ledger-id {:defaultContext [test-utils/default-str-context
+                                                                      {"ex" "http://example.com/"}]})
+           db0       (fluree/db ledger)]
+       (testing "use default context"
+         (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+                                        "insert"   {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
 
-        (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
-               @(fluree/query db1 {"@context"  nil
-                                   "selectOne" {"http://example.com/t1" ["*"]}}))
-            "default context was used to expand")))
+           (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
+                  @(fluree/query db1 {"@context"  nil
+                                      "selectOne" {"http://example.com/t1" ["*"]}}))
+               "default context was used to expand")))
 
-    (testing "use instead of default context"
-      (let [db2 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {"ex" "DEFAULTOVERRIDEN:ns/"}]
-                                     "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
-        (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
-               @(fluree/query db2 {"@context"  nil
-                                   "selectOne" {"DEFAULTOVERRIDEN:ns/t2" ["*"]}}))
-            "supplied context used, default context not used")))
+       (testing "use instead of default context"
+         (let [db2 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {"ex" "DEFAULTOVERRIDEN:ns/"}]
+                                        "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
+           (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
+                  @(fluree/query db2 {"@context"  nil
+                                      "selectOne" {"DEFAULTOVERRIDEN:ns/t2" ["*"]}}))
+               "supplied context used, default context not used")))
 
-    (testing "use with default context"
-      (let [db3 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" "" {"foo" "ns:foo/"}]
-                                     "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
-        (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
-               @(fluree/query db3 {"@context"  nil
-                                   "selectOne" {"http://example.com/t3" ["*"]}}))
-            "default context used, supplemented by supplied context")))
+       (testing "use with default context"
+         (let [db3 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" "" {"foo" "ns:foo/"}]
+                                        "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
+           (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
+                  @(fluree/query db3 {"@context"  nil
+                                      "selectOne" {"http://example.com/t3" ["*"]}}))
+               "default context used, supplemented by supplied context")))
 
-    (testing "use no context"
-      ;; clearing context with nil produces an error because `insert` can't be found
-      (let [db4 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {}]
-                                     "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
-        (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
-               @(fluree/query db4 {"@context"  nil
-                                   "selectOne" {"ex:t4" ["*"]}}))
-            "no default context was used")))))
+       (testing "use no context"
+         ;; clearing context with nil produces an error because `insert` can't be found
+         (let [db4 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {}]
+                                        "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
+           (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
+                  @(fluree/query db4 {"@context"  nil
+                                      "selectOne" {"ex:t4" ["*"]}}))
+               "no default context was used"))))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -1067,9 +1067,7 @@
 
         (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
                @(fluree/query db1 {"@context"  nil
-                                   "where"     [["?s" "@id" "http://example.com/t1"]
-                                                ["?s" "@type" "my:ContextTest"]]
-                                   "selectOne" {"?s" ["*"]}}))
+                                   "selectOne" {"http://example.com/t1" ["*"]}}))
             "default context was used to expand")))
 
     (testing "use instead of default context"
@@ -1077,8 +1075,7 @@
                                      "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
         (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
                @(fluree/query db2 {"@context"  nil
-                                   "where"     [["?s" "@id" "DEFAULTOVERRIDEN:ns/t2"]]
-                                   "selectOne" {"?s" ["*"]}}))
+                                   "selectOne" {"DEFAULTOVERRIDEN:ns/t2" ["*"]}}))
             "supplied context used, default context not used")))
 
     (testing "use with default context"
@@ -1086,8 +1083,7 @@
                                      "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
         (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
                @(fluree/query db3 {"@context"  nil
-                                   "where"     [["?s" "@id" "http://example.com/t3"]]
-                                   "selectOne" {"?s" ["*"]}}))
+                                   "selectOne" {"http://example.com/t3" ["*"]}}))
             "default context used, supplemented by supplied context")))
 
     (testing "use no context"
@@ -1096,6 +1092,5 @@
                                      "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
         (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
                @(fluree/query db4 {"@context"  nil
-                                   "where"     [["?s" "@id" "ex:t4"]]
-                                   "selectOne" {"?s" ["*"]}}))
+                                   "selectOne" {"ex:t4" ["*"]}}))
             "no default context was used")))))

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1289,12 +1289,14 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                             "SHACL PropertyShape exception - sh:in: value must be one of "))
 
       (is (not (util/exception? db3)))
-      (is (= [{"id"       "ex:PastelPony"
-               "type" "ex:Pony"
-               "ex:color" [{"id" "ex:Pink"} {"id" "ex:Purple"}]}]
-             @(fluree/query db3 '{"select" {"?p" ["*"]}
-                                  "where"  {"id" "?p"
-                                            "type" "ex:Pony"}})))))
+      (is (= {"id"       "ex:PastelPony"
+              "type" "ex:Pony"
+              "ex:color" [{"id" "ex:Pink"} {"id" "ex:Purple"}]}
+             (-> @(fluree/query db3 '{"select" {"?p" ["*"]}
+                                      "where"  {"id" "?p"
+                                                "type" "ex:Pony"}})
+                 first
+                 (update "ex:color" (partial sort-by #(get % "id"))))))))
   (testing "mixed values and refs"
     (let [conn   @(fluree/connect {:method :memory
                                    :defaults

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -310,11 +310,12 @@
                               #"Invalid transaction, missing required keys: .+ledger"
                               @(fluree/transact! conn txn nil)))))))
 
-(deftest ^:pending base-and-vocab-test
+(deftest ^:integration base-and-vocab-test
   (testing "@base & @vocab work w/ stage"
-    (let [conn        (test-utils/create-conn)
+    (let [conn        @(fluree/connect {:method :memory})
           ctx         {"@base"  "http://example.org/"
-                       "@vocab" "http://example.org/terms/"}
+                       "@vocab" "http://example.org/terms/"
+                       "f"      "https://ns.flur.ee/ledger#"}
           ledger-name "cookbook/base"
           txn         {"@context" ctx
                        "f:ledger" ledger-name
@@ -332,7 +333,7 @@
                                  "where"    '{"@id" ?m
                                               "@type" "http://example.org/terms/SeaMonster"}})))))
   (testing "@base & @vocab work w/ stage2"
-    (let [conn        (test-utils/create-conn)
+    (let [conn        @(fluree/connect {:method :memory})
           ctx         ["https://ns.flur.ee"
                        {"@base"  "http://example.org/"
                         "@vocab" "http://example.org/terms/"}]


### PR DESCRIPTION
If a user supplies additional context for a transaction we need to preserve it after the initial expansion for second round when we expand the @type @json values.