### PR TITLE
Feature/allow iri value maps

### DIFF
--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -532,7 +532,7 @@
   [db t commit-sid annotation]
   (if annotation
     (let [allowed-vars #{}
-          parsed       (q-parse/parse-triples allowed-vars (util/sequential annotation))
+          parsed       (q-parse/parse-triples allowed-vars nil (util/sequential annotation))
           a-sid        (->> parsed ffirst where/get-iri (iri/encode-iri db))
           db-vol       (volatile! db)
           flakes       (into [(flake/create commit-sid const/$_commit:annotation a-sid const/$xsd:anyURI t true nil)]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -614,7 +614,7 @@
 (defn parse-object-value
   [v datatype context metadata]
   (let [datatype* (iri/normalize datatype)]
-    (if (= datatype* const/iri-anyURI)
+    (if (= datatype* const/iri-id)
       (where/match-iri (json-ld/expand-iri v context))
       (where/anonymous-value v datatype* metadata))))
 

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -623,7 +623,7 @@
    {:keys [list id value type language] :as v-map}]
   (cond list
         (reduce (fn [triples [i list-item]]
-                  (parse-obj-cmp allowed-vars subj-cmp pred-cmp {:i i} triples list-item))
+                  (parse-obj-cmp allowed-vars context subj-cmp pred-cmp {:i i} triples list-item))
                 triples
                 (map vector (range) list))
 
@@ -651,7 +651,7 @@
                     ;; project newly created bnode-id into v-map
                     (assoc v-map :id (where/get-iri ref-cmp))
                     v-map)]
-      (conj (parse-subj-cmp allowed-vars triples v-map*)
+      (conj (parse-subj-cmp allowed-vars context triples v-map*)
             [subj-cmp pred-cmp ref-cmp]))))
 
 (defn parse-pred-cmp

--- a/src/clj/fluree/db/reasoner.cljc
+++ b/src/clj/fluree/db/reasoner.cljc
@@ -198,7 +198,7 @@
                          by-subj)
             parsed     (->> statements
                             json-ld/expand
-                            (q-parse/parse-triples nil))]
+                            (q-parse/parse-triples nil nil))]
         (assoc acc rule-id {:insert parsed})))
     {}
     inserts))

