### PR TITLE
Fix/limit

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -26,7 +26,11 @@
 
 (set! *warn-on-reflection* true)
 
-
+(defn read-json-resource
+  "Utility function to read and parse a json file on the resource path into edn
+  without converting anything to keywords"
+  [rsc]
+  (-> rsc io/resource slurp (json/parse false)))
 
 (comment
 

--- a/src/fluree/db/permissions_validate.cljc
+++ b/src/fluree/db/permissions_validate.cljc
@@ -26,8 +26,8 @@
                           (swap! (:cache policy) assoc s classes)
                           classes))
           fns       (keep #(or (get-in policy [const/iri-view :class % p :function])
-                               (get-in policy [const/iri-view :class % :default
-                                               :function])) class-ids)]
+                               (get-in policy [const/iri-view :class % :default :function]))
+                          class-ids)]
       (loop [[[async? f] & r] fns]
         ;; return first truthy response, else false
         (if f

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -349,9 +349,7 @@
          opts        {:idx         idx
                       :from-t      t
                       :to-t        t
-                      :start-test  >=
                       :start-flake start-flake
-                      :end-test    <=
                       :end-flake   end-flake
                       :flake-xf    flake-xf*}]
      (-> (query-range/resolve-flake-slices conn idx-root novelty error-ch opts)

--- a/src/fluree/db/query/subject_crawl/common.cljc
+++ b/src/fluree/db/query/subject_crawl/common.cljc
@@ -4,16 +4,17 @@
             [fluree.db.flake :as flake]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.log :as log :include-macros true]
+            [fluree.db.query.json-ld.response :as json-ld-resp]
             [fluree.db.dbproto :as dbproto]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn result-af
-  [{:keys [result-fn error-ch] :as _opts}]
+  [{:keys [db cache context compact-fn fuel-vol fuel select-spec error-ch] :as _opts}]
   (fn [flakes port]
     (go
       (try*
-        (let [result (<? (result-fn flakes))]
+        (let [result (<? (json-ld-resp/flakes->res db cache context compact-fn fuel-vol fuel select-spec 0 flakes))]
           (when (not-empty result)
             (>! port result)))
         (async/close! port)

--- a/src/fluree/db/query/subject_crawl/common.cljc
+++ b/src/fluree/db/query/subject_crawl/common.cljc
@@ -2,27 +2,11 @@
   (:require [clojure.core.async :refer [go] :as async]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.flake :as flake]
-            [fluree.db.index :as index]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.log :as log :include-macros true]
-            [fluree.db.util.schema :as schema-util]
-            [fluree.db.dbproto :as dbproto]
-            [fluree.db.permissions-validate :as perm-validate]))
+            [fluree.db.dbproto :as dbproto]))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-(defn where-subj-xf
-  "Transducing function to extract matching subjects from initial where clause."
-  [{:keys [start-test start-flake end-test end-flake xf]}]
-  (apply comp (cond-> [(filter index/resolved-leaf?)
-                       (map :flakes)
-                       (map (fn [flakes]
-                              (flake/subrange flakes
-                                              start-test start-flake
-                                              end-test end-flake)))]
-                      xf
-                      (conj xf))))
-
 
 (defn result-af
   [{:keys [result-fn error-ch] :as _opts}]

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -6,7 +6,6 @@
             [fluree.db.util.log :as log :include-macros true]
             [fluree.db.query.subject-crawl.subject :refer [subj-crawl]]
             [fluree.db.query.subject-crawl.common :refer [order-results]]
-            [fluree.db.query.json-ld.response :as json-ld-resp]
             [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -73,11 +72,11 @@
         select-spec (retrieve-select-spec db parsed-query)
         context     (:context parsed-query)
         compact-fn  (json-ld/compact-fn context)
-        result-fn   (partial json-ld-resp/flakes->res db cache context compact-fn fuel-vol fuel select-spec 0)
         finish-fn   (build-finishing-fn parsed-query)
         opts        {:rdf-type?     rdf-type?
                      :db            db
                      :cache         cache
+                     :compact-fn    compact-fn
                      :fuel-vol      fuel-vol
                      :max-fuel      fuel
                      :select-spec   select-spec
@@ -91,7 +90,6 @@
                      :f-where       f-where
                      :parse-json?   (:parse-json? opts)
                      :query         parsed-query
-                     :result-fn     result-fn
                      :finish-fn     finish-fn}]
     (log/trace "simple-subject-crawl opts:" opts)
     (if rel-binding?

--- a/src/fluree/db/query/subject_crawl/core.cljc
+++ b/src/fluree/db/query/subject_crawl/core.cljc
@@ -87,8 +87,6 @@
                      :filter-map    filter-map
                      :limit         (if order-by util/max-long limit) ;; if ordering, limit performed by finish-fn after sort
                      :offset        (if order-by 0 offset)
-                     :permissioned? (not (get-in db [:policy const/iri-view
-                                                     :root?]))
                      :parallelism   3
                      :f-where       f-where
                      :parse-json?   (:parse-json? opts)

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -83,22 +83,6 @@
       (async/close! return-ch))
     return-ch))
 
