### PR TITLE
allow use of id-maps in :values pattern

### DIFF
--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -75,21 +75,17 @@
 (defn match-value-binding-map
   [var-match binding-map context]
   (let [attrs (expand-keys binding-map context)
-
-        {id const/iri-id val const/iri-value} attrs]
-    (if id
-      (let [expanded (json-ld/expand-iri id context)]
-        (where/match-iri var-match expanded))
-      (if-let [dt-iri (get-expanded-datatype attrs context)]
-        (if (or (= const/iri-anyURI dt-iri)
-                (= const/iri-id dt-iri))
-          (let [expanded (json-ld/expand-iri val context)]
-            (where/match-iri var-match expanded))
-          (where/match-value var-match val dt-iri))
-        (if-let [lang (get attrs const/iri-language)]
-          (where/match-value var-match val const/iri-lang-string {:lang lang})
-          (let [dt (datatype/infer-iri val)]
-            (where/match-value var-match val dt)))))))
+        {val const/iri-value} attrs]
+    (if-let [dt-iri (get-expanded-datatype attrs context)]
+      (if (or (= const/iri-anyURI dt-iri)
+              (= const/iri-id dt-iri))
+        (let [expanded (json-ld/expand-iri val context)]
+          (where/match-iri var-match expanded))
+        (where/match-value var-match val dt-iri))
+      (if-let [lang (get attrs const/iri-language)]
+        (where/match-value var-match val const/iri-lang-string {:lang lang})
+        (let [dt (datatype/infer-iri val)]
+          (where/match-value var-match val dt))))))
 
 (defn match-value-binding
   [var-match value context]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -75,20 +75,20 @@
 (defn match-value-binding-map
   [var-match binding-map context]
   (let [attrs (expand-keys binding-map context)
-        id    (get attrs const/iri-id)
-        val   (get attrs const/iri-value)]
-    (cond id (let [expanded (json-ld/expand-iri id context)]
-               (where/match-iri var-match expanded))
-          :else
-          (if-let [dt-iri (get-expanded-datatype attrs context)]
-            (if (= const/iri-anyURI dt-iri)
-              (let [expanded (json-ld/expand-iri val context)]
-                (where/match-iri var-match expanded))
-              (where/match-value var-match val dt-iri))
-            (if-let [lang (get attrs const/iri-language)]
-              (where/match-value var-match val const/iri-lang-string {:lang lang})
-              (let [dt (datatype/infer-iri val)]
-                (where/match-value var-match val dt)))))))
+
+        {id const/iri-id val const/iri-value} attrs]
+    (if id
+      (let [expanded (json-ld/expand-iri id context)]
+        (where/match-iri var-match expanded))
+      (if-let [dt-iri (get-expanded-datatype attrs context)]
+        (if (= const/iri-anyURI dt-iri)
+          (let [expanded (json-ld/expand-iri val context)]
+            (where/match-iri var-match expanded))
+          (where/match-value var-match val dt-iri))
+        (if-let [lang (get attrs const/iri-language)]
+          (where/match-value var-match val const/iri-lang-string {:lang lang})
+          (let [dt (datatype/infer-iri val)]
+            (where/match-value var-match val dt)))))))
 
 (defn match-value-binding
   [var-match value context]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -81,7 +81,8 @@
       (let [expanded (json-ld/expand-iri id context)]
         (where/match-iri var-match expanded))
       (if-let [dt-iri (get-expanded-datatype attrs context)]
-        (if (= const/iri-anyURI dt-iri)
+        (if (or (= const/iri-anyURI dt-iri)
+                (= const/iri-id dt-iri))
           (let [expanded (json-ld/expand-iri val context)]
             (where/match-iri var-match expanded))
           (where/match-value var-match val dt-iri))

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -75,16 +75,20 @@
 (defn match-value-binding-map
   [var-match binding-map context]
   (let [attrs (expand-keys binding-map context)
+        id    (get attrs const/iri-id)
         val   (get attrs const/iri-value)]
-    (if-let [dt-iri (get-expanded-datatype attrs context)]
-      (if (= const/iri-anyURI dt-iri)
-        (let [expanded (json-ld/expand-iri val context)]
-          (where/match-iri var-match expanded))
-        (where/match-value var-match val dt-iri))
-      (if-let [lang (get attrs const/iri-language)]
-        (where/match-value var-match val const/iri-lang-string {:lang lang})
-        (let [dt (datatype/infer-iri val)]
-          (where/match-value var-match val dt))))))
+    (cond id (let [expanded (json-ld/expand-iri id context)]
+               (where/match-iri var-match expanded))
+          :else
+          (if-let [dt-iri (get-expanded-datatype attrs context)]
+            (if (= const/iri-anyURI dt-iri)
+              (let [expanded (json-ld/expand-iri val context)]
+                (where/match-iri var-match expanded))
+              (where/match-value var-match val dt-iri))
+            (if-let [lang (get attrs const/iri-language)]
+              (where/match-value var-match val const/iri-lang-string {:lang lang})
+              (let [dt (datatype/infer-iri val)]
+                (where/match-value var-match val dt)))))))
 
 (defn match-value-binding
   [var-match value context]

--- a/test/fluree/db/query/values_test.clj
+++ b/test/fluree/db/query/values_test.clj
@@ -40,8 +40,8 @@
                 ["Cam" "cam@example.org"]]
                @(fluree/query db1 {"@context" context
                                    "select" ["?name" "?email"]
-                                   "values" ["?s" [{"@id" "ex:brian"}
-                                                   {"@id" "ex:cam"}]]
+                                   "values" ["?s" [{"@type" "@id" "@value" "ex:brian"}
+                                                   {"@type" "@id" "@value" "ex:cam"}]]
                                    "where" [{"@id" "?s" "schema:name" "?name"}
                                             {"@id" "?s" "schema:email" "?email"}]}))
             "id-maps can be used to distinguish iris")
