### PR TITLE
Coerce the where clauses in where,insert,delete txns

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -343,7 +343,10 @@
 (defn parse-where
   [q vars context]
   (when-let [where (:where q)]
-    (parse-where-clause where vars context)))
+    (-> where
+        syntax/coerce-where
+        (log/debug->val "coerced where clause:")
+        (parse-where-clause vars context))))
 
 (defn parse-as-fn
   [f]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -193,6 +193,19 @@
           (ex-info {:status 400, :error :db/invalid-query})
           throw))))
 
+(def coerce-where*
+  (m/coercer ::where fql-transformer {:registry registry}))
+
+(defn coerce-where
+  [where]
+  (try*
+    (coerce-where* where)
+    (catch* e
+      (-> e
+          humanize-error
+          (ex-info {:status 400, :error :db/invalid-query})
+          throw))))
+
 (def parse-selector
   (m/parser ::selector {:registry registry}))
 

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -169,10 +169,13 @@
   [x]
   (triple-validator x))
 
+(def fql-transformer
+  (mt/transformer
+   {:name     :fql
+    :decoders (mt/-json-decoders)}))
+
 (def coerce-query*
-  (m/coercer ::query (mt/transformer {:name :fql}) {:registry registry}))
-
-
+  (m/coercer ::query fql-transformer {:registry registry}))
 
 (defn humanize-error
   [error]
@@ -210,7 +213,7 @@
   (m/parser ::selector {:registry registry}))
 
 (def coerce-modification*
-  (m/coercer ::modification (mt/transformer {:name :fql}) {:registry registry}))
+  (m/coercer ::modification fql-transformer {:registry registry}))
 
 (defn coerce-modification
   [mdfn]

--- a/src/fluree/db/query/history.cljc
+++ b/src/fluree/db/query/history.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.query.history
   (:require [clojure.core.async :as async :refer [go >! <!]]
+            [fluree.db.query.fql.syntax :as syntax]
             [malli.core :as m]
             [malli.transform :as mt]
             [fluree.json-ld :as json-ld]
@@ -114,8 +115,7 @@
        - positive t-value
        - datetime string
        - :latest keyword"
-  (m/coercer ::history-query (mt/transformer {:name :fql})
-             {:registry registry}))
+  (m/coercer ::history-query syntax/fql-transformer {:registry registry}))
 
 (def explain-error
   (m/explainer ::history-query {:registry registry}))

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -294,10 +294,10 @@
                             [:collection [:sequential ::where-pattern]]]
     ::union                [:sequential [:sequential ::where-pattern]]
     ::bind                 [:map-of {:error/message "Invalid bind, must be a map with variable keys"} ::var :any]
-    ::where-op             [:enum {:decode/fql  string->keyword
-                                   :decode/json string->keyword
-                                   :error/message "Unrecognized operation in where map, must be one of: filter, optional, union, bind"}
-                            :filter :optional :union :bind]
+    ::where-op             [:and
+                            :keyword
+                            [:enum {:error/message "Unrecognized operation in where map, must be one of: filter, optional, union, bind"}
+                             :filter :optional :union :bind]]
     ::graph                [:orn {:error/message "Value of \"graph\" should be ledger alias or variable"}
                             [:ledger ::ledger]
                             [:variable ::var]]


### PR DESCRIPTION
Coerce the where clauses in where,insert,delete txns

So things like "optional" get decoded into :optional

Pull json decoders into fql transformer

...so we can coerce things to keywords by just declaring them as such in
the schema.