### PR TITLE
store sh:datatype constraints in pred meta map

### DIFF
--- a/src/fluree/db/datatype.cljc
+++ b/src/fluree/db/datatype.cljc
@@ -412,6 +412,6 @@
   [value datatype]
   (let [value* (coerce value datatype)]
     (if (nil? value*)
-      (throw (ex-info (str "Data type " datatype " cannot be coerced from provided value: " value ".")
+      (throw (ex-info (str "Value " value " cannot be coerced to provided datatype: " datatype ".")
                       {:status 400 :error, :db/value-coercion}))
       value*)))

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -141,7 +141,7 @@
     (get-in schema [:coll collection property])))
 
 (defn- jsonld-p-prop [{:keys [schema] :as this} property predicate]
-  (assert (#{:name :id :iri :type :ref? :idx? :unique :multi :index :upsert
+  (assert (#{:name :id :iri :type :ref? :idx? :unique :multi :index :upsert :datatype
              :component :noHistory :restrictCollection :spec :specDoc :txSpec
              :txSpecDoc :restrictTag :retractDuplicates :subclassOf :new?} property)
           (str "Invalid predicate property: " (pr-str property)))

--- a/src/fluree/db/json_ld/vocab.cljc
+++ b/src/fluree/db/json_ld/vocab.cljc
@@ -246,24 +246,6 @@
     (let [schema  (<? (vocab-map db))]
       (assoc db :schema schema))))
 
-(defn schema
-  [vocab-flakes t]
-  (let [base-schema (base-schema)
-        schema      (update-with* base-schema t vocab-flakes)
-        refs        (extract-ref-sids (:pred schema))]
-    (-> schema
-        (assoc :refs refs))))
-
-(defn load-schema
-  [{:keys [preds t] :as db}]
-  (go-try
-    (loop [[pred-sid & r] preds
-           vocab-flakes (flake/sorted-set-by flake/cmp-flakes-spot)]
-      (if pred-sid
-        (let [pred-flakes (<? (query-range/index-range db :spot = [pred-sid]))]
-          (recur r (into vocab-flakes pred-flakes)))
-        (schema vocab-flakes t)))))
-
 (defn predicate-sids
   "Extract predicate sids from flakes."
   [flakes]
@@ -305,22 +287,27 @@
         (recur r res))
       res)))
 
-;; TODO: this cannot be reconstructed from just the pred sids, need to figure out loading
 (defn add-pred-datatypes
   "Add a :datatype key to the pred meta map for any predicates with a sh:datatype
   constraint. Only one datatype constraint can be valid for a given datatype, most
   recent wins."
-  [{:keys [pred] :as schema} new-flakes]
-  (-> schema
-      (assoc :pred (reduce (fn [pred [pid dt-constraint]]
-                             (let [{:keys [iri] :as pred-meta}
-                                   (-> (get pred pid)
-                                       (assoc :datatype dt-constraint))]
-                               (-> pred
-                                   (assoc pid pred-meta)
-                                   (assoc iri pred-meta))))
-                           pred
-                           (pred-dt-constraints new-flakes)))))
+  [{:keys [pred] :as schema} pred-tuples]
+  (reduce (fn [schema [pid dt]]
+            (let [{:keys [iri] :as pred-meta} (-> schema :pred (get pid)
+                                                  (assoc :datatype dt))]
+              (-> schema
+                  (assoc-in [:pred pid] pred-meta)
+                  (assoc-in [:pred iri] pred-meta))))
+          schema
+          pred-tuples))
+
+(defn build-schema
+  [vocab-flakes t]
+  (let [base-schema (base-schema)
+        schema      (update-with* base-schema t vocab-flakes)
+        refs        (extract-ref-sids (:pred schema))]
+    (-> schema
+        (assoc :refs refs))))
 
 (defn hydrate-schema
   "Updates the :schema key of a by processing just the vocabulary flakes out of the new flakes."
@@ -328,8 +315,8 @@
   (let [pred-sids    (predicate-sids new-flakes)
         vocab-flakes (filterv #(pred-sids (flake/s %)) new-flakes)
         {:keys [t refs coll pred shapes prefix fullText subclasses]}
-        (-> (schema vocab-flakes (:t db))
-            (add-pred-datatypes new-flakes))]
+        (-> (build-schema vocab-flakes (:t db))
+            (add-pred-datatypes (pred-dt-constraints new-flakes)))]
     (-> db
         (assoc-in [:schema :t] t)
         (update-in [:schema :refs] into refs)
@@ -339,3 +326,15 @@
         (update-in [:schema :fullText] into fullText)
         (assoc-in [:schema :subclasses] subclasses)
         (assoc-in [:schema :shapes] shapes))))
