### PR TITLE
return a SHACL Validation Report for validation exceptions

### DIFF
--- a/src/clj/fluree/db/constants.cljc
+++ b/src/clj/fluree/db/constants.cljc
@@ -108,6 +108,23 @@
 (def ^:const iri-owl:maxQualifiedCardinality "http://www.w3.org/2002/07/owl#maxQualifiedCardinality")
 (def ^:const iri-owl:qualifiedCardinality "http://www.w3.org/2002/07/owl#qualifiedCardinality")
 
+;; SHACL validation report iris
+(def ^:const iri_ValidationReport "http://www.w3.org/ns/shacl#ValidationReport")
+(def ^:const iri_conforms "http://www.w3.org/ns/shacl#conforms")
+(def ^:const iri_shapesGraphWellFormed "http://www.w3.org/ns/shacl#shapesGraphWellFormed")
+(def ^:const iri_result "http://www.w3.org/ns/shacl#result")
+(def ^:const iri_ValidationResult "http://www.w3.org/ns/shacl#ValidationResult")
+(def ^:const iri_focusNode "http://www.w3.org/ns/shacl#focusNode")
+(def ^:const iri_resultPath "http://www.w3.org/ns/shacl#resultPath")
+(def ^:const iri_value "http://www.w3.org/ns/shacl#value")
+(def ^:const iri_sourceShape "http://www.w3.org/ns/shacl#sourceShape")
+(def ^:const iri_constraintComponent "http://www.w3.org/ns/shacl#constraintComponent")
+(def ^:const iri_details "http://www.w3.org/ns/shacl#details")
+(def ^:const iri_resultMessage "http://www.w3.org/ns/shacl#resultMessage")
+(def ^:const iri_resultSeverity "http://www.w3.org/ns/shacl#resultSeverity")
+(def ^:const iri_Violation "http://www.w3.org/ns/shacl#Violation")
+(def ^:const iri_expectation (fluree-iri "expectation"))
+
 ;; predicate id constants
 
 (def ^:const $_previous (iri/iri->sid iri-previous))

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -337,17 +337,13 @@
          path       const/sh_path
          [severity] const/sh_severity
          [message]  const/sh_message
-         expect     constraint} shape
-
-        [single-expect :as pretty-expect]
-        (mapv display expect)]
+         expect     constraint}
+        shape]
     (cond-> {:subject (display focus-node)
              :constraint (display constraint)
              :severity (or (display severity) (json-ld/compact const/iri_Violation context))
              :shape (display id)}
-      expect (assoc :expect (if (> (count expect) 1)
-                              pretty-expect
-                              single-expect))
+      expect  (assoc :expect (util/unwrap-singleton (mapv display expect)))
       message (assoc :message message)
       path    (assoc :path (mapv (fn [segment]
                                    (if (iri/sid? segment)

--- a/src/clj/fluree/db/query/json_ld/response.cljc
+++ b/src/clj/fluree/db/query/json_ld/response.cljc
@@ -39,24 +39,13 @@
   [flake]
   (-> flake flake/m (contains? :i)))
 
-(defn unwrap-singleton
-  ([coll]
-   (if (= 1 (count coll))
-     (first coll)
-     coll))
-
-  ([iri context coll]
-   (if (#{:list :set} (-> context (get iri) :container))
-     coll
-     (unwrap-singleton coll))))
-
 (defn type-value
   [db cache compact-fn type-flakes]
   (->> type-flakes
        (into [] (comp (map flake/o)
                       (map (partial cache-sid->iri db cache compact-fn))
                       (map :as)))
-       unwrap-singleton))
+       util/unwrap-singleton))
 
 (defn format-reference
   [db spec sid]
@@ -91,7 +80,7 @@
                                       p-flakes)]
                       (->> p-flakes*
                            (mapv (partial format-object db spec))
-                           (unwrap-singleton p-iri context))))]
+                           (util/unwrap-singleton p-iri context))))]
         [p-iri v]))))
 
 (defn format-subject-xf
@@ -239,7 +228,7 @@
          (async/transduce (comp cat sid-xf)
                           (completing conj
                                       (fn [result]
-                                        [as (unwrap-singleton result)]))
+                                        [as (util/unwrap-singleton result)]))
                           []))))
 
 (defn format-reverse-property

--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -435,6 +435,17 @@
       (get-first k)
       get-id))
 
