### PR TITLE
Feature/credential apis

### DIFF
--- a/src/clj/fluree/db/api/transact.cljc
+++ b/src/clj/fluree/db/api/transact.cljc
@@ -21,89 +21,103 @@
           opts))
 
 (defn stage
-  [db txn {:keys [raw-txn] :as opts}]
+  [db txn opts]
   (go-try
-    (let [{txn* :subject did :did} (or (<? (cred/verify txn))
-                                       {:subject txn})
-          txn-context              (or (:context opts)
-                                       (ctx-util/txn-context txn*))
+   (let [txn-context (or (ctx-util/txn-context txn)
+                         (:context opts))
+         expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
+         parsed-opts (-> (util/get-first-value expanded const/iri-opts) ;; get opts out of transaction
+                         (merge opts) ;; merge with upstream supplied opts (e.g. did, raw-txn
+                         (assoc :context txn-context)
+                         (util/keywordize-keys))
+         track-fuel? (or (:maxFuel parsed-opts)
+                         (:meta parsed-opts))
+         parsed-txn  (q-parse/parse-txn expanded txn-context)
 
-          expanded   (json-ld/expand (ctx-util/use-fluree-context txn*))
-          txn-opts   (util/get-first-value expanded const/iri-opts)
-          parsed-txn (q-parse/parse-txn expanded txn-context)
-
-          {:keys [maxFuel meta], :as parsed-opts}
-          (cond-> opts
-            (not raw-txn) (assoc :raw-txn txn)
-            did           (assoc :did did)
-            txn-context   (assoc :context txn-context)
-            true          (parse-opts txn-opts))
-
-          identity (perm/parse-policy-identity parsed-opts txn-context)]
-      (if (or maxFuel meta)
-        (let [start-time   #?(:clj  (System/nanoTime)
-                              :cljs (util/current-time-millis))
-              fuel-tracker (fuel/tracker maxFuel)]
-          (try*
-            (let [result (<? (tx/stage db fuel-tracker identity parsed-txn parsed-opts))]
-              {:status 200
-               :result result
-               :time   (util/response-time-formatted start-time)
-               :fuel   (fuel/tally fuel-tracker)})
-            (catch* e
-              (throw (ex-info "Error staging database"
-                              {:time (util/response-time-formatted start-time)
-                               :fuel (fuel/tally fuel-tracker)}
-                              e)))))
-        (<? (tx/stage db identity parsed-txn parsed-opts))))))
+         identity    (perm/parse-policy-identity parsed-opts txn-context)]
+     (if track-fuel?
+       (let [start-time #?(:clj (System/nanoTime)
+                           :cljs (util/current-time-millis))
+             fuel-tracker       (fuel/tracker (:maxFuel parsed-opts))]
+         (try*
+          (let [result (<? (tx/stage db fuel-tracker identity parsed-txn parsed-opts))]
+            {:status 200
+             :result result
+             :time   (util/response-time-formatted start-time)
+             :fuel   (fuel/tally fuel-tracker)})
+          (catch* e
+                  (throw (ex-info "Error staging database"
+                                  {:time (util/response-time-formatted start-time)
+                                   :fuel (fuel/tally fuel-tracker)}
+                                  e)))))
+       (<? (tx/stage db identity parsed-txn parsed-opts))))))
 
 (defn transact!
-  [conn txn]
-  (go-try
-    (let [{txn* :subject did :did} (or (<? (cred/verify txn))
-                                       {:subject txn})
+  ([conn txn] (transact! conn txn {:raw-txn txn}))
+  ([conn txn {:keys [context] :as opts}]
+   (go-try
+    (let [txn-context (or (ctx-util/txn-context txn)
+                          context) ;; parent context might come from a Verifiable Credential's context
+          expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
+          ledger-id*  (util/get-first-value expanded const/iri-ledger)
+          _           (when-not ledger-id*
+                        (throw (ex-info "Invalid transaction, missing required key: ledger."
+                                        {:status 400 :error :db/invalid-transaction})))
+          address     (<? (nameservice/primary-address conn ledger-id* nil))
 
-          txn-context (ctx-util/txn-context txn*)
-          expanded    (json-ld/expand (ctx-util/use-fluree-context txn*))
-          ledger-id   (util/get-first-value expanded const/iri-ledger)
-          _ (when-not ledger-id
-              (throw (ex-info "Invalid transaction, missing required key: ledger."
-                              {:status 400 :error :db/invalid-transaction})))
-          address     (<? (nameservice/primary-address conn ledger-id nil))
-
-          opts (cond-> (util/get-first-value expanded const/iri-opts)
-                 did         (assoc :did did)
-                 txn-context (assoc :context txn-context))
-
-          parsed-opts (parse-opts {:raw-txn txn} opts)]
+          parsed-opts (-> (util/get-first-value expanded const/iri-opts)
+                          (merge opts)
+                          (util/keywordize-keys)
+                          (assoc :context txn-context))]
       (if-not (<? (nameservice/exists? conn address))
         (throw (ex-info "Ledger does not exist" {:ledger address}))
-        (let [ledger (<? (jld-ledger/load conn address))
-              db     (<? (stage (ledger/-db ledger) txn* parsed-opts))]
-          (<? (ledger/-commit! ledger db)))))))
+        (let [ledger   (<? (jld-ledger/load conn address))
+              db       (<? (stage (ledger/-db ledger) txn parsed-opts))
+              ;; commit API takes a did-map and parsed context as opts
+              ;; whereas stage API takes a did IRI and unparsed context.
+              ;; Dissoc them until deciding at a later point if they can carry through.
+              cmt-opts (dissoc parsed-opts :context :did)] ;; possible keys at f.d.ledger.json-ld/enrich-commit-opts
+          (<? (ledger/-commit! ledger db cmt-opts))))))))
+
+(defn credential-transact!
+  "Like transact!, but use when leveraging a Verifiable Credential or signed JWS.
+
+  Will throw if signature cannot be extracted."
+  [conn txn opts]
+  (go-try
+   (let [{txn* :subject did :did} (<? (cred/verify txn))
+         parent-context (when (map? txn) ;; parent-context only relevant for verifiable credential
+                          (ctx-util/txn-context txn))]
+     (<? (transact! conn txn* (assoc opts :raw-txn txn
+                                          :did did
+                                          :context parent-context))))))
 
 (defn create-with-txn
-  [conn txn]
-  (go-try
-    (let [{txn* :subject did :did} (or (<? (cred/verify txn))
-                                       {:subject txn})
-
-          txn-context (ctx-util/txn-context txn*)
-          expanded    (json-ld/expand (ctx-util/use-fluree-context txn*))
+  ([conn txn] (create-with-txn conn txn nil))
+  ([conn txn {:keys [context] :as opts}]
+   (go-try
+    (let [expanded    (json-ld/expand (ctx-util/use-fluree-context txn))
+          txn-context (or (ctx-util/txn-context txn)
+                          context) ;; parent context from credential if present
           ledger-id   (util/get-first-value expanded const/iri-ledger)
-          _ (when-not ledger-id
-              (throw (ex-info "Invalid transaction, missing required key: ledger."
-                              {:status 400 :error :db/invalid-transaction})))
+          _           (when-not ledger-id
+                        (throw (ex-info "Invalid transaction, missing required key: ledger."
+                                        {:status 400 :error :db/invalid-transaction})))
           address     (<? (nameservice/primary-address conn ledger-id nil))
-
-          opts (cond-> (util/get-first-value expanded const/iri-opts)
-                 did         (assoc :did did)
-                 txn-context (assoc :context txn-context))
-
-          parsed-opts (parse-opts {:raw-txn txn} opts)]
+          parsed-opts (-> (util/get-first-value expanded const/iri-opts)
+                          (merge opts) ;; override opts 'did', 'raw-txn' with credential's if present
+                          (util/keywordize-keys)
+                          (assoc :context txn-context))]
       (if (<? (nameservice/exists? conn address))
         (throw (ex-info (str "Ledger " ledger-id " already exists")
                         {:status 409 :error :db/ledger-exists}))
         (let [ledger (<? (jld-ledger/create conn ledger-id parsed-opts))
-              db     (<? (stage (ledger/-db ledger) txn* parsed-opts))]
-          (<? (ledger/-commit! ledger db)))))))
+              db     (<? (stage (ledger/-db ledger) txn parsed-opts))]
+          (<? (ledger/-commit! ledger db))))))))
+
+(defn credential-create-with-txn!
+  [conn txn]
+  (let [{txn* :subject did :did} (<? (cred/verify txn))
+        parent-context (when (map? txn) ;; parent-context only relevant for verifiable credential
+                         (ctx-util/txn-context txn))]
+    (create-with-txn conn txn* {:raw-txn txn, :did did :context parent-context})))

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -524,9 +524,7 @@
 
 ;; TODO - txn should really be an IRI, not a string
 (defn txn-flake
-  "Builds and returns the commit txn flakes for the given t and transaction id.
-  Used when committing to an in-memory ledger value and when reifying a ledger
-  from storage on load."
+  "Builds and returns the commit txn flake for the given t and transaction id."
   [t commit-sid txn]
   (flake/create commit-sid const/$_commit:txn txn const/$xsd:string t true nil))
 
@@ -563,8 +561,6 @@
                              (issuer-flakes db t commit-sid issuer-iri))
         message-flakes     (when message
                              (message-flakes t commit-sid message))
-        txn-flake          (when txn
-                             (txn-flake t commit-sid txn))
 
         [db* annotation-flakes] (annotation-flakes db t commit-sid annotation)
 
@@ -574,7 +570,7 @@
                                    issuer-flakes (into issuer-flakes)
                                    annotation-flakes (into annotation-flakes)
                                    message-flakes (into message-flakes)
-                                   txn-flake (conj txn-flake))]
+                                   txn (conj (txn-flake t commit-sid txn)))]
     (-> db*
         (update-novelty commit-flakes)
         add-tt-id)))

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -175,15 +175,15 @@
 
 (defn jsonld->clj
   [jsonld]
-  (let [id      (:id jsonld)
-        v       (get-first-value jsonld const/iri-v)
-        alias   (get-first-value jsonld const/iri-alias)
-        branch  (get-first-value jsonld const/iri-branch)
-        address (-> jsonld
-                    (get-first-value const/iri-address)
-                    not-empty)
-        author  (get-first-value jsonld const/iri-author)
-        txn     (get-first-value jsonld const/iri-txn)
+  (let [id          (:id jsonld)
+        v           (get-first-value jsonld const/iri-v)
+        alias       (get-first-value jsonld const/iri-alias)
+        branch      (get-first-value jsonld const/iri-branch)
+        address     (-> jsonld
+                        (get-first-value const/iri-address)
+                        not-empty)
+        author      (get-first-value jsonld const/iri-author)
+        txn         (get-first-value jsonld const/iri-txn)
 
         time        (get-first-value jsonld const/iri-time)
         message     (get-first-value jsonld const/iri-message)
@@ -194,27 +194,27 @@
         ns          (get-first jsonld const/iri-ns)
         index       (get-first jsonld const/iri-index)]
 
-    (cond-> {:id      id
-             :v       v
-             :alias   alias
-             :branch  branch
-             :time    time
-             :tag     (mapv :value tags)
-             :data    (parse-db-data data)
-             :author  author
-             :txn     txn}
-      address     (assoc :address address)
-      prev-commit (assoc :previous       {:id      (:id prev-commit)
+    (cond-> {:id     id
+             :v      v
+             :alias  alias
+             :branch branch
+             :time   time
+             :tag    (mapv :value tags)
+             :data   (parse-db-data data)
+             :author author}
+            txn (assoc :txn txn)
+            address (assoc :address address)
+            prev-commit (assoc :previous {:id      (:id prev-commit)
                                           :address (get-first-value prev-commit const/iri-address)})
-      message     (assoc :message message)
-      ns          (assoc :ns (->> ns
-                                  util/sequential
-                                  (mapv (fn [namespace]
-                                          (select-keys namespace [:id])))))
-      index       (assoc :index {:id      (:id index)
+            message (assoc :message message)
+            ns (assoc :ns (->> ns
+                               util/sequential
+                               (mapv (fn [namespace]
+                                       (select-keys namespace [:id])))))
+            index (assoc :index {:id      (:id index)
                                  :address (get-first-value index const/iri-address)
                                  :data    (parse-db-data (get-first index const/iri-data))})
-      issuer      (assoc :issuer (select-keys issuer [:id])))))
+            issuer (assoc :issuer (select-keys issuer [:id])))))
 
 (defn update-index-roots
   [commit-map {:keys [spot post opst tspo]}]
@@ -377,15 +377,15 @@
                                 :prev-commit)
                         (assoc :address ""
                                :author author
-                               :txn  txn-id
                                :data data-commit
                                :time (util/current-time-iso)))]
     (cond-> commit
-      issuer (assoc :issuer {:id issuer})
-      prev-commit (assoc :previous prev-commit)
-      message (assoc :message message)
-      annotation (assoc :annotation annotation)
-      tag (assoc :tag tag))))
+            txn-id (assoc :txn txn-id)
+            issuer (assoc :issuer {:id issuer})
+            prev-commit (assoc :previous prev-commit)
+            message (assoc :message message)
+            annotation (assoc :annotation annotation)
+            tag (assoc :tag tag))))
 
 (defn ref?
   [f]
@@ -451,7 +451,7 @@
   "Builds and returns the commit metadata flakes for the given commit, t, and
   db-sid. Used when committing to an in-memory ledger value and when reifying
   a ledger from storage on load."
-  [{:keys [address alias branch data time v author txn] :as _commit} t commit-sid db-sid]
+  [{:keys [address alias branch data time v author] :as _commit} t commit-sid db-sid]
   (let [{db-t :t db-address :address :keys [flakes size]} data]
     [;; commit flakes
      ;; address
@@ -468,8 +468,6 @@
      (flake/create commit-sid const/$_commit:data db-sid const/$xsd:anyURI t true nil)
      ;; author
      (flake/create commit-sid const/$_commit:author author const/$xsd:string t true nil)
-     ;; txn
-     (flake/create commit-sid const/$_commit:txn txn const/$xsd:string t true nil)
 
      ;; db flakes
      ;; t
@@ -524,6 +522,14 @@
   [t commit-sid message]
   [(flake/create commit-sid const/$_commit:message message const/$xsd:string t true nil)])
 
+;; TODO - txn should really be an IRI, not a string
+(defn txn-flake
+  "Builds and returns the commit txn flakes for the given t and transaction id.
+  Used when committing to an in-memory ledger value and when reifying a ledger
+  from storage on load."
+  [t commit-sid txn]
+  (flake/create commit-sid const/$_commit:txn txn const/$xsd:string t true nil))
+
 (defn annotation-flakes
   [db t commit-sid annotation]
   (if annotation
@@ -540,10 +546,10 @@
 (defn add-commit-flakes
   "Translate commit metadata into flakes and merge them into novelty."
   [{:keys [commit] :as db} prev-commit]
-  (let [{:keys [data id issuer message annotation]} commit
-        {db-t :t, db-id :id}                        data
-        {previous-id :id prev-data :data}           prev-commit
-        prev-data-id                                (:id prev-data)
+  (let [{:keys [data id issuer message annotation txn]} commit
+        {db-t :t, db-id :id} data
+        {previous-id :id prev-data :data} prev-commit
+        prev-data-id       (:id prev-data)
 
         t                  db-t
         commit-sid         (iri/encode-iri db id)
@@ -557,15 +563,18 @@
                              (issuer-flakes db t commit-sid issuer-iri))
         message-flakes     (when message
                              (message-flakes t commit-sid message))
+        txn-flake          (when txn
+                             (txn-flake t commit-sid txn))
 
         [db* annotation-flakes] (annotation-flakes db t commit-sid annotation)
 
-        commit-flakes (cond-> base-flakes
-                        prev-commit-flakes (into prev-commit-flakes)
-                        prev-db-flakes     (into prev-db-flakes)
-                        issuer-flakes      (into issuer-flakes)
-                        annotation-flakes  (into annotation-flakes)
-                        message-flakes     (into message-flakes))]
+        commit-flakes      (cond-> base-flakes
+                                   prev-commit-flakes (into prev-commit-flakes)
+                                   prev-db-flakes (into prev-db-flakes)
+                                   issuer-flakes (into issuer-flakes)
+                                   annotation-flakes (into annotation-flakes)
+                                   message-flakes (into message-flakes)
+                                   txn-flake (conj txn-flake))]
     (-> db*
         (update-novelty commit-flakes)
         add-tt-id)))

--- a/src/clj/fluree/db/json_ld/credential.cljc
+++ b/src/clj/fluree/db/json_ld/credential.cljc
@@ -4,7 +4,7 @@
             #?(:cljs [cljs.core.async.interop :refer-macros [<p!]])
             [fluree.crypto :as crypto]
             [fluree.db.did :as did]
-            [fluree.db.util.async :refer [go-try]]
+            [fluree.db.util.async :refer [go-try <?]]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.json :as json]
             [fluree.json-ld :as json-ld]

--- a/src/clj/fluree/db/json_ld/credential.cljc
+++ b/src/clj/fluree/db/json_ld/credential.cljc
@@ -115,7 +115,7 @@
         auth-did                 (did/auth-id->did id)]
     {:subject (json/parse payload false) :did auth-did}))
 
