### PR TITLE
Content addressed storage

### DIFF
--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -33,10 +33,9 @@
           bytes    (bytes/string->UTF8 json)
           hash     (crypto/sha2-256 bytes :hex)
           type-dir (name data-type)
-          path     (str alias
-                        (when branch (str "/" branch))
-                        (str "/" type-dir "/")
-                        hash ".json")
+          path     (->> [alias branch type-dir hash]
+                        (remove nil?)
+                        (str/join "/"))
 
           {:keys [hash address]} (<? (storage/write store path bytes))]
       {:name    path

--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -2,7 +2,6 @@
   (:require [clojure.core.async :as async :refer [go]]
             [fluree.db.util.async :refer [<? go-try]]
             [clojure.string :as str]
-            [fluree.crypto :as crypto]
             [fluree.db.util.core :as util]
             [fluree.json-ld :as json-ld]
             [fluree.db.index :as index]
@@ -31,13 +30,12 @@
                      data
                      (json-ld/normalize-data data))
           bytes    (bytes/string->UTF8 json)
-          hash     (crypto/sha2-256 bytes :hex)
           type-dir (name data-type)
-          path     (->> [alias branch type-dir hash]
+          path     (->> [alias branch type-dir]
                         (remove nil?)
                         (str/join "/"))
 
-          {:keys [hash address]} (<? (storage/write store path bytes))]
+          {:keys [path hash address]} (<? (storage/write store path bytes))]
       {:name    path
        :hash    hash
        :json    json

--- a/src/clj/fluree/db/conn/memory.cljc
+++ b/src/clj/fluree/db/conn/memory.cljc
@@ -10,7 +10,6 @@
             [fluree.db.conn.cache :as conn-cache]
             [fluree.db.indexer.default :as idx-default]
             [fluree.json-ld :as json-ld]
-            [fluree.crypto :as crypto]
             [fluree.db.storage :as storage]
             [fluree.db.storage.memory :as memory-storage]
             #?(:cljs [fluree.db.platform :as platform]))
@@ -21,17 +20,13 @@
 ;; Memory Connection object
 
 (defn- write-data!
-  [store data]
+  [store type data]
   (go-try
-    (let [json (json-ld/normalize-data data)
-          hash (crypto/sha2-256 json)
-
-          {:keys [path address]}
-          (<? (storage/write store hash data))]
+    (let [{:keys [address path hash size]}
+          (<? (storage/write store type data))]
       {:name    path
        :hash    hash
-       :json    json
-       :size    (count json)
+       :size    size
        :address address})))
 
 (defn- read-data
@@ -53,9 +48,9 @@
 
   connection/iStorage
   (-c-read [_ commit-key] (read-data store commit-key))
-  (-c-write [_ _ledger commit-data] (write-data! store commit-data))
+  (-c-write [_ _ledger commit-data] (write-data! store :commit commit-data))
   (-txn-read [_ txn-key] (read-data store txn-key))
-  (-txn-write [_ _ledger txn-data] (write-data! store txn-data))
+  (-txn-write [_ _ledger txn-data] (write-data! store :transaction txn-data))
 
   connection/iConnection
   (-close [_] (close id state))

--- a/src/clj/fluree/db/conn/s3.clj
+++ b/src/clj/fluree/db/conn/s3.clj
@@ -3,7 +3,6 @@
             [clojure.string :as str]
             [fluree.db.nameservice.s3 :as ns-s3]
             [clojure.core.async :as async :refer [go]]
-            [fluree.crypto :as crypto]
             [fluree.db.conn.cache :as conn-cache]
             [fluree.db.connection :as connection]
             [fluree.db.index :as index]
@@ -30,18 +29,16 @@
           json     (if (string? data)
                      data
                      (json-ld/normalize-data data))
-          bytes    (.getBytes ^String json)
-          hash     (crypto/sha2-256 bytes :hex)
           type-dir (name data-type)
-          path     (->> [alias branch type-dir hash]
+          dir      (->> [alias branch type-dir]
                         (remove nil?)
                         (str/join "/"))
-          result   (<? (storage/write store path bytes))]
+          {:keys [address hash path]}  (<? (storage/write store dir json))]
       {:name    path
        :hash    hash
        :json    json
        :size    (count json)
-       :address (:address result)})))
+       :address address})))
 
 (defn read-commit
   [{:keys [store] :as _conn} address]

--- a/src/clj/fluree/db/conn/s3.clj
+++ b/src/clj/fluree/db/conn/s3.clj
@@ -1,5 +1,6 @@
 (ns fluree.db.conn.s3
   (:require [cognitect.aws.client.api :as aws]
+            [clojure.string :as str]
             [fluree.db.nameservice.s3 :as ns-s3]
             [clojure.core.async :as async :refer [go]]
             [fluree.crypto :as crypto]
@@ -32,10 +33,9 @@
           bytes    (.getBytes ^String json)
           hash     (crypto/sha2-256 bytes :hex)
           type-dir (name data-type)
-          path     (str alias
-                        (when branch (str "/" branch))
-                        (str "/" type-dir "/")
-                        hash ".json")
+          path     (->> [alias branch type-dir hash]
+                        (remove nil?)
+                        (str/join "/"))
           result   (<? (storage/write store path bytes))]
       {:name    path
        :hash    hash

--- a/src/clj/fluree/db/nameservice/filesystem.cljc
+++ b/src/clj/fluree/db/nameservice/filesystem.cljc
@@ -151,6 +151,22 @@ changes from different branches into existing metadata map"
          (some #(when (= (get % "@id") branch-iri)
                   (get % "address"))))))
 
