### PR TITLE
Generalize Filter Clauses

### DIFF
--- a/src/clj/fluree/db/constants.cljc
+++ b/src/clj/fluree/db/constants.cljc
@@ -61,6 +61,7 @@
 (def ^:const iri-value "@value")
 (def ^:const iri-language "@language")
 (def ^:const iri-type "@type")
+(def ^:const iri-filter "@filter")
 (def ^:const iri-json "http://www.w3.org/2001/XMLSchema#json")
 (def ^:const iri-anyURI "http://www.w3.org/2001/XMLSchema#anyURI")
 (def ^:const iri-rdf-type "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -1,6 +1,6 @@
 (ns fluree.db.query.exec.where
   (:require [fluree.db.query.range :as query-range]
-            [clojure.core.async :as async :refer [go take! put!]]
+            [clojure.core.async :as async :refer [go]]
             [fluree.db.flake :as flake]
             [fluree.db.fuel :as fuel]
             [fluree.db.index :as index]
@@ -68,13 +68,6 @@
           (matched-sid? mch))
     const/iri-anyURI
     (::datatype-iri mch)))
-
-(defn get-datatype-sid
-  [mch db-alias]
-  (if (or (matched-iri? mch)
-          (matched-sid? mch))
-    const/$xsd:anyURI
-    (get-in mch [::datatype-sids db-alias])))
 
 (defn matched?
   [match]
@@ -296,7 +289,7 @@
   ([db fuel-tracker error-ch components]
    (resolve-flake-range db fuel-tracker nil error-ch components))
 
-  ([{:keys [alias conn t] :as db} fuel-tracker flake-xf error-ch [s-mch p-mch o-mch]]
+  ([{:keys [alias t] :as db} fuel-tracker flake-xf error-ch [s-mch p-mch o-mch]]
    (let [s    (get-sid s-mch alias)
          s-fn (::fn s-mch)
          p    (get-sid p-mch alias)

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -143,8 +143,11 @@
   "Return a function that returns true if the language metadata of a matched
   pattern equals the supplied language code `lang`."
   [lang]
-  (fn [mch]
-    (-> mch ::meta :lang (= lang))))
+  (fn [soln mch]
+    (let [lang* (if (variable? lang)
+                  (-> soln (get lang) get-value)
+                  lang)]
+      (-> mch ::meta :lang (= lang*)))))
 
 (defn ->val-filter
   "Build a query function specification for the explicit value `val` out of the
@@ -187,6 +190,12 @@
   (fn [_ds _fuel-tracker _solution pattern _error-ch]
     (pattern-type pattern)))
 
+(defn assign-solution-filter
+  [component solution]
+  (if (::fn component)
+    (update component ::fn partial solution)
+    component))
+
 (defn assign-matched-values
   "Assigns the value of any variables within the supplied `triple-pattern` that
   were previously matched in the supplied solution map `solution` to their
@@ -196,7 +205,7 @@
           (if-let [variable (::var component)]
             (if-let [match (get solution variable)]
               match
-              component)
+              (assign-solution-filter component solution))
             component))
         triple-pattern))
 

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -166,7 +166,7 @@
   "Build a pattern that matches all the patterns in the supplied `patterns`
   collection."
   [patterns]
-  {::patterns patterns})
+  (vec patterns))
 
 (defn pattern-type
   [pattern]
@@ -497,11 +497,10 @@
   dataset `ds` extending from `solution` that also match all the patterns in the
   parsed where clause collection `clause`."
   [ds fuel-tracker solution clause error-ch]
-  (let [initial-ch (async/to-chan! [solution])
-        patterns   (::patterns clause)]
+  (let [initial-ch (async/to-chan! [solution])]
     (reduce (fn [solution-ch pattern]
               (with-constraint ds fuel-tracker pattern error-ch solution-ch))
-            initial-ch patterns)))
+            initial-ch clause)))
 
 (defn match-alias
   [ds alias fuel-tracker solution clause error-ch]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -345,6 +345,14 @@
   [m _vars context]
   (parse-node-map m context))
 
