### PR TITLE
Refactor/policy identity

### DIFF
--- a/src/clj/fluree/db/api/transact.cljc
+++ b/src/clj/fluree/db/api/transact.cljc
@@ -32,7 +32,7 @@
                          (:meta parsed-opts))
          parsed-txn  (q-parse/parse-txn expanded txn-context)
 
-         identity    (perm/parse-policy-identity parsed-opts txn-context)]
+         identity    (:did parsed-opts)]
      (if track-fuel?
        (let [start-time #?(:clj (System/nanoTime)
                            :cljs (util/current-time-millis))

--- a/src/clj/fluree/db/db/json_ld.cljc
+++ b/src/clj/fluree/db/db/json_ld.cljc
@@ -342,7 +342,7 @@
     (let [tx-state   (->tx-state :db db
                                  :context context
                                  :txn raw-txn
-                                 :author-did (:did identity)
+                                 :author-did identity
                                  :annotation annotation)
           [db** new-flakes] (<? (generate-flakes db fuel-tracker parsed-txn tx-state))
           updated-db (<? (final-db db** new-flakes tx-state))]

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -1,19 +1,7 @@
 (ns fluree.db.json-ld.policy
-  (:require [fluree.json-ld :as json-ld]
-            [fluree.db.constants :as const]))
+  (:require [fluree.db.constants :as const]))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-(defn parse-policy-identity
-  ([opts]
-   (parse-policy-identity opts nil))
-  ([opts context]
-   (when-let [{:keys [role] :as identity} (-> opts
-                                              (select-keys [:did :role :credential])
-                                              not-empty)]
-     (if (and role context)
-       (update identity :role json-ld/expand-iri context)
-       identity))))
 
 (def root-policy-map
   "Base policy (permissions) map that will give access to all flakes."

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -35,8 +35,8 @@
 (defn restrict-db
   [db t context opts]
   (go-try
-    (let [db*  (if-let [policy-identity (perm/parse-policy-identity opts context)]
-                 (<? (perm/wrap-identity-policy db policy-identity false nil))
+    (let [db*  (if-let [did (:did opts)]
+                 (<? (perm/wrap-identity-policy db did true nil))
                  db)
           db** (-> (if t
                      (<? (time-travel/as-of db* t))

--- a/test/fluree/db/policy/identity_based_test.clj
+++ b/test/fluree/db/policy/identity_based_test.clj
@@ -32,9 +32,8 @@
                                     "schema:name"          "Widget"
                                     "schema:price"         99.99
                                     "schema:priceCurrency" "USD"}
-                                   ;; assign root-did to "ex:rootRole"
                                    {"@id" root-did}
-                                   ;; assign alice-did to "ex:userRole" and also link the did to "ex:alice" via "ex:user"
+                                   ;; assign alice-did to "ex:EmployeePolicy" and also link the did to "ex:alice" via "ex:user"
                                    {"@id"           alice-did
                                     "f:policyClass" [{"@id" "ex:EmployeePolicy"}]
                                     "ex:user"       {"@id" "ex:alice"}}


### PR DESCRIPTION
This removes the old policy 'roles' fns. Roles are no longer part of policy.

`fluree/query-connection` (used by fluree/server) was broken because it was still relying on this. Removed remaining traces.

This also defaults identity-policy execution to default-allow? true.

This is based on PR #825 
