### PR TITLE
Indexing process state management

### DIFF
--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -518,11 +518,11 @@
                 {:keys [update-commit-fn port]} index-state*]
             ;; in case event listener wanted final indexed db, put on established port
             (when (fn? update-commit-fn)
-              (let [result (<! (update-commit-fn indexed-db))]
+              (let [result (<! (update-commit-fn indexed-db))] ;; will return 'nil if commit not updated
                 (when (util/exception? result)
                   (log/error result "Exception updating commit with new index: " (ex-message result))
                   (throw result))
-                (when changes-ch
+                (when (and changes-ch result)
                   (>! changes-ch {:event :new-commit
                                   :data  result}))))
 

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -191,8 +191,12 @@
    (iri->sid iri default-namespaces))
   ([iri namespaces]
    (let [[ns nme] (decompose iri)]
-     (when-let [ns-code (get namespaces ns)]
-       (->sid ns-code nme)))))
+     (if-let [ns-code (get namespaces ns)]
+       (->sid ns-code nme)
+       (throw (ex-info (str "Unexpected error: Namespace not registered in the database "
+                            "for iri: " iri ".")
+                       {:status 500
+                        :error :db/unexpected-error}))))))
 
 (defn next-namespace-code
   [namespaces]

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -376,3 +376,106 @@
             (assoc :pred pred-map)
             (update-with db t vocab-flakes)
             (add-pred-datatypes (filterv #(> (count %) 1) preds)))))))
+
+;; schema serialization
+(def ^:const serialized-pred-keys [:id :datatype :subclassOf :parentProps :childProps])
+(def ^:const serialized-pred-keys-reverse (reverse serialized-pred-keys))
+
+(defn schema-tuple
+  [pred-map]
+  (reduce
+   (fn [acc next-key]
+     (let [next-val (get pred-map next-key)]
+       (cond
+         (set? next-val)
+         (if (seq next-val) ;; non-empty?
+           (conj acc
+                 (mapv #(if (iri/sid? %)
+                          (iri/serialize-sid %)
+                          %)
+                       next-val))
+           (if (seq acc) ;; if 'acc' is still empty, keep it that if nothing to add
+             (conj acc nil)
+             acc))
+
+         (iri/sid? next-val)
+         (conj acc (iri/serialize-sid next-val))
+
+         (nil? next-val)
+         (if (empty? acc)
+           acc
+           (conj acc nil))
+
+         :else
+         (conj acc next-val))))
+   (list)
+   serialized-pred-keys-reverse))
+
+(defn serialize-schema
+  "Serializes the schema map to a semi-compact json form which can be stored
+  in the index root file, allowing fast reification of the schema map without
+  requiring database queries to do so."
+  [{:keys [t pred] :as _db-schema}]
+  (let [pred-keys (mapv name serialized-pred-keys)
+        pred-vals (->> pred
+                       (filter #(string? (key %))) ;; every pred map is duplicated for both keys iri, and sid - keep only 1
+                       vals
+                       (mapv schema-tuple))]
+    {"t"    t
+     "pred" {"keys" pred-keys
+             "vals" pred-vals}}))
+
+(defn deserialize-pred-tuple
+  "Takes list of keys and tuples containing values
+  and turns them into a map with the respective keys and tuples"
+  [namespace-codes positions pred-vals]
+  (let [base-map base-property-map
+        max-idx  (dec (count pred-vals))]
+    (loop [[[idx k] & r] positions
+           acc base-map]
+      (let [acc*  (if-let [raw-val (nth pred-vals idx)]
+                    (case k
+                      :id (let [sid (iri/deserialize-sid raw-val)]
+                            (assoc acc :id sid
+                                       :iri (iri/sid->iri sid namespace-codes)))
+                      :datatype (assoc acc :datatype (iri/deserialize-sid raw-val))
+                      :subclassOf (assoc acc :subclassOf (into (:subclassOf base-map) (map iri/deserialize-sid raw-val)))
+                      :parentProps (assoc acc :parentProps (into (:parentProps base-map) (map iri/deserialize-sid raw-val)))
+                      :childProps (assoc acc :childProps (into (:childProps base-map) (map iri/deserialize-sid raw-val)))
+                      ;; else
+                      (throw (ex-info (str "Cannot deserialize schema from index root. "
+                                           "Unrecognized schema property key found: " k
+                                           "which contains a value of: " raw-val)
+                                      {:status 500
+                                       :error  :db/invalid-index})))
+                    acc)]
+        (if (= idx max-idx)
+          acc*
+          (recur r acc*))))))
+
+(defn deserialize-preds
+  [namespace-codes pred-tuples]
+  (let [pred-keys      (mapv keyword (get pred-tuples "keys"))
+        pred-positions (map-indexed vector pred-keys)
+        pred-vals      (get pred-tuples "vals")
+        pred-maps      (map
+                        (partial deserialize-pred-tuple namespace-codes pred-positions)
+                        pred-vals)]
+    (reduce
+     (fn [acc pred-map]
+       (assoc acc (:id pred-map) pred-map
+                  (:iri pred-map) pred-map))
+     {}
+     pred-maps)))
+
+(defn deserialize-schema
+  "Deserializes the schema map from a semi-compact json."
+  [serialized-schema namespace-codes]
+  (let [{pred-tuples "pred"
+         t           "t"} serialized-schema
+        pred (deserialize-preds namespace-codes pred-tuples)]
+    (-> (base-schema)
+        (assoc :t t
+               :pred pred)
+        (refresh-subclasses))))
+

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -73,15 +73,19 @@
                      const/$owl:DatatypeProperty
                      const/$owl:ObjectProperty})
 
+(def ^:const base-property-map
+  {:id          nil
+   :iri         nil
+   :subclassOf  #{}
+   :parentProps #{}
+   :childProps  #{}
+   :datatype    nil})
+
 (defn initial-property-map
   [db sid]
   (let [iri (iri/decode-sid db sid)]
-    {:id          sid
-     :iri         iri
-     :subclassOf  #{}
-     :parentProps #{}
-     :childProps  #{}
-     :datatype    nil}))
+    (assoc base-property-map :id sid
+                             :iri iri)))
 
 (defn add-subclass
   [prop-map subclass]

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -60,11 +60,11 @@
   [db-root]
   (let [{:keys [spot post opst tspo]} db-root]
     (-> db-root
+        (update :namespace-codes numerize-keys)
         (assoc :spot (deserialize-child-node spot)
                :post (deserialize-child-node post)
                :opst (deserialize-child-node opst)
-               :tspo (deserialize-child-node tspo))
-        (update :namespace-codes numerize-keys))))
+               :tspo (deserialize-child-node tspo)))))
 
 
 (defn- deserialize-branch-node

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -42,15 +42,9 @@
          :first (some-> child-node :first deserialize-flake)
          :rhs   (some-> child-node :rhs deserialize-flake)))
 
