### PR TITLE
Nameservice push! refactor to rely on only JSON-LD commit

### DIFF
--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -311,11 +311,7 @@
   {:closed?  false
    :branches branches
    :branch   current-branch
-   :graphs   {}
-   :push     {:complete {:t   0
-                         :dag nil}
-              :pending  {:t   0
-                         :dag nil}}})
+   :graphs   {}})
 
 (defn parse-did
   [conn did]

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -152,11 +152,9 @@
        :write-result  commit-res})))
 
 (defn push-commit
-  [conn {:keys [state] :as _ledger} {:keys [commit-map commit-jsonld write-result]}]
-  (nameservice/push! conn (assoc commit-map
-                                 :meta write-result
-                                 :json-ld commit-jsonld
-                                 :ledger-state state)))
+  [conn {:keys [commit-map commit-jsonld]}]
+  (let [commit-jsonld* (assoc commit-jsonld "address" (:address commit-map))]
+    (nameservice/push! conn commit-jsonld*)))
 
 (defn formalize-commit
   [{prev-commit :commit :as staged-db} new-commit]
@@ -212,7 +210,7 @@
           db  (formalize-commit staged-db commit-map)
           db* (update-commit! ledger branch db index-files-ch)]
 
-      (<? (push-commit conn ledger commit-write-map))
+      (<? (push-commit conn commit-write-map))
 
       (if file-data?
         {:data-file-meta   data-write-result

--- a/src/clj/fluree/db/method/ipfs/core.cljc
+++ b/src/clj/fluree/db/method/ipfs/core.cljc
@@ -6,6 +6,8 @@
             [fluree.json-ld :as json-ld]
             [fluree.db.method.ipfs.directory :as ipfs-dir]
             [fluree.db.method.ipfs.keys :as ipfs-key]
+            [fluree.db.storage :as storage]
+            [fluree.db.util.json :as json]
             [fluree.db.util.log :as log :include-macros true]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -78,37 +80,29 @@
 (defn push!
   "Publishes ledger metadata document (ledger root) to IPFS and recursively updates any
   directory files, culminating in an update to the IPNS address."
-  [ipfs-endpoint commit-map]
+  [ipfs-endpoint {ns      "ns"
+                  address "address"
+                  data    "data"
+                  :as     commit-map}]
   (go-try
-    (let [{:keys [meta db ledger-state ns]} commit-map
-          my-ns-iri   (some #(when (re-matches #"^fluree:ipns:.+" (:id %)) (:id %)) ns)
-          {:keys [t]} db
-          {:keys [hash size]} meta
-          {:keys [ipns-address relative-address]} (address-parts my-ns-iri)
-          current-dag-map  (<? (ipfs-dir/refresh-state ipfs-endpoint (str "/ipns/" ipns-address)))
-          updated-dir-map  (<? (ipfs-dir/update-directory! current-dag-map ipfs-endpoint relative-address hash size))
-          _                (swap! ledger-state update-in [:push :pending] assoc :t t :dag updated-dir-map)
-          ipns-key         (<? (ipfs-key/profile ipfs-endpoint ipns-address))
-          _                (when-not ipns-key
-                             (throw (ex-info (str "IPNS key for address: " ipns-address " appears to no longer be registered "
-                                                  "with the connected IPFS server: " ipfs-endpoint ". Unable to publish updates.")
-                                             {:status 500 :error :db/ipns})))
-          publish-response (<? (ipfs/publish ipfs-endpoint (:hash updated-dir-map) ipns-key))]
-      (when (not= (:name publish-response) ipns-address)
-        (log/warn "IPNS address for key " ipns-key " used to be: " ipns-address
-                  " but now is resolving to: " (:name publish-response) "."
-                  "Publishing is now happening to the new address."))
-      ;; update ledger state with new push event
-      (swap! ledger-state update :push (fn [{:keys [pending complete] :as m}]
-                                         (let [pending*  (if (= t (:t pending))
-                                                           {:t nil :dag nil}
-                                                           (do
-                                                             (log/info "IPNS publishing is slower than your commits and will have delays.")
-                                                             pending))
-                                               complete* (if (> t (:t complete))
-                                                           {:t t :dag (:hash updated-dir-map)}
-                                                           complete)]
-                                           (assoc m :pending pending*
-                                                    :complete complete*))))
-
-      updated-dir-map)))
+   (let [my-ns-iri        (->> (map #(get % "id") ns)
+                               (some #(when (re-matches #"^fluree:ipns:.+" %) %)))
+         t                (get data "t")
+         {:keys [ipns-address relative-address]} (address-parts my-ns-iri)
+         {ipfs-cid :local} (storage/parse-address address)
+         approx-file-size (count (json/stringify commit-map))
+         current-dag-map  (<? (ipfs-dir/refresh-state ipfs-endpoint (str "/ipns/" ipns-address)))
+         updated-dir-map  (<? (ipfs-dir/update-directory! current-dag-map ipfs-endpoint relative-address ipfs-cid approx-file-size))
+         _                (ipns-queue-pending ipns-address t updated-dir-map)
+         ipns-key         (<? (ipfs-key/profile ipfs-endpoint ipns-address))
+         _                (when-not ipns-key
+                            (throw (ex-info (str "IPNS key for address: " ipns-address " appears to no longer be registered "
+                                                 "with the connected IPFS server: " ipfs-endpoint ". Unable to publish updates.")
+                                            {:status 500 :error :db/ipns})))
+         publish-response (<? (ipfs/publish ipfs-endpoint (:hash updated-dir-map) ipns-key))]
+     (when (not= (:name publish-response) ipns-address)
+       (log/warn "IPNS address for key " ipns-key " used to be: " ipns-address
+                 " but now is resolving to: " (:name publish-response) "."
+                 "Publishing is now happening to the new address."))
+     (ipns-queue-complete ipns-address t updated-dir-map)
+     updated-dir-map)))

--- a/src/clj/fluree/db/nameservice/core.cljc
+++ b/src/clj/fluree/db/nameservice/core.cljc
@@ -55,15 +55,15 @@
 
 (defn push!
   "Executes a push operation to all nameservices registered on the connection."
-  [conn commit-data]
+  [conn json-ld-commit]
   (let [nameservices (nameservices conn)]
     (go-try
       (loop [nameservices* nameservices]
         (when-let [ns (first nameservices*)]
           (let [sync? (ns-proto/-sync? ns)]
             (if sync?
-              (<? (ns-proto/-push ns commit-data))
-              (ns-proto/-push ns commit-data))
+              (<? (ns-proto/-push ns json-ld-commit))
+              (ns-proto/-push ns json-ld-commit))
             (recur (rest nameservices*))))))))
 
 (defn lookup-commit

--- a/src/clj/fluree/db/nameservice/filesystem.cljc
+++ b/src/clj/fluree/db/nameservice/filesystem.cljc
@@ -17,8 +17,9 @@
 For now, since we only have a single branch possible,
 always sets default-branch. Eventually will need to merge
 changes from different branches into existing metadata map"
-[ns-address commit-address
- {alias  "alias"
+[ns-address
+ {address "address"
+  alias  "alias"
   branch "branch"
   :as    json-ld-commit}]
 (let [branch-iri (str ns-address "(" branch ")")]
@@ -27,7 +28,7 @@ changes from different branches into existing metadata map"
    "defaultBranch" branch-iri
    "ledgerAlias"   alias
    "branches"      [{"@id"     branch-iri
-                     "address" commit-address
+                     "address" address
                      "commit"  json-ld-commit}]}))
 
 (defn address-path
@@ -92,13 +93,10 @@ changes from different branches into existing metadata map"
 
 (defn push!
   "Pushes updated commit to internal format stored on file system"
-  [local-path base-address {commit-address :address
-                            alias          :alias
-                            meta           :meta
-                            commit-json-ld :json-ld}]
+  [local-path base-address {alias          "alias"
+                            :as commit-json-ld}]
   (let [ns-address     (address base-address alias nil)
-        commit-address (:address meta)
-        record         (ns-record ns-address commit-address commit-json-ld)]
+        record         (ns-record ns-address commit-json-ld)]
     ;; write-ns-record returns a promise chan, with path of file if successful or exception
     (write-ns-record record local-path alias)))
 
@@ -155,7 +153,7 @@ changes from different branches into existing metadata map"
   [alias commit-address local-path legacy-path]
   (async/go
     (let [ns-address (str "fluree:file://" alias)
-          ns-record  (ns-record ns-address commit-address {"alias" alias, "branch" "main"})]
+          ns-record  (ns-record ns-address {"address" commit-address "alias" alias, "branch" "main"})]
       (let [successful? (async/<! (write-ns-record ns-record local-path alias))]
         (if (util/exception? successful?)
           (log/error successful?

--- a/src/clj/fluree/db/nameservice/memory.cljc
+++ b/src/clj/fluree/db/nameservice/memory.cljc
@@ -28,11 +28,12 @@
                  (and platform/BROWSER (.getItem js/localStorage addr-path))))))
 
 (defn push!
-  [data-atom {commit-address   :address
-              nameservice-iris :ns
+  [data-atom {commit-address   "address"
+              nameservice-iris "ns"
               :as              commit-data}]
   (go
-    (let [my-ns-iri   (some #(when (re-matches #"^fluree:memory:(.+)" (:id %)) (:id %)) nameservice-iris)
+    (let [my-ns-iri (->> (map #(get % "id") nameservice-iris)
+                         (some #(when (re-matches #"^fluree:memory:.+" %) %)))
           commit-path (address-path commit-address)
           head-path   (address-path my-ns-iri)]
       (swap! data-atom

--- a/src/clj/fluree/db/nameservice/s3.clj
+++ b/src/clj/fluree/db/nameservice/s3.clj
@@ -7,10 +7,11 @@
 (set! *warn-on-reflection* true)
 
 (defn push
-  [s3-client s3-bucket s3-prefix {commit-address :address
-                                  nameservices   :ns}]
+  [s3-client s3-bucket s3-prefix {commit-address "address"
+                                  nameservices   "ns"}]
   (go
-    (let [my-ns-iri   (some #(when (re-matches #"^fluree:s3:.+" (:id %)) (:id %)) nameservices)
+    (let [my-ns-iri   (->> (map #(get % "id") nameservices)
+                           (some #(when (re-matches #"^fluree:s3:.+" %) %)))
           commit-path (s3/address-path s3-bucket s3-prefix commit-address false)
           head-path   (s3/address-path s3-bucket s3-prefix my-ns-iri)]
       (->> (.getBytes ^String commit-path)

--- a/src/clj/fluree/db/storage/ipfs.cljc
+++ b/src/clj/fluree/db/storage/ipfs.cljc
@@ -49,7 +49,7 @@
           (boolean resp)))))
 
   (read [_ address]
-    (let [{:keys [ns local method]} (storage/parse-address address)
+    (let [{:keys [ns method local]} (storage/parse-address address)
           path                      (build-ipfs-path method local)]
       (when-not (and (= "fluree" ns)
                      (#{"ipfs" "ipns"} method))


### PR DESCRIPTION
While working on fluree/server, the raft implementation was broken because nameservice record support wasn't working properly.

While all the files were getting replicated properly and consensus was working fine, the nameservice record itself kept locally on every server wasn't getting written out properly. Previous refactors around nameservices appear to have broken this and it wasn't realized. This prevented all the servers from being able to properly 'load' ledgers they were maintaining together.

This PR refactors the nameservice push! operations to rely *only* on the JSON-LD commit record, which is known in raft consensus, and means fluree/server can easily maintain proper NS records across a distributed network without a lot of extra work.

Before this PR, several pieces of metadata were sent to `push!` - including the JSON-LD commit we now only rely on, but also the keyword-map commit, the write file results, and even the `ledger`'s state atom. The work in this PR removed the dependency on all of those other pieces of metadata such that just the single JSON-LD commit could be used in all nameservice implementations and work.

