### PR TITLE
Fix list retraction

### DIFF
--- a/test/fluree/db/transact/retraction_test.clj
+++ b/test/fluree/db/transact/retraction_test.clj
@@ -41,4 +41,36 @@
                             {:context [test-utils/default-context
                                        {:ex "http://example.org/ns/"}],
                              :select {:ex/alice [:*]}}))
-          "Alice should no longer have an age property"))))
+          "Alice should no longer have an age property")))
+  (testing "retracting ordered lists"
+    (let [conn             (test-utils/create-conn)
+          ledger           @(fluree/create conn "tx/retract")
+          context          [test-utils/default-str-context
+                            {"ex"        "http://example.org/ns/"
+                             "ex:items2" {"@container" "@list"}}]
+          q1               {:context context
+                            :select  {"ex:list-test" ["*"]}}
+          db               @(fluree/stage
+                             (fluree/db ledger)
+                             {"@context" context
+                              "insert"
+                              [{"id"        "ex:list-test"
+                                "ex:items1" {"@list" ["zero" "one" "two"
+                                                      "three"]}
+                                "ex:items2" ["four" "five" "six" "seven"]}]})
+          before-retract   @(fluree/query db q1)
+          db-after-retract @(fluree/stage
+                             db
+                             {"@context" context
+                              "delete"   {"id"        "ex:list-test"
+                                          "ex:items1" "?items1"
+                                          "ex:items2" "?items2"}
+                              "where"    {"id"        "ex:list-test"
+                                          "ex:items1" "?items1"
+                                          "ex:items2" "?items2"}})
+          after-retract    @(fluree/query db-after-retract q1)]
+      (is (= [{"id"        "ex:list-test"
+               "ex:items1" ["zero" "one" "two" "three"]
+               "ex:items2" ["four" "five" "six" "seven"]}]
+             before-retract))
+      (is (= [{"id" "ex:list-test"}] after-retract)))))


### PR DESCRIPTION
The retraction code was conceptually duplicated from the assertion code, but implemented pretty differently (when 99% of the time the only necessary difference was the `false` arg to `flake/create`). This was causing list retractions to fail b/c lists weren't handled in the retraction code.

This DRY's up the assert/retract code and fixes the list retraction issue. Ideally I would add a test in here for the list retraction issue, and I will attempt to do that. But I don't want to spend too much time on it. I do have an integration test in another project that went from failing to passing with these changes.