### PR TITLE
Include IRIs in `values` bindings

### DIFF
--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -136,14 +136,6 @@
            first
            (= \?))))
 
-(defn ->var-filter
-  "Build a query function specification for the variable `var` out of the
-  parsed function `f`."
-  [var f]
-  (-> var
-      unmatched-var
-      (assoc ::fn f)))
-
 (defn lang-matcher
   "Return a function that returns true if the language metadata of a matched
   pattern equals the supplied language code `lang`."
@@ -154,13 +146,29 @@
                   lang)]
       (-> mch ::meta :lang (= lang*)))))
 
+(defn with-filter
+  [mch f]
+  (assoc mch ::fn f))
+
+(defn ->var-filter
+  "Build a query function specification for the variable `var` out of the
+  parsed function `f`."
+  [var f]
+  (-> var
+      unmatched-var
+      (with-filter f)))
+
 (defn ->val-filter
   "Build a query function specification for the explicit value `val` out of the
   boolean function `f`. `f` should accept a single flake where-match map."
-  [val f]
-  (-> val
-      anonymous-value
-      (assoc ::fn f)))
+  ([val f]
+   (-> val
+       anonymous-value
+       (with-filter f)))
+  ([val dt-iri f]
+   (-> val
+       (anonymous-value dt-iri)
+       (with-filter f))))
 
 (defn ->predicate
   "Build a pattern that already matches the explicit predicate value `value`."

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -38,17 +38,68 @@
      (ex-info (str "variable " x " is not bound in where nor values clause")
               {:status 400, :error :db/invalid-transaction}))))
 
