### PR TITLE
translate SPARQL EXISTS/NOT EXISTS filters into FQL

### DIFF
--- a/resources/sparql.bnf
+++ b/resources/sparql.bnf
@@ -192,7 +192,7 @@ RegexExpression   ::=   <'REGEX'> <'('> Expression <','> Expression ( <','> Expr
 SubstringExpression   ::=   <'SUBSTR'> <'('> Expression <','> Expression ( <','> Expression )? <')'>
 StrReplaceExpression    ::=   <'REPLACE'> <'('> Expression <','> Expression <','> Expression ( <','> Expression )? <')'>
 ExistsFunc    ::=   <'EXISTS'> GroupGraphPattern
-NotExistsFunc   ::=   <'NOT'> <'EXISTS'> GroupGraphPattern
+NotExistsFunc   ::=   <'NOT'> WS <'EXISTS'> GroupGraphPattern
 Aggregate   ::=     'COUNT' WS <'('> WS 'DISTINCT'? WS ( '*' | Expression ) WS <')'> WS
 | 'SUM' WS <'('> WS 'DISTINCT'? Expression <')'>
 | 'MIN' <'('>  WS 'DISTINCT'? Expression <')'>

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -183,7 +183,27 @@
               {"@id" "?s", "schema:name" "?name"}
               [:filter ["(regex ?name \"^Jon\" \"i\")"]]]
              where)
-          "filter by regex call")))
+          "filter by regex call"))
+    (let [query "SELECT ?s
+                 WHERE {
+                   ?s ?p ?o
+                   FILTER EXISTS { ?s ex:name \"Larry\" }
+                 }"
+          {:keys [where]} (sparql/->fql query)]
+      (is (= [{"@id" "?s" "?p" "?o"}
+              ["exists" [{"@id" "?s" "ex:name" "Larry"}]]]
+             where)
+          "EXISTS expression parsing"))
+    (let [query "SELECT ?s
+                 WHERE {
+                   ?s ?p ?o
+                   FILTER NOT EXISTS { ?s ex:name \"Larry\" }
+                 }"
+          {:keys [where]} (sparql/->fql query)]
+      (is (= [{"@id" "?s" "?p" "?o"}
+              ["not-exists" [{"@id" "?s" "ex:name" "Larry"}]]]
+             where)
+          "NOT EXISTS expression parsing")))
   (testing "OPTIONAL"
     (let [query "SELECT ?handle ?num
                  WHERE {?person person:handle ?handle.
@@ -402,7 +422,7 @@
                  }"
           {:keys [where]} (sparql/->fql query)]
       (is (= [{"@id" "?g", "dc:publisher" "?who"}
-        [:graph "?g" [{"@id" "?x", "foaf:mbox" "?mbox"}]]]
+              [:graph "?g" [{"@id" "?x", "foaf:mbox" "?mbox"}]]]
              where)))))
 
 (deftest parse-prefixes


### PR DESCRIPTION
Adds support for translating SPARQL EXISTS and NOT EXISTS filters into FQL.