### PR TITLE
Feature/shacl lang+logical constraints

### DIFF
--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -409,6 +409,7 @@
                            bnode?   (iri/blank-node-sid? v)
                            literal? (not (iri/sid? v))]
                        (condp = nodekind
+                         const/sh_Literal            literal?
                          const/sh_BlankNode          bnode?
                          const/sh_IRI                iri?
                          const/sh_BlankNodeOrIRI     (or iri? bnode?)

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -210,7 +210,6 @@
       (if pid
         (let [value-nodes* (<? (query-range/index-range data-db :spot = [focus-node pid]
                                                         {:flake-xf (map object-node)}))]
-          (println "DEP alt" (pr-str focus-node) (pr-str pid) (pr-str value-nodes*))
           (recur r (into value-nodes value-nodes*)))
         value-nodes))))
 
@@ -802,7 +801,6 @@
                           (<? (validate-property-shape v-ctx or-shape focus-node))
                           (<? (validate-node-shape v-ctx or-shape focus-node value-nodes)))]
 
-            (println "DEP or results" (pr-str results))
             (if results
               (recur r none-conformed?)
               ;; short-circuit if there's a single conforming shape

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -2920,3 +2920,43 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                (ex-data db2)))
         (is (= "Subject ex:invalid path [\"ex:myProperty\"] violates constraint sh:maxCount of shape _:fdb-3 - count 2 is greater than maximum count of 1."
                (ex-message db2)))))))
+
+(deftest target-node
+  (let [conn    @(fluree/connect {:method :memory})
+        ledger  @(fluree/create conn "validation-report")
+        context ["https://ns.flur.ee" test-utils/default-str-context {"ex" "http://example.com/ns/"}]
+        db0     (fluree/db ledger)
+
+        db1 @(fluree/stage db0 {"@context" context
+                                "insert"
+                                {"type"          "sh:NodeShape"
+                                 "sh:targetNode" [{"@id" "ex:nodeA"} {"@id" "ex:nodeB"}]
+                                 "sh:property"   [{"sh:path"     {"@id" "ex:letter"}
+                                                   "sh:maxCount" 1}]}})]
+    (testing "valid target"
+      (let [db2 @(fluree/stage db1 {"@context" context
+                                    "insert"   {"id"        "ex:nodeA"
+                                                "ex:letter" "A"}})]
+        (is (nil? (ex-data db2)))))
+    (testing "invalid target"
+      (let [db2 @(fluree/stage db1 {"@context" context
+                                    "insert"   {"id"        "ex:nodeB"
+                                                "ex:letter" ["A" "B"]}})]
+        (is (= {:status 400,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:maxCount",
+                   "sh:focusNode"           "ex:nodeB",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               2,
+                   "sh:resultPath"          ["ex:letter"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                   "sh:sourceShape"         "_:fdb-3",
+                   "f:expectation"          1}]}}
+               (ex-data db2)))
+        (is (= "Subject ex:nodeB path [\"ex:letter\"] violates constraint sh:maxCount of shape _:fdb-3 - count 2 is greater than maximum count of 1."
+               (ex-message db2)))))))


### PR DESCRIPTION
We were very close and the work was not hard, so I decided to make our SHACL support more complete. 

This PR adds support (and tests) for all remaining SHACL constraints, namely:
- `sh:languageIn`
- `sh:uniqueLang`
- `sh:and`
- `sh:or`
- `sh:xone`

It also adds support for SHACL `sh:alternativePath` paths.

It also adds tests for existing `sh:targetSubjectsOf` and `sh:targetNode` target declarations.

The only unsupported part of SHACL that remains are the recursive `sh:path` variants:
- `sh:zeroOrMorePath`
- `sh:oneOrMorePath`
- `sh:zeroOrOnePath`

