### PR TITLE
Update malli to 0.14.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,8 +9,7 @@
          byte-streams/byte-streams       {:mvn/version "0.2.4"}
          cheshire/cheshire               {:mvn/version "5.12.0"}
          instaparse/instaparse           {:mvn/version "1.4.12"}
-         metosin/malli                   {:git/url "https://github.com/metosin/malli.git"
-                                          :git/sha "2aac49abffb9005188c70ffff825d88efee18069"}
+         metosin/malli                   {:mvn/version "0.14.0"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
                                           :git/sha "c2bef3785631dd178b9261e2f4d2ee012fed984c"}
 


### PR DESCRIPTION
We should be able to go back to regular releases now.