### PR TITLE
Add @type IRI flake for select clause projection

### DIFF
--- a/src/fluree/db/db/json_ld.cljc
+++ b/src/fluree/db/db/json_ld.cljc
@@ -252,6 +252,9 @@
 (def identity-flake
   (flake/create const/$xsd:anyURI const/$xsd:anyURI const/iri-id const/$xsd:string 0 true nil))
 
+(def type-flake
+  (flake/create const/$rdf:type const/$xsd:anyURI "@type" const/$xsd:string 0 true nil))
+
 (defn create
   [{:keys [method alias conn] :as ledger} default-context context-type new-context?]
   (let [novelty       (new-novelty-map index/default-comparators)
@@ -291,4 +294,4 @@
                         :context-cache   (volatile! nil)
                         :new-context?    new-context?
                         :ecount          genesis-ecount})
-        (commit-data/update-novelty [identity-flake]))))
+        (commit-data/update-novelty [identity-flake type-flake]))))

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -930,7 +930,7 @@
                  (testing "queries returning metadata"
                    (let [query* (assoc-in query [:opts :meta] true)
                          sut    (<p! (fluree/query db query*))]
-                     (is (= flake-total (:fuel sut))
+                     (is (= (dec flake-total) (:fuel sut))
                          "Reports that all flakes were traversed"))))
                (testing "short-circuits if request fuel exhausted"
                  (let [query   '{:select [?s ?p ?o]

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -873,7 +873,7 @@
              (testing "queries returning metadata"
                (let [query* (assoc-in query [:opts :meta] true)
                      sut    @(fluree/query db query*)]
-                 (is (= flake-total (:fuel sut))
+                 (is (= (dec flake-total) (:fuel sut))
                      "Reports that all flakes were traversed"))))
            (testing "short-circuits if request fuel exhausted"
              (let [query   '{:select [?s ?p ?o]

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -259,7 +259,7 @@
                                                  :assert  [{:ex/x "foo-1"
                                                             :ex/y "bar-1"
                                                             :id   :ex/alice}]
-                                                 :flakes  6
+                                                 :flakes  7
                                                  :retract []
                                                  :size    pos-int?
                                                  :t       1}
@@ -277,7 +277,7 @@
                                                          :assert   [{:ex/x "foo-cat"
                                                                      :ex/y "bar-cat"
                                                                      :id   :ex/alice}]
-                                                         :flakes   93
+                                                         :flakes   94
                                                          :previous {:id test-utils/db-id?}
                                                          :retract  [{:ex/x "foo-3"
                                                                      :ex/y "bar-3"
@@ -299,7 +299,7 @@
                                                          :assert   [{:ex/x "foo-cat"
                                                                      :ex/y "bar-cat"
                                                                      :id   :ex/cat}]
-                                                         :flakes   75
+                                                         :flakes   76
                                                          :previous {:id test-utils/db-id?}
                                                          :retract  []
                                                          :size     pos-int?
@@ -333,7 +333,7 @@
                                                     :assert   [{:ex/x "foo-cat"
                                                                 :ex/y "bar-cat"
                                                                 :id   :ex/cat}]
-                                                    :flakes   75
+                                                    :flakes   76
                                                     :previous {:id test-utils/db-id?}
                                                     :retract  []
                                                     :size     pos-int?
@@ -354,7 +354,7 @@
                                                   :assert   [{:ex/x "foo-3"
                                                               :ex/y "bar-3"
                                                               :id   :ex/alice}]
-                                                  :flakes   56
+                                                  :flakes   57
                                                   :previous {:id test-utils/db-id?}
                                                   :retract  [{:ex/x "foo-2"
                                                               :ex/y "bar-2"
@@ -377,7 +377,7 @@
                                                   :assert   [{:ex/x "foo-2"
                                                               :ex/y "bar-2"
                                                               :id   :ex/alice}]
-                                                  :flakes   38
+                                                  :flakes   39
                                                   :previous {:id test-utils/db-id?}
                                                   :retract  [{:ex/x "foo-1"
                                                               :ex/y "bar-1"
@@ -402,7 +402,7 @@
                                                  :assert   [{:ex/x "foo-cat"
                                                              :ex/y "bar-cat"
                                                              :id   :ex/cat}]
-                                                 :flakes   75
+                                                 :flakes   76
                                                  :previous {:id test-utils/db-id?}
                                                  :retract  []
                                                  :size     pos-int?
@@ -421,7 +421,7 @@
                                                  :assert   [{:ex/x "foo-cat"
                                                              :ex/y "bar-cat"
                                                              :id   :ex/alice}]
-                                                 :flakes   93
+                                                 :flakes   94
                                                  :previous {:id test-utils/db-id?}
                                                  :retract  [{:ex/x "foo-3"
                                                              :ex/y "bar-3"
@@ -447,7 +447,7 @@
                                                  :assert  [{:ex/x "foo-1"
                                                             :ex/y "bar-1"
                                                             :id   :ex/alice}]
-                                                 :flakes  6
+                                                 :flakes  7
                                                  :retract []
                                                  :size    pos-int?
                                                  :t       1}
@@ -471,7 +471,7 @@
                                                    :assert   [{:ex/x "foo-3"
                                                                :ex/y "bar-3"
                                                                :id   :ex/alice}]
-                                                   :flakes   56
+                                                   :flakes   57
                                                    :previous {:id test-utils/db-id?}
                                                    :retract  [{:ex/x "foo-2"
                                                                :ex/y "bar-2"
@@ -499,7 +499,7 @@
                                                    :assert   [{:ex/x "foo-cat"
                                                                :ex/y "bar-cat"
                                                                :id   :ex/alice}]
-                                                   :flakes   93
+                                                   :flakes   94
                                                    :previous {:id test-utils/db-id?}
                                                    :retract  [{:ex/x "foo-3"
                                                                :ex/y "bar-3"
@@ -585,7 +585,7 @@
                                                   :assert   [{:ex/x "foo-3"
                                                               :ex/y "bar-3"
                                                               :id   :ex/alice}]
-                                                  :flakes   57
+                                                  :flakes   58
                                                   :previous {:id test-utils/db-id?}
                                                   :retract  [{:ex/x "foo-2"
                                                               :ex/y "bar-2"
@@ -611,7 +611,7 @@
                                                   :assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/alice}]
-                                                  :flakes   94
+                                                  :flakes   95
                                                   :previous {:id test-utils/db-id?}
                                                   :retract  [{:ex/x "foo-3"
                                                               :ex/y "bar-3"
@@ -679,7 +679,7 @@
                                                   :assert   [{:ex/x "foo-3"
                                                               :ex/y "bar-3"
                                                               :id   :ex/alice}]
-                                                  :flakes   56
+                                                  :flakes   57
                                                   :previous {:id test-utils/db-id?}
                                                   :retract  [{:ex/x "foo-2"
                                                               :ex/y "bar-2"
@@ -707,7 +707,7 @@
                                                   :assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/alice}]
-                                                  :flakes   93
+                                                  :flakes   94
                                                   :previous {:id test-utils/db-id?}
                                                   :retract  [{:ex/x "foo-3"
                                                               :ex/y "bar-3"
@@ -788,7 +788,7 @@
                                                      :assert   [{:ex/x "foo-3"
                                                                  :ex/y "bar-3"
                                                                  :id   :ex/alice}]
-                                                     :flakes   60
+                                                     :flakes   61
                                                      :previous {:id test-utils/db-id?}
                                                      :retract  [{:ex/x "foo-2"
                                                                  :ex/y "bar-2"
@@ -816,7 +816,7 @@
                                                      :assert   [{:ex/x "foo-cat"
                                                                  :ex/y "bar-cat"
                                                                  :id   :ex/alice}]
-                                                     :flakes   99
+                                                     :flakes   100
                                                      :previous {:id test-utils/db-id?}
                                                      :retract  [{:ex/x "foo-3"
                                                                  :ex/y "bar-3"

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -238,24 +238,16 @@
                    ["fluree:context:68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"
                     :f/address
                     "fluree:memory://68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"]
-                   ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"
+                   ["did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6" :id "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
+                   ["fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw"
                     :id
-                    "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                   ["fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"
-                    :id
-                    "fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"]
-                   ["fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"
+                    "fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw"]
+                   ["fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw"
                     :f/address
-                    "fluree:memory://fb15dfb3f737fca3d90e62cbd9d6ced78c16194b40e58bea2e60c4205ea5300d"]
-                   ["fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"
-                    :f/flakes
-                    20]
-                   ["fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"
-                    :f/size
-                    1318]
-                   ["fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"
-                    :f/t
-                    1]
+                    "fluree:memory://eb42c9187ee0bddcc215c5d7ca829c1528a22bf8ee94f933affbe830b845030a"]
+                   ["fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw" :f/flakes 21]
+                   ["fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw" :f/size 1370]
+                   ["fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw" :f/t 1]
                    [:schema/email :id "http://schema.org/email"]
                    [:schema/name :id "http://schema.org/name"]
                    [:schema/age :id "http://schema.org/age"]
@@ -269,38 +261,28 @@
                    [:f/data :id "https://ns.flur.ee/ledger#data"]
                    [:f/address :id "https://ns.flur.ee/ledger#address"]
                    [:f/v :id "https://ns.flur.ee/ledger#v"]
-                   ["https://www.w3.org/2018/credentials#issuer"
-                    :id
-                    "https://www.w3.org/2018/credentials#issuer"]
+                   ["https://www.w3.org/2018/credentials#issuer" :id "https://www.w3.org/2018/credentials#issuer"]
                    [:f/time :id "https://ns.flur.ee/ledger#time"]
                    [:f/message :id "https://ns.flur.ee/ledger#message"]
                    [:f/previous :id "https://ns.flur.ee/ledger#previous"]
                    [:id :id "@id"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl"
                     :id
-                    "fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
-                    :f/time
-                    720000]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
+                    "fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl"]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl" :f/time 720000]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl"
                     "https://www.w3.org/2018/credentials#issuer"
                     "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
-                    :f/v
-                    0]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl" :f/v 0]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl"
                     :f/address
-                    "fluree:memory://308132a22e9a9c18a42718cf6be5b6fd031af3f79adb703b34b0148d389d9591"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
+                    "fluree:memory://907f04950bd8ab98c1c2ad532c50d24c111221a0f52a95df427382c73d6110ad"]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl"
                     :f/data
-                    "fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
-                    :f/alias
-                    "query/everything"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
-                    :f/branch
-                    "main"]
-                   ["fluree:commit:sha256:bbmsdo3ljxjmhcjnfvr2pb4yshdgfgorsckbdc3bysnairyru4jb5"
+                    "fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw"]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl" :f/alias "query/everything"]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl" :f/branch "main"]
+                   ["fluree:commit:sha256:bzi7qawok23j6feif5wiugabgczftca3jm44d6ko2tr2p7evf2zl"
                     :f/defaultContext
                     "fluree:context:68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"]}
                  (set result))

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,10 +28,10 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:b7mixbkldxge5oausbhahcnglopqbf6vmw4fbrh6y7753wqgbics"
+        (is (= "fluree:commit:sha256:bu2lsnr2ldusbcjw6uzbxlnoc6tlos7rjtgzafaife4mt3jlayqa"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://93627442aadceb049c5d5ee53d8c304269c431a3f20183dc5c2bf066ce69058e"
+        (is (= "fluree:memory://2c341bd4f66f11d98996d17d94c4da112cb7f277672877b321e0b135b7c81775"
                (get-in db1 [:commit :address]))))
       (testing "stable default context id"
         (is (= "fluree:context:68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"
@@ -40,8 +40,8 @@
         (is (= "fluree:memory://68845db506ec672e8481d6d8bce580cd24067e1010d36f869e8643752df0ae35"
                (get-in db1 [:commit :defaultContext :address]))))
       (testing "stable db id"
-        (is (= "fluree:db:sha256:bbgtaymrau2iz3mcdpaifv6liqrvygzl7q57vvgqvifhdpgqyvxkz"
+        (is (= "fluree:db:sha256:bboe6nikw75nolggme4ohcpmqbeknnulujn4c5wqspovvd2munlkw"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://fb15dfb3f737fca3d90e62cbd9d6ced78c16194b40e58bea2e60c4205ea5300d"
+        (is (= "fluree:memory://eb42c9187ee0bddcc215c5d7ca829c1528a22bf8ee94f933affbe830b845030a"
                (get-in db1 [:commit :data :address])))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -40,13 +40,14 @@
              (ex-message stage-id-only)))
       (is (= "Invalid transaction, insert or delete clause must contain nodes with objects."
              (ex-message stage-empty-txn)))
-      (is (= {:flakes 4, :size 278, :indexed 0}
+      (is (= {:flakes 5, :size 330, :indexed 0}
              (:stats stage-empty-node))
           "empty nodes are allowed as long as there is other data, they are just noops")
       (is (= #{[:ex/alice :id "http://example.org/ns/alice"]
                [:ex/alice :schema/age 42]
                [:schema/age :id "http://schema.org/age"]
-               [:id :id "@id"]}
+               [:id :id "@id"]
+               [:type :id "@type"]}
              (set @(fluree/query db-ok '{:select [?s ?p ?o]
                                          :where  {:id ?s
                                                   ?p  ?o}}))))))
@@ -65,7 +66,8 @@
       (is (= #{[:ex/alice :id "http://example.org/ns/alice"]
                [:ex/alice :ex/isCool false]
                [:ex/isCool :id "http://example.org/ns/isCool"]
-               [:id :id "@id"]}
+               [:id :id "@id"]
+               [:type :id "@type"]}
              (set @(fluree/query db-bool '{:select [?s ?p ?o]
                                            :where  {:id ?s, ?p ?o}}))))))
 


### PR DESCRIPTION
When select clause returns predicate matches, and the predicate is @type, the string value for @type was not being returned as there was no flake to resolve it. Instead, it was returning nil.