### PR TITLE
Task/internal renaming

### DIFF
--- a/src/fluree/db/json_ld/bootstrap.cljc
+++ b/src/fluree/db/json_ld/bootstrap.cljc
@@ -2,7 +2,6 @@
   (:require [clojure.core.async :refer [go]]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.dbproto :as db-proto]
-            [fluree.db.json-ld.transact :as jld-transact]
             [fluree.db.util.log :as log :include-macros true]
             [fluree.db.flake :as flake]
             [fluree.db.constants :as const]))
@@ -19,11 +18,15 @@
      (db-proto/-stage blank-db tx {:bootstrap? true})
      (go blank-db))))
 
+(defn base-flakes
+  "Returns base set of flakes needed in any new ledger."
+  [t]
+  [(flake/create const/$xsd:anyURI const/$xsd:anyURI "@id" const/$xsd:string t true nil)])
+
 (defn blank-db
   "When not bootstrapping with a transaction, bootstraps initial base set of flakes required for a db."
   [blank-db]
-  (let [t           (dec (:t blank-db))
-        base-flakes (jld-transact/base-flakes t)]
+  (let [t (dec (:t blank-db))]
     (-> blank-db
         (assoc :t t)
-        (commit-data/update-novelty [(flake/create const/$xsd:anyURI const/$xsd:anyURI const/iri-id const/$xsd:string t true nil)]))))
+        (commit-data/update-novelty (base-flakes t)))))

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -22,13 +22,6 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defn base-flakes
-  "Returns base set of flakes needed in any new ledger."
-  [t]
-  [(flake/create const/$rdf:type const/$xsd:anyURI const/iri-type const/$xsd:string t true nil)
-   (flake/create const/$rdfs:Class const/$xsd:anyURI const/iri-class const/$xsd:string t true nil)
-   (flake/create const/$xsd:anyURI const/$xsd:anyURI "@id" const/$xsd:string t true nil)])
-
 (defn validate-rules
   [{:keys [db-after add] :as staged-map} {:keys [subj-mods] :as _tx-state}]
   (let [subj-mods' @subj-mods

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -93,7 +93,7 @@
                                  (update counter-key inc)))))]
     (get iri->sid* iri)))
 
