### PR TITLE
Adds connect-file CLJ API to default file connection

### DIFF
--- a/src/fluree/db/conn/file.cljc
+++ b/src/fluree/db/conn/file.cljc
@@ -219,7 +219,8 @@
 (defn connect
   "Create a new file system connection."
   [{:keys [defaults parallelism storage-path lru-cache-atom memory serializer nameservices]
-    :or   {serializer (json-serde)} :as _opts}]
+    :or {serializer (json-serde)
+         storage-path "data/ledger"} :as _opts}]
   (go
     (let [storage-path   (trim-last-slash storage-path)
           conn-id        (str (random-uuid))

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -81,6 +81,10 @@
                    :cljs (throw (ex-info "S3 connections not yet supported in ClojureScript"
                                          {:status 400, :error :db/unsupported-operation})))))))
 
+(defn connect-file
+  [opts]
+  (connect (assoc opts :method :file)))
+
 (defn connect-ipfs
   "Forms an ipfs connection using default settings.
   - server - (optional) IPFS http api server endpoint, defaults to http://127.0.0.1:5001/


### PR DESCRIPTION
This creates a `connect-file` API similar to the existing `connect-ipfs` and `connect-memory` that allows a file connection to work by default without any options passed (but options passed will still be used if provided).

I think it could be (and welcome) debate over if we should have this or not, but I personally find it nice and convenient - and we have other helpers but this one was missing. If we don't want it, then I think we should remove all the helpers.

So this will work:
`(def conn @(fluree/connect-file nil))`

