### PR TITLE
Automatic garbage collection

### DIFF
--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -41,6 +41,11 @@
     (-> (<? (storage/read (:store conn) address))
         (json/parse keywordize?))))
 
+(defn delete-data
+  "Will throw if not deleted."
+  [conn address]
+  (storage/delete (:store conn) address))
+
 (defn close
   [id state]
   (log/info "Closing file connection" id)
@@ -61,6 +66,7 @@
   (-index-file-write [conn ledger-alias index-type index-data]
     (write-data conn ledger-alias (str "index/" (name index-type)) index-data))
   (-index-file-read [conn index-address] (read-data conn index-address true))
+  (-index-file-delete [conn index-address] (delete-data conn index-address))
 
   connection/iConnection
   (-close [_] (close id state))

--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -36,10 +36,11 @@
        :size    (count json)
        :address address})))
 
-(defn read-data [conn address keywordize?]
+(defn read-data
+  [conn address keywordize?]
   (go-try
-    (-> (<? (storage/read (:store conn) address))
-        (json/parse keywordize?))))
+   (some-> (<? (storage/read (:store conn) address))
+           (json/parse keywordize?))))
 
 (defn delete-data
   "Will throw if not deleted."

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -24,7 +24,8 @@
   (-txn-write [conn ledger-alias txn-data] "Writes a transaction to storage and returns the key. Expects string keys.")
   (-txn-read [conn txn-key] "Reads a transaction from storage")
   (-index-file-write [conn ledger-alias idx-type index-data] "Writes an index item to storage")
-  (-index-file-read [conn file-address] "Reads an index item from storage"))
+  (-index-file-read [conn file-address] "Reads an index item from storage")
+  (-index-file-delete [conn file-address] "Deletes an index item from storage"))
 
 (comment
  ;; state machine looks like this:

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -369,7 +369,7 @@
 
 (defrecord FlakeDB [conn alias branch commit t tt-id stats spot post opst tspo
                     schema comparators staged novelty policy namespaces namespace-codes
-                    max-namespace-code reindex-min-bytes reindex-max-bytes]
+                    max-namespace-code reindex-min-bytes reindex-max-bytes max-old-indexes]
   dbproto/IFlureeDb
   (-query [this query-map] (fql/query this query-map))
   (-p-prop [_ meta-key property] (match/p-prop schema meta-key property))
@@ -550,9 +550,17 @@
                               100000) ; 100 kb
         reindex-max-bytes (or (:reindex-max-bytes indexing-opts)
                               (:reindex-max-bytes config)
-                              1000000)] ; 1mb
+                              1000000) ; 1mb
+        max-old-indexes (or (:max-old-indexes indexing-opts)
+                            (:max-old-indexes config)
+                            3)] ;; default of 3 maximum old indexes not garbage collected
+    (when-not (and (int? max-old-indexes)
+                   (>= max-old-indexes 0))
+      (throw (ex-info (str "Invalid max-old-indexes value. Must be a non-negative integer.")
+                      {:status 400, :error :db/invalid-config})))
     (assoc root-map :reindex-min-bytes reindex-min-bytes
-                    :reindex-max-bytes reindex-max-bytes)))
+                    :reindex-max-bytes reindex-max-bytes
+                    :max-old-indexes max-old-indexes)))
 
 (defn load
   ([conn ledger-alias branch commit-pair]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -419,7 +419,7 @@
   indexer/Indexable
   (index [db changes-ch]
     (if (idx-default/novelty-min? db reindex-min-bytes)
-      (idx-default/refresh db changes-ch)
+      (idx-default/refresh db changes-ch max-old-indexes)
       (go)))
 
   TimeTravel

--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -366,8 +366,7 @@
                                        (let [write-res (<? (storage/write-garbage refreshed-db* garbage))]
                                          (<! (notify-new-index-file write-res :garbage t changes-ch))
                                          write-res))
-                       ;; TODO - WRITE GARBAGE INTO INDEX ROOT!!!
-                       db-root-res   (<? (storage/write-db-root refreshed-db*))
+                       db-root-res   (<? (storage/write-db-root refreshed-db* (:address garbage-res)))
                        _             (<! (notify-new-index-file db-root-res :root t changes-ch))
 
                        index-address (:address db-root-res)

--- a/src/clj/fluree/db/indexer/garbage.cljc
+++ b/src/clj/fluree/db/indexer/garbage.cljc
@@ -1,0 +1,91 @@
+(ns fluree.db.indexer.garbage
+  (:require [clojure.core.async :as async :refer [<! go]]
+            [fluree.db.indexer.storage :as storage]
+            [fluree.db.util.async #?(:clj :refer :cljs :refer-macros) [<? go-try]]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.log :as log]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn garbage-meta-map
+  "Garbage file metadata that will be passed to the
+  garbage cleaning function that allows it to report
+  on status and have filename addresses."
+  [{:keys [prev-index garbage] :as idx-root}]
+  (when garbage ;; first index will not have garbage
+    (assoc garbage
+      ;; retain not the current index file, but the previous one
+      ;; where the garbage in this file originated
+      :t (:t prev-index)
+      :index (:address prev-index))))
+
+(defn trace-idx-roots
+  [conn commit]
+  (go-try
+   (loop [next-idx-root (<! (storage/read-db-root conn (-> commit :index :address)))
+          garbage       []]
+     (if (or (nil? next-idx-root) ;; no more idx-roots
+             (util/exception? next-idx-root)) ;; if idx-root already deleted, will be exception
+       garbage
+       (let [garbage-meta  (garbage-meta-map next-idx-root)
+             prev-idx-addr (get-in next-idx-root [:prev-index :address])
+             garbage*      (if garbage-meta
+                             (conj garbage garbage-meta)
+                             garbage)]
+         (recur (<! (storage/read-db-root conn prev-idx-addr))
+                garbage*))))))
+
+(defn clean-garbage-record
+  "Cleans up a complete garbage file, which will contain
+  many index segment garbage items within it. Garbage file
+  looks like:
+  {:alias 'ledger-alias',
+   :branch 'main',
+   :garbage ['fluree:file://.../index/segment/1.json', ...]
+   :t 1}"
+  [conn {:keys [address index t] :as _garbage-map}]
+  (go
+    (let [{:keys [alias branch garbage]} (<! (storage/read-garbage conn address))]
+      (log/info "Removing" (count garbage) "unused index segments (garbage) from ledger"
+                alias "branch" branch "from index-t of" t)
+
+      ;; first delete all index segment files
+      (doseq [garbage-item garbage]
+        ;; note if the file was already deleted there could be an exception.
+        ;; this might happen if the server shutdown in the middle of a garbage
+        ;; exceptions are logged downstream, so just swallow exception here
+        ;; and keep rocessing.
+        (<! (storage/delete-garbage-item conn garbage-item)))
+
+      ;; delete main garbage record
+      (<! (storage/delete-garbage-item conn address))
+
+      ;; then delete the parent index root
+      (<! (storage/delete-garbage-item conn index)))))
+
+(defn clean-garbage
+  "Cleans up garbage data for old indexes, but retains
+  the last `max-indexes` indexes. Note that if not retaining
+  at least one prior index, current queries or handles on the latest
+  db might fail, therefore `max-indexes` is recommended to typically
+  be 1 or more."
+  [{:keys [conn commit] :as _db} max-indexes]
+  (go-try
+   (assert (and (int? max-indexes)
+                (>= max-indexes 0)))
+   (let [all-garbage (<? (trace-idx-roots conn commit))
+         to-clean    (->> all-garbage
+                          (drop max-indexes)
+                          (sort-by :t)) ;; clean oldest 't' value first
+         start-time  (util/current-time-millis)]
+     (if (empty? to-clean)
+       (log/debug "Clean-garbage called, but no garbage to clean.")
+       (do
+         (log/info "Starting garbage collection of oldest"
+                   (count to-clean) "indexes.")
+         (doseq [next-garbage to-clean]
+           (<! (clean-garbage-record conn next-garbage)))
+         (log/info "Finished garbage collection of oldest"
+                   (count to-clean) "indexes in"
+                   (- (util/current-time-millis) start-time) "ms.")
+         :done)))))

--- a/src/clj/fluree/db/indexer/garbage.cljc
+++ b/src/clj/fluree/db/indexer/garbage.cljc
@@ -65,10 +65,15 @@
 
 (defn clean-garbage
   "Cleans up garbage data for old indexes, but retains
-  the last `max-indexes` indexes. Note that if not retaining
-  at least one prior index, current queries or handles on the latest
-  db might fail, therefore `max-indexes` is recommended to typically
-  be 1 or more."
+  the most recent `max-indexes` indexes.
+
+  Note that any db's held as a variable will rely on the index-root
+  from when they were pulled from the ledger via (fluree/db <ledger>).
+  If these db vars are held over time, you might want to adjust this
+  setting such that old index-roots are not garbage collected during that
+  expected timeframe. The frequency of new indexes being created is
+  dependent on the frequency and size of updates that is ledger-specific
+  against the ledger's 'reindex-min-bytes' setting."
   [{:keys [conn commit] :as _db} max-indexes]
   (go-try
    (assert (and (int? max-indexes)

--- a/src/clj/fluree/db/indexer/garbage.cljc
+++ b/src/clj/fluree/db/indexer/garbage.cljc
@@ -76,7 +76,7 @@
   against the ledger's 'reindex-min-bytes' setting."
   [{:keys [conn commit] :as _db} max-indexes]
   (go
-    (if (and (int? max-indexes) (>= max-indexes 0))
+    (if (nat-int? max-indexes)
       (let [all-garbage (<? (trace-idx-roots conn commit))
             to-clean    (->> all-garbage
                              (drop max-indexes)

--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -138,12 +138,10 @@
 
 (defn read-garbage
   "Returns garbage file data for a given index t."
-  [conn ledger-alias t]
+  [conn garbage-address]
   (go-try
-    (let [key  (ledger-garbage-key ledger-alias t)
-          data (<? (connection/-index-file-read conn key))]
-      (when data
-        (serdeproto/-deserialize-garbage (serde conn) data)))))
+   (when-let [data (<? (connection/-index-file-read conn garbage-address))]
+     (serdeproto/-deserialize-garbage (serde conn) data))))
 
 (defn reify-schema
   [{:keys [namespace-codes v] :as root-map}]

--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -143,6 +143,12 @@
    (when-let [data (<? (connection/-index-file-read conn garbage-address))]
      (serdeproto/-deserialize-garbage (serde conn) data))))
 
+(defn delete-garbage-item
+  "Deletes an index segment during garbage collection.
+  Returns async chan"
+  [conn idx-segment-address]
+  (connection/-index-file-delete conn idx-segment-address))
+
 (defn reify-schema
   [{:keys [namespace-codes v] :as root-map}]
   (if (not= 1 v)

--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -59,9 +59,10 @@
 (defn write-garbage
   "Writes garbage record out for latest index."
   [db garbage]
-  (let [{:keys [alias conn t]} db
+  (let [{:keys [alias branch conn t]} db
 
-        data {:ledger-alias alias
+        data {:alias        alias
+              :branch       branch
               :t            t
               :garbage      garbage}
         ser  (serdeproto/-serialize-garbage (serde conn) data)]

--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -91,7 +91,7 @@
                                           :reindex-max-bytes reindex-max-bytes}}
                        prev-idx-t (assoc :prev-index {:t       prev-idx-t
                                                       :address prev-idx-addr})
-                       garbage-addr (assoc :garbage garbage-addr))
+                       garbage-addr (assoc-in [:garbage :address] garbage-addr))
         ser           (serdeproto/-serialize-db-root (serde conn) data)]
     (connection/-index-file-write conn alias :root ser)))
 

--- a/src/clj/fluree/db/indexer/storage.cljc
+++ b/src/clj/fluree/db/indexer/storage.cljc
@@ -71,7 +71,8 @@
 (defn write-db-root
   [db garbage-addr]
   (let [{:keys [alias conn schema t stats spot post opst tspo commit
-                namespace-codes reindex-min-bytes reindex-max-bytes]}
+                namespace-codes reindex-min-bytes reindex-max-bytes
+                max-old-indexes]}
         db
         prev-idx-t    (-> commit :index :data :t)
         prev-idx-addr (-> commit :index :address)
@@ -88,7 +89,8 @@
                         :timestamp       (util/current-time-millis)
                         :namespace-codes namespace-codes
                         :config          {:reindex-min-bytes reindex-min-bytes
-                                          :reindex-max-bytes reindex-max-bytes}}
+                                          :reindex-max-bytes reindex-max-bytes
+                                          :max-old-indexes   max-old-indexes}}
                        prev-idx-t (assoc :prev-index {:t       prev-idx-t
                                                       :address prev-idx-addr})
                        garbage-addr (assoc-in [:garbage :address] garbage-addr))

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -157,7 +157,7 @@
       (fn [acc k v]
         (assoc acc (name k)
                    (case k
-                     (:stats :config :garbage)
+                     (:stats :config :garbage :prev-index)
                      (util/stringify-keys v)
 
                      (:spot :post :opst :tspo)

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -143,6 +143,12 @@
                             v)))
     {} m))
 
+(defn serialize-garbage
+  [{:keys [alias branch t garbage]}]
+  {"alias"   alias
+   "branch"  (name branch)
+   "t"       t
+   "garbage" (vec garbage)})
 
 (defrecord Serializer []
   serdeproto/StorageSerializer
@@ -169,8 +175,8 @@
     {"flakes" (map serialize-flake (:flakes leaf))})
   (-deserialize-leaf [_ leaf]
     (deserialize-leaf-node leaf))
-  (-serialize-garbage [_ garbage]
-    (util/stringify-keys garbage))
+  (-serialize-garbage [_ garbage-map]
+    (serialize-garbage garbage-map))
   (-deserialize-garbage [_ garbage]
     (deserialize-garbage garbage)))
 

--- a/src/clj/fluree/db/serde/json.cljc
+++ b/src/clj/fluree/db/serde/json.cljc
@@ -157,7 +157,7 @@
       (fn [acc k v]
         (assoc acc (name k)
                    (case k
-                     (:stats :config)
+                     (:stats :config :garbage)
                      (util/stringify-keys v)
 
                      (:spot :post :opst :tspo)

--- a/src/clj/fluree/db/util/filesystem.cljc
+++ b/src/clj/fluree/db/util/filesystem.cljc
@@ -92,16 +92,16 @@
          (io/delete-file (io/file path))
          :deleted
          (catch Exception e
-           (log/error e (str "Failed to delete file: " path))
-           (throw e))))
+           (log/trace (str "Failed to delete file: " path))
+           e)))
      :cljs
      (async/go
        (try
          (fs/unlinkSync path)
          :deleted
          (catch :default e
-           (log/error e (str "Failed to delete file: " path))
-           (throw e))))))
+           (log/trace (str "Failed to delete file: " path))
+           e)))))
 
 (defn list-files
   [path]


### PR DESCRIPTION
Builds on PR https://github.com/fluree/db/pull/848.

This adds automatic old index garbage collection.

By default we will retain 3 old indexes, but any more than that will be automatically deleted to minimize disk space. If the default setting is not desired, it can be set when creating a new ledger (see below) and the setting is retained in the index-root(s), therefore upon a db load the setting will be preserved.

The easiest way to try this would be to turn `reindex-min-bytes` setting per below way down, so a new index is created with every commit. With `max-old-indexes` set to 1, you'll see at most one old index retained on disk. The rest will be auto garbage collected.

```
 (def ledger 
  @(fluree/create conn "mydb" {:indexing {:reindex-min-bytes 1000 ; 1 kb
                                          :max-old-indexes   1}}))
```