+(defn expand-keys
+  [m context]
+  (reduce-kv (fn [expanded p o]
+               (let [p* (if (v/variable? p)
+                          p
+                          (json-ld/expand-iri p context))]
+                 (assoc expanded p* o)))
+             {} m))
+
+(defn get-expanded-datatype
+  [attrs context]
+  (some-> attrs
+          (get const/iri-type)
+          (json-ld/expand-iri context)))
+
+(defn parse-value-datatype
+  [v attrs context]
+  (if-let [dt-iri (get-expanded-datatype attrs context)]
+    (if (= const/iri-anyURI dt-iri)
+      (-> v
+          (json-ld/expand-iri context)
+          (where/anonymous-value dt-iri))
+      (where/anonymous-value v dt-iri))
+    (where/anonymous-value v)))
+
+(defn parse-value-attributes
+  [v attrs context]
+  (let [mch (parse-value-datatype v attrs context)]
+    (if-let [lang (get attrs const/iri-language)]
+      (let [lang-matcher (where/lang-matcher lang)]
+        (where/with-filter mch lang-matcher))
+      mch)))
+
+(defn match-value-binding-map
+  [var-match binding-map context]
+  (let [attrs (expand-keys binding-map context)
+        val   (get attrs const/iri-value)]
+    (if-let [dt-iri (get-expanded-datatype attrs context)]
+      (if (= const/iri-anyURI dt-iri)
+        (let [expanded (json-ld/expand-iri val context)]
+          (where/match-iri var-match expanded))
+        (where/match-value var-match val dt-iri))
+      (let [dt (datatype/infer-iri val)]
+        (where/match-value var-match val dt)))))
+
+(defn match-value-binding
+  [var-match value context]
+  (if (map? value)
+    (match-value-binding-map var-match value context)
+    (let [dt (datatype/infer-iri value)]
+      (where/match-value var-match value dt))))
+
 (defn parse-value-binding
-  [vars vals]
-  (let [var-matches (mapv parse-variable vars)
-        binding     (mapv (fn [var-match value]
-                            (let [dt (datatype/infer-iri value)]
-                              (where/match-value var-match value dt)))
-                          var-matches vals)]
+  [vars vals context]
+  (let [var-matches (map parse-variable vars)
+        binding     (map (fn [var-match val]
+                           (match-value-binding var-match val context))
+                         var-matches vals)]
     (zipmap vars binding)))
 
 (defn parse-values
-  [q]
+  [q context]
   (when-let [values (:values q)]
     (let [[vars vals] values
           vars*     (keep parse-var-name (util/sequential vars))
@@ -57,7 +108,8 @@
       (if (every? (fn [binding]
                     (= (count binding) var-count))
                   vals*)
-        [vars* (mapv (partial parse-value-binding vars*)
+        [vars* (mapv (fn [vals**]
+                       (parse-value-binding vars* vals** context))
                      vals*)]
         (throw (ex-info (str "Invalid value binding: "
                              "number of variables and values don't match: "
@@ -179,39 +231,6 @@
        (mapcat (fn [pattern]
                  (parse-pattern pattern vars context)))
        where/->where-clause))
-
-(defn expand-keys
-  [m context]
-  (reduce-kv (fn [expanded p o]
-               (let [p* (if (v/variable? p)
-                          p
-                          (json-ld/expand-iri p context))]
-                 (assoc expanded p* o)))
-             {} m))
-
-(defn get-expanded-datatype
-  [attrs context]
-  (some-> attrs
-          (get const/iri-type)
-          (json-ld/expand-iri context)))
-
-(defn parse-value-datatype
-  [v attrs context]
-  (if-let [dt-iri (get-expanded-datatype attrs context)]
-    (if (= const/iri-anyURI dt-iri)
-      (-> v
-          (json-ld/expand-iri context)
-          (where/anonymous-value dt-iri))
-      (where/anonymous-value v dt-iri))
-    (where/anonymous-value v)))
-
-(defn parse-value-attributes
-  [v attrs context]
-  (let [mch (parse-value-datatype v attrs context)]
-    (if-let [lang (get attrs const/iri-language)]
-      (let [lang-matcher (where/lang-matcher lang)]
-        (where/with-filter mch lang-matcher))
-      mch)))
 
 (defn every-binary-pred
   [& fs]
@@ -552,7 +571,7 @@
 (defn parse-analytical-query
   [q]
   (let [context       (context/extract q)
-        [vars values] (parse-values q)
+        [vars values] (parse-values q context)
         where         (parse-where q vars context)
         grouping      (parse-grouping q)
         ordering      (parse-ordering q)]
@@ -672,7 +691,7 @@
 (defn parse-txn
   [txn context]
   (let [vals-map      {:values (util/get-first-value txn const/iri-values)}
-        [vars values] (parse-values vals-map)
+        [vars values] (parse-values vals-map context)
         where-map     {:where (util/get-first-value txn const/iri-where)}
         where         (parse-where where-map vars context)
         bound-vars    (-> where where/bound-variables (into vars))

--- a/src/clj/fluree/db/validation.cljc
+++ b/src/clj/fluree/db/validation.cljc
@@ -20,7 +20,7 @@
   (and (or (string? x) (symbol? x) (keyword? x))
        (-> x name first (= \?))))
 
-(def value? (complement coll?))
+(def value? (complement sequential?))
 
 (defn iri-key?
   [x]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -104,6 +104,18 @@
             (is (= [["Alice" 50]]
                    @(fluree/query db q))
                 "returns only the results related to the bound value")))
+        (testing "with an iri"
+          (let [q {:context [test-utils/default-context
+                             {:ex    "http://example.org/ns/"
+                              :value "@value"}]
+                   :select  '[?name ?age]
+                   :where   '{:id          ?s
+                              :schema/name ?name
+                              :schema/age  ?age}
+                   :values  '[?s [{:value :ex/alice, :type :xsd/anyURI}]]}]
+            (is (= [["Alice" 50]]
+                   @(fluree/query db q))
+                "returns only the results related to the bound value")))
         (testing "with multiple values"
           (let [q {:context [test-utils/default-context
                              {:ex "http://example.org/ns/"}]


### PR DESCRIPTION
Fixes #703 by adding syntax to specify the data type of a values binding using an `@value` map that also contains an `@type` key. when the value of `@type` is `"xsd:anyURI"`, then the value of the `@value` key is treated as an iri and expanded. 