+
+(defn load-schema
+  [{:keys [preds t] :as db}]
+  (go-try
+    (loop [[[pred-sid datatype] & r] preds
+           vocab-flakes (flake/sorted-set-by flake/cmp-flakes-spot)]
+      (if pred-sid
+        (let [pred-flakes (<? (query-range/index-range db :spot = [pred-sid]))]
+          (recur r (into vocab-flakes pred-flakes)))
+        (-> (build-schema vocab-flakes (:t db))
+            ;; only use predicates that have a dt
+            (add-pred-datatypes (filterv #(> (count %) 1) preds)))))))

--- a/src/fluree/db/query/exec/update.cljc
+++ b/src/fluree/db/query/exec/update.cljc
@@ -218,10 +218,12 @@
             ref-iri      (where/get-iri o-mch)
             m            (where/get-meta o-mch)
             dt           (where/get-datatype o-mch)
+            sh-dt        (dbproto/-p-prop db :datatype p-iri)
             existing-dt  (when dt (<? (dbproto/-subid db dt {:expand? false})))
             dt-sid       (cond ref-iri      const/$xsd:anyURI
                                existing-dt  existing-dt
                                (string? dt) (or (get jld-ledger/predefined-properties dt) (next-pid dt))
+                               sh-dt        sh-dt
                                :else        (datatype/infer o-val (:lang m)))
             new-dt-flake (when (and (not existing-dt) (string? dt)) (create-id-flake dt-sid dt t))
 

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -128,11 +128,11 @@
                             :schema/name true}})]
       (is (util/exception? db-int-name)
           "Exception, because :schema/name is an integer and not a string.")
-      (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
+      (is (= "Value 42 cannot be coerced to provided datatype: 1."
              (ex-message db-int-name)))
       (is (util/exception? db-bool-name)
           "Exception, because :schema/name is a boolean and not a string.")
-      (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
+      (is (= "Value true cannot be coerced to provided datatype: 1."
              (ex-message db-bool-name)))
       (is (= @(fluree/query db-ok user-query)
              [{:id          :ex/john
@@ -1063,7 +1063,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
       (is (= "SHACL PropertyShape exception - sh:maxCount of 1 lower than actual count of 2."
              (ex-message db-two-ages)))
       (is (util/exception? db-num-email))
-      (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
+      (is (= "Value 42 cannot be coerced to provided datatype: 1."
              (ex-message db-num-email)))
       (is (= [{:id           :ex/john
                :type     :ex/User
@@ -1345,7 +1345,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                  {"id"      "ex:Bob"
                                                   "ex:name" 123
                                                   "type"    "ex:User"}]})]
-        (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
+        (is (= "Value 123 cannot be coerced to provided datatype: 1."
                (ex-message db-bad-friend-name)))))
     (testing "maxCount"
       (let [conn          @(fluree/connect {:method :memory
@@ -1499,9 +1499,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                            "sh:targetObjectsOf" {"@id" "ex:friend"}
                                            "sh:property" [{"sh:path" {"@id" "ex:name"}
                                                            "sh:datatype" {"@id" "xsd:string"}}]}})
+
+            ;; need to specify type in order to avoid sh:datatype coercion
             db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
                                      "insert" {"id" "ex:Bob"
-                                               "ex:name" 123
+                                               "ex:name" {"@type" "xsd:integer" "@value" 123}
                                                "type" "ex:User"}})
             db-forbidden-friend @(fluree/stage2 db2
                                                 {"@context" "https://ns.flur.ee"
@@ -1703,9 +1705,10 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                   "sh:targetObjectsOf" {"@id" "ex:friend"}
                                   "sh:property" [{"sh:path" {"@id" "ex:name"}
                                                   "sh:datatype" {"@id" "xsd:string"}}]}})
+            ;; need to specify type in order to avoid sh:datatype coercion
             db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
                                      "insert" {"id" "ex:Bob"
-                                               "ex:name" 123
+                                               "ex:name" {"@type" "xsd:integer" "@value" 123}
                                                "type" "ex:User"}})
             db-forbidden-friend @(fluree/stage2 db2
                                                 {"@context" "https://ns.flur.ee"


### PR DESCRIPTION
During transaction processing we can scan the new flakes for `sh:datatype` constraints and store them in the schema pred cache for easy (non-async) access during flake creation. This allows us to use the `sh:datatype` constraint to attempt to coerce object values to a given type.

This does lead to some weird error messages, as instead of shacl validation errors for mismatched datatypes we now get coercion errors. I think we should address that as part of future error message work, though.

Since the `sh:datatype` constraint is not present in the vocab flakes, we needed a mechanism store additional metadata about a predicate in the index root in order for it to survive a load. In the interest of making the smallest change necessary, the vector of pids that we stored in the index root is now a vector of predicate tuples, wherein predicates that have a datatype constraint now carry that datatype as the second element of the tuple. This structure will need to evolve as we store more metadata there, but should suffice for now.

