### PR TITLE
move `log/info` calls so we can keep custom print method

### DIFF
--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -110,6 +110,11 @@
   [conn context-key]
   (json/parse (read-address conn context-key) true))
 
+(defn close
+  [id state]
+  (log/info "Closing file connection" id)
+  (swap! state assoc :closed? true))
+
 (defrecord FileConnection [id state ledger-defaults parallelism msg-in-ch
                            nameservices serializer msg-out-ch lru-cache-atom]
 
@@ -128,9 +133,7 @@
        :cljs (async/go (json/parse (read-address conn index-address) true))))
 
   conn-proto/iConnection
-  (-close [_]
-    (log/info "Closing file connection" id)
-    (swap! state assoc :closed? true))
+  (-close [_] (close id state))
   (-closed? [_] (boolean (:closed? @state)))
   (-method [_] :file)
   (-parallelism [_] parallelism)

--- a/src/fluree/db/conn/ipfs.cljc
+++ b/src/fluree/db/conn/ipfs.cljc
@@ -17,6 +17,11 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+(defn close
+  [id state]
+  (log/info "Closing IPFS Connection" id)
+  (swap! state assoc :closed? true))
+
 ;; IPFS Connection object
 
 (defrecord IPFSConnection [id state ledger-defaults lru-cache-atom
@@ -34,9 +39,7 @@
     (ipfs/write ipfs-endpoint context-data))
 
   conn-proto/iConnection
-  (-close [_]
-    (log/info "Closing IPFS Connection" id)
-    (swap! state assoc :closed? true))
+  (-close [_] (close id state))
   (-closed? [_] (boolean (:closed? @state)))
   (-method [_] :ipfs)
   (-parallelism [_] parallelism)

--- a/src/fluree/db/conn/memory.cljc
+++ b/src/fluree/db/conn/memory.cljc
@@ -79,6 +79,10 @@
   [data-atom context-key]
   (read-data data-atom context-key))
 
+(defn close
+  [id state]
+  (log/info "Closing memory connection" id)
+  (swap! state assoc :closed? true))
 
 (defrecord MemoryConnection [id memory state ledger-defaults lru-cache-atom
                              parallelism msg-in-ch msg-out-ch nameservices data-atom]
@@ -90,9 +94,7 @@
   (-ctx-read [_ context-key] (go (read-context data-atom context-key)))
 
   conn-proto/iConnection
-  (-close [_]
-    (log/info "Closing memory connection" id)
-    (swap! state assoc :closed? true))
+  (-close [_] (close id state))
   (-closed? [_] (boolean (:closed? @state)))
   (-method [_] :memory)
   (-parallelism [_] parallelism)

--- a/src/fluree/db/conn/remote.cljc
+++ b/src/fluree/db/conn/remote.cljc
@@ -16,7 +16,10 @@
             [clojure.string :as str])
   #?(:clj (:import (java.io Writer))))
 
-
+(defn close
+   [id state]
+  (log/info "Closing remote connection" id)
+  (swap! state assoc :closed? true))
 
 (defrecord RemoteConnection [id server-state state lru-cache-atom serializer
                              nameservices ledger-defaults parallelism]
@@ -27,9 +30,7 @@
   (-index-file-read [_ index-address] (remote/remote-read state server-state index-address true))
 
   conn-proto/iConnection
-  (-close [_]
-    (log/info "Closing remote connection" id)
-    (swap! state assoc :closed? true))
+  (-close [_] (close id state))
   (-closed? [_] (boolean (:closed? @state)))
   (-method [_] :remote)
   (-parallelism [_] parallelism)


### PR DESCRIPTION
See https://github.com/fluree/db/pull/634#issuecomment-1789461600

We can't have `log/info` calls in `defrecord`s where we have overridden the print-method.

I tested this fix by doing the following over in `fluree/server`:
```
> make clean
> make uberjar
> java -jar target/server-0.1.47.jar
```

I now get this output: 
```
Caused by: clojure.lang.ExceptionInfo: Cannot start raft without a list of participating servers separated by a comma or semicolon. If this is a single server, please specify this-server instead of servers. {:status 400, :error :db/invalid-server-address}
	at fluree.server.consensus.core$add_server_configs.invokeStatic(core.clj:129)
	at fluree.server.consensus.core$add_server_configs.invoke(core.clj:126)
	at fluree.server.consensus.core$start.invokeStatic(core.clj:183)
	at fluree.server.consensus.core$start.invoke(core.clj:169)
	at fluree.server.components.consensus$start_raft.invokeStatic(consensus.clj:13)
	at fluree.server.components.consensus$start_raft.invoke(consensus.clj:9)
	at fluree.server.components.consensus$fn__77223.invokeStatic(consensus.clj:23)
	at fluree.server.components.consensus$fn__77223.invoke(consensus.clj:20)
	at donut.system$apply_stage_fn.invokeStatic(system.cljc:435)
	at donut.system$apply_stage_fn.invoke(system.cljc:432)
	at donut.system$handler_stage_fn$fn__9230.invoke(system.cljc:530)
	at donut.system$apply_signal_stage$fn__9262.invoke(system.cljc:568)
	... 15 more
```

Instead of this error:
```
Caused by: java.lang.RuntimeException: Can't resolve find-ns
	at clojure.lang.Util.runtimeException(Util.java:221)
	at clojure.lang.LispReader$EvalReader.invoke(LispReader.java:1329)
	at clojure.lang.LispReader$DispatchReader.invoke(LispReader.java:853)
	at clojure.lang.LispReader.read(LispReader.java:285)
	at clojure.lang.LispReader.read(LispReader.java:216)
	at clojure.lang.LispReader.read(LispReader.java:205)
	at clojure.lang.RT.readString(RT.java:1876)
	at clojure.lang.RT.readString(RT.java:1871)
	at fluree.db.conn.remote.RemoteConnection.<clinit>(remote.cljc:21)
	... 188 more
```