-(defn resolve-refs
-  "If the where clause has a ref, we need to resolve it to a subject id."
-  [db vars {:keys [p-ref? o] :as where-clause}]
-  (go-try
-    (if p-ref?
-      (let [v   (if-some [v (:value o)]
-                  v
-                  (when-let [variable (:variable o)]
-                    (get vars variable)))
-            sid (when v
-                  (or (<? (dbproto/-subid db v)) 0))]
-        (if sid
-          (assoc where-clause :o {:value sid})
-          (assoc where-clause :o {:value nil})))
-      where-clause)))
-
 (defn resolve-o-ident
   "If the predicate is a ref? type with an 'o' value, it must be resolved into a subject id."
   [db {:keys [o] :as where-clause}]

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -113,7 +113,8 @@
       (async/pipeline-async parallelism flakes-ch flakes-af sid-ch)
       (async/pipeline-async parallelism result-ch (result-af opts*) limit-ch)
 
-      (let [final-ch (async/transduce identity (completing conj finish-fn) [] result-ch)]
+      (let [final-ch (async/into [] result-ch)]
         (async/alt!
           error-ch ([e] e)
-          final-ch ([results] results))))))
+          final-ch ([results]
+                    (finish-fn results)))))))

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -7,7 +7,6 @@
             [fluree.db.flake :as flake]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.log :as log :include-macros true]
-            [fluree.db.query.exec :refer [drop-offset take-limit]]
             [fluree.db.query.subject-crawl.common :refer [result-af resolve-ident-vars
                                                           filter-subject]]
             [fluree.db.permissions-validate :refer [filter-subject-flakes]]
@@ -74,12 +73,12 @@
     (async/go
       (if (number? _id-val)
         (async/>! return-ch _id-val)
-        (let [sid (async/<! (dbproto/-subid db _id-val))]
+        (let [sid (<! (dbproto/-subid db _id-val))]
           (cond (util/exception? sid)
-                (async/put! error-ch sid)
+                (>! error-ch sid)
 
                 (some? sid)
-                (async/put! return-ch sid))))
+                (>! return-ch sid))))
       (async/close! return-ch))
     return-ch))
 

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -108,13 +108,13 @@
           limit-ch   (if limit
                        (async/take limit flakes-ch)
                        flakes-ch)
-          result-ch (async/chan)]
+          result-ch (async/chan)
+          final-ch  (async/into [] result-ch)]
 
       (async/pipeline-async parallelism flakes-ch flakes-af sid-ch)
       (async/pipeline-async parallelism result-ch (result-af opts*) limit-ch)
 
-      (let [final-ch (async/into [] result-ch)]
-        (async/alt!
-          error-ch ([e] e)
-          final-ch ([results]
-                    (finish-fn results)))))))
+      (async/alt!
+        error-ch ([e] e)
+        final-ch ([results]
+                  (finish-fn results))))))

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -108,9 +108,11 @@
                       (subjects-id-chan db error-ch vars* f-where*)
                       (subjects-chan db error-ch vars* f-where*))
           flakes-af (flakes-xf opts*)
-          flakes-ch (->> (async/chan 32)
-                         (drop-offset f-where)
-                         (take-limit f-where))
+          offset-xf (if offset
+                      (drop offset)
+                      identity)
+          flakes-ch (cond->> (async/chan 32 offset-xf)
+                      limit (async/take limit))
           result-ch (async/chan)]
 
       (async/pipeline-async parallelism flakes-ch flakes-af sid-ch)

--- a/src/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/fluree/db/query/subject_crawl/subject.cljc
@@ -36,7 +36,7 @@
         query-xf    (comp (query-range/extract-query-flakes {:flake-xf filter-xf})
                           cat
                           (map flake/s)
-                          (dedupe))
+                          (distinct))
         resolver    (index/->CachedTRangeResolver conn novelty t t (:lru-cache-atom conn))]
     (index/tree-chan resolver idx-root first-flake last-flake any? 10 query-xf error-ch)))
 

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -276,6 +276,29 @@
              @(fluree/query db {:select {"?s" ["*"]}
                                 :where  {:id          "?s"
                                          :ex/favColor "?color"}})))
+
+      (is (= [{:type         :ex/User
+               :schema/email "cam@example.org"
+               :ex/favNums   [5 10]
+               :schema/age   34
+               :ex/last      "Jones"
+               :schema/name  "Cam"
+               :id           :ex/cam
+               :ex/friend    [{:id :ex/brian} {:id :ex/alice}]
+               :ex/favColor  "Blue"}
+              {:id           :ex/alice
+               :type         :ex/User
+               :schema/name  "Alice"
+               :ex/last      "Smith"
+               :schema/email "alice@example.org"
+               :schema/age   42
+               :ex/favNums   [9 42 76]
+               :ex/favColor  "Green"}]
+             @(fluree/query db {:select {"?s" ["*"]}
+                                :where  {:id          "?s"
+                                         :ex/favColor "?color"}
+                                :limit  2})))
+
       (is (= [{:id           :ex/alice
                :type         :ex/User
                :schema/name  "Alice"


### PR DESCRIPTION
This patch fixes the limit and offset parameters that weren't being applied in simple subject crawl query execution, and cleans up some of the code by using built in async functions/transducers instead of reimplementing them. 