-
-(defn parse-int
-  [x]
-  #?(:clj (Integer/parseInt x)
-     :cljs (js/parseInt x)))
-
 (defn keyword->int
   [k]
-  (-> k name parse-int))
+  (-> k name util/str->int))
 
 (defn numerize-keys
   "Convert the keys of the provided map `m` to integers. Assumes that the keys are
@@ -64,14 +58,13 @@
 (defn- deserialize-db-root
   "Assumes all data comes in as keywordized JSON."
   [db-root]
-  (let [{:keys [v spot post opst tspo]} db-root]
-    (cond-> (assoc db-root :spot (deserialize-child-node spot)
-                           :post (deserialize-child-node post)
-                           :opst (deserialize-child-node opst)
-                           :tspo (deserialize-child-node tspo))
-
-            ;; following only needed for v0 of db-root
-            (nil? v) (update :namespace-codes numerize-keys))))
+  (let [{:keys [spot post opst tspo]} db-root]
+    (-> db-root
+        (assoc :spot (deserialize-child-node spot)
+               :post (deserialize-child-node post)
+               :opst (deserialize-child-node opst)
+               :tspo (deserialize-child-node tspo))
+        (update :namespace-codes numerize-keys))))
 
 
 (defn- deserialize-branch-node

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -64,13 +64,15 @@
 (defn- deserialize-db-root
   "Assumes all data comes in as keywordized JSON."
   [db-root]
-  (let [{:keys [spot post opst tspo]} db-root]
-    (-> db-root
-        (update :namespace-codes numerize-keys)
-        (assoc :spot   (deserialize-child-node spot)
-               :post   (deserialize-child-node post)
-               :opst   (deserialize-child-node opst)
-               :tspo   (deserialize-child-node tspo)))))
+  (let [{:keys [v spot post opst tspo]} db-root]
+    (cond-> (assoc db-root :spot (deserialize-child-node spot)
+                           :post (deserialize-child-node post)
+                           :opst (deserialize-child-node opst)
+                           :tspo (deserialize-child-node tspo))
+
+            ;; following only needed for v0 of db-root
+            (nil? v) (update :namespace-codes numerize-keys))))
+
 
 (defn- deserialize-branch-node
   [branch]

--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -206,7 +206,7 @@
   (reduce-kv
     (fn [acc k v]
       (if (keyword? k)
-        (assoc acc (name k) v)
+        (assoc acc (subs (str k) 1) v)
         (assoc acc k v)))
     {} m))
 


### PR DESCRIPTION
This is a temporary fix to solve the problem of bulk loads under high server demand. It should be replaced by work being done by @zonotope which eliminates ever attempting to update a commit file.

If an index finishes, it attempts to update the latest commit. In a high load scenario, by the time it can update the latest commit there is a new commit. This has some bad effects.

We now have a temporary atom state that maintains the latest index, the two main process changes are:
1) Upon index completion, that index atom is updated
2) When writing new commits, that index atom is always consulted for the latest index files
3) When updating an existing commit with a new index, before writing a check is performed if there have been any newer commits and if so, it no longer will attempt an update at all

While this gets things working fairly reliably, there are still some race conditions that exist and this is not by iteself a permanent fix. At the point we no longer try to update commits it is irrelevant however.