### PR TITLE
Add extra error message context for fn executions

### DIFF
--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -398,7 +398,7 @@
                       allowed-scalar-fns)]
     (if (contains? allowed-fns sym)
       (let [qsym (get qualified-symbols sym sym)]
-        (log/debug "qualified symbol" sym "as" qsym)
+        (log/trace "qualified symbol" sym "as" qsym)
         qsym)
       (let [err-msg (if (and (not allow-aggregates?)
                              (contains? allowed-aggregate-fns sym))
@@ -442,7 +442,7 @@
                            (log/trace "fn bindings:" (quote ~bdg))
                            (let ~bdg
                              ~qualified-code))]
-     (log/debug "compiled fn:" fn-code)
+     (log/trace "compiled fn:" fn-code)
      (eval fn-code))))
 
 (defn compile-filter

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -433,7 +433,6 @@
         ex-msg (or (ex-message e)
                    ;; note: NullPointerException is common but has no ex-message, create one
                    (let [ex-type (str (type e))] ;; attempt to make JS compatible
-                     (log/warn "ex-type is: " ex-type)
                      (if (= ex-type "class java.lang.NullPointerException")
                        "Variable has null value, cannot apply filter"
                        "Unknown error")))

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.query.exec.where
   (:require [fluree.db.query.range :as query-range]
             [clojure.core.async :as async :refer [>! go]]
+            [clojure.string :as str]
             [fluree.db.flake :as flake]
             [fluree.db.fuel :as fuel]
             [fluree.db.index :as index]
@@ -425,6 +426,26 @@
         (-match-class active-graph fuel-tracker solution triple error-ch)))
     nil-channel))
 
+(defn filter-exception
+  "Reformats raw filter exception to try to provide more useful feedback."
+  [e solution pattern]
+  (let [fn-str (->> (pattern-data pattern) meta :fns (str/join " "))
+        ex-msg (or (ex-message e)
+                   ;; note: NullPointerException is common but has no ex-message, create one
+                   (let [ex-type (str (type e))] ;; attempt to make JS compatible
+                     (log/warn "ex-type is: " ex-type)
+                     (if (= ex-type "class java.lang.NullPointerException")
+                       "Variable has null value, cannot apply filter"
+                       "Unknown error")))
+        e* (ex-info (str "Exception in statement '[filter " fn-str "]': " ex-msg)
+                    {:status   400
+                     :error    :db/invalid-query
+                     :function  fn-str
+                     :solution solution}
+                    e)]
+    (log/warn (ex-message e*))
+    e*))
+
 (defmethod match-pattern :filter
   [_ds _fuel-tracker solution pattern error-ch]
   (go
@@ -433,8 +454,7 @@
         (when (f solution)
           solution))
       (catch* e
-              (log/error e "Error applying filter")
-              (>! error-ch e)))))
+              (>! error-ch (filter-exception e solution pattern))))))
 
 (defn with-constraint
   "Return a channel of all solutions from the data set `ds` that extend from the

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -436,12 +436,10 @@
                      (if (= ex-type "class java.lang.NullPointerException")
                        "Variable has null value, cannot apply filter"
                        "Unknown error")))
-        e* (ex-info (str "Exception in statement '[filter " fn-str "]': " ex-msg)
-                    {:status   400
-                     :error    :db/invalid-query
-                     :function  fn-str
-                     :solution solution}
-                    e)]
+        e*     (ex-info (str "Exception in statement '[filter " fn-str "]': " ex-msg)
+                        {:status 400
+                         :error  :db/invalid-query}
+                        e)]
     (log/warn (ex-message e*))
     e*))
 

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -428,8 +428,8 @@
 
 (defn filter-exception
   "Reformats raw filter exception to try to provide more useful feedback."
-  [e solution pattern]
-  (let [fn-str (->> (pattern-data pattern) meta :fns (str/join " "))
+  [e solution f]
+  (let [fn-str (->> f meta :fns (str/join " "))
         ex-msg (or (ex-message e)
                    ;; note: NullPointerException is common but has no ex-message, create one
                    (let [ex-type (str (type e))] ;; attempt to make JS compatible
@@ -448,12 +448,11 @@
 (defmethod match-pattern :filter
   [_ds _fuel-tracker solution pattern error-ch]
   (go
-    (try*
-      (let [f (pattern-data pattern)]
-        (when (f solution)
-          solution))
-      (catch* e
-              (>! error-ch (filter-exception e solution pattern))))))
+    (let [f (pattern-data pattern)]
+      (try*
+       (when (f solution)
+         solution)
+       (catch* e (>! error-ch (filter-exception e solution f)))))))
 
 (defn with-constraint
   "Return a channel of all solutions from the data set `ds` that extend from the

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -385,7 +385,7 @@
                (map parse-code)
                (map eval/compile)
                (apply every-pred))]
-    [(where/->pattern :filter f)]))
+    [(where/->pattern :filter (with-meta f {:fns codes}))]))
 
 (defmethod parse-pattern :union
   [[_ & unions] vars context]

--- a/src/clj/fluree/db/query/range.cljc
+++ b/src/clj/fluree/db/query/range.cljc
@@ -98,7 +98,7 @@
 (defn authorize-flake-exception
   "Wraps upstream exception and logs out a warning message"
   [e db flake]
-  (let [e* (ex-info (str "Error authorizing flake in db "
+  (let [e* (ex-info (str "Policy exception authorizing Flake in "
                          (:alias db) "?t=" (:t db)
                          ". " (ex-message e))
                     {:error  :db/policy-exception


### PR DESCRIPTION
This adds metadata to compile functions (e.g. filter functions) that can be used for enhanced exception reporting to users when errors occur executing the functions.

Some special handling put in for null pointer exceptions, which are common in math functions.