### PR TITLE
Set max namespace code at commit instead of stage

### DIFF
--- a/src/clj/fluree/db/db/json_ld.cljc
+++ b/src/clj/fluree/db/db/json_ld.cljc
@@ -828,8 +828,7 @@
      (let [root-map    (if-let [{:keys [address]} (:index commit-map)]
                          (<? (index-storage/read-db-root conn address))
                          (genesis-root-map ledger-alias))
-           max-ns-code (max iri/last-default-code
-                            (-> root-map :namespace-codes iri/get-max-namespace-code))
+           max-ns-code (-> root-map :namespace-codes iri/get-max-namespace-code)
            indexed-db  (-> root-map
                            (assoc :conn conn
                                   :alias ledger-alias

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -194,6 +194,10 @@
      (when-let [ns-code (get namespaces ns)]
        (->sid ns-code nme)))))
 
+(defn get-max-namespace-code
+  [ns-codes]
+  (->> ns-codes keys (apply max)))
+
 (defn next-namespace-code
   [namespaces]
   (->> namespaces

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -196,14 +196,11 @@
 
 (defn get-max-namespace-code
   [ns-codes]
-  (->> ns-codes keys (apply max)))
+  (->> ns-codes keys (apply max last-default-code)))
 
 (defn next-namespace-code
-  [namespaces]
-  (->> namespaces
-       vals
-       (apply max last-default-code)
-       inc))
+  [ns-codes]
+  (-> ns-codes get-max-namespace-code inc))
 
 (def type-sid
   (iri->sid "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async :refer [<!]]
             [fluree.db.ledger :as ledger]
             [fluree.db.db.json-ld :as jld-db]
+            [fluree.db.json-ld.iri :as iri]
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.json-ld.transact :as transact]
             [fluree.db.did :as did]
@@ -153,11 +154,13 @@
 
 (defn formalize-commit
   [{prev-commit :commit :as staged-db} new-commit]
-  (-> staged-db
-      (update :staged empty)
-      (assoc :commit new-commit
-             :prev-commit prev-commit)
-      (commit-data/add-commit-flakes prev-commit)))
+  (let [max-ns-code (-> staged-db :namespace-codes iri/get-max-namespace-code)]
+    (-> staged-db
+        (update :staged empty)
+        (assoc :commit new-commit
+               :prev-commit prev-commit
+               :max-namespace-code max-ns-code)
+        (commit-data/add-commit-flakes prev-commit))))
 
 (defn commit!
   "Finds all uncommitted transactions and wraps them in a Commit document as the subject

--- a/src/clj/fluree/db/query/exec/update.cljc
+++ b/src/clj/fluree/db/query/exec/update.cljc
@@ -45,10 +45,11 @@
 
 (defn ensure-namespace
   [db ns]
-  (let [nses (:namespaces db)]
+  (let [nses     (:namespaces db)
+        ns-codes (:namespace-codes db)]
     (if (contains? nses ns)
       db
-      (let [new-ns-code (iri/next-namespace-code nses)]
+      (let [new-ns-code (iri/next-namespace-code ns-codes)]
         (-> db
             (update :namespaces assoc ns new-ns-code)
             (update :namespace-codes assoc new-ns-code ns))))))

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -173,49 +173,49 @@
                                                    {:ex "http://example.org/ns/"}]
                                          :select  ['?s '?p '?o]
                                          :where   {:id '?s, '?p '?o}})]
-          (is (=[["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
+          (is (=[["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/address
-                  "fluree:memory://8afce856ee1ed55d175491b629837824fcb27060fd54ea61bbd0264043404355"]
-                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
+                  "fluree:memory://1066be3c23dc5635881c1b4ce74cd944fc96b25556bc9508f4a5c1843a4421af"]
+                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/flakes
                   11]
-                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
+                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/previous
                   "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"]
-                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
+                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/size
                   1082]
-                 ["fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
+                 ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/t
                   1]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   "https://www.w3.org/2018/credentials#issuer"
                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/address
-                  "fluree:memory://dab2f5f1a5a6b37758eee01fabaf3a6bc3c1d37c4e445ce44d08da26bc680c20"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                  "fluree:memory://6a39be21ed7e25ca8f8f7b93ed02b5d53d060bea043471c4e14086f09af9f346"]
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/alias
                   "query/everything"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/author
                   ""]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/branch
                   "main"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/data
-                  "fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                  "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"]
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/previous
                   "fluree:commit:sha256:bvvou3uvnd6ffhehsrw23mw4w3fux5jbpacko2ecosb2nzxkfu5v"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/time
                   720000]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/txn
                   "fluree:memory://6ef43099853b046e0501e67e8df05a6a1e036a1100c680ab48d1d19b884ec9ea"]
-                 ["fluree:commit:sha256:bbm7qobcdxuggm3mlslhi5kihbbsuudg3hl5l3w3v6wmow67mw67y"
+                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
                   :f/v
                   0]
                  [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,14 +28,14 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bfhquuwpmivy6cj4vw3rxelr5psy63jm4rsa3jw7owdxt4mfnpxu"
+        (is (= "fluree:commit:sha256:bc4pgf733mfhelp4ueeciwbfftthr4juvh2btondbmzjbvf6zpf5"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://45b10ddf1fa05e1ccb6253c772386bef62651ac021b55bbe0863bec5e1db75fb"
+        (is (= "fluree:memory://10e1db9dc617a4d4b01a3fbdea6eb97a52f4173a8b01c2cdbb66ec05f90a41c7"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
-        (is (= "fluree:db:sha256:bko3y37k3cyhkopier2bdjxsedeqzuityr25v2pfrthjlc4lldct"
+        (is (= "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://8afce856ee1ed55d175491b629837824fcb27060fd54ea61bbd0264043404355"
+        (is (= "fluree:memory://1066be3c23dc5635881c1b4ce74cd944fc96b25556bc9508f4a5c1843a4421af"
                (get-in db1 [:commit :data :address])))))))


### PR DESCRIPTION
This patch sets the match namespace code at commit time instead of at the time the database is staged. This allows us to accurately compute the new namespaces generated in a commit and save them to the commit file, which, in turn, allows us to load the correct namespaces afterwards after a new index update.