+(defmethod parse-pattern :filter
+  [[_ & codes] _vars _context]
+  (let [f (->> codes
+               (map parse-code)
+               (map eval/compile)
+               (apply every-pred))]
+    [(where/->pattern :filter f)]))
+
 (defmethod parse-pattern :union
   [[_ & unions] vars context]
   (let [parsed (mapv (fn [clause]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -193,13 +193,9 @@
   [clause vars context]
   (let [clause*  (util/sequential clause)
         patterns (->> clause*
-                      (remove filter-pattern?)
                       (mapcat (fn [pattern]
-                                (parse-pattern pattern vars context))))
-        filters  (->> clause*
-                      (filter filter-pattern?)
-                      (parse-filter-maps vars))]
-    (where/->where-clause patterns filters)))
+                                (parse-pattern pattern vars context))))]
+    (where/->where-clause patterns)))
 
 (defn expand-keys
   [m context]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -192,6 +192,13 @@
       (where/->val-filter v matcher))
     (where/anonymous-value v)))
 
+(defn every-binary-pred
+  [& fs]
+  (fn [x y]
+    (every? (fn [f]
+              (f x y))
+            fs)))
+
 (defn parse-variable-attributes
   [var attrs vars]
   (let [lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
@@ -199,7 +206,7 @@
     (if-let [f (some->> [lang-matcher filter-fn]
                         (remove nil?)
                         not-empty
-                        (apply every-pred))]
+                        (apply every-binary-pred))]
       (where/->var-filter var f)
       (where/unmatched-var var))))
 

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -159,26 +159,6 @@
   (fn [pattern _vars _context]
     (v/where-pattern-type pattern)))
 
-(defn filter-pattern?
-  [pattern]
-  (-> pattern v/where-pattern-type (= :filter)))
-
-(defn parse-filter-maps
-  [vars filters]
-  (let [vars (set vars)]
-    (->> filters
-         (mapcat rest)
-         flatten
-         (map (fn [fltr]
-                (parse-filter-function fltr vars)))
-         (reduce (fn [m fltr]
-                   (let [var-name (::where/var fltr)]
-                     (update m var-name (fn [var-fltrs]
-                                          (-> var-fltrs
-                                              (or [])
-                                              (conj fltr))))))
-                 {}))))
-
 (defn parse-bind-map
   [binds]
   (into {}
@@ -191,11 +171,11 @@
 
 (defn parse-where-clause
   [clause vars context]
-  (let [clause*  (util/sequential clause)
-        patterns (->> clause*
-                      (mapcat (fn [pattern]
-                                (parse-pattern pattern vars context))))]
-    (where/->where-clause patterns)))
+  (->> clause
+       util/sequential
+       (mapcat (fn [pattern]
+                 (parse-pattern pattern vars context)))
+       where/->where-clause))
 
 (defn expand-keys
   [m context]

--- a/src/clj/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/reparse.cljc
@@ -165,7 +165,10 @@
   [{:keys [where select vars] :as _parsed-query} db]
   (and (instance? SubgraphSelector select)
        ;;TODO, filtering not supported yet
-       (empty? (::where/filters where))
+       (->> (::where/patterns where)
+            (filter (fn [pattern]
+                      (= :filter (where/pattern-type pattern))))
+            empty?)
        ;;TODO: vars support not complete
        (empty? vars)
        (when-let [{select-var :subj} select]

--- a/src/clj/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/reparse.cljc
@@ -139,8 +139,7 @@
   If where does not end up meeting simple-subject-crawl criteria, returns nil
   so other strategies can be tried."
   [db {:keys [where vars] :as parsed-query}]
-  (let [{::where/keys [patterns]} where
-        [first-pattern & rest-patterns] patterns
+  (let [[first-pattern & rest-patterns] where
         reparsed-first-clause (re-parse-pattern db first-pattern)]
     (when-let [first-s (and (mergeable-where-clause? first-pattern)
                             (clause-subject-var first-pattern))]
@@ -165,20 +164,20 @@
   [{:keys [where select vars] :as _parsed-query} db]
   (and (instance? SubgraphSelector select)
        ;;TODO, filtering not supported yet
-       (->> (::where/patterns where)
+       (->> where
             (filter (fn [pattern]
                       (= :filter (where/pattern-type pattern))))
             empty?)
        ;;TODO: vars support not complete
        (empty? vars)
        (when-let [{select-var :subj} select]
-         (let [{::where/keys [patterns]} where]
-           (every? (fn [pattern]
-                     (and (mergeable-where-clause? pattern)
-                          (let [pred (second pattern)]
-                            (and (= select-var (clause-subject-var pattern))
-                                 (not (has-equivalent-properties? db pattern))
-                                 (not (::where/fullText pred)))))) patterns)))))
+         (every? (fn [pattern]
+                   (and (mergeable-where-clause? pattern)
+                        (let [pred (second pattern)]
+                          (and (= select-var (clause-subject-var pattern))
+                               (not (has-equivalent-properties? db pattern))
+                               (not (::where/fullText pred))))))
+                 where))))
 
 (defn re-parse-as-simple-subj-crawl
   "Returns true if query contains a single subject crawl.

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -107,6 +107,16 @@
                                                        :ex/favColor ?color}]
                                            [:filter "(not (bound ?color))"]]}))))
 
