### PR TITLE
Index wasn't updating latest commit t file

### DIFF
--- a/src/clj/fluree/db/json_ld/branch.cljc
+++ b/src/clj/fluree/db/json_ld/branch.cljc
@@ -108,11 +108,14 @@
     (if (= db-t new-t)
       (if (updatable-commit? current-commit new-commit)
         (update-db branch-map db)
-        (throw (ex-info (str "Commit failed, latest committed db is " current-t
-                             " and you are trying to commit at db at t value of: "
-                             new-t ". These should be one apart. Likely db was "
-                             "updated by another user or process.")
-                        {:status 400 :error :db/invalid-commit})))
+        (do
+          (log/warn "Commit update failure.\n  Current commit:" current-commit
+                    "\n  New commit:" new-commit)
+          (throw (ex-info (str "Commit failed, latest committed db is " current-t
+                               " and you are trying to commit at db at t value of: "
+                               new-t ". These should be one apart. Likely db was "
+                               "updated by another user or process.")
+                          {:status 400 :error :db/invalid-commit}))))
       (throw (ex-info (str "Unexpected Error updating commit database. "
                            "New database has an inconsistent t from its commit:"
                            db-t " and " new-t " respectively.")


### PR DESCRIPTION
When an index was in-process but a new commit happens before it finishes, the index lock state updates the latest commit such that when the indexing finishes, it can update that commit.

It was updating the latest commit in the wrong key, therefore once the indexing completed it was always returning the same commit when the indexing started, not the more updated commit if it existed.

This fixes the key location where it updates the latest commit.