### PR TITLE
Add decode-iri API, rename internal-id->encode-iri

### DIFF
--- a/src/clj/fluree/db/json_ld/api.cljc
+++ b/src/clj/fluree/db/json_ld/api.cljc
@@ -328,9 +328,25 @@
    (json-ld/expand-iri compact-iri
                        (json-ld/parse-context context))))
 
-(defn internal-id
-  "Returns the internal Fluree integer id for a given IRI.
+(defn encode-iri
+  "Returns the internal Fluree IRI identifier (a compact form).
   This can be used for doing range scans, slices and for other
   more advanced needs."
   [db iri]
   (iri/encode-iri db iri))
+
+(defn internal-id
+  "Deprecated, use encode-iri instead."
+  {:deprecated true}
+  [db iri]
+  (do
+    (println "WARNING: (internal-id db iri) is deprecated, use (encode-iri db iri).")
+    (encode-iri db iri)))
+
+(defn decode-iri
+  "Opposite of encode-iri. When doing more advanced features
+  like direct range-scans of indexes, IRIs are returned in their
+  internal compact format. This allows the IRI to be returned
+  as a full string IRI."
+  [db iri]
+  (iri/decode-sid db iri))

--- a/test/fluree/db/policy/subj_flakes_test.clj
+++ b/test/fluree/db/policy/subj_flakes_test.clj
@@ -93,7 +93,7 @@
                                async/<!!)
 
           ssn-iri (fluree/expand-iri context :schema/ssn)
-          ssn-sid (fluree/internal-id db ssn-iri)]
+          ssn-sid (fluree/encode-iri db ssn-iri)]
       (is (= 0
              (count (filter #(= ssn-sid (flake/p %)) alice-db-john)))
           "Alice cannot see John's ssn.")

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -35,7 +35,7 @@
                         :ex/favNums   [5, 10]
                         :ex/friend    [:ex/brian :ex/alice]}]})
           cam-iri (fluree/expand-iri context :ex/cam)
-          cam-sid (fluree/internal-id db cam-iri)]
+          cam-sid (fluree/encode-iri db cam-iri)]
 
       (is (= "http://example.org/ns/cam"
              cam-iri)
@@ -47,7 +47,7 @@
       (testing "Slice operations"
         (testing "Slice for subject id only"
           (let [alice-iri (fluree/expand-iri context :ex/alice)
-                alice-sid (fluree/internal-id db alice-iri)]
+                alice-sid (fluree/encode-iri db alice-iri)]
             (is (= 7
                    (->> @(fluree/slice db :spot [alice-sid])
                         (filterv #(= alice-sid (flake/s %)))
@@ -56,9 +56,9 @@
 
         (testing "Slice for subject + predicate"
           (let [alice-iri   (fluree/expand-iri context :ex/alice)
-                alice-sid   (fluree/internal-id db alice-iri)
+                alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
-                favNums-pid (fluree/internal-id db favNums-iri)]
+                favNums-pid (fluree/encode-iri db favNums-iri)]
             (is (= [[alice-sid favNums-pid 9 const/$xsd:long 1 true nil]
                     [alice-sid favNums-pid 42 const/$xsd:long 1 true nil]
                     [alice-sid favNums-pid 76 const/$xsd:long 1 true nil]]
@@ -68,9 +68,9 @@
 
         (testing "Slice for subject + predicate + value"
           (let [alice-iri   (fluree/expand-iri context :ex/alice)
-                alice-sid   (fluree/internal-id db alice-iri)
+                alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
-                favNums-pid (fluree/internal-id db favNums-iri)]
+                favNums-pid (fluree/encode-iri db favNums-iri)]
             (is (= [[alice-sid favNums-pid 42 const/$xsd:long 1 true nil]]
                    (->> @(fluree/slice db :spot [alice-sid favNums-pid 42])
                         (mapv flake/Flake->parts)))
@@ -78,9 +78,9 @@
 
         (testing "Slice for subject + predicate + value + datatype"
           (let [alice-iri   (fluree/expand-iri context :ex/alice)
-                alice-sid   (fluree/internal-id db alice-iri)
+                alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
-                favNums-pid (fluree/internal-id db favNums-iri)]
+                favNums-pid (fluree/encode-iri db favNums-iri)]
             (is (= [[alice-sid favNums-pid 42 const/$xsd:long 1 true nil]]
                    (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 const/$xsd:long]])
                         (mapv flake/Flake->parts)))
@@ -88,9 +88,9 @@
 
         (testing "Slice for subject + predicate + value + mismatch datatype"
           (let [alice-iri   (fluree/expand-iri context :ex/alice)
-                alice-sid   (fluree/internal-id db alice-iri)
+                alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
-                favNums-pid (fluree/internal-id db favNums-iri)]
+                favNums-pid (fluree/encode-iri db favNums-iri)]
             (is (= []
                    (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 const/$xsd:string]])
                         (mapv flake/Flake->parts)))


### PR DESCRIPTION
Added a `decode-iri` API to correspond with the old `internal-id` API, which got renamed to `encode-iri`.

Had a use case that needed IRI decoding, which prompted this PR.

`internal-id` was the old API when we had internal integer subject IDs. Now that we always have IRIs with a special IRI encoding, `encode-iri` I think is a better description.

We didn't have the opposite API, so this is now in place and called `decode-iri`. 
