### PR TITLE
ledger query-string-t-val

### DIFF
--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -156,6 +156,14 @@
   #?(:clj  (Integer/parseInt s)
      :cljs (js/parseInt s)))
 
+(defn str->long
+  "Converts string to long integer. Assumes you've already verified the string is
+  parsable to a long.
+
+  Note JS only has precision to 2^53-1, so this will not work for larger numbers."
+  [s]
+  #?(:clj  (Long/parseLong s)
+     :cljs (js/parseInt s)))
 
 (defn keyword->str
   "Converts a keyword to string. Can safely be called on a


### PR DESCRIPTION
This allows a ledger alias to contain http query strings to specify the moment in time a db should be loaded.

This is used in `fluree/query-connection` whose primary consumer is fluree/server - allowing more granular time travel capabilities in federated (multi-db) queries.

This expanded syntax is supported for both `from` and `from-named` keys in the query syntax, and can now specify a t value like:
   - my/db?t=42
   - my/db?t=2020-01-01T00:00:00Z
 
global-t is still supported as an opt in `query-connection` and will be used if a more specific t value is not supplied for a db as per above.

API test for this syntax in fluree/server