### PR TITLE
rename api fns

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -49,7 +49,7 @@
                                       {:subject txn})
           txn-context             (or (:context parsed-opts)
                                       (ctx-util/txn-context txn))
-          expanded                (json-ld/expand txn)
+          expanded                (json-ld/expand (ctx-util/use-fluree-context txn))
           opts                    (util/get-first-value expanded const/iri-opts)
           parsed-opts             (cond-> parsed-opts
                                     did (assoc :did did)
@@ -162,7 +162,7 @@
                                       {:subject txn})
 
           txn-context (ctx-util/txn-context txn)
-          expanded    (json-ld/expand txn)
+          expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
           ledger-id   (util/get-first-value expanded const/iri-ledger)
           _ (when-not ledger-id
               (throw (ex-info "Invalid transaction, missing required key: ledger."
@@ -187,7 +187,7 @@
                                       {:subject txn})
 
           txn-context (ctx-util/txn-context txn)
-          expanded    (json-ld/expand txn)
+          expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
           ledger-id   (util/get-first-value expanded const/iri-ledger)
           _ (when-not ledger-id
               (throw (ex-info "Invalid transaction, missing required key: ledger."

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -1,8 +1,5 @@
 (ns fluree.db.api.transact
-  (:require [clojure.walk :refer [keywordize-keys]]
-            [fluree.db.conn.proto :as conn-proto]
-            [fluree.db.constants :as const]
-            [fluree.db.dbproto :as dbproto]
+  (:require [fluree.db.constants :as const]
             [fluree.db.fuel :as fuel]
             [fluree.db.json-ld.transact :as tx]
             [fluree.db.ledger.json-ld :as jld-ledger]
@@ -14,27 +11,6 @@
             [fluree.json-ld :as json-ld]
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.ledger.proto :as ledger-proto]))
-
-(defn stage
-  [db json-ld opts]
-  (go-try
-    (let [opts*    (util/parse-opts opts)
-          max-fuel (:max-fuel opts*)]
-      (if (::util/track-fuel? opts*)
-        (let [start-time   #?(:clj (System/nanoTime)
-                              :cljs (util/current-time-millis))
-              fuel-tracker (fuel/tracker max-fuel)]
-          (try* (let [result (<? (dbproto/-stage db fuel-tracker json-ld opts*))]
-                  {:status 200
-                   :result result
-                   :time   (util/response-time-formatted start-time)
-                   :fuel   (fuel/tally fuel-tracker)})
-                (catch* e
-                  (throw (ex-info "Error staging database"
-                                  {:time (util/response-time-formatted start-time)
-                                   :fuel (fuel/tally fuel-tracker)}
-                                  e)))))
-        (<? (dbproto/-stage db json-ld opts*))))))
 
 (defn parse-opts
   [parsed-opts opts]
@@ -72,88 +48,6 @@
                                :fuel (fuel/tally fuel-tracker)}
                               e)))))
         (<? (tx/stage2 db expanded parsed-opts*))))))
-
-(defn parse-json-ld-txn
-  "Expands top-level keys and parses any opts in json-ld transaction document.
-  Throws if required keys @id or @graph are absent."
-  [conn context-type json-ld]
-  (let [conn-default-ctx (conn-proto/-default-context conn context-type)
-        context-key      (cond
-                           (contains? json-ld "@context") "@context"
-                           (contains? json-ld :context) :context)
-        txn-context      (get json-ld context-key)
-        _                (log/trace "parse-json-ld-txn txn-context:" txn-context)
-        parsed-context   (if (or (nil? txn-context)
-                                 (and (sequential? txn-context)
-                                      (= "" (first txn-context))))
-                           (json-ld/parse-context
-                            (cons conn-default-ctx (rest txn-context)))
-                           (json-ld/parse-context txn-context))
-        _                (log/trace "parse-json-ld-txn parsed-context:" parsed-context)
-
-        {ledger-id const/iri-ledger graph "@graph" :as parsed-txn}
-        (into {}
-              (map (fn [[k v]]
-                     (let [k* (if (= context-key k)
-                                "@context"
-                                (json-ld/expand-iri k parsed-context))
-                           v* (if (= const/iri-opts k*)
-                                (keywordize-keys v)
-                                v)]
-                       [k* v*])))
-              json-ld)]
-    (if-not (and ledger-id graph)
-      (throw (ex-info (str "Invalid transaction, missing required keys:"
-                           (when (nil? ledger-id)
-                             (str " " (json-ld/compact const/iri-ledger
-                                                       parsed-context)))
-                           (when (nil? graph)
-                             " @graph")
-                           ".")
-                      {:status 400 :error :db/invalid-transaction}))
-      parsed-txn)))
-
-(defn ledger-transact!
-  [ledger txn opts]
-  (go-try
-    (let [opts*    (util/parse-opts opts)
-          max-fuel (:max-fuel opts*)]
-      (if (::util/track-fuel? opts*)
-        (let [start-time   #?(:clj  (System/nanoTime)
-                              :cljs (util/current-time-millis))
-              fuel-tracker (fuel/tracker max-fuel)]
-          (try*
-            (let [tx-result (<? (tx/transact! ledger fuel-tracker txn opts*))]
-              {:status 200
-               :result tx-result
-               :time   (util/response-time-formatted start-time)
-               :fuel   (fuel/tally fuel-tracker)})
-            (catch* e
-              (throw
-               (ex-info "Error updating ledger"
-                        (-> e
-                            ex-data
-                            (assoc :time (util/response-time-formatted start-time)
-                                   :fuel (fuel/tally fuel-tracker))))))))
-        (<? (tx/transact! ledger txn opts*))))))
-
-(defn transact!
-  [conn parsed-json-ld opts]
-  (go-try
-    (let [{txn-context     "@context"
-           txn             "@graph"
-           ledger-id       const/iri-ledger
-           txn-opts        const/iri-opts
-           default-context const/iri-default-context} parsed-json-ld
-           address         (<? (nameservice/primary-address conn ledger-id nil))]
-      (if-not (<? (nameservice/exists? conn address))
-        (throw (ex-info "Ledger does not exist" {:ledger address}))
-        (let [ledger (<? (jld-ledger/load conn address))
-              opts   (cond-> opts
-                       txn-opts (merge txn-opts)
-                       txn-context (assoc :txn-context txn-context)
-                       default-context (assoc :defaultContext default-context))]
-          (<? (ledger-transact! ledger txn opts)))))))
 
 (defn transact!2
   [conn txn]

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -18,7 +18,7 @@
           parsed-opts
           opts))
 
-(defn stage2
+(defn stage
   [db txn parsed-opts]
   (go-try
     (let [{txn :subject did :did} (or (<? (cred/verify txn))
@@ -37,7 +37,7 @@
                               :cljs (util/current-time-millis))
               fuel-tracker (fuel/tracker maxFuel)]
           (try*
-            (let [result (<? (tx/stage2 db fuel-tracker expanded parsed-opts*))]
+            (let [result (<? (tx/stage db fuel-tracker expanded parsed-opts*))]
               {:status 200
                :result result
                :time   (util/response-time-formatted start-time)
@@ -47,9 +47,9 @@
                               {:time (util/response-time-formatted start-time)
                                :fuel (fuel/tally fuel-tracker)}
                               e)))))
-        (<? (tx/stage2 db expanded parsed-opts*))))))
+        (<? (tx/stage db expanded parsed-opts*))))))
 
-(defn transact!2
+(defn transact!
   [conn txn]
   (go-try
     (let [{txn :subject did :did} (or (<? (cred/verify txn))
@@ -71,7 +71,7 @@
       (if-not (<? (nameservice/exists? conn address))
         (throw (ex-info "Ledger does not exist" {:ledger address}))
         (let [ledger (<? (jld-ledger/load conn address))
-              db     (<? (stage2 (ledger-proto/-db ledger) txn parsed-opts))]
+              db     (<? (stage (ledger-proto/-db ledger) txn parsed-opts))]
           (<? (ledger-proto/-commit! ledger db)))))))
 
 (defn create-with-txn
@@ -97,5 +97,5 @@
         (throw (ex-info (str "Ledger " ledger-id " already exists")
                         {:status 409 :error :db/ledger-exists}))
         (let [ledger (<? (jld-ledger/create conn ledger-id parsed-opts))
-              db     (<? (stage2 (ledger-proto/-db ledger) txn parsed-opts))]
+              db     (<? (stage (ledger-proto/-db ledger) txn parsed-opts))]
           (<? (ledger-proto/-commit! ledger db)))))))

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -240,9 +240,9 @@
           q-ctx    (ctx-util/get-context query-map)
           ctx      (dbproto/-context this q-ctx ctx-type)]
       (fql/query this ctx query-map)))
-  (-stage [db json-ld] (jld-transact/stage db json-ld nil))
-  (-stage [db json-ld opts] (jld-transact/stage db json-ld opts))
-  (-stage [db fuel-tracker json-ld opts] (jld-transact/stage db fuel-tracker json-ld opts))
+  (-stage [db json-ld] (jld-transact/stage2 db json-ld nil))
+  (-stage [db json-ld opts] (jld-transact/stage2 db json-ld opts))
+  (-stage [db fuel-tracker json-ld opts] (jld-transact/stage2 db fuel-tracker json-ld opts))
   (-index-update [db commit-index] (index-update db commit-index))
   (-context [_] (ctx-util/retrieve-context default-context context-cache ::dbproto/default-context context-type))
   (-context [_ context] (ctx-util/retrieve-context default-context context-cache context context-type))

--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -240,9 +240,9 @@
           q-ctx    (ctx-util/get-context query-map)
           ctx      (dbproto/-context this q-ctx ctx-type)]
       (fql/query this ctx query-map)))
-  (-stage [db json-ld] (jld-transact/stage2 db json-ld nil))
-  (-stage [db json-ld opts] (jld-transact/stage2 db json-ld opts))
-  (-stage [db fuel-tracker json-ld opts] (jld-transact/stage2 db fuel-tracker json-ld opts))
+  (-stage [db json-ld] (jld-transact/stage db json-ld nil))
+  (-stage [db json-ld opts] (jld-transact/stage db json-ld opts))
+  (-stage [db fuel-tracker json-ld opts] (jld-transact/stage db fuel-tracker json-ld opts))
   (-index-update [db commit-index] (index-update db commit-index))
   (-context [_] (ctx-util/retrieve-context default-context context-cache ::dbproto/default-context context-type))
   (-context [_ context] (ctx-util/retrieve-context default-context context-cache context context-type))

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -226,7 +226,6 @@
    (let [result-ch (transact-api/stage db json-ld opts)]
      (promise-wrap result-ch))))
 
-
 (defn commit!
   "Commits a staged database to the ledger with all changes since the last commit
   aggregated together.

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -219,14 +219,6 @@
 
 
 
-;; mutations
-(defn stage
-  "Performs a transaction and queues change if valid (does not commit)"
-  ([db json-ld] (stage db json-ld nil))
-  ([db json-ld opts]
-   (let [result-ch (transact-api/stage db json-ld opts)]
-     (promise-wrap result-ch))))
-
 (defn stage2
   "Performs a transaction and queues change if valid (does not commit)"
   ([db json-ld] (stage2 db json-ld nil))
@@ -249,61 +241,10 @@
    (promise-wrap
      (ledger-proto/-commit! ledger db opts))))
 
-(defn transact!
-  "Expects a conn and json-ld document containing at least the following keys:
-  `https://ns.flur.ee/ledger#ledger`: the id of the ledger to transact to
-  `@graph`: the data to be transacted
-
-  Loads the specified ledger and performs stage and commit! operations.
-  Returns the new db.
-
-  Note: Loading the ledger results in a new ledger object, so references to existing
-  ledger objects will be rendered stale. To obtain a ledger with the new changes,
-  call `load` on the ledger alias."
-  [conn json-ld opts]
-  (promise-wrap
-   (let [context-type (or (:context-type opts) (conn-proto/-context-type conn))
-         parsed-txn   (transact-api/parse-json-ld-txn conn context-type json-ld)]
-     (log/trace "transact! context-type:" context-type)
-     (log/trace "transact! parsed-txn:" parsed-txn)
-     (transact-api/transact! conn parsed-txn opts))))
-
 (defn transact!2
   [conn txn]
   (promise-wrap
     (transact-api/transact!2 conn txn)))
-
-(defn create-with-txn
-  "Creates a new ledger named by the @id key (or its context alias) in txn if it
-  doesn't exist and transacts the data in txn's @graph (or its context alias)
-  into it. Returns a promise with the transaction result (a db value)."
-  ([conn txn] (create-with-txn conn txn nil))
-  ([conn txn opts]
-   (log/trace "create-with-txn txn:" txn)
-   (log/trace "create-with-txn opts:" opts)
-   (let [context-type   (or (:context-type opts) (conn-proto/-context-type conn))
-         {ledger-id       const/iri-ledger
-          txn-context     "@context"
-          txn-opts        const/iri-opts
-          default-context const/iri-default-context
-          :as             parsed-txn} (transact-api/parse-json-ld-txn conn context-type txn)
-         _              (log/trace "create-with-txn parsed-txn:" parsed-txn)
-         ledger-exists? @(exists? conn ledger-id)]
-     (if ledger-exists?
-       (let [err-message (str "Ledger " ledger-id " already exists")]
-         (throw (ex-info err-message
-                         {:status 409
-                          :error  :db/ledger-exists})))
-       (let [opts*          (cond-> opts
-                              txn-opts (clojure.core/merge txn-opts)
-                              txn-context (assoc :txn-context txn-context)
-                              default-context (assoc :defaultContext default-context))
-             create-promise (create conn ledger-id opts*)
-             ledger         @create-promise]
-         (if (util/exception? ledger)
-           create-promise
-           (promise-wrap
-            (transact-api/ledger-transact! ledger parsed-txn opts*))))))))
 
 (defn create-with-txn2
   [conn txn]

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -219,11 +219,11 @@
 
 
 
-(defn stage2
+(defn stage
   "Performs a transaction and queues change if valid (does not commit)"
-  ([db json-ld] (stage2 db json-ld nil))
+  ([db json-ld] (stage db json-ld nil))
   ([db json-ld opts]
-   (let [result-ch (transact-api/stage2 db json-ld opts)]
+   (let [result-ch (transact-api/stage db json-ld opts)]
      (promise-wrap result-ch))))
 
 
@@ -241,12 +241,12 @@
    (promise-wrap
      (ledger-proto/-commit! ledger db opts))))
 
-(defn transact!2
+(defn transact!
   [conn txn]
   (promise-wrap
-    (transact-api/transact!2 conn txn)))
+    (transact-api/transact! conn txn)))
 
-(defn create-with-txn2
+(defn create-with-txn
   [conn txn]
   (promise-wrap
     (transact-api/create-with-txn conn txn)))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -213,9 +213,9 @@
           <?
           dbproto/-rootdb))))
 