-(defn ->tx-state2
+(defn ->tx-state
   [db]
   (let [{:keys [schema branch ledger policy], db-t :t} db
         iri->sid (atom {:last-pid (jld-ledger/last-pid db)
@@ -115,7 +115,7 @@
   (go
     (let [error-ch  (async/chan)
           update-ch (->> (where/search db parsed-txn fuel-tracker error-ch)
-                         (update/modify2 db parsed-txn tx-state fuel-tracker error-ch)
+                         (update/modify db parsed-txn tx-state fuel-tracker error-ch)
                          (exec/into-flakeset fuel-tracker))]
       (async/alt!
         error-ch ([e] e)
@@ -168,7 +168,7 @@
                        o-pred-shapes)))
           subj-mods)))))
 
-(defn final-db2
+(defn final-db
   "Returns map of all elements for a stage transaction required to create an
   updated db."
   [new-flakes {:keys [stage-update? db-before iri->sid policy t] :as tx-state}]
@@ -198,7 +198,7 @@
           ;; wrap it in an atom to reuse old validate-rules and policy/allowed? unchanged
           ;; TODO: remove the atom wrapper once subj-mods is no longer shared code
           tx-state* (assoc tx-state :subj-mods (atom subj-mods))]
-      (-> (final-db2 flakes tx-state)
+      (-> (final-db flakes tx-state)
           <?
           (validate-rules tx-state*)
           <?
@@ -214,7 +214,7 @@
      (let [db* (if-let [policy-opts (perm/policy-opts parsed-opts)]
                  (<? (perm/wrap-policy db policy-opts))
                  db)
-           tx-state      (->tx-state2 db*)
+           tx-state      (->tx-state db*)
 
            txn-context   (dbproto/-context db* (:context parsed-opts))
            parsed-txn    (q-parse/parse-txn txn txn-context)

--- a/src/fluree/db/query/exec/update.cljc
+++ b/src/fluree/db/query/exec/update.cljc
@@ -15,7 +15,7 @@
   [flake]
   (= const/$xsd:anyURI (flake/p flake)))
 
-(defn retract-triple2
+(defn retract-triple
   [db triple {:keys [t]} solution fuel-tracker error-ch]
   (let [retract-flakes-ch (async/chan)]
     (go
@@ -40,26 +40,26 @@
                 (>! error-ch e))))
     retract-flakes-ch))
 
-(defn retract-clause2
+(defn retract-clause
   [db clause tx-state solution fuel-tracker error-ch out-ch]
   (let [clause-ch  (async/to-chan! clause)]
     (async/pipeline-async 2
                           out-ch
                           (fn [triple ch]
                             (-> db
-                                (retract-triple2 triple tx-state solution fuel-tracker error-ch)
+                                (retract-triple triple tx-state solution fuel-tracker error-ch)
                                 (async/pipe ch)))
                           clause-ch)
     out-ch))
 
-(defn retract2
+(defn retract
   [db txn tx-state fuel-tracker error-ch solution-ch]
   (let [{:keys [delete]} txn
         retract-ch       (async/chan 2)]
     (async/pipeline-async 2
                           retract-ch
                           (fn [solution ch]
-                            (retract-clause2 db delete tx-state solution fuel-tracker error-ch ch))
+                            (retract-clause db delete tx-state solution fuel-tracker error-ch ch))
                           solution-ch)
     retract-ch))
 
@@ -78,13 +78,13 @@
   [sid iri t]
   (flake/create sid const/$xsd:anyURI iri const/$xsd:string t true nil))
 
-(defn insert-triple2
+(defn insert-triple
   [db triple {:keys [t next-sid next-pid]} solution error-ch]
   (go
     (try*
       (let [db-alias            (:alias db)
             [s-mch p-mch o-mch] (where/assign-matched-values triple solution nil)]
-        (log/trace "insert-triple2 o-mch:" o-mch)
+        (log/trace "insert-triple o-mch:" o-mch)
         (if-not (and (or (where/get-iri s-mch)
                          (where/get-sid s-mch db-alias))
                      (or (where/get-iri p-mch)
@@ -146,36 +146,36 @@
 
                 ;; o needs to be a sid if it's a ref, otherwise the literal o
                 o*               (or ref-sid (datatype/coerce-value o-val dt-sid))
-                _                (log/trace "insert-triple2 o*:" o*)
+                _                (log/trace "insert-triple o*:" o*)
                 obj-flake        (flake/create sid pid o* dt-sid t true m)]
             (into [] (remove nil?) [new-subj-flake new-pred-flake new-dt-flake new-ref-flake obj-flake]))))
       (catch* e
         (log/error e "Error inserting new triple")
         (>! error-ch e)))))
 
-(defn insert-clause2
+(defn insert-clause
   [db clause tx-state solution error-ch out-ch]
   (async/pipeline-async 2
                         out-ch
                         (fn [triple ch]
                           (-> db
-                              (insert-triple2 triple tx-state solution error-ch)
+                              (insert-triple triple tx-state solution error-ch)
                               (async/pipe ch)))
                         (async/to-chan! clause))
   out-ch)
 
-(defn insert2
+(defn insert
   [db txn tx-state error-ch solution-ch]
   (let [clause    (:insert txn)
         insert-ch (async/chan 2)]
     (async/pipeline-async 2
                           insert-ch
                           (fn [solution ch]
-                            (insert-clause2 db clause tx-state solution error-ch ch))
+                            (insert-clause db clause tx-state solution error-ch ch))
                           solution-ch)
     insert-ch))
 
-(defn insert-retract2
+(defn insert-retract
   [db mdfn tx-state fuel-tracker error-ch solution-ch]
   (let [solution-ch*    (async/chan 2)  ; create an extra channel to multiply so
                                         ; solutions don't get dropped before we
@@ -183,10 +183,10 @@
         solution-mult   (async/mult solution-ch*)
         insert-soln-ch  (->> (async/chan 2)
                              (async/tap solution-mult))
-        insert-ch       (insert2 db mdfn tx-state error-ch insert-soln-ch)
+        insert-ch       (insert db mdfn tx-state error-ch insert-soln-ch)
         retract-soln-ch (->> (async/chan 2)
                              (async/tap solution-mult))
-        retract-ch      (retract2 db mdfn tx-state fuel-tracker error-ch retract-soln-ch)]
+        retract-ch      (retract db mdfn tx-state fuel-tracker error-ch retract-soln-ch)]
     (async/pipe solution-ch solution-ch*) ; now hook up the solution input
                                         ; after everything is wired
     (async/merge [insert-ch retract-ch])))
@@ -199,17 +199,17 @@
   [txn]
   (contains? txn :delete))
 
-(defn modify2
+(defn modify
   [db parsed-txn tx-state fuel-tracker error-ch solution-ch]
   (let [solution-ch* (async/pipe solution-ch
                                  (async/chan 2 (where/with-default where/blank-solution)))]
     (cond
       (and (insert? parsed-txn)
            (retract? parsed-txn))
-      (insert-retract2 db parsed-txn tx-state fuel-tracker error-ch solution-ch*)
+      (insert-retract db parsed-txn tx-state fuel-tracker error-ch solution-ch*)
 
       (insert? parsed-txn)
-      (insert2 db parsed-txn tx-state error-ch solution-ch*)
+      (insert db parsed-txn tx-state error-ch solution-ch*)
 
       (retract? parsed-txn)
-      (retract2 db parsed-txn tx-state fuel-tracker error-ch solution-ch*))))
+      (retract db parsed-txn tx-state fuel-tracker error-ch solution-ch*))))


### PR DESCRIPTION
This is just a followup to the dead code removal - we can remove the suffixes from all the functions that no longer need them.

I also moved a function to the only namespace where it used.