### PR TITLE
Fix/credential test

### DIFF
--- a/src/fluree/db/query/exec/select.cljc
+++ b/src/fluree/db/query/exec/select.cljc
@@ -145,15 +145,15 @@
     [_ db iri-cache context compact error-ch solution]
     (go
       (try*
-        (let [db-alias (:alias db)
-              sid      (if (where/variable? subj)
-                         (-> solution
-                             (get subj)
-                             (where/get-sid db-alias))
-                         (<? (dbproto/-subid db subj true)))
-              flakes   (<? (query-range/index-range db :spot = [sid]))]
-          ;; TODO: Replace these nils with fuel values when we turn fuel back on
-          (<? (json-ld-resp/flakes->res db iri-cache context compact nil nil spec 0 flakes)))
+        (let [db-alias (:alias db)]
+          (when-let [sid (if (where/variable? subj)
+                           (-> solution
+                               (get subj)
+                               (where/get-sid db-alias))
+                           (<? (dbproto/-subid db subj false)))]
+            (let [flakes (<? (query-range/index-range db :spot = [sid]))]
+              ;; TODO: Replace these nils with fuel values when we turn fuel back on
+              (<? (json-ld-resp/flakes->res db iri-cache context compact nil nil spec 0 flakes)))))
         (catch* e
                 (log/error e "Error formatting subgraph for subject:" subj)
                 (>! error-ch e))))))

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -64,7 +64,9 @@
        (or (update/insert? x)
            (update/retract? x))
        (or (contains? x :where)
-           (contains? x "where"))))
+           (contains? x "where")
+           (contains? x :values)
+           (contains? x "values"))))
 
 (defn modify
   ([db t json-ld]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -249,6 +249,9 @@
     (parse-variable p)
     (where/->predicate p)))
 
+(def id-predicate-match
+  (parse-predicate const/iri-id))
+
 (declare parse-statement parse-statements)
 
 (defn parse-object-map
@@ -312,7 +315,10 @@
                   (get const/iri-id)
                   (parse-subject context))
         attrs (dissoc m const/iri-id)]
-    (parse-statements s-mch attrs context)))
+    (if (empty? attrs)
+      (let[o-mch (-> s-mch ::where/iri where/anonymous-value)]
+        [[s-mch id-predicate-match o-mch]])
+      (parse-statements s-mch attrs context))))
 
 (defn parse-node-map
   [m context]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -303,7 +303,8 @@
                             [:iri ::iri]
                             [:map [:ref ::node-map]]
                             [:collection [:sequential [:ref ::node-map-value]]]]
-    ::node-map             [:map-of {:error/message "Invalid node map"}
+    ::node-map             [:map-of {:error/message "Invalid node map"
+                                     :min 1}
                             [:ref ::node-map-key] [:ref ::node-map-value]]
     ::where-pattern        [:multi {:dispatch where-pattern-type
                                     :error/message "where clause patterns must be either a node map or a filter, optional, union, bind, or graph array."}

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -350,6 +350,6 @@
                              [:context {:optional true} ::context]
                              [:delete {:optional true} ::delete]
                              [:insert {:optional true} ::insert]
-                             [:where ::where]
+                             [:where {:optional true} ::where]
                              [:values {:optional true} ::values]]]
     ::context              :any}))

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -112,7 +112,7 @@
                     (done)))))))
 
 #?(:clj
-   (deftest ^:pending ^:integration cred-wrapped-transactions-and-queries
+   (deftest ^:integration cred-wrapped-transactions-and-queries
      (let [conn   @(fluree/connect {:method :memory})
            ledger @(fluree/create conn "credentialtest" {:defaultContext
                                                          [test-utils/default-str-context
@@ -131,12 +131,13 @@
            ;; can't use credentials until after an identity with a role has been created
            db1       @(test-utils/transact ledger tx)
 
-           mdfn {"delete" {"@id" "?s"
-                           "name" "Daniel"
+           mdfn {"delete" {"@id"     "?s"
+                           "name"    "Daniel"
                            "favnums" 1}
-                 "insert" {"@id" "?s"
-                           "name" "D"
+                 "insert" {"@id"     "?s"
+                           "name"    "D"
                            "favnums" [4 5 6]}
+                 "where"  {"@id" "?s"}
                  "values" ["?s" [(:id auth)]]}
 
            db2 @(test-utils/transact ledger (async/<!! (cred/generate mdfn (:private auth))))

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -131,17 +131,13 @@
            ;; can't use credentials until after an identity with a role has been created
            db1       @(test-utils/transact ledger tx)
 
-           mdfn {"delete" {"@id" (:id auth)
+           mdfn {"delete" {"@id" "?s"
                            "name" "Daniel"
                            "favnums" 1}
-                 "insert" [{"@id" (:id auth)
-                            "name" "D"}
-                           {"@id" (:id auth)
-                            "favnums" 4}
-                           {"@id" (:id auth)
-                            "favnums" 5}
-                           {"@id" (:id auth)
-                            "favnums" 6}]}
+                 "insert" {"@id" "?s"
+                           "name" "D"
+                           "favnums" [4 5 6]}
+                 "values" ["?s" [(:id auth)]]}
 
            db2 @(test-utils/transact ledger (async/<!! (cred/generate mdfn (:private auth))))
 


### PR DESCRIPTION
This patch fixes the credential tests that were marked pending after the fql syntax changes. 

It turns out the issue was not with json-ld expansion, but because this particular transaction wasn't recognized as a modification. Furthermore, the syntax changes had no way of doing a pure existence check during a modification for an already known iri.