### PR TITLE
fix pending subjects-as-predicates test

### DIFF
--- a/test/fluree/db/query/property_test.clj
+++ b/test/fluree/db/query/property_test.clj
@@ -142,7 +142,7 @@
                                                    "ex:parent" ?parent}}))))
             "returns all sub properties of ex:parent property")))))
 
-(deftest ^:integration ^:kaocha/pending subjects-as-predicates
+(deftest ^:integration subjects-as-predicates
   (testing "predicate iri-cache loookups"
     (let [conn    @(fluree/connect {:method :memory})
           ledger  @(fluree/create conn "propertypathstest")
@@ -207,7 +207,7 @@
                                  "select"   {"ex:nested" ["id" {"ex:reversed-pred" ["*"]}]}}))
           "via reverse crawl")
       (is (= [{"id" "ex:nested", "ex:reversed-pred" "ex:subject-as-predicate"}]
-             @(fluree/query db2 {"@context" [context {"ex:reversed-pred" {"@reverse" "ex:unlabeled-pred"}}]
+             @(fluree/query db3 {"@context" [context {"ex:reversed-pred" {"@reverse" "ex:unlabeled-pred"}}]
                                  "select"   {"ex:nested" ["id" "ex:reversed-pred"]}}))
           "via reverse no subgraph"))))
 


### PR DESCRIPTION
We were not using the right data for the test - db3 was unused and it was the only db that had an edge between ex:subject-as-predicate and ex:nested via ex:unlabeled. As soon as I changed it to the correct data source the results met expectations.