### PR TITLE
Feature/history api updates

### DIFF
--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -146,13 +146,13 @@
       (let [db (<? db-chan)]
         (<? (history/-history db context from-t to-t commit-details? error-ch history-q)))))
 
-  (-commits [_ context from-t to-t error-ch]
+  (-commits [_ context from-t to-t include error-ch]
     (let [commit-ch (async/chan)]
       (go
         (try*
           (let [db (<? db-chan)]
             (-> db
-                (history/-commits context from-t to-t error-ch)
+                (history/-commits context from-t to-t include error-ch)
                 (async/pipe commit-ch)))
           (catch* e
             (log/error e "Error loading database for commit range")

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -141,10 +141,10 @@
       db-at-t))
 
   history/AuditLog
-  (-history [_ context from-t to-t commit-details? error-ch history-q]
+  (-history [_ context from-t to-t commit-details? include error-ch history-q]
     (go-try
       (let [db (<? db-chan)]
-        (<? (history/-history db context from-t to-t commit-details? error-ch history-q)))))
+        (<? (history/-history db context from-t to-t commit-details? include error-ch history-q)))))
 
   (-commits [_ context from-t to-t include error-ch]
     (let [commit-ch (async/chan)]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -456,8 +456,8 @@
   AuditLog
   (-history [db context from-t to-t commit-details? error-ch history-q]
     (history/query-history db context from-t to-t commit-details? error-ch history-q))
-  (-commits [db context from-t to-t error-ch]
-    (history/query-commits db context from-t to-t error-ch))
+  (-commits [db context from-t to-t include error-ch]
+    (history/query-commits db context from-t to-t include error-ch))
 
   policy/Restrictable
   (wrap-policy [db policy default-allow? values-map]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -454,8 +454,8 @@
     (assoc db :t t))
 
   AuditLog
-  (-history [db context from-t to-t commit-details? error-ch history-q]
-    (history/query-history db context from-t to-t commit-details? error-ch history-q))
+  (-history [db context from-t to-t commit-details? include error-ch history-q]
+    (history/query-history db context from-t to-t commit-details? include error-ch history-q))
   (-commits [db context from-t to-t include error-ch]
     (history/query-commits db context from-t to-t include error-ch))
 

--- a/src/clj/fluree/db/flake/history.cljc
+++ b/src/clj/fluree/db/flake/history.cljc
@@ -209,6 +209,7 @@
 
            assert-key          (json-ld/compact const/iri-assert compact)
            retract-key         (json-ld/compact const/iri-retract compact)
+           t-key               (json-ld/compact const/iri-t compact)
            data-key            (json-ld/compact const/iri-data compact)
            commit-key          (json-ld/compact const/iri-commit compact)
            annotation-key      (json-ld/compact const/iri-annotation compact)]
@@ -224,7 +225,8 @@
                       (assoc-in [commit-key data-key] commit-meta)
                       (cond-> annotation (assoc-in [commit-key annotation-key] annotation)))
            data   (-> (assoc-in [data-key assert-key] asserts)
-                      (assoc-in [data-key retract-key] retracts)))
+                      (assoc-in [data-key retract-key] retracts)
+                      (assoc-in [data-key t-key] (get commit-meta t-key))))
          (-> {commit-key commit-wrapper}
              (assoc-in [commit-key data-key] commit-meta)
              (assoc-in [commit-key data-key assert-key] asserts)

--- a/src/clj/fluree/db/query/history.cljc
+++ b/src/clj/fluree/db/query/history.cljc
@@ -24,18 +24,19 @@
 
 (defprotocol AuditLog
   (-history [db context from-t to-t commit-details? error-ch history-q])
-  (-commits [db context from-t to-t error-ch]))
+  (-commits [db context from-t to-t include error-ch]))
 
 (defn query
   [db context q]
   (go-try
-    (let [{:keys [history t commit-details] :as _parsed-query}
+    (let [{:keys [history t commit-details] :as parsed-query}
           (parse/parse-history-query q)
           ;; from and to are positive ints, need to convert to negative or fill in default values
           [from-t to-t] (<? (find-t-endpoints db t))
           error-ch      (async/chan)
+          include       (not-empty (select-keys parsed-query [:commit :data :txn]))
           result-ch     (if history
                           (-history db context from-t to-t commit-details error-ch history)
-                          (-commits db context from-t to-t error-ch))]
+                          (-commits db context from-t to-t include error-ch))]
       (async/alt! result-ch ([result] result)
                   error-ch  ([e] e)))))

--- a/src/clj/fluree/db/query/history.cljc
+++ b/src/clj/fluree/db/query/history.cljc
@@ -2,7 +2,8 @@
   (:require [clojure.core.async :as async]
             [fluree.db.query.history.parse :as parse]
             [fluree.db.time-travel :as time-travel]
-            [fluree.db.util.async :refer [<? go-try]]))
+            [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.util.log :as log]))
 
 (defn find-t-endpoints
   [db {:keys [from to at] :as _t}]
@@ -38,5 +39,7 @@
           result-ch     (if history
                           (-history db context from-t to-t commit-details include error-ch history)
                           (-commits db context from-t to-t include error-ch))]
+      (when commit-details
+        (log/warn "DEPRECATED history option `commit-details` superseded by options `commit`, `data`, and `txn`."))
       (async/alt! result-ch ([result] result)
                   error-ch  ([e] e)))))

--- a/src/clj/fluree/db/query/history.cljc
+++ b/src/clj/fluree/db/query/history.cljc
@@ -23,7 +23,7 @@
              (nil? to)      (:t db))])))
 
 (defprotocol AuditLog
-  (-history [db context from-t to-t commit-details? error-ch history-q])
+  (-history [db context from-t to-t commit-details? include error-ch history-q])
   (-commits [db context from-t to-t include error-ch]))
 
 (defn query
@@ -36,7 +36,7 @@
           error-ch      (async/chan)
           include       (not-empty (select-keys parsed-query [:commit :data :txn]))
           result-ch     (if history
-                          (-history db context from-t to-t commit-details error-ch history)
+                          (-history db context from-t to-t commit-details include error-ch history)
                           (-commits db context from-t to-t include error-ch))]
       (async/alt! result-ch ([result] result)
                   error-ch  ([e] e)))))

