### PR TITLE
Remove legacy v2 tag proto

### DIFF
--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -9,7 +9,6 @@
             [fluree.db.util.async :refer [<? go-try]]
             #?(:clj  [clojure.core.async :refer [go] :as async]
                :cljs [cljs.core.async :refer [go] :as async])
-            [clojure.string :as str]
             [fluree.json-ld :as json-ld]
             [fluree.db.json-ld.vocab :as vocab]
             [fluree.db.json-ld.branch :as branch]
@@ -148,40 +147,6 @@
   (cond->> (get-in schema [:pred predicate property])
            (= :restrictCollection property) (dbproto/-c-prop this :partition)))
 
-(defn- jsonld-tag
-  "resolves a tags's value given a tag subject id; optionally shortening the
-  return value if it starts with the given predicate name"
-  ([this tag-id]
-   (go-try
-     (let [tag-pred-id 30]
-       (some-> (<? (query-range/index-range (dbproto/-rootdb this)
-                                            :spot = [tag-id tag-pred-id]))
-               first
-               flake/o))))
-  ([this tag-id pred]
-   (go-try
-     (let [pred-name (if (string? pred) pred (dbproto/-p-prop this :name pred))
-           tag       (<? (dbproto/-tag this tag-id))]
-       (when (and pred-name tag)
-         (if (str/includes? tag ":")
-           (-> (str/split tag #":") second)
-           tag))))))
-
-(defn- jsonld-tag-id
-  ([this tag-name]
-   (go-try
-     (let [tag-pred-id const/$_tag:id]
-       (some-> (<? (query-range/index-range (dbproto/-rootdb this) :post = [tag-pred-id tag-name]))
-               first
-               flake/s))))
-  ([this tag-name pred]
-   (go-try
-     (if (str/includes? tag-name "/")
-       (<? (dbproto/-tag-id this tag-name))
-       (let [pred-name (if (string? pred) pred (dbproto/-p-prop this :name pred))]
-         (when pred-name
-           (<? (dbproto/-tag-id this (str pred-name ":" tag-name)))))))))
-
 (defn index-update
   "If provided commit-index is newer than db's commit index, updates db by cleaning novelty.
   If it is not newer, returns original db."
@@ -226,10 +191,6 @@
   (-p-prop [this property predicate] (jsonld-p-prop this property predicate))
   (-expand-iri [this compact-iri] (expand-iri this compact-iri))
   (-expand-iri [this compact-iri context] (expand-iri this compact-iri context))
-  (-tag [this tag-id] (jsonld-tag this tag-id))
-  (-tag [this tag-id pred] (jsonld-tag this tag-id pred))
-  (-tag-id [this tag-name] (jsonld-tag-id this tag-name))
-  (-tag-id [this tag-name pred] (jsonld-tag-id this tag-name pred))
   (-subid [this ident] (subid this ident {:strict? false :expand? true}))
   (-subid [this ident opts] (subid this ident opts))
   (-class-ids [this subject] (class-ids this subject))

--- a/src/fluree/db/dbproto.cljc
+++ b/src/fluree/db/dbproto.cljc
@@ -8,8 +8,6 @@
   (-class-prop [db property class] "Return class properties")
   (-expand-iri [db iri] [db iri context])
   ;; following return async chans
-  (-tag [db tag-id] [db tag-id pred] "Returns resolved tag, shortens namespace if pred provided.")
-  (-tag-id [db tag-name] [db tag-name pred] "Returns the tag sid. If pred provided will namespace tag if not already.")
   (-subid [db ident] [db ident strict?] "Returns subject ID if exists, else nil")
   (-class-ids [db subject-id] "For the provided subject-id (long int), returns a list of class subject ids it is a member of (long ints)")
   (-iri [db subject-id] [db ident compact-fn] "Returns the IRI for the requested subject ID (json-ld only)")


### PR DESCRIPTION
This removes the db protocol for v2's -tag and -tag-id which is no longer relevant in v3.

In v2, 'tags', replicated namespaced IRIs (for tag uniqueness) and some sugar that shortened the longer namespaced names. v3 now fully embraces namespaced IRIs, and natively handles the v2 tag concept.

If a user wants to create "tags" in v3, each tag should just be an IRI, e.g. colors might be `[{"@id": "tag:Red"}, {"@id": "tag:Blue"}]`. @context can be used to shorten the tags in query results if desired (in this case, i.e.: `{"tag": "http://example.org/tags/"}`). If a specific property should be restricted to only allow a specific set of enumerated tags (enum), SHACL can be used to create this restriction.
