### PR TITLE
Feature/where object vectors

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -52,11 +52,12 @@
                              values)
                         {:status 400 :error :db/invalid-query}))))))
 
-(def type-preds #{const/iri-type const/iri-rdf-type})
+(def type-pred-iris #{const/iri-type const/iri-rdf-type})
 
-(defn type-pred?
-  [p]
-  (contains? type-preds p))
+(defn type-pred-match?
+  [p-mch]
+  (let [p-iri (::where/iri p-mch)]
+    (contains? type-pred-iris p-iri)))
 
 (defn safe-read
   [code-str]
@@ -250,35 +251,44 @@
 
 (declare parse-statements)
 
+(defn parse-object-map
+  [s-mch p-mch o context]
+  (let [o* (expand-keys o context)]
+    (if-let [v (get o* const/iri-value)]
+      (let [attrs (dissoc o* const/iri-value)
+            o-mch (parse-value-attributes v attrs)]
+        [[s-mch p-mch o-mch]])
+      (let [id-map  (with-id o*)
+            o-mch   (-> id-map
+                        (get const/iri-id)
+                        (parse-subject context))
+            o-attrs (dissoc id-map const/iri-id)]
+        ;; return a thunk wrapping the recursive call to preserve stack
+        ;; space by delaying execution
+        #(into [[s-mch p-mch o-mch]]
+               (parse-statements o-mch o-attrs context))))))
+
 (defn parse-statement*
   [s-mch p-mch o context]
-  (if (map? o)
-    (let [o* (expand-keys o context)]
-      (if-let [v (get o* const/iri-value)]
-        (let [attrs (dissoc o* const/iri-value)
-              o-mch (parse-value-attributes v attrs)]
-          [[s-mch p-mch o-mch]])
-        (let [id-map  (with-id o*)
-              o-mch   (-> id-map
-                          (get const/iri-id)
-                          (parse-subject context))
-              o-attrs (dissoc id-map const/iri-id)]
-          ;; return a thunk wrapping the recursive call to preserve stack
-          ;; space by delaying execution
-          #(into [[s-mch p-mch o-mch]]
-                 (parse-statements o-mch o-attrs context)))))
-    (if (v/variable? o)
-      (let [o-mch (parse-variable o)]
-        [[s-mch p-mch o-mch]])
-      (if (-> p-mch ::where/iri type-pred?)
-        (let [class-ref (parse-class o context)]
-          [(where/->pattern :class [s-mch p-mch class-ref])])
-        (let [o-mch (where/anonymous-value o)]
-          [[s-mch p-mch o-mch]])))))
+  (cond
+    (v/variable? o)
+    (let [o-mch (parse-variable o)]
+      [[s-mch p-mch o-mch]])
+
+    (map? o)
+    (parse-object-map s-mch p-mch o context)
+
+    (type-pred-match? p-mch)
+    (let [class-ref (parse-class o context)]
+      [(where/->pattern :class [s-mch p-mch class-ref])])
+
+    :else
+    (let [o-mch (where/anonymous-value o)]
+      [[s-mch p-mch o-mch]])))
 
 (defn parse-statement
-  [s-mch p o context]
-  (trampoline parse-statement* s-mch p o context))
+  [s-mch p-mch o context]
+  (trampoline parse-statement* s-mch p-mch o context))
 
 (defn parse-statements*
   [s-mch attrs context]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -249,7 +249,7 @@
     (parse-variable p)
     (where/->predicate p)))
 
