### PR TITLE
Update subquery tests to new API

### DIFF
--- a/test/fluree/db/query/subquery_test.clj
+++ b/test/fluree/db/query/subquery_test.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.query.subquery-test
   (:require [clojure.test :refer :all]
-            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.api :as fluree]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.util.log :as log]))
 


### PR DESCRIPTION
For some reason the subquery PR https://github.com/fluree/db/pull/794 showed green on checks but never ran CICD on the last merge.

There was the one eastwood exception that popped up on `main` with that CICD run.

Fixed here.
 