### PR TITLE
fix SPARQL unicode grammar regex for CLJS

### DIFF
--- a/resources/sparql.js.bnf
+++ b/resources/sparql.js.bnf
@@ -1,0 +1,251 @@
+<Query> ::=  <COMMENT?> WS Prologue WS ( SelectQuery | ConstructQuery | DescribeQuery | AskQuery ) WS Modifiers
+UpdateUnit ::= Update
+Prologue ::= ( BaseDecl | PrefixDecl )*
+BaseDecl ::= <'BASE'> WS IRIREF
+PrefixDecl ::= <'PREFIX'> WS PNAME_NS WS IRIREF
+SelectQuery ::= WS SelectClause WS DatasetClause WS WhereClause WS SolutionModifier WS
+SubSelect ::= SelectClause WhereClause SolutionModifier ValuesClause
+SelectClause ::= WS <'SELECT'> WS ( 'DISTINCT' | 'REDUCED')? ( ( WS ( Var | ( <'('> Expression As Var <')'> ) ) )+ | ( WS '*' ) )
+ConstructQuery	  ::=  	'CONSTRUCT' ( ConstructTemplate DatasetClause WhereClause SolutionModifier | DatasetClause 'WHERE' '{' TriplesTemplate? '}' SolutionModifier )
+DescribeQuery	  ::=  	'DESCRIBE' ( VarOrIri+ | '*' ) DatasetClause WhereClause? SolutionModifier
+AskQuery	  ::=  	'ASK' DatasetClause WhereClause SolutionModifier
+Modifiers         ::= (ValuesClause? | PrettyPrint? ) (PrettyPrint? | ValuesClause? )
+DatasetClause     ::= FromClause*
+<FromClause>      ::= <'FROM'> WS ( DefaultGraphClause | NamedGraphClause )
+DefaultGraphClause	  ::=  	SourceSelector
+NamedGraphClause	  ::=  	<'NAMED'> WS SourceSelector
+<SourceSelector>	  ::=  	iri
+WhereClause	  ::=  	<'WHERE'?> WS GroupGraphPattern WS
+SolutionModifier	  ::=  	GroupClause? HavingClause? OrderClause? LimitOffsetClauses?
+GroupClause	  ::=  	<'GROUP' WS 'BY' WS> GroupCondition+
+GroupCondition	  ::=  	BuiltInCall | FunctionCall | <'('> Expression ( As Var )? <')'> | Var
+HavingClause	  ::=  	<'HAVING'> HavingCondition+
+HavingCondition	  ::=  	Constraint
+OrderClause	  ::=  	<'ORDER' WS 'BY'> WS OrderCondition+ WS
+<OrderCondition>	  ::=  	ExplicitOrderCondition | Constraint | Var
+ExplicitOrderCondition ::= ( 'ASC' | 'DESC' ) WS BrackettedExpression
+<LimitOffsetClauses>	  ::=  	LimitClause OffsetClause? | OffsetClause LimitClause?
+LimitClause	  ::=  	<'LIMIT'> WS INTEGER
+OffsetClause	  ::=  	<'OFFSET'> WS INTEGER
+ValuesClause	  ::=  	( <'VALUES'> WS DataBlock )? WS
+Update	  ::=  	Prologue ( Update1 ( ';' Update )? )?
+Update1	  ::=  	Load | Clear | Drop | Add | Move | Copy | Create | InsertData | DeleteData | DeleteWhere | Modify
+Load	  ::=  	'LOAD' 'SILENT'? iri ( 'INTO' GraphRef )?
+Clear	  ::=  	'CLEAR' 'SILENT'? GraphRefAll
+Drop	  ::=  	'DROP' 'SILENT'? GraphRefAll
+Create	  ::=  	'CREATE' 'SILENT'? GraphRef
+Add	  ::=  	'ADD' 'SILENT'? GraphOrDefault 'TO' GraphOrDefault
+Move	  ::=  	'MOVE' 'SILENT'? GraphOrDefault 'TO' GraphOrDefault
+Copy	  ::=  	'COPY' 'SILENT'? GraphOrDefault 'TO' GraphOrDefault
+InsertData	  ::=  	'INSERT DATA' QuadData
+DeleteData	  ::=  	'DELETE DATA' QuadData
+DeleteWhere	  ::=  	'DELETE WHERE' QuadPattern
+Modify	  ::=  	( 'WITH' iri )? ( DeleteClause InsertClause? | InsertClause ) UsingClause* 'WHERE' GroupGraphPattern
+DeleteClause	  ::=  	'DELETE' QuadPattern
+InsertClause	  ::=  	'INSERT' QuadPattern
+UsingClause	  ::=  	'USING' ( iri | 'NAMED' iri )
+GraphOrDefault	  ::=  	'DEFAULT' | 'GRAPH'? iri
+GraphRef	  ::=  	'GRAPH' iri
+GraphRefAll	  ::=  	GraphRef | 'DEFAULT' | 'NAMED' | 'ALL'
+QuadPattern	  ::=  	'{' Quads '}'
+QuadData	  ::=  	'{' Quads '}'
+Quads	  ::=  	TriplesTemplate? ( QuadsNotTriples '.'? TriplesTemplate? )*
+QuadsNotTriples	  ::=  	'GRAPH' VarOrIri '{' TriplesTemplate? '}'
+TriplesTemplate	  ::=  	TriplesSameSubject ( '.' TriplesTemplate? )?
+<GroupGraphPattern>	  ::=  	WS <'{'> WS ( SubSelect | GroupGraphPatternSub ) WS <'}'> WS
+GroupGraphPatternSub	  ::=  WS TriplesBlock? ( GraphPatternNotTriples WS <'.'?> TriplesBlock? WS )* WS
+TriplesBlock	  ::=  WS TriplesSameSubjectPath WS ( <'.'> TriplesBlock? WS )?
+GraphPatternNotTriples	  ::=  	GroupOrUnionGraphPattern | OptionalGraphPattern | MinusGraphPattern | GraphGraphPattern | ServiceGraphPattern | Filter | Bind | InlineData
+OptionalGraphPattern	  ::=  	<'OPTIONAL'> GroupGraphPattern
+GraphGraphPattern	  ::=  	<'GRAPH'> WS VarOrIri WS GroupGraphPattern
+ServiceGraphPattern	  ::=  	<'SERVICE'> WS 'SILENT'? WS VarOrIri GroupGraphPattern
+Bind	  ::=  	<'BIND' WS '(' WS>  Expression <As> Var <WS ')' WS>
+InlineData	  ::=  	<'VALUES'> WS DataBlock
+<DataBlock>	  ::=  	InlineDataOneVar | InlineDataFull
+InlineDataOneVar	  ::=  	Var <'{'> WS DataBlockValue* <'}'>
+InlineDataFull ::= ( NIL | VarList ) WS <'{'> WS ( ValueList WS | NIL )* <'}'>
+VarList ::= ( <'('> Var* <')'> )
+ValueList ::= ( <'('> WS DataBlockValue* <')'> )
+DataBlockValue	  ::=  	iri | RDFLiteral | NumericLiteral | BooleanLiteral | 'UNDEF' WS
+MinusGraphPattern	  ::=  	'MINUS' GroupGraphPattern
+GroupOrUnionGraphPattern	  ::=  	GroupGraphPattern ( <'UNION'> GroupGraphPattern )*
+Filter	  ::=  	<'FILTER'> WS Constraint
+Constraint	  ::=  	BrackettedExpression | BuiltInCall | FunctionCall
+FunctionCall	  ::=  	iri ArgList
+ArgList	  ::=  	NIL | <'('> 'DISTINCT'? Expression ( <','> Expression )* <')'>
+ExpressionList	  ::=  	NIL | <'('> Expression ( <','> Expression )* <')'>
+ConstructTemplate	  ::=  	'{' ConstructTriples? '}'
+ConstructTriples	  ::=  	TriplesSameSubject ( '.' ConstructTriples? )?
+TriplesSameSubject	  ::=  	VarOrTerm PropertyListNotEmpty | TriplesNode PropertyList
+PropertyList	  ::=  	PropertyListNotEmpty?
+PropertyListNotEmpty	  ::=  	Verb ObjectList ( <';'>  WS ( Verb ObjectList )? )*
+Verb	  ::=  	VarOrIri | Type
+ObjectList	  ::=  	Object ( <','> WS Object )*
+Object	  ::=  	GraphNode
+TriplesSameSubjectPath	  ::=  	VarOrTerm PropertyListPathNotEmpty | TriplesNodePath PropertyListPath WS
+PropertyListPath	  ::=  	PropertyListPathNotEmpty?
+PropertyListPathNotEmpty	  ::=  	( VerbPath | VerbSimple ) ObjectListPath ( <';'> WS ( ( VerbPath | VerbSimple ) ObjectList )? )* WS
+<VerbPath>	  ::=  	Path
+<VerbSimple>	  ::=  	Var
+<ObjectListPath>	  ::=  	ObjectPath WS ( <',' WS> ObjectPath )*
+ObjectPath	  ::=  	GraphNodePath
+<Path>	  ::=  	PathAlternative
+<PathAlternative>	  ::=  	PathSequence ( <'|'> PathSequence )*
+PathSequence	  ::=  	PathEltOrInverse ( <'/'> PathEltOrInverse )*
+<PathElt>	  ::=  	PathPrimary PathMod?
+<PathEltOrInverse>	  ::=  	PathElt | <'^'> PathElt
+PathMod	  ::=  	'?' | '*' | ('+' INTEGER?) WS
+PathPrimary	  ::=  	iri | Type | '!' PathNegatedPropertySet | '(' Path ')'
+PathNegatedPropertySet	  ::=  	PathOneInPropertySet | '(' ( PathOneInPropertySet ( '|' PathOneInPropertySet )* )? ')'
+PathOneInPropertySet	  ::=  	iri | Type | '^' ( iri | Type )
+Integer	  ::=  	INTEGER
+TriplesNode	  ::=  	Collection | BlankNodePropertyList
+BlankNodePropertyList	  ::=  	'[' PropertyListNotEmpty ']'
+TriplesNodePath	  ::=  	CollectionPath WS | BlankNodePropertyListPath WS
+BlankNodePropertyListPath	  ::=  	'[' PropertyListPathNotEmpty ']'
+Collection	  ::=  	'(' GraphNode+ ')'
+CollectionPath	  ::=  	'(' GraphNodePath+ ')'
+<GraphNode>	  ::=  	VarOrTerm | TriplesNode
+<GraphNodePath>	  ::=  	VarOrTerm | TriplesNodePath
+<VarOrTerm>	  ::=  	Var | GraphTerm WS
+<VarOrIri>	  ::=  	Var | iri WS
+Var	  ::=  	VAR1 WS | VAR2 WS
+<Type> ::= (WS 'a' WS)
+<GraphTerm>	  ::=  	iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | NIL
+Expression	  ::=  	WS ConditionalOrExpression WS
+ConditionalOrExpression ::= ConditionalAndExpression ( <'||'> ConditionalAndExpression )*
+ConditionalAndExpression ::= ValueLogical ( <'&&'> ValueLogical )*
+<ValueLogical>	  ::=  	RelationalExpression
+RelationalExpression	  ::=  	NumericExpression WS ( '=' NumericExpression | '!=' NumericExpression | '<' NumericExpression | '>' NumericExpression | '<=' NumericExpression | '>=' NumericExpression | 'IN' WS ExpressionList | 'NOT' WS 'IN' WS ExpressionList )?
+NumericExpression	  ::=  	WS AdditiveExpression WS
+As ::= WS <('AS' | 'as')> WS
+
+<AdditiveExpression>	  ::=  	MultiplicativeExpression ( '+' MultiplicativeExpression | '-' MultiplicativeExpression | ( NumericLiteralPositive | NumericLiteralNegative ) ( ( '*' UnaryExpression ) | ( '/' UnaryExpression ) )* )*
+
+
+MultiplicativeExpression	  ::=  	UnaryExpression ( '*' UnaryExpression | '/' UnaryExpression )*
+<UnaryExpression>	  ::=  	  '!' PrimaryExpression
+| '+' PrimaryExpression
+| '-' PrimaryExpression
+| PrimaryExpression
+<PrimaryExpression>	  ::=  	BrackettedExpression | BuiltInCall | iriOrFunction | RDFLiteral | NumericLiteral | BooleanLiteral | Var
+BrackettedExpression	  ::=  	<'('> WS Expression WS <')'>
+
+<BuiltInCall> ::= Aggregate
+| ExistsFunc
+| NotExistsFunc
+| RegexExpression
+| StrReplaceExpression
+| SubstringExpression
+| Func
+
+Func ::= 'ABS' <'('> Expression <')'>
+| 'BNODE' ( <'('> Expression <')'> | NIL )
+| 'BOUND' <'('> Var <')'>
+| 'CEIL' <'('> Expression <')'>
+| 'COALESCE' WS ExpressionList
+| 'CONCAT' ExpressionList
+| 'CONTAINS' <'('> Expression <','> Expression <')'>
+| 'DATATYPE' <'('> Expression <')'>
+| 'DAY' <'('> Expression <')'>
+| 'ENCODE_FOR_URI' <'('> Expression <')'>
+| 'FLOOR' <'('> Expression <')'>
+| 'HOURS' <'('> Expression <')'>
+| 'IF' <'('> Expression <','> Expression <','> Expression <')'>
+| 'IRI' <'('> Expression <')'>
+| 'LANG' <'('> Expression <')'>
+| 'LANGMATCHES' <'('> Expression <','> Expression <')'>
+| 'LCASE' <'('> Expression <')'>
+| 'MD5' <'('>Expression <')'>
+| 'MINUTES' <'('> Expression <')'>
+| 'MONTH' <'('> Expression <')'>
+| 'NOW' NIL
+| 'RAND' NIL
+| 'ROUND' <'('> Expression <')'>
+| 'SECONDS' <'('> Expression <')'>
+| 'SHA1' <'('> Expression <')'>
+| 'SHA256' <'('> Expression <')'>
+| 'SHA384' <'('> Expression <')'>
+| 'SHA512' <'('> Expression <')'>
+| 'STR' <'('> Expression <')'>
+| 'STRAFTER' <'('> Expression <','> Expression <')'>
+| 'STRBEFORE' <'('> Expression <','> Expression <')'>
+| 'STRDT' <'('> Expression <','> Expression <')'>
+| 'STRENDS' <'('> Expression <','> Expression <')'>
+| 'STRLANG' <'('> Expression <','> Expression <')'>
+| 'STRLEN' <'('> Expression <')'>
+| 'STRSTARTS' <'('> Expression <','> Expression <')'>
+| 'STRUUID' NIL
+| 'TIMEZONE' <'('> Expression <')'>
+| 'TZ' <'('> Expression <')'>
+| 'UCASE' <'('> Expression <')'>
+| 'URI' <'('> Expression <')'>
+| 'UUID' NIL
+| 'YEAR' <'('> Expression <')'>
+| 'isBLANK' <'('> Expression <')'>
+| 'isIRI' <'('> Expression <')'>
+| 'isLITERAL' <'('> Expression <')'>
+| 'isNUMERIC' <'('> Expression <')'>
+| 'isURI' <'('> Expression <')'>
+| 'sameTerm' <'('> Expression <','> Expression <')'>
+
+RegexExpression   ::=   <'REGEX'> <'('> Expression <','> Expression ( <','> Expression )? <')'>
+SubstringExpression   ::=   <'SUBSTR'> <'('> Expression <','> Expression ( <','> Expression )? <')'>
+StrReplaceExpression    ::=   <'REPLACE'> <'('> Expression <','> Expression <','> Expression ( <','> Expression )? <')'>
+ExistsFunc    ::=   <'EXISTS'> GroupGraphPattern
+NotExistsFunc   ::=   <'NOT'> WS <'EXISTS'> GroupGraphPattern
+Aggregate   ::=     'COUNT' WS <'('> WS 'DISTINCT'? WS ( '*' | Expression ) WS <')'> WS
+| 'SUM' WS <'('> WS 'DISTINCT'? Expression <')'>
+| 'MIN' <'('>  WS 'DISTINCT'? Expression <')'>
+| 'MAX' <'('>  WS 'DISTINCT'? Expression <')'>
+| 'AVG' <'('>  WS 'DISTINCT'? Expression <')'>
+| 'SAMPLE' <'('>  WS 'DISTINCT'? Expression? Expression <')'>
+| 'GROUP_CONCAT' <'('> WS 'DISTINCT'? Expression ( <';'> WS 'SEPARATOR' WS <'='> WS String WS )? <')'>
+iriOrFunction	  ::=  	iri ArgList?
+RDFLiteral	  ::=  	String WS ( LANGTAG | ( '^^' iri ) )? WS
+NumericLiteral	  ::=  	NumericLiteralUnsigned WS | NumericLiteralPositive WS | NumericLiteralNegative WS
+<NumericLiteralUnsigned>	  ::=  	INTEGER | DECIMAL | DOUBLE
+<NumericLiteralPositive>	  ::=  	INTEGER_POSITIVE | DECIMAL_POSITIVE | DOUBLE_POSITIVE
+<NumericLiteralNegative>	  ::=  	INTEGER_NEGATIVE | DECIMAL_NEGATIVE | DOUBLE_NEGATIVE
+BooleanLiteral	  ::=  	'true' WS | 'false' WS
+<String>	  ::=  	STRING_LITERAL1 | STRING_LITERAL2 | STRING_LITERAL_LONG1 | STRING_LITERAL_LONG2
+iri	  ::=  ( IRIREF | PrefixedName ) WS
+PrefixedName	  ::=  	( PNAME_LN WS ) | ( PNAME_NS WS)
+BlankNode	  ::=  	BLANK_NODE_LABEL | ANON
+PrettyPrint ::= <'PRETTY-PRINT'> WS
+IRIREF	  ::=  	#"<[^<>\"{}|^`\x00-\x20]*>" WS
+<PNAME_NS>	  ::=  	PN_PREFIX? ':'
+<PNAME_LN>	  ::=  	PNAME_NS PN_LOCAL '*'?
+BLANK_NODE_LABEL	  ::=  	'_:' ( PN_CHARS_U | #"[0-9]" ) ((PN_CHARS|'.')* PN_CHARS)?
+<VAR1>	  ::=  	<'?'> VARNAME
+<VAR2>	  ::=  	<'$'> VARNAME
+LANGTAG ::= #"@[a-zA-Z]+(-[a-zA-Z0-9]+)*" WS
+<INTEGER>	  ::=  	#"[0-9]+"
+<DECIMAL>	  ::=  #"[0-9]*\.[0-9]*"
+<DOUBLE>	  ::=  	#"[0-9]+\.[0-9]*|(\.[0-9]+)|([0-9]+)" EXPONENT
+<INTEGER_POSITIVE>	  ::=  	'+' INTEGER
+<DECIMAL_POSITIVE>	  ::=  	'+' DECIMAL
+<DOUBLE_POSITIVE>	  ::=  	'+' DOUBLE
+<INTEGER_NEGATIVE>	  ::=  	'-' INTEGER
+<DECIMAL_NEGATIVE>	  ::=  	'-' DECIMAL
+<DOUBLE_NEGATIVE>	  ::=  	'-' DOUBLE
+EXPONENT	  ::=  	#"[eE][+-]?[0-9]+"
+<STRING_LITERAL1>	  ::=  	<"'"> ( #"[^\x27\x5C\x0A\x0D]" | ECHAR )* <"'">
+<STRING_LITERAL2>	  ::=  	<'"'> ( #"[^\x27\x5C\x0A\x0D]" | ECHAR )* <'"'>
+<STRING_LITERAL_LONG1>	  ::=  	"'''" ( ( "'" | "''" )? ( #"[^'\\]" | ECHAR ) )* "'''"
+<STRING_LITERAL_LONG2>	  ::=  	'"""' ( ( '"' | '""' )? ( #"[^'\\]" | ECHAR ) )* '"""'
+ECHAR	  ::=  	#"\\[tbnrf]"
+NIL	  ::=  	'(' WS* ')'
+<WS>	  ::=  	<#"[\x20\x09\x0D\x0A]*\#[^\n]*\n*[\x20\x09\x0D\x0A]*|[\x20\x09\x0D\x0A]*">
+ANON	  ::=  	'[' WS* ']'
+<PN_CHARS_BASE>	  ::=  	#"(?u)[a-zA-Z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|[\u{10000}-\u{EFFFF}]"
+<PN_CHARS_U>	  ::=  	PN_CHARS_BASE | #"_"
+<VARNAME>	  ::=  	( PN_CHARS_U | #"[0-9]" ) ( PN_CHARS_U | #"[0-9]|\u00B7|[\u0300-\u036F]|[\u203F-\u2040]" )*
+<PN_CHARS>	  ::=  	PN_CHARS_U | #"-|[0-9]|\u00B7|[\u0300-\u036F]|[\u203F-\u2040]|/"
+<PN_PREFIX>	  ::=  	PN_CHARS_BASE ((PN_CHARS|#"\.")* PN_CHARS)?
+<PN_LOCAL>	  ::=  	( PN_CHARS_U | #"[0-9]" ) ((PN_CHARS|#"\.")* PN_CHARS)?
+<COMMENT>       ::=   <#"\#[^\n]*\n{1}">
+<PLX>	  ::=  	PERCENT | PN_LOCAL_ESC
+<PERCENT>	  ::=  	'%' HEX HEX
+<HEX>	  ::=  	#"[0-9]" | #"[A-F]" | #"[a-f]"
+<PN_LOCAL_ESC>	  ::=  	#"[\\_~.\-!$&'()*+,;=/?#@%]"

--- a/src/clj/fluree/db/query/sparql.cljc
+++ b/src/clj/fluree/db/query/sparql.cljc
@@ -10,7 +10,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (def grammar #?(:clj  (io/resource "sparql.bnf")
-                :cljs (inline-resource "sparql.bnf")))
+                :cljs (inline-resource "sparql.js.bnf")))
 
 (defparser parser grammar)
 


### PR DESCRIPTION
Clojure and Clojurescript default to using their respective platforms' RegExp implementations, and unfortunately the syntax for unicode characters is mutually incompatible.

I've tried several variations to get it to work in the same file, but have unfortunately failed. So the next best thing is the dumb solution, which is two separate grammars, one for cljs and one for clj.

The only difference is in the PN_CHARS_BASE terminal, where we need to specify the unicode flag (the `(?u)` prefix) and use ES2015 Unicode-aware regular expressions syntax: `[\u{10000}-\u{EFFFF}]`.

These are the sources I used to figure it out:
https://mathiasbynens.be/notes/es6-unicode-regex
https://yo-dave.com/2018/04/20/notes-on-clojurescript-regular-expressions/