+(defn unwrap-singleton
+  ([coll]
+   (if (= 1 (count coll))
+     (first coll)
+     coll))
+
+  ([iri context coll]
+   (if (#{:list :set} (-> context (get iri) :container))
+     coll
+     (unwrap-singleton coll))))
+
 (defn parse-opts
   [opts]
   (let [other-keys    (->> opts keys (remove #{:max-fuel :maxFuel}))

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -9,151 +9,144 @@
 
 (deftest ^:integration shacl-not-test
   (testing "shacl basic not constraint works"
-    (let [conn             (test-utils/create-conn)
-          ledger           @(fluree/create conn "shacl/a")
-          context          [test-utils/default-context {:ex "http://example.org/ns/"}]
-          user-query       {:context context
-                            :select  {'?s [:*]}
-                            :where   {:id '?s, :type :ex/User}}
-          db               @(fluree/stage
-                              (fluree/db ledger)
-                              {"@context" ["https://ns.flur.ee" context]
-                               "insert"
-                               {:id             :ex/UserShape
-                                :type           [:sh/NodeShape]
-                                :sh/targetClass :ex/User
-                                :sh/not         [{:sh/path     :schema/companyName
-                                                  :sh/minCount 1}
-                                                 {:sh/path   :schema/name
-                                                  :sh/equals :schema/callSign}]
-                                :sh/property    [{:sh/path     :schema/callSign
-                                                  :sh/minCount 1
-                                                  :sh/maxCount 1
-                                                  :sh/datatype :xsd/string}]}})
-          db-ok            @(fluree/stage
-                              db
-                              {"@context" ["https://ns.flur.ee" context]
-                               "insert"
-                               {:id              :ex/john,
-                                :type            [:ex/User],
-                                :schema/name     "John"
-                                :schema/callSign "j-rock"}})
-          db-company-name  @(fluree/stage
-                              db
-                              {"@context" ["https://ns.flur.ee" context]
-                               "insert"
-                               {:id                 :ex/john,
-                                :type               [:ex/User],
-                                :schema/companyName "WrongCo"
-                                :schema/callSign    "j-rock"}})
-          db-two-names     @(fluree/stage
+    (let [conn       (test-utils/create-conn)
+          ledger     @(fluree/create conn "shacl/a")
+          context    [test-utils/default-context {:ex "http://example.org/ns/"}]
+          user-query {:context context
+                      :select  {'?s [:*]}
+                      :where   {:id '?s, :type :ex/User}}
+          db         @(fluree/stage
+                        (fluree/db ledger)
+                        {"@context" ["https://ns.flur.ee" context]
+                         "insert"
+                         {:id             :ex/UserShape
+                          :type           [:sh/NodeShape]
+                          :sh/targetClass :ex/User
+                          :sh/not         [{:sh/path     :schema/companyName
+                                            :sh/minCount 1}
+                                           {:sh/path   :schema/name
+                                            :sh/equals :schema/callSign}]
+                          :sh/property    [{:sh/path     :schema/callSign
+                                            :sh/minCount 1
+                                            :sh/maxCount 1
+                                            :sh/datatype :xsd/string}]}})]
+      (testing "no violations"
+        (let [db-ok      @(fluree/stage
+                            db
+                            {"@context" ["https://ns.flur.ee" context]
+                             "insert"
+                             {:id              :ex/john,
+                              :type            [:ex/User],
+                              :schema/name     "John"
+                              :schema/callSign "j-rock"}})
+              ok-results @(fluree/query db-ok user-query)]
+          (is (= [{:id              :ex/john,
+                   :type            :ex/User,
+                   :schema/name     "John",
+                   :schema/callSign "j-rock"}]
+                 ok-results)
+              (str "unexpected query result: " (pr-str ok-results)))))
+      (testing "not equal"
+        (let [db-company-name @(fluree/stage
+                                 db
+                                 {"@context" ["https://ns.flur.ee" context]
+                                  "insert"
+                                  {:id                 :ex/john,
+                                   :type               [:ex/User],
+                                   :schema/companyName "WrongCo"
+                                   :schema/callSign    "j-rock"}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-2"}]}}
+                 (ex-data db-company-name)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
+                 (ex-message db-company-name)))))
+      (testing "conforms to minCount"
+        (let [db-two-names @(fluree/stage
                               db
                               {"@context" ["https://ns.flur.ee" context]
                                "insert"
                                {:id                 :ex/john,
                                 :type               [:ex/User],
                                 :schema/companyName ["John", "Johnny"]
-                                :schema/callSign    "j-rock"}})
-          db-callsign-name @(fluree/stage
-                              db
-                              {"@context" ["https://ns.flur.ee" context]
-                               "insert"
-                               {:id              :ex/john
-                                :type            [:ex/User]
-                                :schema/name     "Johnny Boy"
-                                :schema/callSign "Johnny Boy"}})
-          ok-results       @(fluree/query db-ok user-query)]
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-2"}]}
-             (ex-data db-company-name)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
-             (ex-message db-company-name)))
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-2"}]}
-             (ex-data db-two-names)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
-             (ex-message db-two-names)))
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-3"}]}
-             (ex-data db-callsign-name)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-3."
-             (ex-message db-callsign-name)))
-      (is (= [{:id              :ex/john,
-               :type            :ex/User,
-               :schema/name     "John",
-               :schema/callSign "j-rock"}]
-             ok-results)
-          (str "unexpected query result: " (pr-str ok-results)))))
+                                :schema/callSign    "j-rock"}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-2"}]}}
+                 (ex-data db-two-names)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
+                 (ex-message db-two-names)))))
+      (testing "conforms to equals"
+        (let [db-callsign-name @(fluree/stage
+                                  db
+                                  {"@context" ["https://ns.flur.ee" context]
+                                   "insert"
+                                   {:id              :ex/john
+                                    :type            [:ex/User]
+                                    :schema/name     "Johnny Boy"
+                                    :schema/callSign "Johnny Boy"}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-3"}]}}
+                 (ex-data db-callsign-name)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-3."
+                 (ex-message db-callsign-name)))))))
 
   (testing "shacl not w/ value ranges works"
-    (let [conn         (test-utils/create-conn)
-          ledger       @(fluree/create conn "shacl/a")
-          context      [test-utils/default-context {:ex "http://example.org/ns/"}]
-          user-query   {:context context
-                        :select  {'?s [:*]}
-                        :where   {:id '?s, :type :ex/User}}
-          db           @(fluree/stage
-                          (fluree/db ledger)
-                          {"@context" ["https://ns.flur.ee" context]
-                           "insert"
-                           {:id             :ex/UserShape
-                            :type           [:sh/NodeShape]
-                            :sh/targetClass :ex/User
-                            :sh/not         [{:sh/path         :schema/age
-                                              :sh/minInclusive 130}
-                                             {:sh/path         :schema/favNums
-                                              :sh/maxExclusive 9000}]
-                            :sh/property    [{:sh/path     :schema/age
-                                              :sh/minCount 1
-                                              :sh/maxCount 1
-                                              :sh/datatype :xsd/long}]}})
-          db-ok        @(fluree/stage
-                          db
-                          {"@context" ["https://ns.flur.ee" context]
-                           "insert"
-                           {:id              :ex/john,
-                            :type            [:ex/User],
-                            :schema/name     "John"
-                            :schema/callSign "j-rock"
-                            :schema/age      42
-                            :schema/favNums  [9004 9008 9015 9016 9023 9042]}})
-          db-too-old   @(fluree/stage
-                          db
-                          {"@context" ["https://ns.flur.ee" context]
-                           "insert"
-                           {:id                 :ex/john,
-                            :type               [:ex/User],
-                            :schema/companyName "WrongCo"
-                            :schema/callSign    "j-rock"
-                            :schema/age         131}})
-          db-too-low   @(fluree/stage
-                          db
-                          {"@context" ["https://ns.flur.ee" context]
-                           "insert"
-                           {:id                 :ex/john,
-                            :type               [:ex/User],
-                            :schema/companyName ["John", "Johnny"]
-                            :schema/callSign    "j-rock"
-                            :schema/age         27
-                            :schema/favNums     [4 8 15 16 23 42]}})
+    (let [conn       (test-utils/create-conn)
+          ledger     @(fluree/create conn "shacl/a")
+          context    [test-utils/default-context {:ex "http://example.org/ns/"}]
+          user-query {:context context
+                      :select  {'?s [:*]}
+                      :where   {:id '?s, :type :ex/User}}
+          db         @(fluree/stage
+                        (fluree/db ledger)
+                        {"@context" ["https://ns.flur.ee" context]
+                         "insert"
+                         {:id             :ex/UserShape
+                          :type           [:sh/NodeShape]
+                          :sh/targetClass :ex/User
+                          :sh/not         [{:sh/path         :schema/age
+                                            :sh/minInclusive 130}
+                                           {:sh/path         :schema/favNums
+                                            :sh/maxExclusive 9000}]
+                          :sh/property    [{:sh/path     :schema/age
+                                            :sh/minCount 1
+                                            :sh/maxCount 1
+                                            :sh/datatype :xsd/long}]}})
+
+
+
           db-two-probs @(fluree/stage
                           db
                           {"@context" ["https://ns.flur.ee" context]
@@ -163,184 +156,268 @@
                             :schema/name     "Johnny Boy"
                             :schema/callSign "Johnny Boy"
                             :schema/age      900
-                            :schema/favNums  [4 8 15 16 23 42]}})
-          ok-results   @(fluree/query db-ok user-query)]
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-10"}
-               {:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-11"}]}
-             (ex-data db-too-old)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
+                            :schema/favNums  [4 8 15 16 23 42]}})]
+      (testing "no violations"
+        (let [db-ok      @(fluree/stage
+                            db
+                            {"@context" ["https://ns.flur.ee" context]
+                             "insert"
+                             {:id              :ex/john,
+                              :type            [:ex/User],
+                              :schema/name     "John"
+                              :schema/callSign "j-rock"
+                              :schema/age      42
+                              :schema/favNums  [9004 9008 9015 9016 9023 9042]}})
+              ok-results @(fluree/query db-ok user-query)]
+          (is (= [{:id              :ex/john,
+                   :type            :ex/User,
+                   :schema/name     "John",
+                   :schema/callSign "j-rock"
+                   :schema/age      42
+                   :schema/favNums  [9004 9008 9015 9016 9023 9042]}]
+                 ok-results)
+              (str "unexpected query result: " (pr-str ok-results)))))
+      (testing "conforms to min and max"
+        (let [db-too-old @(fluree/stage
+                            db
+                            {"@context" ["https://ns.flur.ee" context]
+                             "insert"
+                             {:id                 :ex/john,
+                              :type               [:ex/User],
+                              :schema/companyName "WrongCo"
+                              :schema/callSign    "j-rock"
+                              :schema/age         131}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-10"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                 (ex-data db-too-old)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
-             (ex-message db-too-old)))
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-11"}]}
-             (ex-data db-too-low)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
-             (ex-message db-too-low)))
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-10"}
-               {:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-11"}]}
-             (ex-data db-two-probs)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
+                 (ex-message db-too-old)))))
+      (testing "conforms to max exclusive"
+        (let [db-too-low @(fluree/stage
+                            db
+                            {"@context" ["https://ns.flur.ee" context]
+                             "insert"
+                             {:id                 :ex/john,
+                              :type               [:ex/User],
+                              :schema/companyName ["John", "Johnny"]
+                              :schema/callSign    "j-rock"
+                              :schema/age         27
+                              :schema/favNums     [4 8 15 16 23 42]}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                 (ex-data db-too-low)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+                 (ex-message db-too-low)))))
+      (testing "conforms to min and max exclusive"
+        (let []
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-10"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                 (ex-data db-two-probs)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
-             (ex-message db-two-probs)))
-      (is (= [{:id              :ex/john,
-               :type            :ex/User,
-               :schema/name     "John",
-               :schema/callSign "j-rock"
-               :schema/age      42
-               :schema/favNums  [9004 9008 9015 9016 9023 9042]}]
-             ok-results)
-          (str "unexpected query result: " (pr-str ok-results)))))
+                 (ex-message db-two-probs)))))))
 
   (testing "shacl not w/ string constraints works"
-    (let [conn                  (test-utils/create-conn)
-          ledger                @(fluree/create conn "shacl/str")
-          context               [test-utils/default-context {:ex "http://example.org/ns/"}]
-          user-query            {:context context
-                                 :select  {'?s [:*]}
-                                 :where   {:id '?s, :type :ex/User}}
-          db                    @(fluree/stage
-                                   (fluree/db ledger)
-                                   {"@context" ["https://ns.flur.ee" context]
-                                    "insert"
-                                    {:id             :ex/UserShape
-                                     :type           [:sh/NodeShape]
-                                     :sh/targetClass :ex/User
-                                     :sh/not         [{:sh/path      :ex/tag
-                                                       :sh/minLength 4}
-                                                      {:sh/path      :schema/name
-                                                       :sh/maxLength 10}
-                                                      {:sh/path    :ex/greeting
-                                                       :sh/pattern "hello.*"}]}})
-          db-ok                 @(fluree/stage
-                                   db
-                                   {"@context" ["https://ns.flur.ee" context]
-                                    "insert"
-                                    {:id          :ex/jean-claude
-                                     :type        :ex/User,
-                                     :schema/name "Jean-Claude"
-                                     :ex/tag      1
-                                     :ex/greeting "HOWDY"}})
-          db-name-too-short     @(fluree/stage
-                                   db
-                                   {"@context" ["https://ns.flur.ee" context]
-                                    "insert"
-                                    {:id          :ex/john,
-                                     :type        [:ex/User],
-                                     :schema/name "John"}})
-          db-tag-too-long       @(fluree/stage
-                                   db
-                                   {"@context" ["https://ns.flur.ee" context]
-                                    "insert"
-                                    {:id     :ex/john,
-                                     :type   [:ex/User],
-                                     :ex/tag 12345}})
-          db-greeting-incorrect @(fluree/stage
+    (let [conn       (test-utils/create-conn)
+          ledger     @(fluree/create conn "shacl/str")
+          context    [test-utils/default-context {:ex "http://example.org/ns/"}]
+          user-query {:context context
+                      :select  {'?s [:*]}
+                      :where   {:id '?s, :type :ex/User}}
+          db         @(fluree/stage
+                        (fluree/db ledger)
+                        {"@context" ["https://ns.flur.ee" context]
+                         "insert"
+                         {:id             :ex/UserShape
+                          :type           [:sh/NodeShape]
+                          :sh/targetClass :ex/User
+                          :sh/not         [{:sh/path      :ex/tag
+                                            :sh/minLength 4}
+                                           {:sh/path      :schema/name
+                                            :sh/maxLength 10}
+                                           {:sh/path    :ex/greeting
+                                            :sh/pattern "hello.*"}]}})]
+      (testing "no constraint violations"
+        (let [db-ok @(fluree/stage
+                       db
+                       {"@context" ["https://ns.flur.ee" context]
+                        "insert"
+                        {:id          :ex/jean-claude
+                         :type        :ex/User,
+                         :schema/name "Jean-Claude"
+                         :ex/tag      1
+                         :ex/greeting "HOWDY"}})]
+          (is (= [{:id          :ex/jean-claude
+                   :type        :ex/User,
+                   :schema/name "Jean-Claude"
+                   :ex/greeting "HOWDY"
+                   :ex/tag      1}]
+                 @(fluree/query db-ok user-query)))))
+      (testing "name conforms"
+        (let [db-name-too-short @(fluree/stage
                                    db
                                    {"@context" ["https://ns.flur.ee" context]
                                     "insert"
                                     {:id          :ex/john,
                                      :type        [:ex/User],
-                                     :ex/greeting "hello!"}})]
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-18"}
-               {:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-19"}
-               {:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-20"}]}
-             (ex-data db-name-too-short)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
+                                     :schema/name "John"}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                 (ex-data db-name-too-short)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
-             (ex-message db-name-too-short)))
-      (is (= {:status 400,
-              :error  :shacl/violation,
-              :report
-              [{:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-18"}
-               {:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-19"}
-               {:subject    :ex/john,
-                :constraint :sh/not,
-                :shape      :ex/UserShape,
-                :value      :ex/john,
-                :message    ":ex/john conforms to shape _:fdb-20"}]}
-             (ex-data db-tag-too-long)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
+                 (ex-message db-name-too-short)))))
+      (testing "tag conforms"
+        (let [db-tag-too-long @(fluree/stage
+                                 db
+                                 {"@context" ["https://ns.flur.ee" context]
+                                  "insert"
+                                  {:id     :ex/john,
+                                   :type   [:ex/User],
+                                   :ex/tag 12345}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                 (ex-data db-tag-too-long)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
-             (ex-message db-tag-too-long)))
-      (is (= {:status 400,
-              :error :shacl/violation,
-              :report
-              [{:subject :ex/john,
-                :constraint :sh/not,
-                :shape :ex/UserShape,
-                :value :ex/john,
-                :message ":ex/john conforms to shape _:fdb-18"}
-               {:subject :ex/john,
-                :constraint :sh/not,
-                :shape :ex/UserShape,
-                :value :ex/john,
-                :message ":ex/john conforms to shape _:fdb-19"}
-               {:subject :ex/john,
-                :constraint :sh/not,
-                :shape :ex/UserShape,
-                :value :ex/john,
-                :message ":ex/john conforms to shape _:fdb-20"}]}
-             (ex-data db-greeting-incorrect)))
-      (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
+                 (ex-message db-tag-too-long)))))
+      (testing "greeting conforms"
+        (let [db-greeting-incorrect @(fluree/stage
+                                       db
+                                       {"@context" ["https://ns.flur.ee" context]
+                                        "insert"
+                                        {:id          :ex/john,
+                                         :type        [:ex/User],
+                                         :ex/greeting "hello!"}})]
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                 (ex-data db-greeting-incorrect)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
 Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
-             (ex-message db-greeting-incorrect)))
-      (is (= [{:id          :ex/jean-claude
-               :type        :ex/User,
-               :schema/name "Jean-Claude"
-               :ex/greeting "HOWDY"
-               :ex/tag      1}]
-             @(fluree/query db-ok user-query))))))
+                 (ex-message db-greeting-incorrect))))))))


### PR DESCRIPTION
https://www.w3.org/TR/shacl/#validation-report

This utilizes the official SHACL vocabulary for validation report results. I had to augment the official vocabulary with `f:expectation`, as I think that's a very useful part of the validation result.

I also added support for user-specified severity and message keys on the shape, according to the spec.

While updating the test expectations I restructured multiple tests to allow the data and the expectation to live adjacent to each other.