--- a/src/clj/fluree/db/transact.cljc
+++ b/src/clj/fluree/db/transact.cljc
@@ -19,10 +19,10 @@
                    (mapcat rest)                      ; discard keys
                    (mapcat (partial remove
                                     (fn [v]
-                                      ;; remove value objects unless they have type xsd:anyURI
+                                      ;; remove value objects unless they have type @id
                                       (and
                                         (some? (:value v))
-                                        (not= (:type v) const/iri-anyURI)))))))
+                                        (not= (:type v) const/iri-id)))))))
        not-empty))
 
 (defn extract-annotation

--- a/src/clj/fluree/db/transact.cljc
+++ b/src/clj/fluree/db/transact.cljc
@@ -1,7 +1,8 @@
 (ns fluree.db.transact
   (:require [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util]
-            [fluree.json-ld :as json-ld]))
+            [fluree.json-ld :as json-ld]
+            [fluree.db.constants :as const]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -16,7 +17,12 @@
        (into []
              (comp (remove (fn [[k _]] (keyword? k)))  ; remove :id :idx :type
                    (mapcat rest)                      ; discard keys
-                   (mapcat (partial remove :value)))) ; remove value objects
+                   (mapcat (partial remove
+                                    (fn [v]
+                                      ;; remove value objects unless they have type xsd:anyURI
+                                      (and
+                                        (some? (:value v))
+                                        (not= (:type v) const/iri-anyURI)))))))
        not-empty))
 
 (defn extract-annotation
@@ -28,9 +34,11 @@
     (when-let [specified-id (:id annotation)]
       (throw (ex-info "Commit annotation cannot specify a subject identifier."
                       {:status 400, :error :db/invalid-annotation :id specified-id})))
-    (when (or (> (count expanded) 1)
-              (nested-nodes? annotation))
+    (when (> (count expanded) 1)
       (throw (ex-info "Commit annotation must only have a single subject."
+                      {:status 400, :error :db/invalid-annotation})))
+    (when (nested-nodes? annotation)
+      (throw (ex-info "Commit annotation cannot reference other subjects."
                       {:status 400, :error :db/invalid-annotation})))
     ;; everything is good
     expanded))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1087,7 +1087,7 @@
                                                           "schema:name" "Betty"
                                                           "schema:age"  55}]}
                                         {:annotation [{"ex:originator" "opts" "ex:friend"
-                                                       {"@type" "xsd:anyURI" "@value" "ex:betty"}}]})]
+                                                       {"@type" "id" "@value" "ex:betty"}}]})]
             (is (= "Commit annotation cannot reference other subjects." (ex-message invalid4))
                 "using value-map with type xsd:anyURI"))
           (let [invalid1 @(fluree/stage db0 {"@context" context

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1007,73 +1007,74 @@
                               (select-keys ["f:author" "f:txn" "f:data"]))))))))))
 
 (deftest ^:integration txn-annotation
-  (let [bnode-counter (atom 0)]
-    (with-redefs [fluree.db.util.core/current-time-iso    (fn [] "1970-01-01T00:12:00.00000Z")
-                  fluree.db.json-ld.iri/new-blank-node-id (fn [] (str "_:fdb-" (swap! bnode-counter inc)))]
-      (let [conn        @(fluree/connect {:method :memory})
-            ledger-name "annotationtest"
-            ledger      @(fluree/create conn ledger-name)
-            context     [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
+  (let [bnode-counter (atom 0)
 
-            db0         (fluree/db ledger)
+        conn        @(fluree/connect {:method :memory})
+        ledger-name "annotationtest"
+        ledger      @(fluree/create conn ledger-name)
+        context     [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
 
-            db1         (->> @(fluree/stage db0 {"@context" context
-                                                 "insert"   [{"@id"         "ex:betty"
-                                                              "@type"       "ex:Yeti"
-                                                              "schema:name" "Betty"
-                                                              "schema:age"  55}]})
-                             (fluree/commit! ledger)
-                             (deref))
+        db0 (fluree/db ledger)]
+    (testing "valid annotations"
+      (with-redefs [fluree.db.util.core/current-time-iso    (fn [] "1970-01-01T00:12:00.00000Z")
+                    fluree.db.json-ld.iri/new-blank-node-id (fn [] (str "_:fdb-" (swap! bnode-counter inc)))]
+        (let [db1         (->> @(fluree/stage db0 {"@context" context
+                                                   "insert"   [{"@id"         "ex:betty"
+                                                                "@type"       "ex:Yeti"
+                                                                "schema:name" "Betty"
+                                                                "schema:age"  55}]})
+                               (fluree/commit! ledger)
+                               (deref))
 
-            db2         (->> @(fluree/stage db1 {"@context" context
-                                                 "insert"   [{"@id"         "ex:freddy"
-                                                              "@type"       "ex:Yeti"
-                                                              "schema:name" "Freddy"
-                                                              "schema:age"  1002}]}
-                                            {:annotation {"ex:originator" "opts" "ex:data" "ok"}})
-                             (fluree/commit! ledger)
-                             (deref))
+              db2         (->> @(fluree/stage db1 {"@context" context
+                                                   "insert"   [{"@id"         "ex:freddy"
+                                                                "@type"       "ex:Yeti"
+                                                                "schema:name" "Freddy"
+                                                                "schema:age"  1002}]}
+                                              {:annotation {"ex:originator" "opts" "ex:data" "ok"}})
+                               (fluree/commit! ledger)
+                               (deref))
 
-            db3         (->> @(fluree/stage db2 {"@context" context
-                                                 "insert"   [{"@id"         "ex:letty"
-                                                              "@type"       "ex:Yeti"
-                                                              "schema:name" "Leticia"
-                                                              "schema:age"  38}]
-                                                 "opts"     {"annotation" {"ex:originator" "txn" "ex:data" "ok"}}})
-                             (fluree/commit! ledger)
-                             (deref))]
-        (testing "annotations in commit-details"
-          (is (= [{}
-                  {"f:annotation" {"id" "_:fdb-3" "ex:data" "ok" "ex:originator" "opts"}}
+              db3         (->> @(fluree/stage db2 {"@context" context
+                                                   "insert"   [{"@id"         "ex:letty"
+                                                                "@type"       "ex:Yeti"
+                                                                "schema:name" "Leticia"
+                                                                "schema:age"  38}]
+                                                   "opts"     {"annotation" {"ex:originator" "txn" "ex:data" "ok"}}})
+                               (fluree/commit! ledger)
+                               (deref))]
+          (testing "annotations in commit-details"
+            (is (= [{}
+                    {"f:annotation" {"id" "_:fdb-3" "ex:data" "ok" "ex:originator" "opts"}}
 
-                  {"f:annotation" {"id" "_:fdb-5" "ex:data" "ok" "ex:originator" "txn"}}]
-                 (->> @(fluree/history ledger {:context        context
-                                               :commit-details true
-                                               :t              {:from 1 :to :latest}})
-                      (mapv (fn [c] (-> c (get "f:commit") (select-keys ["f:txn" "f:annotation"]))))))))
+                    {"f:annotation" {"id" "_:fdb-5" "ex:data" "ok" "ex:originator" "txn"}}]
+                   (->> @(fluree/history ledger {:context        context
+                                                 :commit-details true
+                                                 :t              {:from 1 :to :latest}})
+                        (mapv (fn [c] (-> c (get "f:commit") (select-keys ["f:txn" "f:annotation"])))))))))))
+    (testing "invalid annotations"
+      (testing "only single annotation subject permitted"
+        (let [invalid1 @(fluree/stage db0 {"@context" context
+                                           "insert" [{"@id" "ex:betty"
+                                                      "@type" "ex:Yeti"
+                                                      "schema:name" "Betty"
+                                                      "schema:age" 55}]}
+                                      {:annotation {"ex:originator" "opts" "ex:nested" {"invalid" "true"}}})
+              invalid2 @(fluree/stage db0 {"@context" context
+                                           "insert" [{"@id" "ex:betty"
+                                                      "@type" "ex:Yeti"
+                                                      "schema:name" "Betty"
+                                                      "schema:age" 55}]}
+                                      {:annotation [{"ex:originator" "opts" "ex:multiple" true}
+                                                    {"ex:originator" "opts" "ex:invalid" true}]})]
+          (is (= "Commit annotation must only have a single subject." (ex-message invalid1)))
+          (is (= "Commit annotation must only have a single subject." (ex-message invalid2)))))
 
-        (testing "only single annotation subject permitted"
-          (let [invalid1 @(fluree/stage db0 {"@context" context
-                                             "insert"   [{"@id"         "ex:betty"
-                                                          "@type"       "ex:Yeti"
-                                                          "schema:name" "Betty"
-                                                          "schema:age"  55}]}
-                                        {:annotation {"ex:originator" "opts" "ex:nested" {"invalid" "true"}}})
-                invalid2 @(fluree/stage db0 {"@context" context
-                                             "insert"   [{"@id"         "ex:betty"
-                                                          "@type"       "ex:Yeti"
-                                                          "schema:name" "Betty"
-                                                          "schema:age"  55}]}
-                                        {:annotation [{"ex:originator" "opts" "ex:multiple" true}
-                                                      {"ex:originator" "opts" "ex:invalid" true}]})]
-            (is (= "Commit annotation must only have a single subject." (ex-message invalid1)))
-            (is (= "Commit annotation must only have a single subject." (ex-message invalid2)))))
-
-        (testing "annotation has no references"
-          (let [invalid3 @(fluree/stage db0 {"@context" context
-                                             "insert"   [{"@id"         "ex:betty"
-                                                          "@type"       "ex:Yeti"
-                                                          "schema:name" "Betty"
-                                                          "schema:age"  55}]}
-                                        {:annotation [{"ex:originator" "opts" "@id" "invalid:subj"}]})]
-            (is (= "Commit annotation cannot specify a subject identifier." (ex-message invalid3)))))))))
+      (testing "annotation has no references"
+        (let [invalid3 @(fluree/stage db0 {"@context" context
+                                           "insert" [{"@id" "ex:betty"
+                                                      "@type" "ex:Yeti"
+                                                      "schema:name" "Betty"
+                                                      "schema:age" 55}]}
+                                      {:annotation [{"ex:originator" "opts" "@id" "invalid:subj"}]})]
+          (is (= "Commit annotation cannot specify a subject identifier." (ex-message invalid3))))))))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1018,63 +1018,83 @@
     (testing "valid annotations"
       (with-redefs [fluree.db.util.core/current-time-iso    (fn [] "1970-01-01T00:12:00.00000Z")
                     fluree.db.json-ld.iri/new-blank-node-id (fn [] (str "_:fdb-" (swap! bnode-counter inc)))]
-        (let [db1         (->> @(fluree/stage db0 {"@context" context
-                                                   "insert"   [{"@id"         "ex:betty"
-                                                                "@type"       "ex:Yeti"
-                                                                "schema:name" "Betty"
-                                                                "schema:age"  55}]})
-                               (fluree/commit! ledger)
-                               (deref))
+        (let [db1 (->> @(fluree/stage db0 {"@context" context
+                                           "insert"   [{"@id"         "ex:betty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Betty"
+                                                        "schema:age"  55}]})
+                       (fluree/commit! ledger)
+                       (deref))
 
-              db2         (->> @(fluree/stage db1 {"@context" context
-                                                   "insert"   [{"@id"         "ex:freddy"
-                                                                "@type"       "ex:Yeti"
-                                                                "schema:name" "Freddy"
-                                                                "schema:age"  1002}]}
-                                              {:annotation {"ex:originator" "opts" "ex:data" "ok"}})
-                               (fluree/commit! ledger)
-                               (deref))
+              db2 (->> @(fluree/stage db1 {"@context" context
+                                           "insert"   [{"@id"         "ex:freddy"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Freddy"
+                                                        "schema:age"  1002}]}
+                                      {:annotation {"ex:originator" "opts" "ex:data" "ok"}})
+                       (fluree/commit! ledger)
+                       (deref))
 
-              db3         (->> @(fluree/stage db2 {"@context" context
-                                                   "insert"   [{"@id"         "ex:letty"
-                                                                "@type"       "ex:Yeti"
-                                                                "schema:name" "Leticia"
-                                                                "schema:age"  38}]
-                                                   "opts"     {"annotation" {"ex:originator" "txn" "ex:data" "ok"}}})
-                               (fluree/commit! ledger)
-                               (deref))]
+              db3 (->> @(fluree/stage db2 {"@context" context
+                                           "insert"   [{"@id"         "ex:letty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Leticia"
+                                                        "schema:age"  38}]
+                                           "opts"     {"annotation" {"ex:originator" "txn" "ex:data" "ok"}}})
+                       (fluree/commit! ledger)
+                       (deref))]
           (testing "annotations in commit-details"
             (is (= [{}
                     {"f:annotation" {"id" "_:fdb-3" "ex:data" "ok" "ex:originator" "opts"}}
-
                     {"f:annotation" {"id" "_:fdb-5" "ex:data" "ok" "ex:originator" "txn"}}]
                    (->> @(fluree/history ledger {:context        context
                                                  :commit-details true
                                                  :t              {:from 1 :to :latest}})
-                        (mapv (fn [c] (-> c (get "f:commit") (select-keys ["f:txn" "f:annotation"])))))))))))
-    (testing "invalid annotations"
-      (testing "only single annotation subject permitted"
-        (let [invalid1 @(fluree/stage db0 {"@context" context
-                                           "insert" [{"@id" "ex:betty"
-                                                      "@type" "ex:Yeti"
-                                                      "schema:name" "Betty"
-                                                      "schema:age" 55}]}
-                                      {:annotation {"ex:originator" "opts" "ex:nested" {"invalid" "true"}}})
-              invalid2 @(fluree/stage db0 {"@context" context
-                                           "insert" [{"@id" "ex:betty"
-                                                      "@type" "ex:Yeti"
-                                                      "schema:name" "Betty"
-                                                      "schema:age" 55}]}
-                                      {:annotation [{"ex:originator" "opts" "ex:multiple" true}
-                                                    {"ex:originator" "opts" "ex:invalid" true}]})]
-          (is (= "Commit annotation must only have a single subject." (ex-message invalid1)))
-          (is (= "Commit annotation must only have a single subject." (ex-message invalid2)))))
+                        (mapv (fn [c] (-> c (get "f:commit") (select-keys ["f:txn" "f:annotation"]))))))))))
 
