### PR TITLE
allow ordering by `as` select bindings

### DIFF
--- a/src/clj/fluree/db/query/exec.cljc
+++ b/src/clj/fluree/db/query/exec.cljc
@@ -52,6 +52,7 @@
           result-ch (->> (where/search ds q fuel-tracker error-ch)
                          (group/combine q)
                          (having/filter q error-ch)
+                         (select/modify q)
                          (order/arrange q)
                          (select/format ds q fuel-tracker error-ch)
                          (drop-offset q)

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -25,4 +25,14 @@
                        :where   '{:schema/name ?name}}
               subject @(fluree/query db qry)]
           (is (= [[4]] subject)
-              "aggregates bindings for all results"))))))
+              "aggregates bindings for all results")))
+      (testing "with ordering"
+        (let [qry {:context  [test-utils/default-context
+                              {:ex "http://example.org/ns/"}]
+                   :where    '{:schema/name ?name
+                               :ex/favNums  ?favNums}
+                   :group-by '?name
+                   :order-by '?count
+                   :select   '[?name (as (count ?favNums) ?count)]}]
+          (is (= [["Brian" 1] ["Cam" 2] ["Liam" 2] ["Alice" 3]]
+                 @(fluree/query db qry))))))))


### PR DESCRIPTION
This fixes a bug whereby trying to `order-by` a variable that is bound in the select clause doesn't work.

When we execute a query, we process it in this order:
- `where/search`
- `group/combine`
- `having/filter`
- `order/arrange`
- `select/format`

The problem is that the aggregate vars only appear in the select clause, but by the time we add that binding to the solution, the solutions are already sorted - the binding just isn't available to sort by.

Fortunately, we already had all the necessary code written, I just needed to rearrange it. `select/format` first filters out any `SolutionModifier` Selectors, and then applies them in a transducer, which is then piped into the formatting pipeline.

All I had to do was factor out the modification xformer into a new function and then call that before order/arrange. So now it looks like this:
- `where/search`
- `group/combine`
- `having/filter`
- `select/modify`
- `order/arrange`
- `select/format`
