### PR TITLE
Allow indexing options & persist

### DIFF
--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -215,11 +215,11 @@
   (:db-chan async-db))
 
 (defn load
-  [conn ledger-alias branch commit-jsonld]
+  [conn ledger-alias branch commit-jsonld indexing-opts]
   (let [commit-map (commit-data/jsonld->clj commit-jsonld)
         t          (-> commit-map :data :t)
         async-db   (->AsyncDB ledger-alias branch commit-map t (async/promise-chan))]
     (go
-      (let [db (<! (flake-db/load conn ledger-alias branch [commit-jsonld commit-map]))]
+      (let [db (<! (flake-db/load conn ledger-alias branch [commit-jsonld commit-map] indexing-opts))]
         (deliver! async-db db)))
     async-db))

--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -70,7 +70,7 @@
 (defn write-db-root
   [db]
   (let [{:keys [alias conn schema t stats spot post opst tspo
-                namespace-codes]}
+                namespace-codes reindex-min-bytes reindex-max-bytes]}
         db
 
         data {:ledger-alias    alias
@@ -84,7 +84,9 @@
               :tspo            (child-data tspo)
               :timestamp       (util/current-time-millis)
               :prevIndex       (or (:indexed stats) 0)
-              :namespace-codes namespace-codes}
+              :namespace-codes namespace-codes
+              :config {:reindex-min-bytes reindex-min-bytes
+                       :reindex-max-bytes reindex-max-bytes}}
         ser  (serdeproto/-serialize-db-root (serde conn) data)]
     (connection/-index-file-write conn alias :root ser)))
 

--- a/src/clj/fluree/db/json_ld/branch.cljc
+++ b/src/clj/fluree/db/json_ld/branch.cljc
@@ -37,7 +37,7 @@
 (defn load-db
   [conn alias branch commit]
   (let [commit-jsonld (commit-map->commit-jsonld commit)]
-    (async-db/load conn alias branch commit-jsonld)))
+    (async-db/load conn alias branch commit-jsonld nil)))
 
 (defn update-index
   [{current-commit :commit, :as current-state}
@@ -96,17 +96,19 @@
 
 (defn state-map
   "Returns a branch map for specified branch name at supplied commit"
-  [conn ledger-alias branch-name commit-jsonld]
-  (let [initial-db (async-db/load conn ledger-alias branch-name commit-jsonld)
-        commit-map (commit-data/jsonld->clj commit-jsonld)
-        state      (atom {:commit     commit-map
-                          :current-db initial-db})
-        idx-q      (index-queue conn ledger-alias branch-name state)]
-    {:name        branch-name
-     :conn        conn
-     :alias       ledger-alias
-     :state       state
-     :index-queue idx-q}))
+  ([conn ledger-alias branch-name commit-jsonld]
+   (state-map conn ledger-alias branch-name commit-jsonld nil))
+  ([conn ledger-alias branch-name commit-jsonld indexing-opts]
+   (let [initial-db (async-db/load conn ledger-alias branch-name commit-jsonld indexing-opts)
+         commit-map (commit-data/jsonld->clj commit-jsonld)
+         state      (atom {:commit     commit-map
+                           :current-db initial-db})
+         idx-q      (index-queue conn ledger-alias branch-name state)]
+     {:name        branch-name
+      :conn        conn
+      :alias       ledger-alias
+      :state       state
+      :index-queue idx-q})))
 
 (defn next-commit?
   [current-commit new-commit]

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -326,17 +326,18 @@
     (connection/-did conn)))
 
 (defn parse-ledger-options
-  [conn {:keys [did branch]
+  [conn {:keys [did branch indexing]
          :or   {branch :main}}]
-  (let [did*    (parse-did conn did)]
-    {:did     did*
-     :branch  branch}))
+  (let [did* (parse-did conn did)]
+    {:did      did*
+     :branch   branch
+     :indexing indexing}))
 
 (defn create*
   "Creates a new ledger, optionally bootstraps it as permissioned or with default context."
   [conn ledger-alias opts]
   (go-try
-    (let [{:keys [did branch]}
+    (let [{:keys [did branch indexing]}
           (parse-ledger-options conn opts)
 
           ledger-alias*  (normalize-alias ledger-alias)
@@ -345,7 +346,7 @@
           genesis-commit (json-ld/expand
                            (<? (write-genesis-commit conn ledger-alias branch ns-addresses)))
           ;; map of all branches and where they are branched from
-          branches       {branch (branch/state-map conn ledger-alias* branch genesis-commit)}]
+          branches       {branch (branch/state-map conn ledger-alias* branch genesis-commit indexing)}]
       (map->JsonLDLedger
         {:id       (random-uuid)
          :did      did

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -151,7 +151,7 @@
       (fn [acc k v]
         (assoc acc (name k)
                    (case k
-                     :stats
+                     (:stats :config)
                      (util/stringify-keys v)
 
                      (:spot :post :opst :tspo)


### PR DESCRIPTION
We lost the ability to set indexing options `reindex-min-bytes` and `reindex-max-bytes`.

This restores that and gives the ability to do so when creating a ledger.

In addition, it stores these settings in the index-root, so when loading a DB from disk it will retain the original settings, but there is the ability to override it (and then preserve the new settings upon the next index).

I discovered this issue when working on indexing garbage collection which is broken, but this needed to get addressed first.