+(defn convert-legacy-ns-record
+  [alias commit-address local-path legacy-path]
+  (async/go
+    (let [ns-address (str "fluree:file://" alias)
+          ns-record  (ns-record ns-address commit-address {"alias" alias, "branch" "main"})]
+      (let [successful? (async/<! (write-ns-record ns-record local-path alias))]
+        (if (util/exception? successful?)
+          (log/error successful?
+                     (str "Unable to update legacy nameservice file for ledger: " alias
+                          "with exception: " (ex-message successful?)))
+          #?(:clj (try
+                    (.renameTo (io/file legacy-path) (io/file (str legacy-path ".legacy")))
+                    (catch Exception e
+                      (log/error "Exception renaming legacy nameservice file for ledger: " alias
+                                 "with exception: " (ex-message e))))))))))
+
 (defn try-legacy-ns-lookup
   "This is for legacy filesystem nameservice file format only.
   It should be removed once Fluree v3 is GA, but will allow for
@@ -158,37 +174,27 @@ changes from different branches into existing metadata map"
   If deemed important, this can be done in an upgrade script instead as part of
   the v3 GA launch."
   [local-path alias]
-  (go-try (let [path           (str local-path "/" alias "/main/head")
-                commit-address (when-let [address (<? (fs/read-file path))]
-                                 (cond
-                                   (str/starts-with? address "//")
-                                   (str "fluree:file:" address)
+  (go-try
+    (let [legacy-path    (str local-path "/" alias "/main/head")
+          commit-address (when-let [address (<? (fs/read-file legacy-path))]
+                           (cond
+                             (str/starts-with? address "//")
+                             (str "fluree:file:" address)
 
-                                   (str/starts-with? address "fluree:")
-                                   address
+                             (str/starts-with? address "fluree:")
+                             address
 
-                                   :else
-                                   (do
-                                     (log/warn "Unexpected commit address format in legacy nameservice file:" path
-                                               "with address:" address)
-                                     nil)))]
-            (when commit-address
-              ;; write out new NS file record format in the background
-              (async/go
-                (let [ns-address (str "fluree:file://" alias)
-                      ns-record  (ns-record ns-address commit-address {"alias" alias, "branch" "main"})]
-                  (let [successful? (async/<! (write-ns-record ns-record local-path alias))]
-                    (if (util/exception? successful?)
-                      (log/error successful?
-                                 (str "Unable to update legacy nameservice file for ledger: " alias
-                                      "with exception: " (ex-message successful?)))
-                      #?(:clj (try
-                                (.renameTo (io/file path) (io/file (str path ".legacy")))
-                                (catch Exception e
-                                  (log/error "Exception renaming legacy nameservice file for ledger: " alias
-                                             "with exception: " (ex-message e)))))))))
+                             :else
+                             (do
+                               (log/warn "Unexpected commit address format in legacy nameservice file:"
+                                         legacy-path
+                                         "with address:" address)
+                               nil)))]
+      (when commit-address
+        ;; write out new NS file record format in the background
+        (convert-legacy-ns-record alias commit-address local-path legacy-path)
 
-              commit-address))))
+        commit-address))))
 
 (defn lookup
   "When provided a 'relative' ledger alias, looks in file system to see if

--- a/src/clj/fluree/db/nameservice/filesystem.cljc
+++ b/src/clj/fluree/db/nameservice/filesystem.cljc
@@ -158,37 +158,37 @@ changes from different branches into existing metadata map"
   If deemed important, this can be done in an upgrade script instead as part of
   the v3 GA launch."
   [local-path alias]
-  (let [path           (str local-path "/" alias "/main/head")
-        commit-address (when-let [address (fs/read-file path)]
-                         (cond
-                           (str/starts-with? address "//")
-                           (str "fluree:file:" address)
+  (go-try (let [path           (str local-path "/" alias "/main/head")
+                commit-address (when-let [address (<? (fs/read-file path))]
+                                 (cond
+                                   (str/starts-with? address "//")
+                                   (str "fluree:file:" address)
 
-                           (str/starts-with? address "fluree:")
-                           address
+                                   (str/starts-with? address "fluree:")
+                                   address
 
-                           :else
-                           (do
-                             (log/warn "Unexpected commit address format in legacy nameservice file:" path
-                                       "with address:" address)
-                             nil)))]
-    (when commit-address
-      ;; write out new NS file record format in the background
-      (async/go
-        (let [ns-address (str "fluree:file://" alias)
-              ns-record  (ns-record ns-address commit-address {"alias" alias, "branch" "main"})]
-          (let [successful? (async/<! (write-ns-record ns-record local-path alias))]
-            (if (util/exception? successful?)
-              (log/error successful?
-                         (str "Unable to update legacy nameservice file for ledger: " alias
-                              "with exception: " (ex-message successful?)))
-              #?(:clj (try
-                        (.renameTo (io/file path) (io/file (str path ".legacy")))
-                        (catch Exception e
-                          (log/error "Exception renaming legacy nameservice file for ledger: " alias
-                                     "with exception: " (ex-message e)))))))))
+                                   :else
+                                   (do
+                                     (log/warn "Unexpected commit address format in legacy nameservice file:" path
+                                               "with address:" address)
+                                     nil)))]
+            (when commit-address
+              ;; write out new NS file record format in the background
+              (async/go
+                (let [ns-address (str "fluree:file://" alias)
+                      ns-record  (ns-record ns-address commit-address {"alias" alias, "branch" "main"})]
+                  (let [successful? (async/<! (write-ns-record ns-record local-path alias))]
+                    (if (util/exception? successful?)
+                      (log/error successful?
+                                 (str "Unable to update legacy nameservice file for ledger: " alias
+                                      "with exception: " (ex-message successful?)))
+                      #?(:clj (try
+                                (.renameTo (io/file path) (io/file (str path ".legacy")))
+                                (catch Exception e
+                                  (log/error "Exception renaming legacy nameservice file for ledger: " alias
+                                             "with exception: " (ex-message e)))))))))
 
-      commit-address)))
+              commit-address))))
 
 (defn lookup
   "When provided a 'relative' ledger alias, looks in file system to see if
@@ -202,7 +202,7 @@ changes from different branches into existing metadata map"
             (throw (ex-info (str "No nameservice record found for ledger alias: " ns-address)
                             {:status 404 :error :db/ledger-not-found})))
         ;; Note, below is for leagacy conversion only, will get removed in v3 GA