-(defn is-JWS?
+(defn jws?
   [signed-transaction]
   (string? signed-transaction))
 
@@ -126,7 +126,7 @@
   Will throw if no :did is detected."
   [signed-command]
   (go-try
-   (let [result (if (is-JWS? signed-command)
+   (let [result (if (jws? signed-command)
                   (verify-jws signed-command)
                   (<? (verify-credential signed-command)))]
      (if (:did result)

--- a/src/clj/fluree/db/json_ld/credential.cljc
+++ b/src/clj/fluree/db/json_ld/credential.cljc
@@ -116,8 +116,9 @@
     {:subject (json/parse payload false) :did auth-did}))
 
 (defn jws?
-  [signed-transaction]
-  (string? signed-transaction))
+  [x]
+  (and (string? x)
+       (re-matches #"(^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$)" x)))
 
 (defn verify
   "Verifies a signed query/transaction. Returns keys:

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -64,16 +64,17 @@
 (defn query-fql
   "Execute a query against a database source. Returns core async channel
   containing result or exception."
-  [ds query]
-  (go-try
-    (let [{query :subject, did :did} (or (<? (cred/verify query))
-                                         {:subject query})
-          {:keys [t opts] :as query*} (update query :opts sanitize-query-options did)
+  ([ds query] (query-fql ds query nil))
+  ([ds query {:keys [did issuer] :as _opts}]
+   (go-try
+    ;; TODO - verify if both 'did' and 'issuer' opts are still needed upstream
+    (let [{:keys [t opts] :as query*} (update query :opts sanitize-query-options (or did issuer))
 
           ;; TODO: extracting query context here for policy only to do it later
           ;; while parsing the query. We need to consolidate both policy and
           ;; query parsing while cleaning up the query api call stack.
           q-ctx    (ctx-util/extract query*)
+          ;; TODO - remove restrict-db from here, restriction should happen upstream if needed
           ds*      (if (dataset? ds)
                      ds
                      (<? (restrict-db ds t q-ctx opts)))
@@ -81,7 +82,7 @@
           max-fuel (:max-fuel opts)]
       (if (::util/track-fuel? opts)
         (<? (track-query ds* max-fuel query**))
-        (<? (fql/query ds* query**))))))
+        (<? (fql/query ds* query**)))))))
 
 (defn query-sparql
   [db query]
@@ -207,11 +208,9 @@
         (dataset db-map defaults)))))
 
 (defn query-connection-fql
-  [conn query]
+  [conn query {:keys [did] :as opts}]
   (go-try
-    (let [{query :subject, did :did} (or (<? (cred/verify query))
-                                         {:subject query})
-          {:keys [t opts] :as query*}  (update query :opts sanitize-query-options did)
+    (let [{:keys [t opts] :as query*}  (update query :opts sanitize-query-options did)
 
           default-aliases (some-> query* :from util/sequential)
           named-aliases   (some-> query* :from-named util/sequential)]
@@ -230,13 +229,14 @@
 
 
 (defn query-connection-sparql
-  [conn query]
+  [conn query opts]
   (go-try
     (let [fql (sparql/->fql query)]
-      (<? (query-connection-fql conn fql)))))
+      (<? (query-connection-fql conn fql opts)))))
 
 (defn query-connection
-  [conn query {:keys [format] :as _opts :or {format :fql}}]
+  [conn query {:keys [format] :as opts :or {format :fql}}]
   (case format
-    :fql (query-connection-fql conn query)
-    :sparql (query-connection-sparql conn query)))
+    :fql (query-connection-fql conn query opts)
+    :sparql (query-connection-sparql conn query opts)))
+

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -69,7 +69,7 @@
 
        (testing "verify not a credential"
          (let [non-cred example-cred-subject]
-           (is (nil? (async/<!! (cred/verify non-cred)))))))))
+           (is (util/exception? (async/<!! (cred/verify non-cred)))))))))
 
 #?(:cljs
    (deftest generate

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -109,7 +109,7 @@
        (async/go
         (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:00:00.00000Z")]
                      (let [non-cred example-cred-subject]
-                       (is (nil? (async/<! (cred/verify non-cred))))
+                       (is (util/exception? (async/<! (cred/verify non-cred))))
                        (done)))))))
 
 #?(:clj

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -11,57 +11,63 @@
 (deftest ^:integration history-query-test
   (let [ts-primeval (util/current-time-iso)
 
-        conn    (test-utils/create-conn)
-        ledger  @(fluree/create conn "historytest")
-        context [test-utils/default-context {:ex "http://example.org/ns/"}]
+        conn        (test-utils/create-conn)
+        ledger-id   "historytest"
+        context     [test-utils/default-context {:ex "http://example.org/ns/"}]
 
-        db1 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                          "insert"   [{:id   :ex/dan
-                                                       :ex/x "foo-1"
-                                                       :ex/y "bar-1"}
-                                                      {:id   :ex/cat
-                                                       :ex/x "foo-1"
-                                                       :ex/y "bar-1"}
-                                                      {:id   :ex/dog
-                                                       :ex/x "foo-1"
-                                                       :ex/y "bar-1"}]})
-        db2 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                          "delete"   {:id   :ex/dan
-                                                      :ex/x "foo-1"
-                                                      :ex/y "bar-1"}
-                                          "insert"   {:id   :ex/dan
-                                                      :ex/x "foo-2"
-                                                      :ex/y "bar-2"}})
-        ts2 (-> db2 :commit :time)
-        db3 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                          "delete"   {:id   :ex/dan
-                                                      :ex/x "foo-2"
-                                                      :ex/y "bar-2"}
-                                          "insert"   {:id   :ex/dan
-                                                      :ex/x "foo-3"
-                                                      :ex/y "bar-3"}})
+        db1         @(fluree/create-with-txn conn {"@context" ["https://ns.flur.ee" context]
+                                                   "ledger"   ledger-id
+                                                   "insert"   [{:id   :ex/dan
+                                                                :ex/x "foo-1"
+                                                                :ex/y "bar-1"}
+                                                               {:id   :ex/cat
+                                                                :ex/x "foo-1"
+                                                                :ex/y "bar-1"}
+                                                               {:id   :ex/dog
+                                                                :ex/x "foo-1"
+                                                                :ex/y "bar-1"}]})
+        db2         @(fluree/transact! conn {"@context" ["https://ns.flur.ee" context]
+                                             "ledger"   ledger-id
+                                             "delete"   {:id   :ex/dan
+                                                         :ex/x "foo-1"
+                                                         :ex/y "bar-1"}
+                                             "insert"   {:id   :ex/dan
+                                                         :ex/x "foo-2"
+                                                         :ex/y "bar-2"}})
+        ts2         (-> db2 :commit :time)
+        db3         @(fluree/transact! conn {"@context" ["https://ns.flur.ee" context]
+                                             "ledger"   ledger-id
+                                             "delete"   {:id   :ex/dan
+                                                         :ex/x "foo-2"
+                                                         :ex/y "bar-2"}
+                                             "insert"   {:id   :ex/dan
+                                                         :ex/x "foo-3"
+                                                         :ex/y "bar-3"}})
 
-        ts3 (-> db3 :commit :time)
-        db4 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                          "delete"   [{:id   :ex/cat
-                                                       :ex/x "foo-1"
-                                                       :ex/y "bar-1"}
-                                                      {:id   :ex/dog
-                                                       :ex/x "foo-1"
-                                                       :ex/y "bar-1"}]
-                                          "insert"   [{:id   :ex/cat
-                                                       :ex/x "foo-cat"
-                                                       :ex/y "bar-cat"}
-                                                      {:id   :ex/dog
-                                                       :ex/x "foo-dog"
-                                                       :ex/y "bar-dog"}]})
-        db5 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                          "delete"   {:id   :ex/dan
-                                                      :ex/x "foo-3"
-                                                      :ex/y "bar-3"}
-                                          "insert"   {:id   :ex/dan
-                                                      :ex/x "foo-cat"
-                                                      :ex/y "bar-cat"}})]
+        ts3         (-> db3 :commit :time)
+        db4         @(fluree/transact! conn {"@context" ["https://ns.flur.ee" context]
+                                             "ledger"   ledger-id
+                                             "delete"   [{:id   :ex/cat
+                                                          :ex/x "foo-1"
+                                                          :ex/y "bar-1"}
+                                                         {:id   :ex/dog
+                                                          :ex/x "foo-1"
+                                                          :ex/y "bar-1"}]
+                                             "insert"   [{:id   :ex/cat
+                                                          :ex/x "foo-cat"
+                                                          :ex/y "bar-cat"}
+                                                         {:id   :ex/dog
+                                                          :ex/x "foo-dog"
+                                                          :ex/y "bar-dog"}]})
+        db5         @(fluree/transact! conn {"@context" ["https://ns.flur.ee" context]
+                                             "ledger"   ledger-id
+                                             "delete"   {:id   :ex/dan
+                                                         :ex/x "foo-3"
+                                                         :ex/y "bar-3"}
+                                             "insert"   {:id   :ex/dan
+                                                         :ex/x "foo-cat"
+                                                         :ex/y "bar-cat"}})
+        ledger      @(fluree/load conn ledger-id)]
     (testing "subject history"
       (is (= [{:f/t       1
                :f/assert  [{:id :ex/dan :ex/x "foo-1" :ex/y "bar-1"}]
@@ -233,21 +239,25 @@
                    :cause))))
 
     (testing "small cache"
-      (let [conn    (test-utils/create-conn)
-            ledger  @(fluree/create conn "historycachetest")
-            context [test-utils/default-context {:ex "http://example.org/ns/"}]
+      (let [conn      (test-utils/create-conn)
+            ledger-id "historycachetest"
+            context   [test-utils/default-context {:ex "http://example.org/ns/"}]
 
-            db1 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                              "insert"   [{:id   :ex/dan
+            db1       @(fluree/create-with-txn conn {"@context" ["https://ns.flur.ee" context]
+                                                     "ledger"   ledger-id
+                                                     "insert"   [{:id   :ex/dan
+                                                                  :ex/x "foo-1"
+                                                                  :ex/y "bar-1"}]})
+            db2       @(fluree/transact! conn {"@context" ["https://ns.flur.ee" context]
+                                               "ledger"   ledger-id
+                                               "delete"   {:id   :ex/dan
                                                            :ex/x "foo-1"
-                                                           :ex/y "bar-1"}]})
-            db2 @(test-utils/transact ledger {"@context" ["https://ns.flur.ee" context]
-                                              "delete"   {:id   :ex/dan
-                                                          :ex/x "foo-1"
-                                                          :ex/y "bar-1"}
-                                              "insert"   {:id   :ex/dan
-                                                          :ex/x "foo-2"
-                                                          :ex/y "bar-2"}})]
+                                                           :ex/y "bar-1"}
+                                               "insert"   {:id   :ex/dan
+                                                           :ex/x "foo-2"
+                                                           :ex/y "bar-2"}})
+            ledger    @(fluree/load conn ledger-id)]
+
         (testing "no t-range cache collision"
           (is (= [{:f/t       2
                    :f/assert  [{:ex/x "foo-2" :ex/y "bar-2" :id :ex/dan}]
@@ -258,82 +268,86 @@
 
 (deftest ^:integration commit-details-test
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
-    (let [conn    (test-utils/create-conn)
-          ledger  @(fluree/create conn "committest")
-          context ["https://ns.flur.ee" test-utils/default-context {:ex "http://example.org/ns/"}]
+    (let [conn      (test-utils/create-conn)
+          ledger-id "committest"
+          context   ["https://ns.flur.ee" test-utils/default-context {:ex "http://example.org/ns/"}]
 
-          db1 @(test-utils/transact ledger {"@context" context
-                                            "insert"   {:id   :ex/alice
-                                                        :ex/x "foo-1"
-                                                        :ex/y "bar-1"}})
-          db2 @(test-utils/transact ledger {"@context" context
-                                            "insert"   {:id   :ex/alice
-                                                        :ex/x "foo-2"
-                                                        :ex/y "bar-2"}})
-          db3 @(test-utils/transact ledger {"@context" context
-                                            "insert"   {:id   :ex/alice
-                                                        :ex/x "foo-3"
-                                                        :ex/y "bar-3"}})
-          db4 @(test-utils/transact ledger {"@context" context
-                                            "insert"   {:id   :ex/cat
-                                                        :ex/x "foo-cat"
-                                                        :ex/y "bar-cat"}})
-          db5 @(test-utils/transact ledger {"@context" context
-                                            "insert"   {:id   :ex/alice
-                                                        :ex/x "foo-cat"
-                                                        :ex/y "bar-cat"}}
-                                    {:message "meow"})]
+          db1       @(fluree/create-with-txn conn {"@context" context
+                                                   "ledger"   ledger-id
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-1"
+                                                               :ex/y "bar-1"}})
+          db2       @(fluree/transact! conn {"@context" context
+                                             "ledger"   ledger-id
+                                             "insert"   {:id   :ex/alice
+                                                         :ex/x "foo-2"
+                                                         :ex/y "bar-2"}})
+          db3       @(fluree/transact! conn {"@context" context
+                                             "ledger"   ledger-id
+                                             "insert"   {:id   :ex/alice
+                                                         :ex/x "foo-3"
+                                                         :ex/y "bar-3"}})
+          db4       @(fluree/transact! conn {"@context" context
+                                             "ledger"   ledger-id
+                                             "insert"   {:id   :ex/cat
+                                                         :ex/x "foo-cat"
+                                                         :ex/y "bar-cat"}})
+          db5       @(fluree/transact! conn {"@context" context
+                                             "ledger"   ledger-id
+                                             "insert"   {:id   :ex/alice
+                                                         :ex/x "foo-cat"
+                                                         :ex/y "bar-cat"}}
+                                       {:message "meow"})
+          ledger    @(fluree/load conn ledger-id)]
+
       (testing "at time t"
         (is (pred-match?
-              [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
-                           {:id test-utils/did?}
-                           :f/address test-utils/address?
-                           :f/alias   "committest"
-                           :f/author  ""
-                           :f/branch  "main"
-                           :f/previous
-                           {:id test-utils/commit-id?}
-                           :f/data    {:f/address  test-utils/address?
-                                       :f/assert   [{:ex/x "foo-1"
-                                                     :ex/y "bar-1"
-                                                     :id   :ex/alice}]
-                                       :f/flakes   2
-                                       :f/retract  []
-                                       :f/size     pos-int?
-                                       :f/t        1
-                                       :f/previous {:id test-utils/db-id?}
-                                       :id         test-utils/db-id?}
-                           :f/time    720000
-                           :f/txn     string?
-                           :f/v       0
-                           :id        test-utils/commit-id?}}]
-              @(fluree/history ledger {:context        context
-                                       :commit-details true
-                                       :t              {:from 1 :to 1}})))
-        (let [commit-5 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
-                                   {:id test-utils/did?}
-                                   :f/address  test-utils/address?
-                                   :f/alias    "committest"
-                                   :f/author   ""
-                                   :f/branch   "main"
-                                   :f/data     {:f/address  test-utils/address?
-                                                :f/assert   [{:ex/x "foo-cat"
-                                                              :ex/y "bar-cat"
-                                                              :id   :ex/alice}]
-                                                :f/flakes   70
-                                                :f/previous {:id test-utils/db-id?}
-                                                :f/retract  [{:ex/x "foo-3"
-                                                              :ex/y "bar-3"
-                                                              :id   :ex/alice}]
-                                                :f/size     pos-int?
-                                                :f/t        5
-                                                :id         test-utils/db-id?}
-                                   :f/message  "meow"
-                                   :f/previous {:id test-utils/commit-id?}
-                                   :f/time     720000
-                                   :f/txn      string?
-                                   :f/v        0
-                                   :id         test-utils/commit-id?}}
+             [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                          {:id test-utils/did?}
+                          :f/address test-utils/address?
+                          :f/alias   "committest"
+                          :f/author  ""
+                          :f/branch  "main"
+                          :f/previous
+                          {:id test-utils/commit-id?}
+                          :f/data    {:f/address  test-utils/address?
+                                      :f/assert   [{:ex/x "foo-1"
+                                                    :ex/y "bar-1"
+                                                    :id   :ex/alice}]
+                                      :f/flakes   2
+                                      :f/retract  []
+                                      :f/size     pos-int?
+                                      :f/t        1
+                                      :f/previous {:id test-utils/db-id?}
+                                      :id         test-utils/db-id?}
+                          :f/time    720000
+                          :f/v       0
+                          :id        test-utils/commit-id?}}]
+             @(fluree/history ledger {:context        context
+                                      :commit-details true
+                                      :t              {:from 1 :to 1}})))
+        (let [commit-5 {:f/commit {"https://www.w3.org/2018/credentials#issuer" {:id test-utils/did?}
+                                   :f/address                                   test-utils/address?
+                                   :f/alias                                     "committest"
+                                   :f/author                                    ""
+                                   :f/branch                                    "main"
+                                   :f/data                                      {:f/address  test-utils/address?
+                                                                                 :f/assert   [{:ex/x "foo-cat"
+                                                                                               :ex/y "bar-cat"
+                                                                                               :id   :ex/alice}]
+                                                                                 :f/flakes   66
+                                                                                 :f/previous {:id test-utils/db-id?}
+                                                                                 :f/retract  [#_{:ex/x "foo-3"
+                                                                                                 :ex/y "bar-3"
+                                                                                                 :id   :ex/alice}]
+                                                                                 :f/size     pos-int?
+                                                                                 :f/t        5
+                                                                                 :id         test-utils/db-id?}
+                                   :f/message                                   "meow"
+                                   :f/previous                                  {:id test-utils/commit-id?}
+                                   :f/time                                      720000
+                                   :f/v                                         0
+                                   :id                                          test-utils/commit-id?}}
               commit-4 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                                    {:id test-utils/did?}
                                    :f/address  test-utils/address?
@@ -344,7 +358,7 @@
                                                 :f/assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/cat}]
-                                                :f/flakes   53
+                                                :f/flakes   50
                                                 :f/previous {:id test-utils/db-id?}
                                                 :f/retract  []
                                                 :f/size     pos-int?
@@ -352,7 +366,6 @@
                                                 :id         test-utils/db-id?}
                                    :f/previous {:id test-utils/commit-id?}
                                    :f/time     720000
-                                   :f/txn      string?
                                    :f/v        0
                                    :id         test-utils/commit-id?}}]
           (is (pred-match?
@@ -368,37 +381,164 @@
 
       (testing "time range"
         (let [[c2 c3 c4 :as response] @(fluree/history
-                                         ledger
-                                         {:context        context
-                                          :commit-details true
-                                          :t              {:from 2 :to 4}})]
+                                        ledger
+                                        {:context        context
+                                         :commit-details true
+                                         :t              {:from 2 :to 4}})]
           (testing "all commits in time range are returned"
             (is (= 3 (count response)))
             (is (pred-match?
-                  {:f/commit {"https://www.w3.org/2018/credentials#issuer"
-                              {:id test-utils/did?}
-                              :f/address  test-utils/address?
-                              :f/alias    "committest"
-                              :f/author   ""
-                              :f/branch   "main"
-                              :f/data     {:f/address  test-utils/address?
-                                           :f/assert   [{:ex/x "foo-cat"
-                                                         :ex/y "bar-cat"
-                                                         :id   :ex/cat}]
-                                           :f/flakes   53
-                                           :f/previous {:id test-utils/db-id?}
-                                           :f/retract  []
-                                           :f/size     pos-int?
-                                           :f/t        4
-                                           :id         test-utils/db-id?}
-                              :f/previous {:id test-utils/commit-id?}
-                              :f/time     720000
-                              :f/txn      string?
-                              :f/v        0
-                              :id         test-utils/commit-id?}}
+                 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                             {:id test-utils/did?}
+                             :f/address  test-utils/address?
+                             :f/alias    "committest"
+                             :f/author   ""
+                             :f/branch   "main"
+                             :f/data     {:f/address  test-utils/address?
+                                          :f/assert   [{:ex/x "foo-cat"
+                                                        :ex/y "bar-cat"
+                                                        :id   :ex/cat}]
+                                          :f/flakes   50
+                                          :f/previous {:id test-utils/db-id?}
+                                          :f/retract  []
+                                          :f/size     pos-int?
+                                          :f/t        4
+                                          :id         test-utils/db-id?}
+                             :f/previous {:id test-utils/commit-id?}
+                             :f/time     720000
+                             :f/v        0
+                             :id         test-utils/commit-id?}}
                  c4)))
           (is (pred-match?
-                {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+               {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                           {:id test-utils/did?}
+                           :f/address  test-utils/address?
+                           :f/alias    "committest"
+                           :f/author   ""
+                           :f/branch   "main"
+                           :f/data     {:f/address  test-utils/address?
+                                        :f/assert   [{:ex/x "foo-3"
+                                                      :ex/y "bar-3"
+                                                      :id   :ex/alice}]
+                                        :f/flakes   34
+                                        :f/previous {:id test-utils/db-id?}
+                                        :f/retract  [{:ex/x "foo-2"
+                                                      :ex/y "bar-2"
+                                                      :id   :ex/alice}]
+                                        :f/size     pos-int?
+                                        :f/t        3
+                                        :id         test-utils/db-id?}
+                           :f/previous {:id test-utils/commit-id?}
+                           :f/time     720000
+                           :f/v        0
+                           :id         test-utils/commit-id?}}
+               c3))
+          (is (pred-match?
+               {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                           {:id test-utils/did?}
+                           :f/address  test-utils/address?
+                           :f/alias    "committest"
+                           :f/author   ""
+                           :f/branch   "main"
+                           :f/data     {:f/address  test-utils/address?
+                                        :f/assert   [{:ex/x "foo-2"
+                                                      :ex/y "bar-2"
+                                                      :id   :ex/alice}]
+                                        :f/flakes   18
+                                        :f/previous {:id test-utils/db-id?}
+                                        :f/retract  [{:ex/x "foo-1"
+                                                      :ex/y "bar-1"
+                                                      :id   :ex/alice}]
+                                        :f/size     pos-int?
+                                        :f/t        2
+                                        :id         test-utils/db-id?}
+                           :f/previous {:id test-utils/commit-id?}
+                           :f/time     720000
+                           :f/v        0
+                           :id         test-utils/commit-id?}}
+               c2))))
+
+      (testing "time range from"
+        (is (pred-match?
+             [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                          {:id test-utils/did?}
+                          :f/address  test-utils/address?
+                          :f/alias    "committest"
+                          :f/author   ""
+                          :f/branch   "main"
+                          :f/data     {:f/address  test-utils/address?
+                                       :f/assert   [{:ex/x "foo-cat"
+                                                     :ex/y "bar-cat"
+                                                     :id   :ex/cat}]
+                                       :f/flakes   50
+                                       :f/previous {:id test-utils/db-id?}
+                                       :f/retract  []
+                                       :f/size     pos-int?
+                                       :f/t        4
+                                       :id         test-utils/db-id?}
+                          :f/previous {:id test-utils/commit-id?}
+                          :f/time     720000
+                          :f/v        0
+                          :id         test-utils/commit-id?}}
+              {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                          {:id test-utils/did?}
+                          :f/address  test-utils/address?
+                          :f/alias    "committest"
+                          :f/author   ""
+                          :f/branch   "main"
+                          :f/data     {:f/address  test-utils/address?
+                                       :f/assert   [{:ex/x "foo-cat"
+                                                     :ex/y "bar-cat"
+                                                     :id   :ex/alice}]
+                                       :f/flakes   66
+                                       :f/previous {:id test-utils/db-id?}
+                                       :f/retract  [{:ex/x "foo-3"
+                                                     :ex/y "bar-3"
+                                                     :id   :ex/alice}]
+                                       :f/size     pos-int?
+                                       :f/t        5
+                                       :id         test-utils/db-id?}
+                          :f/message  "meow"
+                          :f/previous {:id test-utils/commit-id?}
+                          :f/time     720000
+                          :f/v        0
+                          :id         test-utils/commit-id?}}]
+             @(fluree/history ledger {:context        context
+                                      :commit-details true
+                                      :t              {:from 4}}))))
+
+      (testing "time range to"
+        (is (pred-match?
+             [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                          {:id test-utils/did?}
+                          :f/address  test-utils/address?
+                          :f/alias    "committest"
+                          :f/author   ""
+                          :f/branch   "main"
+                          :f/previous {:id test-utils/commit-id?}
+                          :f/data     {:f/address  test-utils/address?
+                                       :f/assert   [{:ex/x "foo-1"
+                                                     :ex/y "bar-1"
+                                                     :id   :ex/alice}]
+                                       :f/flakes   2
+                                       :f/retract  []
+                                       :f/size     pos-int?
+                                       :f/t        1
+                                       :f/previous {:id test-utils/db-id?}
+                                       :id         test-utils/db-id?}
+                          :f/time     720000
+                          :f/v        0
+                          :id         test-utils/commit-id?}}]
+             @(fluree/history ledger {:context        context
+                                      :commit-details true
+                                      :t              {:to 1}}))))
+
+      (testing "history commit details"
+        (is (pred-match?
+             [#:f{:assert  [{:ex/x "foo-3"
+                             :ex/y "bar-3"
+                             :id   :ex/alice}]
+                  :commit  {"https://www.w3.org/2018/credentials#issuer"
                             {:id test-utils/did?}
                             :f/address  test-utils/address?
                             :f/alias    "committest"
@@ -408,7 +548,7 @@
                                          :f/assert   [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
-                                         :f/flakes   36
+                                         :f/flakes   34
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-2"
                                                        :ex/y "bar-2"
@@ -418,181 +558,47 @@
                                          :id         test-utils/db-id?}
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/txn      string?
                             :f/v        0
-                            :id         test-utils/commit-id?}}
-               c3))
-          (is (pred-match?
-                {:f/commit {"https://www.w3.org/2018/credentials#issuer"
+                            :id         test-utils/commit-id?}
+                  :retract [{:ex/x "foo-2"
+                             :ex/y "bar-2"
+                             :id   :ex/alice}]
+                  :t       3}
+              #:f{:assert  [{:ex/x "foo-cat"
+                             :ex/y "bar-cat"
+                             :id   :ex/alice}]
+                  :commit  {"https://www.w3.org/2018/credentials#issuer"
                             {:id test-utils/did?}
                             :f/address  test-utils/address?
                             :f/alias    "committest"
                             :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
-                                         :f/assert   [{:ex/x "foo-2"
-                                                       :ex/y "bar-2"
+                                         :f/assert   [{:ex/x "foo-cat"
+                                                       :ex/y "bar-cat"
                                                        :id   :ex/alice}]
-                                         :f/flakes   19
+                                         :f/flakes   66
                                          :f/previous {:id test-utils/db-id?}
-                                         :f/retract  [{:ex/x "foo-1"
-                                                       :ex/y "bar-1"
+                                         :f/retract  [{:ex/x "foo-3"
+                                                       :ex/y "bar-3"
                                                        :id   :ex/alice}]
                                          :f/size     pos-int?
-                                         :f/t        2
+                                         :f/t        5
                                          :id         test-utils/db-id?}
+                            :f/message  "meow"
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/txn      string?
                             :f/v        0
-                            :id         test-utils/commit-id?}}
-               c2))))
+                            :id         test-utils/commit-id?}
+                  :retract [{:ex/x "foo-3"
+                             :ex/y "bar-3"
+                             :id   :ex/alice}]
+                  :t       5}]
+             @(fluree/history ledger {:context        context
+                                      :history        :ex/alice
+                                      :commit-details true
+                                      :t              {:from 3}}))))
 