-      (testing "annotation has no references"
-        (let [invalid3 @(fluree/stage db0 {"@context" context
-                                           "insert" [{"@id" "ex:betty"
-                                                      "@type" "ex:Yeti"
-                                                      "schema:name" "Betty"
-                                                      "schema:age" 55}]}
-                                      {:annotation [{"ex:originator" "opts" "@id" "invalid:subj"}]})]
-          (is (= "Commit annotation cannot specify a subject identifier." (ex-message invalid3))))))))
+      (testing "invalid annotations"
+        (testing "only single annotation subject permitted"
+          (let [invalid2 @(fluree/stage db0 {"@context" context
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
+                                        {:annotation [{"ex:originator" "opts" "ex:multiple" true}
+                                                      {"ex:originator" "opts" "ex:invalid" true}]})]
+            (is (= "Commit annotation must only have a single subject." (ex-message invalid2)))))
+
+        (testing "cannot specify id"
+          (let [invalid3 @(fluree/stage db0 {"@context" context
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
+                                        {:annotation [{"ex:originator" "opts" "@id" "invalid:subj"}]})]
+            (is (= "Commit annotation cannot specify a subject identifier." (ex-message invalid3)))))
+
+        (testing "annotation has no references"
+          (let [invalid4 @(fluree/stage db0 {"@context" context
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
+                                        {:annotation [{"ex:originator" "opts" "ex:friend" {"@id" "ex:betty"}}]})]
+            (is (= "Commit annotation cannot reference other subjects." (ex-message invalid4))
+                "using id-map"))
+          (let [invalid4 @(fluree/stage db0 {"@context" context
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
+                                        {:annotation [{"ex:originator" "opts" "ex:friend"
+                                                       {"@type" "xsd:anyURI" "@value" "ex:betty"}}]})]
+            (is (= "Commit annotation cannot reference other subjects." (ex-message invalid4))
+                "using value-map with type xsd:anyURI"))
+          (let [invalid1 @(fluree/stage db0 {"@context" context
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
+                                        {:annotation {"ex:originator" "opts" "ex:nested" {"valid" false}}})]
+            (is (= "Commit annotation cannot reference other subjects." (ex-message invalid1))
+                "using implicit blank node identifier")))))))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -156,7 +156,21 @@
                   :select  {:ex/wes [:*]}}]
       (is (= [{:id                        :ex/wes
                :ex/aFewOfMyFavoriteThings [2011 "jabalí"]}]
-             @(fluree/query db query))))))
+             @(fluree/query db query)))))
+  (testing "iri value maps are handled correctly"
+    (let [conn @(fluree/connect {:method :memory})
+          ledger @(fluree/create conn "any-iri")
+          db0 (fluree/db ledger)
+
+          db1 @(fluree/stage db0 {"@context" {"ex" "http://example.com/"}
+                                  "insert" [{"@id" "ex:foo"
+                                             "ex:bar" {"@type" "http://www.w3.org/2001/XMLSchema#anyURI"
+                                                       "@value" "ex:baz"}}]})]
+      (is (= [{"@id" "http://example.com/foo"
+               "http://example.com/bar" {"@id" "http://example.com/baz"}}]
+             @(fluree/query db1 {"@context" nil
+                                 "select" {"http://example.com/foo" ["*"]}}))
+          "ex:baz is properly expanded and wrapped in an id-map"))))
 
 (deftest object-var-test
   (testing "var in object position works"

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -164,7 +164,7 @@
 
           db1 @(fluree/stage db0 {"@context" {"ex" "http://example.com/"}
                                   "insert" [{"@id" "ex:foo"
-                                             "ex:bar" {"@type" "http://www.w3.org/2001/XMLSchema#anyURI"
+                                             "ex:bar" {"@type" "@id"
                                                        "@value" "ex:baz"}}]})]
       (is (= [{"@id" "http://example.com/foo"
                "http://example.com/bar" {"@id" "http://example.com/baz"}}]


### PR DESCRIPTION
In the discussion around allowing [id-maps for values patterns](https://github.com/fluree/db/pull/809), I discovered that we don't actually support IRIs in value maps for regular processing - only as special value-pattern syntax.

This PR adds support for that style of IRI ref construction. I could have added support for IRIs in value-maps to the json-ld library, but that is not how `expand` works according to the json-ld spec. Since this is a proprietary extension I chose to implement it `db`, though, since our json-ld processor library is _not_ a compliant processor, we could sneak it there if we'd like.

I also had to re-work the annotation validation logic to detect references that are represented with value maps. 