### PR TITLE
JWS support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,7 +33,8 @@
          com.fluree/alphabase            {:mvn/version "3.3.0"}
 
          ;; cryptography
-         com.fluree/crypto               {:mvn/version "0.4.0"}
+         com.fluree/crypto               {:git/url "https://github.com/fluree/fluree.crypto"
+                                          :git/sha "da7b0f63601519726bb00a8f388e2b809ea35458"}
 
          org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 


### PR DESCRIPTION
https://github.com/fluree/core/issues/56

This adds basic support for JWS's as an auth method. This deliberately does not support EDN transactions or queries at this time, it assumes that the JWS payload is a json string. We can add EDN support in the future if necessary.

