### PR TITLE
relax context requirement

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -49,7 +49,7 @@
                                       {:subject txn})
           txn-context             (or (:context parsed-opts)
                                       (ctx-util/txn-context txn))
-          expanded                (json-ld/expand txn)
+          expanded                (json-ld/expand (ctx-util/use-fluree-context txn))
           opts                    (util/get-first-value expanded const/iri-opts)
           parsed-opts             (cond-> parsed-opts
                                     did (assoc :did did)
@@ -162,7 +162,7 @@
                                       {:subject txn})
 
           txn-context (ctx-util/txn-context txn)
-          expanded    (json-ld/expand txn)
+          expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
           ledger-id   (util/get-first-value expanded const/iri-ledger)
           _ (when-not ledger-id
               (throw (ex-info "Invalid transaction, missing required key: ledger."
@@ -187,7 +187,7 @@
                                       {:subject txn})
 
           txn-context (ctx-util/txn-context txn)
-          expanded    (json-ld/expand txn)
+          expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
           ledger-id   (util/get-first-value expanded const/iri-ledger)
           _ (when-not ledger-id
               (throw (ex-info "Invalid transaction, missing required key: ledger."

--- a/src/fluree/db/util/context.cljc
+++ b/src/fluree/db/util/context.cljc
@@ -198,13 +198,24 @@
 (defn txn-context
   "Remove the fluree context from the supplied context."
   [txn]
-  (validate-txn-context txn)
-  (let [supplied-context (->> (get txn "@context" (:context txn))
-                              (util/sequential)
-                              (remove #{"https://ns.flur.ee"}))]
+  (let [supplied-context (when (or (contains? txn :context)
+                                   (contains? txn "@context"))
+                              (->> (get txn "@context" (:context txn))
+                                   (util/sequential)
+                                   (remove #{"https://ns.flur.ee"})))]
+
     (if (seq supplied-context)
       supplied-context
       ::dbproto/default-context)))
+
+(defn use-fluree-context
+  "Clobber the top-level context and use the fluree context. This is only intended to be
+  use for the initial expansion of the top-level document, where all the keys should be
+  fluree vocabulary terms."
+  [txn]
+  (-> txn
+      (dissoc :context "@context")
+      (assoc "@context" "https://ns.flur.ee")))
 
 (defn extract
   [db jsonld opts]

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -1133,8 +1133,7 @@
                                                                       {"ex" "http://example.com/"}]})
            db0       (fluree/db ledger)]
        (testing "use default context"
-         (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
-                                        "insert"   {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
+         (let [db1 @(fluree/stage2 db0 {"insert" {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
 
            (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
                   @(fluree/query db1 {"@context"  nil
@@ -1142,7 +1141,7 @@
                "default context was used to expand")))
 
        (testing "use instead of default context"
-         (let [db2 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {"ex" "DEFAULTOVERRIDEN:ns/"}]
+         (let [db2 @(fluree/stage2 db0 {"@context" {"ex" "DEFAULTOVERRIDEN:ns/"}
                                         "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
            (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
                   @(fluree/query db2 {"@context"  nil
@@ -1150,7 +1149,7 @@
                "supplied context used, default context not used")))
 
        (testing "use with default context"
-         (let [db3 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" "" {"foo" "ns:foo/"}]
+         (let [db3 @(fluree/stage2 db0 {"@context" ["" {"foo" "ns:foo/"}]
                                         "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
            (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
                   @(fluree/query db3 {"@context"  nil
@@ -1158,8 +1157,7 @@
                "default context used, supplemented by supplied context")))
 
        (testing "use no context"
-         ;; clearing context with nil produces an error because `insert` can't be found
-         (let [db4 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {}]
+         (let [db4 @(fluree/stage2 db0 {"@context" nil
                                         "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
            (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
                   @(fluree/query db4 {"@context"  nil

--- a/test/fluree/db/query/property_test.clj
+++ b/test/fluree/db/query/property_test.clj
@@ -187,11 +187,10 @@
                  {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
                (set @(fluree/query db2 {"select" {"?s" ["*"]}
                                         "where"  {"@id" "?s", "ex:givenName" "?o"}}))))
-        (is (= [{"id" "ex:dan", "ex:givenName" "Dan"}
-                {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}]
-               @(fluree/query db2 {"select" {"?s" ["*"]}
-                                   "where"  {"@id" "?s", "ex:firstName" "?o"}})))
-
+        (is (= #{{"id" "ex:dan", "ex:givenName" "Dan"}
+                 {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
+               (set @(fluree/query db2 {"select" {"?s" ["*"]}
+                                        "where"  {"@id" "?s", "ex:firstName" "?o"}}))))
         (is (= [["ex:other" true false]]
                @(fluree/query db2 {"select" ["?s" "?cool" "?fool"]
                                    "where"  {"@id"     "?s",
@@ -199,10 +198,10 @@
                                              "ex:fool" "?fool"}}))
             "handle list values"))
       (testing "after load"
-        (is (= [{"id" "ex:dan", "ex:givenName" "Dan"}
-                {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}]
-               @(fluree/query dbl {"select" {"?s" ["*"]}
-                                   "where"  {"@id" "?s", "ex:givenName" "?o"}})))
+        (is (= #{{"id" "ex:dan", "ex:givenName" "Dan"}
+                 {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
+               (set @(fluree/query dbl {"select" {"?s" ["*"]}
+                                        "where"  {"@id" "?s", "ex:givenName" "?o"}}))))
         (is (= #{{"id" "ex:dan", "ex:givenName" "Dan"}
                  {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
                (set @(fluree/query dbl {"select" {"?s" ["*"]}

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -13,30 +13,25 @@
   (testing "Disallow staging invalid transactions"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "tx/disallow" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+          db0    (fluree/db ledger)
 
-          stage-id-only    (try
-                             @(fluree/stage2
-                                (fluree/db ledger)
-                                {"@context" "https://ns.flur.ee"
-                                 "insert"   {:id :ex/alice}})
-                             (catch Exception e e))
-          stage-empty-txn  (try
-                             @(fluree/stage2
-                                (fluree/db ledger)
-                                {"@context" "https://ns.flur.ee"
-                                 "insert"   {}})
-                             (catch Exception e e))
-          stage-empty-node (try
-                             @(fluree/stage2
-                                (fluree/db ledger)
-                                {"@context" "https://ns.flur.ee"
-                                 "insert"
-                                 [{:id         :ex/alice
-                                   :schema/age 42}
-                                  {}]})
-                             (catch Exception e e))
+          stage-id-only    @(fluree/stage2
+                              db0
+                              {"@context" "https://ns.flur.ee"
+                               "insert"   {:id :ex/alice}})
+          stage-empty-txn  @(fluree/stage2
+                              db0
+                              {"@context" "https://ns.flur.ee"
+                               "insert"   {}})
+          stage-empty-node @(fluree/stage2
+                              db0
+                              {"@context" "https://ns.flur.ee"
+                               "insert"
+                               [{:id         :ex/alice
+                                 :schema/age 42}
+                                {}]})
           db-ok            @(fluree/stage2
-                              (fluree/db ledger)
+                              db0
                               {"@context" "https://ns.flur.ee"
                                "insert"
                                {:id         :ex/alice


### PR DESCRIPTION

Fixes https://github.com/fluree/core/issues/54

Users no longer need to supply the fluree context in their transactions, unless they are wrapping them in a verifiable credential.