+    (testing "filtering bound variables"
+      (is (= ["Cam"]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '?name
+                                :where   '[{:type        :ex/User
+                                            :schema/name ?name}
+                                           [:bind ?nameLength "(strLen ?name)"]
+                                           [:filter "(> 4 ?nameLength)"]]}))))
+
     ;;TODO: simple-subject-crawl does not yet support filters.
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -85,6 +85,18 @@
                                             :schema/name ?name}
                                            [:filter "(> ?age (/ (+ ?age 47) 2))"]]}))))
 
+    (testing "filtering for absence"
+      (is (= ["Brian" "David"]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '?name
+                                :where   '[{:id          ?s
+                                            :type        :ex/User
+                                            :schema/name ?name}
+                                           [:optional {:id          ?s
+                                                       :ex/favColor ?color}]
+                                           [:filter "(not (bound ?color))"]]}))))
+
     ;;TODO: simple-subject-crawl does not yet support filters.
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -55,6 +55,16 @@
                                             :schema/age  ?age
                                             :schema/name ?name}
                                            [:filter "(> ?age 45)"]]}))))
+    (testing "single filter, different vars"
+      (is (= [["Brian" "Smith"]]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '[?name ?last]
+                                :where   '[{:type        :ex/User
+                                            :schema/age  ?age
+                                            :schema/name ?name
+                                            :ex/last     ?last}
+                                           [:filter "(and (> ?age 45) (strEnds ?last \"ith\"))"]]}))))
     (testing "multiple filters on same var"
       (is (= [["David" 46]]
              @(fluree/query db {:context [test-utils/default-context

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -117,6 +117,18 @@
                                            [:bind ?nameLength "(strLen ?name)"]
                                            [:filter "(> 4 ?nameLength)"]]}))))
 
+    (testing "value map filters"
+      (is (= [["Brian" "Smith"]]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '[?name ?last]
+                                :where   '[{:type        :ex/User
+                                            :schema/age  {"@value"  ?age
+                                                          "@filter" "(> ?age 45)"}
+                                            :schema/name ?name
+                                            :ex/last     {"@value" ?last
+                                                          "@filter" "(strEnds ?last \"ith\")"}}]}))))
+
     ;;TODO: simple-subject-crawl does not yet support filters.
     ;;these are being run as regular analytial queries
     (testing "simple-subject-crawl"

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -120,14 +120,16 @@
     (testing "value map filters"
       (is (= [["Brian" "Smith"]]
              @(fluree/query db {:context [test-utils/default-context
-                                          {:ex "http://example.org/ns/"}]
+                                          {:ex     "http://example.org/ns/"
+                                           :value  "@value"
+                                           :filter "@filter"}]
                                 :select  '[?name ?last]
                                 :where   '[{:type        :ex/User
-                                            :schema/age  {"@value"  ?age
-                                                          "@filter" "(> ?age 45)"}
+                                            :schema/age  {:value  ?age
+                                                          :filter "(> ?age 45)"}
                                             :schema/name ?name
-                                            :ex/last     {"@value" ?last
-                                                          "@filter" "(strEnds ?last \"ith\")"}}]}))))
+                                            :ex/last     {:value  ?last
+                                                          :filter "(strEnds ?last \"ith\")"}}]}))))
 
     ;;TODO: simple-subject-crawl does not yet support filters.
     ;;these are being run as regular analytial queries


### PR DESCRIPTION
This patch generalizes filter clauses by removing the constraint that they only reference a single variable defined in the where clause and removes the optimization of applying prospective filters defined in filter clause only in index range scans directly. Removing that optimizations allows us to apply filters to variables not bound by range scans, like from a bind clause. It also allows us to filter for the absences of a variable, like from an optional clause.

This patch also adds a new "variable map" syntax where single-variable filters can be defined where the index range scan optimization will be applied. This allows users to still have an option of directing the query engine to apply the index range scan optimization where possible, while still being able to define more general filters referencing multiple variables or variables not bound in an index range scan. 