### PR TITLE
Update test-with-files to v1.0.1

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -62,8 +62,8 @@
   {:extra-paths ["test" "dev-resources" "test-resources"]
    :extra-deps  {lambdaisland/kaocha                   {:mvn/version "1.87.1366"}
                  org.clojure/test.check                {:mvn/version "1.1.1"}
-                 io.github.cap10morgan/test-with-files {:git/tag "v1.0.0"
-                                                        :git/sha "9181a2e"}}
+                 io.github.cap10morgan/test-with-files {:git/tag "v1.0.1"
+                                                        :git/sha "a48d6d0"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/skip-meta [:pending]}}
 
@@ -71,8 +71,8 @@
   {:extra-paths ["test" "dev-resources" "test-resources"]
    :extra-deps  {lambdaisland/kaocha                   {:mvn/version "1.87.1366"}
                  org.clojure/test.check                {:mvn/version "1.1.1"}
-                 io.github.cap10morgan/test-with-files {:git/tag "v1.0.0"
-                                                        :git/sha "9181a2e"}}
+                 io.github.cap10morgan/test-with-files {:git/tag "v1.0.1"
+                                                        :git/sha "a48d6d0"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/focus-meta [:pending]}}
 


### PR DESCRIPTION
This makes temp file deletes fail silently, which is better than blowing
up a whole test run because a temp file wouldn't delete for whatever
reason.