-      (testing "time range from"
-        (is (pred-match?
-              [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
-                           {:id test-utils/did?}
-                           :f/address  test-utils/address?
-                           :f/alias    "committest"
-                           :f/author   ""
-                           :f/branch   "main"
-                           :f/data     {:f/address  test-utils/address?
-                                        :f/assert   [{:ex/x "foo-cat"
-                                                      :ex/y "bar-cat"
-                                                      :id   :ex/cat}]
-                                        :f/flakes   53
-                                        :f/previous {:id test-utils/db-id?}
-                                        :f/retract  []
-                                        :f/size     pos-int?
-                                        :f/t        4
-                                        :id         test-utils/db-id?}
-                           :f/previous {:id test-utils/commit-id?}
-                           :f/time     720000
-                           :f/txn      string?
-                           :f/v        0
-                           :id         test-utils/commit-id?}}
-               {:f/commit {"https://www.w3.org/2018/credentials#issuer"
-                           {:id test-utils/did?}
-                           :f/address  test-utils/address?
-                           :f/alias    "committest"
-                           :f/author   ""
-                           :f/branch   "main"
-                           :f/data     {:f/address  test-utils/address?
-                                        :f/assert   [{:ex/x "foo-cat"
-                                                      :ex/y "bar-cat"
-                                                      :id   :ex/alice}]
-                                        :f/flakes   70
-                                        :f/previous {:id test-utils/db-id?}
-                                        :f/retract  [{:ex/x "foo-3"
-                                                      :ex/y "bar-3"
-                                                      :id   :ex/alice}]
-                                        :f/size     pos-int?
-                                        :f/t        5
-                                        :id         test-utils/db-id?}
-                           :f/message  "meow"
-                           :f/previous {:id test-utils/commit-id?}
-                           :f/time     720000
-                           :f/txn      string?
-                           :f/v        0
-                           :id         test-utils/commit-id?}}]
-              @(fluree/history ledger {:context        context
-                                       :commit-details true
-                                       :t              {:from 4}}))))
-
-      (testing "time range to"
-        (is (pred-match?
-              [{:f/commit {"https://www.w3.org/2018/credentials#issuer"
-                           {:id test-utils/did?}
-                           :f/address  test-utils/address?
-                           :f/alias    "committest"
-                           :f/author   ""
-                           :f/branch   "main"
-                           :f/previous {:id test-utils/commit-id?}
-                           :f/data     {:f/address  test-utils/address?
-                                        :f/assert   [{:ex/x "foo-1"
-                                                      :ex/y "bar-1"
-                                                      :id   :ex/alice}]
-                                        :f/flakes   2
-                                        :f/retract  []
-                                        :f/size     pos-int?
-                                        :f/t        1
-                                        :f/previous {:id test-utils/db-id?}
-                                        :id         test-utils/db-id?}
-                           :f/time     720000
-                           :f/txn      string?
-                           :f/v        0
-                           :id         test-utils/commit-id?}}]
-              @(fluree/history ledger {:context        context
-                                       :commit-details true
-                                       :t              {:to 1}}))))
-
-      (testing "history commit details"
-        (is (pred-match?
-              [#:f{:assert  [{:ex/x "foo-3"
-                              :ex/y "bar-3"
-                              :id   :ex/alice}]
-                   :commit  {"https://www.w3.org/2018/credentials#issuer"
-                             {:id test-utils/did?}
-                             :f/address  test-utils/address?
-                             :f/alias    "committest"
-                             :f/author   ""
-                             :f/branch   "main"
-                             :f/data     {:f/address  test-utils/address?
-                                          :f/assert   [{:ex/x "foo-3"
-                                                        :ex/y "bar-3"
-                                                        :id   :ex/alice}]
-                                          :f/flakes   36
-                                          :f/previous {:id test-utils/db-id?}
-                                          :f/retract  [{:ex/x "foo-2"
-                                                        :ex/y "bar-2"
-                                                        :id   :ex/alice}]
-                                          :f/size     pos-int?
-                                          :f/t        3
-                                          :id         test-utils/db-id?}
-                             :f/previous {:id test-utils/commit-id?}
-                             :f/time     720000
-                             :f/txn      string?
-                             :f/v        0
-                             :id         test-utils/commit-id?}
-                   :retract [{:ex/x "foo-2"
-                              :ex/y "bar-2"
-                              :id   :ex/alice}]
-                   :t       3}
-               #:f{:assert  [{:ex/x "foo-cat"
-                              :ex/y "bar-cat"
-                              :id   :ex/alice}]
-                   :commit  {"https://www.w3.org/2018/credentials#issuer"
-                             {:id test-utils/did?}
-                             :f/address  test-utils/address?
-                             :f/alias    "committest"
-                             :f/author   ""
-                             :f/branch   "main"
-                             :f/data     {:f/address  test-utils/address?
-                                          :f/assert   [{:ex/x "foo-cat"
-                                                        :ex/y "bar-cat"
-                                                        :id   :ex/alice}]
-                                          :f/flakes   70
-                                          :f/previous {:id test-utils/db-id?}
-                                          :f/retract  [{:ex/x "foo-3"
-                                                        :ex/y "bar-3"
-                                                        :id   :ex/alice}]
-                                          :f/size     pos-int?
-                                          :f/t        5
-                                          :id         test-utils/db-id?}
-                             :f/message  "meow"
-                             :f/previous {:id test-utils/commit-id?}
-                             :f/time     720000
-                             :f/txn      string?
-                             :f/v        0
-                             :id         test-utils/commit-id?}
-                   :retract [{:ex/x "foo-3"
-                              :ex/y "bar-3"
-                              :id   :ex/alice}]
-                   :t       5}]
-              @(fluree/history ledger {:context        context
-                                       :history        :ex/alice
-                                       :commit-details true
-                                       :t              {:from 3}}))))
       (testing "multiple history results"
         (let [history-with-commits @(fluree/history ledger {:context        context
                                                             :history        :ex/alice
@@ -613,149 +619,54 @@
     (testing "history commit details on a loaded memory ledger"
       (let [ledger-name   "loaded-history-mem"
             conn          @(fluree/connect {:method :memory})
-            ledger        @(fluree/create conn ledger-name)
             context       [test-utils/default-context {:ex "http://example.org/ns/"}]
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-1"
-                                                                    :ex/y "bar-1"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "delete"   {:id   :ex/alice
-                                                                    :ex/x "foo-1"
-                                                                    :ex/y "bar-1"}
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-2"
-                                                                    :ex/y "bar-2"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "delete"   {:id   :ex/alice
-                                                                    :ex/x "foo-2"
-                                                                    :ex/y "bar-2"}
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-3"
-                                                                    :ex/y "bar-3"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/cat
-                                                                    :ex/x "foo-cat"
-                                                                    :ex/y "bar-cat"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "delete"   {:id   :ex/alice
-                                                                    :ex/x "foo-3"
-                                                                    :ex/y "bar-3"}
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-cat"
-                                                                    :ex/y "bar-cat"}}
-                                                {:message "meow"})
+            _             @(fluree/create-with-txn conn {"@context" ["https://ns.flur.ee"
+                                                                     context]
+                                                         "ledger"   ledger-name
+                                                         "insert"   {:id   :ex/alice
+                                                                     :ex/x "foo-1"
+                                                                     :ex/y "bar-1"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "delete"   {:id   :ex/alice
+                                                               :ex/x "foo-1"
+                                                               :ex/y "bar-1"}
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-2"
+                                                               :ex/y "bar-2"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "delete"   {:id   :ex/alice
+                                                               :ex/x "foo-2"
+                                                               :ex/y "bar-2"}
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-3"
+                                                               :ex/y "bar-3"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "insert"   {:id   :ex/cat
+                                                               :ex/x "foo-cat"
+                                                               :ex/y "bar-cat"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "delete"   {:id   :ex/alice
+                                                               :ex/x "foo-3"
+                                                               :ex/y "bar-3"}
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-cat"
+                                                               :ex/y "bar-cat"}}
+                                             {:message "meow"})
             loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+
         (is (pred-match?
              [#:f{:assert  [{:ex/x "foo-3"
                              :ex/y "bar-3"
                              :id   :ex/alice}]
                   :commit  {:f/address  test-utils/address?
-                            :f/alias    ledger-name
-                            :f/author   ""
-                            :f/branch   "main"
-                            :f/data     {:f/address  test-utils/address?
-                                         :f/assert   [{:ex/x "foo-3"
-                                                       :ex/y "bar-3"
-                                                       :id   :ex/alice}]
-                                         :f/flakes   38
-                                         :f/previous {:id test-utils/db-id?}
-                                         :f/retract  [{:ex/x "foo-2"
-                                                       :ex/y "bar-2"
-                                                       :id   :ex/alice}]
-                                         :f/size     pos-int?
-                                         :f/t        3
-                                         :id test-utils/db-id?}
-                            :f/previous {:id test-utils/commit-id?}
-                            :f/time     720000
-                            :f/txn      string?
-                            :f/v        0
-                            :id         test-utils/commit-id?}
-                  :retract [{:ex/x "foo-2"
-                             :ex/y "bar-2"
-                             :id   :ex/alice}]
-                  :t       3}
-              #:f{:assert  [{:ex/x "foo-cat"
-                             :ex/y "bar-cat"
-                             :id   :ex/alice}]
-                  :commit  {:f/address  test-utils/address?
-                            :f/alias    ledger-name
-                            :f/author   ""
-                            :f/branch   "main"
-                            :f/data     {:f/address  test-utils/address?
-                                         :f/assert   [{:ex/x "foo-cat"
-                                                       :ex/y "bar-cat"
-                                                       :id   :ex/alice}]
-                                         :f/flakes   72
-                                         :f/previous {:id test-utils/db-id?}
-                                         :f/retract  [{:ex/x "foo-3"
-                                                       :ex/y "bar-3"
-                                                       :id   :ex/alice}]
-                                         :f/size     pos-int?
-                                         :f/t        5
-                                         :id         test-utils/db-id?}
-                            :f/message  "meow"
-                            :f/previous {:id test-utils/commit-id?}
-                            :f/time     720000
-                            :f/txn      string?
-                            :f/v        0
-                            :id         test-utils/commit-id?}
-                  :retract [{:ex/x "foo-3"
-                             :ex/y "bar-3"
-                             :id   :ex/alice}]
-                  :t       5}]
-             @(fluree/history loaded-ledger {:context        context
-                                             :history        :ex/alice
-                                             :commit-details true
-                                             :t              {:from 3}})))))
-
-    (testing "history commit details on a loaded memory ledger w/ issuer"
-      (let [ledger-name "loaded-history-mem-issuer"
-            conn        @(fluree/connect {:method   :memory
-                                          :defaults {:did (did/private->did-map
-                                                           test-utils/default-private-key)}})
-            ledger      @(fluree/create conn ledger-name)
-            context     [test-utils/default-context {:ex "http://example.org/ns/"}]
-
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-1"
-                                                                    :ex/y "bar-1"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-2"
-                                                                    :ex/y "bar-2"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-3"
-                                                                    :ex/y "bar-3"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/cat
-                                                                    :ex/x "foo-cat"
-                                                                    :ex/y "bar-cat"}})
-            _             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                    context]
-                                                        "insert"   {:id   :ex/alice
-                                                                    :ex/x "foo-cat"
-                                                                    :ex/y "bar-cat"}}
-                                                {:message "meow"})
-            loaded-ledger (test-utils/retry-load conn ledger-name 100)]
-        (is (pred-match?
-             [#:f{:assert  [{:ex/x "foo-3"
-                             :ex/y "bar-3"
-                             :id   :ex/alice}]
-                  :commit  {"https://www.w3.org/2018/credentials#issuer"
-                            {:id test-utils/did?}
-                            :f/address  test-utils/address?
                             :f/alias    ledger-name
                             :f/author   ""
                             :f/branch   "main"
@@ -773,7 +684,108 @@
                                          :id         test-utils/db-id?}
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/txn      string?
+                            :f/v        0
+                            :id         test-utils/commit-id?}
+                  :retract [{:ex/x "foo-2"
+                             :ex/y "bar-2"
+                             :id   :ex/alice}]
+                  :t       3}
+              #:f{:assert  [{:ex/x "foo-cat"
+                             :ex/y "bar-cat"
+                             :id   :ex/alice}]
+                  :commit  {:f/address  test-utils/address?
+                            :f/alias    ledger-name
+                            :f/author   ""
+                            :f/branch   "main"
+                            :f/data     {:f/address  test-utils/address?
+                                         :f/assert   [{:ex/x "foo-cat"
+                                                       :ex/y "bar-cat"
+                                                       :id   :ex/alice}]
+                                         :f/flakes   68
+                                         :f/previous {:id test-utils/db-id?}
+                                         :f/retract  [{:ex/x "foo-3"
+                                                       :ex/y "bar-3"
+                                                       :id   :ex/alice}]
+                                         :f/size     pos-int?
+                                         :f/t        5
+                                         :id         test-utils/db-id?}
+                            :f/message  "meow"
+                            :f/previous {:id test-utils/commit-id?}
+                            :f/time     720000
+                            :f/v        0
+                            :id         test-utils/commit-id?}
+                  :retract [{:ex/x "foo-3"
+                             :ex/y "bar-3"
+                             :id   :ex/alice}]
+                  :t       5}]
+             @(fluree/history loaded-ledger {:context        context
+                                             :history        :ex/alice
+                                             :commit-details true
+                                             :t              {:from 3}})))))
+
+    (testing "history commit details on a loaded memory ledger w/ issuer"
+      (let [ledger-name   "loaded-history-mem-issuer"
+            conn          @(fluree/connect {:method   :memory
+                                            :defaults {:did (did/private->did-map
+                                                             test-utils/default-private-key)}})
+            context       [test-utils/default-context {:ex "http://example.org/ns/"}]
+
+            _             @(fluree/create-with-txn conn {"@context" ["https://ns.flur.ee"
+                                                                     context]
+                                                         "ledger"   ledger-name
+                                                         "insert"   {:id   :ex/alice
+                                                                     :ex/x "foo-1"
+                                                                     :ex/y "bar-1"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-2"
+                                                               :ex/y "bar-2"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-3"
+                                                               :ex/y "bar-3"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "insert"   {:id   :ex/cat
+                                                               :ex/x "foo-cat"
+                                                               :ex/y "bar-cat"}})
+            _             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                               context]
+                                                   "ledger"   ledger-name
+                                                   "insert"   {:id   :ex/alice
+                                                               :ex/x "foo-cat"
+                                                               :ex/y "bar-cat"}}
+                                             {:message "meow"})
+            loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+        (is (pred-match?
+             [#:f{:assert  [{:ex/x "foo-3"
+                             :ex/y "bar-3"
+                             :id   :ex/alice}]
+                  :commit  {"https://www.w3.org/2018/credentials#issuer"
+                            {:id test-utils/did?}
+                            :f/address  test-utils/address?
+                            :f/alias    ledger-name
+                            :f/author   ""
+                            :f/branch   "main"
+                            :f/data     {:f/address  test-utils/address?
+                                         :f/assert   [{:ex/x "foo-3"
+                                                       :ex/y "bar-3"
+                                                       :id   :ex/alice}]
+                                         :f/flakes   34
+                                         :f/previous {:id test-utils/db-id?}
+                                         :f/retract  [{:ex/x "foo-2"
+                                                       :ex/y "bar-2"
+                                                       :id   :ex/alice}]
+                                         :f/size     pos-int?
+                                         :f/t        3
+                                         :id         test-utils/db-id?}
+                            :f/previous {:id test-utils/commit-id?}
+                            :f/time     720000
                             :f/v        0
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-2"
@@ -793,18 +805,17 @@
                                          :f/assert   [{:ex/x "foo-cat"
                                                        :ex/y "bar-cat"
                                                        :id   :ex/alice}]
-                                         :f/flakes   70
+                                         :f/flakes   66
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
                                          :f/size     pos-int?
                                          :f/t        5
-                                         :id test-utils/db-id?}
+                                         :id         test-utils/db-id?}
                             :f/message  "meow"
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/txn      string?
                             :f/v        0
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-3"
@@ -820,116 +831,118 @@
   (with-redefs [fluree.db.util.core/current-time-iso (constantly "1970-01-01T00:12:00.00000Z")]
     (testing "history commit details on a loaded file ledger"
       (with-tmp-dir storage-path
-        (let [ledger-name "loaded-history-file"
-              conn        @(fluree/connect {:method       :file
-                                            :storage-path storage-path
-                                            :defaults     {:did (did/private->did-map
-                                                                 test-utils/default-private-key)}})
-              ledger      @(fluree/create conn ledger-name)
-              context     [test-utils/default-context {:ex "http://example.org/ns/"}]
+                    (let [ledger-name   "loaded-history-file"
+                          conn          @(fluree/connect {:method       :file
+                                                          :storage-path storage-path
+                                                          :defaults     {:did (did/private->did-map
+                                                                               test-utils/default-private-key)}})
+                          context       [test-utils/default-context {:ex "http://example.org/ns/"}]
 
-              a             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                      context]
-                                                          "insert"   {:id   :ex/alice
-                                                                      :ex/x "foo-1"
-                                                                      :ex/y "bar-1"}})
-              b             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                      context]
-                                                          "delete"   {:id   :ex/alice
-                                                                      :ex/x "foo-1"
-                                                                      :ex/y "bar-1"}
-                                                          "insert"   {:id   :ex/alice
-                                                                      :ex/x "foo-2"
-                                                                      :ex/y "bar-2"}})
-              c             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                      context]
-                                                          "delete"   {:id   :ex/alice
-                                                                      :ex/x "foo-2"
-                                                                      :ex/y "bar-2"}
-                                                          "insert"   {:id   :ex/alice
-                                                                      :ex/x "foo-3"
-                                                                      :ex/y "bar-3"}})
-              d             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                      context]
-                                                          "insert"   {:id   :ex/cat
-                                                                      :ex/x "foo-cat"
-                                                                      :ex/y "bar-cat"}})
-              e             @(test-utils/transact ledger {"@context" ["https://ns.flur.ee"
-                                                                      context]
-                                                          "delete"   {:id   :ex/alice
-                                                                      :ex/x "foo-3"
-                                                                      :ex/y "bar-3"}
-                                                          "insert"   {:id   :ex/alice
-                                                                      :ex/x "foo-cat"
-                                                                      :ex/y "bar-cat"}}
-                                                  {:message "meow"})
-              loaded-ledger (test-utils/retry-load conn ledger-name 100)]
-          (is (pred-match?
-               [#:f{:assert  [{:ex/x "foo-3"
-                               :ex/y "bar-3"
-                               :id   :ex/alice}]
-                    :commit  {"https://www.w3.org/2018/credentials#issuer"
-                              {:id test-utils/did?}
-                              :f/address  test-utils/address?
-                              :f/alias    ledger-name
-                              :f/author   ""
-                              :f/branch   "main"
-                              :f/data     {:f/address  test-utils/address?
-                                           :f/assert   [{:ex/x "foo-3"
-                                                         :ex/y "bar-3"
-                                                         :id   :ex/alice}]
-                                           :f/flakes   40
-                                           :f/previous {:id test-utils/db-id?}
-                                           :f/retract  [{:ex/x "foo-2"
-                                                         :ex/y "bar-2"
-                                                         :id   :ex/alice}]
-                                           :f/size     pos-int?
-                                           :f/t        3
-                                           :id         test-utils/db-id?}
-                              :f/previous {:id test-utils/commit-id?}
-                              :f/time     720000
-                              :f/txn      string?
-                              :f/v        0
-                              :id         test-utils/commit-id?}
-                    :retract [{:ex/x "foo-2"
-                               :ex/y "bar-2"
-                               :id   :ex/alice}]
-                    :t       3}
-                #:f{:assert  [{:ex/x "foo-cat"
-                               :ex/y "bar-cat"
-                               :id   :ex/alice}]
-                    :commit  {"https://www.w3.org/2018/credentials#issuer"
-                              {:id test-utils/did?}
-                              :f/address  test-utils/address?
-                              :f/alias    ledger-name
-                              :f/author   ""
-                              :f/branch   "main"
-                              :f/data     {:f/address  test-utils/address?
-                                           :f/assert   [{:ex/x "foo-cat"
-                                                         :ex/y "bar-cat"
-                                                         :id   :ex/alice}]
-                                           :f/flakes   76
-                                           :f/previous {:id test-utils/db-id?}
-                                           :f/retract  [{:ex/x "foo-3"
-                                                         :ex/y "bar-3"
-                                                         :id   :ex/alice}]
-                                           :f/size     pos-int?
-                                           :f/t        5
-                                           :id         test-utils/db-id?}
-                              :f/message  "meow"
-                              :f/previous {:id test-utils/commit-id?}
-                              :f/time     720000
-                              :f/txn      string?
-                              :f/v        0
-                              :id         test-utils/commit-id?}
-                    :retract [{:ex/x "foo-3"
-                               :ex/y "bar-3"
-                               :id   :ex/alice}]
-                    :t       5}]
-               @(fluree/history loaded-ledger {:context        context
-                                               :history        :ex/alice
-                                               :commit-details true
-                                               :t              {:from 3}}))))))))
+                          a             @(fluree/create-with-txn conn {"@context" ["https://ns.flur.ee"
+                                                                                   context]
+                                                                       "ledger"   ledger-name
+                                                                       "insert"   {:id   :ex/alice
+                                                                                   :ex/x "foo-1"
+                                                                                   :ex/y "bar-1"}})
+                          b             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                                             context]
+                                                                 "ledger"   ledger-name
+                                                                 "delete"   {:id   :ex/alice
+                                                                             :ex/x "foo-1"
+                                                                             :ex/y "bar-1"}
+                                                                 "insert"   {:id   :ex/alice
+                                                                             :ex/x "foo-2"
+                                                                             :ex/y "bar-2"}})
+                          c             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                                             context]
+                                                                 "ledger"   ledger-name
+                                                                 "delete"   {:id   :ex/alice
+                                                                             :ex/x "foo-2"
+                                                                             :ex/y "bar-2"}
+                                                                 "insert"   {:id   :ex/alice
+                                                                             :ex/x "foo-3"
+                                                                             :ex/y "bar-3"}})
+                          d             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                                             context]
+                                                                 "ledger"   ledger-name
+                                                                 "insert"   {:id   :ex/cat
+                                                                             :ex/x "foo-cat"
+                                                                             :ex/y "bar-cat"}})
+                          e             @(fluree/transact! conn {"@context" ["https://ns.flur.ee"
+                                                                             context]
+                                                                 "ledger"   ledger-name
+                                                                 "delete"   {:id   :ex/alice
+                                                                             :ex/x "foo-3"
+                                                                             :ex/y "bar-3"}
+                                                                 "insert"   {:id   :ex/alice
+                                                                             :ex/x "foo-cat"
+                                                                             :ex/y "bar-cat"}}
+                                                           {:message "meow"})
+                          loaded-ledger (test-utils/retry-load conn ledger-name 100)]
+                      (is (pred-match?
+                           [#:f{:assert  [{:ex/x "foo-3"
+                                           :ex/y "bar-3"
+                                           :id   :ex/alice}]
+                                :commit  {"https://www.w3.org/2018/credentials#issuer"
+                                          {:id test-utils/did?}
+                                          :f/address  test-utils/address?
+                                          :f/alias    ledger-name
+                                          :f/author   ""
+                                          :f/branch   "main"
+                                          :f/data     {:f/address  test-utils/address?
+                                                       :f/assert   [{:ex/x "foo-3"
+                                                                     :ex/y "bar-3"
+                                                                     :id   :ex/alice}]
+                                                       :f/flakes   38
+                                                       :f/previous {:id test-utils/db-id?}
+                                                       :f/retract  [{:ex/x "foo-2"
+                                                                     :ex/y "bar-2"
+                                                                     :id   :ex/alice}]
+                                                       :f/size     pos-int?
+                                                       :f/t        3
+                                                       :id         test-utils/db-id?}
+                                          :f/previous {:id test-utils/commit-id?}
+                                          :f/time     720000
+                                          :f/v        0
+                                          :id         test-utils/commit-id?}
+                                :retract [{:ex/x "foo-2"
+                                           :ex/y "bar-2"
+                                           :id   :ex/alice}]
+                                :t       3}
+                            #:f{:assert  [{:ex/x "foo-cat"
+                                           :ex/y "bar-cat"
+                                           :id   :ex/alice}]
+                                :commit  {"https://www.w3.org/2018/credentials#issuer"
+                                          {:id test-utils/did?}
+                                          :f/address  test-utils/address?
+                                          :f/alias    ledger-name
+                                          :f/author   ""
+                                          :f/branch   "main"
+                                          :f/data     {:f/address  test-utils/address?
+                                                       :f/assert   [{:ex/x "foo-cat"
+                                                                     :ex/y "bar-cat"
+                                                                     :id   :ex/alice}]
+                                                       :f/flakes   72
+                                                       :f/previous {:id test-utils/db-id?}
+                                                       :f/retract  [{:ex/x "foo-3"
+                                                                     :ex/y "bar-3"
+                                                                     :id   :ex/alice}]
+                                                       :f/size     pos-int?
+                                                       :f/t        5
+                                                       :id         test-utils/db-id?}
+                                          :f/message  "meow"
+                                          :f/previous {:id test-utils/commit-id?}
+                                          :f/time     720000
+                                          :f/v        0
+                                          :id         test-utils/commit-id?}
+                                :retract [{:ex/x "foo-3"
+                                           :ex/y "bar-3"
+                                           :id   :ex/alice}]
+                                :t       5}]
+                           @(fluree/history loaded-ledger {:context        context
+                                                           :history        :ex/alice
+                                                           :commit-details true
+                                                           :t              {:from 3}}))))))))
 
 (deftest ^:integration author-and-txn-id
   (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")]
@@ -940,47 +953,51 @@
           root-privkey "89e0ab9ac36fb82b172890c89e9e231224264c7c757d58cfd8fcd6f3d4442199"
           root-did     (:id (did/private->did-map root-privkey))
 
-          db0 (fluree/db ledger)
-          db1 @(fluree/stage db0 {"@context" context
-                                  "insert"   [{"@id"         "ex:betty"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Betty"
-                                               "schema:age"  55}
-                                              {"@id"         "ex:freddy"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Freddy"
-                                               "schema:age"  1002}
-                                              {"@id"         "ex:letty"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Leticia"
-                                               "schema:age"  38}
-                                              {"@id"    root-did
-                                               "f:role" {"@id" "ex:rootRole"}}]})
-          db2 (->> @(fluree/stage db1 {"@context" context
-                                       "insert"   {"@id"          "ex:rootPolicy"
-                                                   "@type"        ["f:Policy"]
-                                                   "f:targetNode" {"@id" "f:allNodes"}
-                                                   "f:allow"      [{"@id"          "ex:rootAccessAllow"
-                                                                    "f:targetRole" {"@id" "ex:rootRole"}
-                                                                    "f:action"     [{"@id" "f:view"}
-                                                                                    {"@id" "f:modify"}]}]}})
-                   (fluree/commit! ledger)
-                   (deref))
+          db0          (fluree/db ledger)
+          db1          @(fluree/stage db0 {"@context" context
+                                           "insert"   [{"@id"         "ex:betty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Betty"
+                                                        "schema:age"  55}
+                                                       {"@id"         "ex:freddy"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Freddy"
+                                                        "schema:age"  1002}
+                                                       {"@id"         "ex:letty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Leticia"
+                                                        "schema:age"  38}
+                                                       {"@id"    root-did
+                                                        "f:role" {"@id" "ex:rootRole"}}]})
+          db2          (->> @(fluree/stage db1 {"@context" context
+                                                "insert"   {"@id"          "ex:rootPolicy"
+                                                            "@type"        ["f:Policy"]
+                                                            "f:targetNode" {"@id" "f:allNodes"}
+                                                            "f:allow"      [{"@id"          "ex:rootAccessAllow"
+                                                                             "f:targetRole" {"@id" "ex:rootRole"}
+                                                                             "f:action"     [{"@id" "f:view"}
+                                                                                             {"@id" "f:modify"}]}]}})
+                            (fluree/commit! ledger)
+                            (deref))
 
-          db3 @(test-utils/transact ledger (crypto/create-jws
-                                             (json/stringify {"@context" context "insert" {"ex:foo" 3}})
-                                             root-privkey))
+          db3          @(fluree/credential-transact! conn (crypto/create-jws
+                                                           (json/stringify {"@context" context
+                                                                            "ledger"   ledger-name
+                                                                            "insert"   {"ex:foo" 3}})
+                                                           root-privkey))
 
-          db4 @(test-utils/transact ledger (crypto/create-jws
-                                             (json/stringify {"@context" context "insert" {"ex:foo" 5}})
-                                             root-privkey))]
-      (is (= [{"f:author" "", "f:txn" "", "f:data" {"f:t" 1}}
+          db4          @(fluree/credential-transact! conn (crypto/create-jws
+                                                           (json/stringify {"@context" context
+                                                                            "ledger"   ledger-name
+                                                                            "insert"   {"ex:foo" 5}})
+                                                           root-privkey))]
+      (is (= [{"f:author" "", "f:data" {"f:t" 1}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn" "fluree:memory://8bf810310a1f54a186acde9c7f05c91e0cf0facf6fb9ce5aa17987be0957bfd9",
-               "f:data" {"f:t" 2}}
+               "f:txn"    "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
+               "f:data"   {"f:t" 2}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn" "fluree:memory://3b4f6c72ffbea9b6c601fb30d1df4934520dfffc20139ece2aecb15b6a610804",
-               "f:data" {"f:t" 3}}]
+               "f:txn"    "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
+               "f:data"   {"f:t" 3}}]
              (->> @(fluree/history ledger {:context        context
                                            :commit-details true
                                            :t              {:from 1 :to :latest}})
@@ -991,50 +1008,45 @@
 
 (deftest ^:integration txn-annotation
   (let [bnode-counter (atom 0)]
-    (with-redefs [fluree.db.util.core/current-time-iso (fn [] "1970-01-01T00:12:00.00000Z")
+    (with-redefs [fluree.db.util.core/current-time-iso    (fn [] "1970-01-01T00:12:00.00000Z")
                   fluree.db.json-ld.iri/new-blank-node-id (fn [] (str "_:fdb-" (swap! bnode-counter inc)))]
-      (let [conn         @(fluree/connect {:method :memory})
-            ledger-name  "annotationtest"
-            ledger       @(fluree/create conn ledger-name)
-            context      [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
+      (let [conn        @(fluree/connect {:method :memory})
+            ledger-name "annotationtest"
+            ledger      @(fluree/create conn ledger-name)
+            context     [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
 
-            db0 (fluree/db ledger)
-            db1 (->> @(fluree/stage db0 {"@context" context
-                                         "insert" [{"@id" "ex:betty"
-                                                    "@type" "ex:Yeti"
-                                                    "schema:name" "Betty"
-                                                    "schema:age" 55}]})
-                     (fluree/commit! ledger)
-                     (deref))
+            db0         (fluree/db ledger)
 
+            db1         (->> @(fluree/stage db0 {"@context" context
+                                                 "insert"   [{"@id"         "ex:betty"
+                                                              "@type"       "ex:Yeti"
+                                                              "schema:name" "Betty"
+                                                              "schema:age"  55}]})
+                             (fluree/commit! ledger)
+                             (deref))
 
+            db2         (->> @(fluree/stage db1 {"@context" context
+                                                 "insert"   [{"@id"         "ex:freddy"
+                                                              "@type"       "ex:Yeti"
+                                                              "schema:name" "Freddy"
+                                                              "schema:age"  1002}]}
+                                            {:annotation {"ex:originator" "opts" "ex:data" "ok"}})
+                             (fluree/commit! ledger)
+                             (deref))
 
-
-
-            db2 (->> @(fluree/stage db1 {"@context" context
-                                         "insert" [{"@id" "ex:freddy"
-                                                    "@type" "ex:Yeti"
-                                                    "schema:name" "Freddy"
-                                                    "schema:age" 1002}]}
-                                    {:annotation {"ex:originator" "opts" "ex:data" "ok"}})
-                     (fluree/commit! ledger)
-                     (deref))
-
-            db3 (->> @(fluree/stage db2 {"@context" context
-                                         "insert"   [{"@id"         "ex:letty"
-                                                      "@type"       "ex:Yeti"
-                                                      "schema:name" "Leticia"
-                                                      "schema:age"  38}]
-                                         "opts" {"annotation" {"ex:originator" "txn" "ex:data" "ok"}}})
-                     (fluree/commit! ledger)
-                     (deref))]
+            db3         (->> @(fluree/stage db2 {"@context" context
+                                                 "insert"   [{"@id"         "ex:letty"
+                                                              "@type"       "ex:Yeti"
+                                                              "schema:name" "Leticia"
+                                                              "schema:age"  38}]
+                                                 "opts"     {"annotation" {"ex:originator" "txn" "ex:data" "ok"}}})
+                             (fluree/commit! ledger)
+                             (deref))]
         (testing "annotations in commit-details"
-          (is (= [{"f:txn" "fluree:memory://2c28ed0d4102ff436641911c90f47f0681a9ae251640823f7f361f7e22a57fef"}
-                  {"f:txn" "fluree:memory://cd26d7c28c0a5368694a6b8fbd11c573f0623313c06ae96c15ff016572972568"
-                   "f:annotation" {"id" "_:fdb-3" "ex:data" "ok" "ex:originator" "opts"}}
+          (is (= [{}
+                  {"f:annotation" {"id" "_:fdb-3" "ex:data" "ok" "ex:originator" "opts"}}
 
-                  {"f:txn" "fluree:memory://40ce18ee7469c565297e9b9e348788a891ab1bca8fdfda2116d7a2b6c2c82a86"
-                   "f:annotation" {"id" "_:fdb-5" "ex:data" "ok" "ex:originator" "txn"}}]
+                  {"f:annotation" {"id" "_:fdb-5" "ex:data" "ok" "ex:originator" "txn"}}]
                  (->> @(fluree/history ledger {:context        context
                                                :commit-details true
                                                :t              {:from 1 :to :latest}})
@@ -1042,16 +1054,16 @@
 
         (testing "only single annotation subject permitted"
           (let [invalid1 @(fluree/stage db0 {"@context" context
-                                             "insert" [{"@id" "ex:betty"
-                                                        "@type" "ex:Yeti"
-                                                        "schema:name" "Betty"
-                                                        "schema:age" 55}]}
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
                                         {:annotation {"ex:originator" "opts" "ex:nested" {"invalid" "true"}}})
                 invalid2 @(fluree/stage db0 {"@context" context
-                                             "insert" [{"@id" "ex:betty"
-                                                        "@type" "ex:Yeti"
-                                                        "schema:name" "Betty"
-                                                        "schema:age" 55}]}
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
                                         {:annotation [{"ex:originator" "opts" "ex:multiple" true}
                                                       {"ex:originator" "opts" "ex:invalid" true}]})]
             (is (= "Commit annotation must only have a single subject." (ex-message invalid1)))
@@ -1059,9 +1071,9 @@
 
         (testing "annotation has no references"
           (let [invalid3 @(fluree/stage db0 {"@context" context
-                                             "insert" [{"@id" "ex:betty"
-                                                        "@type" "ex:Yeti"
-                                                        "schema:name" "Betty"
-                                                        "schema:age" 55}]}
+                                             "insert"   [{"@id"         "ex:betty"
+                                                          "@type"       "ex:Yeti"
+                                                          "schema:name" "Betty"
+                                                          "schema:age"  55}]}
                                         {:annotation [{"ex:originator" "opts" "@id" "invalid:subj"}]})]
             (is (= "Commit annotation cannot specify a subject identifier." (ex-message invalid3)))))))))

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -188,34 +188,31 @@
                  ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/t
                   1]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   "https://www.w3.org/2018/credentials#issuer"
                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/address
-                  "fluree:memory://6a39be21ed7e25ca8f8f7b93ed02b5d53d060bea043471c4e14086f09af9f346"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                  "fluree:memory://48d8a107deb2ee5ff87bc8795e11118848bd2add942aeb69b26d3f904ef2b72e"]
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/alias
                   "query/everything"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/author
                   ""]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/branch
                   "main"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/data
                   "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/previous
                   "fluree:commit:sha256:bvvou3uvnd6ffhehsrw23mw4w3fux5jbpacko2ecosb2nzxkfu5v"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/time
                   720000]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
-                  :f/txn
-                  "fluree:memory://6ef43099853b046e0501e67e8df05a6a1e036a1100c680ab48d1d19b884ec9ea"]
-                 ["fluree:commit:sha256:bbotrki6dconqj6toctgbuu7qjpfrfywu6srolrk32yaogy5xmsvl"
+                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
                   :f/v
                   0]
                  [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,10 +28,10 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bc4pgf733mfhelp4ueeciwbfftthr4juvh2btondbmzjbvf6zpf5"
+        (is (= "fluree:commit:sha256:bbmpvuetgbce2qs5q7dwlbjgj5zcxknvaun2gutewa5pgg5seks5e"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://10e1db9dc617a4d4b01a3fbdea6eb97a52f4173a8b01c2cdbb66ec05f90a41c7"
+        (is (= "fluree:memory://e5417a11d9ead4187d63a3e29f14ff79069dd47bcb3f664771d25f1b518fa021"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
         (is (= "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -174,13 +174,6 @@
       #?(:clj @commit-p, :cljs (<p! commit-p))
       ledger)))
 
-(defn transact
-  ([ledger data]
-   (transact ledger data {}))
-  ([ledger data commit-opts]
-   (let [staged @(fluree/stage (fluree/db ledger) data)]
-     (fluree/commit! ledger staged commit-opts))))
-
 (defn retry-promise-wrapped
   "Retries a fn that when deref'd might return a Throwable. Intended for
   retrying promise-wrapped API fns. Do not deref the return value, this will

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -70,271 +70,271 @@
    (deftest load-from-file-test
      (testing "can load a file ledger with single cardinality predicates"
        (with-tmp-dir storage-path
-         (let [conn         @(fluree/connect {:method :file, :storage-path storage-path})
-               ledger-alias "load-from-file-test-single-card"
-               ledger       @(fluree/create conn ledger-alias )
-               db           @(fluree/stage
-                               (fluree/db ledger)
-                               {"@context" ["https://ns.flur.ee"
-                                            test-utils/default-context
-                                            {:ex "http://example.org/ns/"}]
-                                "insert"
-                                [{:id           :ex/brian
-                                  :type         :ex/User
-                                  :schema/name  "Brian"
-                                  :schema/email "brian@example.org"
-                                  :schema/age   50
-                                  :ex/favNums   7
-                                  :ex/height    6.2}
+                     (let [conn         @(fluree/connect {:method :file, :storage-path storage-path})
+                           ledger-alias "load-from-file-test-single-card"
+                           ledger       @(fluree/create conn ledger-alias)
+                           db           @(fluree/stage
+                                          (fluree/db ledger)
+                                          {"@context" ["https://ns.flur.ee"
+                                                       test-utils/default-context
+                                                       {:ex "http://example.org/ns/"}]
+                                           "insert"
+                                           [{:id           :ex/brian
+                                             :type         :ex/User
+                                             :schema/name  "Brian"
+                                             :schema/email "brian@example.org"
+                                             :schema/age   50
+                                             :ex/favNums   7
+                                             :ex/height    6.2}
 
-                                 {:id           :ex/cam
-                                  :type         :ex/User
-                                  :schema/name  "Cam"
-                                  :schema/email "cam@example.org"
-                                  :schema/age   34
-                                  :ex/favNums   5
-                                  :ex/friend    :ex/brian}]})
-               db        @(fluree/commit! ledger db)
-               db        @(fluree/stage
-                            db
-                            {"@context" ["https://ns.flur.ee"
-                                         test-utils/default-context
-                                         {:ex "http://example.org/ns/"}]
-                             "insert"
-                             {:id         :ex/brian
-                              :ex/favNums 7}})
-               db        @(fluree/commit! ledger db)
-               target-t  (:t db)
-               ;; TODO: Replace this w/ :syncTo equivalent once we have it
-               loaded    (test-utils/load-to-t conn ledger-alias target-t 100)
-               loaded-db (fluree/db loaded)]
-           (is (= target-t (:t loaded-db))))))
+                                            {:id           :ex/cam
+                                             :type         :ex/User
+                                             :schema/name  "Cam"
+                                             :schema/email "cam@example.org"
+                                             :schema/age   34
+                                             :ex/favNums   5
+                                             :ex/friend    :ex/brian}]})
+                           db           @(fluree/commit! ledger db)
+                           db           @(fluree/stage
+                                          db
+                                          {"@context" ["https://ns.flur.ee"
+                                                       test-utils/default-context
+                                                       {:ex "http://example.org/ns/"}]
+                                           "insert"
+                                           {:id         :ex/brian
+                                            :ex/favNums 7}})
+                           db           @(fluree/commit! ledger db)
+                           target-t     (:t db)
+                           ;; TODO: Replace this w/ :syncTo equivalent once we have it
+                           loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
+                           loaded-db    (fluree/db loaded)]
+                       (is (= target-t (:t loaded-db))))))
 
      (testing "can load a file ledger with multi-cardinality predicates"
        (with-tmp-dir storage-path
-         (let [conn         @(fluree/connect {:method :file, :storage-path storage-path})
-               ledger-alias "load-from-file-test-multi-card"
-               ledger       @(fluree/create conn ledger-alias)
-               db           @(fluree/stage
-                               (fluree/db ledger)
-                               {"@context" ["https://ns.flur.ee"
-                                            test-utils/default-context
-                                            {:ex "http://example.org/ns/"}]
-                                "insert"
-                                [{:id           :ex/brian
-                                  :type         :ex/User
-                                  :schema/name  "Brian"
-                                  :schema/email "brian@example.org"
-                                  :schema/age   50
-                                  :ex/favNums   7}
+                     (let [conn         @(fluree/connect {:method :file, :storage-path storage-path})
+                           ledger-alias "load-from-file-test-multi-card"
+                           ledger       @(fluree/create conn ledger-alias)
+                           db           @(fluree/stage
+                                          (fluree/db ledger)
+                                          {"@context" ["https://ns.flur.ee"
+                                                       test-utils/default-context
+                                                       {:ex "http://example.org/ns/"}]
+                                           "insert"
+                                           [{:id           :ex/brian
+                                             :type         :ex/User
+                                             :schema/name  "Brian"
+                                             :schema/email "brian@example.org"
+                                             :schema/age   50
+                                             :ex/favNums   7}
 
-                                 {:id           :ex/alice
-                                  :type         :ex/User
-                                  :schema/name  "Alice"
-                                  :schema/email "alice@example.org"
-                                  :schema/age   50
-                                  :ex/favNums   [42 76 9]}
+                                            {:id           :ex/alice
+                                             :type         :ex/User
+                                             :schema/name  "Alice"
+                                             :schema/email "alice@example.org"
+                                             :schema/age   50
+                                             :ex/favNums   [42 76 9]}
 
-                                 {:id           :ex/cam
-                                  :type         :ex/User
-                                  :schema/name  "Cam"
-                                  :schema/email "cam@example.org"
-                                  :schema/age   34
-                                  :ex/favNums   [5 10]
-                                  :ex/friend    [:ex/brian :ex/alice]}]})
-               db        @(fluree/commit! ledger db)
-               db        @(fluree/stage
-                            db
-                            ;; test a multi-cardinality retraction
-                            {"@context" ["https://ns.flur.ee"
-                                         test-utils/default-context
-                                         {:ex "http://example.org/ns/"}]
-                             "insert"
-                             [{:id         :ex/alice
-                               :ex/favNums [42 76 9]}]})
-               db        @(fluree/commit! ledger db)
-               target-t  (:t db)
-               ;; TODO: Replace this w/ :syncTo equivalent once we have it
-               loaded    (test-utils/load-to-t conn ledger-alias target-t 100)
-               loaded-db (fluree/db loaded)]
-           (is (= target-t (:t loaded-db))))))
+                                            {:id           :ex/cam
+                                             :type         :ex/User
+                                             :schema/name  "Cam"
+                                             :schema/email "cam@example.org"
+                                             :schema/age   34
+                                             :ex/favNums   [5 10]
+                                             :ex/friend    [:ex/brian :ex/alice]}]})
+                           db           @(fluree/commit! ledger db)
+                           db           @(fluree/stage
+                                          db
+                                          ;; test a multi-cardinality retraction
+                                          {"@context" ["https://ns.flur.ee"
+                                                       test-utils/default-context
+                                                       {:ex "http://example.org/ns/"}]
+                                           "insert"
+                                           [{:id         :ex/alice
+                                             :ex/favNums [42 76 9]}]})
+                           db           @(fluree/commit! ledger db)
+                           target-t     (:t db)
+                           ;; TODO: Replace this w/ :syncTo equivalent once we have it
+                           loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
+                           loaded-db    (fluree/db loaded)]
+                       (is (= target-t (:t loaded-db))))))
 
      (testing "query returns the correct results from a loaded ledger"
        (with-tmp-dir storage-path
-         (let [conn         @(fluree/connect {:method :file, :storage-path storage-path})
-               ledger-alias "load-from-file-query"
-               ledger       @(fluree/create conn ledger-alias)
-               db           @(fluree/stage
-                               (fluree/db ledger)
-                               {"@context" ["https://ns.flur.ee"
-                                            {:id     "@id"
-                                             :type   "@type"
-                                             :ex     "http://example.com/"
-                                             :schema "http://schema.org/"}]
-                                "insert"
-                                [{:id          :ex/Andrew
-                                  :type        :schema/Person
-                                  :schema/name "Andrew"
-                                  :ex/friend   {:id          :ex/Jonathan
-                                                :type        :schema/Person
-                                                :schema/name "Jonathan"}}]})
-               query        {:context {:ex "http://example.com/"}
-                             :select  {:ex/Andrew [:*]}}
-               res1         @(fluree/query db query)
-               _            @(fluree/commit! ledger db)
-               loaded       (test-utils/retry-load conn ledger-alias 100)
-               loaded-db    (fluree/db loaded)
-               res2         @(fluree/query loaded-db query)]
-           (is (= res1 res2)))))
+                     (let [conn         @(fluree/connect {:method :file, :storage-path storage-path})
+                           ledger-alias "load-from-file-query"
+                           ledger       @(fluree/create conn ledger-alias)
+                           db           @(fluree/stage
+                                          (fluree/db ledger)
+                                          {"@context" ["https://ns.flur.ee"
+                                                       {:id     "@id"
+                                                        :type   "@type"
+                                                        :ex     "http://example.com/"
+                                                        :schema "http://schema.org/"}]
+                                           "insert"
+                                           [{:id          :ex/Andrew
+                                             :type        :schema/Person
+                                             :schema/name "Andrew"
+                                             :ex/friend   {:id          :ex/Jonathan
+                                                           :type        :schema/Person
+                                                           :schema/name "Jonathan"}}]})
+                           query        {:context {:ex "http://example.com/"}
+                                         :select  {:ex/Andrew [:*]}}
+                           res1         @(fluree/query db query)
+                           _            @(fluree/commit! ledger db)
+                           loaded       (test-utils/retry-load conn ledger-alias 100)
+                           loaded-db    (fluree/db loaded)
+                           res2         @(fluree/query loaded-db query)]
+                       (is (= res1 res2)))))
 
      (testing "can load a ledger with `list` values"
        (with-tmp-dir storage-path
-         (let [conn         @(fluree/connect {:method       :file
-                                              :storage-path storage-path})
-               ledger-alias "load-lists-test"
-               ledger       @(fluree/create conn ledger-alias
-                                            {:reindex-min-bytes 0}) ; force reindex on every commit
-               db           @(fluree/stage
-                               (fluree/db ledger)
-                               {"@context" ["https://ns.flur.ee"
-                                            test-utils/default-context
-                                            {:ex "http://example.org/ns/"}]
-                                "insert"
-                                [{:id         :ex/alice,
+                     (let [conn         @(fluree/connect {:method       :file
+                                                          :storage-path storage-path})
+                           ledger-alias "load-lists-test"
+                           ledger       @(fluree/create conn ledger-alias
+                                                        {:reindex-min-bytes 0}) ; force reindex on every commit
+                           db           @(fluree/stage
+                                          (fluree/db ledger)
+                                          {"@context" ["https://ns.flur.ee"
+                                                       test-utils/default-context
+                                                       {:ex "http://example.org/ns/"}]
+                                           "insert"
+                                           [{:id         :ex/alice,
+                                             :type       :ex/User,
+                                             :ex/friends {:list [:ex/john :ex/cam]}}
+                                            {:id         :ex/cam,
+                                             :type       :ex/User
+                                             :ex/numList {:list [7 8 9 10]}}
+                                            {:id   :ex/john,
+                                             :type :ex/User}]})
+                           db           @(fluree/commit! ledger db)
+                           target-t     (:t db)
+                           loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
+                           loaded-db    (fluree/db loaded)]
+                       (is (= target-t (:t loaded-db)))
+                       (testing "query returns expected `list` values"
+                         (is (= [{:id         :ex/alice,
                                   :type       :ex/User,
-                                  :ex/friends {:list [:ex/john :ex/cam]}}
+                                  :ex/friends [{:id :ex/john} {:id :ex/cam}]}
                                  {:id         :ex/cam,
-                                  :type       :ex/User
-                                  :ex/numList {:list [7 8 9 10]}}
-                                 {:id   :ex/john,
-                                  :type :ex/User}]})
-               db           @(fluree/commit! ledger db)
-               target-t     (:t db)
-               loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
-               loaded-db    (fluree/db loaded)]
-           (is (= target-t (:t loaded-db)))
-           (testing "query returns expected `list` values"
-             (is (= [{:id         :ex/alice,
-                      :type       :ex/User,
-                      :ex/friends [{:id :ex/john} {:id :ex/cam}]}
-                     {:id         :ex/cam,
-                      :type       :ex/User,
-                      :ex/numList [7 8 9 10]}
-                     {:id :ex/john, :type :ex/User}]
-                    @(fluree/query loaded-db {:context [test-utils/default-context
-                                                        {:ex "http://example.org/ns/"}]
-                                              :select  '{?s [:*]}
-                                              :where   '{:id ?s, :type :ex/User}}))))))
+                                  :type       :ex/User,
+                                  :ex/numList [7 8 9 10]}
+                                 {:id :ex/john, :type :ex/User}]
+                                @(fluree/query loaded-db {:context [test-utils/default-context
+                                                                    {:ex "http://example.org/ns/"}]
+                                                          :select  '{?s [:*]}
+                                                          :where   '{:id ?s, :type :ex/User}}))))))
 
        (testing "can load with policies"
          (with-tmp-dir storage-path
-           (let [conn         @(fluree/connect {:method       :file
-                                                :storage-path storage-path})
-                 ledger-alias "load-policy-test"
-                 ledger       @(fluree/create conn ledger-alias)
-                 db           @(fluree/stage
-                                 (fluree/db ledger)
-                                 {"@context" ["https://ns.flur.ee"
-                                              test-utils/default-context
-                                              {:ex "http://example.org/ns/"}]
-                                  "insert"
-                                  [{:id          :ex/alice,
-                                    :type        :ex/User,
-                                    :schema/name "Alice"
-                                    :schema/ssn  "111-11-1111"
-                                    :ex/friend   :ex/john}
-                                   {:id          :ex/john,
-                                    :schema/name "John"
-                                    :type        :ex/User,
-                                    :schema/ssn  "888-88-8888"}
-                                   {:id      "did:fluree:123"
-                                    :ex/user :ex/alice
-                                    :f/role  :ex/userRole}]})
-                 db+policy    @(fluree/stage
-                                 db
-                                 {"@context" ["https://ns.flur.ee"
-                                              test-utils/default-context
-                                              {:ex "http://example.org/ns/"}]
-                                  "insert"
-                                  [{:id            :ex/UserPolicy,
+                       (let [conn         @(fluree/connect {:method       :file
+                                                            :storage-path storage-path})
+                             ledger-alias "load-policy-test"
+                             ledger       @(fluree/create conn ledger-alias)
+                             db           @(fluree/stage
+                                            (fluree/db ledger)
+                                            {"@context" ["https://ns.flur.ee"
+                                                         test-utils/default-context
+                                                         {:ex "http://example.org/ns/"}]
+                                             "insert"
+                                             [{:id          :ex/alice,
+                                               :type        :ex/User,
+                                               :schema/name "Alice"
+                                               :schema/ssn  "111-11-1111"
+                                               :ex/friend   :ex/john}
+                                              {:id          :ex/john,
+                                               :schema/name "John"
+                                               :type        :ex/User,
+                                               :schema/ssn  "888-88-8888"}
+                                              {:id      "did:fluree:123"
+                                               :ex/user :ex/alice
+                                               :f/role  :ex/userRole}]})
+                             db+policy    @(fluree/stage
+                                            db
+                                            {"@context" ["https://ns.flur.ee"
+                                                         test-utils/default-context
+                                                         {:ex "http://example.org/ns/"}]
+                                             "insert"
+                                             [{:id            :ex/UserPolicy,
+                                               :type          :f/Policy,
+                                               :f/targetClass :ex/User
+                                               :f/allow
+                                               [{:id           :ex/globalViewAllow
+                                                 :f/targetRole :ex/userRole
+                                                 :f/action     [:f/view]}]
+                                               :f/property
+                                               [{:f/path :schema/ssn
+                                                 :f/allow
+                                                 [{:id           :ex/ssnViewRule
+                                                   :f/targetRole :ex/userRole
+                                                   :f/action     [:f/view]
+                                                   :f/equals
+                                                   {:list [:f/$identity :ex/user]}}]}]}]})
+                             db+policy    @(fluree/commit! ledger db+policy)
+                             target-t     (:t db+policy)
+                             loaded       (test-utils/load-to-t conn ledger-alias target-t
+                                                                100)
+                             loaded-db    (fluree/db loaded)]
+                         (is (= target-t (:t loaded-db)))
+                         (testing "query returns expected policy"
+                           (is (= [{:id            :ex/UserPolicy,
                                     :type          :f/Policy,
-                                    :f/targetClass :ex/User
-                                    :f/allow
-                                    [{:id           :ex/globalViewAllow
-                                      :f/targetRole :ex/userRole
-                                      :f/action     [:f/view]}]
-                                    :f/property
-                                    [{:f/path :schema/ssn
-                                      :f/allow
-                                      [{:id           :ex/ssnViewRule
-                                        :f/targetRole :ex/userRole
-                                        :f/action     [:f/view]
-                                        :f/equals
-                                        {:list [:f/$identity :ex/user]}}]}]}]})
-                 db+policy    @(fluree/commit! ledger db+policy)
-                 target-t     (:t db+policy)
-                 loaded       (test-utils/load-to-t conn ledger-alias target-t
-                                                    100)
-                 loaded-db    (fluree/db loaded)]
-             (is (= target-t (:t loaded-db)))
-             (testing "query returns expected policy"
-               (is (= [{:id            :ex/UserPolicy,
-                        :type          :f/Policy,
-                        :f/allow       {:id           :ex/globalViewAllow,
-                                        :f/action     {:id :f/view},
-                                        :f/targetRole {:id :ex/userRole}},
-                        :f/property    {:f/path  {:id :schema/ssn}
-                                        :f/allow {:id           :ex/ssnViewRule,
-                                                  :f/action     {:id :f/view},
-                                                  :f/targetRole {:id :ex/userRole}
-                                                  :f/equals     [{:id :f/$identity} {:id :ex/user}]},},
-                        :f/targetClass {:id :ex/User}}]
-                      @(fluree/query loaded-db
-                                     {:context [test-utils/default-context
-                                                {:ex "http://example.org/ns/"}]
-                                      :select  '{?s [:id
-                                                     :type
-                                                     :f/targetClass
-                                                     {:f/allow [:*]}
-                                                     {:f/property
-                                                      [:f/path
-                                                       {:f/allow [:*]}]}]}
-                                      :where   '{:id ?s, :type :f/Policy}}))))))))
+                                    :f/allow       {:id           :ex/globalViewAllow,
+                                                    :f/action     {:id :f/view},
+                                                    :f/targetRole {:id :ex/userRole}},
+                                    :f/property    {:f/path  {:id :schema/ssn}
+                                                    :f/allow {:id           :ex/ssnViewRule,
+                                                              :f/action     {:id :f/view},
+                                                              :f/targetRole {:id :ex/userRole}
+                                                              :f/equals     [{:id :f/$identity} {:id :ex/user}]},},
+                                    :f/targetClass {:id :ex/User}}]
+                                  @(fluree/query loaded-db
+                                                 {:context [test-utils/default-context
+                                                            {:ex "http://example.org/ns/"}]
+                                                  :select  '{?s [:id
+                                                                 :type
+                                                                 :f/targetClass
+                                                                 {:f/allow [:*]}
+                                                                 {:f/property
+                                                                  [:f/path
+                                                                   {:f/allow [:*]}]}]}
+                                                  :where   '{:id ?s, :type :f/Policy}}))))))))
 
      (testing "Can load a ledger with time values"
        (with-tmp-dir storage-path
-         (let [conn   @(fluree/connect {:method       :file
-                                        :storage-path storage-path})
-               ledger @(fluree/create conn "index/datetimes")
-               db     @(fluree/stage
-                         (fluree/db ledger)
-                         {"@context" ["https://ns.flur.ee"
-                                      test-utils/default-str-context
-                                      {"ex" "http://example.org/ns/"}]
-                          "insert"
-                          [{"@id"   "ex:Foo",
-                            "@type" "ex:Bar",
+                     (let [conn      @(fluree/connect {:method       :file
+                                                       :storage-path storage-path})
+                           ledger    @(fluree/create conn "index/datetimes")
+                           db        @(fluree/stage
+                                       (fluree/db ledger)
+                                       {"@context" ["https://ns.flur.ee"
+                                                    test-utils/default-str-context
+                                                    {"ex" "http://example.org/ns/"}]
+                                        "insert"
+                                        [{"@id"                "ex:Foo",
+                                          "@type"              "ex:Bar",
 
-                            "ex:offsetDateTime"  {"@type"  "xsd:dateTime"
-                                                  "@value" "2023-04-01T00:00:00.000Z"}
-                            "ex:localDateTime"   {"@type"  "xsd:dateTime"
-                                                  "@value" "2021-09-24T11:14:32.833"}
-                            "ex:offsetDateTime2" {"@type"  "xsd:date"
-                                                  "@value" "2022-01-05Z"}
-                            "ex:localDate"       {"@type"  "xsd:date"
-                                                  "@value" "2024-02-02"}
-                            "ex:offsetTime"      {"@type"  "xsd:time"
-                                                  "@value" "12:42:00Z"}
-                            "ex:localTime"       {"@type"  "xsd:time"
-                                                  "@value" "12:42:00"}}]})
-               db-commit @(fluree/commit! ledger db)
-               loaded    (test-utils/retry-load conn (:alias ledger) 100)
-               q         {"@context" [test-utils/default-str-context
-                                      {"ex" "http://example.org/ns/"}]
-                          "select"   {"?s" ["*"]}
-                          "where"    {"@id" "?s", "type" "ex:Bar"}}]
-           (is (= @(fluree/query (fluree/db loaded) q)
-                  @(fluree/query db q))))))))
+                                          "ex:offsetDateTime"  {"@type"  "xsd:dateTime"
+                                                                "@value" "2023-04-01T00:00:00.000Z"}
+                                          "ex:localDateTime"   {"@type"  "xsd:dateTime"
+                                                                "@value" "2021-09-24T11:14:32.833"}
+                                          "ex:offsetDateTime2" {"@type"  "xsd:date"
+                                                                "@value" "2022-01-05Z"}
+                                          "ex:localDate"       {"@type"  "xsd:date"
+                                                                "@value" "2024-02-02"}
+                                          "ex:offsetTime"      {"@type"  "xsd:time"
+                                                                "@value" "12:42:00Z"}
+                                          "ex:localTime"       {"@type"  "xsd:time"
+                                                                "@value" "12:42:00"}}]})
+                           db-commit @(fluree/commit! ledger db)
+                           loaded    (test-utils/retry-load conn (:alias ledger) 100)
+                           q         {"@context" [test-utils/default-str-context
+                                                  {"ex" "http://example.org/ns/"}]
+                                      "select"   {"?s" ["*"]}
+                                      "where"    {"@id" "?s", "type" "ex:Bar"}}]
+                       (is (= @(fluree/query (fluree/db loaded) q)
+                              @(fluree/query db q))))))))
 
 #?(:clj
    (deftest load-from-memory-test
@@ -343,39 +343,39 @@
              ledger-alias "load-from-memory-test-single-card"
              ledger       @(fluree/create conn ledger-alias)
              db           @(fluree/stage
-                             (fluree/db ledger)
-                             {"@context" ["https://ns.flur.ee"
-                                          test-utils/default-context
-                                          {:ex "http://example.org/ns/"}]
-                              "insert"
-                              [{:id           :ex/brian
-                                :type         :ex/User
-                                :schema/name  "Brian"
-                                :schema/email "brian@example.org"
-                                :schema/age   50
-                                :ex/favNums   7}
+                            (fluree/db ledger)
+                            {"@context" ["https://ns.flur.ee"
+                                         test-utils/default-context
+                                         {:ex "http://example.org/ns/"}]
+                             "insert"
+                             [{:id           :ex/brian
+                               :type         :ex/User
+                               :schema/name  "Brian"
+                               :schema/email "brian@example.org"
+                               :schema/age   50
+                               :ex/favNums   7}
 
-                               {:id           :ex/cam
-                                :type         :ex/User
-                                :schema/name  "Cam"
-                                :schema/email "cam@example.org"
-                                :schema/age   34
-                                :ex/favNums   5
-                                :ex/friend    :ex/brian}]})
-             db        @(fluree/commit! ledger db)
-             db        @(fluree/stage
-                          db
-                          {"@context" ["https://ns.flur.ee"
-                                       test-utils/default-context
-                                       {:ex "http://example.org/ns/"}]
-                           "insert"
-                           {:id         :ex/brian
-                            :ex/favNums 7}})
-             db        @(fluree/commit! ledger db)
-             target-t  (:t db)
+                              {:id           :ex/cam
+                               :type         :ex/User
+                               :schema/name  "Cam"
+                               :schema/email "cam@example.org"
+                               :schema/age   34
+                               :ex/favNums   5
+                               :ex/friend    :ex/brian}]})
+             db           @(fluree/commit! ledger db)
+             db           @(fluree/stage
+                            db
+                            {"@context" ["https://ns.flur.ee"
+                                         test-utils/default-context
+                                         {:ex "http://example.org/ns/"}]
+                             "insert"
+                             {:id         :ex/brian
+                              :ex/favNums 7}})
+             db           @(fluree/commit! ledger db)
+             target-t     (:t db)
              ;; TODO: Replace this w/ :syncTo equivalent once we have it
-             loaded    (test-utils/load-to-t conn ledger-alias target-t 100)
-             loaded-db (fluree/db loaded)]
+             loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
+             loaded-db    (fluree/db loaded)]
          (is (= target-t (:t loaded-db)))))
 
      (testing "can load a memory ledger with multi-cardinality predicates"
@@ -383,74 +383,74 @@
              ledger-alias "load-from-memory-test-multi-card"
              ledger       @(fluree/create conn ledger-alias)
              db           @(fluree/stage
-                             (fluree/db ledger)
-                             {"@context" ["https://ns.flur.ee"
-                                          test-utils/default-context
-                                          {:ex "http://example.org/ns/"}]
-                              "insert"
-                              [{:id           :ex/brian
-                                :type         :ex/User
-                                :schema/name  "Brian"
-                                :schema/email "brian@example.org"
-                                :schema/age   50
-                                :ex/favNums   7}
+                            (fluree/db ledger)
+                            {"@context" ["https://ns.flur.ee"
+                                         test-utils/default-context
+                                         {:ex "http://example.org/ns/"}]
+                             "insert"
+                             [{:id           :ex/brian
+                               :type         :ex/User
+                               :schema/name  "Brian"
+                               :schema/email "brian@example.org"
+                               :schema/age   50
+                               :ex/favNums   7}
 
-                               {:id           :ex/alice
-                                :type         :ex/User
-                                :schema/name  "Alice"
-                                :schema/email "alice@example.org"
-                                :schema/age   50
-                                :ex/favNums   [42 76 9]}
+                              {:id           :ex/alice
+                               :type         :ex/User
+                               :schema/name  "Alice"
+                               :schema/email "alice@example.org"
+                               :schema/age   50
+                               :ex/favNums   [42 76 9]}
 
-                               {:id           :ex/cam
-                                :type         :ex/User
-                                :schema/name  "Cam"
-                                :schema/email "cam@example.org"
-                                :schema/age   34
-                                :ex/favNums   [5 10]
-                                :ex/friend    [:ex/brian :ex/alice]}]})
-             db        @(fluree/commit! ledger db)
-             db        @(fluree/stage
-                          db
-                          ;; test a multi-cardinality retraction
-                          {"@context" ["https://ns.flur.ee"
-                                       test-utils/default-context
-                                       {:ex "http://example.org/ns/"}]
-                           "insert"
-                           [{:id         :ex/alice
-                             :ex/favNums [42 76 9]}]})
-             db        @(fluree/commit! ledger db)
-             target-t  (:t db)
+                              {:id           :ex/cam
+                               :type         :ex/User
+                               :schema/name  "Cam"
+                               :schema/email "cam@example.org"
+                               :schema/age   34
+                               :ex/favNums   [5 10]
+                               :ex/friend    [:ex/brian :ex/alice]}]})
+             db           @(fluree/commit! ledger db)
+             db           @(fluree/stage
+                            db
+                            ;; test a multi-cardinality retraction
+                            {"@context" ["https://ns.flur.ee"
+                                         test-utils/default-context
+                                         {:ex "http://example.org/ns/"}]
+                             "insert"
+                             [{:id         :ex/alice
+                               :ex/favNums [42 76 9]}]})
+             db           @(fluree/commit! ledger db)
+             target-t     (:t db)
              ;; TODO: Replace this w/ :syncTo equivalent once we have it
-             loaded    (test-utils/load-to-t conn ledger-alias target-t 100)
-             loaded-db (fluree/db loaded)]
+             loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
+             loaded-db    (fluree/db loaded)]
          (is (= target-t (:t loaded-db)))))
 
      (testing "query returns the correct results from a loaded ledger"
-       (let [conn           @(fluree/connect {:method :memory})
-             ledger-alias   "load-from-memory-query"
-             ledger         @(fluree/create conn ledger-alias)
-             db             @(fluree/stage
-                               (fluree/db ledger)
-                               {"@context" ["https://ns.flur.ee"
-                                            {:id     "@id"
-                                             :type   "@type"
-                                             :ex     "http://example.com/"
-                                             :schema "http://schema.org/"}]
-                                "insert"
-                                [{:id          :ex/Andrew
-                                  :type        :schema/Person
-                                  :schema/name "Andrew"
-                                  :ex/friend   {:id          :ex/Jonathan
-                                                :type        :schema/Person
-                                                :schema/name "Jonathan"}}]})
-             query          {:context {:ex "http://example.com/"}
-                             :select '{:ex/Andrew [:*]}}
-             res1           @(fluree/query db query)
-             _              @(fluree/commit! ledger db)
-             loaded         (test-utils/retry-load conn ledger-alias 100)
-             loaded-db      (fluree/db loaded)
-             res2           @(fluree/query loaded-db query)]
+       (let [conn         @(fluree/connect {:method :memory})
+             ledger-alias "load-from-memory-query"
+             ledger       @(fluree/create conn ledger-alias)
+             db           @(fluree/stage
+                            (fluree/db ledger)
+                            {"@context" ["https://ns.flur.ee"
+                                         {:id     "@id"
+                                          :type   "@type"
+                                          :ex     "http://example.com/"
+                                          :schema "http://schema.org/"}]
+                             "insert"
+                             [{:id          :ex/Andrew
+                               :type        :schema/Person
+                               :schema/name "Andrew"
+                               :ex/friend   {:id          :ex/Jonathan
+                                             :type        :schema/Person
+                                             :schema/name "Jonathan"}}]})
+             query        {:context {:ex "http://example.com/"}
+                           :select  '{:ex/Andrew [:*]}}
+             res1         @(fluree/query db query)
+             _            @(fluree/commit! ledger db)
+             loaded       (test-utils/retry-load conn ledger-alias 100)
+             loaded-db    (fluree/db loaded)
+             res2         @(fluree/query loaded-db query)]
          (is (= res1 res2))))
 
      (testing "can load a ledger with `list` values"
@@ -458,19 +458,19 @@
              ledger-alias "load-lists-test"
              ledger       @(fluree/create conn ledger-alias)
              db           @(fluree/stage
-                             (fluree/db ledger)
-                             {"@context" ["https://ns.flur.ee"
-                                          test-utils/default-context
-                                          {:ex "http://example.org/ns/"}]
-                              "insert"
-                              [{:id         :ex/alice,
-                                :type       :ex/User,
-                                :ex/friends {:list [:ex/john :ex/cam]}}
-                               {:id         :ex/cam,
-                                :type       :ex/User
-                                :ex/numList {:list [7 8 9 10]}}
-                               {:id   :ex/john,
-                                :type :ex/User}]})
+                            (fluree/db ledger)
+                            {"@context" ["https://ns.flur.ee"
+                                         test-utils/default-context
+                                         {:ex "http://example.org/ns/"}]
+                             "insert"
+                             [{:id         :ex/alice,
+                               :type       :ex/User,
+                               :ex/friends {:list [:ex/john :ex/cam]}}
+                              {:id         :ex/cam,
+                               :type       :ex/User
+                               :ex/numList {:list [7 8 9 10]}}
+                              {:id   :ex/john,
+                               :type :ex/User}]})
              db           @(fluree/commit! ledger db)
              target-t     (:t db)
              loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
@@ -494,40 +494,40 @@
                ledger-alias "load-policy-test"
                ledger       @(fluree/create conn ledger-alias)
                db           @(fluree/stage
-                               (fluree/db ledger)
-                               {"@context" ["https://ns.flur.ee"
-                                            test-utils/default-context
-                                            {:ex "http://example.org/ns/"}]
-                                "insert"
-                                [{:id          :ex/alice,
-                                  :type        :ex/User,
-                                  :schema/name "Alice"
-                                  :schema/ssn  "111-11-1111"
-                                  :ex/friend   :ex/john}
-                                 {:id          :ex/john,
-                                  :schema/name "John"
-                                  :type        :ex/User,
-                                  :schema/ssn  "888-88-8888"}
-                                 {:id      "did:fluree:123"
-                                  :ex/user :ex/alice
-                                  :f/role  :ex/userRole}]})
+                              (fluree/db ledger)
+                              {"@context" ["https://ns.flur.ee"
+                                           test-utils/default-context
+                                           {:ex "http://example.org/ns/"}]
+                               "insert"
+                               [{:id          :ex/alice,
+                                 :type        :ex/User,
+                                 :schema/name "Alice"
+                                 :schema/ssn  "111-11-1111"
+                                 :ex/friend   :ex/john}
+                                {:id          :ex/john,
+                                 :schema/name "John"
+                                 :type        :ex/User,
+                                 :schema/ssn  "888-88-8888"}
+                                {:id      "did:fluree:123"
+                                 :ex/user :ex/alice
+                                 :f/role  :ex/userRole}]})
                db+policy    @(fluree/stage
-                               db
-                               {"@context" ["https://ns.flur.ee"
-                                            test-utils/default-context
-                                            {:ex "http://example.org/ns/"}]
-                                "insert"
-                                [{:id            :ex/UserPolicy,
-                                  :type          [:f/Policy],
-                                  :f/targetClass :ex/User
-                                  :f/allow       [{:id           :ex/globalViewAllow
-                                                   :f/targetRole :ex/userRole
-                                                   :f/action     [:f/view]}]
-                                  :f/property    [{:f/path  :schema/ssn
-                                                   :f/allow [{:id           :ex/ssnViewRule
-                                                              :f/targetRole :ex/userRole
-                                                              :f/action     [:f/view]
-                                                              :f/equals     {:list [:f/$identity :ex/user]}}]}]}]})
+                              db
+                              {"@context" ["https://ns.flur.ee"
+                                           test-utils/default-context
+                                           {:ex "http://example.org/ns/"}]
+                               "insert"
+                               [{:id            :ex/UserPolicy,
+                                 :type          [:f/Policy],
+                                 :f/targetClass :ex/User
+                                 :f/allow       [{:id           :ex/globalViewAllow
+                                                  :f/targetRole :ex/userRole
+                                                  :f/action     [:f/view]}]
+                                 :f/property    [{:f/path  :schema/ssn
+                                                  :f/allow [{:id           :ex/ssnViewRule
+                                                             :f/targetRole :ex/userRole
+                                                             :f/action     [:f/view]
+                                                             :f/equals     {:list [:f/$identity :ex/user]}}]}]}]})
                db+policy    @(fluree/commit! ledger db+policy)
                target-t     (:t db+policy)
                loaded       (test-utils/load-to-t conn ledger-alias target-t 100)
@@ -559,17 +559,17 @@
      (testing "loading predefined properties"
        (let [conn           (test-utils/create-conn)
              ledger-alias   "shacl/a"
-             ledger         @(fluree/create conn "shacl/a")
-             db1            @(test-utils/transact ledger
-                                                  {"@context" ["https://ns.flur.ee"
-                                                               test-utils/default-str-context
-                                                               {"ex" "http://example.org/ns/"}]
-                                                   "insert"
-                                                   {"@type"          "sh:NodeShape",
-                                                    "sh:targetClass" {"id" "schema:Person"}
-                                                    "sh:property"
-                                                    [{"sh:path"     {"id" "schema:familyName"}
-                                                      "sh:datatype" {"id" "xsd:string"}}]}})
+             db1            @(fluree/create-with-txn conn
+                                                     {"@context" ["https://ns.flur.ee"
+                                                                  test-utils/default-str-context
+                                                                  {"ex" "http://example.org/ns/"}]
+                                                      "ledger"   ledger-alias
+                                                      "insert"
+                                                      {"@type"          "sh:NodeShape",
+                                                       "sh:targetClass" {"id" "schema:Person"}
+                                                       "sh:property"
+                                                       [{"sh:path"     {"id" "schema:familyName"}
+                                                         "sh:datatype" {"id" "xsd:string"}}]}})
              property-query {"@context" [test-utils/default-str-context
                                          {"ex" "http://example.org/ns/"}]
                              :select    {"?s" ["*" {"sh:property" ["sh:path" "sh:datatype"]}]}
@@ -589,31 +589,32 @@
                   "sh:property"    {"sh:path" {"id" "schema:familyName"}, "sh:datatype" {"id" "xsd:string"}}}]
                 @(fluree/query (fluree/db loaded1) property-query)))
          (testing "load ref retracts"
-           (let [db2     @(test-utils/transact loaded1
-                                               {"@context" ["https://ns.flur.ee"
-                                                            test-utils/default-str-context
-                                                            {"ex" "http://example.org/ns/"}]
-                                                "where"    [{"@id"         shape-id
-                                                             "sh:property" "?prop"}
-                                                            {"@id" "?prop"
-                                                             "?p"  "?o"}]
-                                                "delete"
-                                                {"@id" "?prop" "?p" "?o"}
-                                                "insert"
-                                                {"@id"         "?prop"
-                                                 "sh:path"     {"id" "schema:age"}
-                                                 "sh:datatype" {"id" "xsd:string"}}})
+           (let [db2     @(fluree/transact! conn
+                                            {"@context" ["https://ns.flur.ee"
+                                                         test-utils/default-str-context
+                                                         {"ex" "http://example.org/ns/"}]
+                                             "ledger"   ledger-alias
+                                             "where"    [{"@id"         shape-id
+                                                          "sh:property" "?prop"}
+                                                         {"@id" "?prop"
+                                                          "?p"  "?o"}]
+                                             "delete"
+                                             {"@id" "?prop" "?p" "?o"}
+                                             "insert"
+                                             {"@id"         "?prop"
+                                              "sh:path"     {"id" "schema:age"}
+                                              "sh:datatype" {"id" "xsd:string"}}})
                  loaded2 (test-utils/retry-load conn ledger-alias 100)]
              (is (= [{"id"             shape-id
                       "type"           "sh:NodeShape",
                       "sh:targetClass" {"id" "schema:Person"},
                       "sh:property"    {"sh:path" {"id" "schema:age"}, "sh:datatype" {"id" "xsd:string"}}}]
                     @(fluree/query (fluree/db loaded2) property-query)))))))
-    (testing "can load after deletion of entire subjects"
-      (let [conn              @(fluree/connect {:method :memory})
-            ledger-alias      "tx/delete"
-            ledger            @(fluree/create conn ledger-alias)
-            db1               @(fluree/stage
+     (testing "can load after deletion of entire subjects"
+       (let [conn              @(fluree/connect {:method :memory})
+             ledger-alias      "tx/delete"
+             ledger            @(fluree/create conn ledger-alias)
+             db1               @(fluree/stage
                                  (fluree/db ledger)
                                  {"@context" ["https://ns.flur.ee"
                                               test-utils/default-context
@@ -632,27 +633,27 @@
                                     {:id                 :ex/kittens
                                      :type               :ex/Animal
                                      :schema/description "We ❤️ catnip"}]}})
-            description-query {:context [test-utils/default-context
-                                         {:ex "http://example.org/ns/"}]
-                               :select  '{?s [:id]}
-                               :where   '{:id ?s, :schema/description ?description}}
-            _                 @(fluree/commit! ledger db1)
-            loaded1           (test-utils/retry-load conn ledger-alias 100)
-            loaded-db1        (fluree/db loaded1)
-            db2               @(fluree/stage
+             description-query {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '{?s [:id]}
+                                :where   '{:id ?s, :schema/description ?description}}
+             _                 @(fluree/commit! ledger db1)
+             loaded1           (test-utils/retry-load conn ledger-alias 100)
+             loaded-db1        (fluree/db loaded1)
+             db2               @(fluree/stage
                                  loaded-db1
                                  {"@context" ["https://ns.flur.ee"
                                               test-utils/default-context
                                               {:ex "http://example.org/ns/"}]
                                   "where"    {:id :ex/mosquitos, "?p" "?o"}
                                   "delete"   {:id :ex/mosquitos, "?p" "?o"}})
-            _                 @(fluree/commit! ledger db2)
-            loaded2           (test-utils/retry-load conn ledger-alias 100)
-            loaded-db2        (fluree/db loaded2)]
-        (is (= [{:id :ex/fluree} {:id :ex/w3c} {:id :ex/kittens}]
+             _                 @(fluree/commit! ledger db2)
+             loaded2           (test-utils/retry-load conn ledger-alias 100)
+             loaded-db2        (fluree/db loaded2)]
+         (is (= [{:id :ex/fluree} {:id :ex/w3c} {:id :ex/kittens}]
                 @(fluree/query loaded-db2 description-query))
              "The id :ex/mosquitos should be removed")
-        (let [db3        @(fluree/stage
+         (let [db3        @(fluree/stage
                             loaded-db2
                             {"@context" ["https://ns.flur.ee"
                                          test-utils/default-context
@@ -661,10 +662,10 @@
                              "where"    {:id   "?s"
                                          :type :schema/Organization
                                          "?p"  "?o"}})
-              _          @(fluree/commit! ledger db3)
-              loaded3    (test-utils/retry-load conn ledger-alias 100)
-              loaded-db3 (fluree/db loaded3)]
-          (is (= [{:id :ex/kittens}]
+               _          @(fluree/commit! ledger db3)
+               loaded3    (test-utils/retry-load conn ledger-alias 100)
+               loaded-db3 (fluree/db loaded3)]
+           (is (= [{:id :ex/kittens}]
                   @(fluree/query loaded-db3 description-query))
                "Only :ex/kittens should be left"))))))
 
@@ -688,11 +689,11 @@
          :cljs
          (async done
            (go
-             (let [conn    (<! (test-utils/create-conn))
-                   ledger  (<! (test-utils/load-people conn))
-                   results (<p! (fluree/query (fluree/db ledger) query))]
-               (is (= expected results))
-               (done))))))))
+            (let [conn    (<! (test-utils/create-conn))
+                  ledger  (<! (test-utils/load-people conn))
+                  results (<p! (fluree/query (fluree/db ledger) query))]
+              (is (= expected results))
+              (done))))))))
 
 (deftest ^:integration fuel-test
   #?(:clj
@@ -756,7 +757,7 @@
                    db      @(fluree/stage db0 {"@context" ["https://ns.flur.ee"
                                                            test-utils/default-context
                                                            {:ex "http://example.org/ns/"}]
-                                               "insert" test-utils/people})
+                                               "insert"   test-utils/people})
                    results @(fluree/query db query)]
                (is (util/exception? results))
                (is (re-find #"Fuel limit exceeded"
@@ -764,76 +765,76 @@
      :cljs
      (async done
        (go
-         (testing "fuel tracking"
-           (let [conn   (<! (test-utils/create-conn))
-                 ledger (<p! (fluree/create conn "test/fuel-tracking"))
-                 db0    (fluree/db ledger)]
-             (testing "transactions"
-               (testing "with the `:meta` option"
-                 (let [response    (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
-                                                                       test-utils/default-context
-                                                                       {:ex "http://example.org/ns/"}]
-                                                           "insert"   test-utils/people} {:meta true}))
-                       db          (:result response)
-                       flake-total (- (-> db :stats :flakes)
-                                      (-> db0 :stats :flakes))]
-                   (is (= flake-total (:fuel response))
-                       "Reports fuel for all the generated flakes")))
-               (testing "without the `:meta` option"
-                 (let [response (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
-                                                                    test-utils/default-context
-                                                                    {:ex "http://example.org/ns/"}]
-                                                        "insert"   test-utils/people}))]
-                   (is (nil? (:fuel response))
-                       "Returns no fuel")))
-               (testing "short-circuits if request fuel exhausted"
-                 (let [response (try
-                                  (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
+        (testing "fuel tracking"
+          (let [conn   (<! (test-utils/create-conn))
+                ledger (<p! (fluree/create conn "test/fuel-tracking"))
+                db0    (fluree/db ledger)]
+            (testing "transactions"
+              (testing "with the `:meta` option"
+                (let [response    (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
                                                                       test-utils/default-context
                                                                       {:ex "http://example.org/ns/"}]
-                                                          "insert"   test-utils/people}
-                                                     {:maxFuel 1}))
-                                  (catch :default e (ex-cause e)))]
-                   (is (re-find #"Fuel limit exceeded"
-                                (-> response ex-cause ex-message))))))
-             (testing "queries"
-               (let [db          (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
-                                                                     test-utils/default-context
-                                                                     {:ex "http://example.org/ns/"}]
-                                                         "insert"   test-utils/people}))
-                     flake-total (-> db :stats :flakes)
-                     query       {:context [test-utils/default-context
-                                            {:ex "http://example.org/ns/"}]
-                                  :select '[?s ?p ?o]
-                                  :where  '{:id ?s
-                                            ?p  ?o}}]
-                 (testing "queries not returning metadata"
-                   (let [sut (<p! (fluree/query db query))]
-                     (is (nil? (:fuel sut))
-                         "Reports no fuel")))
-                 (testing "queries returning metadata"
-                   (let [query* (assoc-in query [:opts :meta] true)
-                         sut    (<p! (fluree/query db query*))]
-                     (is (= flake-total (:fuel sut))
-                         "Reports that all flakes were traversed"))))
-               (testing "short-circuits if request fuel exhausted"
-                 (let [query   {:context [test-utils/default-context
-                                          {:ex "http://example.org/ns/"}]
-                                :select '[?s ?p ?o]
-                                :where  '{:id ?s
-                                          ?p  ?o}
-                                :opts   {:max-fuel 1}}
-                       db      (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
+                                                          "insert"   test-utils/people} {:meta true}))
+                      db          (:result response)
+                      flake-total (- (-> db :stats :flakes)
+                                     (-> db0 :stats :flakes))]
+                  (is (= flake-total (:fuel response))
+                      "Reports fuel for all the generated flakes")))
+              (testing "without the `:meta` option"
+                (let [response (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
                                                                    test-utils/default-context
                                                                    {:ex "http://example.org/ns/"}]
-                                                       "insert"   test-utils/people}))
-                       results (try
-                                 (<p! (fluree/query db query))
+                                                       "insert"   test-utils/people}))]
+                  (is (nil? (:fuel response))
+                      "Returns no fuel")))
+              (testing "short-circuits if request fuel exhausted"
+                (let [response (try
+                                 (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
+                                                                     test-utils/default-context
+                                                                     {:ex "http://example.org/ns/"}]
+                                                         "insert"   test-utils/people}
+                                                    {:maxFuel 1}))
                                  (catch :default e (ex-cause e)))]
-                   (is (util/exception? results))
-                   (is (re-find #"Fuel limit exceeded"
-                                (-> results ex-cause ex-message))))))))
-         (done)))))
+                  (is (re-find #"Fuel limit exceeded"
+                               (-> response ex-cause ex-message))))))
+            (testing "queries"
+              (let [db          (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
+                                                                    test-utils/default-context
+                                                                    {:ex "http://example.org/ns/"}]
+                                                        "insert"   test-utils/people}))
+                    flake-total (-> db :stats :flakes)
+                    query       {:context [test-utils/default-context
+                                           {:ex "http://example.org/ns/"}]
+                                 :select  '[?s ?p ?o]
+                                 :where   '{:id ?s
+                                            ?p  ?o}}]
+                (testing "queries not returning metadata"
+                  (let [sut (<p! (fluree/query db query))]
+                    (is (nil? (:fuel sut))
+                        "Reports no fuel")))
+                (testing "queries returning metadata"
+                  (let [query* (assoc-in query [:opts :meta] true)
+                        sut    (<p! (fluree/query db query*))]
+                    (is (= flake-total (:fuel sut))
+                        "Reports that all flakes were traversed"))))
+              (testing "short-circuits if request fuel exhausted"
+                (let [query   {:context [test-utils/default-context
+                                         {:ex "http://example.org/ns/"}]
+                               :select  '[?s ?p ?o]
+                               :where   '{:id ?s
+                                          ?p  ?o}
+                               :opts    {:max-fuel 1}}
+                      db      (<p! (fluree/stage db0 {"@context" ["https://ns.flur.ee"
+                                                                  test-utils/default-context
+                                                                  {:ex "http://example.org/ns/"}]
+                                                      "insert"   test-utils/people}))
+                      results (try
+                                (<p! (fluree/query db query))
+                                (catch :default e (ex-cause e)))]
+                  (is (util/exception? results))
+                  (is (re-find #"Fuel limit exceeded"
+                               (-> results ex-cause ex-message))))))))
+        (done)))))
 
 #?(:clj
    (deftest transaction-test
@@ -842,94 +843,94 @@
            ledger    @(fluree/create conn ledger-id)
            db0       (fluree/db ledger)
 
-           db1 @(fluree/stage db0 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}]
-                                   "insert"   [{"@id"       "ex:dp"
-                                                "ex:name"   "Dan"
-                                                "ex:child"  [{"@id" "ex:ap" "ex:name" "AP"}
-                                                             {"@id" "ex:np" "ex:name" "NP"}]
-                                                "ex:spouse" [{"@id"       "ex:kp" "ex:name" "KP"
-                                                              "ex:spouse" {"@id" "ex:dp"}}]}]})
+           db1       @(fluree/stage db0 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}]
+                                         "insert"   [{"@id"       "ex:dp"
+                                                      "ex:name"   "Dan"
+                                                      "ex:child"  [{"@id" "ex:ap" "ex:name" "AP"}
+                                                                   {"@id" "ex:np" "ex:name" "NP"}]
+                                                      "ex:spouse" [{"@id"       "ex:kp" "ex:name" "KP"
+                                                                    "ex:spouse" {"@id" "ex:dp"}}]}]})
 
