### PR TITLE
deterministic where patterns

### DIFF
--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -683,7 +683,9 @@
                        :else            (where/match-iri id))]
     (reduce (partial parse-pred-cmp allowed-vars subj-cmp)
             triples
-            (dissoc node :id :idx))))
+            (->> (dissoc node :id :idx)
+                 ;; deterministic patterns for each pred
+                 (sort-by (comp str first))))))
 
 (defn parse-triples
   "Flattens and parses expanded json-ld into update triples."


### PR DESCRIPTION
If a node-pattern in a where clause has multiple predicates, the order that they are converted into triple patterns isn't deterministic. This commit sorts the keys before converting them into new patterns.