### PR TITLE
Index serialization issues

### DIFF
--- a/src/fluree/db/serde/avro.clj
+++ b/src/fluree/db/serde/avro.clj
@@ -298,7 +298,7 @@
     (try
       (avro/binary-encoded FdbLeafNode-schema leaf)
       (catch Exception e (log/error e (str "Error serializing index leaf data: " (pr-str leaf)))
-                         (throw (ex-info "Unexpected error serializing index branch."
+                         (throw (ex-info "Unexpected error serializing index leaf."
                                          {:status 500 :error :db/unexpected-error})))))
   (-deserialize-leaf [_ leaf]
     (binding [avro/*avro-readers* bindings]
@@ -307,15 +307,15 @@
     (try
       (avro/binary-encoded FdbGarbage-schema garbage)
       (catch Exception e (log/error e (str "Error serializing index garbage data: " (pr-str garbage)))
-                         (throw (ex-info "Unexpected error serializing index branch."
+                         (throw (ex-info "Unexpected error serializing index garbage file."
                                          {:status 500 :error :db/unexpected-error})))))
   (-deserialize-garbage [_ garbage]
     (avro/decode FdbGarbage-schema garbage))
   (-serialize-db-pointer [_ pointer]
     (try
       (avro/binary-encoded FdbDbPointer-schema pointer)
-      (catch Exception e (log/error e (str "Error serializing db index pointer: " (pr-str pointer)))
-                         (throw (ex-info "Unexpected error serializing index branch."
+      (catch Exception e (log/error e (str "Error serializing db index pointer file: " (pr-str pointer)))
+                         (throw (ex-info "Unexpected error serializing index pointer file."
                                          {:status 500 :error :db/unexpected-error})))))
   (-deserialize-db-pointer [_ pointer]
     (avro/decode FdbDbPointer-schema pointer)))

--- a/src/fluree/db/session.cljc
+++ b/src/fluree/db/session.cljc
@@ -92,7 +92,7 @@
   (go-try
    (let [{:keys [index], latest-block :block, :as ledger-info}
          (<? (load-ledger-info conn network dbid))]
-     (when-let [indexed-db (<? (storage/reify-db conn network dbid blank-db index))]
+     (when-let [indexed-db (<? (storage/reify-db conn network dbid blank-db index ledger-info))]
        (loop [db         indexed-db
               next-block (-> indexed-db :block inc)]
          (if (> next-block latest-block)

--- a/src/fluree/db/storage/core.cljc
+++ b/src/fluree/db/storage/core.cljc
@@ -146,7 +146,13 @@
           his-key       (str leaf-key "-his")
           data          {:flakes flakes
                          :his    his-key}
-          ser           (serdeproto/-serialize-leaf (serde conn) data)
+          ser           (try* (serdeproto/-serialize-leaf (serde conn) data)
+                              (catch* e
+                                      (log/error e (str "Error serializing leaf: " leaf-key " with error " (ex-message e)
+                                                        "\n" "Data: " (pr-str data)))
+                                      (throw (ex-info (str "Error serializing leaf: " leaf-key " with error " (ex-message e))
+                                                      {}
+                                                      e))))
           write-his-ch  (write-history conn history his-key nil)
           write-leaf-ch (storage-write conn leaf-key ser)]
       ;; write history and leaf node in parallel


### PR DESCRIPTION
For the v1.x branch.

Adds error capturing and reporting for avro serialization for index leafs, in addition to being able to recover from an earlier index if the latest index root is unavailable.

These changes go with a PR on fluree/ledger that address an indexing bug.