### PR TITLE
Stop throwing error when namespace hasn't been registered

### DIFF
--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -191,12 +191,8 @@
    (iri->sid iri default-namespaces))
   ([iri namespaces]
    (let [[ns nme] (decompose iri)]
-     (if-let [ns-code (get namespaces ns)]
-       (->sid ns-code nme)
-       (throw (ex-info (str "Unexpected error: Namespace not registered in the database "
-                            "for iri: " iri ".")
-                       {:status 500
-                        :error :db/unexpected-error}))))))
+     (when-let [ns-code (get namespaces ns)]
+       (->sid ns-code nme)))))
 
 (defn next-namespace-code
   [namespaces]


### PR DESCRIPTION
Throwing errors in this case causes queries for iris with namespaces that haven't previously been registered to throw an error while queries for iris that have registered namespaces but don't exist in the database return an empty result set. These two types of queries should behave the same because they are both querying for non-existent iris.