-           db2 @(fluree/stage db1 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}]
-                                   "where"    {"id" "?s", "ex:name" "?name"}
-                                   "delete"   {"@id" "?s" "ex:name" "?name"}
-                                   "insert"   {"@graph"
-                                               [{"@id" "?s" "ex:name" "BORG"}
-                                                {"@id"         "ex:mp"
-                                                 "@type"       "ex:Cat"
-                                                 "ex:isPerson" false
-                                                 "ex:isOrange" true
-                                                 "ex:nickname" {"@language" "en" "@value" "The Wretch"}
-                                                 "ex:name"     "Murray"
-                                                 "ex:address"
-                                                 {"ex:street" "55 Bashford"
-                                                  "ex:city"   "St. Paul"
-                                                  "ex:zip"    {"@value" 55105 "@type" "ex:PostalCode"}
-                                                  "ex:state"  "MN"}
-                                                 "ex:favs"     {"@list" ["Persey" {"@id" "ex:dp"}]}}]}})
-           db3 @(fluree/stage db2 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}]
-                                   "insert"   {"@type"          "sh:NodeShape"
-                                               "sh:targetClass" {"@id" "ex:Friend"}
-                                               "sh:property"
-                                               [{"sh:path"     {"@id" "ex:nickname"}
-                                                 "sh:maxCount" 1
-                                                 "sh:datatype" {"@id" "xsd:string"}}]}})
+           db2       @(fluree/stage db1 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}]
+                                         "where"    {"id" "?s", "ex:name" "?name"}
+                                         "delete"   {"@id" "?s" "ex:name" "?name"}
+                                         "insert"   {"@graph"
+                                                     [{"@id" "?s" "ex:name" "BORG"}
+                                                      {"@id"         "ex:mp"
+                                                       "@type"       "ex:Cat"
+                                                       "ex:isPerson" false
+                                                       "ex:isOrange" true
+                                                       "ex:nickname" {"@language" "en" "@value" "The Wretch"}
+                                                       "ex:name"     "Murray"
+                                                       "ex:address"
+                                                       {"ex:street" "55 Bashford"
+                                                        "ex:city"   "St. Paul"
+                                                        "ex:zip"    {"@value" 55105 "@type" "ex:PostalCode"}
+                                                        "ex:state"  "MN"}
+                                                       "ex:favs"     {"@list" ["Persey" {"@id" "ex:dp"}]}}]}})
+           db3       @(fluree/stage db2 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}]
+                                         "insert"   {"@type"          "sh:NodeShape"
+                                                     "sh:targetClass" {"@id" "ex:Friend"}
+                                                     "sh:property"
+                                                     [{"sh:path"     {"@id" "ex:nickname"}
+                                                       "sh:maxCount" 1
+                                                       "sh:datatype" {"@id" "xsd:string"}}]}})
 
