### PR TITLE
Fix read-only f:allNodes policy

### DIFF
--- a/src/fluree/db/json_ld/policy.cljc
+++ b/src/fluree/db/json_ld/policy.cljc
@@ -306,7 +306,8 @@
                           ;; allow policy is restricted, therefore not 'root'
                           actions
                           (into actions (map #(get % "@id")
-                                             (get next-policy const/iri-action)))))
+                                             (-> (get next-policy const/iri-action)
+                                                 util/sequential)))))
                       #{} (get node-policy const/iri-allow))]
     (not-empty root-actions)))
 


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/65

We weren't building the `:policy` map properly in cases where permissions on `f:allNodes` only had one `f:action`. We were expecting `f:action` to always have a collection of actions in it, without ensuring that this was the case. This resulted in `nil` keys in the `:policy` map.