### PR TITLE
Write garbage addr, previous idx info into index-root

### DIFF
--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -366,8 +366,7 @@
                                        (let [write-res (<? (storage/write-garbage refreshed-db* garbage))]
                                          (<! (notify-new-index-file write-res :garbage t changes-ch))
                                          write-res))
-                       ;; TODO - WRITE GARBAGE INTO INDEX ROOT!!!
-                       db-root-res   (<? (storage/write-db-root refreshed-db*))
+                       db-root-res   (<? (storage/write-db-root refreshed-db* (:address garbage-res)))
                        _             (<! (notify-new-index-file db-root-res :root t changes-ch))
 
                        index-address (:address db-root-res)


### PR DESCRIPTION
Builds on https://github.com/fluree/db/pull/846

This captures the garbage file address and puts it in the index-root, so the file can be found and utilized for garbage collection in the future.

In addition, the previous index's t value written to the index-root was wrong, and the previous index's address wasn't being captured at all. This would make it impossible to find previous index root files from the current one, and therefore impossible to do garbage collection (without having to read every historical commit file ever produced).