-           db4 @(fluree/stage db3 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}]
-                                   "insert"   {"@id"         "ex:mp"
-                                               "@type"       "ex:Friend"
-                                               "ex:nickname" "Murrseph Gordon-Levitt"}})
+           db4       @(fluree/stage db3 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}]
+                                         "insert"   {"@id"         "ex:mp"
+                                                     "@type"       "ex:Friend"
+                                                     "ex:nickname" "Murrseph Gordon-Levitt"}})
 
            root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
            alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
 
-           db5 @(fluree/stage db3 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}]
-                                   "insert"   {"@graph"
-                                               [{"@id" root-did "f:role" {"@id" "ex:rootRole"}}
-                                                {"@id" alice-did "f:role" {"@id" "ex:userRole"} "ex:user" {"@id" "ex:alice"}}
-                                                {"@id"              "ex:alice"
-                                                 "@type"            "ex:User"
-                                                 "schema:name"      "Alice"
-                                                 "schema:email"     "alice@flur.ee"
-                                                 "schema:birthDate" "2022-08-17"
-                                                 "schema:ssn"       "111-11-1111"
-                                                 "ex:address"       {"ex:state" "NC" "ex:country" "USA"}}
-                                                {"@id"              "ex:john"
-                                                 "@type"            "ex:User"
-                                                 "schema:name"      "John"
-                                                 "schema:email"     "john@flur.ee"
-                                                 "schema:birthDate" "2022-08-17"
-                                                 "schema:ssn"       "222-22-2222"
-                                                 "ex:address"       {"ex:state" "SC" "ex:country" "USA"}}]}})
+           db5       @(fluree/stage db3 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}]
+                                         "insert"   {"@graph"
+                                                     [{"@id" root-did "f:role" {"@id" "ex:rootRole"}}
+                                                      {"@id" alice-did "f:role" {"@id" "ex:userRole"} "ex:user" {"@id" "ex:alice"}}
+                                                      {"@id"              "ex:alice"
+                                                       "@type"            "ex:User"
+                                                       "schema:name"      "Alice"
+                                                       "schema:email"     "alice@flur.ee"
+                                                       "schema:birthDate" "2022-08-17"
+                                                       "schema:ssn"       "111-11-1111"
+                                                       "ex:address"       {"ex:state" "NC" "ex:country" "USA"}}
+                                                      {"@id"              "ex:john"
+                                                       "@type"            "ex:User"
+                                                       "schema:name"      "John"
+                                                       "schema:email"     "john@flur.ee"
+                                                       "schema:birthDate" "2022-08-17"
+                                                       "schema:ssn"       "222-22-2222"
+                                                       "ex:address"       {"ex:state" "SC" "ex:country" "USA"}}]}})
 
