### PR TITLE
Fix Schema Map Deserialization 

### DIFF
--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -67,28 +67,14 @@
         ser  (serdeproto/-serialize-garbage (serde conn) data)]
     (connection/-index-file-write conn ledger :garbage ser)))
 
-(defn extract-schema-root
-  "Transform the schema cache for serialization by turning every predicate into a
-  tuple of [pid datatype]."
-  [{:keys [schema]}]
-  (->> (:pred schema)
-       (reduce (fn [root [k {:keys [datatype]}]]
-                 (if (iri/sid? k)
-                   (let [sid (iri/serialize-sid k)]
-                     (if datatype
-                       (conj root [sid (iri/serialize-sid datatype)])
-                       (conj root [sid])))
-                   root))
-               [])))
-
 (defn write-db-root
   [db]
   (let [{:keys [conn ledger commit t stats spot psot post opst tspo
-                namespace-codes]}
+                schema namespace-codes]}
         db
 
         ledger-alias (:id commit)
-        preds        (extract-schema-root db)
+        preds        (vocab/serialize-schema-predicates schema)
         data         {:ledger-alias    ledger-alias
                       :t               t
                       :preds           preds
@@ -126,12 +112,12 @@
                                 {:status 500
                                  :error  :db/unexpected-error})))]
     (cond-> index-data
-            (:rhs index-data) (update :rhs flake/parts->Flake)
-            (:first index-data) (update :first flake/parts->Flake)
-            true (assoc :comparator cmp
-                        :ledger-alias ledger-alias
-                        :t t
-                        :leftmost? true))))
+      (:rhs index-data)   (update :rhs flake/parts->Flake)
+      (:first index-data) (update :first flake/parts->Flake)
+      true                (assoc :comparator cmp
+                                 :ledger-alias ledger-alias
+                                 :t t
+                                 :leftmost? true))))
 
 
 (defn reify-db-root

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -150,6 +150,13 @@
 (def serialize-sid
   (juxt get-ns-code get-name))
 
+(defn serialized-sid?
+  [x]
+  (and (vector? x)
+       (= (count x) 2)
+       (number? (nth x 0))
+       (string? (nth x 1))))
+
 #?(:clj (defmethod print-method SID [^SID sid ^java.io.Writer w]
           (doto w
             (.write "#fluree/SID ")

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -357,7 +357,7 @@
      (assoc db :schema schema))))
 
 (defn load-schema
-  [{:keys [preds t] :as db}]
+  [db preds]
   (go-try
     (loop [[[pred-sid] & r] preds
            vocab-flakes (flake/sorted-set-by flake/cmp-flakes-spot)]

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -356,6 +356,18 @@
      (invalidate-shape-cache! db mods)
      (assoc db :schema schema))))
 
+(defn serialize-schema-predicates
+  [schema]
+  (reduce (fn [root [k {:keys [datatype]}]]
+            (if (iri/sid? k)
+              (let [sid (iri/serialize-sid k)]
+                (if datatype
+                  (conj root [sid (iri/serialize-sid datatype)])
+                  (conj root [sid])))
+              root))
+          []
+          (:pred schema)))
+
 (defn load-schema
   [db preds]
   (go-try


### PR DESCRIPTION
The schema map wasn't being properly (de)serialized. First, the schema serialization code was checking for a number when it should have been checking for an sid when deciding which keys in the schema map to serialize. Secondly, the deserialization code didn't take into account that the serialized schema sids were wrapped in vectors. This patch fixes both of those issues so that the schema now loads properly. 