### PR TITLE
Index after every commit in migration

### DIFF
--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -119,9 +119,9 @@
                                 :main)
           ledger            (<? (jld-ledger/->ledger conn ledger-alias {:branch branch}))
           commit-opts*      (assoc commit-opts :branch branch)
-          tuples-chans      (->> all-commit-tuples
-                                 (map (fn [commit-tuple]
-                                        [commit-tuple (async/chan)])))
+          tuples-chans      (map (fn [commit-tuple]
+                                   [commit-tuple (async/chan)])
+                                 all-commit-tuples)
           changes-chs       (map second tuples-chans)
           _                 (-> (async/merge changes-chs)
                                 (async/pipe changes-ch))

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -42,7 +42,7 @@
     (let [db-address (-> commit
                          (get-first const/iri-data)
                          (get-first-value const/iri-address))
-          _ (log/info "Migrating commit at address:" db-address)
+          _          (log/info "Migrating commit at address:" db-address)
           db-data    (<? (reify/read-db conn db-address))
           t-new      (reify/db-t db-data)
           ns-mapping (db->namespace-mapping db)

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -123,7 +123,8 @@
                                    [commit-tuple (async/chan)])
                                  all-commit-tuples)
           changes-chs       (map second tuples-chans)
-          _                 (-> (async/merge changes-chs)
+          _                 (-> changes-chs
+                                async/merge
                                 (async/pipe changes-ch))
           db                (<? (merge-commits ledger commit-opts* tuples-chans))]
       (ledger/-db-update ledger db)

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -1,6 +1,5 @@
 (ns fluree.db.json-ld.migrate.sid
   (:require [fluree.db.constants :as const]
-            [fluree.db.indexer.storage :as storage]
             [fluree.db.query.exec.update :as update]
             [fluree.db.json-ld.commit :as commit]
             [fluree.db.json-ld.commit-data :as commit-data]
@@ -8,7 +7,6 @@
             [fluree.db.json-ld.reify :as reify]
             [fluree.db.ledger.json-ld :as jld-ledger]
             [fluree.db.indexer.default :as indexer]
-            [fluree.db.index :as index]
             [fluree.db.db.json-ld :as db]
             [fluree.db.nameservice.core :as nameservice]
             [fluree.db.util.core :as util :refer [get-first get-first-id get-first-value]]
@@ -44,6 +42,7 @@
     (let [db-address (-> commit
                          (get-first const/iri-data)
                          (get-first-value const/iri-address))
+          _ (log/info "Migrating commit at address:" db-address)
           db-data    (<? (reify/read-db conn db-address))
           t-new      (reify/db-t db-data)
           ns-mapping (db->namespace-mapping db)


### PR DESCRIPTION
This patch changes the migration script to index after every commit instead of all at once at the end. That way, the indexer will decide if the index should actually need to be run, and it's less likely that we'll run into memory issues migrating larger ledgers. 

It also creates a unique file changes channel for each commit, and merges those channels into the changes channel that was passed in to the migrator. This is so we can run the indexer after each commit because it closes the changes channel after it runs, but we'd like to keep the original changes channel open in this case.  