### PR TITLE
don't include author in commit for unsigned transactions

### DIFF
--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -198,7 +198,7 @@
                            :t          t
                            :time       commit-time
                            :db-address db-address
-                           :author     (or author "")
+                           :author     author
                            :annotation annotation
                            :txn-id     txn-id
                            :flakes     (:flakes stats)

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -306,7 +306,6 @@
                           {:id test-utils/did?}
                           :f/address test-utils/address?
                           :f/alias   "committest"
-                          :f/author  ""
                           :f/branch  "main"
                           :f/previous
                           {:id test-utils/commit-id?}
@@ -329,13 +328,12 @@
         (let [commit-5 {:f/commit {"https://www.w3.org/2018/credentials#issuer" {:id test-utils/did?}
                                    :f/address                                   test-utils/address?
                                    :f/alias                                     "committest"
-                                   :f/author                                    ""
                                    :f/branch                                    "main"
                                    :f/data                                      {:f/address  test-utils/address?
                                                                                  :f/assert   [{:ex/x "foo-cat"
                                                                                                :ex/y "bar-cat"
                                                                                                :id   :ex/alice}]
-                                                                                 :f/flakes   66
+                                                                                 :f/flakes   62
                                                                                  :f/previous {:id test-utils/db-id?}
                                                                                  :f/retract  [#_{:ex/x "foo-3"
                                                                                                  :ex/y "bar-3"
@@ -352,13 +350,12 @@
                                    {:id test-utils/did?}
                                    :f/address  test-utils/address?
                                    :f/alias    "committest"
-                                   :f/author   ""
                                    :f/branch   "main"
                                    :f/data     {:f/address  test-utils/address?
                                                 :f/assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/cat}]
-                                                :f/flakes   50
+                                                :f/flakes   47
                                                 :f/previous {:id test-utils/db-id?}
                                                 :f/retract  []
                                                 :f/size     pos-int?
@@ -392,13 +389,12 @@
                              {:id test-utils/did?}
                              :f/address  test-utils/address?
                              :f/alias    "committest"
-                             :f/author   ""
                              :f/branch   "main"
                              :f/data     {:f/address  test-utils/address?
                                           :f/assert   [{:ex/x "foo-cat"
                                                         :ex/y "bar-cat"
                                                         :id   :ex/cat}]
-                                          :f/flakes   50
+                                          :f/flakes   47
                                           :f/previous {:id test-utils/db-id?}
                                           :f/retract  []
                                           :f/size     pos-int?
@@ -414,13 +410,12 @@
                            {:id test-utils/did?}
                            :f/address  test-utils/address?
                            :f/alias    "committest"
-                           :f/author   ""
                            :f/branch   "main"
                            :f/data     {:f/address  test-utils/address?
                                         :f/assert   [{:ex/x "foo-3"
                                                       :ex/y "bar-3"
                                                       :id   :ex/alice}]
-                                        :f/flakes   34
+                                        :f/flakes   32
                                         :f/previous {:id test-utils/db-id?}
                                         :f/retract  [{:ex/x "foo-2"
                                                       :ex/y "bar-2"
@@ -438,13 +433,12 @@
                            {:id test-utils/did?}
                            :f/address  test-utils/address?
                            :f/alias    "committest"
-                           :f/author   ""
                            :f/branch   "main"
                            :f/data     {:f/address  test-utils/address?
                                         :f/assert   [{:ex/x "foo-2"
                                                       :ex/y "bar-2"
                                                       :id   :ex/alice}]
-                                        :f/flakes   18
+                                        :f/flakes   17
                                         :f/previous {:id test-utils/db-id?}
                                         :f/retract  [{:ex/x "foo-1"
                                                       :ex/y "bar-1"
@@ -464,13 +458,12 @@
                           {:id test-utils/did?}
                           :f/address  test-utils/address?
                           :f/alias    "committest"
-                          :f/author   ""
                           :f/branch   "main"
                           :f/data     {:f/address  test-utils/address?
                                        :f/assert   [{:ex/x "foo-cat"
                                                      :ex/y "bar-cat"
                                                      :id   :ex/cat}]
-                                       :f/flakes   50
+                                       :f/flakes   47
                                        :f/previous {:id test-utils/db-id?}
                                        :f/retract  []
                                        :f/size     pos-int?
@@ -484,13 +477,12 @@
                           {:id test-utils/did?}
                           :f/address  test-utils/address?
                           :f/alias    "committest"
-                          :f/author   ""
                           :f/branch   "main"
                           :f/data     {:f/address  test-utils/address?
                                        :f/assert   [{:ex/x "foo-cat"
                                                      :ex/y "bar-cat"
                                                      :id   :ex/alice}]
-                                       :f/flakes   66
+                                       :f/flakes   62
                                        :f/previous {:id test-utils/db-id?}
                                        :f/retract  [{:ex/x "foo-3"
                                                      :ex/y "bar-3"
@@ -513,7 +505,6 @@
                           {:id test-utils/did?}
                           :f/address  test-utils/address?
                           :f/alias    "committest"
-                          :f/author   ""
                           :f/branch   "main"
                           :f/previous {:id test-utils/commit-id?}
                           :f/data     {:f/address  test-utils/address?
@@ -542,13 +533,12 @@
                             {:id test-utils/did?}
                             :f/address  test-utils/address?
                             :f/alias    "committest"
-                            :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
                                          :f/assert   [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
-                                         :f/flakes   34
+                                         :f/flakes   32
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-2"
                                                        :ex/y "bar-2"
@@ -571,13 +561,12 @@
                             {:id test-utils/did?}
                             :f/address  test-utils/address?
                             :f/alias    "committest"
-                            :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
                                          :f/assert   [{:ex/x "foo-cat"
                                                        :ex/y "bar-cat"
                                                        :id   :ex/alice}]
-                                         :f/flakes   66
+                                         :f/flakes   62
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
@@ -668,13 +657,12 @@
                              :id   :ex/alice}]
                   :commit  {:f/address  test-utils/address?
                             :f/alias    ledger-name
-                            :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
                                          :f/assert   [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
-                                         :f/flakes   36
+                                         :f/flakes   34
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-2"
                                                        :ex/y "bar-2"
@@ -695,13 +683,12 @@
                              :id   :ex/alice}]
                   :commit  {:f/address  test-utils/address?
                             :f/alias    ledger-name
-                            :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
                                          :f/assert   [{:ex/x "foo-cat"
                                                        :ex/y "bar-cat"
                                                        :id   :ex/alice}]
-                                         :f/flakes   68
+                                         :f/flakes   64
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
@@ -770,13 +757,12 @@
                             {:id test-utils/did?}
                             :f/address  test-utils/address?
                             :f/alias    ledger-name
-                            :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
                                          :f/assert   [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
-                                         :f/flakes   34
+                                         :f/flakes   32
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-2"
                                                        :ex/y "bar-2"
@@ -799,13 +785,12 @@
                             {:id test-utils/did?}
                             :f/address  test-utils/address?
                             :f/alias    ledger-name
-                            :f/author   ""
                             :f/branch   "main"
                             :f/data     {:f/address  test-utils/address?
                                          :f/assert   [{:ex/x "foo-cat"
                                                        :ex/y "bar-cat"
                                                        :id   :ex/alice}]
-                                         :f/flakes   66
+                                         :f/flakes   62
                                          :f/previous {:id test-utils/db-id?}
                                          :f/retract  [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
@@ -887,13 +872,12 @@
                                           {:id test-utils/did?}
                                           :f/address  test-utils/address?
                                           :f/alias    ledger-name
-                                          :f/author   ""
                                           :f/branch   "main"
                                           :f/data     {:f/address  test-utils/address?
                                                        :f/assert   [{:ex/x "foo-3"
                                                                      :ex/y "bar-3"
                                                                      :id   :ex/alice}]
-                                                       :f/flakes   38
+                                                       :f/flakes   36
                                                        :f/previous {:id test-utils/db-id?}
                                                        :f/retract  [{:ex/x "foo-2"
                                                                      :ex/y "bar-2"
@@ -916,13 +900,12 @@
                                           {:id test-utils/did?}
                                           :f/address  test-utils/address?
                                           :f/alias    ledger-name
-                                          :f/author   ""
                                           :f/branch   "main"
                                           :f/data     {:f/address  test-utils/address?
                                                        :f/assert   [{:ex/x "foo-cat"
                                                                      :ex/y "bar-cat"
                                                                      :id   :ex/alice}]
-                                                       :f/flakes   72
+                                                       :f/flakes   68
                                                        :f/previous {:id test-utils/db-id?}
                                                        :f/retract  [{:ex/x "foo-3"
                                                                      :ex/y "bar-3"
@@ -991,7 +974,7 @@
                                                                             "ledger"   ledger-name
                                                                             "insert"   {"ex:foo" 5}})
                                                            root-privkey))]
-      (is (= [{"f:author" "", "f:data" {"f:t" 1}}
+      (is (= [{"f:data" {"f:t" 1}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
                "f:txn"    "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
                "f:data"   {"f:t" 2}}

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -188,31 +188,28 @@
                  ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/t
                   1]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   "https://www.w3.org/2018/credentials#issuer"
                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/address
-                  "fluree:memory://48d8a107deb2ee5ff87bc8795e11118848bd2add942aeb69b26d3f904ef2b72e"]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                  "fluree:memory://322ca14416b1a885bd87c1d0be9b6bf2a56432fef2456b53e06a335d0aa5b7d5"]
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/alias
                   "query/everything"]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
-                  :f/author
-                  ""]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/branch
                   "main"]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/data
                   "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/previous
                   "fluree:commit:sha256:bvvou3uvnd6ffhehsrw23mw4w3fux5jbpacko2ecosb2nzxkfu5v"]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/time
                   720000]
-                 ["fluree:commit:sha256:bb2nz6edfuibobhmajjfbyxxp5s4vmuwv5lsmwbuxxnmagicnvhy3"
+                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
                   :f/v
                   0]
                  [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,10 +28,10 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bbmpvuetgbce2qs5q7dwlbjgj5zcxknvaun2gutewa5pgg5seks5e"
+        (is (= "fluree:commit:sha256:bby2vwaws2jotvncr2s6f2h7xgoba5yzmbc2iiceryc6ib4xnyci4"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://e5417a11d9ead4187d63a3e29f14ff79069dd47bcb3f664771d25f1b518fa021"
+        (is (= "fluree:memory://77de4933247471aaac184ae88aa510e2639d04316ec47c2e1dab4f370076f83c"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
         (is (= "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"


### PR DESCRIPTION
Instead of saving an empty string, we now omit the `author` flake for unsigned transactions.