### PR TITLE
rdfs:subPropertyOf support (within db)

### DIFF
--- a/src/clj/fluree/db/json_ld/ledger.cljc
+++ b/src/clj/fluree/db/json_ld/ledger.cljc
@@ -112,6 +112,7 @@
     const/$owl:equivalentProperty
     const/$rdfs:Class
     const/$rdfs:subClassOf
+    const/$rdfs:subPropertyOf
     const/$sh:alternativePath
     const/$sh:class
     const/$sh:datatype

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -374,10 +374,10 @@
     (when (and (some? s*) (some? p*) (some? o*))
       [s* p* o*])))
 
-(defn get-equivalent-properties
+(defn get-child-properties
   [db prop]
   (-> db
-      (get-in [:schema :pred prop :equivalentProperty])
+      (get-in [:schema :pred prop :childProps])
       not-empty))
 
 (def nil-channel
@@ -393,7 +393,7 @@
         triple     (assign-matched-values tuple solution)]
     (if-let [[s p o] (compute-sids db triple)]
       (let [pid (get-sid p db-alias)]
-        (if-let [props (and pid (get-equivalent-properties db pid))]
+        (if-let [props (and pid (get-child-properties db pid))]
           (let [prop-ch (-> props (conj pid) async/to-chan!)]
             (async/pipeline-async 2
                                   matched-ch

--- a/src/clj/fluree/db/query/subject_crawl/reparse.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/reparse.cljc
@@ -155,7 +155,7 @@
 (defn has-equivalent-properties?
   [db pattern]
   (if-let [p-val (get-in pattern [1 ::where/val])]
-    (some? (where/get-equivalent-properties db p-val))
+    (some? (where/get-child-properties db p-val))
     false))
 
 (defn simple-subject-crawl?


### PR DESCRIPTION
This adds support for rdfs:subPropertyOf along with a corresponding test.

As the test shows, if you declare properties to be a rdfs:subPropertyOf of another property, when you query for the parent property all child properties will show up in the results.
e.g. if you inserted:
```
{
 "@context": {"ex":   "http://example.org/ns/",
                        "rdf":   "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
                        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"},
 "insert": 
     [{"@id":                           "ex:mother",
       "@type":                       "rdf:Property",
       "rdfs:subPropertyOf": {"@id": "ex:parent"}},
      {"@id":                           "ex:father",
       "@type":                       "rdf:Property",
       "rdfs:subPropertyOf": {"@id": "ex:parent"}}]
}
```

And then queried for the property of `ex:parent` like:
```
{"@context": {"ex" "http://example.org/ns/"},
 "select":       "?parent",
 "where":       {"@id":          "ex:bob",
                        "ex:parent": "?parent"}}
```
All of the values stored within `ex:mother` and `ex:father` would appear in the results.
