### PR TITLE
Allow time-travel in query-connection using a global `t` value

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -198,7 +198,7 @@
              (empty? named))
       (let [alias (first defaults)]
         (<? (load-alias conn alias global-t opts))) ; return an unwrapped db if the data set
-                                               ; consists of one ledger
+                                                    ; consists of one ledger
       (let [all-aliases  (->> defaults (concat named) distinct)
             db-map       (<? (load-aliases conn all-aliases global-t opts))
             default-coll (-> db-map

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -180,13 +180,13 @@
       (<? (restrict-db db t opts)))))
 
 (defn load-aliases
-  [conn aliases opts]
+  [conn aliases global-t opts]
   (go-try
     (loop [[alias & r] aliases
            db-map      {}]
       (if alias
         ;; TODO: allow restricting federated dataset components individually by t
-        (let [db      (<? (load-alias conn alias nil opts))
+        (let [db      (<? (load-alias conn alias global-t opts))
               db-map* (assoc db-map alias db)]
           (recur r db-map*))
         db-map))))
@@ -200,7 +200,7 @@
         (<? (load-alias conn alias global-t opts))) ; return an unwrapped db if the data set
                                                ; consists of one ledger
       (let [all-aliases  (->> defaults (concat named) distinct)
-            db-map       (<? (load-aliases conn all-aliases opts))
+            db-map       (<? (load-aliases conn all-aliases global-t opts))
             default-coll (-> db-map
                              (select-keys defaults)
                              vals)

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -1,5 +1,6 @@
 (ns fluree.db.query.time-travel-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.util.core :as util]))
@@ -89,3 +90,44 @@
       (is (= 4 (count all-movies)))
       (is (util/exception? too-early))
       (is (re-matches #"There is no data as of .+" (ex-message too-early))))))
+
+(deftest ^:integration federated-time-travel-test
+  (testing "Federated queries with time travel"
+    (let [conn    (test-utils/create-conn {:defaults {:context-type :string
+                                                      :context      {"id"     "@id",
+                                                                     "type"   "@type",
+                                                                     "ex"     "http://example.org/",
+                                                                     "f"      "https://ns.flur.ee/ledger#",
+                                                                     "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                                                                     "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
+                                                                     "schema" "http://schema.org/",
+                                                                     "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
+
+          t1 @(fluree/create-with-txn conn
+                                      {"f:ledger" "test/time"
+                                       "@graph"   [{"@id"   "ex:time-test"
+                                                    "@type" "ex:foo"
+                                                    "ex:time" 1}]}
+                                      {:context-type :string})
+          t2 @(fluree/transact! conn {"f:ledger" "test/time"
+                                      "@graph"   [{"@id"   "ex:time-test"
+                                                   "ex:time" 2}]}
+                                {:context-type :string})]
+
+      (testing "Single ledger"
+        (let [q '{:from   "test/time"
+                  :select {"ex:time-test" ["*"]}
+                  :t      1}]
+          (is (= [{:id       "ex:time-test"
+                   :type     "ex:foo"
+                   "ex:time" 1}]
+                 @(fluree/query-connection conn q))
+              "should return only results for `t` of `1`"))
+        (let [q            '{:from   "test/time"
+                             :select {"ex:time-test" ["*"]}
+                             :t      "1988-05-30T12:40:44.823Z"}
+              invalid-time (try @(fluree/query-connection conn q)
+                                (catch Exception e e))]
+          (is (str/includes?  (ex-message invalid-time)
+                              "There is no data as of")
+              "should return an error"))))))

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -91,35 +91,65 @@
       (is (util/exception? too-early))
       (is (re-matches #"There is no data as of .+" (ex-message too-early))))))
 
-(deftest ^:integration federated-time-travel-test
-  (testing "Federated queries with time travel"
-    (let [conn    (test-utils/create-conn {:defaults {:context-type :string
-                                                      :context      {"id"     "@id",
-                                                                     "type"   "@type",
-                                                                     "ex"     "http://example.org/",
-                                                                     "f"      "https://ns.flur.ee/ledger#",
-                                                                     "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                                                                     "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
-                                                                     "schema" "http://schema.org/",
-                                                                     "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
+(deftest ^:integration query-connection-time-travel
+  (testing "query-connection queries with time travel"
+    (let [t1         "2023-11-04T00:00:00Z"
+          query-time "2023-11-05T00:00:00Z"
+          t2         "2023-11-06T00:00:00Z"
+          conn       @(fluree/connect {:method :memory
+                                       :defaults
+                                       {:context      {"id"     "@id",
+                                                       "type"   "@type",
+                                                       "ex"     "http://example.org/",
+                                                       "f"      "https://ns.flur.ee/ledger#",
+                                                       "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                                                       "rdfs"   "http://www.w3.org/2000/01/rdf-schema#",
+                                                       "schema" "http://schema.org/",
+                                                       "xsd"    "http://www.w3.org/2001/XMLSchema#"}
+                                        :context-type :string}})
 
-          ledger1 @(fluree/create-with-txn conn
-                                      {"f:ledger" "test/time1"
-                                       "@graph"   [{"@id"   "ex:time-test"
-                                                    "@type" "ex:foo"
-                                                    "ex:time" 1}]}
-                                      {:context-type :string})
-          _ @(fluree/transact! conn {"f:ledger" "test/time1"
-                                     "@graph"   [{"@id"   "ex:time-test"
-                                                  "ex:time" 2}]}
-                                {:context-type :string})]
-
+          ledger1 (with-redefs [util/current-time-iso (fn [] t1)]
+                    @(fluree/create-with-txn conn
+                                             {"f:ledger" "test/time1"
+                                              "@graph"   [{"@id"     "ex:time-test"
+                                                           "@type"   "ex:foo"
+                                                           "ex:time" 1}]}
+                                             {:context-type :string}))
+          ledger2 (with-redefs [util/current-time-iso (fn [] t1)]
+                    @(fluree/create-with-txn conn
+                                             {"f:ledger" "test/time2"
+                                              "@graph"   [{"@id"   "ex:time-test"
+                                                           "ex:p1" "value1"}
+                                                          {"@id"   "ex:foo"
+                                                           "ex:p2" "t1"}]}
+                                             {:context-type :string}))
+          _       (with-redefs [util/current-time-iso (fn [] t2)]
+                    @(fluree/transact! conn {"f:ledger" "test/time1"
+                                             "@graph"   [{"@id"     "ex:time-test"
+                                                          "ex:time" 2}]}
+                                       {:context-type :string}))
+          _       (with-redefs [util/current-time-iso (fn [] t2)]
+                    @(fluree/transact! conn
+                                       {"f:ledger" "test/time2"
+                                        "@graph"   [{"@id"   "ex:time-test"
+                                                     "ex:p1" "value2"}
+                                                    {"@id"   "ex:foo"
+                                                     "ex:p2" "t2"}]}
+                                       {:context-type :string}))]
       (testing "Single ledger"
         (let [q '{:from   "test/time1"
                   :select {"ex:time-test" ["*"]}
                   :t      1}]
-          (is (= [{:id       "ex:time-test"
-                   :type     "ex:foo"
+          (is (= [{"id"      "ex:time-test"
+                   "type"    "ex:foo"
+                   "ex:time" 1}]
+                 @(fluree/query-connection conn q))
+              "should return only results for `t` of `1`"))
+        (let [q {:from   "test/time1"
+                 :select {"ex:time-test" ["*"]}
+                 :t      query-time}]
+          (is (= [{"id"      "ex:time-test"
+                   "type"    "ex:foo"
                    "ex:time" 1}]
                  @(fluree/query-connection conn q))
               "should return only results for `t` of `1`"))
@@ -137,55 +167,41 @@
                              "test/time1")
               "message should report which ledger has an error")))
       (testing "Across multiple ledgers"
-        (let [ledger2 @(fluree/create-with-txn conn
-                                               {"f:ledger" "test/time2"
-                                                "@graph"   [{"@id"   "ex:time-test"
-                                                             "ex:p1" "value1"}
-                                                            {"@id" "ex:foo"
-                                                             "ex:p2" "t1"}]}
-                                               {:context-type :string})
-              _ @(fluree/transact! conn
-                                   {"f:ledger" "test/time2"
-                                    "@graph"   [{"@id"   "ex:time-test"
-                                                 "ex:p1" "value2"}
-                                                {"@id"   "ex:foo"
-                                                 "ex:p2" "t2"}]}
-                                   {:context-type :string})]
-
-          (let [q '{:from   ["test/time1" "test/time2"]
-                    :select [?p1 ?time]
-                    :where {"@id" "ex:time-test"
-                            "ex:p1" ?p1
-                            "ex:time" ?time}
-                    :t      1}]
-            (is (= [["value1" 1]]
-                   @(fluree/query-connection conn q))
-                "should return results for `t` of `1` across both ledgers")))
-        (let [q '{:from-named ["test/time1" "test/time2"]
-                  :select     [?p2 ?time]
-                  :where      [[:graph "test/time1" {"@id"     "ex:time-test"
-                                                     "ex:time" ?time}]
-                               [:graph "test/time2" {"@id"   "ex:foo"
-                                                     "ex:p2" ?p2}]]
-                  :t 1}]
-          (is (= [["t1" 1]]
+        (let [q {:from   ["test/time1" "test/time2"]
+                 :select '[?p1 ?time]
+                 :where  '{"@id"     "ex:time-test"
+                           "ex:p1"   ?p1
+                           "ex:time" ?time}
+                 :t      query-time}]
+          (is (= [["value1" 1]]
                  @(fluree/query-connection conn q))
-              "should be results as of `t` = 1 for both ledgers"))
-        (testing "Some ledgers do not have data for given t"
+              "should return results for first commit from both ledgers"))
+        (testing "from-named"
+          (let [q {:from-named ["test/time1" "test/time2"]
+                   :select     '[?p2 ?time]
+                   :where      '[[:graph "test/time1" {"@id"     "ex:time-test"
+                                                       "ex:time" ?time}]
+                                 [:graph "test/time2" {"@id"   "ex:foo"
+                                                       "ex:p2" ?p2}]]
+                   :t          query-time}]
+            (is (= [["t1" 1]]
+                   @(fluree/query-connection conn q))
+                "should be results as of `t` = 1 for both ledgers")))
+        (testing "Not all ledgers have data for given `t`"
           (with-redefs [util/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
             (let [ledger-valid @(fluree/create-with-txn conn
-                                                         {"f:ledger" "test/time-before"
-                                                          "@graph" [{"@id" "ex:time-test"
-                                                                     "ex:p1" "value"}]}
-                                                         {:context-type :string})]
-              (let [q '{:from   ["test/time1" "test/time-before"]
-                        :select [?p1 ?time]
-                        :where {"@id" "ex:time-test"
-                                "ex:p1" ?p1
-                                "ex:time" ?time}
-                        ;;`t` is valid for "ledger-valid",
-                        ;;but not "test/time1"
-                        :t      "1988-05-30T12:40:44.823Z"}
+                                                        {"f:ledger" "test/time-before"
+                                                         "@graph"   [{"@id"   "ex:time-test"
+                                                                      "ex:p1" "value"}]}
+                                                        {:context-type :string})]
+              (let [q            '{:from   ["test/time1" "test/time-before"]
+                                   :select [?p1 ?time]
+                                   :where  {"@id"     "ex:time-test"
+                                            "ex:p1"   ?p1
+                                            "ex:time" ?time}
+                                   ;;`t` is valid for "ledger-valid",
+                                   ;;but not "test/time1"
+                                   :t      "1988-05-30T12:40:44.823Z"}
                     invalid-time (try @(fluree/query-connection conn q)
                                       (catch Exception e e))]
                 (is (util/exception? invalid-time))
@@ -194,4 +210,19 @@
                                    "There is no data as of"))
                 (is (str/includes? (ex-message invalid-time)
                                    "test/time1")
-                    "message should report which ledger has an error")))))))))
+                    "message should report which ledger has an error")))))
+        (testing "Federated queries must use wall-clock time as global `t` value"
+          (with-redefs [util/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
+            (let [q            '{:from   ["test/time1" "test/time-before"]
+                                 :select [?p1 ?time]
+                                 :where  {"@id"     "ex:time-test"
+                                          "ex:p1"   ?p1
+                                          "ex:time" ?time}
+                                 :t      1}
+                  invalid-time (try @(fluree/query-connection conn q)
+                                    (catch Exception e e))]
+              (is (util/exception? invalid-time))
+              (is (= 400 (-> invalid-time ex-data :status)))
+              (is (str/includes? (ex-message invalid-time)
+                                 "Error in federated query: top-level `t` value")
+                  "error message should indicate invalid t value type"))))))))


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/50

Implements basic time travel for federated queries, wherein the `t` is applied globally to all the ledgers in the query.

If that `t` is invalid for any one of the ledgers, an error will be thrown. The query will only succeed if it's valid for all ledgers.

I also did a little work to add the alias of the failing ledger to 400 errors during loading (which is when you'll get errors for invalid `t`s), because just getting the underlying error without that context seemed confusing.

Someday we will probably want to enable supplying individual `t`s per ledger, but today is not that day.