### PR TITLE
Fix irregular deletions after indexing

### DIFF
--- a/src/clj/fluree/db/db/json_ld.cljc
+++ b/src/clj/fluree/db/db/json_ld.cljc
@@ -363,6 +363,10 @@
           db        (assoc file-data "f:address" db-address)]
       (json-ld/expand db))))
 
+(defn get-max-ns-code
+  [ns-codes]
+  (->> ns-codes keys (apply max)))
+
 (defn with-namespaces
   [{:keys [namespaces max-namespace-code] :as db} new-namespaces]
   (let [new-ns-map          (into namespaces
@@ -372,7 +376,7 @@
                                                    [ns ns-code])))
                                   new-namespaces)
         new-ns-codes        (map-invert new-ns-map)
-        max-namespace-code* (apply max (vals new-ns-map))]
+        max-namespace-code* (get-max-ns-code new-ns-codes)]
     (assoc db
            :namespaces new-ns-map
            :namespace-codes new-ns-codes
@@ -615,8 +619,8 @@
           assert             (db-assert db-data)
           nses               (map :value
                                   (get db-data const/iri-namespaces))
-          _                  (log/debug "merge-commit new namespaces:" nses)
-          _                  (log/debug "db max-namespace-code:"
+          _                  (log/trace "merge-commit new namespaces:" nses)
+          _                  (log/trace "db max-namespace-code:"
                                         (:max-namespace-code db))
           db*                (with-namespaces db nses)
           asserted-flakes    (assert-flakes db* t-new assert)
@@ -812,10 +816,6 @@
      :namespaces      iri/default-namespaces
      :namespace-codes iri/default-namespace-codes
      :schema          (vocab/base-schema)}))
-
-(defn get-max-ns-code
-  [ns-codes]
-  (->> ns-codes keys (apply max)))
 
 (defn load-novelty
   [conn indexed-db index-t commit-jsonld]

--- a/src/clj/fluree/db/json_ld/branch.cljc
+++ b/src/clj/fluree/db/json_ld/branch.cljc
@@ -2,13 +2,11 @@
   (:require [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.indexer :as indexer]
             [fluree.json-ld :as json-ld]
-            [fluree.db.db.json-ld :as jld-db]
             [fluree.db.database.async :as async-db]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.async :refer [<?]]
             [fluree.db.util.log :as log :include-macros true]
-            [clojure.core.async :as async :refer [<! go-loop]]
-            [fluree.db.index :as index]))
+            [clojure.core.async :as async :refer [<! go-loop]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -196,7 +196,7 @@
           new-commit      (commit-data/new-db-commit-map base-commit-map)
           keypair         (select-keys opts* [:did :private])
 
-          {:keys [commit-map write-result] :as commit-write-map}
+          {:keys [commit-map commit-write-result] :as commit-write-map}
           (<? (write-commit conn alias keypair new-commit))
 
           db  (formalize-commit staged-db commit-map)
@@ -206,7 +206,7 @@
 
       (if file-data?
         {:data-file-meta   data-write-result
-         :commit-file-meta write-result
+         :commit-file-meta commit-write-result
          :db               db*}
         db*))))
 

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -13,7 +13,7 @@
 
 (defn deserialize-meta
   [serialized-meta]
-  (util/keywordize-keys serialized-meta))
+  (some-> serialized-meta util/keywordize-keys))
 
 (defn subject-reference?
   [dt]

--- a/src/clj/fluree/db/storage.cljc
+++ b/src/clj/fluree/db/storage.cljc
@@ -34,6 +34,10 @@
      :method method
      :local  local}))
 
+(defn parse-local-path
+  [address]
+  (-> address parse-address :local))
+
 (defprotocol Store
   (write [store k v] "Writes `v` to Store associated with `k`. Returns value's address.")
   (exists? [store address] "Returns true when address exists in Store.")

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -173,49 +173,49 @@
                                                    {:ex "http://example.org/ns/"}]
                                          :select  ['?s '?p '?o]
                                          :where   {:id '?s, '?p '?o}})]
-          (is (=[["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
+          (is (=[["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
                   :f/address
-                  "fluree:memory://1066be3c23dc5635881c1b4ce74cd944fc96b25556bc9508f4a5c1843a4421af"]
-                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
+                  "fluree:memory://8afce856ee1ed55d175491b629837824fcb27060fd54ea61bbd0264043404355"]
+                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
                   :f/flakes
                   11]
-                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
+                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
                   :f/previous
                   "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"]
-                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
+                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
                   :f/size
                   1082]
-                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
+                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
                   :f/t
                   1]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   "https://www.w3.org/2018/credentials#issuer"
                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/address
-                  "fluree:memory://6a39be21ed7e25ca8f8f7b93ed02b5d53d060bea043471c4e14086f09af9f346"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                  "fluree:memory://dab2f5f1a5a6b37758eee01fabaf3a6bc3c1d37c4e445ce44d08da26bc680c20"]
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/alias
                   "query/everything"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/author
                   ""]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/branch
                   "main"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/data
-                  "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                  "fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"]
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/previous
                   "fluree:commit:sha256:bvvou3uvnd6ffhehsrw23mw4w3fux5jbpacko2ecosb2nzxkfu5v"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/time
                   720000]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/txn
                   "fluree:memory://6ef43099853b046e0501e67e8df05a6a1e036a1100c680ab48d1d19b884ec9ea"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
                   :f/v
                   0]
                  [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,14 +28,14 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bc4pgf733mfhelp4ueeciwbfftthr4juvh2btondbmzjbvf6zpf5"
+        (is (= "fluree:commit:sha256:bfhquuwpmivy6cj4vw3rxelr5psy63jm4rsa3jw7owdxt4mfnpxu"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://10e1db9dc617a4d4b01a3fbdea6eb97a52f4173a8b01c2cdbb66ec05f90a41c7"
+        (is (= "fluree:memory://45b10ddf1fa05e1ccb6253c772386bef62651ac021b55bbe0863bec5e1db75fb"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
-        (is (= "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
+        (is (= "fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://1066be3c23dc5635881c1b4ce74cd944fc96b25556bc9508f4a5c1843a4421af"
+        (is (= "fluree:memory://8afce856ee1ed55d175491b629837824fcb27060fd54ea61bbd0264043404355"
                (get-in db1 [:commit :data :address])))))))

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -5,8 +5,7 @@
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.log :as log]
             [fluree.db.json-ld.iri :as iri]
-            #?@(:cljs [[clojure.core.async.interop :refer [<p!]]])
-            [clojure.string :as str]))
+            #?@(:cljs [[clojure.core.async.interop :refer [<p!]]])))
 
 (def default-context
   {:id     "@id"


### PR DESCRIPTION
There were two issues that prevented delete (and other) transactions from correctly modifying data and/or queries from returning accurate results after data was modified. 

The first issue stemmed from the `max-namespace-code` field on `JsonLdDb` records not being incremented after a transaction. This caused new namespace codes to be generated for previously encountered namespaces, and left flakes that should have had the same subject id (or other iri flake components) with different subject ids because there were two different namespace codes for the same namespace. This was fixed in 311f375.

The second issue stemmed from our flake deserialization process converting `nil` into `{}` for the flake meta component. That meant that flakes in novelty could have `nil` as the meta value, but `{}` when they move from novelty to the index nodes. This caused queries to return inconsistent results because retracting flakes in novelty could not be linked to their assertions in the index nodes. This was fixed in 32c799c.

The rest of these changes are a bit of cleanup and debugging aides. 