-(defn stage2
+(defn stage
   ([db txn parsed-opts]
-   (stage2 db nil txn parsed-opts))
+   (stage db nil txn parsed-opts))
   ([db fuel-tracker txn parsed-opts]
    (go-try
      (let [db* (if-let [policy-opts (perm/policy-opts parsed-opts)]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -1,349 +1,26 @@
 (ns fluree.db.json-ld.transact
-  (:refer-clojure :exclude [vswap!])
   (:require [clojure.core.async :as async :refer [go alts!]]
             [fluree.db.constants :as const]
-            [fluree.db.datatype :as datatype]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.flake :as flake]
             [fluree.db.fuel :as fuel]
             [fluree.db.json-ld.branch :as branch]
             [fluree.db.json-ld.commit-data :as commit-data]
-            [fluree.db.json-ld.credential :as cred]
             [fluree.db.json-ld.ledger :as jld-ledger]
             [fluree.db.json-ld.policy :as perm]
-            [fluree.db.json-ld.reify :as jld-reify]
             [fluree.db.json-ld.shacl :as shacl]
             [fluree.db.json-ld.vocab :as vocab]
             [fluree.db.ledger.proto :as ledger-proto]
             [fluree.db.policy.enforce-tx :as policy]
-            [fluree.db.query.fql :as fql]
             [fluree.db.query.fql.parse :as q-parse]
             [fluree.db.query.exec :as exec]
             [fluree.db.query.exec.update :as update]
             [fluree.db.query.exec.where :as where]
             [fluree.db.query.range :as query-range]
             [fluree.db.util.async :refer [<? go-try]]
-            [fluree.db.util.core :as util :refer [vswap!]]
-            [fluree.db.util.context :as ctx-util]
-            [fluree.db.util.log :as log]
-            [fluree.db.validation :as v]
-            [fluree.json-ld :as json-ld]
-            [malli.core :as m]))
+            [fluree.db.util.core :as util]))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-(def registry
-  (merge
-   (m/base-schemas)
-   (m/type-schemas)
-   v/registry
-   {::triple       ::v/triple
-    ::txn-leaf-map [:map-of
-                    [:orn [:string :string] [:keyword :keyword]]
-                    :any]
-    ::retract      [:and
-                    [:map-of :keyword :any]
-                    [:map [:retract ::txn-leaf-map]]]
-    ::modification ::v/modification-txn
-    ::txn-map      [:orn
-                    [:retract ::retract]
-                    [:modification ::modification]
-                    [:assert ::txn-leaf-map]]
-    ::txn          [:orn
-                    [:single-map ::txn-map]
-                    [:sequence-of-maps [:sequential ::txn-map]]]}))
-
-(declare json-ld-node->flakes)
-
-(defn json-ld-type-data
-  "Returns two-tuple of [class-subject-ids class-flakes]
-  where class-flakes will only contain newly generated class
-  flakes if they didn't already exist."
-  [class-iris {:keys [t next-pid ^clojure.lang.Volatile iris db-before] :as _tx-state}]
-  (go-try
-    (loop [[class-iri & r] (util/sequential class-iris)
-           class-sids   #{}
-           class-flakes #{}]
-      (if class-iri
-        (if-let [existing (<? (jld-reify/get-iri-sid class-iri db-before iris))]
-          (recur r (conj class-sids existing) class-flakes)
-          (let [type-sid (if-let [predefined-pid (get jld-ledger/predefined-properties class-iri)]
-                           predefined-pid
-                           (next-pid))]
-            (vswap! iris assoc class-iri type-sid)
-            (recur r
-                   (conj class-sids type-sid)
-                   (conj class-flakes
-                         (flake/create type-sid const/$xsd:anyURI class-iri const/$xsd:string t true nil)))))
-        [class-sids class-flakes]))))
-
-(defn retract-flakes
-  [db s p t]
-  (query-range/index-range db
-                           :spot = [s p]
-                           {:flake-xf (map #(flake/flip-flake % t))}))
-
-(defn add-property
-  "Adds property. Parameters"
-  [sid pid shacl-dt shape->p-shapes check-retracts? list? {:keys [language value] :as v-map}
-   {:keys [t db-before subj-mods] :as tx-state}]
-  (go-try
-    (let [retractions (when check-retracts? ;; don't need to check if generated pid during this transaction
-                        (<? (retract-flakes db-before sid pid t)))
-
-          m           (cond-> nil
-                        list? (assoc :i (-> v-map :idx last))
-                        language (assoc :lang language))
-
-          flakes      (cond
-                        ;; a new node's data is contained, process as another node then link to this one
-                        (jld-reify/node? v-map)
-                        (let [[node-sid node-flakes] (<? (json-ld-node->flakes v-map tx-state pid))]
-                          (conj node-flakes (flake/create sid pid node-sid const/$xsd:anyURI t true m)))
-
-                        ;; a literal value
-                        (and (some? value) (not= shacl-dt const/$xsd:anyURI))
-                        (let [[value* dt] (datatype/from-expanded v-map shacl-dt)]
-                          [(flake/create sid pid value* dt t true m)])
-
-                        :else
-                        (throw (ex-info (str "JSON-LD value must be a node or a value, instead found ambiguous value: " v-map)
-                                        {:status 400 :error :db/invalid-transaction})))
-          [valid? err-msg] (shacl/coalesce-validation-results
-                            (into []
-                                  (mapcat (fn [[shape-id p-shapes]]
-                                            ;; register the validated pid so we can enforce the sh:closed constraint later
-                                            (swap! subj-mods update-in [:shape->validated-properties shape-id]
-                                                   (fnil conj #{}) pid)
-                                            ;; do the actual validation
-                                            (mapv (fn [p-shape]
-                                                    (shacl/validate-simple-property-constraints p-shape flakes))
-                                                  p-shapes)))
-                                  shape->p-shapes))]
-      (when-not valid?
-        (shacl/throw-shacl-exception err-msg))
-      (into flakes retractions))))
-
-(defn list-value?
-  "returns true if json-ld value is a list object."
-  [v]
-  (and (map? v)
-       (= :list (-> v first key))))
-
-(defn get-subject-types
-  "Returns a set of all :type Class subject ids for the provided subject.
-  new-types are a set of newly created types in the transaction."
-  [db sid added-classes]
-  (go-try
-    (let [type-sids (<? (query-range/index-range db
-                                                 :spot = [sid const/$rdf:type]
-                                                 {:flake-xf (map flake/o)}))]
-      (if (seq type-sids)
-        (into added-classes type-sids)
-        added-classes))))
-
-(defn iri-only?
-  "Returns true if a JSON-LD node contains only an IRI and no actual property data.
-
-  Note, this is only used if we already know the node is a subject (not a scalar value)
-  so no need to check for presence of :id."
-  [node]
-  (= 2 (count node)))
-
-(defn register-node
-  "Registers nodes being created/updated in an atom to verify the same node isn't being
-  manipulated multiple spots and also registering shacl rules that need further processing
-  once completed."
-  [subj-mods node sid node-meta-map]
-  (swap! subj-mods update sid
-         (fn [existing]
-           (if-not existing
-             node-meta-map
-             (cond
-               ;; if previously created, but this is just using the IRI it is OK
-               (:iri-only? node-meta-map)
-               existing
-
-               ;; if previously updated, but prior updates were only the IRI then it is OK
-               (:iri-only? existing)
-               ;; shacl constraint may have been discovered on previous node.
-               ;; in that case, we'd want to keep it and not override it.
-               (if (:shacl existing)
-                 (update existing :shacl (fnil into #{}) (:shacl node-meta-map))
-                 node-meta-map)
-
-               :else
-               (throw (ex-info (str "Subject " (:id node) " is being updated in more than one JSON-LD map. "
-                                    "All items for a single subject should be consolidated.")
-                               {:status 400 :error :db/invalid-transaction})))))))
-
-(defn consolidate-advanced-validation
-  "We need to have the shacl :datatype constraints at hand for each pid so that we can
-  properly coerce flake `dt` fields, where possible.
-
-  We also need an efficient structure for finding the p-shapes for advanced validation.
-
-  This function assembles both structures in one pass through the shacl-shapes.
-
-  Returns a two tuple of:
-  pid->shape->p-shapes
-  {<pid> {<shape-id-iri> [<p-shape1> <p-shape2> ...]}}
-
-  pid->shacl-dt
-  {<pid> <dt>}"
-  [shacl-shapes]
-  (reduce (fn [[pid->shape->p-shapes pid->shacl-dt*]
-               {:keys [advanced-validation pid->shacl-dt] :as _shape}]
-            [(if advanced-validation
-               (merge-with merge pid->shape->p-shapes advanced-validation)
-               pid->shape->p-shapes)
-             (merge pid->shacl-dt* pid->shacl-dt)])
-          [{} {}]
-          shacl-shapes))
-
-(defn rdf-type-iri?
-  [iri]
-  (= const/iri-rdf-type iri))
-
-(defn new-iri-flake
-  [s iri t]
-  (flake/create s const/$xsd:anyURI iri const/$xsd:string t true nil))
-
-(defn property-value->flakes
-  [sid pid property value pid->shape->p-shapes pid->shacl-dt new-subj? existing-pid?
-   {:keys [t db-before] :as tx-state}]
-  (go-try
-    (if (rdf-type-iri? property)
-      (throw (ex-info (str (pr-str const/iri-rdf-type) " is not a valid predicate IRI."
-                           " Please use the JSON-LD \"@type\" keyword instead.")
-                      {:status 400 :error :db/invalid-predicate}))
-      (let [list?           (list-value? value)
-            v*              (if list?
-                              (let [list-vals (:list value)]
-                                (when-not (sequential? list-vals)
-                                  (throw (ex-info (str "List values have to be vectors, provided: " value)
-                                                  {:status 400 :error :db/invalid-transaction})))
-                                list-vals)
-                              (util/sequential value))
-            shape->p-shapes (get pid->shape->p-shapes pid)
-            shacl-dt        (get pid->shacl-dt pid)
-
-            ;; check-retracts? - a new subject or property don't require checking for flake retractions
-            check-retracts? (or (not new-subj?) existing-pid?)
-            new-prop-flakes (cond-> []
-                              (not existing-pid?) (conj (new-iri-flake pid property t)))]
-        (if (nil? value)
-          (into new-prop-flakes (<? (retract-flakes db-before sid pid t)))
-          (into new-prop-flakes (loop [[v' & r] v*
-                                       flakes []]
-                                  (if v'
-                                    (recur r (into flakes (<? (add-property sid pid shacl-dt shape->p-shapes check-retracts? list? v' tx-state))))
-                                    flakes))))))))
-
-(defn json-ld-node->flakes
-  "Returns two-tuple of [sid node-flakes] that will contain the top-level sid
-  and all flakes from the target node and all children nodes that ultimately get processed.
-
-  If property-id is non-nil, it can be checked when assigning new subject id for the node
-  if it meets certain criteria. It will only be non-nil for nested subjects in the json-ld."
-  [{:keys [id type] :as node}
-   {:keys [t next-pid next-sid iris db-before subj-mods
-           shacl-target-objects-of? refs] :as tx-state}
-   referring-pid]
-  (go-try
-    (let [existing-sid   (when id
-                           (<? (jld-reify/get-iri-sid id db-before iris)))
-          new-subj?      (not existing-sid)
-          [new-type-sids type-flakes] (when type
-                                        (<? (json-ld-type-data type tx-state)))
-          sid            (if new-subj?
-                           ;; TODO - this will check if subject is rdfs:Class, but we already have the new-type-sids above and know that - this can be a little faster, but reify.cljc also uses this logic and they need to align
-                           (jld-ledger/generate-new-sid node referring-pid iris next-pid next-sid)
-                           existing-sid)
-          classes        (if new-subj?
-                           new-type-sids
-                           ;;note: use of `db-before` here (and below)
-                           ;; means we cannot transact shacl in same txn as
-                           ;;data and have it enforced.
-                           (<? (get-subject-types db-before sid new-type-sids)))
-
-          class-shapes   (<? (shacl/class-shapes db-before classes))
-          referring-pids (when shacl-target-objects-of?
-                           (cond-> (<? (query-range/index-range db-before :opst = [sid] {:flake-xf (map flake/p)}))
-                             referring-pid (conj referring-pid)))
-          pred-shapes    (when (seq referring-pids)
-                           (<? (shacl/targetobject-shapes db-before referring-pids)))
-          shacl-shapes   (into class-shapes pred-shapes)
-
-          [pid->shape->p-shapes pid->shacl-dt] (consolidate-advanced-validation shacl-shapes)
-
-          id*            (if (and new-subj? (nil? id))
-                           (str "_:f" sid) ;; create a blank node id
-                           id)
-          base-flakes    (cond-> []
-                           new-subj? (conj (flake/create sid const/$xsd:anyURI id* const/$xsd:string t true nil))
-                           new-type-sids (into (map #(flake/create sid const/$rdf:type % const/$xsd:anyURI t true nil) new-type-sids)))]
-      ;; save SHACL, class data into atom for later validation - checks that same @id not being updated in multiple spots
-      (register-node subj-mods node sid {:iri-only? (iri-only? node)
-                                         :shacl     shacl-shapes
-                                         :new?      new-subj?
-                                         :classes   classes})
-      (loop [[[k v] & r] (dissoc node :id :idx :type)
-             subj-flakes (into base-flakes type-flakes)]
-        (if k
-          (let [existing-pid (<? (jld-reify/get-iri-sid k db-before iris))
-                ref?         (not (:value (first v))) ; either a ref or a value
-                pid          (or existing-pid
-                                 (get jld-ledger/predefined-properties k)
-                                 (jld-ledger/generate-new-pid k iris next-pid ref? refs))]
-            (if-let [values (not-empty v)]
-              (let [new-flakes (loop [[value & r] values
-                                      existing? (some? existing-pid)
-                                      flakes    []]
-                                 (if value
-                                   (let [new-flakes (<? (property-value->flakes sid pid k value pid->shape->p-shapes pid->shacl-dt
-                                                                                new-subj? existing? tx-state))]
-                                     (recur r true (into flakes new-flakes)))
-                                   flakes))]
-                (recur r (into subj-flakes new-flakes)))
-              (let [retracting-flakes (<? (retract-flakes db-before sid pid t))]
-                (recur r (into subj-flakes retracting-flakes)))))
-          ;; return two-tuple of node's final sid (needed to link nodes together) and the resulting flakes
-          [sid subj-flakes])))))
-
-(defn ->tx-state
-  [db {:keys [bootstrap? did context-type txn-context] :as _opts}]
-  (let [{:keys [schema branch ledger policy], db-t :t} db
-        last-pid  (volatile! (jld-ledger/last-pid db))
-        last-sid  (volatile! (jld-ledger/last-sid db))
-        commit-t  (-> (ledger-proto/-status ledger branch) branch/latest-commit-t)
-        t         (-> commit-t inc -) ;; commit-t is always positive, need to make negative for internal indexing
-        db-before (dbproto/-rootdb db)]
-    {:did                      did
-     :db-before                db-before
-     :policy                   policy
-     :bootstrap?               bootstrap?
-     :default-ctx              (if context-type
-                                 (dbproto/-context db ::dbproto/default-context context-type)
-                                 (dbproto/-context db))
-     :stage-update?            (= t db-t) ;; if a previously staged db is getting updated again before committed
-     :refs                     (volatile! (or (:refs schema) #{const/$rdf:type}))
-     :t                        t
-     :last-pid                 last-pid
-     :last-sid                 last-sid
-     :next-pid                 (fn [] (vswap! last-pid inc))
-     :next-sid                 (fn [] (vswap! last-sid inc))
-     :subj-mods                (atom {}) ;; holds map of subj ids (keys) for modified flakes map with shacl shape and classes
-     :iris                     (volatile! {})
-     :txn-context              txn-context
-     :shacl-target-objects-of? (shacl/has-target-objects-of-rule? db-before)}))
-
-(defn final-ecount
-  [tx-state]
-  (let [{:keys [db-before last-pid last-sid]} tx-state
-        {:keys [ecount]} db-before]
-    (assoc ecount const/$_predicate @last-pid
-                  const/$_default @last-sid)))
 
 (defn base-flakes
   "Returns base set of flakes needed in any new ledger."
@@ -351,101 +28,6 @@
   [(flake/create const/$rdf:type const/$xsd:anyURI const/iri-type const/$xsd:string t true nil)
    (flake/create const/$rdfs:Class const/$xsd:anyURI const/iri-class const/$xsd:string t true nil)
    (flake/create const/$xsd:anyURI const/$xsd:anyURI "@id" const/$xsd:string t true nil)])
-
-;; TODO - can use transient! below
-(defn stage-update-novelty
-  "If a db is staged more than once, any retractions in a previous stage will
-  get completely removed from novelty. This returns flakes that must be added and removed
-  from novelty."
-  [novelty-flakes new-flakes]
-  (loop [[f & r] new-flakes
-         adds    new-flakes
-         removes (empty new-flakes)]
-    (if f
-      (if (true? (flake/op f))
-        (recur r adds removes)
-        (let [flipped (flake/flip-flake f)]
-          (if (contains? novelty-flakes flipped)
-            (recur r (disj adds f) (conj removes flipped))
-            (recur r adds removes))))
-      [(not-empty adds) (not-empty removes)])))
-
-(defn db-after
-  [{:keys [add remove] :as _staged} {:keys [db-before policy bootstrap? t] :as tx-state}]
-  (let [new-db (-> db-before
-                   (assoc :ecount (final-ecount tx-state)
-                          :policy policy ;; re-apply policy to db-after
-                          :t t)
-                   (commit-data/update-novelty add remove))]
-    (if bootstrap?
-      new-db
-      ;; TODO - we used to add tt-id to break the cache, so multiple 'staged' dbs with same t value don't get cached as the same
-      ;; TODO - now that each db should have its own unique hash, we can use the db's hash id instead of 't' or 'tt-id' for caching
-      (commit-data/add-tt-id new-db))))
-
-(defn final-db
-  "Returns map of all elements for a stage transaction required to create an
-  updated db."
-  [new-flakes {:keys [stage-update? db-before] :as tx-state}]
-  (go-try
-    (let [[add remove] (if stage-update?
-                         (stage-update-novelty (get-in db-before [:novelty :spot]) new-flakes)
-                         [new-flakes nil])
-          vocab-flakes (jld-reify/get-vocab-flakes new-flakes)
-          staged-map   {:add    add
-                        :remove remove}
-          db-after     (cond-> (db-after staged-map tx-state)
-                         vocab-flakes vocab/refresh-schema
-                         vocab-flakes <?)]
-      (assoc staged-map :db-after db-after))))
-
-(defn track-into
-  [flakes track-fuel additions]
-  (if track-fuel
-    (into flakes track-fuel additions)
-    (into flakes additions)))
-
-(defn init-db?
-  [db]
-  (-> db :t zero?))
-
-(defn validate-node
-  "Throws if node is invalid, otherwise returns node."
-  [node]
-  (if (empty? (dissoc node :idx :id))
-    (throw (ex-info (str "Invalid transaction, transaction node contains no properties"
-                         (some->> (:id node)
-                                  (str " for @id: "))
-                         ".")
-                    {:status 400 :error :db/invalid-transaction}))
-    node))
-
-(defn insert
-  "Performs insert transaction. Returns async chan with resulting flakes."
-  [{:keys [t] :as db} fuel-tracker json-ld {:keys [default-ctx txn-context] :as tx-state}]
-  (go-try
-    (let [track-fuel (when fuel-tracker
-                       (fuel/track fuel-tracker))
-          flakeset   (cond-> (flake/sorted-set-by flake/cmp-flakes-spot)
-                       (init-db? db) (track-into track-fuel (base-flakes t)))]
-      (loop [[node & r] (util/sequential json-ld)
-             flakes flakeset]
-        (if node
-          (let [node*   {"@context" txn-context
-                         "@graph"   [node]}
-                [expanded] (json-ld/expand node* default-ctx)
-                flakes* (if (map? expanded)
-                          (let [[_sid node-flakes] (<? (json-ld-node->flakes (validate-node expanded) tx-state nil))]
-                            (track-into flakes track-fuel node-flakes))
-                          ;;node expanded to a list of child nodes
-                          (loop [[child & children] expanded
-                                 all-flakes flakes]
-                            (if child
-                              (let [[_sid child-flakes] (<? (json-ld-node->flakes (validate-node child) tx-state nil))]
-                                (recur children (track-into all-flakes track-fuel child-flakes)))
-                              all-flakes)))]
-            (recur r flakes*))
-          flakes)))))
 
 (defn validate-rules
   [{:keys [db-after add] :as staged-map} {:keys [subj-mods] :as _tx-state}]
@@ -488,64 +70,23 @@
                 (vocab/reset-shapes (:schema db-after)))
               staged-map)))))))
 
-(defn flakes->final-db
-  "Takes final set of proposed staged flakes and turns them into a new db value
-  along with performing any final validation and policy enforcement."
-  [tx-state flakes]
-  (go-try
-    (-> flakes
-        (final-db tx-state)
-        <?
-        (validate-rules tx-state)
-        <?
-        (policy/allowed? tx-state)
-        <?
-        ;; unwrap the policy
-        dbproto/-rootdb)))
-
-(defn stage
-  "Stages changes, but does not commit.
-  Returns async channel that will contain updated db or exception."
-  ([db json-ld opts]
-   (stage db nil json-ld opts))
-  ([db fuel-tracker json-ld opts]
-   (go-try
-     (let [{tx :subject did :did}   (or (<? (cred/verify json-ld))
-                                        {:subject json-ld})
-           opts*                    (cond-> opts did (assoc :did did))
-           db*                      (if-let [policy-opts (perm/policy-opts opts*)]
-                                      (<? (perm/wrap-policy db policy-opts))
-                                      db)
-           {:keys [t] :as tx-state} (->tx-state db* opts*)
-           flakes-ch                (if (fql/update? tx)
-                                      (fql/modify db t fuel-tracker tx)
-                                      (insert db fuel-tracker tx tx-state))
-           fuel-error-ch            (:error-ch fuel-tracker)
-           chans                    (remove nil? [fuel-error-ch flakes-ch])
-           [flakes]                 (alts! chans :priority true)]
-       (when (util/exception? flakes)
-         (throw flakes))
-       (log/trace "stage flakes:" flakes)
-       (<? (flakes->final-db tx-state flakes))))))
-
-(defn stage-ledger
-  ([ledger json-ld opts]
-   (stage-ledger ledger nil json-ld opts))
-  ([ledger fuel-tracker json-ld opts]
-   (let [{:keys [defaultContext]} opts
-         db (cond-> (ledger-proto/-db ledger)
-              defaultContext (dbproto/-default-context-update defaultContext))]
-     (stage db fuel-tracker json-ld opts))))
-
-(defn transact!
-  ([ledger json-ld opts]
-   (transact! ledger nil json-ld opts))
-  ([ledger fuel-tracker json-ld opts]
-   (go-try
-     (let [staged (<? (stage-ledger ledger fuel-tracker json-ld opts))]
-       (<? (ledger-proto/-commit! ledger staged))))))
-
-;; ----------------------------------------
+;; TODO - can use transient! below
+(defn stage-update-novelty
+  "If a db is staged more than once, any retractions in a previous stage will
+  get completely removed from novelty. This returns flakes that must be added and removed
+  from novelty."
+  [novelty-flakes new-flakes]
+  (loop [[f & r] new-flakes
+         adds    new-flakes
+         removes (empty new-flakes)]
+    (if f
+      (if (true? (flake/op f))
+        (recur r adds removes)
+        (let [flipped (flake/flip-flake f)]
+          (if (contains? novelty-flakes flipped)
+            (recur r (disj adds f) (conj removes flipped))
+            (recur r adds removes))))
+      [(not-empty adds) (not-empty removes)])))
 
 (defn next-id
   "Generate the next subject id - `counter-key` is either :last-pid or :last-sid."

--- a/src/fluree/db/json_ld/vocab.cljc
+++ b/src/fluree/db/json_ld/vocab.cljc
@@ -220,32 +220,6 @@
   (reset! shapes {:class {}
                   :pred  {}}))
 
-(defn vocab-map
-  "Returns a map of the schema for a db to allow quick lookups of schema properties.
-  Schema is a map with keys:
-  - :t - the 't' value when schema built, allows schema equality checks
-  - :coll - collection info, mapping cid->name and name->cid all within the same map
-  - :pred - predicate info, mapping pid->properties and name->properties for quick lookup based on id or name respectively
-  - :fullText - contains predicate ids that need fulltext search
-  "
-  [{:keys [t] :as db}]
-  (go-try
-    (let [vocab-flakes (<? (query-range/index-range db :spot
-                                                    >= [schema-util/schema-sid-end]
-                                                    <= [0]))
-          base-schema  (base-schema)
-          schema       (update-with* base-schema t vocab-flakes)
-          refs         (extract-ref-sids (:pred schema))]
-      (-> schema
-          (assoc :refs refs)))))
-
-(defn refresh-schema
-  "Updates the schema map of a db."
-  [db]
-  (go-try
-    (let [schema (<? (vocab-map db))]
-      (assoc db :schema schema))))
-
 (defn predicate-flakes-by-type
   "Returns a map of predicate flakes mapped by type"
   [flakes]

--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -71,14 +71,3 @@
       (let [track-fuel (fuel/track fuel-tracker)]
         (async/transduce track-fuel into flakeset flake-ch))
       (async/reduce into flakeset flake-ch))))
-
-(defn modify
-  [db t fuel-tracker mdfn]
-  (go
-    (let [error-ch  (async/chan)
-          update-ch (->> (where/search db mdfn fuel-tracker error-ch)
-                         (update/modify db mdfn t fuel-tracker error-ch)
-                         (into-flakeset fuel-tracker))]
-      (async/alt!
-        error-ch ([e] e)
-        update-ch ([flakes] flakes)))))

--- a/src/fluree/db/query/exec/update.cljc
+++ b/src/fluree/db/query/exec/update.cljc
@@ -1,6 +1,5 @@
 (ns fluree.db.query.exec.update
   (:require [fluree.db.flake :as flake]
-            [fluree.db.fuel :as fuel]
             [fluree.db.constants :as const]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.query.exec.where :as where]
@@ -15,121 +14,6 @@
 (defn iri-mapping?
   [flake]
   (= const/$xsd:anyURI (flake/p flake)))
-
-(defn retract-triple
-  [db triple t solution fuel-tracker error-ch]
-  (let [retract-xf (keep (fn [f]
-                           ;;do not retract the flakes which map subject ids to iris.
-                           ;;they are an internal optimization, which downstream code
-                           ;;(eg the commit pipeline) relies on
-                           (when-not (iri-mapping? f)
-                             (flake/flip-flake f t))))
-        matched    (where/assign-matched-values triple solution nil)]
-    (where/resolve-flake-range db fuel-tracker retract-xf error-ch matched)))
-
-(defn retract-clause
-  [db clause t solution fuel-tracker error-ch out-ch]
-  (let [clause-ch  (async/to-chan! clause)]
-    (async/pipeline-async 2
-                          out-ch
-                          (fn [triple ch]
-                            (go (let [triple* (<! (where/resolve-sids db error-ch triple))]
-                                  (-> db
-                                      (retract-triple triple* t solution fuel-tracker error-ch)
-                                      (async/pipe ch)))))
-                          clause-ch)
-    out-ch))
-
-(defn retract
-  [db mdfn t fuel-tracker error-ch solution-ch]
-  (let [{:keys [delete]} mdfn
-        retract-ch       (async/chan 2)]
-    (async/pipeline-async 2
-                          retract-ch
-                          (fn [solution ch]
-                            (retract-clause db delete t solution fuel-tracker error-ch ch))
-                          solution-ch)
-    retract-ch))
-
-(defn insert-triple
-  [db triple t solution error-ch]
-  (go
-    (try* (let [alias               (:alias db)
-                [s-mch p-mch o-mch] (where/assign-matched-values triple solution nil)
-                s                   (where/get-sid s-mch alias)
-                p                   (where/get-sid p-mch alias)
-                o                   (or (where/get-sid o-mch alias)
-                                        (where/get-value o-mch))
-                dt                  (where/get-datatype o-mch)]
-            (when (and (some? s) (some? p) (some? o) (some? dt))
-              ;; wrap created flake in a vector so the output of this function has the
-              ;; same shape as the retract functions
-              [(flake/create s p o dt t true nil)]))
-          (catch* e
-                  (log/error e "Error inserting new triple")
-                  (>! error-ch e)))))
-
-(defn insert-clause
-  [db clause t solution error-ch out-ch]
-  (async/pipeline-async 2
-                        out-ch
-                        (fn [triple ch]
-                           (go (let [triple* (<! (where/resolve-sids db error-ch triple))]
-                                (-> db
-                                    (insert-triple triple* t solution error-ch)
-                                    (async/pipe ch)))))
-                        (async/to-chan! clause))
-  out-ch)
-
-(defn insert
-  [db mdfn t error-ch solution-ch]
-  (let [clause    (:insert mdfn)
-        insert-ch (async/chan 2)]
-    (async/pipeline-async 2
-                          insert-ch
-                          (fn [solution ch]
-                            (insert-clause db clause t solution error-ch ch))
-                          solution-ch)
-    insert-ch))
-
-(defn insert-retract
-  [db mdfn t fuel-tracker error-ch solution-ch]
-  (let [solution-ch*    (async/chan 2) ; create an extra channel to multiply so
-                                       ; solutions don't get dropped before we
-                                       ; can add taps to process them.
-        solution-mult   (async/mult solution-ch*)
-        insert-soln-ch  (->> (async/chan 2)
-                             (async/tap solution-mult))
-        insert-ch       (insert db mdfn t error-ch insert-soln-ch)
-        retract-soln-ch (->> (async/chan 2)
-                             (async/tap solution-mult))
-        retract-ch      (retract db mdfn t fuel-tracker error-ch retract-soln-ch)]
-    (async/pipe solution-ch solution-ch*) ; now hook up the solution input
-                                          ; after everything is wired
-    (async/merge [insert-ch retract-ch])))
-
-(defn insert?
-  [mdfn]
-  (or (contains? mdfn :insert)
-      (contains? mdfn "insert")))
-
-(defn retract?
-  [mdfn]
-  (or (contains? mdfn :delete)
-      (contains? mdfn "delete")))
-
-(defn modify
-  [db mdfn t fuel-tracker error-ch solution-ch]
-  (cond
-    (and (insert? mdfn)
-         (retract? mdfn))
-    (insert-retract db mdfn t fuel-tracker error-ch solution-ch)
-
-    (insert? mdfn)
-    (insert db mdfn t error-ch solution-ch)
-
-    (retract? mdfn)
-    (retract db mdfn t fuel-tracker error-ch solution-ch)))
 
 (defn retract-triple2
   [db triple {:keys [t]} solution fuel-tracker error-ch]
@@ -306,6 +190,14 @@
     (async/pipe solution-ch solution-ch*) ; now hook up the solution input
                                         ; after everything is wired
     (async/merge [insert-ch retract-ch])))
+
+(defn insert?
+  [txn]
+  (contains? txn :insert))
+
+(defn retract?
+  [txn]
+  (contains? txn :delete))
 
 (defn modify2
   [db parsed-txn tx-state fuel-tracker error-ch solution-ch]

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -1,12 +1,10 @@
 (ns fluree.db.query.fql
   (:require [clojure.core.async :as async :refer [<! go]]
-            [fluree.db.util.log :as log :include-macros true]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.context :as ctx-util]
             [fluree.db.query.subject-crawl.core :refer [simple-subject-crawl]]
             [fluree.db.query.fql.parse :as parse]
             [fluree.db.query.exec :as exec]
-            [fluree.db.query.exec.update :as update]
             [fluree.db.query.subject-crawl.reparse :refer [re-parse-as-simple-subj-crawl]])
   (:refer-clojure :exclude [var? vswap!])
   #?(:cljs (:require-macros [clojure.core])))
@@ -57,22 +55,3 @@
          (if (= :simple-subject-crawl (:strategy q))
            (simple-subject-crawl db* q)
            (exec/query db* fuel-tracker q)))))))
-
-(defn update?
-  [x]
-  (and (map? x)
-       (or (update/insert? x)
-           (update/retract? x))
-       (or (contains? x :where)
-           (contains? x "where")
-           (contains? x :values)
-           (contains? x "values"))))
-
-(defn modify
-  ([db t json-ld]
-   (modify db t nil json-ld))
-
-  ([db t fuel-tracker {:keys [opts] :as mdfn-map}]
-   (let [ctx  (ctx-util/extract db mdfn-map opts)
-         mdfn (parse/parse-modification mdfn-map ctx)]
-     (exec/modify db t fuel-tracker mdfn))))

--- a/src/fluree/db/util/context.cljc
+++ b/src/fluree/db/util/context.cljc
@@ -198,13 +198,24 @@
 (defn txn-context
   "Remove the fluree context from the supplied context."
   [txn]
-  (validate-txn-context txn)
-  (let [supplied-context (->> (get txn "@context" (:context txn))
-                              (util/sequential)
-                              (remove #{"https://ns.flur.ee"}))]
+  (let [supplied-context (when (or (contains? txn :context)
+                                   (contains? txn "@context"))
+                              (->> (get txn "@context" (:context txn))
+                                   (util/sequential)
+                                   (remove #{"https://ns.flur.ee"})))]
+
     (if (seq supplied-context)
       supplied-context
       ::dbproto/default-context)))
+
+(defn use-fluree-context
+  "Clobber the top-level context and use the fluree context. This is only intended to be
+  use for the initial expansion of the top-level document, where all the keys should be
+  fluree vocabulary terms."
+  [txn]
+  (-> txn
+      (dissoc :context "@context")
+      (assoc "@context" "https://ns.flur.ee")))
 
 (defn extract
   [db jsonld opts]

--- a/test/fluree/db/indexer/default_test.clj
+++ b/test/fluree/db/indexer/default_test.clj
@@ -19,7 +19,7 @@
                                                :reindex-max-bytes 10000000}
                                     :context (merge test-utils/default-str-context {"ex" "http://example.org/ns/"})}})
             ledger @(fluree/create conn "index/datetimes")
-            db @(fluree/stage2
+            db @(fluree/stage
                   (fluree/db ledger)
                   {"@context" "https://ns.flur.ee"
                    "insert"

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -23,7 +23,7 @@
              check1       @(fluree/exists? conn ledger-alias)
              ledger       @(fluree/create conn ledger-alias)
              check2       @(fluree/exists? conn ledger-alias)
-             _            @(fluree/stage2 (fluree/db ledger)
+             _            @(fluree/stage (fluree/db ledger)
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{:id :f/me
@@ -36,7 +36,7 @@
        (let [conn         (test-utils/create-conn)
              ledger-alias "testledger"
              ledger       @(fluree/create conn ledger-alias)
-             db           @(fluree/stage2 (fluree/db ledger)
+             db           @(fluree/stage (fluree/db ledger)
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{:id           :f/me
@@ -52,7 +52,7 @@
           (let [conn         (<! (test-utils/create-conn))
                 ledger-alias "testledger"
                 ledger       (<p! (fluree/create conn ledger-alias))
-                db           (<p! (fluree/stage2 (fluree/db ledger)
+                db           (<p! (fluree/stage (fluree/db ledger)
                                                  {"@context" "https://ns.flur.ee"
                                                   "insert"
                                                   [{:id           :f/me
@@ -88,7 +88,7 @@
                                  :context-type :keyword}})
                ledger-alias "load-from-file-test-single-card"
                ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-               db           @(fluree/stage2
+               db           @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -108,7 +108,7 @@
                                   :ex/favNums   5
                                   :ex/friend    :ex/brian}]})
                db        @(fluree/commit! ledger db)
-               db        @(fluree/stage2
+               db        @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -131,7 +131,7 @@
                                  :context-type :keyword}})
                ledger-alias "load-from-file-test-multi-card"
                ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-               db           @(fluree/stage2
+               db           @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -157,7 +157,7 @@
                                   :ex/favNums   [5 10]
                                   :ex/friend    [:ex/brian :ex/alice]}]})
                db        @(fluree/commit! ledger db)
-               db        @(fluree/stage2
+               db        @(fluree/stage
                             db
                             ;; test a multi-cardinality retraction
                             {"@context" "https://ns.flur.ee"
@@ -185,7 +185,7 @@
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn ledger-alias
                                               {:defaultContext ["" ledger-context]})
-               db             @(fluree/stage2
+               db             @(fluree/stage
                                  (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -232,7 +232,7 @@
                ledger-alias   "load-from-file-query"
                ledger         @(fluree/create conn ledger-alias
                                               {:defaultContext ["" ledger-context]})
-               db             @(fluree/stage2
+               db             @(fluree/stage
                                  (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -264,7 +264,7 @@
                ledger-alias   "load-from-file-with-context"
                ledger         @(fluree/create conn1 ledger-alias
                                               {:defaultContext ["" ledger-context]})
-               db             @(fluree/stage2
+               db             @(fluree/stage
                                  (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -298,7 +298,7 @@
                                  :context-type :keyword}})
                ledger-alias "load-lists-test"
                ledger       @(fluree/create conn ledger-alias)
-               db           @(fluree/stage2
+               db           @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -337,7 +337,7 @@
                                    :context-type :keyword}})
                  ledger-alias "load-policy-test"
                  ledger       @(fluree/create conn ledger-alias)
-                 db           @(fluree/stage2
+                 db           @(fluree/stage
                                  (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -353,7 +353,7 @@
                                    {:id      "did:fluree:123"
                                     :ex/user :ex/alice
                                     :f/role  :ex/userRole}]})
-                 db+policy    @(fluree/stage2
+                 db+policy    @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -409,7 +409,7 @@
                                         {:context (merge test-utils/default-str-context
                                                          {"ex" "http://example.org/ns/"})}})
                ledger @(fluree/create conn "index/datetimes")
-               db     @(fluree/stage2
+               db     @(fluree/stage
                          (fluree/db ledger)
                          {"@context" "https://ns.flur.ee"
                           "insert"
@@ -445,7 +445,7 @@
                               :context-type :keyword}})
              ledger-alias "load-from-memory-test-single-card"
              ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-             db           @(fluree/stage2
+             db           @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -464,7 +464,7 @@
                                 :ex/favNums   5
                                 :ex/friend    :ex/brian}]})
              db           @(fluree/commit! ledger db)
-             db           @(fluree/stage2
+             db           @(fluree/stage
                              db
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -486,7 +486,7 @@
                               :context-type :keyword}})
              ledger-alias "load-from-memory-test-multi-card"
              ledger       @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-             db           @(fluree/stage2
+             db           @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -512,7 +512,7 @@
                                 :ex/favNums   [5 10]
                                 :ex/friend    [:ex/brian :ex/alice]}]})
              db           @(fluree/commit! ledger db)
-             db           @(fluree/stage2
+             db           @(fluree/stage
                              db
                              ;; test a multi-cardinality retraction
                              {"@context" "https://ns.flur.ee"
@@ -539,7 +539,7 @@
              ledger-alias   "load-from-memory-with-context"
              ledger         @(fluree/create conn ledger-alias
                                             {:defaultContext ["" ledger-context]})
-             db             @(fluree/stage2
+             db             @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -583,7 +583,7 @@
              ledger-alias   "load-from-memory-query"
              ledger         @(fluree/create conn ledger-alias
                                             {:defaultContext ["" ledger-context]})
-             db             @(fluree/stage2
+             db             @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -610,7 +610,7 @@
                               :context-type :keyword}})
              ledger-alias "load-lists-test"
              ledger       @(fluree/create conn ledger-alias)
-             db           @(fluree/stage2
+             db           @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -647,7 +647,7 @@
                                 :context-type :keyword}})
                ledger-alias "load-policy-test"
                ledger       @(fluree/create conn ledger-alias)
-               db           @(fluree/stage2
+               db           @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -663,7 +663,7 @@
                                  {:id      "did:fluree:123"
                                   :ex/user :ex/alice
                                   :f/role  :ex/userRole}]})
-               db+policy    @(fluree/stage2
+               db+policy    @(fluree/stage
                                db
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -761,7 +761,7 @@
                                     :context-type :keyword}})
              ledger-alias      "tx/delete"
              ledger            @(fluree/create conn ledger-alias {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-             db1               @(fluree/stage2
+             db1               @(fluree/stage
                                   (fluree/db ledger)
                                   {"@context" "https://ns.flur.ee"
                                    "insert"
@@ -783,7 +783,7 @@
              _                 @(fluree/commit! ledger db1)
              loaded1           (test-utils/retry-load conn ledger-alias 100)
              loaded-db1        (fluree/db loaded1)
-             db2               @(fluree/stage2
+             db2               @(fluree/stage
                                   loaded-db1
                                   {"@context" "https://ns.flur.ee"
                                    "where" {:id :ex/mosquitos, "?p" "?o"}
@@ -794,7 +794,7 @@
          (is (= [{:id :ex/fluree} {:id :ex/w3c} {:id :ex/kittens}]
                 @(fluree/query loaded-db2 description-query))
              "The id :ex/mosquitos should be removed")
-         (let [db3        @(fluree/stage2
+         (let [db3        @(fluree/stage
                              loaded-db2
                              {"@context" "https://ns.flur.ee"
                               "delete" {:id "?s", "?p" "?o"}
@@ -842,7 +842,7 @@
              db0    (fluree/db ledger)]
          (testing "transactions"
            (testing "with the `:meta` option"
-             (let [response    @(fluree/stage2 db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people}
+             (let [response    @(fluree/stage db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people}
                                               {:meta true})
                    db          (:result response)
                    flake-total (- (-> db :stats :flakes)
@@ -852,16 +852,16 @@
                       (:fuel response))
                    "Reports fuel for all the generated flakes")))
            (testing "without the `:meta` option"
-             (let [response @(fluree/stage2 db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people})]
+             (let [response @(fluree/stage db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people})]
                (is (nil? (:fuel response))
                    "Returns no fuel")))
            (testing "short-circuits if request fuel exhausted"
-             (let [response @(fluree/stage2 db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people}
+             (let [response @(fluree/stage db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people}
                                             {:maxFuel 1})]
                (is (re-find #"Fuel limit exceeded"
                             (-> response ex-cause ex-message))))))
          (testing "queries"
-           (let [db          @(fluree/stage2 db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people})
+           (let [db          @(fluree/stage db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people})
                  flake-total (-> db :stats :flakes)
                  query       '{:select [?s ?p ?o]
                                :where  {:id ?s
@@ -880,7 +880,7 @@
                              :where  {:id ?s
                                       ?p ?o}
                              :opts   {:max-fuel 1}}
-                   db      @(fluree/stage2 db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people})
+                   db      @(fluree/stage db0 {"@context" "https://ns.flur.ee" "insert" test-utils/people})
                    results @(fluree/query db query)]
                (is (util/exception? results))
                (is (re-find #"Fuel limit exceeded"
@@ -896,7 +896,7 @@
                  db0    (fluree/db ledger)]
              (testing "transactions"
                (testing "with the `:meta` option"
-                 (let [response    (<p! (fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+                 (let [response    (<p! (fluree/stage db0 {"@context" "https://ns.flur.ee"
                                                             "insert" test-utils/people} {:meta true}))
                        db          (:result response)
                        flake-total (- (-> db :stats :flakes)
@@ -904,20 +904,20 @@
                    (is (= flake-total (:fuel response))
                        "Reports fuel for all the generated flakes")))
                (testing "without the `:meta` option"
-                 (let [response (<p! (fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+                 (let [response (<p! (fluree/stage db0 {"@context" "https://ns.flur.ee"
                                                          "insert" test-utils/people}))]
                    (is (nil? (:fuel response))
                        "Returns no fuel")))
                (testing "short-circuits if request fuel exhausted"
                  (let [response (try
-                                  (<p! (fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+                                  (<p! (fluree/stage db0 {"@context" "https://ns.flur.ee"
                                                            "insert" test-utils/people}
                                                       {:maxFuel 1}))
                                   (catch :default e (ex-cause e)))]
                    (is (re-find #"Fuel limit exceeded"
                                 (-> response ex-cause ex-message))))))
              (testing "queries"
-               (let [db          (<p! (fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+               (let [db          (<p! (fluree/stage db0 {"@context" "https://ns.flur.ee"
                                                           "insert" test-utils/people}))
                      flake-total (-> db :stats :flakes)
                      query       '{:select [?s ?p ?o]
@@ -937,7 +937,7 @@
                                  :where  {:id ?s
                                           ?p ?o}
                                  :opts   {:max-fuel 1}}
-                       db      (<p! (fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+                       db      (<p! (fluree/stage db0 {"@context" "https://ns.flur.ee"
                                                         "insert" test-utils/people}))
                        results (try
                                  (<p! (fluree/query db query))
@@ -954,7 +954,7 @@
            ledger @(fluree/create conn ledger-id {:defaultContext [test-utils/default-str-context {"ex" "ns:ex/"}]})
            db0    (fluree/db ledger)
 
-           db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+           db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                     "insert" [{"@id" "ex:dp"
                                                "ex:name" "Dan"
                                                "ex:child" [{"@id" "ex:ap" "ex:name" "AP"}
@@ -962,7 +962,7 @@
                                                "ex:spouse" [{"@id" "ex:kp" "ex:name" "KP"
                                                              "ex:spouse" {"@id" "ex:dp"}}]}]})
 
-           db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+           db2 @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                     "where" {"id" "?s", "ex:name" "?name"}
                                     "delete" {"@id" "?s" "ex:name" "?name"}
                                     "insert" {"@graph"
@@ -979,7 +979,7 @@
                                                  "ex:zip" {"@value" 55105 "@type" "ex:PostalCode"}
                                                  "ex:state" "MN"}
                                                 "ex:favs" {"@list" ["Persey" {"@id" "ex:dp"}]}}]}})
-           db3 @(fluree/stage2 db2 {"@context" "https://ns.flur.ee"
+           db3 @(fluree/stage db2 {"@context" "https://ns.flur.ee"
                                     "insert" {"@type" "sh:NodeShape"
                                               "sh:targetClass" {"@id" "ex:Friend"}
                                               "sh:property"
@@ -987,7 +987,7 @@
                                                 "sh:maxCount" 1
                                                 "sh:datatype" {"@id" "xsd:string"}}]}})
 
-           db4 @(fluree/stage2 db3 {"@context" "https://ns.flur.ee"
+           db4 @(fluree/stage db3 {"@context" "https://ns.flur.ee"
                                     "insert" {"@id" "ex:mp"
                                               "@type" "ex:Friend"
                                               "ex:nickname" "Murrseph Gordon-Levitt"}})
@@ -995,7 +995,7 @@
            root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
            alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
 
-           db5 @(fluree/stage2 db3 {"@context" "https://ns.flur.ee"
+           db5 @(fluree/stage db3 {"@context" "https://ns.flur.ee"
                                     "insert" {"@graph"
                                               [{"@id" root-did "f:role" {"@id" "ex:rootRole"}}
                                                {"@id" alice-did "f:role" {"@id" "ex:userRole"} "ex:user" {"@id" "ex:alice"}}
@@ -1033,7 +1033,7 @@
                                                                                      [{"@id" "f:$identity"}
                                                                                       {"@id" "ex:user"}]}}}}]}})
 
-           db6 @(fluree/stage2 db5 {"@context" "https://ns.flur.ee",
+           db6 @(fluree/stage db5 {"@context" "https://ns.flur.ee",
                                     "insert" [{"@id" "schema:givenName", "@type" "rdf:Property"}
                                               {"@id" "ex:firstName",
                                                "@type" "rdf:Property",
@@ -1042,7 +1042,7 @@
                                                "@type" "rdf:Property",
                                                "owl:equivalentProperty" {"@id" "ex:firstName"}}]})
 
-           db7 @(fluree/stage2 db6 {"@context" "https://ns.flur.ee",
+           db7 @(fluree/stage db6 {"@context" "https://ns.flur.ee",
                                     "insert" [{"@id" "ex:andrew", "schema:givenName" "Andrew"}
                                               {"@id" "ex:freddy", "foaf:name" "Freddy"}
                                               {"@id" "ex:letty", "ex:firstName" "Leticia"}
@@ -1133,7 +1133,7 @@
                                                                       {"ex" "http://example.com/"}]})
            db0       (fluree/db ledger)]
        (testing "use default context"
-         (let [db1 @(fluree/stage2 db0 {"insert" {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
+         (let [db1 @(fluree/stage db0 {"insert" {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
 
            (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
                   @(fluree/query db1 {"@context"  nil
@@ -1141,24 +1141,24 @@
                "default context was used to expand")))
 
        (testing "use instead of default context"
-         (let [db2 @(fluree/stage2 db0 {"@context" {"ex" "DEFAULTOVERRIDEN:ns/"}
-                                        "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
+         (let [db2 @(fluree/stage db0 {"@context" {"ex" "DEFAULTOVERRIDEN:ns/"}
+                                       "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
            (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
                   @(fluree/query db2 {"@context"  nil
                                       "selectOne" {"DEFAULTOVERRIDEN:ns/t2" ["*"]}}))
                "supplied context used, default context not used")))
 
        (testing "use with default context"
-         (let [db3 @(fluree/stage2 db0 {"@context" ["" {"foo" "ns:foo/"}]
-                                        "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
+         (let [db3 @(fluree/stage db0 {"@context" ["" {"foo" "ns:foo/"}]
+                                       "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
            (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
                   @(fluree/query db3 {"@context"  nil
                                       "selectOne" {"http://example.com/t3" ["*"]}}))
                "default context used, supplemented by supplied context")))
 
        (testing "use no context"
-         (let [db4 @(fluree/stage2 db0 {"@context" nil
-                                        "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
+         (let [db4 @(fluree/stage db0 {"@context" nil
+                                       "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
            (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
                   @(fluree/query db4 {"@context"  nil
                                       "selectOne" {"ex:t4" ["*"]}}))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -1133,8 +1133,7 @@
                                                                       {"ex" "http://example.com/"}]})
            db0       (fluree/db ledger)]
        (testing "use default context"
-         (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
-                                        "insert"   {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
+         (let [db1 @(fluree/stage2 db0 {"insert" {"@id" "ex:t1" "@type" "my:ContextTest" "ex:pred" true}})]
 
            (is (= {"@id" "http://example.com/t1" "@type" "my:ContextTest" "http://example.com/pred" true}
                   @(fluree/query db1 {"@context"  nil
@@ -1142,7 +1141,7 @@
                "default context was used to expand")))
 
        (testing "use instead of default context"
-         (let [db2 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {"ex" "DEFAULTOVERRIDEN:ns/"}]
+         (let [db2 @(fluree/stage2 db0 {"@context" {"ex" "DEFAULTOVERRIDEN:ns/"}
                                         "insert"   {"@id" "ex:t2" "@type" "my:ContextTest" "ex:pred" true}})]
            (is (= {"@id" "DEFAULTOVERRIDEN:ns/t2" "@type" "my:ContextTest" "DEFAULTOVERRIDEN:ns/pred" true}
                   @(fluree/query db2 {"@context"  nil
@@ -1150,7 +1149,7 @@
                "supplied context used, default context not used")))
 
        (testing "use with default context"
-         (let [db3 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" "" {"foo" "ns:foo/"}]
+         (let [db3 @(fluree/stage2 db0 {"@context" ["" {"foo" "ns:foo/"}]
                                         "insert"   {"@id" "ex:t3" "@type" "my:ContextTest" "ex:pred" {"@id" "foo:me"}}})]
            (is (= {"@id" "http://example.com/t3" "@type" "my:ContextTest" "http://example.com/pred" {"@id" "ns:foo/me"}}
                   @(fluree/query db3 {"@context"  nil
@@ -1158,8 +1157,7 @@
                "default context used, supplemented by supplied context")))
 
        (testing "use no context"
-         ;; clearing context with nil produces an error because `insert` can't be found
-         (let [db4 @(fluree/stage2 db0 {"@context" ["https://ns.flur.ee" {}]
+         (let [db4 @(fluree/stage2 db0 {"@context" nil
                                         "insert"   {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}})]
            (is (= {"@id" "ex:t4" "@type" "my:ContextTest" "ex:pred" "not expanded"}
                   @(fluree/query db4 {"@context"  nil

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -14,7 +14,7 @@
           ledger    @(fluree/create conn "policy/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
-          db        @(fluree/stage2
+          db        @(fluree/stage
                        (fluree/db ledger)
                        {"@context" "https://ns.flur.ee"
                         "insert"
@@ -45,7 +45,7 @@
                           :ex/user :ex/alice
                           :f/role  :ex/userRole}]})
 
-          db+policy @(fluree/stage2
+          db+policy @(fluree/stage
                        db
                        ;; add policy targeting :ex/rootRole that can view and modify everything
                        {"@context" "https://ns.flur.ee"
@@ -268,7 +268,7 @@
                                         :schema "http://schema.org/"
                                         :ex     "http://example.org/ns/"}})
           alice-did   "did:fluree:Tf6i5oh2ssYNRpxxUM2zea1Yo7x4uRqyTeU"
-          db          @(fluree/stage2
+          db          @(fluree/stage
                          (fluree/db ledger)
                          {"@context" "https://ns.flur.ee"
                           "insert"
@@ -286,7 +286,7 @@
                             :schema/price         99.99
                             :schema/priceCurrency "USD"
                             :ex/secret            "this is overpriced"}]})
-          db          @(fluree/stage2
+          db          @(fluree/stage
                          db
                          {"@context" "https://ns.flur.ee"
                           "insert"
@@ -328,7 +328,7 @@
 
         alice-did    "did:fluree:Tf6i5oh2ssYNRpxxUM2zea1Yo7x4uRqyTeU"
 
-        db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+        db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                  "insert" [{"id" "ex:alice"
                                             "type" "ex:User"
                                             "ex:secret" "alice's secret"}

--- a/test/fluree/db/policy/parsing_test.clj
+++ b/test/fluree/db/policy/parsing_test.clj
@@ -50,7 +50,7 @@
           root-did     (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did    (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           customer-did (:id (did/private->did-map "854358f6cb3a78ff81febe0786010d6e22839ea6bd52e03365a728d7b693b5a0"))
-          db           @(fluree/stage2
+          db           @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -132,7 +132,7 @@
           ledger   @(fluree/create conn "policy-parse/a" {:defaultContext ["" {"ex" "http://example.org/ns/"}]
                                                           :context-type   :string})
           root-did (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
-          db       @(fluree/stage2
+          db       @(fluree/stage
                       (fluree/db ledger)
                       {"@context" "https://ns.flur.ee"
                        "insert"

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -17,7 +17,7 @@
           ledger          @(fluree/create conn "policy/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did        (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did       (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
-          db              @(fluree/stage2
+          db              @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -48,7 +48,7 @@
                                 :ex/user :ex/alice
                                 :f/role  :ex/userRole}]})
 
-          db+policy       @(fluree/stage2
+          db+policy       @(fluree/stage
                              db
                              ;; add policy targeting :ex/rootRole that can view and modify everything
                              {"@context" "https://ns.flur.ee"
@@ -117,7 +117,7 @@
     (let [conn      (test-utils/create-conn)
           ledger    @(fluree/create conn "policy/b" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
-          db        @(fluree/stage2
+          db        @(fluree/stage
                        (fluree/db ledger)
                        {"@context" "https://ns.flur.ee"
                         "insert"
@@ -134,7 +134,7 @@
                           :ex/user :ex/alice
                           :f/role  :ex/userRole}]})
 
-          db+policy @(fluree/stage2
+          db+policy @(fluree/stage
                        db
                        ;; add policy targeting :ex/rootRole that can view and modify everything
                        {"@context" "https://ns.flur.ee"

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -12,7 +12,7 @@
           ledger    @(fluree/create conn "policy/tx-a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
-          db        @(fluree/stage2
+          db        @(fluree/stage
                        (fluree/db ledger)
                        {"@context" "https://ns.flur.ee"
                         "insert"
@@ -43,7 +43,7 @@
                           :ex/user :ex/alice
                           :f/role  [:ex/userRole :ex/otherRole]}]})
 
-          db+policy @(fluree/stage2
+          db+policy @(fluree/stage
                        db
                        {"@context" "https://ns.flur.ee"
                         "insert"
@@ -83,7 +83,7 @@
                                                       :f/action     [:f/view :f/modify]}]}]}]})]
       (testing "Policy allowed modification"
         (testing "using role + id"
-          (let [update-name @(fluree/stage2 db+policy
+          (let [update-name @(fluree/stage db+policy
                                             {"@context" "https://ns.flur.ee"
                                              "delete"
                                              {:id          :ex/alice
@@ -106,7 +106,7 @@
                                    :opts {:did alice-did}}))
                 "Alice should be allowed to update her own name.")))
         (testing "using role only"
-            (let [update-price @(fluree/stage2 db+policy
+            (let [update-price @(fluree/stage db+policy
                                                {"@context" "https://ns.flur.ee"
                                                 "delete"
                                                 {:id          :ex/widget
@@ -125,7 +125,7 @@
                                     {:select {'?s [:*]}
                                      :where  {:id '?s, :type :ex/Product}}))
                   "Updated :schema/price should have been allowed, and entire product is visible in query."))
-            (let [update-name @(fluree/stage2 db+policy
+            (let [update-name @(fluree/stage db+policy
                                               {"@context" "https://ns.flur.ee"
                                                "delete"
                                                {:id          :ex/widget
@@ -143,7 +143,7 @@
                                      :opts {:role :ex/userRole}}))
                   "Updated :schema/name should have been allowed, and only name is visible in query."))))
       (testing "Policy doesn't allow a modification"
-        (let [update-price @(fluree/stage2 db+policy {"@context" "https://ns.flur.ee"
+        (let [update-price @(fluree/stage db+policy {"@context" "https://ns.flur.ee"
                                                       "insert" {:id           :ex/widget
                                                                 :schema/price 42.99}}
                                           {:did root-did
@@ -154,7 +154,7 @@
           (is (= :db/policy-exception
                  (:error (ex-data update-price)))
               "Exception should be of type :db/policy-exception"))
-        (let [update-email @(fluree/stage2 db+policy {"@context" "https://ns.flur.ee"
+        (let [update-email @(fluree/stage db+policy {"@context" "https://ns.flur.ee"
                                                       "insert"   {:id           :ex/john
                                                                   :schema/email "john@foo.bar"}}
                                           {:role :ex/user})]
@@ -165,7 +165,7 @@
           (is (= :db/policy-exception
                  (:error (ex-data update-email)))
               "exception should be of type :db/policy-exception"))
-        (let [update-name-other-role @(fluree/stage2 db+policy {"@context" "https://ns.flur.ee"
+        (let [update-name-other-role @(fluree/stage db+policy {"@context" "https://ns.flur.ee"
                                                                 "insert" {:id          :ex/widget
                                                                           :schema/name "Widget2"}}
                                                     {:did alice-did

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -15,7 +15,7 @@
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "ledger/datatype")]
     (testing "Querying predicates with mixed datatypes"
-      (let [mixed-db @(fluree/stage2 (fluree/db ledger)
+      (let [mixed-db @(fluree/stage (fluree/db ledger)
                                      {"@context" "https://ns.flur.ee"
                                       "insert"
                                       [{:context     default-context

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -7,7 +7,7 @@
 (deftest ^:integration filter-test
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/filter" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-        db     @(fluree/stage2
+        db     @(fluree/stage
                   (fluree/db ledger)
                   {"@context" "https://ns.flur.ee"
                    "insert"

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -197,7 +197,7 @@
   (testing "Querying ledgers loaded with language-tagged strings"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "jobs")
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" ["https://ns.flur.ee"
                                  {"ex"         "http://example.com/vocab/"
@@ -244,7 +244,7 @@
         ledger @(fluree/create conn "people"
                                {:defaultContext
                                 ["" {:ex "http://example.org/ns/"}]})
-        db     @(fluree/stage2
+        db     @(fluree/stage
                   (fluree/db ledger)
                   {"@context" "https://ns.flur.ee"
                    "insert"
@@ -277,7 +277,7 @@
                                  "schema" "http://schema.org/",
                                  "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
         ledger @(fluree/create conn "test/love")
-        db     @(fluree/stage2 (fluree/db ledger)
+        db     @(fluree/stage (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
                                 [{"@id"                "ex:fluree",
@@ -347,7 +347,7 @@
                                                                   "schema" "http://schema.org/",
                                                                   "xsd"    "http://www.w3.org/2001/XMLSchema#"}}})
 
-          authors @(fluree/create-with-txn2 conn
+          authors @(fluree/create-with-txn conn
                                             {"@context" ["https://ns.flur.ee" "" "https://schema.org"]
                                              "ledger"   "test/authors"
                                              "insert"   [{"@id"   "https://www.wikidata.org/wiki/Q42"
@@ -356,7 +356,7 @@
                                                          {"@id"   "https://www.wikidata.org/wiki/Q173540"
                                                           "@type" "Person"
                                                           "name"  "Margaret Mitchell"}]})
-          books   @(fluree/create-with-txn2 conn
+          books   @(fluree/create-with-txn conn
                                             {"@context" ["https://ns.flur.ee" "" "https://schema.org"]
                                              "ledger"   "test/books"
                                              "insert"   [{"id"     "https://www.wikidata.org/wiki/Q3107329",
@@ -369,7 +369,7 @@
                                                           "name"   "Gone with the Wind",
                                                           "isbn"   "0-582-41805-4",
                                                           "author" {"@id" "https://www.wikidata.org/wiki/Q173540"}}]})
-          movies  @(fluree/create-with-txn2 conn
+          movies  @(fluree/create-with-txn conn
                                             {"@context" ["https://ns.flur.ee" "" "https://schema.org"]
                                              "ledger"   "test/movies"
                                              "insert"   [{"id"                        "https://www.wikidata.org/wiki/Q836821",

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -12,7 +12,7 @@
     (let [conn    (test-utils/create-conn)
           ledger  @(fluree/create conn "query/index-range"
                                   {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db      @(fluree/stage2
+          db      @(fluree/stage
                      (fluree/db ledger)
                      {"@context" "https://ns.flur.ee"
                       "insert"

--- a/test/fluree/db/query/json_ld_basic_test.clj
+++ b/test/fluree/db/query/json_ld_basic_test.clj
@@ -124,7 +124,7 @@
     (let [conn   (test-utils/create-conn)
           movies (test-utils/load-movies conn)]
       (testing "define @list container in context"
-        (let [db        @(fluree/stage2 (fluree/db movies)
+        (let [db        @(fluree/stage (fluree/db movies)
                                         {"@context" "https://ns.flur.ee"
                                          "insert"
                                          {:context {:id      "@id"
@@ -139,7 +139,7 @@
                  query-res)
               "Order of query result is different from transaction.")))
       (testing "define @list directly on subject"
-        (let [db        @(fluree/stage2 (fluree/db movies)
+        (let [db        @(fluree/stage (fluree/db movies)
                                         {"@context" "https://ns.flur.ee"
                                          "insert"
                                          {:context {:id      "@id"
@@ -156,7 +156,7 @@
 (deftest ^:integration simple-subject-crawl-test
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/simple-subject-crawl" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-        db     @(fluree/stage2
+        db     @(fluree/stage
                   (fluree/db ledger)
                   {"@context" "https://ns.flur.ee"
                    "insert"

--- a/test/fluree/db/query/json_ld_compound_test.clj
+++ b/test/fluree/db/query/json_ld_compound_test.clj
@@ -8,7 +8,7 @@
   (testing "Simple compound queries."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/compounda" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -355,12 +355,12 @@
       (is (= [[:ex/User]]
              @(fluree/query db '{:select [?class]
                                  :where  {:id :ex/jane, :type ?class}})))
-      (is (= [[:ex/jane :ex/User]
-              [:ex/bob :ex/User]
-              [:ex/alice :ex/User]
-              [:ex/dave :ex/nonUser]]
-             @(fluree/query db '{:select [?s ?class]
-                                 :where  {:id ?s, :type ?class}}))))
+      (is (= #{[:ex/jane :ex/User]
+               [:ex/bob :ex/User]
+               [:ex/alice :ex/User]
+               [:ex/dave :ex/nonUser]}
+             (set @(fluree/query db '{:select [?s ?class]
+                                      :where  {:id ?s, :type ?class}})))))
     (testing "shacl targetClass"
       (let [shacl-db @(fluree/stage
                         (fluree/db ledger)

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -8,7 +8,7 @@
   (testing "Select index's subject id in query using special keyword"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/subid" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"
@@ -31,7 +31,7 @@
 (deftest ^:integration result-formatting
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query-context" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-        db     @(fluree/stage2 (fluree/db ledger) {"@context" "https://ns.flur.ee"
+        db     @(fluree/stage (fluree/db ledger) {"@context" "https://ns.flur.ee"
                                                    "insert"   [{:id :ex/dan :ex/x 1}
                                                                {:id :ex/wes :ex/x 2}]})]
 
@@ -95,7 +95,7 @@
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/everything" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"
@@ -330,7 +330,7 @@
 (deftest ^:integration class-queries
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "query/class" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-        db     @(fluree/stage2
+        db     @(fluree/stage
                   (fluree/db ledger)
                   {"@context" "https://ns.flur.ee"
                    "insert"
@@ -362,7 +362,7 @@
              @(fluree/query db '{:select [?s ?class]
                                  :where  {:id ?s, :type ?class}}))))
     (testing "shacl targetClass"
-      (let [shacl-db @(fluree/stage2
+      (let [shacl-db @(fluree/stage
                         (fluree/db ledger)
                         {"@context" "https://ns.flur.ee"
                          "insert"
@@ -380,7 +380,7 @@
   (let [conn @(fluree/connect {:method :memory})
         ledger @(fluree/create conn "type-handling" {:defaultContext [test-utils/default-str-context {"ex" "http://example.org/ns/"}]})
         db0 (fluree/db ledger)
-        db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+        db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                  "insert" [{"id" "ex:ace"
                                             "type" "ex:Spade"}
                                            {"id" "ex:king"
@@ -389,10 +389,10 @@
                                             "type" "ex:Heart"}
                                            {"id" "ex:jack"
                                             "type" "ex:Club"}]})
-        db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+        db2 @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                  "insert" [{"id" "ex:two"
                                             "rdf:type" "ex:Diamond"}]})
-        db3 @(fluree/stage2 db1 {"@context" ["https://ns.flur.ee" "" {"rdf:type" "@type"}]
+        db3 @(fluree/stage db1 {"@context" ["https://ns.flur.ee" "" {"rdf:type" "@type"}]
                                  "insert" {"id" "ex:two"
                                            "rdf:type" "ex:Diamond"}})]
     (is (= #{{"id" "ex:queen" "type" "ex:Heart"}

--- a/test/fluree/db/query/optional_query_test.clj
+++ b/test/fluree/db/query/optional_query_test.clj
@@ -10,7 +10,7 @@
   (testing "Testing various 'optional' query clauses."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/optional" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"

--- a/test/fluree/db/query/property_test.clj
+++ b/test/fluree/db/query/property_test.clj
@@ -187,11 +187,10 @@
                  {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
                (set @(fluree/query db2 {"select" {"?s" ["*"]}
                                         "where"  {"@id" "?s", "ex:givenName" "?o"}}))))
-        (is (= [{"id" "ex:dan", "ex:givenName" "Dan"}
-                {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}]
-               @(fluree/query db2 {"select" {"?s" ["*"]}
-                                   "where"  {"@id" "?s", "ex:firstName" "?o"}})))
-
+        (is (= #{{"id" "ex:dan", "ex:givenName" "Dan"}
+                 {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
+               (set @(fluree/query db2 {"select" {"?s" ["*"]}
+                                        "where"  {"@id" "?s", "ex:firstName" "?o"}}))))
         (is (= [["ex:other" true false]]
                @(fluree/query db2 {"select" ["?s" "?cool" "?fool"]
                                    "where"  {"@id"     "?s",
@@ -199,10 +198,10 @@
                                              "ex:fool" "?fool"}}))
             "handle list values"))
       (testing "after load"
-        (is (= [{"id" "ex:dan", "ex:givenName" "Dan"}
-                {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}]
-               @(fluree/query dbl {"select" {"?s" ["*"]}
-                                   "where"  {"@id" "?s", "ex:givenName" "?o"}})))
+        (is (= #{{"id" "ex:dan", "ex:givenName" "Dan"}
+                 {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
+               (set @(fluree/query dbl {"select" {"?s" ["*"]}
+                                        "where"  {"@id" "?s", "ex:givenName" "?o"}}))))
         (is (= #{{"id" "ex:dan", "ex:givenName" "Dan"}
                  {"id" "ex:andrew", "ex:firstName" "Andrew", "ex:age" 35}}
                (set @(fluree/query dbl {"select" {"?s" ["*"]}

--- a/test/fluree/db/query/property_test.clj
+++ b/test/fluree/db/query/property_test.clj
@@ -16,7 +16,7 @@
                    "owl"    "http://www.w3.org/2002/07/owl#"}
           db      (-> ledger
                       (fluree/db)
-                      (fluree/stage2 {"@context" ["https://ns.flur.ee" context]
+                      (fluree/stage {"@context" ["https://ns.flur.ee" context]
                                       "insert"   [{"@id"   "vocab1:givenName"
                                                    "@type" "rdf:Property"}
                                                   {"@id"                    "vocab2:firstName"
@@ -26,7 +26,7 @@
                                                    "@type"                  "rdf:Property"
                                                    "owl:equivalentProperty" {"@id" "vocab2:firstName"}}]})
                       deref
-                      (fluree/stage2 {"@context" ["https://ns.flur.ee" context]
+                      (fluree/stage {"@context" ["https://ns.flur.ee" context]
                                       "insert"   [{"@id"              "ex:brian"
                                                    "ex:age"           50
                                                    "vocab1:givenName" "Brian"}
@@ -77,19 +77,19 @@
     (let [conn   @(fluree/connect {:method :memory})
           ledger @(fluree/create conn "propertypathstest" {:defaultContext [test-utils/default-str-context {"ex" "http://example.com/"}]})
           db0    (fluree/db ledger)
-          db1    @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1    @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                       "insert" [{"@id"            "ex:unlabeled-pred"
                                                  "ex:description" "created as a subject first"}
                                                 {"@id"            "ex:labeled-pred"
                                                  "@type"          "rdf:Property"
                                                  "ex:description" "created as a subject first, labelled as Property"}]})
-          db2    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          db2    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                       "insert" [{"@id"               "ex:subject-as-predicate"
                                                  "ex:labeled-pred"   "labeled"
                                                  "ex:unlabeled-pred" "unlabeled"
                                                  "ex:new-pred"       {"@id"               "ex:nested"
                                                                       "ex:unlabeled-pred" "unlabeled-nested"}}]})
-          db3    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          db3    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                       "insert" [{"@id"               "ex:subject-as-predicate"
                                                  "ex:labeled-pred"   "labeled"
                                                  "ex:unlabeled-pred" {"@id"               "ex:nested"
@@ -150,13 +150,13 @@
                                     {:defaultContext
                                      ["" {"ex"  "http://example.com/"
                                           "owl" "http://www.w3.org/2002/07/owl#"}]})
-          db0       (->> @(fluree/stage2 (fluree/db ledger) {"@context" "https://ns.flur.ee"
+          db0       (->> @(fluree/stage (fluree/db ledger) {"@context" "https://ns.flur.ee"
                                                              "insert"   {"ex:new" true}})
                          (fluree/commit! ledger)
                          (deref))
 
 
-          db1 @(fluree/transact!2
+          db1 @(fluree/transact!
                  conn {"ledger"   ledger-id
                        "@context" "https://ns.flur.ee"
                        "insert"
@@ -169,7 +169,7 @@
                                                             {"@id"   "ex:fool"
                                                              "@type" "rdf:Property"}]}}]})
 
-          db2    @(fluree/transact!2
+          db2    @(fluree/transact!
                     conn {"ledger"   ledger-id
                           "@context" "https://ns.flur.ee"
                           "insert"   [{"@id"          "ex:andrew"

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -8,7 +8,7 @@
   (testing "Test that the @reverse context values pulls select values back correctly."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/reverse" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -333,7 +333,7 @@
          (go
           (let [conn   (<! (test-utils/create-conn {:context-type :string}))
                 ledger (<p! (fluree/create conn "people"))
-                db     (<p! (fluree/stage2 (fluree/db ledger) {"@context" "https://ns.flur.ee"
+                db     (<p! (fluree/stage (fluree/db ledger) {"@context" "https://ns.flur.ee"
                                                                "insert" people-data}))]
             (testing "basic query works"
               (let [query   "SELECT ?person ?fullName
@@ -354,7 +354,7 @@
                                       ["" {"person" "http://example.org/Person#"}]})
                       deref
                       fluree/db
-                      (fluree/stage2 {"@context" "https://ns.flur.ee"
+                      (fluree/stage {"@context" "https://ns.flur.ee"
                                       "insert" people-data})
                       deref)]
          (testing "keyword context-type throws an error"
@@ -544,7 +544,7 @@
                            "type"                          "http://example.org/Book"
                            "http://example.org/book/title" "The Hitchhiker's Guide to the Galaxy"}]]
            (testing "BASE IRI gets prefixed onto relative IRIs"
-             (let [book-db @(fluree/stage2 db {"@context" "https://ns.flur.ee"
+             (let [book-db @(fluree/stage db {"@context" "https://ns.flur.ee"
                                                "insert" book-data})
                    query   "BASE <http://example.org/book/>
                             SELECT ?book ?title
@@ -554,7 +554,7 @@
                        ["2" "The Hitchhiker's Guide to the Galaxy"]]
                       results))))
            (testing "PREFIX declarations go into the context"
-             (let [book-db @(fluree/stage2 db {"@context" "https://ns.flur.ee"
+             (let [book-db @(fluree/stage db {"@context" "https://ns.flur.ee"
                                                "insert" book-data})
                    query   "PREFIX book: <http://example.org/book/>
                             SELECT ?book ?title

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -8,7 +8,7 @@
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "stable-commit-id"
                                  {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db0    @(fluree/stage2
+          db0    @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"

--- a/test/fluree/db/query/subclass_test.clj
+++ b/test/fluree/db/query/subclass_test.clj
@@ -7,7 +7,7 @@
   (testing "Subclass queries work."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/subclass")
-          db1    @(fluree/stage2
+          db1    @(fluree/stage
                    (fluree/db ledger)
                    {"@context" "https://ns.flur.ee"
                     "insert"
@@ -25,7 +25,7 @@
                                                             "@type" "Person"
                                                             "name"  "Douglas Adams"}}}})
           ;; add CreativeWork class
-          db2    @(fluree/stage2
+          db2    @(fluree/stage
                    db1
                    {"@context" "https://ns.flur.ee"
                     "insert"
@@ -39,7 +39,7 @@
                      "schema:source"   {"@id" "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"}}})
 
           ;; Make Book and Movie subclasses of CreativeWork
-          db3    @(fluree/stage2
+          db3    @(fluree/stage
                    db2
                    {"@context" "https://ns.flur.ee"
                     "insert"
@@ -74,7 +74,7 @@
           ledger-name "subclass-inferencing-test"
           ledger      @(fluree/create conn ledger-name)
           db0         (fluree/db ledger)
-          db1         @(fluree/stage2
+          db1         @(fluree/stage
                         db0
                         {"@context" "https://ns.flur.ee"
                          "insert"
@@ -90,7 +90,7 @@
                           {"@id"         "ex:andrew"
                            "@type"       "schema:Person",
                            "schema:name" "Andrew Johnson"}]})
-          db2         @(fluree/stage2
+          db2         @(fluree/stage
                         db1
                         {"@context" "https://ns.flur.ee"
                          "insert"
@@ -123,7 +123,7 @@
           ledger-name "subclass-inferencing-test"
           ledger      @(fluree/create conn ledger-name)
           db0         (fluree/db ledger)
-          db1         @(fluree/stage2
+          db1         @(fluree/stage
                         db0
                         {"@context" "https://ns.flur.ee"
                          "insert"
@@ -139,7 +139,7 @@
                           {"@id"         "ex:andrew"
                            "@type"       "schema:Person",
                            "schema:name" "Andrew Johnson"}]})
-          db2         @(fluree/stage2
+          db2         @(fluree/stage
                         db1
                         {"@context" "https://ns.flur.ee"
                          "insert"

--- a/test/fluree/db/query/subject_crawl_reparse_test.clj
+++ b/test/fluree/db/query/subject_crawl_reparse_test.clj
@@ -13,7 +13,7 @@
                                                                         :owl "http://www.w3.org/2002/07/owl#"
                                                                         :vocab1 "http://vocab1.example.org"
                                                                         :vocab2 "http://vocab2.example.org"}]})
-        db     @(fluree/stage2
+        db     @(fluree/stage
                   (fluree/db ledger)
                   {"@context" "https://ns.flur.ee"
                    "insert"

--- a/test/fluree/db/query/time_travel_test.clj
+++ b/test/fluree/db/query/time_travel_test.clj
@@ -52,7 +52,7 @@
                                                   #'util/current-time-iso
                                                   (fn [] start-iso)}
                                    (fn []
-                                     (let [db1 @(fluree/stage2
+                                     (let [db1 @(fluree/stage
                                                   (fluree/db ledger)
                                                   {"@context" "https://ns.flur.ee"
                                                    "insert" (first test-utils/movies)})]
@@ -62,7 +62,7 @@
                                                   #'util/current-time-iso
                                                   (fn [] three-loaded-iso)}
                                    (fn []
-                                     (let [db2 @(fluree/stage2
+                                     (let [db2 @(fluree/stage
                                                   (fluree/db ledger)
                                                   {"@context" "https://ns.flur.ee"
                                                    "insert" (second test-utils/movies)})]
@@ -72,7 +72,7 @@
                                                   #'util/current-time-iso
                                                   (fn [] all-loaded-iso)}
                                    (fn []
-                                     (let [db3 @(fluree/stage2
+                                     (let [db3 @(fluree/stage
                                                   (fluree/db ledger)
                                                   {"@context" "https://ns.flur.ee"
                                                    "insert" (nth test-utils/movies 2)})]
@@ -112,14 +112,14 @@
                                         :context-type :string}})
 
           ledger1 (with-redefs [util/current-time-iso (fn [] t1)]
-                    @(fluree/create-with-txn2 conn
+                    @(fluree/create-with-txn conn
                                               {"@context" "https://ns.flur.ee"
                                                "ledger"   "test/time1"
                                                "insert"   [{"@id"     "ex:time-test"
                                                             "@type"   "ex:foo"
                                                             "ex:time" 1}]}))
           ledger2 (with-redefs [util/current-time-iso (fn [] t1)]
-                    @(fluree/create-with-txn2 conn
+                    @(fluree/create-with-txn conn
                                               {"@context" "https://ns.flur.ee"
                                                "ledger"   "test/time2"
                                                "insert"   [{"@id"   "ex:time-test"
@@ -127,12 +127,12 @@
                                                            {"@id"   "ex:foo"
                                                             "ex:p2" "t1"}]}))
           _       (with-redefs [util/current-time-iso (fn [] t2)]
-                    @(fluree/transact!2 conn {"@context" "https://ns.flur.ee"
+                    @(fluree/transact! conn {"@context" "https://ns.flur.ee"
                                               "ledger"   "test/time1"
                                               "insert"   [{"@id"   "ex:time-test"
                                                           "ex:time" 2}]}))
           _       (with-redefs [util/current-time-iso (fn [] t2)]
-                    @(fluree/transact!2 conn
+                    @(fluree/transact! conn
                                         {"@context" "https://ns.flur.ee"
                                          "ledger"   "test/time2"
                                          "insert"   [{"@id"   "ex:time-test"
@@ -192,7 +192,7 @@
                 "should be results as of `t` = 1 for both ledgers")))
         (testing "Not all ledgers have data for given `t`"
           (with-redefs [util/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
-            (let [ledger-valid @(fluree/create-with-txn2 conn
+            (let [ledger-valid @(fluree/create-with-txn conn
                                                          {"@context" "https://ns.flur.ee"
                                                           "ledger"   "test/time-before"
                                                           "insert"   [{"@id"   "ex:time-test"

--- a/test/fluree/db/query/union_query_test.clj
+++ b/test/fluree/db/query/union_query_test.clj
@@ -8,7 +8,7 @@
   (testing "Testing various 'union' query clauses."
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "query/union" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2
+          db     @(fluree/stage
                     (fluree/db ledger)
                     {"@context" "https://ns.flur.ee"
                      "insert"

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -10,12 +10,12 @@
   (testing "Class not used as class initially can still be used as one."
     (let [conn      (test-utils/create-conn)
           ledger    @(fluree/create conn "class/testing" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          db1       @(fluree/stage2
+          db1       @(fluree/stage
                        (fluree/db ledger)
                        {"@context" "https://ns.flur.ee"
                         "insert" {:id :ex/MyClass
                                   :schema/description "Just a basic object not used as a class"}})
-          db2       @(fluree/stage2
+          db2       @(fluree/stage
                        db1
                        {:context "https://ns.flur.ee"
                         "insert" {:id :ex/myClassInstance
@@ -34,7 +34,7 @@
           ledger       @(fluree/create conn "shacl/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
                         :where  {:id '?s, :type :ex/User}}
-          db           @(fluree/stage2
+          db           @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -45,7 +45,7 @@
                                               :sh/minCount 1
                                               :sh/maxCount 1
                                               :sh/datatype :xsd/string}]}})
-          db-ok        @(fluree/stage2
+          db-ok        @(fluree/stage
                          db
                          {"@context" "https://ns.flur.ee"
                           "insert"
@@ -55,7 +55,7 @@
                            :schema/callSign "j-rock"}})
           ; no :schema/name
           db-no-names  (try
-                         @(fluree/stage2
+                         @(fluree/stage
                            db
                            {"@context" "https://ns.flur.ee"
                             "insert"
@@ -64,7 +64,7 @@
                              :schema/callSign "j-rock"}})
                          (catch Exception e e))
           db-two-names (try
-                         @(fluree/stage2
+                         @(fluree/stage
                            db
                            {"@context" "https://ns.flur.ee"
                             "insert"
@@ -95,7 +95,7 @@
           ledger       @(fluree/create conn "shacl/b" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
                         :where  {:id '?s, :type :ex/User}}
-          db           @(fluree/stage2
+          db           @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -104,7 +104,7 @@
                             :sh/targetClass :ex/User
                             :sh/property    [{:sh/path     :schema/name
                                               :sh/datatype :xsd/string}]}})
-          db-ok        @(fluree/stage2
+          db-ok        @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -112,14 +112,14 @@
                             :type        :ex/User
                             :schema/name "John"}})
           ;; no :schema/name
-          db-int-name  @(fluree/stage2
+          db-int-name  @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
                            {:id          :ex/john
                             :type        :ex/User
                             :schema/name 42}})
-          db-bool-name @(fluree/stage2
+          db-bool-name @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -146,7 +146,7 @@
           ledger        @(fluree/create conn "shacl/c" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query    {:select {'?s [:*]}
                          :where  {:id '?s, :type :ex/User}}
-          db            @(fluree/stage2
+          db            @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -158,7 +158,7 @@
                             :sh/closed            true
                             :sh/ignoredProperties [:type]}})
 
-          db-ok         @(fluree/stage2
+          db-ok         @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -167,7 +167,7 @@
                             :schema/name "John"}})
           ; no :schema/name
           db-extra-prop (try
-                          @(fluree/stage2
+                          @(fluree/stage
                              db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -193,7 +193,7 @@
           user-query {:select {'?s [:*]}
                       :where  {:id '?s, :type :ex/User}}]
       (testing "single-cardinality equals"
-        (let [db           @(fluree/stage2
+        (let [db           @(fluree/stage
                               (fluree/db ledger)
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -202,7 +202,7 @@
                                 :sh/targetClass :ex/User
                                 :sh/property    [{:sh/path   :schema/name
                                                   :sh/equals :ex/firstName}]}})
-              db-ok        @(fluree/stage2
+              db-ok        @(fluree/stage
                               db
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -212,7 +212,7 @@
                                 :ex/firstName "Alice"}})
 
               db-not-equal (try
-                             @(fluree/stage2
+                             @(fluree/stage
                                 db
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
@@ -232,7 +232,7 @@
                    :ex/firstName "Alice"}]
                  @(fluree/query db-ok user-query)))))
       (testing "multi-cardinality equals"
-        (let [db            @(fluree/stage2
+        (let [db            @(fluree/stage
                                (fluree/db ledger)
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -241,7 +241,7 @@
                                  :sh/targetClass :ex/User
                                  :sh/property    [{:sh/path   :ex/favNums
                                                    :sh/equals :ex/luckyNums}]}})
-              db-ok         @(fluree/stage2
+              db-ok         @(fluree/stage
                               db
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -251,7 +251,7 @@
                                 :ex/favNums   [11 17]
                                 :ex/luckyNums [11 17]}})
 
-              db-ok2        @(fluree/stage2
+              db-ok2        @(fluree/stage
                               db
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -262,7 +262,7 @@
                                 :ex/luckyNums [17 11]}})
 
               db-not-equal1 (try
-                              @(fluree/stage2
+                              @(fluree/stage
                                 db
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
@@ -273,7 +273,7 @@
                                   :ex/luckyNums [13 18]}})
                               (catch Exception e e))
               db-not-equal2 (try
-                              @(fluree/stage2
+                              @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -284,7 +284,7 @@
                                    :ex/luckyNums [11]}})
                               (catch Exception e e))
               db-not-equal3 (try
-                              @(fluree/stage2
+                              @(fluree/stage
                                 db
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
@@ -295,7 +295,7 @@
                                   :ex/luckyNums [11 17 18]}})
                               (catch Exception e e))
               db-not-equal4 (try
-                              @(fluree/stage2
+                              @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -334,7 +334,7 @@
                    :ex/luckyNums [11 17]}]
                  @(fluree/query db-ok2 user-query)))))
       (testing "disjoint"
-        (let [db               @(fluree/stage2
+        (let [db               @(fluree/stage
                                   (fluree/db ledger)
                                   {"@context" "https://ns.flur.ee"
                                    "insert"
@@ -343,7 +343,7 @@
                                     :sh/targetClass :ex/User
                                     :sh/property    [{:sh/path     :ex/favNums
                                                       :sh/disjoint :ex/luckyNums}]}})
-              db-ok            @(fluree/stage2
+              db-ok            @(fluree/stage
                                   db
                                   {"@context" "https://ns.flur.ee"
                                    "insert"
@@ -354,7 +354,7 @@
                                     :ex/luckyNums 1}})
 
               db-not-disjoint1 (try
-                                 @(fluree/stage2
+                                 @(fluree/stage
                                     db
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
@@ -365,7 +365,7 @@
                                       :ex/luckyNums 11}})
                                  (catch Exception e e))
               db-not-disjoint2 (try
-                                 @(fluree/stage2
+                                 @(fluree/stage
                                     db
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
@@ -377,7 +377,7 @@
                                  (catch Exception e e))
 
               db-not-disjoint3 (try
-                                 @(fluree/stage2
+                                 @(fluree/stage
                                     db
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
@@ -410,7 +410,7 @@
                    :ex/luckyNums 1}]
                  @(fluree/query db-ok user-query)))))
       (testing "lessThan"
-        (let [db       @(fluree/stage2
+        (let [db       @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -419,7 +419,7 @@
                             :sh/targetClass :ex/User
                             :sh/property    [{:sh/path     :ex/p1
                                               :sh/lessThan :ex/p2}]}})
-              db-ok1   @(fluree/stage2
+              db-ok1   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -430,7 +430,7 @@
                             :ex/p2       [18 19]}})
 
 
-              db-ok2   @(fluree/stage2
+              db-ok2   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -441,7 +441,7 @@
                             :ex/p2       [18]}})
 
               db-fail1 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -453,7 +453,7 @@
                          (catch Exception e e))
 
               db-fail2 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -466,7 +466,7 @@
 
 
               db-fail3 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -478,7 +478,7 @@
                          (catch Exception e e))
 
               db-fail4 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -488,7 +488,7 @@
                               :ex/p1       [11 17]
                               :ex/p2       [12 16]}})
                          (catch Exception e e))
-              db-iris  (try @(fluree/stage2
+              db-iris  (try @(fluree/stage
                                db
                                {"@context" "https://ns.flur.ee"
                                 "insert"
@@ -537,7 +537,7 @@
                    :ex/p2       18}]
                  @(fluree/query db-ok2 user-query)))))
       (testing "lessThanOrEquals"
-        (let [db       @(fluree/stage2
+        (let [db       @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -546,7 +546,7 @@
                             :sh/targetClass :ex/User
                             :sh/property    [{:sh/path             :ex/p1
                                               :sh/lessThanOrEquals :ex/p2}]}})
-              db-ok1   @(fluree/stage2
+              db-ok1   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -557,7 +557,7 @@
                             :ex/p2       [17 19]}})
 
 
-              db-ok2   @(fluree/stage2
+              db-ok2   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -568,7 +568,7 @@
                             :ex/p2       17}})
 
               db-fail1 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -580,7 +580,7 @@
                          (catch Exception e e))
 
               db-fail2 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -592,7 +592,7 @@
                          (catch Exception e e))
 
               db-fail3 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -604,7 +604,7 @@
                          (catch Exception e e))
 
               db-fail4 (try
-                         @(fluree/stage2
+                         @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -655,7 +655,7 @@
           user-query {:select {'?s [:*]}
                       :where  {:id '?s, :type :ex/User}}]
       (testing "exclusive constraints"
-        (let [db          @(fluree/stage2
+        (let [db          @(fluree/stage
                             (fluree/db ledger)
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -665,14 +665,14 @@
                               :sh/property    [{:sh/path         :schema/age
                                                 :sh/minExclusive 1
                                                 :sh/maxExclusive 100}]}})
-              db-ok       @(fluree/stage2
+              db-ok       @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "insert"
                              {:id         :ex/john
                               :type       :ex/User
                               :schema/age 2}})
-              db-too-low  (try @(fluree/stage2
+              db-too-low  (try @(fluree/stage
                                   db
                                   {"@context" "https://ns.flur.ee"
                                    "insert"
@@ -680,7 +680,7 @@
                                     :type       :ex/User
                                     :schema/age 1}})
                                (catch Exception e e))
-              db-too-high (try @(fluree/stage2
+              db-too-high (try @(fluree/stage
                                   db
                                   {"@context" "https://ns.flur.ee"
                                    "insert"
@@ -703,7 +703,7 @@
                    :type       :ex/User
                    :schema/age 2}]))))
       (testing "inclusive constraints"
-        (let [db          @(fluree/stage2
+        (let [db          @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -713,28 +713,28 @@
                                :sh/property    [{:sh/path         :schema/age
                                                  :sh/minInclusive 1
                                                  :sh/maxInclusive 100}]}})
-              db-ok       @(fluree/stage2
+              db-ok       @(fluree/stage
                              db
                              {"@context" "https://ns.flur.ee"
                               "insert"
                               {:id         :ex/brian
                                :type       :ex/User
                                :schema/age 1}})
-              db-ok2      @(fluree/stage2
+              db-ok2      @(fluree/stage
                              db-ok
                              {"@context" "https://ns.flur.ee"
                               "insert"
                               {:id         :ex/alice
                                :type       :ex/User
                                :schema/age 100}})
-              db-too-low  @(fluree/stage2
+              db-too-low  @(fluree/stage
                              db
                              {"@context" "https://ns.flur.ee"
                               "insert"
                               {:id         :ex/alice
                                :type       :ex/User
                                :schema/age 0}})
-              db-too-high @(fluree/stage2
+              db-too-high @(fluree/stage
                              db
                              {"@context" "https://ns.flur.ee"
                               "insert"
@@ -758,7 +758,7 @@
                    :type       :ex/User
                    :schema/age 1}]))))
       (testing "non-numeric values"
-        (let [db         @(fluree/stage2
+        (let [db         @(fluree/stage
                             (fluree/db ledger)
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -767,7 +767,7 @@
                               :sh/targetClass :ex/User
                               :sh/property    [{:sh/path         :schema/age
                                                 :sh/minExclusive 0}]}})
-              db-subj-id (try @(fluree/stage2
+              db-subj-id (try @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -775,7 +775,7 @@
                                    :type       :ex/User
                                    :schema/age :ex/brian}})
                               (catch Exception e e))
-              db-string  (try @(fluree/stage2
+              db-string  (try @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -801,7 +801,7 @@
                                                ["" {:ex "http://example.org/ns/"}]})
           user-query          {:select {'?s [:*]}
                                :where  {:id '?s, :type :ex/User}}
-          db                  @(fluree/stage2
+          db                  @(fluree/stage
                                  (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -811,7 +811,7 @@
                                    :sh/property    [{:sh/path      :schema/name
                                                      :sh/minLength 4
                                                      :sh/maxLength 10}]}})
-          db-ok-str           @(fluree/stage2
+          db-ok-str           @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -819,7 +819,7 @@
                                    :type        :ex/User
                                    :schema/name "John"}})
 
-          db-ok-non-str       @(fluree/stage2
+          db-ok-non-str       @(fluree/stage
                                  db
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
@@ -828,7 +828,7 @@
                                    :schema/name 12345}})
 
           db-too-short-str    (try
-                                @(fluree/stage2
+                                @(fluree/stage
                                    db
                                    {"@context" "https://ns.flur.ee"
                                     "insert"
@@ -837,7 +837,7 @@
                                      :schema/name "Al"}})
                                 (catch Exception e e))
           db-too-long-str     (try
-                                @(fluree/stage2
+                                @(fluree/stage
                                    db
                                    {"@context" "https://ns.flur.ee"
                                     "insert"
@@ -846,7 +846,7 @@
                                      :schema/name "Jean-Claude"}})
                                 (catch Exception e e))
           db-too-long-non-str (try
-                                @(fluree/stage2
+                                @(fluree/stage
                                    db
                                    {"@context" "https://ns.flur.ee"
                                     "insert"
@@ -855,7 +855,7 @@
                                      :schema/name 12345678910}})
                                 (catch Exception e e))
           db-ref-value        (try
-                                @(fluree/stage2
+                                @(fluree/stage
                                    db
                                    {"@context" "https://ns.flur.ee"
                                     "insert"
@@ -896,7 +896,7 @@
                                                   ["" {:ex "http://example.org/ns/"}]})
           user-query             {:select {'?s [:*]}
                                   :where  {:id '?s, :type :ex/User}}
-          db                     @(fluree/stage2
+          db                     @(fluree/stage
                                     (fluree/db ledger)
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
@@ -908,7 +908,7 @@
                                                         :sh/flags   ["x" "s"]}
                                                        {:sh/path    :ex/birthYear
                                                         :sh/pattern "(19|20)[0-9][0-9]"}]}})
-          db-ok-greeting         @(fluree/stage2
+          db-ok-greeting         @(fluree/stage
                                     db
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
@@ -916,7 +916,7 @@
                                       :type        :ex/User
                                       :ex/greeting "hello\nworld!"}})
 
-          db-ok-birthyear        @(fluree/stage2
+          db-ok-birthyear        @(fluree/stage
                                     db
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
@@ -924,7 +924,7 @@
                                       :type         :ex/User
                                       :ex/birthYear 1984}})
           db-wrong-case-greeting (try
-                                   @(fluree/stage2
+                                   @(fluree/stage
                                       db
                                       {"@context" "https://ns.flur.ee"
                                        "insert"
@@ -933,7 +933,7 @@
                                         :ex/greeting "HELLO\nWORLD!"}})
                                    (catch Exception e e))
           db-wrong-birth-year    (try
-                                   @(fluree/stage2
+                                   @(fluree/stage
                                       db
                                       {"@context" "https://ns.flur.ee"
                                        "insert"
@@ -942,7 +942,7 @@
                                         :ex/birthYear 1776}})
                                    (catch Exception e e))
           db-ref-value           (try
-                                   @(fluree/stage2
+                                   @(fluree/stage
                                       db
                                       {"@context" "https://ns.flur.ee"
                                        "insert"
@@ -981,7 +981,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
           ledger       @(fluree/create conn "shacl/b" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
                         :where  {:id '?s, :type :ex/User}}
-          db           @(fluree/stage2
+          db           @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -999,7 +999,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                               :sh/maxInclusive 130}
                                              {:sh/path     :schema/email
                                               :sh/datatype :xsd/string}]}})
-          db-ok        @(fluree/stage2
+          db-ok        @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -1008,7 +1008,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                             :schema/name  "John"
                             :schema/age   40
                             :schema/email "john@example.org"}})
-          db-no-name   @(fluree/stage2
+          db-no-name   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -1016,7 +1016,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                             :type         :ex/User
                             :schema/age   40
                             :schema/email "john@example.org"}})
-          db-two-names @(fluree/stage2
+          db-two-names @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -1025,7 +1025,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                             :schema/name  ["John" "Billy"]
                             :schema/age   40
                             :schema/email "john@example.org"}})
-          db-too-old   @(fluree/stage2
+          db-too-old   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -1034,7 +1034,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                             :schema/name  "John"
                             :schema/age   140
                             :schema/email "john@example.org"}})
-          db-two-ages  @(fluree/stage2
+          db-two-ages  @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -1043,7 +1043,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                             :schema/name  "John"
                             :schema/age   [40 21]
                             :schema/email "john@example.org"}})
-          db-num-email @(fluree/stage2
+          db-num-email @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -1080,19 +1080,19 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
         db0    (fluree/db ledger)]
     (testing "inverse path"
       (let [;; a valid Parent is anybody who is the object of a parent predicate
-            db1          @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+            db1          @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                               "insert" {"@type"          "sh:NodeShape"
                                                         "id"             "ex:ParentShape"
                                                         "sh:targetClass" {"@id" "ex:Parent"}
                                                         "sh:property"    [{"sh:path"     {"sh:inversePath" {"id" "ex:parent"}}
                                                                            "sh:minCount" 1}]}})
-            valid-parent @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            valid-parent @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                               "insert" {"id"          "ex:Luke"
                                                         "schema:name" "Luke"
                                                         "ex:parent"   {"id"          "ex:Anakin"
                                                                        "type"        "ex:Parent"
                                                                        "schema:name" "Anakin"}}})
-            invalid-pal  @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            invalid-pal  @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                               "insert" {"id"          "ex:bad-parent"
                                                         "type"        "ex:Parent"
                                                         "schema:name" "Darth Vader"}})]
@@ -1109,18 +1109,18 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                (ex-message invalid-pal)))))
     (testing "sequence paths"
       (let [;; a valid Pal is anybody who has a pal with a name
-            db1         @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+            db1         @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                              "insert" {"@type"          "sh:NodeShape"
                                                        "sh:targetClass" {"@id" "ex:Pal"}
                                                        "sh:property"    [{"sh:path"     {"@list" [{"id" "ex:pal"} {"id" "schema:name"}]}
                                                                           "sh:minCount" 1}]}})
-            valid-pal   @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            valid-pal   @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                              "insert" {"id"          "ex:good-pal"
                                                        "type"        "ex:Pal"
                                                        "schema:name" "J.D."
                                                        "ex:pal"      [{"schema:name" "Turk"}
                                                                       {"schema:name" "Rowdy"}]}})
-            invalid-pal @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            invalid-pal @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                              "insert" {"id"          "ex:bad-pal"
                                                        "type"        "ex:Pal"
                                                        "schema:name" "Darth Vader"
@@ -1136,14 +1136,14 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                (ex-message invalid-pal)))))
     (testing "inverse sequence path"
       (let [;; a valid Princess is anybody who is the child of someone's queen
-            db1              @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+            db1              @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                                   "insert" {"@type"          "sh:NodeShape"
                                                             "id"             "ex:PrincessShape"
                                                             "sh:targetClass" {"@id" "ex:Princess"}
                                                             "sh:property"    [{"sh:path"     {"@list" [{"sh:inversePath" {"id" "ex:child"}}
                                                                                                        {"sh:inversePath" {"id" "ex:queen"}}]}
                                                                                "sh:minCount" 1}]}})
-            valid-princess   @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            valid-princess   @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                                   "insert" {"id"          "ex:Pleb"
                                                             "schema:name" "Pleb"
                                                             "ex:queen"    {"id"          "ex:Buttercup"
@@ -1151,7 +1151,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                                            "ex:child"    {"id"          "ex:Mork"
                                                                                           "type"        "ex:Princess"
                                                                                           "schema:name" "Mork"}}}})
-            invalid-princess @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            invalid-princess @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                                   "insert" {"id"          "ex:Pleb"
                                                             "schema:name" "Pleb"
                                                             "ex:child"    {"id"          "ex:Gerb"
@@ -1168,7 +1168,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
   (let [conn   @(fluree/connect {:method :memory})
         ledger @(fluree/create conn "classtest" {:defaultContext test-utils/default-str-context})
         db0    (fluree/db ledger)
-        db1    @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+        db1    @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                     "insert" [{"@type" "sh:NodeShape"
                                                "sh:targetClass" {"@id" "https://example.com/Country"}
                                                "sh:property"
@@ -1188,7 +1188,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                  "sh:maxCount" 1
                                                  "sh:datatype" {"@id" "xsd:string"}}]}]})
         ;; valid inline type
-        db2    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+        db2    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                     "insert" {"@id"                           "https://example.com/Actor/65731"
                                               "https://example.com/country"   {"@id"                      "https://example.com/Country/AU"
                                                                                "@type"                    "https://example.com/Country"
@@ -1200,7 +1200,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                               "@type"                         "https://example.com/Actor"
                                               "https://example.com/name"      "Sam Worthington"}})
         ;; valid node ref
-        db3    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+        db3    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                     "insert" [{"@id"                      "https://example.com/Country/US"
                                                "@type"                    "https://example.com/Country"
                                                "https://example.com/name" "United States of America"}
@@ -1210,7 +1210,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                "@type"                       "https://example.com/Actor"
                                                "https://example.com/name"    "Rindsey Rohan"}]})
         ;; invalid inline type
-        db4    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+        db4    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                     "insert" {"@id"                         "https://example.com/Actor/1001"
                                               "https://example.com/country" {"@id"                      "https://example.com/Country/Absurdistan"
                                                                              "@type"                    "https://example.com/FakeCountry"
@@ -1219,7 +1219,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                               "@type"                       "https://example.com/Actor"
                                               "https://example.com/name"    "Not Real"}})
         ;; invalid node ref type
-        db5    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+        db5    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                     "insert" [{"@id"                      "https://example.com/Country/Absurdistan"
                                                "@type"                    "https://example.com/FakeCountry"
                                                "https://example.com/name" "Absurdistan"}
@@ -1245,12 +1245,12 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
           ledger @(fluree/create conn "shacl-in-test"
                                  {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
           db0    (fluree/db ledger)
-          db1    @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1    @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                       "insert" [{"type"           ["sh:NodeShape"]
                                                  "sh:targetClass" {"id" "ex:Pony"}
                                                  "sh:property"    [{"sh:path" {"id" "ex:color"}
                                                                     "sh:in"   '("cyan" "magenta")}]}]})
-          db2    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          db2    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                       "insert" {"id"       "ex:YellowPony"
                                                 "type"     "ex:Pony"
                                                 "ex:color" "yellow"}})]
@@ -1263,13 +1263,13 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                    {:context test-utils/default-str-context}})
           ledger @(fluree/create conn "shacl-in-test")
           db0    (fluree/db ledger)
-          db1    @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1    @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                       "insert" [{"type"           ["sh:NodeShape"]
                                                  "sh:targetClass" {"id" "ex:Pony"}
                                                  "sh:property"    [{"sh:path" {"id" "ex:color"}
                                                                     "sh:in"   '({"id" "ex:Pink"}
                                                                                 {"id" "ex:Purple"})}]}]})
-          db2    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          db2    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                       "insert" [{"id"   "ex:Pink"
                                                  "type" "ex:color"}
                                                 {"id"   "ex:Purple"
@@ -1280,7 +1280,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                  "type"     "ex:Pony"
                                                  "ex:color" [{"id" "ex:Pink"}
                                                              {"id" "ex:Green"}]}]})
-          db3    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          db3    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                       "insert"   [{"id"       "ex:PastelPony"
                                                    "type"     "ex:Pony"
                                                    "ex:color" [{"id" "ex:Pink"}
@@ -1304,14 +1304,14 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                    {:context test-utils/default-str-context}})
           ledger @(fluree/create conn "shacl-in-test")
           db0    (fluree/db ledger)
-          db1    @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1    @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                       "insert" [{"type"           ["sh:NodeShape"]
                                                  "sh:targetClass" {"id" "ex:Pony"}
                                                  "sh:property"    [{"sh:path" {"id" "ex:color"}
                                                                     "sh:in"   '({"id" "ex:Pink"}
                                                                                 {"id" "ex:Purple"}
                                                                                 "green")}]}]})
-          db2    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          db2    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                       "insert" {"id"       "ex:RainbowPony"
                                                 "type"     "ex:Pony"
                                                 "ex:color" [{"id" "ex:Pink"}
@@ -1328,7 +1328,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                  {:context test-utils/default-str-context}})
             ledger             @(fluree/create conn "shacl-target-objects-of-test"
                                                {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-            db1                @(fluree/stage2 (fluree/db ledger)
+            db1                @(fluree/stage (fluree/db ledger)
                                                {"@context" "https://ns.flur.ee"
                                                 "insert"
                                                 {"@id"                "ex:friendShape"
@@ -1336,7 +1336,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                  "sh:targetObjectsOf" {"@id" "ex:friend"}
                                                  "sh:property"        [{"sh:path"     {"@id" "ex:name"}
                                                                         "sh:datatype" {"@id" "xsd:string"}}]}})
-            db-bad-friend-name @(fluree/stage2 db1
+            db-bad-friend-name @(fluree/stage db1
                                                {"@context" "https://ns.flur.ee"
                                                 "insert"
                                                 [{"id"        "ex:Alice"
@@ -1354,7 +1354,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                             {:context test-utils/default-str-context}})
             ledger        @(fluree/create conn "shacl-target-objects-of-test"
                                           {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-            db1           @(fluree/stage2 (fluree/db ledger)
+            db1           @(fluree/stage (fluree/db ledger)
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            {"@id"                "ex:friendShape"
@@ -1362,7 +1362,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                             "sh:targetObjectsOf" {"@id" "ex:friend"}
                                             "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
                                                                    "sh:maxCount" 1}]}})
-            db-excess-ssn @(fluree/stage2 db1
+            db-excess-ssn @(fluree/stage db1
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{"id"        "ex:Alice"
@@ -1381,7 +1381,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                             {:context test-utils/default-str-context}})
             ledger        @(fluree/create conn "shacl-target-objects-of-test"
                                           {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-            db1           @(fluree/stage2 (fluree/db ledger)
+            db1           @(fluree/stage (fluree/db ledger)
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{"@id"                "ex:friendShape"
@@ -1389,7 +1389,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
                                              "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
                                                                     "sh:minCount" 1}]}]})
-            db-just-alice @(fluree/stage2 db1
+            db-just-alice @(fluree/stage db1
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{"id"        "ex:Alice"
@@ -1404,7 +1404,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                             {:context test-utils/default-str-context}})
             ledger        @(fluree/create conn "shacl-target-objects-of-test"
                                           {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-            db1           @(fluree/stage2 (fluree/db ledger)
+            db1           @(fluree/stage (fluree/db ledger)
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{"@id"            "ex:UserShape"
@@ -1417,7 +1417,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
                                              "sh:property"        [{"sh:path"     {"@id" "ex:name"}
                                                                     "sh:maxCount" 1}]}]})
-            db-bad-friend @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            db-bad-friend @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                                "insert" [{"id"        "ex:Alice"
                                                           "ex:name"   "Alice"
                                                           "type"      "ex:User"
@@ -1436,7 +1436,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
             ledger                 @(fluree/create conn "shacl-target-objects-of-test"
                                                    {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
 
-            db1                    @(fluree/stage2 (fluree/db ledger)
+            db1                    @(fluree/stage (fluree/db ledger)
                                                    {"@context" "https://ns.flur.ee"
                                                     "insert"
                                                     [{"@id"                "ex:friendShape"
@@ -1444,11 +1444,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                       "sh:targetObjectsOf" {"@id" "ex:friend"}
                                                       "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
                                                                              "sh:maxCount" 1}]}]})
-            db2                    @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            db2                    @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                                         "insert" [{"id"     "ex:Bob"
                                                                    "ex:ssn" ["111-11-1111" "222-22-2222"]
                                                                    "type"   "ex:User"}]})
-            db-db-forbidden-friend @(fluree/stage2 db2
+            db-db-forbidden-friend @(fluree/stage db2
                                                    {"@context" "https://ns.flur.ee"
                                                     "insert"
                                                     {"id"        "ex:Alice"
@@ -1461,7 +1461,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                             {:context test-utils/default-str-context}})
             ledger        @(fluree/create conn "shacl-target-objects-of-test"
                                           {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-            db1           @(fluree/stage2 (fluree/db ledger)
+            db1           @(fluree/stage (fluree/db ledger)
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{"@id"                "ex:friendShape"
@@ -1469,7 +1469,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
                                              "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
                                                                     "sh:maxCount" 1}]}]})
-            db2           @(fluree/stage2 db1
+            db2           @(fluree/stage db1
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            [{"id"        "ex:Alice"
@@ -1479,7 +1479,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                             {"id"      "ex:Bob"
                                              "ex:name" "Bob"
                                              "type"    "ex:User"}]})
-            db-excess-ssn @(fluree/stage2 db2
+            db-excess-ssn @(fluree/stage db2
                                           {"@context" "https://ns.flur.ee"
                                            "insert"
                                            {"id"     "ex:Bob"
@@ -1493,7 +1493,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                    {:context test-utils/default-str-context}})
             ledger @(fluree/create conn "shacl-target-objects-of-test"
                                    {:defaultContext ["" {"ex" "http://example.com/ns/"}]})
-            db1 @(fluree/stage2 (fluree/db ledger)
+            db1 @(fluree/stage (fluree/db ledger)
                                 {"@context" "https://ns.flur.ee"
                                  "insert" {"@id" "ex:friendShape"
                                            "type" ["sh:NodeShape"]
@@ -1502,11 +1502,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                            "sh:datatype" {"@id" "xsd:string"}}]}})
 
             ;; need to specify type in order to avoid sh:datatype coercion
-            db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            db2 @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                      "insert" {"id" "ex:Bob"
                                                "ex:name" {"@type" "xsd:integer" "@value" 123}
                                                "type" "ex:User"}})
-            db-forbidden-friend @(fluree/stage2 db2
+            db-forbidden-friend @(fluree/stage db2
                                                 {"@context" "https://ns.flur.ee"
                                                  "insert"
                                                  {"id" "ex:Alice"
@@ -1522,7 +1522,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                                            {"ex" "http://example.com/"}]})
           db0    (fluree/db ledger)
 
-          db1            @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1            @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                               "insert"   [{"id"          "ex:AddressShape"
                                                            "type"        "sh:NodeShape"
                                                            "sh:property" [{"sh:path"     {"id" "ex:postalCode"}
@@ -1533,11 +1533,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                            "sh:property"    [{"sh:path"     {"id" "ex:address"}
                                                                               "sh:node"     {"id" "ex:AddressShape"}
                                                                               "sh:minCount" 1}]}]})
-          valid-person   @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          valid-person   @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                               "insert"   {"id"         "ex:Bob"
                                                           "type"       "ex:Person"
                                                           "ex:address" {"ex:postalCode" "12345"}}})
-          invalid-person @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          invalid-person @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                               "insert"   {"id"         "ex:Reto"
                                                           "type"       "ex:Person"
                                                           "ex:address" {"ex:postalCode" ["12345" "45678"]}}})]
@@ -1553,7 +1553,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
           ledger      @(fluree/create conn "shape-constaints" {:defaultContext [test-utils/default-str-context
                                                                                 {"ex" "http://example.com/"}]})
           db0         (fluree/db ledger)
-          db1         @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1         @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                            "insert"   [{"id"             "ex:KidShape"
                                                         "type"           "sh:NodeShape"
                                                         "sh:targetClass" {"id" "ex:Kid"}
@@ -1568,11 +1568,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                         "ex:gender" "male"}
                                                        {"id"        "ex:Jane"
                                                         "ex:gender" "female"}]})
-          valid-kid   @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          valid-kid   @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                            "insert"   {"id"        "ex:ValidKid"
                                                        "type"      "ex:Kid"
                                                        "ex:parent" [{"id" "ex:Bob"} {"id" "ex:Jane"}]}})
-          invalid-kid @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          invalid-kid @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                            "insert"   {"id"        "ex:InvalidKid"
                                                        "type"      "ex:Kid"
                                                        "ex:parent" [{"id" "ex:Bob"}
@@ -1593,7 +1593,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                                            {"ex" "http://example.com/"}]})
           db0    (fluree/db ledger)
 
-          db1         @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1         @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                            "insert"   [{"id"             "ex:KidShape"
                                                         "type"           "sh:NodeShape"
                                                         "sh:targetClass" {"id" "ex:Kid"}
@@ -1614,11 +1614,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                        {"id"        "ex:Dad"
                                                         "type"      "ex:Parent"
                                                         "ex:gender" "male"}]})
-          valid-kid   @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          valid-kid   @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                            "insert"   {"id"        "ex:ValidKid"
                                                        "type"      "ex:Kid"
                                                        "ex:parent" [{"id" "ex:Mom"} {"id" "ex:Dad"}]}})
-          invalid-kid @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          invalid-kid @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                            "insert"   {"id"        "ex:InvalidKid"
                                                        "type"      "ex:Kid"
                                                        "ex:parent" [{"id" "ex:Bob"}
@@ -1640,7 +1640,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                                            {"ex" "http://example.com/"}]})
           db0    (fluree/db ledger)
 
-          db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                    "insert"   [{"id"      "ex:Digit"
                                                 "ex:name" "Toe"}
                                                {"id"             "ex:HandShape"
@@ -1662,7 +1662,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                   "sh:qualifiedMaxCount"            4
                                                   "sh:qualifiedValueShapesDisjoint" true}]}]})
 
-          valid-hand   @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          valid-hand   @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                             "insert"   {"id"       "ex:ValidHand"
                                                         "type"     "ex:Hand"
                                                         "ex:digit" [{"ex:name" "Thumb"}
@@ -1670,7 +1670,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                                     {"ex:name" "Finger"}
                                                                     {"ex:name" "Finger"}
                                                                     {"ex:name" "Finger"}]}})
-          invalid-hand @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+          invalid-hand @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                             "insert"   {"id"       "ex:InvalidHand"
                                                         "type"     "ex:Hand"
                                                         "ex:digit" [{"ex:name" "Thumb"}
@@ -1698,7 +1698,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                                                         {"ex" "http://example.com/"}]})
         db0 (fluree/db ledger)]
     (testing "shacl-objects-of-test"
-      (let [db1 @(fluree/stage2 db0
+      (let [db1 @(fluree/stage db0
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
                                  {"@id" "ex:friendShape"
@@ -1707,11 +1707,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                   "sh:property" [{"sh:path" {"@id" "ex:name"}
                                                   "sh:datatype" {"@id" "xsd:string"}}]}})
             ;; need to specify type in order to avoid sh:datatype coercion
-            db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            db2 @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                      "insert" {"id" "ex:Bob"
                                                "ex:name" {"@type" "xsd:integer" "@value" 123}
                                                "type" "ex:User"}})
-            db-forbidden-friend @(fluree/stage2 db2
+            db-forbidden-friend @(fluree/stage db2
                                                 {"@context" "https://ns.flur.ee"
                                                  "insert"
                                                  {"id"        "ex:Alice"
@@ -1720,7 +1720,7 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
         (is (= "SHACL PropertyShape exception - sh:datatype: every datatype must be 1."
                (ex-message db-forbidden-friend)))))
     (testing "shape constraints"
-      (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+      (let [db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                      "insert"
                                      [{"id" "ex:CoolShape"
                                        "type" "sh:NodeShape"
@@ -1733,11 +1733,11 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
                                        "sh:property" [{"sh:path" {"id" "ex:cool"}
                                                        "sh:node" {"id" "ex:CoolShape"}
                                                        "sh:minCount" 1}]}]})
-            valid-person @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            valid-person @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                               "insert" {"id" "ex:Bob"
                                                         "type" "ex:Person"
                                                         "ex:cool" {"ex:isCool" true}}})
-            invalid-person @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            invalid-person @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                                 "insert" {"id" "ex:Reto"
                                                           "type" "ex:Person"
                                                           "ex:cool" {"ex:isCool" false}}})]
@@ -1748,18 +1748,18 @@ WORLD! does not match pattern \"hello   (.*?)world\" with provided sh:flags: [\"
         (is (= "SHACL PropertyShape exception - sh:hasValue: at least one value must be true."
                (ex-message invalid-person)))))
     (testing "extended path constraints"
-      (let [db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+      (let [db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                      "insert" {"id" "ex:PersonShape"
                                                "type" "sh:NodeShape"
                                                "sh:targetClass" {"id" "ex:Person"}
                                                "sh:property" [{"sh:path" {"@list" [{"id" "ex:cool"} {"id" "ex:dude"}]}
                                                                "sh:nodeKind" {"id" "sh:BlankNode"}
                                                                "sh:minCount" 1}]}})
-            valid-person @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            valid-person @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                               "insert" {"id" "ex:Bob"
                                                         "type" "ex:Person"
                                                         "ex:cool" {"ex:dude" {"ex:isBlank" true}}}})
-            invalid-person @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+            invalid-person @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                                 "insert" {"id" "ex:Reto"
                                                           "type" "ex:Person"
                                                           "ex:cool" {"ex:dude" {"id" "ex:Dude"

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -13,7 +13,7 @@
                                             ["" {:ex "http://example.org/ns/"}]})
           user-query       {:select {'?s [:*]}
                             :where  {:id '?s, :type :ex/User}}
-          db               @(fluree/stage2
+          db               @(fluree/stage
                               (fluree/db ledger)
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -28,7 +28,7 @@
                                                   :sh/minCount 1
                                                   :sh/maxCount 1
                                                   :sh/datatype :xsd/string}]}})
-          db-ok            @(fluree/stage2
+          db-ok            @(fluree/stage
                               db
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -37,7 +37,7 @@
                                 :schema/name     "John"
                                 :schema/callSign "j-rock"}})
           db-company-name  (try
-                             @(fluree/stage2
+                             @(fluree/stage
                                 db
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
@@ -47,7 +47,7 @@
                                   :schema/callSign    "j-rock"}})
                              (catch Exception e e))
           db-two-names     (try
-                             @(fluree/stage2
+                             @(fluree/stage
                                 db
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
@@ -57,7 +57,7 @@
                                   :schema/callSign    "j-rock"}})
                              (catch Exception e e))
           db-callsign-name (try
-                             @(fluree/stage2
+                             @(fluree/stage
                                 db
                                 {"@context" "https://ns.flur.ee"
                                  "insert"
@@ -90,7 +90,7 @@
                                         ["" {:ex "http://example.org/ns/"}]})
           user-query   {:select {'?s [:*]}
                         :where  {:id '?s, :type :ex/User}}
-          db           @(fluree/stage2
+          db           @(fluree/stage
                           (fluree/db ledger)
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -105,7 +105,7 @@
                                               :sh/minCount 1
                                               :sh/maxCount 1
                                               :sh/datatype :xsd/long}]}})
-          db-ok        @(fluree/stage2
+          db-ok        @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -115,7 +115,7 @@
                             :schema/callSign "j-rock"
                             :schema/age      42
                             :schema/favNums  [9004 9008 9015 9016 9023 9042]}})
-          db-too-old   @(fluree/stage2
+          db-too-old   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -124,7 +124,7 @@
                             :schema/companyName "WrongCo"
                             :schema/callSign    "j-rock"
                             :schema/age         131}})
-          db-too-low   @(fluree/stage2
+          db-too-low   @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -134,7 +134,7 @@
                             :schema/callSign    "j-rock"
                             :schema/age         27
                             :schema/favNums     [4 8 15 16 23 42]}})
-          db-two-probs @(fluree/stage2
+          db-two-probs @(fluree/stage
                           db
                           {"@context" "https://ns.flur.ee"
                            "insert"
@@ -171,7 +171,7 @@
                                       ["" {:ex "http://example.org/ns/"}]})
           user-query {:select {'?s [:*]}
                       :where  {:id '?s, :type :ex/User}}
-          db         @(fluree/stage2
+          db         @(fluree/stage
                         (fluree/db ledger)
                         {"@context" "https://ns.flur.ee"
                          "insert"
@@ -184,14 +184,14 @@
                                             :sh/maxLength 10}
                                            {:sh/path    :ex/greeting
                                             :sh/pattern "hello.*"}]}})
-          db-ok-name @(fluree/stage2
+          db-ok-name @(fluree/stage
                         db
                         {"@context" "https://ns.flur.ee"
                          "insert"
                          {:id          :ex/jean-claude
                           :type        :ex/User,
                           :schema/name "Jean-Claude"}})
-          db-ok-tag  @(fluree/stage2
+          db-ok-tag  @(fluree/stage
                         db
                         {"@context" "https://ns.flur.ee"
                          "insert"
@@ -199,14 +199,14 @@
                           :type   :ex/User,
                           :ex/tag 1}})
 
-          db-ok-greeting        @(fluree/stage2
+          db-ok-greeting        @(fluree/stage
                                    db
                                    {"@context" "https://ns.flur.ee"
                                     "insert"
                                     {:id          :ex/al,
                                      :type        :ex/User,
                                      :ex/greeting "HOWDY"}})
-          db-name-too-short     (try @(fluree/stage2
+          db-name-too-short     (try @(fluree/stage
                                         db
                                         {"@context" "https://ns.flur.ee"
                                          "insert"
@@ -214,7 +214,7 @@
                                           :type        [:ex/User],
                                           :schema/name "John"}})
                                      (catch Exception e e))
-          db-tag-too-long       (try @(fluree/stage2
+          db-tag-too-long       (try @(fluree/stage
                                         db
                                         {"@context" "https://ns.flur.ee"
                                          "insert"
@@ -222,7 +222,7 @@
                                           :type   [:ex/User],
                                           :ex/tag 12345}})
                                      (catch Exception e e))
-          db-greeting-incorrect (try @(fluree/stage2
+          db-greeting-incorrect (try @(fluree/stage
                                         db
                                         {"@context" "https://ns.flur.ee"
                                          "insert"

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -127,7 +127,7 @@
   [conn]
   (let [ledger @(fluree/create conn "test/movies")]
     (doseq [movie movies]
-      (let [staged @(fluree/stage2 (fluree/db ledger) {"@context" "https://ns.flur.ee" "insert" movie})]
+      (let [staged @(fluree/stage (fluree/db ledger) {"@context" "https://ns.flur.ee" "insert" movie})]
         @(fluree/commit! ledger staged
                          {:message (str "Commit " (get movie "name"))
                           :push?   true})))
@@ -140,7 +140,7 @@
                                  {:defaultContext
                                   ["" {:ex "http://example.org/ns/"}]})
          ledger   #?(:clj @ledger-p :cljs (<p! ledger-p))
-         staged-p (fluree/stage2 (fluree/db ledger) {"@context" "https://ns.flur.ee" "insert" people})
+         staged-p (fluree/stage (fluree/db ledger) {"@context" "https://ns.flur.ee" "insert" people})
          staged   #?(:clj @staged-p :cljs (<p! staged-p))
          commit-p (fluree/commit! ledger staged {:message "Adding people"
                                                  :push? true})]
@@ -151,7 +151,7 @@
   ([ledger data]
    (transact ledger data {}))
   ([ledger data commit-opts]
-   (let [staged @(fluree/stage2 (fluree/db ledger) data)]
+   (let [staged @(fluree/stage (fluree/db ledger) data)]
      (fluree/commit! ledger staged commit-opts))))
 
 (defn retry-promise-wrapped

--- a/test/fluree/db/transact/default_context_test.clj
+++ b/test/fluree/db/transact/default_context_test.clj
@@ -37,7 +37,7 @@
                                    "insert"  [{:id       :ex-new/foo2
                                                :ex-new/x "foo-2"
                                                :ex-new/y "bar-2"}]}
-                                  (fluree/stage2 db-update-ctx)
+                                  (fluree/stage db-update-ctx)
                                   deref
                                   (fluree/commit! ledger)
                                   deref))
@@ -198,7 +198,7 @@
                                        "insert"  [{:id       :ex-new/foo2
                                                    :ex-new/x "foo-2"
                                                    :ex-new/y "bar-2"}]}
-                                      (fluree/stage2 db-update-ctx)
+                                      (fluree/stage db-update-ctx)
                                       deref
                                       (fluree/commit! ledger)
                                       deref))

--- a/test/fluree/db/transact/retraction_test.clj
+++ b/test/fluree/db/transact/retraction_test.clj
@@ -7,7 +7,7 @@
   (testing "Retractions of individual properties and entire subjects."
     (let [conn           (test-utils/create-conn)
           ledger         @(fluree/create conn "tx/retract")
-          db             @(fluree/stage2
+          db             @(fluree/stage
                             (fluree/db ledger)
                             {"@context" "https://ns.flur.ee"
                              "insert"
@@ -25,7 +25,7 @@
                                          :schema/name "Jane"
                                          :schema/age  30}]}})
           ;; retract Alice's age attribute
-          db-age-retract @(fluree/stage2
+          db-age-retract @(fluree/stage
                             db
                             {"@context" "https://ns.flur.ee"
                              "delete"

--- a/test/fluree/db/transact/stable_context_test.clj
+++ b/test/fluree/db/transact/stable_context_test.clj
@@ -21,7 +21,7 @@
         db1-load (fluree/db (test-utils/retry-load conn "ctx/stability-mem-ld"
                                                    100))
 
-        db2      (->> @(fluree/stage2 db1-load {"@context" "https://ns.flur.ee"
+        db2      (->> @(fluree/stage db1-load {"@context" "https://ns.flur.ee"
                                                 "insert"   [{:id      :blah/two
                                                              :ex/name "Two"}]})
                       (fluree/commit! ledger)
@@ -29,7 +29,7 @@
         db2-load (fluree/db (test-utils/retry-load conn "ctx/stability-mem-ld"
                                                    100))
 
-        db3      (->> @(fluree/stage2 db2-load {"@context" "https://ns.flur.ee"
+        db3      (->> @(fluree/stage db2-load {"@context" "https://ns.flur.ee"
                                                 "insert"   [{:id      :blah/three
                                                              :ex/name "Three"}]})
                       (fluree/commit! ledger)

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -15,22 +15,22 @@
           ledger @(fluree/create conn "tx/disallow" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
           db0    (fluree/db ledger)
 
-          stage-id-only    @(fluree/stage2
+          stage-id-only    @(fluree/stage
                               db0
                               {"@context" "https://ns.flur.ee"
                                "insert"   {:id :ex/alice}})
-          stage-empty-txn  @(fluree/stage2
+          stage-empty-txn  @(fluree/stage
                               db0
                               {"@context" "https://ns.flur.ee"
                                "insert"   {}})
-          stage-empty-node @(fluree/stage2
+          stage-empty-node @(fluree/stage
                               db0
                               {"@context" "https://ns.flur.ee"
                                "insert"
                                [{:id         :ex/alice
                                  :schema/age 42}
                                 {}]})
-          db-ok            @(fluree/stage2
+          db-ok            @(fluree/stage
                               db0
                               {"@context" "https://ns.flur.ee"
                                "insert"
@@ -56,7 +56,7 @@
           ledger  @(fluree/create conn "tx/bools"
                                   {:defaultContext
                                    ["" {:ex "http://example.org/ns/"}]})
-          db-bool @(fluree/stage2
+          db-bool @(fluree/stage
                      (fluree/db ledger)
                      {"@context" "https://ns.flur.ee"
                       "insert"
@@ -74,7 +74,7 @@
           ledger @(fluree/create conn "tx/mixed-dts"
                                  {:defaultContext
                                   ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2 (fluree/db ledger)
+          db     @(fluree/stage (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
                                   {:id               :ex/brian
@@ -93,7 +93,7 @@
           ledger @(fluree/create conn "tx/mixed-dts"
                                  {:defaultContext
                                   ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2 (fluree/db ledger)
+          db     @(fluree/stage (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
                                   {:id :ex/wes
@@ -112,7 +112,7 @@
           ledger @(fluree/create conn "tx/mixed-dts"
                                  {:defaultContext
                                   ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2 (fluree/db ledger)
+          db     @(fluree/stage (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
                                   {:id               :ex/brian
@@ -131,7 +131,7 @@
           ledger @(fluree/create conn "tx/mixed-dts"
                                  {:defaultContext
                                   ["" {:ex "http://example.org/ns/"}]})
-          db     @(fluree/stage2 (fluree/db ledger)
+          db     @(fluree/stage (fluree/db ledger)
                                  {"@context" "https://ns.flur.ee"
                                   "insert"
                                   {:id :ex/wes
@@ -149,13 +149,13 @@
   (testing "var in object position works"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "var-in-obj")
-          db1    @(fluree/stage2
+          db1    @(fluree/stage
                    (fluree/db ledger)
                    {"@context" ["https://ns.flur.ee" {"ex" "http://example.org/"}]
                     "insert"   {"@id"       "ex:jane"
                                 "ex:friend" {"@id"           "ex:alice"
                                              "ex:bestFriend" {"@id" "ex:bob"}}}})
-          db2    @(fluree/stage2
+          db2    @(fluree/stage
                    db1
                    {"@context" ["https://ns.flur.ee" {"ex" "http://example.org/"}]
                     "where"    {"@id"       "?s"
@@ -191,11 +191,11 @@
                             :f/allow       [{:id           :ex/globalViewAllow
                                              :f/targetRole :ex/userRole
                                              :f/action     [:f/view]}]}]
-          db-data-first   @(fluree/stage2
+          db-data-first   @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert" (into data policy)})
-          db-policy-first @(fluree/stage2
+          db-policy-first @(fluree/stage
                              (fluree/db ledger)
                              {"@context" "https://ns.flur.ee"
                               "insert" (into policy data)})
@@ -222,12 +222,12 @@
                                     {:defaultContext
                                      ["" {"ex" "https://example.com/"}]})
             db      (fluree/db ledger)
-            db0     @(fluree/stage2 db {"@context" "https://ns.flur.ee"
+            db0     @(fluree/stage db {"@context" "https://ns.flur.ee"
                                         "insert"   shacl})
             _       (assert (not (util/exception? db0)))
             db1     @(fluree/commit! ledger db0)
             _       (assert (not (util/exception? db1)))
-            db2     @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+            db2     @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                          "insert"   movies})
             _       (assert (not (util/exception? db2)))
             query   {"select" "?title"
@@ -249,7 +249,7 @@
                                     {:defaultContext
                                      ["" {:ex "http://example.org/ns/"}]})
         ;; can't `transact!` until ledger can be loaded (ie has at least one commit)
-        db          @(fluree/stage2 (fluree/db ledger)
+        db          @(fluree/stage (fluree/db ledger)
                                     {"@context" "https://ns.flur.ee"
                                      "insert"
                                      {:id   :ex/firstTransaction
@@ -272,7 +272,7 @@
                               :type        :ex/User
                               :foo/baz     "baz"
                               :schema/name "Bob"}]}
-            db  @(fluree/transact!2 conn txn)]
+            db  @(fluree/transact! conn txn)]
         (is (= #{{:id          :ex/bob,
                   :type        :ex/User,
                   :schema/name "Bob",
@@ -290,7 +290,7 @@
                  "ledger"   ledger-name
                  "insert"   {:id-alias         :ex/alice
                              :schema/givenName "Alicia"}}
-            db  @(fluree/transact!2 conn txn)]
+            db  @(fluree/transact! conn txn)]
         (is (= #{{:id          :ex/bob,
                   :type        :ex/User,
                   :schema/name "Bob",
@@ -311,7 +311,7 @@
                  "insert"   [{:context    {:quux "http://quux.com/"}
                               :id         :ex/alice
                               :quux/corge "grault"}]}
-            db  @(fluree/transact!2 conn txn)]
+            db  @(fluree/transact! conn txn)]
         (is (= #{{:id          :ex/bob
                   :type        :ex/User
                   :schema/name "Bob"
@@ -337,17 +337,17 @@
                   "insert"   [{:id      :ex/bar
                                :type    :ex/Person
                                :ex/name "Bar"}]}
-            db1  @(fluree/transact!2 conn txn1)]
+            db1  @(fluree/transact! conn txn1)]
         (is (= [{:id :ex/foo, :type :ex/Person, :ex/name "Foo"}]
                @(fluree/query db1 '{:select {?p [:*]}
                                     :where  {:id ?p, :type :ex/Person}})))
         (is (= "Invalid compact-iri: :id Error at idx: [0 :id]"
-               (ex-message @(fluree/transact!2 conn txn2))))))
+               (ex-message @(fluree/transact! conn txn2))))))
     (testing "Throws on invalid txn"
       (let [txn {"@context" ["https://ns.flur.ee" "" {:quux "http://quux.com/"}]
                  "insert"   {:id :ex/cam :quux/corge "grault"}}]
         (is (= "Invalid transaction, missing required key: ledger."
-               (ex-message @(fluree/transact!2 conn txn))))))))
+               (ex-message @(fluree/transact! conn txn))))))))
 
 
 (deftest ^:integration base-and-vocab-test
@@ -364,7 +364,7 @@
                                     "isScary" false}]}
           ledger      @(fluree/create conn ledger-name)
           db0         (fluree/db ledger)
-          db1         @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+          db1         @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                            "insert"  txn})]
       (is (= [{"@id"                              "http://example.org/nessie"
                "@type"                            "http://example.org/terms/SeaMonster"
@@ -373,7 +373,7 @@
                                  "select"   '{?m ["*"]}
                                  "where"    '{"@id" ?m
                                               "@type" "http://example.org/terms/SeaMonster"}})))))
-  (testing "@base & @vocab work w/ stage2"
+  (testing "@base & @vocab work w/ stage"
     (let [conn        @(fluree/connect {:method :memory})
           ctx         ["https://ns.flur.ee"
                        {"@base"  "http://example.org/"
@@ -386,7 +386,7 @@
                                    "isScary" false}}
           ledger      @(fluree/create conn ledger-name)
           db0         (fluree/db ledger)
-          db1         @(fluree/stage2 db0 txn)]
+          db1         @(fluree/stage db0 txn)]
       (is (= [{"@id"                              "http://example.org/nessie"
                "@type"                            "http://example.org/terms/SeaMonster"
                "http://example.org/terms/isScary" false}]
@@ -402,7 +402,7 @@
           ledger @(fluree/create conn "jsonpls" {:defaultContext [test-utils/default-str-context
                                                                   {"ex" "http://example.org/ns/"}]})
           db0    (fluree/db ledger)
-          db1    @(fluree/stage2
+          db1    @(fluree/stage
                     db0
                     {"@context" "https://ns.flur.ee"
                      "insert"
@@ -437,10 +437,10 @@
         ledger @(fluree/create conn "insert-delete")
         db0    (fluree/db ledger)
 
-        db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee"
+        db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee"
                                  "insert"   [{"@id" "ex:andrew" "schema:name" "Andrew"}]})
 
-        db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee"
+        db2 @(fluree/stage db1 {"@context" "https://ns.flur.ee"
                                  "where"    {"@id"                "ex:andrew"
                                              "schema:description" "?o"}
                                  "delete"   {"@id"                "ex:andrew"
@@ -465,7 +465,7 @@
                                                 "xsd" "http://www.w3.org/2001/XMLSchema#"}})
 
         db0 (fluree/db ledger)
-        db1 @(fluree/stage2 db0 {"@context" "https://ns.flur.ee",
+        db1 @(fluree/stage db0 {"@context" "https://ns.flur.ee",
                                  "ledger"   ledger-id
                                  "insert"   {"@id"            "ex:NodeShape/Yeti",
                                              "@type"          "sh:NodeShape",
@@ -475,7 +475,7 @@
                                                                 "sh:datatype" {"@id" "xsd:integer"}}]}})
 
 
-        db2 @(fluree/stage2 db1 {"@context" "https://ns.flur.ee",
+        db2 @(fluree/stage db1 {"@context" "https://ns.flur.ee",
                                  "ledger"   ledger-id
                                  "insert"   {"@id"         "ex:freddy",
                                              "@type"       "ex:Yeti",
@@ -485,7 +485,7 @@
         _ @(fluree/commit! ledger db2)
         loaded @(fluree/load conn ledger-id)
 
-        db3 @(fluree/stage2 (fluree/db loaded) {"@context" "https://ns.flur.ee",
+        db3 @(fluree/stage (fluree/db loaded) {"@context" "https://ns.flur.ee",
                                                 "ledger" ledger-id
                                                 "insert" {"@id" "ex:letti",
                                                           "@type" "ex:Yeti",

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -13,30 +13,25 @@
   (testing "Disallow staging invalid transactions"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "tx/disallow" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+          db0    (fluree/db ledger)
 
-          stage-id-only    (try
-                             @(fluree/stage2
-                                (fluree/db ledger)
-                                {"@context" "https://ns.flur.ee"
-                                 "insert"   {:id :ex/alice}})
-                             (catch Exception e e))
-          stage-empty-txn  (try
-                             @(fluree/stage2
-                                (fluree/db ledger)
-                                {"@context" "https://ns.flur.ee"
-                                 "insert"   {}})
-                             (catch Exception e e))
-          stage-empty-node (try
-                             @(fluree/stage2
-                                (fluree/db ledger)
-                                {"@context" "https://ns.flur.ee"
-                                 "insert"
-                                 [{:id         :ex/alice
-                                   :schema/age 42}
-                                  {}]})
-                             (catch Exception e e))
+          stage-id-only    @(fluree/stage2
+                              db0
+                              {"@context" "https://ns.flur.ee"
+                               "insert"   {:id :ex/alice}})
+          stage-empty-txn  @(fluree/stage2
+                              db0
+                              {"@context" "https://ns.flur.ee"
+                               "insert"   {}})
+          stage-empty-node @(fluree/stage2
+                              db0
+                              {"@context" "https://ns.flur.ee"
+                               "insert"
+                               [{:id         :ex/alice
+                                 :schema/age 42}
+                                {}]})
           db-ok            @(fluree/stage2
-                              (fluree/db ledger)
+                              db0
                               {"@context" "https://ns.flur.ee"
                                "insert"
                                {:id         :ex/alice

--- a/test/nodejs/flureenjs.test.js
+++ b/test/nodejs/flureenjs.test.js
@@ -52,9 +52,11 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
   const db = await flureenjs.db(ledger);
 
   const db1 = await flureenjs.stage(db, {
-    id: "ex:john",
-    "@type": "ex:User",
-    "schema:name": "John"
+    insert: {
+      id: "ex:john",
+      "@type": "ex:User",
+      "schema:name": "John"
+    }
   });
 
   const dc = flureenjs.defaultContext(db1);
@@ -108,10 +110,12 @@ test("expect conn, ledger, stage, commit, defaultContext, and query to work", as
 
 
   const db2 = await flureenjs.stage(db, {
-    "@id": "uniqueId",
-    foo: "foo",
-    bar: "bar",
-    "fake:iri/baz": "baz",
+    insert: {
+      "@id": "uniqueId",
+      foo: "foo",
+      bar: "bar",
+      "fake:iri/baz": "baz"
+    }
   });
 
   //  await flureenjs.commit(db);


### PR DESCRIPTION
This removes dead code and renames the top-level api functions:

`stage2` -> `stage`
`transact!2` -> `transact!`
`create-with-txn2` -> `create-with-txn`

Also propagates the api changes to our js tests, fixing https://github.com/fluree/db/issues/666

Currently based on https://github.com/fluree/db/pull/674, so that needs to be merged first.