-(declare parse-statements)
+(declare parse-statement parse-statements)
 
 (defn parse-object-map
   [s-mch p-mch o context]
@@ -277,6 +277,11 @@
 
     (map? o)
     (parse-object-map s-mch p-mch o context)
+
+    (sequential? o)
+    #(mapcat (fn [o*]
+               (parse-statement s-mch p-mch o* context))
+             o)
 
     (type-pred-match? p-mch)
     (let [class-ref (parse-class o context)]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -293,7 +293,7 @@
     ::node-map-key         [:orn {:error/message "node map keys must be an iri or variable"}
                             [:iri ::iri]
                             [:var ::var]]
-    ::node-map-value       [:orn {:error/message "node map values must be an iri, string, number, boolean, map, or variable"}
+    ::node-map-value       [:orn {:error/message "node map values must be an iri, string, number, boolean, map, variable, or array"}
                             [:var ::var]
                             [:string :string]
                             [:boolean :boolean]
@@ -301,7 +301,8 @@
                             [:double :double]
                             [:nil :nil]
                             [:iri ::iri]
-                            [:map [:ref ::node-map]]]
+                            [:map [:ref ::node-map]]
+                            [:collection [:sequential [:ref ::node-map-value]]]]
     ::node-map             [:map-of {:error/message "Invalid node map"}
                             [:ref ::node-map-key] [:ref ::node-map-value]]
     ::where-pattern        [:multi {:dispatch where-pattern-type}

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -175,9 +175,7 @@
                                                     "ex:hours" "?hours"
                                                     "ex:minutes" "?minutes"
                                                     "ex:seconds" "?seconds"
-                                                    "ex:tz" "?tz1"}
-                                                   {"id" "?s"
-                                                    "ex:tz" "?tz2"}]
+                                                    "ex:tz" ["?tz1" "?tz2"]}]
                                          "values" ["?s" ["ex:datetime-fns"]]}))]
           (is (= {"ex:now" "2023-06-13T19:53:57.234345Z"
                   "ex:year" 2023
@@ -253,9 +251,7 @@
                                         "insert" [{"id" "?s"
                                                    "ex:strStarts" "?a-start"
                                                    "ex:strEnds" "?a-end"
-                                                   "ex:subStr" "?sub1"}
-                                                  {"id" "?s"
-                                                   "ex:subStr" "?sub2"
+                                                   "ex:subStr" ["?sub1" "?sub2"]
                                                    "ex:strLen" "?strlen"
                                                    "ex:ucase" "?upcased"
                                                    "ex:lcase" "?downcased"
@@ -309,9 +305,7 @@
                                           "insert" [{"id" "?s"
                                                      "ex:uuid" "?uuid"
                                                      "ex:struuid" "?struuid"
-                                                     "ex:str" "?str"}
-                                                    {"id" "?s"
-                                                     "ex:str" "?str2"
+                                                     "ex:str" ["?str" "?str2"]
                                                      "ex:isNumeric" "?isnum"
                                                      "ex:isNotNumeric" "?isNotNum"
                                                      "ex:isBlank" "?isBlank"
@@ -325,14 +319,14 @@
                   "ex:isNumeric" true
                   "ex:isNotNumeric" false}
                  @(fluree/query @updated {"selectOne" {"ex:rdf-term-fns" ["ex:isIRI" "ex:isURI" "ex:isLiteral"
-                                                             "ex:lang" "ex:datatype" "ex:IRI" "ex:bnode" "ex:strdt" "ex:strLang"
-                                                             "ex:isBlank"
-                                                             "ex:isNotBlank"
-                                                             "ex:isNumeric"
-                                                             "ex:isNotNumeric"
-                                                             "ex:str"
-                                                             "ex:uuid"
-                                                             "ex:struuid"]}}))))))
+                                                                          "ex:lang" "ex:datatype" "ex:IRI" "ex:bnode" "ex:strdt" "ex:strLang"
+                                                                          "ex:isBlank"
+                                                                          "ex:isNotBlank"
+                                                                          "ex:isNumeric"
+                                                                          "ex:isNotNumeric"
+                                                                          "ex:str"
+                                                                          "ex:uuid"
+                                                                          "ex:struuid"]}}))))))
 
     (testing "functional forms"
       (let [updated (-> @(fluree/stage db1 [{"id" "ex:create-predicates"
@@ -381,7 +375,7 @@
             run-err   @(fluree/stage db2 {"delete" []
                                           "where" [{"id" "?s", "ex:text" "?text"}
                                                    ["bind" "?err" "(abs ?text)"]]
-                                          "insert" [["?s" "ex:error" "?err"]]
+                                          "insert" {"id" "?s", "ex:error" "?err"}
                                           "values" ["?s" ["ex:error"]]})]
         (is (= "Query function references illegal symbol: foo"
                (-> parse-err


### PR DESCRIPTION
This patch builds on #631 to allow for nested vectors in the node maps found in where clauses as well as insert/delete modifications, allowing for where clauses like this:

```clojure
'{"@context" {"foaf" "http://xmlns.com/foaf/0.1"
              "ex"   "http://example.com"}
  :select    ?name
  :where     {"foaf:name"  ?name
              "foaf:knows" [{"@id" "ex:Peter"}
                            {"@id" "ex:Paul"}
                            {"foaf:name" "Mary"}]}}
```