### PR TITLE
Remove custom Java conn print-writers

### DIFF
--- a/src/fluree/db/conn/core.cljc
+++ b/src/fluree/db/conn/core.cljc
@@ -113,7 +113,7 @@
                              (or existing new-p-chan)))
         p-chan      (get-in new-state [:ledger ledger-alias])
         not-cached? (= p-chan new-p-chan)]
-    (log/debug "Registering ledger: " ledger-alias " not-cached? " not-cached?)
+    (log/debug "Registering ledger: " ledger-alias " cached? " (not not-cached?))
     [not-cached? p-chan]))
 
 (defn release-ledger

--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -178,12 +178,6 @@
        (-write w "#FileConnection ")
        (-write w (pr (conn-core/printer-map conn))))))
 
-#?(:clj
-   (defmethod print-method FileConnection [^FileConnection conn, ^Writer w]
-     (.write w (str "#FileConnection "))
-     (binding [*out* w]
-       (pr (conn-core/printer-map conn)))))
-
 (defn trim-last-slash
   [s]
   (if (str/ends-with? s "/")

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -88,11 +88,6 @@
        (-write w "#IPFSConnection ")
        (-write w (pr (conn-core/printer-map conn))))))
 
-#?(:clj
-   (defmethod print-method IPFSConnection [^IPFSConnection conn, ^Writer w]
-     (.write w (str "#IPFSConnection "))
-     (binding [*out* w]
-       (pr (conn-core/printer-map conn)))))
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -137,11 +137,6 @@
        (-write w "#MemoryConnection ")
        (-write w (pr (conn-core/printer-map conn))))))
 
-#?(:clj
-   (defmethod print-method MemoryConnection [^MemoryConnection conn, ^Writer w]
-     (.write w (str "#MemoryConnection "))
-     (binding [*out* w]
-       (pr (conn-core/printer-map conn)))))
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"

--- a/src/fluree/db/conn/remote.cljc
+++ b/src/fluree/db/conn/remote.cljc
@@ -73,11 +73,6 @@
        (-write w "#RemoteConnection ")
        (-write w (pr (conn-core/printer-map conn))))))
 
-#?(:clj
-   (defmethod print-method RemoteConnection [^RemoteConnection conn, ^Writer w]
-     (.write w (str "#RemoteConnection "))
-     (binding [*out* w]
-       (pr (conn-core/printer-map conn)))))
 
 (defn ledger-defaults
   "Normalizes ledger defaults settings"


### PR DESCRIPTION
The custom print-writers work in the REPL, but when building uberjars as a dependency (from fluree/server) a run-time exception of where it cannot find the namespace occurs.

I tried many things to get this to work, as we have used this for years for the ^FlureeDb Defrecord type without issue, and it presents no issue outside of uberjar building.

The concern, and reason I put these in to begin with, is now that a conn has pointers to ledgers, and ledgers have pointers to conn, there is an infinite loop of refs which when logging, will create a stack overflow.

Either we need to cache ledgers in its own global atom, eliminate a ledger needing a conn reference, or fix this print-writer else this issue now re-exists.