### PR TITLE
Rename main db record to `FlakeDB`

### DIFF
--- a/dev/indexing_test.clj
+++ b/dev/indexing_test.clj
@@ -1,7 +1,7 @@
 (ns indexing-test
   (:require [fluree.db.method.ipfs.core :as ipfs]
-            [fluree.db.db.json-ld :as jld-db]
-            [fluree.db.transact :as jld-tx]
+            [fluree.db.flake.flake-db :as flake-db]
+            [fluree.db.json-ld.transact :as jld-tx]
             [clojure.core.async :as async]
             [fluree.db.flake :as flake]
             [fluree.db.api :as fluree]

--- a/dev/json_ld.clj
+++ b/dev/json_ld.clj
@@ -1,7 +1,7 @@
 (ns json-ld
   (:require [fluree.db.method.ipfs.core :as ipfs]
-            [fluree.db.db.json-ld :as jld-db]
             [fluree.db.transact :as jld-tx]
+            [fluree.db.flake.flake-db :as flake-db]
             [clojure.core.async :as async]
             [fluree.db.flake :as flake]
             [fluree.db.api :as fluree]

--- a/dev/json_ld.cljc
+++ b/dev/json_ld.cljc
@@ -1,7 +1,7 @@
 (ns json-ld
   (:require [fluree.db.method.ipfs.core :as ipfs]
-            [fluree.db.db.json-ld :as jld-db]
             [fluree.db.transact :as jld-tx]
+            [fluree.db.flake.flake-db :as flake-db]
             [clojure.core.async :as async]
             [fluree.db.flake :as flake]
             [fluree.db.api :as fluree]

--- a/dev/json_ld/lists.clj
+++ b/dev/json_ld/lists.clj
@@ -1,7 +1,7 @@
 (ns json-ld.lists
   (:require [fluree.db.method.ipfs.core :as ipfs]
-            [fluree.db.db.json-ld :as jld-db]
             [fluree.db.transact :as jld-tx]
+            [fluree.db.flake.flake-db :as flake-db]
             [clojure.core.async :as async]
             [fluree.db.flake :as flake]
             [fluree.db.api :as fluree]

--- a/dev/json_ld/shacl.clj
+++ b/dev/json_ld/shacl.clj
@@ -1,7 +1,7 @@
 (ns json-ld.shacl
   (:require [fluree.db.method.ipfs.core :as ipfs]
-            [fluree.db.db.json-ld :as jld-db]
             [fluree.db.transact :as jld-tx]
+            [fluree.db.flake.flake-db :as flake-db]
             [clojure.core.async :as async]
             [fluree.db.flake :as flake]
             [fluree.db.api :as fluree]

--- a/dev/json_ld/subclass.clj
+++ b/dev/json_ld/subclass.clj
@@ -1,7 +1,7 @@
 (ns json-ld.subclass
   (:require [fluree.db.method.ipfs.core :as ipfs]
-            [fluree.db.db.json-ld :as jld-db]
             [fluree.db.transact :as jld-tx]
+            [fluree.db.flake.flake-db :as flake-db]
             [clojure.core.async :as async]
             [fluree.db.flake :as flake]
             [fluree.db.api :as fluree]

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -4,7 +4,7 @@
             [fluree.db.conn.memory :as memory-conn]
             [fluree.db.conn.remote :as remote-conn]
             [fluree.json-ld :as json-ld]
-            [fluree.db.db.json-ld :as jld-db]
+            [fluree.db.flake.flake-db :as flake-db]
             #?(:clj [fluree.db.conn.s3 :as s3-conn])
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.platform :as platform]
@@ -427,7 +427,7 @@
   [db]
   (let [spot (-> db :novelty :spot)]
     (reduce (fn [n flake]
-              (if (jld-db/reasoned-rule? flake)
+              (if (flake-db/reasoned-rule? flake)
                 (inc n)
                 n))
             0 spot)))
@@ -460,9 +460,9 @@
                                (if (iri/sid? o)
                                  (decode-iri db o)
                                  o))
-                        #(jld-db/reasoned-rule? %))
+                        #(flake-db/reasoned-rule? %))
          result   (->> db :novelty :spot
-                       jld-db/reasoned-flakes
+                       flake-db/reasoned-flakes
                        (mapv triples+))]
      (if group-fn
        (group-by group-fn result)

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -1,4 +1,4 @@
-(ns fluree.db.database.async
+(ns fluree.db.async-db
   (:refer-clojure :exclude [load])
   (:require [#?(:clj clojure.pprint, :cljs cljs.pprint) :as pprint :refer [pprint]]
             [clojure.core.async :as async :refer [<! >! go]]

--- a/src/clj/fluree/db/database/async.cljc
+++ b/src/clj/fluree/db/database/async.cljc
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [load])
   (:require [#?(:clj clojure.pprint, :cljs cljs.pprint) :as pprint :refer [pprint]]
             [clojure.core.async :as async :refer [<! >! go]]
-            [fluree.db.db.json-ld :as jld-db]
+            [fluree.db.flake.flake-db :as flake-db]
             [fluree.db.indexer :as indexer]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.json-ld.policy :as policy]
@@ -220,6 +220,6 @@
         t          (-> commit-map :data :t)
         async-db   (->AsyncDB ledger-alias branch commit-map t (async/promise-chan))]
     (go
-      (let [db (<! (jld-db/load conn ledger-alias branch [commit-jsonld commit-map]))]
+      (let [db (<! (flake-db/load conn ledger-alias branch [commit-jsonld commit-map]))]
         (deliver! async-db db)))
     async-db))

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -614,10 +614,9 @@
 
 ;; ================ end Jsonld record support fns ============================
 
-(defrecord JsonLdDb [conn alias branch commit t tt-id stats spot post opst tspo
-                     schema comparators staged novelty policy namespaces
-                     namespace-codes max-namespace-code reindex-min-bytes
-                     reindex-max-bytes]
+(defrecord FlakeDB [conn alias branch commit t tt-id stats spot post opst tspo
+                    schema comparators staged novelty policy namespaces namespace-codes
+                    max-namespace-code reindex-min-bytes reindex-max-bytes]
   dbproto/IFlureeDb
   (-query [this query-map] (fql/query this query-map))
   (-p-prop [_ meta-key property] (p-prop schema meta-key property))
@@ -717,28 +716,28 @@
 
 (defn db?
   [x]
-  (instance? JsonLdDb x))
+  (instance? FlakeDB x))
 
-(def ^String label "#fluree/JsonLdDb ")
+(def ^String label "#fluree/FlakeDB ")
 
 (defn display
   [db]
   (select-keys db [:alias :branch :t :stats :policy]))
 
 #?(:cljs
-   (extend-type JsonLdDb
+   (extend-type FlakeDB
      IPrintWithWriter
      (-pr-writer [db w _opts]
        (-write w label)
        (-write w (-> db display pr)))))
 
 #?(:clj
-   (defmethod print-method JsonLdDb [^JsonLdDb db, ^Writer w]
+   (defmethod print-method FlakeDB [^FlakeDB db, ^Writer w]
      (.write w label)
      (binding [*out* w]
        (-> db display pr))))
 
-(defmethod pprint/simple-dispatch JsonLdDb
+(defmethod pprint/simple-dispatch FlakeDB
   [db]
   (print label)
   (-> db display pprint))
@@ -800,7 +799,7 @@
                                   :max-namespace-code max-ns-code
                                   :reindex-min-bytes reindex-min-bytes
                                   :reindex-max-bytes reindex-max-bytes)
-                           map->JsonLdDb
+                           map->FlakeDB
                            policy/root)
            indexed-db* (if (nil? (:schema root-map)) ;; needed for legacy (v0) root index map
                          (<? (vocab/load-schema indexed-db (:preds root-map)))

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -1,23 +1,28 @@
-(ns fluree.db.db.json-ld
+(ns fluree.db.flake.flake-db
   (:refer-clojure :exclude [load vswap!])
   (:require [#?(:clj clojure.pprint, :cljs cljs.pprint) :as pprint :refer [pprint]]
             [clojure.core.async :as async :refer [go]]
             [clojure.set :refer [map-invert]]
             [fluree.db.connection :as connection]
-            [fluree.db.constants :as const]
             [fluree.db.datatype :as datatype]
-            [fluree.db.db.json-ld.format :as jld-format]
-            [fluree.db.db.json-ld.history :as history]
-            [fluree.db.dbproto :as dbproto]
-            [fluree.db.flake :as flake]
             [fluree.db.fuel :as fuel]
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.json-ld.iri :as iri]
+            [fluree.db.query.exec.where :as where]
+            [fluree.db.time-travel :refer [TimeTravel]]
+            [fluree.db.query.history :refer [AuditLog]]
+            [fluree.db.flake.history :as history]
+            [fluree.db.flake.format :as jld-format]
+            [fluree.db.constants :as const]
+            [fluree.db.flake :as flake]
+            [fluree.db.util.core :as util :refer [get-first get-first-value
+                                                  get-first-id vswap!]]
             [fluree.db.index :as index]
             [fluree.db.indexer :as indexer]
             [fluree.db.indexer.default :as idx-default]
             [fluree.db.query.fql :as fql]
             [fluree.db.indexer.storage :as index-storage]
             [fluree.db.json-ld.commit-data :as commit-data]
-            [fluree.db.json-ld.iri :as iri]
             [fluree.db.json-ld.policy :as policy]
             [fluree.db.json-ld.policy.query :as qpolicy]
             [fluree.db.json-ld.policy.rules :as policy-rules]
@@ -27,18 +32,10 @@
             [fluree.db.json-ld.vocab :as vocab]
             [fluree.db.json-ld.policy.modify :as tx-policy]
             [fluree.db.query.exec.update :as update]
-            [fluree.db.query.exec.where :as where]
-            [fluree.db.query.history :refer [AuditLog]]
             [fluree.db.query.json-ld.response :as jld-response]
             [fluree.db.query.range :as query-range]
             [fluree.db.serde.json :as serde-json]
-            [fluree.db.time-travel :refer [TimeTravel]]
             [fluree.db.util.async :refer [<? go-try]]
-            [fluree.db.util.core :as util
-             #?@(:clj  [:refer [get-first get-first-value get-first-id vswap!
-                                try* catch*]]
-                 :cljs [:refer [get-first get-first-value get-first-id vswap!]
-                        :refer-macros [try* catch*]])]
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld])
   #?(:clj (:import (java.io Writer))))
@@ -942,7 +939,7 @@
 
 (defn db->jsonld
   "Creates the JSON-LD map containing a new ledger update"
-  [{:keys [t commit stats staged max-namespace-code] :as db}
+  [{:keys [t commit stats staged] :as db}
    {:keys [type-key compact ctx-used-atom id-key] :as commit-opts}]
   (let [prev-dbid   (commit-data/data-id commit)
 

--- a/src/clj/fluree/db/flake/format.cljc
+++ b/src/clj/fluree/db/flake/format.cljc
@@ -1,4 +1,4 @@
-(ns fluree.db.db.json-ld.format
+(ns fluree.db.flake.format
   (:require [fluree.db.query.json-ld.response :as jld-response]
             [clojure.core.async :as async :refer [go]]
             [fluree.db.query.range :as query-range]

--- a/src/clj/fluree/db/flake/history.cljc
+++ b/src/clj/fluree/db/flake/history.cljc
@@ -1,9 +1,9 @@
-(ns fluree.db.db.json-ld.history
+(ns fluree.db.flake.history
   (:require [clojure.core.async :as async :refer [go >! <!]]
             [fluree.db.query.history.parse :as parse]
             [fluree.json-ld :as json-ld]
             [fluree.db.constants :as const]
-            [fluree.db.db.json-ld.format :as jld-format]
+            [fluree.db.flake.format :as jld-format]
             [fluree.db.flake :as flake]
             [fluree.db.index :as index]
             [fluree.db.time-travel :as time-travel]

--- a/src/clj/fluree/db/json_ld/api.cljc
+++ b/src/clj/fluree/db/json_ld/api.cljc
@@ -6,7 +6,7 @@
             [fluree.db.conn.memory :as memory-conn]
             [fluree.db.conn.remote :as remote-conn]
             [fluree.json-ld :as json-ld]
-            [fluree.db.db.json-ld :as jld-db]
+            [fluree.db.flake.flake-db :as flake-db]
             #?(:clj [fluree.db.conn.s3 :as s3-conn])
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.platform :as platform]
@@ -595,7 +595,7 @@
   (log/warn "DEPRECATED function `reasoned-count` superseded by `fluree.db.api/reasoned-count`")
   (let [spot (-> db :novelty :spot)]
     (reduce (fn [n flake]
-              (if (jld-db/reasoned-rule? flake)
+              (if (flake-db/reasoned-rule? flake)
                 (inc n)
                 n))
             0 spot)))
@@ -628,12 +628,12 @@
          triples+ (juxt #(decode-iri db (flake/s %))
                         #(decode-iri db (flake/p %))
                         #(as-> (flake/o %) o
-                           (if (iri/sid? o)
-                             (decode-iri db o)
-                             o))
-                        #(jld-db/reasoned-rule? %))
+                               (if (iri/sid? o)
+                                 (decode-iri db o)
+                                 o))
+                        #(flake-db/reasoned-rule? %))
          result   (->> db :novelty :spot
-                       jld-db/reasoned-flakes
+                       flake-db/reasoned-flakes
                        (mapv triples+))]
      (if group-fn
        (group-by group-fn result)

--- a/src/clj/fluree/db/json_ld/branch.cljc
+++ b/src/clj/fluree/db/json_ld/branch.cljc
@@ -2,7 +2,7 @@
   (:require [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.indexer :as indexer]
             [fluree.json-ld :as json-ld]
-            [fluree.db.database.async :as async-db]
+            [fluree.db.async-db :as async-db]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.async :refer [<?]]
             [fluree.db.util.log :as log :include-macros true]

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -6,7 +6,7 @@
             [fluree.db.json-ld.reify :as reify]
             [fluree.db.ledger.json-ld :as jld-ledger]
             [fluree.db.indexer.default :as indexer]
-            [fluree.db.db.json-ld :as db]
+            [fluree.db.flake.flake-db :as db]
             [fluree.db.nameservice.core :as nameservice]
             [fluree.db.util.core :as util :refer [get-first get-first-id get-first-value]]
             [fluree.db.util.async :refer [<? go-try]]

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -1,11 +1,11 @@
 (ns fluree.db.ledger.json-ld
   (:require [clojure.core.async :as async :refer [<!]]
             [fluree.db.ledger :as ledger]
-            [fluree.db.db.json-ld :as jld-db]
-            [fluree.db.json-ld.iri :as iri]
+            [fluree.db.flake.flake-db :as flake-db]
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.transact :as transact]
             [fluree.db.did :as did]
+            [fluree.db.json-ld.iri :as iri]
             [fluree.db.util.context :as context]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.json-ld.branch :as branch]
@@ -178,7 +178,7 @@
           (->> opts normalize-opts (enrich-commit-opts ledger))
 
           {:keys [dbid db-jsonld staged-txns]}
-          (jld-db/db->jsonld staged-db opts*)
+          (flake-db/db->jsonld staged-db opts*)
 
           ;; TODO - we do not support multiple "transactions" in a single commit (although other code assumes we do which needs cleaning)
           [[txn-id author annotation] :as txns]

--- a/src/clj/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/subject.cljc
@@ -1,7 +1,7 @@
 (ns fluree.db.query.subject-crawl.subject
   (:require [clojure.core.async :as async :refer [<! >! go]]
             [fluree.db.util.async :refer [<? go-try]]
-            [fluree.db.db.json-ld.format :as jld-format]
+            [fluree.db.flake.format :as jld-format]
             [fluree.db.query.analytical-filter :as filter]
             [fluree.db.query.range :as query-range]
             [fluree.db.index :as index]

--- a/src/clj/fluree/db/reasoner.cljc
+++ b/src/clj/fluree/db/reasoner.cljc
@@ -5,7 +5,7 @@
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.reasoner.util :refer [parse-rules-graph]]
             [fluree.db.util.log :as log]
-            [fluree.db.db.json-ld :as db :refer [db?]]
+            [fluree.db.flake.flake-db :as db :refer [db?]]
             [fluree.db.util.async :refer [go-try <?]]
             [fluree.db.reasoner.resolve :as resolve]
             [fluree.db.fuel :as fuel]

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -7,7 +7,7 @@
             [fluree.db.api :as fluree]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.util.core :as util]
-            #?@(:clj ([fluree.db.database.async :as async-db]
+            #?@(:clj ([fluree.db.async-db :as async-db]
                       [clojure.core.async :as async]))
             #?(:clj  [test-with-files.tools :refer [with-tmp-dir]
                       :as twf]


### PR DESCRIPTION
This patch is a smaller subset of the changes in #789. That pull request became very large and is now out of date. Instead of resolving the conflicts there and landing all those changes at once, I figured it would be less disruptive to break that pull request into more manageable pieces.

This patch renames the main db record from `JsonLdDb` to `FlakeDB`, and changes the implementing namespace from `fluree.db.db.json-ld` to `fluree.db.flake.flake-db`. Since we now have multiple db records, I think these names are more descriptive