@@ -64,13 +64,13 @@
               "iri literal")
           (is (= [["ex:cam"] ["ex:liam"]]
                  @(fluree/query db1 {"@context" context
-                                     "values" ["?friend" [{"@id" "ex:alice"}]]
+                                     "values" ["?friend" [{"@value" "ex:alice" "@type" "@id"}]]
                                      "where" [{"@id" "?s" "ex:friend" "?friend"}]
                                      "select" ["?s"]}))
               "variable")
           (is (= [["ex:cam"] ["ex:liam"]]
                  @(fluree/query db1 {"@context" context
-                                     "values" ["?friend" [{"@id" "ex:alice"}]]
+                                     "values" ["?friend" [{"@value" "ex:alice" "@type" "@id"}]]
                                      "where" [{"@id" "?s" "ex:friend" {"@id" "?friend"}}]
                                      "select" ["?s"]}))
               "variable in id-map"))))
@@ -95,7 +95,7 @@
                                             {"@id" "?s" "schema:email" "?email"}
                                             ["values"
                                              [["?s"] [[{"@type" "xsd:anyURI" "@value" "ex:cam"}]
-                                                      [{"@id" "ex:brian"}]]]]]}))
+                                                      [{"@type" "@id" "@value" "ex:brian"}]]]]]}))
             "syntactic form is parsed correctly"))
       (testing "nested under optional clause"
         (is (= [["Nikola" nil true]]

--- a/test/fluree/db/query/values_test.clj
+++ b/test/fluree/db/query/values_test.clj
@@ -40,11 +40,10 @@
                 ["Cam" "cam@example.org"]]
                @(fluree/query db1 {"@context" context
                                    "select" ["?name" "?email"]
+                                   "values" ["?s" [{"@id" "ex:brian"}
+                                                   {"@id" "ex:cam"}]]
                                    "where" [{"@id" "?s" "schema:name" "?name"}
-                                            {"@id" "?s" "schema:email" "?email"}
-                                            ["values"
-                                             ["?s" [{"@id" "ex:cam"}
-                                                    {"@id" "ex:brian"}]]]]}))
+                                            {"@id" "?s" "schema:email" "?email"}]}))
             "id-maps can be used to distinguish iris")
         (testing "equivalent syntactic forms"
           (is (= [["ex:cam"] ["ex:liam"]]

--- a/test/fluree/db/query/values_test.clj
+++ b/test/fluree/db/query/values_test.clj
@@ -45,7 +45,25 @@
                                             ["values"
                                              ["?s" [{"@id" "ex:cam"}
                                                     {"@id" "ex:brian"}]]]]}))
