### PR TITLE
Fix/wildcard selector

### DIFF
--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -93,18 +93,13 @@
   (implicit-grouping? [_] false)
   (format-value
     [_ db iri-cache _context compact _fuel-tracker error-ch solution]
-    (go-loop [ks (keys solution)
-              formatted {}]
-      (let [k          (first ks)
-            fv         (-> solution
-                           (get k)
-                           (display db iri-cache compact error-ch)
-                           <!)
-            formatted' (assoc formatted k fv)
-            next-ks    (rest ks)]
-        (if (seq next-ks)
-          (recur next-ks formatted')
-          formatted'))))
+    (go-loop [[var & vars] (sort (keys solution))
+              result {}]
+      (if var
+        (recur vars (assoc result var (-> (get solution var)
+                                          (display db iri-cache compact error-ch)
+                                          <!)))
+        result)))
   (solution-value
     [_ _ solution]
     solution))

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -506,18 +506,19 @@
 
 (defn parse-selector
   [context depth s]
-  (let [[selector-type selector-val] (syntax/parse-selector s)]
-    (case selector-type
-      :wildcard select/wildcard-selector
-      :var (-> selector-val symbol select/variable-selector)
-      :aggregate (case (first selector-val)
-                   :string-fn (if (re-find #"^\(as " s)
+  (if (syntax/wildcard? s)
+    select/wildcard-selector
+    (let [[selector-type selector-val] (syntax/parse-selector s)]
+      (case selector-type
+        :var (-> selector-val symbol select/variable-selector)
+        :aggregate (case (first selector-val)
+                     :string-fn (if (re-find #"^\(as " s)
+                                  (parse-as-fn s)
+                                  (parse-fn s))
+                     :list-fn (if (= 'as (first s))
                                 (parse-as-fn s)
-                                (parse-fn s))
-                   :list-fn (if (= 'as (first s))
-                              (parse-as-fn s)
-                              (parse-fn s)))
-      :select-map (parse-select-map s depth context))))
+                                (parse-fn s)))
+        :select-map (parse-select-map s depth context)))))
 
 (defn parse-select-clause
   [clause context depth]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -142,19 +142,19 @@
     ::select-map        [:map-of {:max           1
                                   :error/message "Only one key/val for select-map"}
                          ::select-map-key ::subselection]
-    ::selector          [:orn {:error/message "selector must be either a variable, wildcard symbol (`*`), iri, function application, or select map"}
-                         [:wildcard ::wildcard]
+    ::selector          [:orn {:error/message "selector must be either a variable, iri, function application, or select map"}
                          [:var ::var]
                          [:aggregate ::function]
                          [:select-map ::select-map]]
-    ::select            [:orn {:error/message "Select must be a valid selector or vector of selectors"}
+    ::select            [:orn {:error/message "Select must be a valid selector, a wildcard symbol (`*`), or a vector of selectors"}
+                         [:wildcard ::wildcard]
                          [:selector ::selector]
                          [:collection [:sequential ::selector]]]
-    ::subquery-selector [:orn {:error/message "selector must be either a variable, wildcard symbol (`*`), iri, function application, or select map"}
-                         [:wildcard ::wildcard]
+    ::subquery-selector [:orn {:error/message "selector must be either a variable iri, function application, or select map"}
                          [:var ::var]
                          [:aggregate ::as-function]]
-    ::subquery-select   [:orn {:error/message "Select must be a valid selector or vector of selectors. Subqueries do not allow graph crawl syntax (e.g. {?x [*]})."}
+    ::subquery-select   [:orn {:error/message "Select must be a valid selector, a wildcard symbol (`*`), or a vector of selectors. Subqueries do not allow graph crawl syntax (e.g. {?x [*]})."}
+                         [:wildcard ::wildcard]
                          [:selector ::subquery-selector]
                          [:collection [:sequential ::subquery-selector]]]
     ::direction         [:orn {:error/message "Direction must be \"asc\" or \"desc\""}

--- a/src/clj/fluree/db/query/sparql/translator.cljc
+++ b/src/clj/fluree/db/query/sparql/translator.cljc
@@ -363,6 +363,7 @@
                         select-clause)
            result     []]
       (if term
+        ;; either multiple terms or a single wildcard
         (cond (rule? term)
               (let [[tag & body] term]
                 (if (= tag :Var)
@@ -377,7 +378,7 @@
                     (recur (if as? r* r) (conj result expr)))))
 
               (= "*" term)
-              (recur r (conj result "*")))
+              (recur nil term))
         [[select-key result]]))))
 
 (defmethod parse-term :DefaultGraphClause

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -425,4 +425,10 @@
                  {?favNums [7], ?name "Brian", ?s :ex/brian}
                  {?favNums [5 10], ?name "Cam", ?s :ex/cam}
                  {?favNums [11 42], ?name "Liam", ?s :ex/liam}]
-               results))))))
+               results))))
+    (testing "select * does not compose with other selectors"
+      (let [query {:context {:ex "http://example.com/ns/"}
+                   :select [:* '?foo]
+                   :where [{:id '?s :ex/foo '?foo}]}]
+        (is (= "Error in value for \"select\"; Select must be a valid selector, a wildcard symbol (`*`), or a vector of selectors; Provided: [:* ?foo];  See documentation for details: https://next.developers.flur.ee/docs/reference/errorcodes#query-invalid-select"
+               (ex-message @(fluree/query db query))))))))

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -26,7 +26,7 @@
                  WHERE {?person person:handle ?handle;
                                 person:favNums ?favNums.}"
           {:keys [select]} (sparql/->fql query)]