--- a/src/clj/fluree/db/query/history/parse.cljc
+++ b/src/clj/fluree/db/query/history/parse.cljc
@@ -14,8 +14,12 @@
   [:and
    [:map-of ::json-ld-keyword :any]
    [:fn {:error/message "Must supply a value for either \"history\" or \"commit-details\""}
-    (fn [{:keys [history commit-details]}]
-      (or (string? history) (keyword? history) (seq history) commit-details))]
+    (fn [{:keys [history commit-details commit data txn]}]
+      (or (string? history) (keyword? history) (seq history)
+          commit-details
+          commit
+          data
+          txn))]
    (into
     [:map
      [:history {:optional true}
@@ -35,6 +39,12 @@
           [:o [:not :nil]]]]]]]
      [:commit-details {:optional      true
                        :error/message "Invalid value of \"commit-details\" key"} :boolean]
+     [:commit {:optional true
+               :error/message "Invalid value of \"commit\" key"} :boolean]
+     [:data {:optional true
+             :error/message "Invalid value of \"commit\" key"} :boolean]
+     [:txn {:optional true
+            :error/message "Invalid value of \"txn\" key"} :boolean]
      [:context {:optional true} ::context]
      [:opts {:optional true} [:map-of :keyword :any]]
      [:t
@@ -70,7 +80,6 @@
                                   (<= from to)
                                   true))]]]]
     extra-kvs)])
