### PR TITLE
Expand policy opts role using supplied context

### DIFF
--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -27,11 +27,15 @@
   [db query-map]
   (go-try
    (let [{:keys [opts]} query-map
-         db*            (if-let [policy-opts (perm/policy-opts opts)]
-                          (<? (perm/wrap-policy db policy-opts))
-                          db)
          {:keys [history t commit-details] :as parsed} (history/parse-history-query query-map)
-
+         ;;TODO only using query supplied context for policy opts,
+         ;;should be the only context operation once we have removed
+         ;;default-context
+         q-ctx          (ctx-util/extract+parse-supplied-context parsed)
+         db*            (if-let [policy-identity (perm/policy-identity
+                                                  (assoc opts :context q-ctx))]
+                          (<? (perm/wrap-policy db policy-identity))
+                          db)
          ;; from and to are positive ints, need to convert to negative or fill in default values
          {:keys [from to at]} t
          [from-t to-t] (if at
@@ -110,8 +114,8 @@
 (defn restrict-db
   [db t opts]
   (go-try
-    (let [db*  (if-let [policy-opts (perm/policy-opts opts)]
-                 (<? (perm/wrap-policy db policy-opts))
+    (let [db*  (if-let [policy-identity (perm/policy-identity opts)]
+                 (<? (perm/wrap-policy db policy-identity))
                  db)
           db** (-> (if t
                      (<? (time-travel/as-of db* t))
@@ -144,8 +148,10 @@
     (let [{query :subject, did :did}  (or (<? (cred/verify query))
                                           {:subject query})
           {:keys [t opts] :as query*} (update query :opts sanitize-query-options did)
-
-          db*      (<? (restrict-db db t opts))
+          ;;TODO: only using query context for opts, should be only context
+          ;;once default-context is removed
+          q-ctx    (ctx-util/extract+parse-supplied-context query*)
+          db*      (<? (restrict-db db t (assoc opts :context q-ctx)))
           query**  (update query* :opts dissoc   :meta :max-fuel ::util/track-fuel?)
           ctx      (ctx-util/extract db* query** opts)
           max-fuel (:max-fuel opts)]

--- a/src/fluree/db/api/query.cljc
+++ b/src/fluree/db/api/query.cljc
@@ -250,7 +250,8 @@
           named-aliases   (some-> query* :from-named util/sequential)]
       (if (or (seq default-aliases)
               (seq named-aliases))
-        (let [ds          (<? (load-dataset conn default-aliases named-aliases t opts))
+        (let [ds          (<? (load-dataset conn default-aliases named-aliases t
+                                            (assoc  opts :context (ctx-util/extract+parse-supplied-context query))))
               query**     (update query* :opts dissoc :meta :max-fuel ::util/track-fuel?)
               max-fuel    (:max-fuel opts)
               default-ctx (conn-proto/-default-context conn)

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -30,6 +30,9 @@
           parsed-opts             (cond-> parsed-opts
                                     did (assoc :did did)
                                     txn-context (assoc :context txn-context)
+                                    ;;TODO once we remove default-context, this supplied-context
+                                    ;;can just replace `txn-context` above as the value of
+                                    ;;the `:context` key
                                     true (assoc :supplied-context (ctx-util/extract+parse-supplied-context txn)))
 
           {:keys [maxFuel meta] :as parsed-opts*} (parse-opts parsed-opts opts)]

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -33,7 +33,7 @@
                                     ;;TODO once we remove default-context, this supplied-context
                                     ;;can just replace `txn-context` above as the value of
                                     ;;the `:context` key
-                                    true (assoc :supplied-context (ctx-util/extract+parse-supplied-context txn)))
+                                    true (assoc :supplied-context (ctx-util/extract-supplied-context txn)))
 
           {:keys [maxFuel meta] :as parsed-opts*} (parse-opts parsed-opts opts)]
       (if (or maxFuel meta)

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -29,7 +29,8 @@
           opts                    (util/get-first-value expanded const/iri-opts)
           parsed-opts             (cond-> parsed-opts
                                     did (assoc :did did)
-                                    txn-context (assoc :context txn-context))
+                                    txn-context (assoc :context txn-context)
+                                    true (assoc :supplied-context (ctx-util/extract+parse-supplied-context txn)))
 
           {:keys [maxFuel meta] :as parsed-opts*} (parse-opts parsed-opts opts)]
       (if (or maxFuel meta)

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -301,7 +301,7 @@
   allows the permission attributes to be modified.
 
   Returns promise"
-  [db {:keys [context] :as identity-map}]
+  [db identity-map]
   (promise-wrap
    (->> identity-map
         perm/policy-identity

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -303,11 +303,9 @@
   Returns promise"
   [db {:keys [context] :as identity-map}]
   (promise-wrap
-   (let    [identity-map* (cond-> identity-map
-                            context (update :context json-ld/parse-context))]
-     (->> identity-map*
-          perm/policy-identity
-          (perm/wrap-policy db)))))
+   (->> identity-map
+        perm/policy-identity
+        (perm/wrap-policy db))))
 
 
 (defn query

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -4,6 +4,7 @@
             [fluree.db.conn.file :as file-conn]
             [fluree.db.conn.memory :as memory-conn]
             [fluree.db.conn.remote :as remote-conn]
+            [fluree.json-ld :as json-ld]
             #?(:clj [fluree.db.conn.s3 :as s3-conn])
             [fluree.db.conn.proto :as conn-proto]
             [fluree.db.constants :as const]
@@ -300,9 +301,13 @@
   allows the permission attributes to be modified.
 
   Returns promise"
-  [db identity-map]
+  [db {:keys [context] :as identity-map}]
   (promise-wrap
-    (perm/wrap-policy db identity-map)))
+   (let    [identity-map* (cond-> identity-map
+                            context (update :context json-ld/parse-context))]
+     (->> identity-map*
+          perm/policy-identity
+          (perm/wrap-policy db)))))
 
 
 (defn query

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -493,8 +493,9 @@
   [{:keys [context] :as identity-map}]
   (when-let [{:keys [role] :as identity} (-> (select-keys identity-map [:did :role :credential])
                                              not-empty)]
-    (cond-> identity
-      (and role context) (update :role json-ld/expand-iri (json-ld/parse-context context)))))
+    (if (and role context)
+      (update identity :role json-ld/expand-iri (json-ld/parse-context context))
+      identity)))
 
 (defn role-sids-for-sid
   [db sid]

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.json-ld.policy
   (:require [clojure.core.async :as async]
             [fluree.db.constants :as const]
+            [fluree.json-ld :as json-ld]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.json-ld.policy-validate :as validate]
@@ -488,10 +489,12 @@
          (throw e))))))
 
 
-(defn policy-opts
-  [opts]
-  (-> (select-keys opts [:did :role :credential])
-      not-empty))
+(defn policy-identity
+  [{:keys [context] :as identity-map}]
+  (when-let [{:keys [role] :as identity} (-> (select-keys identity-map [:did :role :credential])
+                                             not-empty)]
+    (cond-> identity
+      (and role context) (update :role json-ld/expand-iri context))))
 
 (defn role-sids-for-sid
   [db sid]

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -491,7 +491,8 @@
 
 (defn policy-identity
   [{:keys [context] :as identity-map}]
-  (when-let [{:keys [role] :as identity} (-> (select-keys identity-map [:did :role :credential])
+  (when-let [{:keys [role] :as identity} (-> identity-map
+                                             (select-keys [:did :role :credential])
                                              not-empty)]
     (if (and role context)
       (update identity :role json-ld/expand-iri (json-ld/parse-context context))

--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -494,7 +494,7 @@
   (when-let [{:keys [role] :as identity} (-> (select-keys identity-map [:did :role :credential])
                                              not-empty)]
     (cond-> identity
-      (and role context) (update :role json-ld/expand-iri context))))
+      (and role context) (update :role json-ld/expand-iri (json-ld/parse-context context)))))
 
 (defn role-sids-for-sid
   [db sid]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -214,6 +214,9 @@
    (go-try
     (let [db* (if-let [policy-identity (perm/policy-identity
                                         (-> parsed-opts
+                                            ;;TODO once we remove default-context,
+                                            ;;should only have one context, with no need
+                                            ;;to swap here
                                             (assoc :context
                                                    (:supplied-context parsed-opts))
                                             (dissoc :supplied-context)))]

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -18,6 +18,7 @@
             [fluree.db.query.exec.where :as where]
             [fluree.db.query.range :as query-range]
             [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.util.context :as ctx-util]
             [fluree.db.util.core :as util]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -211,8 +212,12 @@
    (stage db nil txn parsed-opts))
   ([db fuel-tracker txn parsed-opts]
    (go-try
-     (let [db* (if-let [policy-opts (perm/policy-opts parsed-opts)]
-                 (<? (perm/wrap-policy db policy-opts))
+    (let [db* (if-let [policy-identity (perm/policy-identity
+                                        (-> parsed-opts
+                                            (assoc :context
+                                                   (:supplied-context parsed-opts))
+                                            (dissoc :supplied-context)))]
+                (<? (perm/wrap-policy db policy-identity))
                  db)
            tx-state      (->tx-state db*)
 

--- a/src/fluree/db/util/context.cljc
+++ b/src/fluree/db/util/context.cljc
@@ -221,8 +221,9 @@
   [db jsonld opts]
   (dbproto/-context db (get-context jsonld) (:context-type opts)))
 
-(defn extract+parse-supplied-context
+(defn extract-supplied-context
+  "Just retrieves the context from the given data,
+  without any default-context fallback logic"
   [jsonld]
-  (when-let [supplied-context (cond (contains? jsonld :context) (:context jsonld)
-                                    (contains? jsonld "@context") (get jsonld "@context"))]
-    (json-ld/parse-context supplied-context)))
+  (cond (contains? jsonld :context) (:context jsonld)
+        (contains? jsonld "@context") (get jsonld "@context")))

--- a/src/fluree/db/util/context.cljc
+++ b/src/fluree/db/util/context.cljc
@@ -220,3 +220,9 @@
 (defn extract
   [db jsonld opts]
   (dbproto/-context db (get-context jsonld) (:context-type opts)))
+
+(defn extract+parse-supplied-context
+  [jsonld]
+  (when-let [supplied-context (cond (contains? jsonld :context) (:context jsonld)
+                                    (contains? jsonld "@context") (get jsonld "@context"))]
+    (json-ld/parse-context supplied-context)))

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -208,18 +208,18 @@
             (is (= [["Alice" "111-11-1111"] ["John" nil]]
                    @(fluree/query-connection conn
                                              {:context context
-                                              :from "policy/a"
-                                              :select '[?name ?ssn]
-                                              :where  '[{:id          ?p
-                                                         :schema/name ?name}
-                                                        [:optional {:id         ?p
-                                                                    :schema/ssn ?ssn}]]
-                                              :opts   {:did  alice-did
-                                                       :role :ex/userRole}}))
+                                              :from    "policy/a"
+                                              :select  '[?name ?ssn]
+                                              :where   '[{:id          ?p
+                                                          :schema/name ?name}
+                                                         [:optional {:id         ?p
+                                                                     :schema/ssn ?ssn}]]
+                                              :opts    {:did  alice-did
+                                                        :role :ex/userRole}}))
                 "Both user names should show, but only SSN for Alice"))
           (testing "history query"
             (is (= []
-                   @(fluree/history ledger {:context context
+                   @(fluree/history ledger {:context        context
                                             :history        [:ex/john :schema/ssn] :t {:from 1}
                                             :commit-details true
                                             :opts           {:did  alice-did

--- a/test/fluree/db/policy/basic_test.clj
+++ b/test/fluree/db/policy/basic_test.clj
@@ -10,13 +10,15 @@
 
 (deftest ^:integration query-policy-enforcement
   (testing "Testing basic policy enforcement on queries."
-    (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "policy/a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
+    (let [conn      @(fluree/connect {:method :memory
+                                      :defaults {:context-type :keyword}})
+          context   [test-utils/default-context {:ex "http://example.org/ns/"}]
+          ledger    @(fluree/create conn "policy/a")
           root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
           alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
           db        @(fluree/stage
                        (fluree/db ledger)
-                       {"@context" "https://ns.flur.ee"
+                       {"@context"          context
                         "insert"
                         [{:id               :ex/alice,
                           :type             :ex/User,
@@ -48,7 +50,7 @@
           db+policy @(fluree/stage
                        db
                        ;; add policy targeting :ex/rootRole that can view and modify everything
-                       {"@context" "https://ns.flur.ee"
+                       {"@context" context
                         "insert"
                         [{:id           :ex/rootPolicy,
                           :type         [:f/Policy], ;; must be of type :f/Policy, else it won't be treated as a policy
@@ -69,15 +71,17 @@
                                                       :f/action     [:f/view]
                                                       :f/equals     {:list [:f/$identity :ex/user]}}]}]}]})]
       (let [root-wrapped-db            @(fluree/wrap-policy
-                                          db+policy {:did  root-did
-                                                     :role :ex/rootRole})
+                                         db+policy {:did  root-did
+                                                    :role :ex/rootRole
+                                                    :context context})
             double-policy-query-result @(fluree/query
-                                          root-wrapped-db
-                                          {:select {'?s [:* {:ex/location [:*]}]}
-                                           :where  {:id   '?s
-                                                    :type :ex/User}
-                                           :opts   {:did  root-did
-                                                    :role :ex/rootRole}})]
+                                         root-wrapped-db
+                                         {:context context
+                                          :select {'?s [:* {:ex/location [:*]}]}
+                                          :where  {:id   '?s
+                                                   :type :ex/User}
+                                          :opts   {:did  root-did
+                                                   :role :ex/rootRole}})]
         (is (util/exception? double-policy-query-result)
             "Should be an error to try to apply policy twice on one db.")
         (is (str/includes? (ex-message double-policy-query-result)
@@ -99,7 +103,8 @@
                :ex/location      {:id         "_:f211106232532993",
                                   :ex/state   "NC",
                                   :ex/country "USA"}}]
-             @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
+             @(fluree/query db+policy {:context context
+                                       :select {'?s [:* {:ex/location [:*]}]}
                                        :where  {:id   '?s
                                                 :type :ex/User}
                                        :opts   {:did  root-did
@@ -121,7 +126,8 @@
                :ex/location      {:id         "_:f211106232532993",
                                   :ex/state   "NC",
                                   :ex/country "USA"}}]
-             @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
+             @(fluree/query db+policy {:context context
+                                       :select {'?s [:* {:ex/location [:*]}]}
                                        :where  {:id   '?s
                                                 :type :ex/User}
                                        :opts   {:did  root-did
@@ -134,7 +140,8 @@
                :schema/name          "Widget",
                :schema/price         99.99M,
                :schema/priceCurrency "USD"}]
-             @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
+             @(fluree/query db+policy {:context context
+                                       :select {'?s [:* {:ex/location [:*]}]}
                                        :where  {:id   '?s
                                                 :type :ex/Product}
                                        :opts   {:role :ex/rootRole}}))
@@ -149,7 +156,8 @@
                :schema/name      "Alice",
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17"}]
-             @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
+             @(fluree/query db+policy {:context context
+                                       :select {'?s [:* {:ex/location [:*]}]}
                                        :where  {:id   '?s
                                                 :type :ex/User}
                                        :opts   {:role :ex/userRole}}))
@@ -157,7 +165,8 @@
 
       ;; Alice cannot see product data as it was not explicitly allowed
       (is (= []
-             @(fluree/query db+policy {:select {'?s [:*]}
+             @(fluree/query db+policy {:context context
+                                       :select {'?s [:*]}
                                        :where  {:id   '?s
                                                 :type :ex/Product}
                                        :opts   {:did  alice-did
@@ -175,7 +184,8 @@
                :schema/email     "alice@flur.ee",
                :schema/birthDate "2022-08-17",
                :schema/ssn       "111-11-1111"}]
-             @(fluree/query db+policy {:select {'?s [:* {:ex/location [:*]}]}
+             @(fluree/query db+policy {:context context
+                                       :select {'?s [:* {:ex/location [:*]}]}
                                        :where  {:id   '?s
                                                 :type :ex/User}
                                        :opts   {:did  alice-did
@@ -184,7 +194,8 @@
 
       ;; Alice can only see her allowed data in a non-graph-crawl query too
       (is (= [["Alice" "111-11-1111"] ["John" nil]]
-             @(fluree/query db+policy {:select '[?name ?ssn]
+             @(fluree/query db+policy {:context context
+                                       :select '[?name ?ssn]
                                        :where  '[{:id          ?p
                                                   :schema/name ?name}
                                                  [:optional {:id         ?p
@@ -195,7 +206,8 @@
       (testing "history query"
         (let [_ @(fluree/commit! ledger db+policy)]
           (is (= []
-                 @(fluree/history ledger {:history        [:ex/john :schema/ssn] :t {:from 1}
+                 @(fluree/history ledger {:context context
+                                          :history        [:ex/john :schema/ssn] :t {:from 1}
                                           :commit-details true
                                           :opts           {:did  alice-did
                                                            :role :ex/userRole}}))
@@ -203,11 +215,13 @@
           (is (= [{:f/t       1,
                    :f/assert  [{:schema/ssn "111-11-1111", :id :ex/alice}],
                    :f/retract []}]
-                 @(fluree/history ledger {:history [:ex/alice :schema/ssn] :t {:from 1}
+                 @(fluree/history ledger {:context context
+                                          :history [:ex/alice :schema/ssn] :t {:from 1}
                                           :opts    {:did  alice-did
                                                     :role :ex/userRole}}))
               "Alice should be able to see history for her own ssn.")
-          (let [[history-result]       @(fluree/history ledger {:history        [:ex/alice :schema/ssn] :t {:from 1}
+          (let [[history-result]       @(fluree/history ledger {:context context
+                                                                :history        [:ex/alice :schema/ssn] :t {:from 1}
                                                                 :commit-details true
                                                                 :opts           {:did  alice-did
                                                                                  :role :ex/userRole}})
@@ -226,7 +240,8 @@
                      :id               :ex/alice}]
                    commit-details-asserts)
                 "Alice should be able to see her own ssn in commit details, but not John's."))
-          (let [[history-result]       @(fluree/history ledger {:history        [:ex/alice :schema/ssn] :t {:from 1}
+          (let [[history-result]       @(fluree/history ledger {:context context
+                                                                :history        [:ex/alice :schema/ssn] :t {:from 1}
                                                                 :commit-details true
                                                                 :opts           {:did  root-did
                                                                                  :role :ex/rootRole}})
@@ -239,7 +254,7 @@
                             :schema/ssn       "888-88-8888",
                             :id               :ex/john})
                 "Root can see John's ssn in commit details."))
-          (let [_ @(test-utils/transact ledger {"@context" "https://ns.flur.ee"
+          (let [_ @(test-utils/transact ledger {"@context" context
                                                 "delete"   {:id          :ex/john
                                                             :schema/name "John"}
                                                 "insert"   {:id          :ex/john
@@ -250,7 +265,8 @@
                     {:f/t       2,
                      :f/assert  [{:schema/name "Jack", :id :ex/john}],
                      :f/retract [{:schema/name "John", :id :ex/john}]}]
-                   @(fluree/history ledger {:history [:ex/john :schema/name] :t {:from 1}
+                   @(fluree/history ledger {:context context
+                                            :history [:ex/john :schema/name] :t {:from 1}
                                             :opts    {:did  alice-did
                                                       :role :ex/userRole}}))
                 "Alice should be able to see all history for John's name")))))))

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -8,171 +8,176 @@
 
 (deftest ^:integration policy-enforcement
   (testing "Testing basic policy enforcement."
-    (let [conn      (test-utils/create-conn)
-          ledger    @(fluree/create conn "policy/tx-a" {:defaultContext ["" {:ex "http://example.org/ns/"}]})
-          root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
-          alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
-          db        @(fluree/stage
-                       (fluree/db ledger)
-                       {"@context" "https://ns.flur.ee"
-                        "insert"
-                        [{:id               :ex/alice,
-                          :type             :ex/User,
-                          :schema/name      "Alice"
-                          :schema/email     "alice@flur.ee"
-                          :schema/birthDate "2022-08-17"
-                          :schema/ssn       "111-11-1111"
-                          :ex/location      {:ex/state   "NC"
-                                             :ex/country "USA"}}
-                         {:id               :ex/john,
-                          :type             :ex/User,
-                          :schema/name      "John"
-                          :schema/email     "john@flur.ee"
-                          :schema/birthDate "2021-08-17"
-                          :schema/ssn       "888-88-8888"}
-                         {:id                   :ex/widget,
-                          :type                 :ex/Product,
-                          :schema/name          "Widget"
-                          :schema/price         99.99
-                          :schema/priceCurrency "USD"}
-                         ;; assign root-did to :ex/rootRole
-                         {:id     root-did
-                          :f/role :ex/rootRole}
-                         ;; assign alice-did to :ex/userRole and also link the did to :ex/alice via :ex/user
-                         {:id      alice-did
-                          :ex/user :ex/alice
-                          :f/role  [:ex/userRole :ex/otherRole]}]})
+    (let [conn      @(fluree/connect {:method :memory
+                                    :defaults {:context-type :keyword}})
+        context   [test-utils/default-context {:ex "http://example.org/ns/"}]
+        ledger    @(fluree/create conn "policy/tx-a")
+        root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+        alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+        db        @(fluree/stage
+                    (fluree/db ledger)
+                    {"@context"  context
+                     "insert"
+                     [{:id               :ex/alice,
+                       :type             :ex/User,
+                       :schema/name      "Alice"
+                       :schema/email     "alice@flur.ee"
+                       :schema/birthDate "2022-08-17"
+                       :schema/ssn       "111-11-1111"
+                       :ex/location      {:ex/state   "NC"
+                                          :ex/country "USA"}}
+                      {:id               :ex/john,
+                       :type             :ex/User,
+                       :schema/name      "John"
+                       :schema/email     "john@flur.ee"
+                       :schema/birthDate "2021-08-17"
+                       :schema/ssn       "888-88-8888"}
+                      {:id                   :ex/widget,
+                       :type                 :ex/Product,
+                       :schema/name          "Widget"
+                       :schema/price         99.99
+                       :schema/priceCurrency "USD"}
+                      ;; assign root-did to :ex/rootRole
+                      {:id     root-did
+                       :f/role :ex/rootRole}
+                      ;; assign alice-did to :ex/userRole and also link the did to :ex/alice via :ex/user
+                      {:id      alice-did
+                       :ex/user :ex/alice
+                       :f/role  [:ex/userRole :ex/otherRole]}]})
 
-          db+policy @(fluree/stage
-                       db
-                       {"@context" "https://ns.flur.ee"
-                        "insert"
-                        ;; add policy targeting :ex/rootRole that can view and modify everything
-                        [{:id           :ex/rootPolicy,
-                          :type         [:f/Policy], ;; must be of type :f/Policy, else it won't be treated as a policy
-                          :f/targetNode :f/allNodes ;; :f/allNodes special keyword meaning every node (everything)
-                          :f/allow      [{:id           :ex/rootAccessAllow
-                                          :f/targetRole :ex/rootRole ;; our name for global / root role
-                                          :f/action     [:f/view :f/modify]}]}
-                         ;; add a policy targeting :ex/userRole that can see all users, but only SSN if belonging to themselves
-                         {:id            :ex/UserPolicy,
-                          :type          [:f/Policy],
-                          :f/targetClass :ex/User
-                          :f/allow       [{:id           :ex/globalViewAllow
-                                           :f/targetRole :ex/userRole ;; our assigned name for standard user's role (given to Alice above)
-                                           :f/action     [:f/view]}]
-                          :f/property    [{:f/path  :schema/ssn
-                                           :f/allow [{:id           :ex/ssnViewRule
-                                                      :f/targetRole :ex/userRole
-                                                      :f/action     [:f/view]
-                                                      :f/equals     {:list [:f/$identity :ex/user]}}]}
-                                          {:f/path  :schema/email
-                                           :f/allow [{:id           :ex/emailChangeRule
-                                                      :f/targetRole :ex/userRole
-                                                      :f/action     [:f/view :f/modify]
-                                                      :f/equals     {:list [:f/$identity :ex/user]}}]}]}
-                         ;; add a :ex/Product policy allows view & modify for only :schema/name
-                         {:id            :ex/ProductPolicy,
-                          :type          [:f/Policy],
-                          :f/targetClass :ex/Product
-                          :f/property    [{:f/path  :type
-                                           :f/allow [{:f/targetRole :ex/userRole
-                                                      :f/action     [:f/view]}]}
-                                          {:f/path  :schema/name
-                                           :f/allow [{:f/targetRole :ex/userRole
-                                                      :f/action     [:f/view :f/modify]}]}]}]})]
-      (testing "Policy allowed modification"
-        (testing "using role + id"
-          (let [update-name @(fluree/stage db+policy
-                                            {"@context" "https://ns.flur.ee"
+        db+policy @(fluree/stage
+                    db
+                    {"@context" context
+                     "insert"
+                     ;; add policy targeting :ex/rootRole that can view and modify everything
+                     [{:id           :ex/rootPolicy,
+                       :type         [:f/Policy], ;; must be of type :f/Policy, else it won't be treated as a policy
+                       :f/targetNode :f/allNodes ;; :f/allNodes special keyword meaning every node (everything)
+                       :f/allow      [{:id           :ex/rootAccessAllow
+                                       :f/targetRole :ex/rootRole ;; our name for global / root role
+                                       :f/action     [:f/view :f/modify]}]}
+                      ;; add a policy targeting :ex/userRole that can see all users, but only SSN if belonging to themselves
+                      {:id            :ex/UserPolicy,
+                       :type          [:f/Policy],
+                       :f/targetClass :ex/User
+                       :f/allow       [{:id           :ex/globalViewAllow
+                                        :f/targetRole :ex/userRole ;; our assigned name for standard user's role (given to Alice above)
+                                        :f/action     [:f/view]}]
+                       :f/property    [{:f/path  :schema/ssn
+                                        :f/allow [{:id           :ex/ssnViewRule
+                                                   :f/targetRole :ex/userRole
+                                                   :f/action     [:f/view]
+                                                   :f/equals     {:list [:f/$identity :ex/user]}}]}
+                                       {:f/path  :schema/email
+                                        :f/allow [{:id           :ex/emailChangeRule
+                                                   :f/targetRole :ex/userRole
+                                                   :f/action     [:f/view :f/modify]
+                                                   :f/equals     {:list [:f/$identity :ex/user]}}]}]}
+                      ;; add a :ex/Product policy allows view & modify for only :schema/name
+                      {:id            :ex/ProductPolicy,
+                       :type          [:f/Policy],
+                       :f/targetClass :ex/Product
+                       :f/property    [{:f/path  :type
+                                        :f/allow [{:f/targetRole :ex/userRole
+                                                   :f/action     [:f/view]}]}
+                                       {:f/path  :schema/name
+                                        :f/allow [{:f/targetRole :ex/userRole
+                                                   :f/action     [:f/view :f/modify]}]}]}]})]
+    (testing "Policy allowed modification"
+      (testing "using role + id"
+        (let [update-name @(fluree/stage db+policy
+                                         {"@context" context
+                                          "delete"
+                                          {:id          :ex/alice
+                                           :schema/email "alice@flur.ee"}
+                                          "insert"
+                                          {:id          :ex/alice
+                                           :schema/email "alice@foo.bar"}}
+                                         {:did alice-did
+                                          :role      :ex/userRole})]
+          (is (= [{:id :ex/alice,
+                   :type :ex/User,
+                   :schema/name "Alice",
+                   :schema/email "alice@foo.bar",
+                   :schema/birthDate "2022-08-17",
+                   :schema/ssn "111-11-1111",
+                   :ex/location {:id nil}}]
+                 @(fluree/query update-name
+                                {:context context
+                                 :select {'?s [:*]}
+                                 :where  {:id '?s, :schema/name "Alice"}
+                                 :opts {:did alice-did}}))
+              "Alice should be allowed to update her own name.")))
+      (testing "using role only"
+        (let [update-price @(fluree/stage db+policy
+                                            {"@context" context
                                              "delete"
-                                             {:id          :ex/alice
-                                              :schema/email "alice@flur.ee"}
+                                             {:id          :ex/widget
+                                              :schema/price 99.99}
                                              "insert"
-                                             {:id          :ex/alice
-                                              :schema/email "alice@foo.bar"}}
-                                            {:did alice-did
-                                             :role      :ex/userRole})]
-            (is (= [{:id :ex/alice,
-                     :type :ex/User,
-                     :schema/name "Alice",
-                     :schema/email "alice@foo.bar",
-                     :schema/birthDate "2022-08-17",
-                     :schema/ssn "111-11-1111",
-                     :ex/location {:id nil}}]
+                                             {:id          :ex/widget
+                                              :schema/price 105.99}}
+                                            {:role :ex/rootRole})]
+
+            (is (= [{:id :ex/widget,
+                     :type :ex/Product,
+                     :schema/name "Widget",
+                     :schema/price 105.99M,
+                     :schema/priceCurrency "USD"}]
+                   @(fluree/query update-price
+                                  {:context context
+                                   :select {'?s [:*]}
+                                   :where  {:id '?s, :type :ex/Product}}))
+                "Updated :schema/price should have been allowed, and entire product is visible in query."))
+        (let [update-name @(fluree/stage db+policy
+                                         {"@context" context
+                                          "delete"
+                                          {:id          :ex/widget
+                                           :schema/name "Widget"}
+                                          "insert"
+                                          {:id          :ex/widget
+                                           :schema/name "Widget2"}}
+                                         {:role :ex/userRole})]
+
+          (is (= [{:type    :ex/Product
+                     :schema/name "Widget2"}]
                    @(fluree/query update-name
-                                  {:select {'?s [:*]}
-                                   :where  {:id '?s, :schema/name "Alice"}
-                                   :opts {:did alice-did}}))
-                "Alice should be allowed to update her own name.")))
-        (testing "using role only"
-            (let [update-price @(fluree/stage db+policy
-                                               {"@context" "https://ns.flur.ee"
-                                                "delete"
-                                                {:id          :ex/widget
-                                                 :schema/price 99.99}
-                                                "insert"
-                                                {:id          :ex/widget
-                                                 :schema/price 105.99}}
-                                               {:role :ex/rootRole})]
+                                  {:context context
+                                   :select {'?s [:*]}
+                                   :where  {:id '?s, :type :ex/Product}
+                                   :opts {:role :ex/userRole}}))
+                "Updated :schema/name should have been allowed, and only name is visible in query."))))
+    (testing "Policy doesn't allow a modification"
+      (let [update-price @(fluree/stage db+policy {"@context" context
+                                                   "insert" {:id           :ex/widget
+                                                             :schema/price 42.99}}
+                                        {:did root-did
+                                         :role      :ex/userRole})]
+        (is (util/exception? update-price)
+            "Attempted update should have thrown an exception, `:ex/userRole` cannot modify product prices regardless of identity")
 
-              (is (= [{:id :ex/widget,
-                       :type :ex/Product,
-                       :schema/name "Widget",
-                       :schema/price 105.99M,
-                       :schema/priceCurrency "USD"}]
-                     @(fluree/query update-price
-                                    {:select {'?s [:*]}
-                                     :where  {:id '?s, :type :ex/Product}}))
-                  "Updated :schema/price should have been allowed, and entire product is visible in query."))
-            (let [update-name @(fluree/stage db+policy
-                                              {"@context" "https://ns.flur.ee"
-                                               "delete"
-                                               {:id          :ex/widget
-                                                :schema/name "Widget"}
-                                               "insert"
-                                               {:id          :ex/widget
-                                                :schema/name "Widget2"}}
-                                              {:role :ex/userRole})]
+        (is (= :db/policy-exception
+               (:error (ex-data update-price)))
+            "Exception should be of type :db/policy-exception"))
+      (let [update-email @(fluree/stage db+policy {"@context" context
+                                                   "insert"   {:id           :ex/john
+                                                               :schema/email "john@foo.bar"}}
+                                        {:role :ex/user})]
 
-              (is (= [{:type    :ex/Product
-                       :schema/name "Widget2"}]
-                     @(fluree/query update-name
-                                    {:select {'?s [:*]}
-                                     :where  {:id '?s, :type :ex/Product}
-                                     :opts {:role :ex/userRole}}))
-                  "Updated :schema/name should have been allowed, and only name is visible in query."))))
-      (testing "Policy doesn't allow a modification"
-        (let [update-price @(fluree/stage db+policy {"@context" "https://ns.flur.ee"
-                                                      "insert" {:id           :ex/widget
-                                                                :schema/price 42.99}}
-                                          {:did root-did
-                                           :role      :ex/userRole})]
-          (is (util/exception? update-price)
-              "Attempted update should have thrown an exception, `:ex/userRole` cannot modify product prices regardless of identity")
+        (is (util/exception? update-email)
+            "attempted update should have thrown an exception, no identity was provided")
 
-          (is (= :db/policy-exception
-                 (:error (ex-data update-price)))
-              "Exception should be of type :db/policy-exception"))
-        (let [update-email @(fluree/stage db+policy {"@context" "https://ns.flur.ee"
-                                                      "insert"   {:id           :ex/john
-                                                                  :schema/email "john@foo.bar"}}
-                                          {:role :ex/user})]
+        (is (= :db/policy-exception
+               (:error (ex-data update-email)))
+            "exception should be of type :db/policy-exception"))
+      (let [update-name-other-role @(fluree/stage db+policy {"@context" context
+                                                             "insert" {:id          :ex/widget
+                                                                       :schema/name "Widget2"}}
+                                                  {:did alice-did
+                                                   :role      :ex/otherRole})]
+        (is (util/exception? update-name-other-role)
+            "Attempted update should have thrown an exception, this role cannot modify product names")
 
-          (is (util/exception? update-email)
-              "attempted update should have thrown an exception, no identity was provided")
-
-          (is (= :db/policy-exception
-                 (:error (ex-data update-email)))
-              "exception should be of type :db/policy-exception"))
-        (let [update-name-other-role @(fluree/stage db+policy {"@context" "https://ns.flur.ee"
-                                                                "insert" {:id          :ex/widget
-                                                                          :schema/name "Widget2"}}
-                                                    {:did alice-did
-                                                     :role      :ex/otherRole})]
-          (is (util/exception? update-name-other-role)
-              "Attempted update should have thrown an exception, this role cannot modify product names")
-
-          (is (= :db/policy-exception
-                 (:error (ex-data update-name-other-role)))
-              "Exception should be of type :db/policy-exception"))))))
+        (is (= :db/policy-exception
+               (:error (ex-data update-name-other-role)))
+            "Exception should be of type :db/policy-exception"))))))

--- a/test/fluree/db/policy/transact_test.clj
+++ b/test/fluree/db/policy/transact_test.clj
@@ -9,175 +9,175 @@
 (deftest ^:integration policy-enforcement
   (testing "Testing basic policy enforcement."
     (let [conn      @(fluree/connect {:method :memory
-                                    :defaults {:context-type :keyword}})
-        context   [test-utils/default-context {:ex "http://example.org/ns/"}]
-        ledger    @(fluree/create conn "policy/tx-a")
-        root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
-        alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
-        db        @(fluree/stage
-                    (fluree/db ledger)
-                    {"@context"  context
-                     "insert"
-                     [{:id               :ex/alice,
-                       :type             :ex/User,
-                       :schema/name      "Alice"
-                       :schema/email     "alice@flur.ee"
-                       :schema/birthDate "2022-08-17"
-                       :schema/ssn       "111-11-1111"
-                       :ex/location      {:ex/state   "NC"
-                                          :ex/country "USA"}}
-                      {:id               :ex/john,
-                       :type             :ex/User,
-                       :schema/name      "John"
-                       :schema/email     "john@flur.ee"
-                       :schema/birthDate "2021-08-17"
-                       :schema/ssn       "888-88-8888"}
-                      {:id                   :ex/widget,
-                       :type                 :ex/Product,
-                       :schema/name          "Widget"
-                       :schema/price         99.99
-                       :schema/priceCurrency "USD"}
-                      ;; assign root-did to :ex/rootRole
-                      {:id     root-did
-                       :f/role :ex/rootRole}
-                      ;; assign alice-did to :ex/userRole and also link the did to :ex/alice via :ex/user
-                      {:id      alice-did
-                       :ex/user :ex/alice
-                       :f/role  [:ex/userRole :ex/otherRole]}]})
+                                      :defaults {:context-type :keyword}})
+          context   [test-utils/default-context {:ex "http://example.org/ns/"}]
+          ledger    @(fluree/create conn "policy/tx-a")
+          root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+          alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+          db        @(fluree/stage
+                       (fluree/db ledger)
+                       {"@context" context
+                        "insert"
+                        [{:id               :ex/alice,
+                          :type             :ex/User,
+                          :schema/name      "Alice"
+                          :schema/email     "alice@flur.ee"
+                          :schema/birthDate "2022-08-17"
+                          :schema/ssn       "111-11-1111"
+                          :ex/location      {:ex/state   "NC"
+                                             :ex/country "USA"}}
+                         {:id               :ex/john,
+                          :type             :ex/User,
+                          :schema/name      "John"
+                          :schema/email     "john@flur.ee"
+                          :schema/birthDate "2021-08-17"
+                          :schema/ssn       "888-88-8888"}
+                         {:id                   :ex/widget,
+                          :type                 :ex/Product,
+                          :schema/name          "Widget"
+                          :schema/price         99.99
+                          :schema/priceCurrency "USD"}
+                         ;; assign root-did to :ex/rootRole
+                         {:id     root-did
+                          :f/role :ex/rootRole}
+                         ;; assign alice-did to :ex/userRole and also link the did to :ex/alice via :ex/user
+                         {:id      alice-did
+                          :ex/user :ex/alice
+                          :f/role  [:ex/userRole :ex/otherRole]}]})
 
-        db+policy @(fluree/stage
-                    db
-                    {"@context" context
-                     "insert"
-                     ;; add policy targeting :ex/rootRole that can view and modify everything
-                     [{:id           :ex/rootPolicy,
-                       :type         [:f/Policy], ;; must be of type :f/Policy, else it won't be treated as a policy
-                       :f/targetNode :f/allNodes ;; :f/allNodes special keyword meaning every node (everything)
-                       :f/allow      [{:id           :ex/rootAccessAllow
-                                       :f/targetRole :ex/rootRole ;; our name for global / root role
-                                       :f/action     [:f/view :f/modify]}]}
-                      ;; add a policy targeting :ex/userRole that can see all users, but only SSN if belonging to themselves
-                      {:id            :ex/UserPolicy,
-                       :type          [:f/Policy],
-                       :f/targetClass :ex/User
-                       :f/allow       [{:id           :ex/globalViewAllow
-                                        :f/targetRole :ex/userRole ;; our assigned name for standard user's role (given to Alice above)
-                                        :f/action     [:f/view]}]
-                       :f/property    [{:f/path  :schema/ssn
-                                        :f/allow [{:id           :ex/ssnViewRule
-                                                   :f/targetRole :ex/userRole
-                                                   :f/action     [:f/view]
-                                                   :f/equals     {:list [:f/$identity :ex/user]}}]}
-                                       {:f/path  :schema/email
-                                        :f/allow [{:id           :ex/emailChangeRule
-                                                   :f/targetRole :ex/userRole
-                                                   :f/action     [:f/view :f/modify]
-                                                   :f/equals     {:list [:f/$identity :ex/user]}}]}]}
-                      ;; add a :ex/Product policy allows view & modify for only :schema/name
-                      {:id            :ex/ProductPolicy,
-                       :type          [:f/Policy],
-                       :f/targetClass :ex/Product
-                       :f/property    [{:f/path  :type
-                                        :f/allow [{:f/targetRole :ex/userRole
-                                                   :f/action     [:f/view]}]}
-                                       {:f/path  :schema/name
-                                        :f/allow [{:f/targetRole :ex/userRole
-                                                   :f/action     [:f/view :f/modify]}]}]}]})]
-    (testing "Policy allowed modification"
-      (testing "using role + id"
-        (let [update-name @(fluree/stage db+policy
-                                         {"@context" context
-                                          "delete"
-                                          {:id          :ex/alice
-                                           :schema/email "alice@flur.ee"}
-                                          "insert"
-                                          {:id          :ex/alice
-                                           :schema/email "alice@foo.bar"}}
-                                         {:did alice-did
-                                          :role      :ex/userRole})]
-          (is (= [{:id :ex/alice,
-                   :type :ex/User,
-                   :schema/name "Alice",
-                   :schema/email "alice@foo.bar",
-                   :schema/birthDate "2022-08-17",
-                   :schema/ssn "111-11-1111",
-                   :ex/location {:id nil}}]
-                 @(fluree/query update-name
-                                {:context context
-                                 :select {'?s [:*]}
-                                 :where  {:id '?s, :schema/name "Alice"}
-                                 :opts {:did alice-did}}))
-              "Alice should be allowed to update her own name.")))
-      (testing "using role only"
-        (let [update-price @(fluree/stage db+policy
+          db+policy @(fluree/stage
+                       db
+                       {"@context" context
+                        "insert"
+                        ;; add policy targeting :ex/rootRole that can view and modify everything
+                        [{:id           :ex/rootPolicy,
+                          :type         [:f/Policy], ;; must be of type :f/Policy, else it won't be treated as a policy
+                          :f/targetNode :f/allNodes ;; :f/allNodes special keyword meaning every node (everything)
+                          :f/allow      [{:id           :ex/rootAccessAllow
+                                          :f/targetRole :ex/rootRole ;; our name for global / root role
+                                          :f/action     [:f/view :f/modify]}]}
+                         ;; add a policy targeting :ex/userRole that can see all users, but only SSN if belonging to themselves
+                         {:id            :ex/UserPolicy,
+                          :type          [:f/Policy],
+                          :f/targetClass :ex/User
+                          :f/allow       [{:id           :ex/globalViewAllow
+                                           :f/targetRole :ex/userRole ;; our assigned name for standard user's role (given to Alice above)
+                                           :f/action     [:f/view]}]
+                          :f/property    [{:f/path  :schema/ssn
+                                           :f/allow [{:id           :ex/ssnViewRule
+                                                      :f/targetRole :ex/userRole
+                                                      :f/action     [:f/view]
+                                                      :f/equals     {:list [:f/$identity :ex/user]}}]}
+                                          {:f/path  :schema/email
+                                           :f/allow [{:id           :ex/emailChangeRule
+                                                      :f/targetRole :ex/userRole
+                                                      :f/action     [:f/view :f/modify]
+                                                      :f/equals     {:list [:f/$identity :ex/user]}}]}]}
+                         ;; add a :ex/Product policy allows view & modify for only :schema/name
+                         {:id            :ex/ProductPolicy,
+                          :type          [:f/Policy],
+                          :f/targetClass :ex/Product
+                          :f/property    [{:f/path  :type
+                                           :f/allow [{:f/targetRole :ex/userRole
+                                                      :f/action     [:f/view]}]}
+                                          {:f/path  :schema/name
+                                           :f/allow [{:f/targetRole :ex/userRole
+                                                      :f/action     [:f/view :f/modify]}]}]}]})]
+      (testing "Policy allowed modification"
+        (testing "using role + id"
+          (let [update-name @(fluree/stage db+policy
                                             {"@context" context
                                              "delete"
-                                             {:id          :ex/widget
-                                              :schema/price 99.99}
+                                             {:id          :ex/alice
+                                              :schema/email "alice@flur.ee"}
                                              "insert"
-                                             {:id          :ex/widget
-                                              :schema/price 105.99}}
-                                            {:role :ex/rootRole})]
-
-            (is (= [{:id :ex/widget,
-                     :type :ex/Product,
-                     :schema/name "Widget",
-                     :schema/price 105.99M,
-                     :schema/priceCurrency "USD"}]
-                   @(fluree/query update-price
-                                  {:context context
-                                   :select {'?s [:*]}
-                                   :where  {:id '?s, :type :ex/Product}}))
-                "Updated :schema/price should have been allowed, and entire product is visible in query."))
-        (let [update-name @(fluree/stage db+policy
-                                         {"@context" context
-                                          "delete"
-                                          {:id          :ex/widget
-                                           :schema/name "Widget"}
-                                          "insert"
-                                          {:id          :ex/widget
-                                           :schema/name "Widget2"}}
-                                         {:role :ex/userRole})]
-
-          (is (= [{:type    :ex/Product
-                     :schema/name "Widget2"}]
+                                             {:id          :ex/alice
+                                              :schema/email "alice@foo.bar"}}
+                                            {:did alice-did
+                                             :role      :ex/userRole})]
+            (is (= [{:id :ex/alice,
+                     :type :ex/User,
+                     :schema/name "Alice",
+                     :schema/email "alice@foo.bar",
+                     :schema/birthDate "2022-08-17",
+                     :schema/ssn "111-11-1111",
+                     :ex/location {:id nil}}]
                    @(fluree/query update-name
                                   {:context context
                                    :select {'?s [:*]}
-                                   :where  {:id '?s, :type :ex/Product}
-                                   :opts {:role :ex/userRole}}))
-                "Updated :schema/name should have been allowed, and only name is visible in query."))))
-    (testing "Policy doesn't allow a modification"
-      (let [update-price @(fluree/stage db+policy {"@context" context
-                                                   "insert" {:id           :ex/widget
-                                                             :schema/price 42.99}}
-                                        {:did root-did
-                                         :role      :ex/userRole})]
-        (is (util/exception? update-price)
-            "Attempted update should have thrown an exception, `:ex/userRole` cannot modify product prices regardless of identity")
+                                   :where  {:id '?s, :schema/name "Alice"}
+                                   :opts {:did alice-did}}))
+                "Alice should be allowed to update her own name.")))
+        (testing "using role only"
+            (let [update-price @(fluree/stage db+policy
+                                               {"@context" context
+                                                "delete"
+                                                {:id          :ex/widget
+                                                 :schema/price 99.99}
+                                                "insert"
+                                                {:id          :ex/widget
+                                                 :schema/price 105.99}}
+                                               {:role :ex/rootRole})]
 
-        (is (= :db/policy-exception
-               (:error (ex-data update-price)))
-            "Exception should be of type :db/policy-exception"))
-      (let [update-email @(fluree/stage db+policy {"@context" context
-                                                   "insert"   {:id           :ex/john
-                                                               :schema/email "john@foo.bar"}}
-                                        {:role :ex/user})]
+              (is (= [{:id :ex/widget,
+                       :type :ex/Product,
+                       :schema/name "Widget",
+                       :schema/price 105.99M,
+                       :schema/priceCurrency "USD"}]
+                     @(fluree/query update-price
+                                    {:context context
+                                     :select {'?s [:*]}
+                                     :where  {:id '?s, :type :ex/Product}}))
+                  "Updated :schema/price should have been allowed, and entire product is visible in query."))
+            (let [update-name @(fluree/stage db+policy
+                                              {"@context" context
+                                               "delete"
+                                               {:id          :ex/widget
+                                                :schema/name "Widget"}
+                                               "insert"
+                                               {:id          :ex/widget
+                                                :schema/name "Widget2"}}
+                                              {:role :ex/userRole})]
 
-        (is (util/exception? update-email)
-            "attempted update should have thrown an exception, no identity was provided")
+              (is (= [{:type    :ex/Product
+                       :schema/name "Widget2"}]
+                     @(fluree/query update-name
+                                    {:context context
+                                     :select {'?s [:*]}
+                                     :where  {:id '?s, :type :ex/Product}
+                                     :opts {:role :ex/userRole}}))
+                  "Updated :schema/name should have been allowed, and only name is visible in query."))))
+      (testing "Policy doesn't allow a modification"
+        (let [update-price @(fluree/stage db+policy {"@context" context
+                                                      "insert" {:id           :ex/widget
+                                                                :schema/price 42.99}}
+                                          {:did root-did
+                                           :role      :ex/userRole})]
+          (is (util/exception? update-price)
+              "Attempted update should have thrown an exception, `:ex/userRole` cannot modify product prices regardless of identity")
 
-        (is (= :db/policy-exception
-               (:error (ex-data update-email)))
-            "exception should be of type :db/policy-exception"))
-      (let [update-name-other-role @(fluree/stage db+policy {"@context" context
-                                                             "insert" {:id          :ex/widget
-                                                                       :schema/name "Widget2"}}
-                                                  {:did alice-did
-                                                   :role      :ex/otherRole})]
-        (is (util/exception? update-name-other-role)
-            "Attempted update should have thrown an exception, this role cannot modify product names")
+          (is (= :db/policy-exception
+                 (:error (ex-data update-price)))
+              "Exception should be of type :db/policy-exception"))
+        (let [update-email @(fluree/stage db+policy {"@context" context
+                                                      "insert"   {:id           :ex/john
+                                                                  :schema/email "john@foo.bar"}}
+                                          {:role :ex/user})]
 
-        (is (= :db/policy-exception
-               (:error (ex-data update-name-other-role)))
-            "Exception should be of type :db/policy-exception"))))))
+          (is (util/exception? update-email)
+              "attempted update should have thrown an exception, no identity was provided")
+
+          (is (= :db/policy-exception
+                 (:error (ex-data update-email)))
+              "exception should be of type :db/policy-exception"))
+        (let [update-name-other-role @(fluree/stage db+policy {"@context" context
+                                                                "insert" {:id          :ex/widget
+                                                                          :schema/name "Widget2"}}
+                                                    {:did alice-did
+                                                     :role      :ex/otherRole})]
+          (is (util/exception? update-name-other-role)
+              "Attempted update should have thrown an exception, this role cannot modify product names")
+
+          (is (= :db/policy-exception
+                 (:error (ex-data update-name-other-role)))
+              "Exception should be of type :db/policy-exception"))))))


### PR DESCRIPTION
Part of https://github.com/fluree/core/issues/61

Up to now, the `wrap-policy` process has relied entirely on default context to expand the iri of the provided `:role` and look up its subject id. The call it has been making to `subid` has a  default behavior that expands using the db's default context.

This PR updates our policy opts helper (renamed to `policy-identity`) to expand the iri itself when given a context. Also updates our api fns to pass the supplied context from the request to that helper fn.

I removed the use of default context from a large number of the policy tests, but not all of them.

I did not want to mess with removing any existing default context logic yet (and have to change _many_ unrelated tests), so there's some redundancy here. I have introduced a context helper that just pulls out the supplied context from the request map, with no interaction with the default context whatsoever. I just use this when processing opts, leaving existing context retrieval/calculation processes (which do use default context) intact. 