### PR TITLE
Pretty Print DB Records

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -9,7 +9,6 @@
             [fluree.db.flake :as flake]
             [fluree.db.util.json :as json]
             [fluree.db.serde.json :as serdejson]
-            [fluree.db.indexer.storage :as storage]
             [fluree.db.query.fql :as fql]
             [fluree.db.query.range :as query-range]
             [fluree.db.dbproto :as dbproto]

--- a/src/clj/fluree/db/db/json_ld.cljc
+++ b/src/clj/fluree/db/db/json_ld.cljc
@@ -131,7 +131,7 @@
   (decode-sid [_ sid]
     (iri/sid->iri sid namespace-codes)))
 
-(def label "#fluree/JsonLdDb ")
+(def ^String label "#fluree/JsonLdDb ")
 
 (defn display
   [db]

--- a/src/clj/fluree/db/db/json_ld.cljc
+++ b/src/clj/fluree/db/db/json_ld.cljc
@@ -134,16 +134,19 @@
      IPrintWithWriter
      (-pr-writer [db w _opts]
        (-write w "#FlureeJsonLdDb ")
-       (-write w (pr {:method      (:method db) :alias (:alias db)
-                      :t           (:t db) :stats (:stats db)
-                      :policy      (:policy db)})))))
+       (-write w (pr {:alias  (:alias db)
+                      :t      (:t db)
+                      :stats  (:stats db)
+                      :policy (:policy db)})))))
 
 #?(:clj
    (defmethod print-method JsonLdDb [^JsonLdDb db, ^Writer w]
      (.write w (str "#FlureeJsonLdDb "))
      (binding [*out* w]
-       (pr {:method (:method db) :alias (:alias db)
-            :t      (:t db) :stats (:stats db) :policy (:policy db)}))))
+       (pr {:alias  (:alias db)
+            :t      (:t db)
+            :stats  (:stats db)
+            :policy (:policy db)}))))
 
 (defn new-novelty-map
   [comparators]

--- a/src/clj/fluree/db/db/json_ld.cljc
+++ b/src/clj/fluree/db/db/json_ld.cljc
@@ -11,7 +11,9 @@
             [fluree.db.json-ld.branch :as branch]
             [fluree.db.json-ld.transact :as jld-transact]
             [fluree.db.util.log :as log]
-            [fluree.db.json-ld.commit-data :as commit-data])
+            [fluree.db.json-ld.commit-data :as commit-data]
+            [clojure.set :refer [map-invert]]
+            [#?(:clj clojure.pprint, :cljs cljs.pprint) :as pprint :refer [pprint]])
   #?(:clj (:import (java.io Writer))))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -129,24 +131,29 @@
   (decode-sid [_ sid]
     (iri/sid->iri sid namespace-codes)))
 
+(def label "#fluree/JsonLdDb ")
+
+(defn display
+  [db]
+  (select-keys db [:alias :t :stats :policy]))
+
 #?(:cljs
    (extend-type JsonLdDb
      IPrintWithWriter
      (-pr-writer [db w _opts]
-       (-write w "#FlureeJsonLdDb ")
-       (-write w (pr {:alias  (:alias db)
-                      :t      (:t db)
-                      :stats  (:stats db)
-                      :policy (:policy db)})))))
+       (-write w label)
+       (-write w (-> db display pr)))))
 
 #?(:clj
    (defmethod print-method JsonLdDb [^JsonLdDb db, ^Writer w]
-     (.write w (str "#FlureeJsonLdDb "))
+     (.write w label)
      (binding [*out* w]
-       (pr {:alias  (:alias db)
-            :t      (:t db)
-            :stats  (:stats db)
-            :policy (:policy db)}))))
+       (-> db display pr))))
+
+(defmethod pprint/simple-dispatch JsonLdDb
+  [db]
+  (print label)
+  (-> db display pprint))
 
 (defn new-novelty-map
   [comparators]

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -114,12 +114,6 @@
    ["address" :address]
    ["data" :data]])
 
-(def json-ld-default-ctx-template
-  "Note, key-val pairs are in vector form to preserve ordering of final commit map"
-  [["id" :id]
-   ["type" ["Context"]]
-   ["address" :address]])
-
 (defn merge-template
   "Merges provided map with template and places any
   values in map with respective template value. If value

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -233,9 +233,7 @@
                        :error  :db/unexpected-error})))))
 
 (defn new-blank-node-id
-  "Generate a temporary blank-node id. This will get replaced during flake creation
-  when a sid is generated."
   []
   (let [now (util/current-time-millis)
         suf (nano-id 8)]
-    (str/join "-" [blank-node-prefix now suf] )))
+    (str/join "-" [blank-node-prefix now suf])))

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -357,7 +357,7 @@
      (assoc db :schema schema))))
 
 (defn load-schema
-  [{:keys [preds t] :as db}]
+  [{:keys [preds] :as db}]
   (go-try
     (loop [[[pred-sid] & r] preds
            vocab-flakes (flake/sorted-set-by flake/cmp-flakes-spot)]


### PR DESCRIPTION
This patch adds a method to pretty-print db records by selecting a subset of the keys to print as the regular print-methods do. There's also some miscellaneous cleanup. 