-           db6 @(fluree/stage db5 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}],
-                                   "insert"   [{"@id" "schema:givenName", "@type" "rdf:Property"}
-                                               {"@id"                    "ex:firstName",
-                                                "@type"                  "rdf:Property",
-                                                "owl:equivalentProperty" {"@id" "schema:givenName"}}
-                                               {"@id"                    "foaf:name",
-                                                "@type"                  "rdf:Property",
-                                                "owl:equivalentProperty" {"@id" "ex:firstName"}}]})
+           db6       @(fluree/stage db5 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}],
+                                         "insert"   [{"@id" "schema:givenName", "@type" "rdf:Property"}
+                                                     {"@id"                    "ex:firstName",
+                                                      "@type"                  "rdf:Property",
+                                                      "owl:equivalentProperty" {"@id" "schema:givenName"}}
+                                                     {"@id"                    "foaf:name",
+                                                      "@type"                  "rdf:Property",
+                                                      "owl:equivalentProperty" {"@id" "ex:firstName"}}]})
 
-           db7 @(fluree/stage db6 {"@context" ["https://ns.flur.ee"
-                                               test-utils/default-str-context
-                                               {"ex" "ns:ex/"}],
-                                   "insert"   [{"@id" "ex:andrew", "schema:givenName" "Andrew"}
-                                               {"@id" "ex:freddy", "foaf:name" "Freddy"}
-                                               {"@id" "ex:letty", "ex:firstName" "Leticia"}
-                                               {"@id" "ex:betty", "ex:firstName" "Betty"}]})
+           db7       @(fluree/stage db6 {"@context" ["https://ns.flur.ee"
+                                                     test-utils/default-str-context
+                                                     {"ex" "ns:ex/"}],
+                                         "insert"   [{"@id" "ex:andrew", "schema:givenName" "Andrew"}
+                                                     {"@id" "ex:freddy", "foaf:name" "Freddy"}
+                                                     {"@id" "ex:letty", "ex:firstName" "Leticia"}
+                                                     {"@id" "ex:betty", "ex:firstName" "Betty"}]})
 
            committed @(fluree/commit! ledger db7)
            loaded    @(fluree/load conn ledger-id)]


### PR DESCRIPTION
This PR creates the remaining credential/signature specific APIs. Now queries, transactions, etc. that are wrapped in signatures have an independent API.

The primary motivation for this work right now is getting back a "zero-trust" setting for fluree/server like we had in v2 and this supports that being done. In the zero-trust (formerly called open-api: false), all interactions must happen with signatures. I also think those APIs make more sense separate as they not only have a different input format, but are quite intentional - you should know if you need it or not. I think it also helps ensure you don't accidentally do the wrong thing, as security here is of high concern.

In addition, there was some intersecting work, the biggest change is that `f:txn` (source transaction) *only* gets written to disk and included in the commit if it was originally wrapped in a signature. Storing every transaction is expensive, and it's purpose is for replayable cryptographic proof - when a ledger is being used without signatures it does nothing for that use case.

There were a number of tests that used test-utils/transact, which I assume was created before we had the fluree/transact! API - so those tests now use our external API and the helper util is removed.
