### PR TITLE
Use error-ch arg in fuel/track

### DIFF
--- a/src/fluree/db/fuel.cljc
+++ b/src/fluree/db/fuel.cljc
@@ -6,16 +6,10 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn tracker
-  "Creates a new fuel tracker w/ optional fuel limit (0 means unlimited) and
-  returns a map with the following keys:
-  - :error-ch - a core.async channel that should be checked for errors. If
-                anything is taken from that channel, the request should be
-                cancelled and the exception from the channel returned.
-  Any other keys in the map should be considered implementation details."
+  "Creates a new fuel tracker w/ optional fuel limit (0 means unlimited)."
   ([] (tracker nil))
   ([limit]
-   {:error-ch (async/chan 1)
-    :limit    (or limit 0)
+   {:limit    (or limit 0)
     :counters (atom [])}))
 
 (defn tally
@@ -25,7 +19,7 @@
           0 @(:counters trkr)))
 
 (defn track
-  [trkr]
+  [trkr error-ch]
   (fn [rf]
     (let [counter (volatile! 0)]
       (swap! (:counters trkr) conj counter)
@@ -41,7 +35,7 @@
                limit (:limit trkr)]
            (when (and (> limit 0) (> t limit))
              (log/trace "Fuel limit of" limit "exceeded:" t)
-             (put! (:error-ch trkr)
+             (put! error-ch
                    (ex-info "Fuel limit exceeded" {:used t, :limit limit})))
            (rf result next)))
 

--- a/src/fluree/db/json_ld/transact.cljc
+++ b/src/fluree/db/json_ld/transact.cljc
@@ -115,7 +115,7 @@
     (let [error-ch  (async/chan)
           update-ch (->> (where/search db parsed-txn fuel-tracker error-ch)
                          (update/modify db parsed-txn tx-state fuel-tracker error-ch)
-                         (exec/into-flakeset fuel-tracker))]
+                         (exec/into-flakeset fuel-tracker error-ch))]
       (async/alt!
         error-ch ([e] e)
         update-ch ([flakes] flakes)))))

--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -65,9 +65,9 @@
         result-ch ([result] result)))))
 
 (defn into-flakeset
-  [fuel-tracker flake-ch]
+  [fuel-tracker error-ch flake-ch]
   (let [flakeset (flake/sorted-set-by flake/cmp-flakes-spot)]
     (if fuel-tracker
-      (let [track-fuel (fuel/track fuel-tracker)]
+      (let [track-fuel (fuel/track fuel-tracker error-ch)]
         (async/transduce track-fuel into flakeset flake-ch))
       (async/reduce into flakeset flake-ch))))

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -333,9 +333,7 @@
          start-flake (flake/create s p o* o-dt nil nil util/min-integer)
          end-flake   (flake/create s p o* o-dt nil nil util/max-integer)
          track-fuel  (when fuel-tracker
-                       (take! (:error-ch fuel-tracker)
-                              #(put! error-ch %))
-                       (fuel/track fuel-tracker))
+                       (fuel/track fuel-tracker error-ch))
          subj-filter (when s-fn
                        (filter (fn [f]
                                  (-> unmatched


### PR DESCRIPTION
...instead of one embedded in fuel-tracker map. This was causing a bug when too many takes piled up.