### PR TITLE
Fix/db sid load

### DIFF
--- a/dev/commit_explore.clj
+++ b/dev/commit_explore.clj
@@ -1,0 +1,67 @@
+(ns commit-explore
+  (:require [clojure.java.io :as io]
+            [fluree.db.util.json :as json]))
+
+;; helper functions that allow you to find/view commits sitting on disk for
+;; debugging purposes
+
+
+(defn list-files
+  "List all files in a directory"
+  [source-dir]
+  (->> (file-seq (io/file source-dir))
+       (filter #(.isFile %))
+       (map #(.getName %))))
+
+(defn parsed-files
+  "Lazily returns every file in a directory as a parsed json object"
+  [source-dir]
+  (let [files (list-files source-dir)]
+    (map #(json/parse (slurp (io/file source-dir %)) false) files)))
+
+(defn data-file?
+  "Truthy if the parsed file is a data file (@type = f:DB)"
+  [commit]
+  (= ["f:DB"] (get commit "@type")))
+
+(defn commit-file?
+  "Truthy if the parsed file is a commit file (@type = f:Commit)"
+  [commit]
+  (= ["Commit"] (get commit "type")))
+
+(defn only-data-files
+  "Lazily filters all files to only return those that are data/db files."
+  [commits]
+  (filter data-file? commits))
+
+(defn only-commit-files
+  "Lazily filters all files to only return those that are commit files."
+  [commits]
+  (filter commit-file? commits))
+
+(defn for-t
+  "Returns all parsed files to only return those that are from the
+  provided 't' value (should be two - one commit and one data file)"
+  [t commits]
+  (filter #(if (commit-file? %)
+             (= t (get-in % ["data" "t"]))
+             (= t (get % "f:t")))
+          commits))
+
+
+
+
+(comment
+
+ (def source-dir "data/redshift/test/main/commit")
+ (list-files source-dir)
+
+ (->> (parsed-files source-dir)
+      (only-commit-files)
+      first)
+
+ (->> (parsed-files source-dir)
+      (for-t 156)
+      only-commit-files)
+
+ )

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -1,7 +1,8 @@
 (ns fluree.db.json-ld.commit-data
   (:require [fluree.crypto :as crypto]
             [fluree.db.flake :as flake]
-            [fluree.db.util.core :as util :refer [get-first get-first-value]]
+            [fluree.db.util.core :as util :refer [get-first get-first-value try* catch*]]
+            [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.iri :as iri]
@@ -360,22 +361,29 @@
    (update-novelty db add []))
 
   ([db add rem]
-   (let [ref-add     (ref-flakes add)
-         ref-rem     (ref-flakes rem)
-         flake-count (cond-> 0
-                             add (+ (count add))
-                             rem (- (count rem)))
-         flake-size  (cond-> 0
-                             add (+ (flake/size-bytes add))
-                             rem (- (flake/size-bytes rem)))]
-     (-> db
-         (update-in [:novelty :spot] flake/revise add rem)
-         (update-in [:novelty :post] flake/revise add rem)
-         (update-in [:novelty :opst] flake/revise ref-add ref-rem)
-         (update-in [:novelty :tspo] flake/revise add rem)
-         (update-in [:novelty :size] + flake-size)
-         (update-in [:stats :size] + flake-size)
-         (update-in [:stats :flakes] + flake-count)))))
+   (try*
+    (let [ref-add     (ref-flakes add)
+          ref-rem     (ref-flakes rem)
+          flake-count (cond-> 0
+                              add (+ (count add))
+                              rem (- (count rem)))
+          flake-size  (cond-> 0
+                              add (+ (flake/size-bytes add))
+                              rem (- (flake/size-bytes rem)))]
+      (-> db
+          (update-in [:novelty :spot] flake/revise add rem)
+          (update-in [:novelty :post] flake/revise add rem)
+          (update-in [:novelty :opst] flake/revise ref-add ref-rem)
+          (update-in [:novelty :tspo] flake/revise add rem)
+          (update-in [:novelty :size] + flake-size)
+          (update-in [:stats :size] + flake-size)
+          (update-in [:stats :flakes] + flake-count)))
+    (catch* e
+            (log/error (str "Update novelty unexpected error while attempting to updated db: "
+                            (pr-str db) " due to exception: " (ex-message e))
+                       {:add-flakes add
+                        :rem-flakes rem})
+            (throw e)))))
 
 (defn add-tt-id
   "Associates a unique tt-id for any in-memory staged db in their index roots.

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -52,13 +52,13 @@
           retracted-flakes (reify/retract-flakes ns-mapping t-new retract)
           db*              (set-namespaces db ns-mapping)
 
-          {:keys [previous issuer message] :as commit-metadata}
+          {:keys [previous issuer message data] :as commit-metadata}
           (commit-data/json-ld->map commit db*)
 
           commit-id          (:id commit-metadata)
           commit-sid         (iri/encode-iri db* commit-id)
           [prev-commit _]    (some->> previous :address (reify/read-commit conn) <?)
-          db-sid             (iri/encode-iri db* alias)
+          db-sid             (iri/encode-iri db* (:id data))
           metadata-flakes    (commit-data/commit-metadata-flakes commit-metadata
                                                                  t-new commit-sid db-sid)
           previous-id        (when prev-commit (:id prev-commit))

--- a/src/clj/fluree/db/json_ld/reify.cljc
+++ b/src/clj/fluree/db/json_ld/reify.cljc
@@ -302,13 +302,13 @@
           retract          (db-retract db-data)
           retracted-flakes (retract-flakes db t-new retract)
 
-          {:keys [previous issuer message] :as commit-metadata}
+          {:keys [previous issuer message data] :as commit-metadata}
           (commit-data/json-ld->map commit db)
 
           commit-id          (:id commit-metadata)
           commit-sid         (iri/encode-iri db commit-id)
           [prev-commit _]    (some->> previous :address (read-commit conn) <?)
-          db-sid             (iri/encode-iri db alias)
+          db-sid             (iri/encode-iri db (:id data))
           metadata-flakes    (commit-data/commit-metadata-flakes commit-metadata
                                                                  t-new commit-sid db-sid)
           previous-id        (when prev-commit (:id prev-commit))


### PR DESCRIPTION
When generating commit metadata flakes, the `db-id` was trying to use the db's alias instead of the `@id` of the data file in the commit in two of the three places it is used.

This resulted in `nil` sids, and while it could load in simple dbs, once indexed we'd start getting errors.

This uses @id instead of alias and all three locations are consistent.

Also made change to log out merge flake exceptions, even if verbose. This is a place many `nil` flake issues are caught as it throws when trying to create a db 'size' calc on `nil`
