### PR TITLE
Fix/policy modify

### DIFF
--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -39,6 +39,8 @@
     (seq (apply concat (keep #(get class-policies %) classes)))))
 
 (defn policies-for-property
+  "Returns policy properties if they exist for the provided property
+  else nil"
   [policy-map modify? property]
   (let [prop-policies (property-policy-map policy-map modify?)]
     (get prop-policies property)))
@@ -63,9 +65,8 @@
            {:status 403 :error :db/policy-exception}))
 
 (defn default-val
-  "Returns the default policy value if no policies are found.
-  For transactions/modifications, this is an exception. For queries/view
-  it is just a boolean true/false."
+  "Returns the default policy value if no policies are found. (true/false)
+  If false and a transactions/modification, an exception is thrown."
   [{:keys [default-allow?] :as _policy} modify? policies]
   (if (true? default-allow?)
     true
@@ -86,6 +87,7 @@
          (if (seq result)
            true
            (recur r)))
+       ;; no more policies left to evaluate - all returned false
        (if modify?
          (modify-exception policies-to-eval)
          false)))))

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -60,7 +60,7 @@
   [policies]
   (ex-info (or (some :ex-message policies)
                "Policy enforcement prevents modification.")
-           {:status 400 :error :db/policy-exception}))
+           {:status 403 :error :db/policy-exception}))
 
 (defn default-val
   "Returns the default policy value if no policies are found.

--- a/src/clj/fluree/db/json_ld/policy/modify.cljc
+++ b/src/clj/fluree/db/json_ld/policy/modify.cljc
@@ -17,6 +17,11 @@
        seq))
 
 (defn allowed?
+  "Checks if all 'adds' are allowed by the policy. If so
+  returns final db.
+
+  If encounters a policy error, will throw with policy error
+  message (if available)."
   [{:keys [db-after add mods]}]
   (go-try
    (let [{:keys [policy]} db-after]

--- a/src/clj/fluree/db/json_ld/policy/modify.cljc
+++ b/src/clj/fluree/db/json_ld/policy/modify.cljc
@@ -29,15 +29,27 @@
        db-after
        (loop [[flake & r] add]
          (if flake
-           (if-let [p-policies (enforce/policies-for-property policy true (flake/p flake))]
-             (let [result (<? (enforce/policies-allow? db-after true (flake/s flake) (:values-map policy) p-policies))]
-               (if (true? result)
-                 (recur r)
-                 (enforce/default-val policy true p-policies)))
-             (if-let [classes (classes-for-sid (flake/s flake) mods db-after)]
+           (let [p-policies (enforce/policies-for-property policy true (flake/p flake))
+                 classes    (when (nil? p-policies)
+                              (classes-for-sid (flake/s flake) mods db-after))]
+
+             ;; all items in 'cond' below with throw if policy not allowed
+             ;; and loop will terminate on first such exception
+             (cond
+               ;; property policies override all others
+               p-policies
+               (<? (enforce/policies-allow? db-after true (flake/s flake) (:values-map policy) p-policies))
+
+               ;; if not property policies, check class policies
+               classes
                (<? (enforce/class-allow? db-after (flake/s flake) true classes))
-               (let [default-result (enforce/default-val policy true nil)]
-                 (if (util/exception? default-result)
-                   default-result
-                   (recur r)))))
+
+               ;; if no class policies, check if default-allow?, else deny
+               :else
+               (let [default (enforce/default-val policy true nil)]
+                 (when (util/exception? default)
+                   (throw default))))
+
+             (recur r))
+           ;; no more flakes, all passed so return final db
            db-after))))))

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -11,6 +11,7 @@
             [fluree.db.util.log :as log]
             [fluree.db.query.history :as history]
             [fluree.db.query.sparql :as sparql]
+            [fluree.db.query.fql.syntax :as syntax]
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.async :as async-util :refer [<? go-try]]
             [fluree.db.util.context :as ctx-util]
@@ -210,8 +211,9 @@
 (defn query-connection-fql
   [conn query did]
   (go-try
-   (let [{:keys [t opts] :as query*} (update query :opts sanitize-query-options did)
-
+   (let [{:keys [t opts] :as query*} (-> query
+                                         syntax/coerce-query
+                                         (update :opts sanitize-query-options did))
          default-aliases (some-> query* :from util/sequential)
          named-aliases   (some-> query* :from-named util/sequential)]
      (if (or (seq default-aliases)


### PR DESCRIPTION
This addresses:

a) Policy-modify logic bug that would get hit in certain policy combos fixed
b) Return 403 for policy exception
c) `query-connection-fql` bypassed parsing, and could only be used by keyword-based queries (not string keys). This wasn't exposed before because fluree/server was the only one using it, and it parses queries as well... so they were parsed before hitting the API.
d) `transact!` API did not enforce policy. fluree/server implemented it's own custom transact function (addressed in an upcoming PR) instead of using the fluree/db API so it wasn't exposed.