-
 
 (def registry
   (merge

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1048,69 +1048,62 @@
                                         :txn     true
                                         :t       {:from 1 :to :latest}}))))
       (testing ":commit returns just the commit wrapper"
-        (is (= [{"f:commit"
-                 {"f:alias"  "authortest",
-                  "f:time"   720000,
-                  "f:previous" {"id" "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
-                  "id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"
-                  "f:v"      0,
-                  "f:branch" "main",
-                  "f:address" "fluree:memory://7a209c60839afefae379863296b698aa5bf38eea9a23537806b637d749899196"
-                  "f:data"
-                  {"f:address"
-                   "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
-                   "f:flakes" 16,
-                   "f:previous"
-                   {"id"
-                    "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
-                   "f:size"   1902,
-                   "f:t"      1,
-                   "id"
-                   "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}}}
-                {"f:commit"
-                 {"f:alias"  "authortest",
-                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                  "f:time"   720000,
-                  "f:txn"
-                  "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
-                  "f:previous" {"id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"},
-                  "id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"
-                  "f:v"      0,
-                  "f:branch" "main",
-                  "f:address" "fluree:memory://308b1fecb30f0151230a314c681db46f23b44c7a17dd4cef79ffa4bff20c4cb1"
-                  "f:data"
-                  {"f:address" "fluree:memory://9083d154b0235031424ef66d9bce5c3ce3c02b6f2acc595541afe0f5cf49efee"
-                   "f:flakes" 29,
-                   "f:previous"
-                   {"id"
-                    "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"},
-                   "f:size"   4906,
-                   "f:t"      2,
-                   "id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"}}}
-                {"f:commit"
-                 {"f:alias"  "authortest",
-                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                  "f:time"   720000,
-                  "f:txn"
-                  "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
-                  "f:previous" {"id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"},
-                  "id" "fluree:commit:sha256:bbncvid2dq2abcl4h23mnwixs7wg65of4gnowub5plg7r5xmwugbw"
-                  "f:v"      0,
-                  "f:branch" "main",
-                  "f:address" "fluree:memory://b50638cebc79c904766e9527f46891e7d06c376b058fbf7ab008e9cc54f8861e"
-                  "f:data"
-                  {"f:address" "fluree:memory://6c1de9ab6995e04f16ada3712d43bc14f54ec469dcb63022ea85d0c05d64cb13"
-                   "f:flakes" 44,
-                   "f:previous" {"id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"},
-                   "f:size"   8520,
-                   "f:t"      3,
-                   "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}}}]
-               @(fluree/history ledger {:context context
-                                        :commit  true
-                                        :t       {:from 1 :to :latest}}))))
+        (is (pred-match?
+              [{"f:commit"
+                {"f:alias"    "authortest",
+                 "f:time"     720000,
+                 "f:previous" {"id" test-utils/commit-id?},
+                 "id"         test-utils/commit-id?
+                 "f:v"        0,
+                 "f:branch"   "main",
+                 "f:address"  test-utils/address?
+                 "f:data"
+                 {"f:address"  test-utils/address?
+                  "f:flakes"   16,
+                  "f:previous" {"id" test-utils/db-id?},
+                  "f:size"     pos-int?,
+                  "f:t"        1,
+                  "id"         test-utils/db-id?}}}
+               {"f:commit"
+                {"f:alias"    "authortest",
+                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                 "f:time"     720000,
+                 "f:txn"      test-utils/address?
+                 "f:previous" {"id" test-utils/commit-id?}
+                 "id"         test-utils/commit-id?
+                 "f:v"        0,
+                 "f:branch"   "main",
+                 "f:address"  test-utils/address?
+                 "f:data"
+                 {"f:address"  test-utils/address?
+                  "f:flakes"   29,
+                  "f:previous" {"id" test-utils/db-id?},
+                  "f:size"     pos-int?
+                  "f:t"        2,
+                  "id"         test-utils/db-id?}}}
+               {"f:commit"
+                {"f:alias"    "authortest",
+                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                 "f:time"     720000,
+                 "f:txn"      test-utils/address?
+                 "f:previous" {"id" test-utils/commit-id?},
+                 "id"         test-utils/commit-id?
+                 "f:v"        0,
+                 "f:branch"   "main",
+                 "f:address"  test-utils/address?
+                 "f:data"
+                 {"f:address"  test-utils/address?
+                  "f:flakes"   44,
+                  "f:previous" {"id" test-utils/db-id?},
+                  "f:size"     pos-int?,
+                  "f:t"        3,
+                  "id"         test-utils/db-id?}}}]
+              @(fluree/history ledger {:context context
+                                       :commit  true
+                                       :t       {:from 1 :to :latest}}))))
       (testing ":data returns just the asserts and retracts"
         (is (= [{"f:data"
-                 {"f:t" 1
+                 {"f:t"       1
                   "f:assert"
                   [{"f:role" {"id" "ex:rootRole"},
                     "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
@@ -1134,234 +1127,212 @@
                     "f:targetNode" {"id" "f:allNodes"},
                     "id"           "ex:rootPolicy"}],
                   "f:retract" []}}
-                {"f:data" {"f:t" 2
-                           "f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}],
+                {"f:data" {"f:t"       2
+                           "f:assert"  [{"ex:foo" 3, "id" "_:fdb-4"}],
                            "f:retract" []}}
-                {"f:data" {"f:t" 3
-                           "f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}],
+                {"f:data" {"f:t"       3
+                           "f:assert"  [{"ex:foo" 5, "id" "_:fdb-6"}],
                            "f:retract" []}}]
                @(fluree/history ledger {:context context
                                         :data    true
                                         :t       {:from 1 :to :latest}}))))
       (testing ":commit :data :and txn can be composed together"
-        (is (= [{"f:txn" nil
-                 "f:commit"
-                 {"f:alias"  "authortest",
-                  "f:time"   720000,
-                  "f:previous" {"id" "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
-                  "id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"
-                  "f:v"      0,
-                  "f:branch" "main",
-                  "f:address" "fluree:memory://7a209c60839afefae379863296b698aa5bf38eea9a23537806b637d749899196"
-                  "f:data"
-                  {"f:address"
-                   "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
-                   "f:flakes" 16,
-                   "f:previous"
-                   {"id"
-                    "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
-                   "f:size"   1902,
-                   "f:t"      1,
-                   "id"
-                   "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}},
+        (is (pred-match?
+              [{"f:txn" nil
+                "f:commit"
+                {"f:alias"    "authortest",
+                 "f:time"     720000,
+                 "f:previous" {"id" test-utils/commit-id?},
+                 "id"         test-utils/commit-id?
+                 "f:v"        0,
+                 "f:branch"   "main",
+                 "f:address"  test-utils/address?
                  "f:data"
-                 {"f:t" 1,
-                  "f:assert"
-                  [{"f:role" {"id" "ex:rootRole"},
-                    "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                   {"type"        "ex:Yeti",
-                    "schema:age"  55,
-                    "schema:name" "Betty",
-                    "id"          "ex:betty"}
-                   {"type"        "ex:Yeti",
-                    "schema:age"  1002,
-                    "schema:name" "Freddy",
-                    "id"          "ex:freddy"}
-                   {"type"        "ex:Yeti",
-                    "schema:age"  38,
-                    "schema:name" "Leticia",
-                    "id"          "ex:letty"}
-                   {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
-                    "f:targetRole" {"id" "ex:rootRole"},
-                    "id"           "ex:rootAccessAllow"}
-                   {"type"         "f:Policy",
-                    "f:allow"      {"id" "ex:rootAccessAllow"},
-                    "f:targetNode" {"id" "f:allNodes"},
-                    "id"           "ex:rootPolicy"}],
-                  "f:retract" []}}
-                {"f:txn"  jws1
-                 "f:commit"
-                 {"f:alias"  "authortest",
-                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                  "f:time"   720000,
-                  "f:txn"
-                  "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
-                  "f:previous"
-                  {"id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"},
-                  "id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"
-                  "f:v"      0,
-                  "f:branch" "main",
-                  "f:address" "fluree:memory://308b1fecb30f0151230a314c681db46f23b44c7a17dd4cef79ffa4bff20c4cb1"
-                  "f:data"
-                  {"f:address" "fluree:memory://9083d154b0235031424ef66d9bce5c3ce3c02b6f2acc595541afe0f5cf49efee"
-                   "f:flakes" 29
-                   "f:previous"
-                   {"id"
-                    "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"},
-                   "f:size"   4906,
-                   "f:t"      2,
-                   "id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"}},
-                 "f:data" {"f:t" 2
-                           "f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}],
-                           "f:retract" []}}
-                {"f:txn"  jws2
-                 "f:commit"
-                 {"f:alias"  "authortest",
-                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                  "f:time"   720000,
-                  "f:txn"
-                  "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
-                  "f:previous" {"id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"},
-                  "id" "fluree:commit:sha256:bbncvid2dq2abcl4h23mnwixs7wg65of4gnowub5plg7r5xmwugbw"
-                  "f:v"      0,
-                  "f:branch" "main",
-                  "f:address" "fluree:memory://b50638cebc79c904766e9527f46891e7d06c376b058fbf7ab008e9cc54f8861e"
-                  "f:data"
-                  {"f:address" "fluree:memory://6c1de9ab6995e04f16ada3712d43bc14f54ec469dcb63022ea85d0c05d64cb13"
-                   "f:flakes" 44,
-                   "f:previous"
-                   {"id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"},
-                   "f:size"   8520,
-                   "f:t"      3,
-                   "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}},
-                 "f:data" {"f:t" 3
-                           "f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}],
-                           "f:retract" []}}]
-               @(fluree/history ledger {:context context
-                                        :txn     true
-                                        :data    true
-                                        :commit  true
-                                        :t       {:from 1 :to :latest}}))))
+                 {"f:address"  test-utils/address?
+                  "f:flakes"   16,
+                  "f:previous" {"id" test-utils/db-id?},
+                  "f:size"     pos-int?
+                  "f:t"        1,
+                  "id"         test-utils/db-id?}},
+                "f:data"
+                {"f:t"       1,
+                 "f:assert"
+                 [{"f:role" {"id" "ex:rootRole"},
+                   "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
+                  {"type"        "ex:Yeti",
+                   "schema:age"  55,
+                   "schema:name" "Betty",
+                   "id"          "ex:betty"}
+                  {"type"        "ex:Yeti",
+                   "schema:age"  1002,
+                   "schema:name" "Freddy",
+                   "id"          "ex:freddy"}
+                  {"type"        "ex:Yeti",
+                   "schema:age"  38,
+                   "schema:name" "Leticia",
+                   "id"          "ex:letty"}
+                  {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
+                   "f:targetRole" {"id" "ex:rootRole"},
+                   "id"           "ex:rootAccessAllow"}
+                  {"type"         "f:Policy",
+                   "f:allow"      {"id" "ex:rootAccessAllow"},
+                   "f:targetNode" {"id" "f:allNodes"},
+                   "id"           "ex:rootPolicy"}],
+                 "f:retract" []}}
+               {"f:txn"  jws1
+                "f:commit"
+                {"f:alias"    "authortest",
+                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                 "f:time"     720000,
+                 "f:txn"      test-utils/address?
+                 "f:previous" {"id" test-utils/commit-id?},
+                 "id"         test-utils/commit-id?
+                 "f:v"        0,
+                 "f:branch"   "main",
+                 "f:address"  test-utils/address?
+                 "f:data"
+                 {"f:address"  test-utils/address?
+                  "f:flakes"   29,
+                  "f:previous" {"id" test-utils/db-id?},
+                  "f:size"     pos-int?
+                  "f:t"        2,
+                  "id"         test-utils/db-id?}},
+                "f:data" {"f:t"       2
+                          "f:assert"  [{"ex:foo" 3, "id" "_:fdb-4"}],
+                          "f:retract" []}}
+               {"f:txn"  jws2
+                "f:commit"
+                {"f:alias"    "authortest",
+                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                 "f:time"     720000,
+                 "f:txn"      test-utils/address?
+                 "f:previous" {"id" test-utils/commit-id?},
+                 "id"         test-utils/commit-id?
+                 "f:v"        0,
+                 "f:branch"   "main",
+                 "f:address"  test-utils/address?
+                 "f:data"
+                 {"f:address"  test-utils/address?
+                  "f:flakes"   44,
+                  "f:previous" {"id" test-utils/db-id?},
+                  "f:size"     pos-int?
+                  "f:t"        3,
+                  "id"         test-utils/db-id?}},
+                "f:data" {"f:t"       3
+                          "f:assert"  [{"ex:foo" 5, "id" "_:fdb-6"}],
+                          "f:retract" []}}]
+              @(fluree/history ledger {:context context
+                                       :txn     true
+                                       :data    true
+                                       :commit  true
+                                       :t       {:from 1 :to :latest}}))))
       (testing ":commit :data :and txn can be composed together with history"
-        (is (= [{"f:t" 1,
-                 "f:assert" [{"type" "ex:Yeti",
-                              "schema:age" 1002,
+        (is (pred-match?
+              [{"f:t"       1,
+                "f:assert"  [{"type"        "ex:Yeti",
+                              "schema:age"  1002,
                               "schema:name" "Freddy",
-                              "id" "ex:freddy"}],
-                 "f:retract" [],
-                 "f:txn" nil,
-                 "f:commit" {"f:alias" "authortest",
-                             "f:time" 720000,
-                             "f:previous"
-                             {"id"
-                              "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
-                             "id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"
-                             "f:v" 0,
-                             "f:branch" "main",
-                             "f:address" "fluree:memory://7a209c60839afefae379863296b698aa5bf38eea9a23537806b637d749899196"
+                              "id"          "ex:freddy"}],
+                "f:retract" [],
+                "f:txn"     nil,
+                "f:commit"  {"f:alias"    "authortest",
+                             "f:time"     720000,
+                             "f:previous" {"id" test-utils/commit-id?},
+                             "id"         test-utils/commit-id?
+                             "f:v"        0,
+                             "f:branch"   "main",
+                             "f:address"  test-utils/address?
                              "f:data"
-                             {"f:address"
-                              "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
-                              "f:flakes" 16,
-                              "f:previous"
-                              {"id"
-                               "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
-                              "f:size" 1902,
-                              "f:t" 1,
-                              "id"
-                              "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}},
-                 "f:data" {"f:t" 1,
-                           "f:assert"
-                           [{"f:role" {"id" "ex:rootRole"},
-                             "id" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                            {"type" "ex:Yeti",
-                             "schema:age" 55,
-                             "schema:name" "Betty",
-                             "id" "ex:betty"}
-                            {"type" "ex:Yeti",
-                             "schema:age" 1002,
-                             "schema:name" "Freddy",
-                             "id" "ex:freddy"}
-                            {"type" "ex:Yeti",
-                             "schema:age" 38,
-                             "schema:name" "Leticia",
-                             "id" "ex:letty"}
-                            {"f:action" [{"id" "f:modify"} {"id" "f:view"}],
-                             "f:targetRole" {"id" "ex:rootRole"},
-                             "id" "ex:rootAccessAllow"}
-                            {"type" "f:Policy",
-                             "f:allow" {"id" "ex:rootAccessAllow"},
-                             "f:targetNode" {"id" "f:allNodes"},
-                             "id" "ex:rootPolicy"}],
-                           "f:retract" []}}]
-               @(fluree/history ledger {:context context
-                                        :history "ex:freddy"
-                                        :txn     true
-                                        :data    true
-                                        :commit  true
-                                        :t       {:from 1 :to :latest}}))))
+                             {"f:address"  test-utils/address?
+                              "f:flakes"   16,
+                              "f:previous" {"id" test-utils/db-id?},
+                              "f:size"     pos-int?,
+                              "f:t"        1,
+                              "id"         test-utils/db-id?}},
+                "f:data"    {"f:t"       1,
+                             "f:assert"
+                             [{"f:role" {"id" "ex:rootRole"},
+                               "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
+                              {"type"        "ex:Yeti",
+                               "schema:age"  55,
+                               "schema:name" "Betty",
+                               "id"          "ex:betty"}
+                              {"type"        "ex:Yeti",
+                               "schema:age"  1002,
+                               "schema:name" "Freddy",
+                               "id"          "ex:freddy"}
+                              {"type"        "ex:Yeti",
+                               "schema:age"  38,
+                               "schema:name" "Leticia",
+                               "id"          "ex:letty"}
+                              {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
+                               "f:targetRole" {"id" "ex:rootRole"},
+                               "id"           "ex:rootAccessAllow"}
+                              {"type"         "f:Policy",
+                               "f:allow"      {"id" "ex:rootAccessAllow"},
+                               "f:targetNode" {"id" "f:allNodes"},
+                               "id"           "ex:rootPolicy"}],
+                             "f:retract" []}}]
+              @(fluree/history ledger {:context context
+                                       :history "ex:freddy"
+                                       :txn     true
+                                       :data    true
+                                       :commit  true
+                                       :t       {:from 1 :to :latest}}))))
       (testing ":commit :data :and txn can be composed together with commit-details"
-        (is (= [{"f:t" 1,
-                 "f:assert" [{"type" "ex:Yeti",
-                              "schema:age" 1002,
+        (is (pred-match?
+              [{"f:t"       1,
+                "f:assert"  [{"type"        "ex:Yeti",
+                              "schema:age"  1002,
                               "schema:name" "Freddy",
-                              "id" "ex:freddy"}],
-                 "f:retract" [],
-                 "f:txn" nil,
-                 "f:commit" {"f:alias" "authortest",
-                             "f:author" "",
-                             "f:time" 720000,
-                             "f:previous"
-                             {"id"
-                              "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
-                             "id"
-                             "fluree:commit:sha256:bb25t37mxaum2u7nfxccasdbsqevbeco74p2dt3is2w66cxah5m52",
-                             "f:v" 0,
-                             "f:branch" "main",
-                             "f:address"
-                             "fluree:memory://3c501c97724a2366bd16540dd16818aad934728294446fba35667bd663f710e3",
+                              "id"          "ex:freddy"}],
+                "f:retract" [],
+                "f:txn"     nil,
+                "f:commit"  {"f:alias"    "authortest",
+                             "f:time"     720000,
+                             "f:previous" {"id" test-utils/commit-id?},
+                             "id"         test-utils/commit-id?
+                             "f:v"        0,
+                             "f:branch"   "main",
+                             "f:address"  test-utils/address?
                              "f:data"
-                             {"f:address"
-                              "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
-                              "f:flakes" 16,
-                              "f:previous"
-                              {"id"
-                               "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
-                              "f:size" 1902,
-                              "f:t" 1,
-                              "id"
-                              "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}}
-                 "f:data" {"f:t" 1,
-                           "f:assert"
-                           [{"f:role" {"id" "ex:rootRole"},
-                             "id" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                            {"type" "ex:Yeti",
-                             "schema:age" 55,
-                             "schema:name" "Betty",
-                             "id" "ex:betty"}
-                            {"type" "ex:Yeti",
-                             "schema:age" 1002,
-                             "schema:name" "Freddy",
-                             "id" "ex:freddy"}
-                            {"type" "ex:Yeti",
-                             "schema:age" 38,
-                             "schema:name" "Leticia",
-                             "id" "ex:letty"}
-                            {"f:action" [{"id" "f:modify"} {"id" "f:view"}],
-                             "f:targetRole" {"id" "ex:rootRole"},
-                             "id" "ex:rootAccessAllow"}
-                            {"type" "f:Policy",
-                             "f:allow" {"id" "ex:rootAccessAllow"},
-                             "f:targetNode" {"id" "f:allNodes"},
-                             "id" "ex:rootPolicy"}],
-                           "f:retract" []}}]
-               @(fluree/history ledger {:context context
-                                        :history "ex:freddy"
-                                        :commit-details true
-                                        :txn     true
-                                        :data    true
-                                        :commit  true
-                                        :t       {:from 1 :to :latest}})))))))
+                             {"f:address"  test-utils/address?
+                              "f:flakes"   16,
+                              "f:previous" {"id" test-utils/db-id?},
+                              "f:size"     pos-int?
+                              "f:t"        1,
+                              "id"         test-utils/db-id?}}
+                "f:data"    {"f:t"       1,
+                             "f:assert"
+                             [{"f:role" {"id" "ex:rootRole"},
+                               "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
+                              {"type"        "ex:Yeti",
+                               "schema:age"  55,
+                               "schema:name" "Betty",
+                               "id"          "ex:betty"}
+                              {"type"        "ex:Yeti",
+                               "schema:age"  1002,
+                               "schema:name" "Freddy",
+                               "id"          "ex:freddy"}
+                              {"type"        "ex:Yeti",
+                               "schema:age"  38,
+                               "schema:name" "Leticia",
+                               "id"          "ex:letty"}
+                              {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
+                               "f:targetRole" {"id" "ex:rootRole"},
+                               "id"           "ex:rootAccessAllow"}
+                              {"type"         "f:Policy",
+                               "f:allow"      {"id" "ex:rootAccessAllow"},
+                               "f:targetNode" {"id" "f:allNodes"},
+                               "id"           "ex:rootPolicy"}],
+                             "f:retract" []}}]
+              @(fluree/history ledger {:context        context
+                                       :history        "ex:freddy"
+                                       :commit-details true
+                                       :txn            true
+                                       :data           true
+                                       :commit         true
+                                       :t              {:from 1 :to :latest}})))))))
 
 (deftest ^:integration txn-annotation
   (let [bnode-counter (atom 0)

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1110,7 +1110,8 @@
                                         :t       {:from 1 :to :latest}}))))
       (testing ":data returns just the asserts and retracts"
         (is (= [{"f:data"
-                 {"f:assert"
+                 {"f:t" 1
+                  "f:assert"
                   [{"f:role" {"id" "ex:rootRole"},
                     "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
                    {"type"        "ex:Yeti",
@@ -1133,8 +1134,12 @@
                     "f:targetNode" {"id" "f:allNodes"},
                     "id"           "ex:rootPolicy"}],
                   "f:retract" []}}
-                {"f:data" {"f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}], "f:retract" []}}
-                {"f:data" {"f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}], "f:retract" []}}]
+                {"f:data" {"f:t" 2
+                           "f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}],
+                           "f:retract" []}}
+                {"f:data" {"f:t" 3
+                           "f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}],
+                           "f:retract" []}}]
                @(fluree/history ledger {:context context
                                         :data    true
                                         :t       {:from 1 :to :latest}}))))
@@ -1160,7 +1165,8 @@
                    "id"
                    "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}},
                  "f:data"
-                 {"f:assert"
+                 {"f:t" 1,
+                  "f:assert"
                   [{"f:role" {"id" "ex:rootRole"},
                     "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
                    {"type"        "ex:Yeti",
@@ -1205,7 +1211,9 @@
                    "f:size"   4906,
                    "f:t"      2,
                    "id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"}},
-                 "f:data" {"f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}], "f:retract" []}}
+                 "f:data" {"f:t" 2
+                           "f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}],
+                           "f:retract" []}}
                 {"f:txn"  jws2
                  "f:commit"
                  {"f:alias"  "authortest",
@@ -1226,7 +1234,9 @@
                    "f:size"   8520,
                    "f:t"      3,
                    "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}},
-                 "f:data" {"f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}], "f:retract" []}}]
+                 "f:data" {"f:t" 3
+                           "f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}],
+                           "f:retract" []}}]
                @(fluree/history ledger {:context context
                                         :txn     true
                                         :data    true
@@ -1260,7 +1270,8 @@
                               "f:t" 1,
                               "id"
                               "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}},
-                 "f:data" {"f:assert"
+                 "f:data" {"f:t" 1,
+                           "f:assert"
                            [{"f:role" {"id" "ex:rootRole"},
                              "id" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
                             {"type" "ex:Yeti",
@@ -1320,7 +1331,8 @@
                               "f:t" 1,
                               "id"
                               "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}}
-                 "f:data" {"f:assert"
+                 "f:data" {"f:t" 1,
+                           "f:assert"
                            [{"f:role" {"id" "ex:rootRole"},
                              "id" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
                             {"type" "ex:Yeti",

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -1,5 +1,5 @@
 (ns fluree.db.query.history-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [fluree.crypto :as crypto]
             [fluree.db.did :as did]
             [fluree.db.api :as fluree]
@@ -7,6 +7,8 @@
             [fluree.db.util.core :as util]
             [fluree.db.util.json :as json]
             [test-with-files.tools :refer [with-tmp-dir]]))
+
+(use-fixtures :each test-utils/deterministic-blank-node-fixture)
 
 (deftest ^:integration history-query-test
   (let [ts-primeval (util/current-time-iso)
@@ -936,58 +938,253 @@
           root-privkey "89e0ab9ac36fb82b172890c89e9e231224264c7c757d58cfd8fcd6f3d4442199"
           root-did     (:id (did/private->did-map root-privkey))
 
-          db0          (fluree/db ledger)
-          db1          @(fluree/stage db0 {"@context" context
-                                           "insert"   [{"@id"         "ex:betty"
-                                                        "@type"       "ex:Yeti"
-                                                        "schema:name" "Betty"
-                                                        "schema:age"  55}
-                                                       {"@id"         "ex:freddy"
-                                                        "@type"       "ex:Yeti"
-                                                        "schema:name" "Freddy"
-                                                        "schema:age"  1002}
-                                                       {"@id"         "ex:letty"
-                                                        "@type"       "ex:Yeti"
-                                                        "schema:name" "Leticia"
-                                                        "schema:age"  38}
-                                                       {"@id"    root-did
-                                                        "f:role" {"@id" "ex:rootRole"}}]})
-          db2          (->> @(fluree/stage db1 {"@context" context
-                                                "insert"   {"@id"          "ex:rootPolicy"
-                                                            "@type"        ["f:Policy"]
-                                                            "f:targetNode" {"@id" "f:allNodes"}
-                                                            "f:allow"      [{"@id"          "ex:rootAccessAllow"
-                                                                             "f:targetRole" {"@id" "ex:rootRole"}
-                                                                             "f:action"     [{"@id" "f:view"}
-                                                                                             {"@id" "f:modify"}]}]}})
-                            (fluree/commit! ledger)
-                            (deref))
+          db0 (fluree/db ledger)
+          db1 @(fluree/stage db0 {"@context" context
+                                  "insert"   [{"@id"         "ex:betty"
+                                               "@type"       "ex:Yeti"
+                                               "schema:name" "Betty"
+                                               "schema:age"  55}
+                                              {"@id"         "ex:freddy"
+                                               "@type"       "ex:Yeti"
+                                               "schema:name" "Freddy"
+                                               "schema:age"  1002}
+                                              {"@id"         "ex:letty"
+                                               "@type"       "ex:Yeti"
+                                               "schema:name" "Leticia"
+                                               "schema:age"  38}
+                                              {"@id"    root-did
+                                               "f:role" {"@id" "ex:rootRole"}}]})
+          db2 (->> @(fluree/stage db1 {"@context" context
+                                       "insert"   {"@id"          "ex:rootPolicy"
+                                                   "@type"        ["f:Policy"]
+                                                   "f:targetNode" {"@id" "f:allNodes"}
+                                                   "f:allow"      [{"@id"          "ex:rootAccessAllow"
+                                                                    "f:targetRole" {"@id" "ex:rootRole"}
+                                                                    "f:action"     [{"@id" "f:view"}
+                                                                                    {"@id" "f:modify"}]}]}})
+                   (fluree/commit! ledger)
+                   (deref))
 
-          db3          @(fluree/credential-transact! conn (crypto/create-jws
-                                                           (json/stringify {"@context" context
-                                                                            "ledger"   ledger-name
-                                                                            "insert"   {"ex:foo" 3}})
-                                                           root-privkey))
+          jws1 (crypto/create-jws
+                 (json/stringify {"@context" context
+                                  "ledger"   ledger-name
+                                  "insert"   {"ex:foo" 3}})
+                 root-privkey)
+          db3  @(fluree/credential-transact! conn jws1)
 
-          db4          @(fluree/credential-transact! conn (crypto/create-jws
-                                                           (json/stringify {"@context" context
-                                                                            "ledger"   ledger-name
-                                                                            "insert"   {"ex:foo" 5}})
-                                                           root-privkey))]
-      (is (= [{"f:data" {"f:t" 1}}
-              {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn"    "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
-               "f:data"   {"f:t" 2}}
-              {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn"    "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
-               "f:data"   {"f:t" 3}}]
-             (->> @(fluree/history ledger {:context        context
-                                           :commit-details true
-                                           :t              {:from 1 :to :latest}})
-                  (mapv (fn [c]
-                          (-> (get c "f:commit")
-                              (update "f:data" select-keys ["f:t"])
-                              (select-keys ["f:author" "f:txn" "f:data"]))))))))))
+          jws2 (crypto/create-jws
+                 (json/stringify {"@context" context
+                                  "ledger"   ledger-name
+                                  "insert"   {"ex:foo" 5}})
+                 root-privkey)
+          db4  @(fluree/credential-transact! conn jws2)]
+      (testing "author and txn show up in commit-details"
+        (is (= [{"f:data" {"f:t" 1}}
+                {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                 "f:txn"    "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
+                 "f:data"   {"f:t" 2}}
+                {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                 "f:txn"    "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
+                 "f:data"   {"f:t" 3}}]
+               (->> @(fluree/history ledger {:context        context
+                                             :commit-details true
+                                             :t              {:from 1 :to :latest}})
+                    (mapv (fn [c]
+                            (-> (get c "f:commit")
+                                (update "f:data" select-keys ["f:t"])
+                                (select-keys ["f:author" "f:txn" "f:data"]))))))))
+      (testing ":txn returns the raw transaction"
+        (is (= [{"f:txn" nil}
+                {"f:txn" jws1}
+                {"f:txn" jws2}]
+               (->> @(fluree/history ledger {:context context
+                                             :txn     true
+                                             :t       {:from 1 :to :latest}})))))
+      (testing ":commit returns just the commit wrapper"
+        (is (= [{"f:commit"
+                 {"f:alias"  "authortest",
+                  "f:time"   720000,
+                  "f:previous" {"id" "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
+                  "id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"
+                  "f:v"      0,
+                  "f:branch" "main",
+                  "f:address" "fluree:memory://7a209c60839afefae379863296b698aa5bf38eea9a23537806b637d749899196"
+                  "f:data"
+                  {"f:address"
+                   "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
+                   "f:flakes" 16,
+                   "f:previous"
+                   {"id"
+                    "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
+                   "f:size"   1902,
+                   "f:t"      1,
+                   "id"
+                   "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}}}
+                {"f:commit"
+                 {"f:alias"  "authortest",
+                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                  "f:time"   720000,
+                  "f:txn"
+                  "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
+                  "f:previous" {"id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"},
+                  "id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"
+                  "f:v"      0,
+                  "f:branch" "main",
+                  "f:address" "fluree:memory://308b1fecb30f0151230a314c681db46f23b44c7a17dd4cef79ffa4bff20c4cb1"
+                  "f:data"
+                  {"f:address" "fluree:memory://9083d154b0235031424ef66d9bce5c3ce3c02b6f2acc595541afe0f5cf49efee"
+                   "f:flakes" 29,
+                   "f:previous"
+                   {"id"
+                    "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"},
+                   "f:size"   4906,
+                   "f:t"      2,
+                   "id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"}}}
+                {"f:commit"
+                 {"f:alias"  "authortest",
+                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                  "f:time"   720000,
+                  "f:txn"
+                  "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
+                  "f:previous" {"id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"},
+                  "id" "fluree:commit:sha256:bbncvid2dq2abcl4h23mnwixs7wg65of4gnowub5plg7r5xmwugbw"
+                  "f:v"      0,
+                  "f:branch" "main",
+                  "f:address" "fluree:memory://b50638cebc79c904766e9527f46891e7d06c376b058fbf7ab008e9cc54f8861e"
+                  "f:data"
+                  {"f:address" "fluree:memory://6c1de9ab6995e04f16ada3712d43bc14f54ec469dcb63022ea85d0c05d64cb13"
+                   "f:flakes" 44,
+                   "f:previous" {"id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"},
+                   "f:size"   8520,
+                   "f:t"      3,
+                   "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}}}]
+               (->> @(fluree/history ledger {:context context
+                                             :commit  true
+                                             :t       {:from 1 :to :latest}})))))
+      (testing ":data returns just the asserts and retracts"
+        (is (= [{"f:data"
+                 {"f:assert"
+                  [{"f:role" {"id" "ex:rootRole"},
+                    "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
+                   {"type"        "ex:Yeti",
+                    "schema:age"  55,
+                    "schema:name" "Betty",
+                    "id"          "ex:betty"}
+                   {"type"        "ex:Yeti",
+                    "schema:age"  1002,
+                    "schema:name" "Freddy",
+                    "id"          "ex:freddy"}
+                   {"type"        "ex:Yeti",
+                    "schema:age"  38,
+                    "schema:name" "Leticia",
+                    "id"          "ex:letty"}
+                   {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
+                    "f:targetRole" {"id" "ex:rootRole"},
+                    "id"           "ex:rootAccessAllow"}
+                   {"type"         "f:Policy",
+                    "f:allow"      {"id" "ex:rootAccessAllow"},
+                    "f:targetNode" {"id" "f:allNodes"},
+                    "id"           "ex:rootPolicy"}],
+                  "f:retract" []}}
+                {"f:data" {"f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}], "f:retract" []}}
+                {"f:data" {"f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}], "f:retract" []}}]
+               (->> @(fluree/history ledger {:context context
+                                             :data    true
+                                             :t       {:from 1 :to :latest}})))))
+      (testing ":commit :data :and txn can be composed together"
+        (is (= [{"f:txn" nil
+                 "f:commit"
+                 {"f:alias"  "authortest",
+                  "f:time"   720000,
+                  "f:previous" {"id" "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
+                  "id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"
+                  "f:v"      0,
+                  "f:branch" "main",
+                  "f:address" "fluree:memory://7a209c60839afefae379863296b698aa5bf38eea9a23537806b637d749899196"
+                  "f:data"
+                  {"f:address"
+                   "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
+                   "f:flakes" 16,
+                   "f:previous"
+                   {"id"
+                    "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
+                   "f:size"   1902,
+                   "f:t"      1,
+                   "id"
+                   "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}},
+                 "f:data"
+                 {"f:assert"
+                  [{"f:role" {"id" "ex:rootRole"},
+                    "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
+                   {"type"        "ex:Yeti",
+                    "schema:age"  55,
+                    "schema:name" "Betty",
+                    "id"          "ex:betty"}
+                   {"type"        "ex:Yeti",
+                    "schema:age"  1002,
+                    "schema:name" "Freddy",
+                    "id"          "ex:freddy"}
+                   {"type"        "ex:Yeti",
+                    "schema:age"  38,
+                    "schema:name" "Leticia",
+                    "id"          "ex:letty"}
+                   {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
+                    "f:targetRole" {"id" "ex:rootRole"},
+                    "id"           "ex:rootAccessAllow"}
+                   {"type"         "f:Policy",
+                    "f:allow"      {"id" "ex:rootAccessAllow"},
+                    "f:targetNode" {"id" "f:allNodes"},
+                    "id"           "ex:rootPolicy"}],
+                  "f:retract" []}}
+                {"f:txn"  jws1
+                 "f:commit"
+                 {"f:alias"  "authortest",
+                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                  "f:time"   720000,
+                  "f:txn"
+                  "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
+                  "f:previous"
+                  {"id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"},
+                  "id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"
+                  "f:v"      0,
+                  "f:branch" "main",
+                  "f:address" "fluree:memory://308b1fecb30f0151230a314c681db46f23b44c7a17dd4cef79ffa4bff20c4cb1"
+                  "f:data"
+                  {"f:address" "fluree:memory://9083d154b0235031424ef66d9bce5c3ce3c02b6f2acc595541afe0f5cf49efee"
+                   "f:flakes" 29
+                   "f:previous"
+                   {"id"
+                    "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"},
+                   "f:size"   4906,
+                   "f:t"      2,
+                   "id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"}},
+                 "f:data" {"f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}], "f:retract" []}}
+                {"f:txn"  jws2
+                 "f:commit"
+                 {"f:alias"  "authortest",
+                  "f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                  "f:time"   720000,
+                  "f:txn"
+                  "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
+                  "f:previous" {"id" "fluree:commit:sha256:bbx2zcis3nuxi4xyyshvg45wrjz2istdocnd2eawjzw2tz4ekwmaq"},
+                  "id" "fluree:commit:sha256:bbncvid2dq2abcl4h23mnwixs7wg65of4gnowub5plg7r5xmwugbw"
+                  "f:v"      0,
+                  "f:branch" "main",
+                  "f:address" "fluree:memory://b50638cebc79c904766e9527f46891e7d06c376b058fbf7ab008e9cc54f8861e"
+                  "f:data"
+                  {"f:address" "fluree:memory://6c1de9ab6995e04f16ada3712d43bc14f54ec469dcb63022ea85d0c05d64cb13"
+                   "f:flakes" 44,
+                   "f:previous"
+                   {"id" "fluree:db:sha256:b7fcqtfrabf73raflq3ydyag6vjlxwzzdk7umr4l5pdu5pbtnjis"},
+                   "f:size"   8520,
+                   "f:t"      3,
+                   "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}},
+                 "f:data" {"f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}], "f:retract" []}}]
+               (->> @(fluree/history ledger {:context context
+                                             :txn     true
+                                             :data    true
+                                             :commit  true
+                                             :t       {:from 1 :to :latest}}))))))))
 
 (deftest ^:integration txn-annotation
   (let [bnode-counter (atom 0)

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -997,9 +997,9 @@
         (is (= [{"f:txn" nil}
                 {"f:txn" jws1}
                 {"f:txn" jws2}]
-               (->> @(fluree/history ledger {:context context
-                                             :txn     true
-                                             :t       {:from 1 :to :latest}})))))
+               @(fluree/history ledger {:context context
+                                        :txn     true
+                                        :t       {:from 1 :to :latest}}))))
       (testing ":commit returns just the commit wrapper"
         (is (= [{"f:commit"
                  {"f:alias"  "authortest",
@@ -1058,9 +1058,9 @@
                    "f:size"   8520,
                    "f:t"      3,
                    "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}}}]
-               (->> @(fluree/history ledger {:context context
-                                             :commit  true
-                                             :t       {:from 1 :to :latest}})))))
+               @(fluree/history ledger {:context context
+                                        :commit  true
+                                        :t       {:from 1 :to :latest}}))))
       (testing ":data returns just the asserts and retracts"
         (is (= [{"f:data"
                  {"f:assert"
@@ -1088,9 +1088,9 @@
                   "f:retract" []}}
                 {"f:data" {"f:assert" [{"ex:foo" 3, "id" "_:fdb-4"}], "f:retract" []}}
                 {"f:data" {"f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}], "f:retract" []}}]
-               (->> @(fluree/history ledger {:context context
-                                             :data    true
-                                             :t       {:from 1 :to :latest}})))))
+               @(fluree/history ledger {:context context
+                                        :data    true
+                                        :t       {:from 1 :to :latest}}))))
       (testing ":commit :data :and txn can be composed together"
         (is (= [{"f:txn" nil
                  "f:commit"
@@ -1180,11 +1180,68 @@
                    "f:t"      3,
                    "id" "fluree:db:sha256:bsfjn7tehnhojgltwopo7ml3boncyq2ebnhvwqmev4uq5hgg3l2x"}},
                  "f:data" {"f:assert" [{"ex:foo" 5, "id" "_:fdb-6"}], "f:retract" []}}]
-               (->> @(fluree/history ledger {:context context
-                                             :txn     true
-                                             :data    true
-                                             :commit  true
-                                             :t       {:from 1 :to :latest}}))))))))
+               @(fluree/history ledger {:context context
+                                        :txn     true
+                                        :data    true
+                                        :commit  true
+                                        :t       {:from 1 :to :latest}}))))
+      (testing ":commit :data :and txn can be composed together with history"
+        (is (= [{"f:t" 1,
+                 "f:assert" [{"type" "ex:Yeti",
+                              "schema:age" 1002,
+                              "schema:name" "Freddy",
+                              "id" "ex:freddy"}],
+                 "f:retract" [],
+                 "f:txn" nil,
+                 "f:commit" {"f:alias" "authortest",
+                             "f:time" 720000,
+                             "f:previous"
+                             {"id"
+                              "fluree:commit:sha256:bku3fg5vpmre72rxdeklap5ckbxidyne7zz6ncurg2niwy5264ih"},
+                             "id" "fluree:commit:sha256:bbqny7mff6byds77crqwbpq7bukzrki6sdzbiwro2c24xpc36gv2a"
+                             "f:v" 0,
+                             "f:branch" "main",
+                             "f:address" "fluree:memory://7a209c60839afefae379863296b698aa5bf38eea9a23537806b637d749899196"
+                             "f:data"
+                             {"f:address"
+                              "fluree:memory://06b103176ccba03d7615b63a1dc0e1efad45cf4804f37d18f9d4151558f38a60",
+                              "f:flakes" 16,
+                              "f:previous"
+                              {"id"
+                               "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"},
+                              "f:size" 1902,
+                              "f:t" 1,
+                              "id"
+                              "fluree:db:sha256:bbozj3rqh62e2chzynu575hbxcsmxdpsl2s5c3jxl3iqbtssawoq5"}},
+                 "f:data" {"f:assert"
+                           [{"f:role" {"id" "ex:rootRole"},
+                             "id" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
+                            {"type" "ex:Yeti",
+                             "schema:age" 55,
+                             "schema:name" "Betty",
+                             "id" "ex:betty"}
+                            {"type" "ex:Yeti",
+                             "schema:age" 1002,
+                             "schema:name" "Freddy",
+                             "id" "ex:freddy"}
+                            {"type" "ex:Yeti",
+                             "schema:age" 38,
+                             "schema:name" "Leticia",
+                             "id" "ex:letty"}
+                            {"f:action" [{"id" "f:modify"} {"id" "f:view"}],
+                             "f:targetRole" {"id" "ex:rootRole"},
+                             "id" "ex:rootAccessAllow"}
+                            {"type" "f:Policy",
+                             "f:allow" {"id" "ex:rootAccessAllow"},
+                             "f:targetNode" {"id" "f:allNodes"},
+                             "id" "ex:rootPolicy"}],
+                           "f:retract" []}}]
+               @(fluree/history ledger {:context context
+                                        :history "ex:freddy"
+                                        :txn     true
+                                        :data    true
+                                        :commit  true
+                                        :t       {:from 1 :to :latest}})))))))
 
 (deftest ^:integration txn-annotation
   (let [bnode-counter (atom 0)


### PR DESCRIPTION
Fixes https://github.com/fluree/core/issues/110

This PR is meant to allow users to be receive more granular information from the history api. It teases apart some different categories of data:
- `:commit` - the commit metadata that wraps the actual data: `f:address` `f:alias` `f:author` `f:branch` `f:data` `f:previous` `f:time` `f:v` `id` `f:annotation` and `f:txn`.
- `:data` - the asserts and retracts that represent the facts changed: `f:assert` `f:retract`
- `:txn` - the raw transaction string (or `nil` if there was no signed transaction associated with the commit.
 
Each of these history keys can be composed with the existing keys `:history` and `:t`, but overrides the `:commit-details` and is meant to be a replacement for that option.