-        (try-legacy-ns-lookup local-path alias)))))
+        (<? (try-legacy-ns-lookup local-path alias))))))
 
 
 (defrecord FileNameService

--- a/src/clj/fluree/db/storage.cljc
+++ b/src/clj/fluree/db/storage.cljc
@@ -35,7 +35,6 @@
      :local  local}))
 
 (defprotocol Store
-  (address [store k] "Returns the address that would be constructed by writing to `k`.")
   (write [store k v] "Writes `v` to Store associated with `k`. Returns value's address.")
   (exists? [store address] "Returns true when address exists in Store.")
   (delete [store address] "Remove value associated with `address` from the Store.")

--- a/src/clj/fluree/db/storage/file.cljc
+++ b/src/clj/fluree/db/storage/file.cljc
@@ -31,7 +31,7 @@
                          :path dir
                          :data data})))
       (let [hash     (crypto/sha2-256 data :hex)
-            path     (str/join "/" [dir hash])
+            path     (str/join "/" [dir hash ".json"])
             absolute (full-path root path)
             bytes    (if (string? data)
                        (bytes/string->UTF8 data)

--- a/src/clj/fluree/db/storage/file.cljc
+++ b/src/clj/fluree/db/storage/file.cljc
@@ -16,12 +16,13 @@
   (let [relative-path (:local (storage/parse-address address))]
     (full-path root relative-path)))
 
+(defn file-address
+  [path]
+  (storage/build-fluree-address method-name path))
+
 (defrecord FileStore [root]
   storage/Store
-  (address [_ path]
-    (storage/build-fluree-address method-name path))
-
-  (write [store path v]
+  (write [_ path v]
     (go-try
       (when (not (storage/hashable? v))
         (throw (ex-info "Must serialize v before writing to FileStore."
@@ -35,7 +36,7 @@
                     v)]
         (<? (fs/write-file path* bytes))
         {:path    path
-         :address (storage/address store path)
+         :address (file-address path)
          :hash    hash
          :size    (count bytes)})))
 

--- a/src/clj/fluree/db/storage/ipfs.cljc
+++ b/src/clj/fluree/db/storage/ipfs.cljc
@@ -13,12 +13,13 @@
   [method local]
   (str/join "/" ["" method local]))
 
+(defn ipfs-address
+  [path]
+  (storage/build-fluree-address method-name path))
+
 (defrecord IpfsStore [endpoint]
   storage/Store
-  (address [_ path]
-    (storage/build-fluree-address method-name path))
-
-  (write [store path v]
+  (write [_ path v]
     (go-try
       (let [content (if (string? v)
                       v
@@ -32,7 +33,7 @@
               {:status 500 :error :db/push-ipfs :result res})))
         {:path    hash
          :hash    hash
-         :address (storage/address store hash)
+         :address (ipfs-address hash)
          :size    size})))
 
   (list [_ prefix]

--- a/src/clj/fluree/db/storage/localstorage.cljs
+++ b/src/clj/fluree/db/storage/localstorage.cljs
@@ -9,12 +9,13 @@
 
 (def method-name "localstorage")
 
+(defn local-storage-address
+  [path]
+  (storage/build-fluree-address method-name path))
+
 (defrecord LocalStorageStore []
   storage/Store
-  (address [_ path]
-    (storage/build-fluree-address method-name path))
-
-  (write [store k v]
+  (write [_ k v]
     (go
       (let [hashable (if (storage/hashable? v)
                        v
@@ -22,7 +23,7 @@
             hash     (crypto/sha2-256 hashable)]
         (.setItem js/localStorage k v)
         {:path    k
-         :address (storage/address store k)
+         :address (local-storage-address k)
          :hash    hash
          :size    (count hashable)})))
 

--- a/src/clj/fluree/db/storage/localstorage.cljs
+++ b/src/clj/fluree/db/storage/localstorage.cljs
@@ -4,8 +4,7 @@
             [clojure.string :as str]
             [fluree.crypto :as crypto]
             [fluree.db.platform :as platform]
-            [fluree.db.storage :as storage]
-            [fluree.json-ld :as json-ld]))
+            [fluree.db.storage :as storage]))
 
 (def method-name "localstorage")
 
@@ -19,7 +18,7 @@
     (go
       (let [hashable (if (storage/hashable? v)
                        v
-                       (json-ld/normalize-data v))
+                       (pr-str v))
             hash     (crypto/sha2-256 hashable)]
         (.setItem js/localStorage k v)
         {:path    k

--- a/src/clj/fluree/db/storage/memory.cljc
+++ b/src/clj/fluree/db/storage/memory.cljc
@@ -12,15 +12,15 @@
 
 (defrecord MemoryStore [contents]
   storage/Store
-  (write [_ path v]
+  (write [_ _ v]
     (go
       (let [hashable (if (storage/hashable? v)
                        v
                        (pr-str v))
             hash     (crypto/sha2-256 hashable)]
-        (swap! contents assoc path v)
-        {:path    path
-         :address (memory-address path)
+        (swap! contents assoc hash v)
+        {:path    hash
+         :address (memory-address hash)
          :hash    hash
          :size    (count hashable)})))
 

--- a/src/clj/fluree/db/storage/memory.cljc
+++ b/src/clj/fluree/db/storage/memory.cljc
@@ -6,12 +6,13 @@
 
 (def method-name "memory")
 
+(defn memory-address
+  [path]
+  (storage/build-fluree-address method-name path))
+
 (defrecord MemoryStore [contents]
   storage/Store
-  (address [_ path]
-    (storage/build-fluree-address method-name path))
-
-  (write [store path v]
+  (write [_ path v]
     (go
       (let [hashable (if (storage/hashable? v)
                        v
@@ -19,7 +20,7 @@
             hash     (crypto/sha2-256 hashable)]
         (swap! contents assoc path v)
         {:path    path
-         :address (storage/address store path)
+         :address (memory-address path)
          :hash    hash
          :size    (count hashable)})))
 

--- a/src/clj/fluree/db/storage/s3.clj
+++ b/src/clj/fluree/db/storage/s3.clj
@@ -16,7 +16,7 @@
             bytes   (if (string? data)
                      (bytes/string->UTF8 data)
                      data)
-            path    (str/join "/" [dir hash])
+            path    (str/join "/" [dir hash ".json"])
             result  (<! (s3/write-s3-data client bucket prefix path bytes))
             address (s3/s3-address bucket prefix path)]
         (if (instance? Throwable result)

--- a/src/clj/fluree/db/storage/s3.clj
+++ b/src/clj/fluree/db/storage/s3.clj
@@ -8,19 +8,17 @@
             [clojure.string :as str]
             [fluree.db.util.bytes :as bytes]))
 
-(defn s3-address [bucket prefix k]
-  (s3/s3-address bucket prefix k))
-
 (defrecord S3Store [client bucket prefix]
   storage/Store
-  (write [_ k v]
+  (write [_ dir data]
     (go
-      (let [hash    (crypto/sha2-256 v)
-            bytes   (if (string? v)
-                     (bytes/string->UTF8 v)
-                     v)
-            result  (<! (s3/write-s3-data client bucket prefix k bytes))
-            address (s3-address bucket prefix k)]
+      (let [hash    (crypto/sha2-256 data)
+            bytes   (if (string? data)
+                     (bytes/string->UTF8 data)
+                     data)
+            path    (str/join "/" [dir hash])
+            result  (<! (s3/write-s3-data client bucket prefix path bytes))
+            address (s3/s3-address bucket prefix path)]
         (if (instance? Throwable result)
           result
           {:hash    hash

--- a/src/clj/fluree/db/storage/s3.clj
+++ b/src/clj/fluree/db/storage/s3.clj
@@ -8,19 +8,19 @@
             [clojure.string :as str]
             [fluree.db.util.bytes :as bytes]))
 
+(defn s3-address [bucket prefix k]
+  (s3/s3-address bucket prefix k))
+
 (defrecord S3Store [client bucket prefix]
   storage/Store
-  (address [_ k]
-    (s3/s3-address bucket prefix k))
-
-  (write [store k v]
+  (write [_ k v]
     (go
       (let [hash    (crypto/sha2-256 v)
             bytes   (if (string? v)
                      (bytes/string->UTF8 v)
                      v)
             result  (<! (s3/write-s3-data client bucket prefix k bytes))
-            address (storage/address store k)]
+            address (s3-address bucket prefix k)]
         (if (instance? Throwable result)
           result
           {:hash    hash

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -971,10 +971,10 @@
                                              root-privkey))]
       (is (= [{"f:author" "", "f:txn" "", "f:data" {"f:t" 1}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn" "fluree:memory://9f321be5fd184f43d998ef7b02cdded2625579cc52b95e1d8f12c9b28cd7a5b0",
+               "f:txn" "fluree:memory://8bf810310a1f54a186acde9c7f05c91e0cf0facf6fb9ce5aa17987be0957bfd9",
                "f:data" {"f:t" 2}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn" "fluree:memory://5e7e5ce8d21011c95844d6b8f804e162a0afdda7c794c1dc2b52bc19565bfc64",
+               "f:txn" "fluree:memory://3b4f6c72ffbea9b6c601fb30d1df4934520dfffc20139ece2aecb15b6a610804",
                "f:data" {"f:t" 3}}]
              (->> @(fluree/history ledger {:context        context
                                            :commit-details true
@@ -1024,11 +1024,11 @@
                      (fluree/commit! ledger)
                      (deref))]
         (testing "annotations in commit-details"
-          (is (= [{"f:txn" "fluree:memory://5c54eee1fd6be197402fcd76b035cd6f42b55723f35c294992d76e6eea2cf874"}
-                  {"f:txn" "fluree:memory://6ab2e58c44af9db30feb461c212b3b566a35fdfe92d53b61018eab425ca0c342"
+          (is (= [{"f:txn" "fluree:memory://2c28ed0d4102ff436641911c90f47f0681a9ae251640823f7f361f7e22a57fef"}
+                  {"f:txn" "fluree:memory://cd26d7c28c0a5368694a6b8fbd11c573f0623313c06ae96c15ff016572972568"
                    "f:annotation" {"id" "_:fdb-3" "ex:data" "ok" "ex:originator" "opts"}}
 
-                  {"f:txn" "fluree:memory://22738244510e8c756cbc14eedc3d223e4b66024ffbc3debb856c7d7b063798df"
+                  {"f:txn" "fluree:memory://40ce18ee7469c565297e9b9e348788a891ab1bca8fdfda2116d7a2b6c2c82a86"
                    "f:annotation" {"id" "_:fdb-5" "ex:data" "ok" "ex:originator" "txn"}}]
                  (->> @(fluree/history ledger {:context        context
                                                :commit-details true

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -175,35 +175,35 @@
                                          :where   {:id '?s, '?p '?o}})]
           (is (= [["fluree:db:sha256:byqg2alei2vf5fyre2bjcdc5w5c77ejbg3h4x5gxt72ze6snnbmq"
                    :f/address
-                   "fluree:memory://7aa94e177be8d03a59de148cedbb10c18203fb970451299dee03f9417942e17d"]
+                   "fluree:memory://bbc98e973e03e393b885d68b945dae4405c3271bb990d1aa63d35ae966a61542"]
                   ["fluree:db:sha256:byqg2alei2vf5fyre2bjcdc5w5c77ejbg3h4x5gxt72ze6snnbmq" :f/flakes 11]
                   ["fluree:db:sha256:byqg2alei2vf5fyre2bjcdc5w5c77ejbg3h4x5gxt72ze6snnbmq" :f/size 1082]
                   ["fluree:db:sha256:byqg2alei2vf5fyre2bjcdc5w5c77ejbg3h4x5gxt72ze6snnbmq" :f/t 1]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    "https://www.w3.org/2018/credentials#issuer"
                    "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/address
-                   "fluree:memory://1a6a6f53b417743b76d7c5c700337027689332fe7f1dada341553db9e9c0c28b"]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                   "fluree:memory://0419f95b802208b816adf3d4c0d29c8fafb834870c799e304927c1dcf285c6da"]
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/alias
                    "query/everything"]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/author
                    ""]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/branch
                    "main"]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/data
                    "fluree:db:sha256:byqg2alei2vf5fyre2bjcdc5w5c77ejbg3h4x5gxt72ze6snnbmq"]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/time
                    720000]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/txn
-                   "fluree:memory://144908452423d421230317bbc681f6023039201145ab05336b69c39c3958e39c"]
-                  ["fluree:commit:sha256:bbge6sgyrptodsb6tyqxstpq3vduub6bfd4v2tezbpuwrgug6zdi4"
+                   "fluree:memory://6ef43099853b046e0501e67e8df05a6a1e036a1100c680ab48d1d19b884ec9ea"]
+                  ["fluree:commit:sha256:bbxm3m5wni2bpzzvkvd25m7imjtzhh5bd4ih23k6zbd3slc7e6wbh"
                    :f/v
                    0]
                   [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,14 +28,14 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bkrvlgxear36ne2asqn764os64z37zz7etuhds57vljxaguoqqeh"
+        (is (= "fluree:commit:sha256:bbp7v4fjjamvvqzeb57ov3spebd3rlfksyb3ytvetvfulty3gtnjq"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://9da9356cc9b1cff7c4b7984f4ac1a1b6c02c3d72b54b64538ae79e28192583b0"
+        (is (= "fluree:memory://15ec3030532c28bf25eb9e6e0a7b9bc620d044e596ac67ac970942085fe166a9"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
         (is (= "fluree:db:sha256:byqg2alei2vf5fyre2bjcdc5w5c77ejbg3h4x5gxt72ze6snnbmq"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://7aa94e177be8d03a59de148cedbb10c18203fb970451299dee03f9417942e17d"
+        (is (= "fluree:memory://bbc98e973e03e393b885d68b945dae4405c3271bb990d1aa63d35ae966a61542"
                (get-in db1 [:commit :data :address])))))))


### PR DESCRIPTION
This patch moves our storage implementations to be more content addressed. There were a few places where code outside the storage implementation produced content hashes that were then passed down and used by the storage implementation, and these hashes often didn't match the data that was actually being stored. This patch relies on the storage implementations themselves to produce content hashes and faithfully stores the data under those hashes that was passed to it. All of the paths and addresses are also generated by the storage implementations and not by any code outside of it. This should further separate the storage concern to be behind the storage abstraction and should help these storage records to be truly interchangeable. 

This patch also removes the ".json" suffix from stored files because we can't assume all the files we store will always be json, and it removes `address` from the storage abstraction because the address because the address will only be reliably known after the data is stored, and nothing outside of the storage abstraction should need to generate an address outside of the context of storing data, so they should rely on the `:address` field of the map returned by a successful storage operation. 

I also found one error in legacy nameservice lookups where an async operation was treated as synchronous. I fixed that issue in https://github.com/fluree/db/commit/95ba0919119dfc538ec7bfec31a794e87ecb8aa4 and https://github.com/fluree/db/commit/ff60dd2e091feeb55753b8b90fd0bb3d9d076134