### PR TITLE
Feature/multiple clause optional

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -326,19 +326,19 @@
   (parse-node-map m context))
 
 (defmethod parse-pattern :union
-  [[_ & union] vars context]
+  [[_ & unions] vars context]
   (let [parsed (mapv (fn [clause]
                        (parse-where-clause clause vars context))
-                     union)]
+                     unions)]
     [(where/->pattern :union parsed)]))
 
 (defmethod parse-pattern :optional
-  [[_ & optional] vars context]
+  [[_ & optionals] vars context]
   (into []
         (comp (map (fn [clause]
                  (parse-where-clause clause vars context)))
               (map (partial where/->pattern :optional)))
-        optional))
+        optionals))
 
 (defmethod parse-pattern :bind
   [[_ & binds] _vars _context]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -333,9 +333,12 @@
     [(where/->pattern :union parsed)]))
 
 (defmethod parse-pattern :optional
-  [[_ optional] vars context]
-  (let [parsed (parse-where-clause optional vars context)]
-    [(where/->pattern :optional parsed)]))
+  [[_ & optional] vars context]
+  (into []
+        (comp (map (fn [clause]
+                 (parse-where-clause clause vars context)))
+              (map (partial where/->pattern :optional)))
+        optional))
 
 (defmethod parse-pattern :bind
   [[_ & binds] _vars _context]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -276,7 +276,7 @@
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]]
-    ::optional             [:+ {:error/message "optional clause must be a sequence of valid where clauses."}
+    ::optional             [:+ {:error/message "optional pattern must be a sequence of valid where clauses."}
                             [:schema [:ref ::where]]]
     ::union                [:+ {:error/message "union pattern must be a sequence of valid where clauses."}
                             [:schema [:ref ::where]]]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -276,8 +276,8 @@
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]]
-    ::optional             [:ref {:error/message "optional clause must be a valid where clause."}
-                            ::where]
+    ::optional             [:+ {:error/message "optional clause must be a sequence of valid where clauses."}
+                            [:schema [:ref ::where]]]
     ::union                [:+ {:error/message "union pattern must be a sequence of valid where clauses."}
                             [:schema [:ref ::where]]]
     ::bind                 [:+ {:error/message "bind values must be mappings from variables to functions"}
@@ -310,7 +310,9 @@
                             [:filter [:catn
                                       [:op ::where-op]
                                       [:fns [:* ::function]]]]
-                            [:optional [:tuple ::where-op [:ref ::optional]]]
+                            [:optional [:catn
+                                        [:op ::where-op]
+                                        [:clauses ::optional]]]
                             [:union [:catn
                                      [:op ::where-op]
                                      [:clauses ::union]]]

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -80,6 +80,18 @@
               ["Alice" "Green" "alice@flur.ee"]
               ["Brian" nil nil]]))
 
+      ;; query with two optionals in the same vector
+      (is (= @(fluree/query db '{:select [?name ?favColor ?email]
+                                 :where  [{:id          ?s
+                                           :type        :ex/User
+                                           :schema/name ?name}
+                                          [:optional
+                                           {:id ?s, :ex/favColor ?favColor}
+                                           {:id ?s, :schema/email ?email}]]})
+             [["Cam" nil "cam@flur.ee"]
+              ["Alice" "Green" "alice@flur.ee"]
+              ["Brian" nil nil]]))
+
       ;; optional with unnecessary embedded vector statement
       (is (= @(fluree/query db '{:select [?name ?favColor]
                                  :where  [{:id ?s


### PR DESCRIPTION
This patch allows for passing multiple where clauses in an optional pattern, and those clauses will be treated independently during query execution. This means users will no longer have to include multiple optional patterns if they want the clauses within them to be treated independently (although multiple optional patterns is still valid)

Instead of 
```clojure
'{:select [?name ?favColor ?email]
  :where  [{:id          ?s
            :type        :ex/User
            :schema/name ?name}
           [:optional {:id ?s, :ex/favColor ?favColor}]
           [:optional {:id ?s, :schema/email ?email}]]}
```

you can write
```clojure
'{:select [?name ?favColor ?email]
  :where  [{:id          ?s
            :type        :ex/User
            :schema/name ?name}
           [:optional
            {:id ?s, :ex/favColor ?favColor}
            {:id ?s, :schema/email ?email}]]}
```