-      (is (= ["*"] select))))
+      (is (= "*" select))))
   (testing "aggregates"
     (testing "AVG"
       (let [query "SELECT (AVG(?favNums) AS ?nums)
@@ -673,18 +673,18 @@
                           WHERE {?person person:handle ?handle;
                                          person:favNums ?favNums.}"
                  results @(fluree/query db query {:format :sparql})]
-             (is (= '[[{?favNums 23, ?handle "bbob", ?person "ex:bbob"}]
-                      [{?favNums 0, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 3, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 5, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 6, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 7, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 8, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 9, ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums 3, ?handle "jdoe", ?person "ex:jdoe"}]
-                      [{?favNums 7, ?handle "jdoe", ?person "ex:jdoe"}]
-                      [{?favNums 42, ?handle "jdoe", ?person "ex:jdoe"}]
-                      [{?favNums 99, ?handle "jdoe", ?person "ex:jdoe"}]]
+             (is (= '[{?favNums 23, ?handle "bbob", ?person "ex:bbob"}
+                      {?favNums 0, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 3, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 5, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 6, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 7, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 8, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 9, ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums 3, ?handle "jdoe", ?person "ex:jdoe"}
+                      {?favNums 7, ?handle "jdoe", ?person "ex:jdoe"}
+                      {?favNums 42, ?handle "jdoe", ?person "ex:jdoe"}
+                      {?favNums 99, ?handle "jdoe", ?person "ex:jdoe"}]
                     results))))
          (testing "basic wildcard query w/ grouping works"
            (let [query   "PREFIX person: <http://example.org/Person#>
@@ -693,9 +693,9 @@
                                          person:favNums ?favNums.}
                           GROUP BY ?person ?handle"
                  results @(fluree/query db query {:format :sparql})]
-             (is (= '[[{?favNums [23], ?handle "bbob", ?person "ex:bbob"}]
-                      [{?favNums [0 3 5 6 7 8 9], ?handle "jbob", ?person "ex:jbob"}]
-                      [{?favNums [3 7 42 99], ?handle "jdoe", ?person "ex:jdoe"}]]
+             (is (= '[{?favNums [23], ?handle "bbob", ?person "ex:bbob"}
+                      {?favNums [0 3 5 6 7 8 9], ?handle "jbob", ?person "ex:jbob"}
+                      {?favNums [3 7 42 99], ?handle "jdoe", ?person "ex:jdoe"}]
                     results))))
          (testing "basic query w/ OPTIONAL works"
            (let [query   "PREFIX person: <http://example.org/Person#>


### PR DESCRIPTION
During the SPARQL work I discovered a weird additional nesting that wildcard queries introduced. It was introduced by select notation like this:
```
{:select ["*"] ...}
```
In SPARQL, wildcard selectors cannot be composed with any other selectors, and putting it in a sequence like that introduces the extra layer of nesting in the results (see the changes to sparql_test.cljc). The solution was to never translate "SELECT *" into `:select ["*"]`, but rather to this:
```
{:select "*" ...}
```

In the course of investigating this, I discovered that in FQL we do allow the composition of a wildcard selector alongside other selectors. I don't think this composition was intentional, but I do think if users come across it they will be confused by the results. The second commit, 111d0c449d7c251661f15f19f4d8433836cdd1a0, rearranges the FQL grammar to only allow a single wildcard in select and disallows composition with other selectors. You can still have multiple wildcards if you have multiple subgraph selectors: 
```
{:select [{?s ["*"]} {?foo ["*"]}]}
```