### PR TITLE
Close indexing changes-ch in exception condition

### DIFF
--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -535,7 +535,9 @@
               (async/close! changes-ch)))
           (catch* e
                   (log/error e "Error encountered creating index for db: " db ". "
-                             "Indexing stopped."))))
+                             "Indexing stopped.")
+                  (when changes-ch
+                    (async/close! changes-ch)))))
       (when changes-ch ;; if we don't have a lock, nothing to index so close changes-ch if it exists
         (async/close! changes-ch)))
     port))


### PR DESCRIPTION
When an exception condition happens in indexing, it wasn't closing the `changes-ch`.

`changes-ch` is an async channel used to stream indexing files to some process that is distributing them outside of the local environment. We use it in fluree/server to send indexing file updates out to other servers connected to the network.