-            "id-maps can be used to distinguish iris")))
+            "id-maps can be used to distinguish iris")
+        (testing "equivalent syntactic forms"
+          (is (= [["ex:cam"] ["ex:liam"]]
+                 @(fluree/query db1 {"@context" context
+                                     "where" [{"@id" "?s" "ex:friend" {"@id" "ex:alice"}}]
+                                     "select" ["?s"]}))
+              "iri literal")
+          (is (= [["ex:cam"] ["ex:liam"]]
+                 @(fluree/query db1 {"@context" context
+                                     "values" ["?friend" [{"@id" "ex:alice"}]]
+                                     "where" [{"@id" "?s" "ex:friend" "?friend"}]
+                                     "select" ["?s"]}))
+              "variable")
+          (is (= [["ex:cam"] ["ex:liam"]]
+                 @(fluree/query db1 {"@context" context
+                                     "values" ["?friend" [{"@id" "ex:alice"}]]
+                                     "where" [{"@id" "?s" "ex:friend" {"@id" "?friend"}}]
+                                     "select" ["?s"]}))
+              "variable in id-map"))))
     (testing "where pattern"
       (testing "single var"
         (is (= [["Brian" "brian@example.org"]

--- a/test/fluree/db/query/values_test.clj
+++ b/test/fluree/db/query/values_test.clj
@@ -34,7 +34,18 @@
           (is (= [["foo1"] ["foo2"] ["foo3"]]
                  @(fluree/query db1 {"select" ["?foo"]
                                      "values" ["?foo" ["foo1" "foo2" "foo3" ]]}))
-              "syntactic form is parsed correctly"))))
+              "syntactic form is parsed correctly")))
+      (testing "iri values"
+        (is (= [["Brian" "brian@example.org"]
+                ["Cam" "cam@example.org"]]
+               @(fluree/query db1 {"@context" context
+                                   "select" ["?name" "?email"]
+                                   "where" [{"@id" "?s" "schema:name" "?name"}
+                                            {"@id" "?s" "schema:email" "?email"}
+                                            ["values"
+                                             ["?s" [{"@id" "ex:cam"}
+                                                    {"@id" "ex:brian"}]]]]}))
+            "id-maps can be used to distinguish iris")))
     (testing "where pattern"
       (testing "single var"
         (is (= [["Brian" "brian@example.org"]
@@ -56,7 +67,7 @@
                                             {"@id" "?s" "schema:email" "?email"}
                                             ["values"
                                              [["?s"] [[{"@type" "xsd:anyURI" "@value" "ex:cam"}]
-                                                      [{"@type" "xsd:anyURI" "@value" "ex:brian"}]]]]]}))
+                                                      [{"@id" "ex:brian"}]]]]]}))
             "syntactic form is parsed correctly"))
       (testing "nested under optional clause"
         (is (= [["Nikola" nil true]]

--- a/test/fluree/db/query/values_test.clj
+++ b/test/fluree/db/query/values_test.clj
@@ -45,6 +45,17 @@
                                    "where" [{"@id" "?s" "schema:name" "?name"}
                                             {"@id" "?s" "schema:email" "?email"}]}))
             "id-maps can be used to distinguish iris")
+        (is (= [["Brian" "brian@example.org"]
+                ["Cam" "cam@example.org"]]
+               @(fluree/query db1 {"@context" context
+                                   "select" ["?name" "?email"]
+                                   "values" ["?s" [{"@value" "ex:brian"
+                                                    "@type" "@id"}
+                                                   {"@value" "ex:cam"
+                                                    "@type" "@id"}]]
+                                   "where" [{"@id" "?s" "schema:name" "?name"}
+                                            {"@id" "?s" "schema:email" "?email"}]}))
+            "id-maps can be used to distinguish iris")
         (testing "equivalent syntactic forms"
           (is (= [["ex:cam"] ["ex:liam"]]
                  @(fluree/query db1 {"@context" context

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -130,14 +130,14 @@
     "schema:email" "cam@example.org"
     "schema:age"   34
     "ex:favNums"   [5, 10]
-    "ex:friend"    ["ex:brian" "ex:alice"]}
+    "ex:friend"    [{"@id" "ex:brian"} {"@id" "ex:alice"}]}
    {"id"           "ex:liam"
     "type"         "ex:User"
     "schema:name"  "Liam"
     "schema:email" "liam@example.org"
     "schema:age"   13
     "ex:favNums"   [42, 11]
-    "ex:friend"    ["ex:brian" "ex:alice" "ex:cam"]}])
+    "ex:friend"    [{"@id" "ex:brian"} {"@id" "ex:alice"} {"@id" "ex:cam"}]}])
 
 (defn create-conn
   ([]


### PR DESCRIPTION
The json-ld standard does not actually support iri expansion in a value map. Also, iris are denoted with id maps in every other bit of FQL syntax. This commit allows both json-ld-compliant iri declaration and makes our syntax more consistent.

[Here's](https://json-ld.org/playground/#startTab=tab-expanded&json-ld=%7B%22%40context%22%3A%7B%22ex%22%3A%22http%3A%2F%2Fexample.com%2F%22%2C%22ex%3Abaz%22%3A%7B%22%40type%22%3A%22%40id%22%7D%7D%2C%22ex%3Afoo%22%3A%7B%22%40value%22%3A%22ex%3Ame%22%2C%22%40type%22%3A%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23anyURI%22%7D%2C%22ex%3Abar%22%3A%7B%22%40id%22%3A%22ex%3Ayou%22%7D%2C%22ex%3Abaz%22%3A%22ex%3Afark%22%7D) an example of our current value-map syntax not expanding iris

I believe we should deprecate the `{"@value" <iri> "@type" "xsd:anyURI"}` syntax for iri values and not document this usage for public use.