### PR TITLE
fix flake meta json serialization

### DIFF
--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -100,7 +100,7 @@
   [flake]
   (-> (vec flake)
       (update 2 serialize-flake-value (flake/dt flake))
-      (cond-> (flake/m flake) (assoc 5 (util/stringify-keys (flake/m flake))))))
+      (cond-> (flake/m flake) (assoc 6 (util/stringify-keys (flake/m flake))))))
 
 (defn- deserialize-garbage
   [garbage-data]

--- a/test/fluree/db/json_ld/api_test.cljc
+++ b/test/fluree/db/json_ld/api_test.cljc
@@ -208,6 +208,7 @@
                                  {:id   :ex/john,
                                   :type :ex/User}]})
                db           @(fluree/commit! ledger db)
+               _            (test-utils/force-index! db)
                target-t     (:t db)
                loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
                loaded-db    (fluree/db loaded)]

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -1,8 +1,10 @@
 (ns fluree.db.test-utils
-  (:require [fluree.db.did :as did]
+  (:require [clojure.core.async :as async]
+            [fluree.db.did :as did]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.log :as log]
+            [fluree.db.json-ld.commit :as commit]
             #?@(:cljs [[clojure.core.async :refer [go go-loop]]
                        [clojure.core.async.interop :refer [<p!]]])))
 
@@ -192,6 +194,10 @@
         (if (and (< db-t t) (pos-int? attempts-left))
           (recur (- attempts-left attempts-per-batch))
           ledger)))))
+
+(defn force-index!
+  [db]
+  (commit/run-index db {:branch (:branch db)} (async/chan)))
 
 (defn retry-exists?
   "Retry calling exists? until it returns true or max-attempts."


### PR DESCRIPTION
Fixes https://github.com/fluree/core/issues/91

Serializing a flake with meta would incorrectly override the `op` value of the flake. This fixes that.

old, incorrect:
(serialize-flake #Flake [211106232533006 1008 "two" 1 -4 true {:i 2}]) [211106232533006 1008 "two" 1 -4 {"i" 2} {:i 2}]

new, correct:
(serialize-flake #Flake [211106232533006 1008 "two" 1 -4 true {:i 2}]) [211106232533006 1008 "two" 1 -4 true {"i" 2}]

This was causing list values to be materialized on load in an arbitrary order, which was sometimes correct, sometimes not.