### PR TITLE
change cache size opts to cache-max-mb

### DIFF
--- a/src/clj/fluree/db/conn/cache.cljc
+++ b/src/clj/fluree/db/conn/cache.cljc
@@ -12,10 +12,10 @@
 
 (defn memory->cache-size
   "Validate system memory is enough to build a usable cache, then derive cache size."
-  [memory]
-  (let [memory      (or memory 1000000)        ; default 1MB memory
-        object-size 100000                     ; estimate 100kb index node size
-        cache-size  (quot memory object-size)] ; number of objects to keep in cache
+  [cache-max-mb]
+  (let [memory      (or cache-max-mb 100) ; default 100MB memory
+        object-size 0.1 ; estimate 100kb index node size
+        cache-size  (int (quot memory object-size))] ; number of objects to keep in cache
     (when (< cache-size 10)
       (throw (ex-info (str "Must allocate at least 1MB of memory for Fluree. You've allocated: " memory " bytes.")
                       {:status 400 :error :db/invalid-configuration})))

--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -116,7 +116,7 @@
 
 (defn connect
   "Create a new file system connection."
-  [{:keys [defaults parallelism storage-path lru-cache-atom memory serializer nameservices]
+  [{:keys [defaults parallelism storage-path lru-cache-atom cache-max-mb serializer nameservices]
     :or   {serializer (json-serde)} :as _opts}]
   (log/debug "Initialized file connection with options: " _opts)
   (go
@@ -124,7 +124,7 @@
           state          (connection/blank-state)
           nameservices*  (util/sequential
                            (or nameservices (default-file-nameservice storage-path)))
-          cache-size     (conn-cache/memory->cache-size memory)
+          cache-size     (conn-cache/memory->cache-size cache-max-mb)
           lru-cache-atom (or lru-cache-atom (atom (conn-cache/create-lru-cache cache-size)))
           file-store     (file-storage/open storage-path)]
       ;; TODO - need to set up monitor loops for async chans

--- a/src/clj/fluree/db/conn/ipfs.cljc
+++ b/src/clj/fluree/db/conn/ipfs.cljc
@@ -125,7 +125,7 @@
            enabled and commits will not succeed until the ns file is written to
            disk. It should be used as the primary nameservice whenever used for
            a ledger receiving frequent updates or timeliness is important."
-  [{:keys [server parallelism lru-cache-atom memory defaults serializer
+  [{:keys [server parallelism lru-cache-atom cache-max-mb defaults serializer
            ;; only include if you want to configure custom nameservice(s)
            nameservices
            ;; if not providing preconfigured 'nameservices', ipns + file nameservices used
@@ -141,7 +141,6 @@
   (go-try
     (let [ipfs-endpoint   (validate-http-url server)
           ledger-defaults (ledger-defaults defaults)
-          memory          (or memory 1000000) ; default 1MB memory
           conn-id         (str (random-uuid))
           state           (connection/blank-state)
           nameservices*   (if nameservices ;; provided pre-configured nameservices to connection
@@ -149,7 +148,7 @@
                             (cond-> [] ;; utilize default nameservices with provided config options
                                     ipns-nameservice (conj (<? (default-ipns-nameservice ipns-nameservice ipfs-endpoint)))
                                     file-nameservice (conj (default-file-nameservice file-nameservice))))
-          cache-size      (conn-cache/memory->cache-size memory)
+          cache-size      (conn-cache/memory->cache-size cache-max-mb)
           lru-cache-atom  (or lru-cache-atom (atom (conn-cache/create-lru-cache cache-size)))
           ipfs-store      (ipfs-storage/open ipfs-endpoint)]
       (when (empty? nameservices*)

--- a/src/clj/fluree/db/conn/memory.cljc
+++ b/src/clj/fluree/db/conn/memory.cljc
@@ -100,7 +100,7 @@
 
 (defn connect
   "Creates a new memory connection."
-  [{:keys [parallelism lru-cache-atom memory defaults nameservices]}]
+  [{:keys [parallelism lru-cache-atom cache-max-mb defaults nameservices]}]
   (go-try
     (let [ledger-defaults (<? (ledger-defaults defaults))
           conn-id         (str (random-uuid))
@@ -118,7 +118,7 @@
                                 ;; independent of the data held in commit and
                                 ;; index storage.
                                 (default-memory-nameservice (:contents mem-store))))
-          cache-size      (conn-cache/memory->cache-size memory)
+          cache-size      (conn-cache/memory->cache-size cache-max-mb)
           lru-cache-atom  (or lru-cache-atom (atom (conn-cache/create-lru-cache
                                                      cache-size)))]
       (map->MemoryConnection {:id              conn-id

--- a/src/clj/fluree/db/conn/remote.cljc
+++ b/src/clj/fluree/db/conn/remote.cljc
@@ -81,7 +81,7 @@
 
 (defn connect
   "Creates a new memory connection."
-  [{:keys [parallelism lru-cache-atom memory defaults servers serializer nameservices]
+  [{:keys [parallelism lru-cache-atom cache-max-mb defaults servers serializer nameservices]
     :or   {serializer (json-serde)}}]
   (go-try
     (let [ledger-defaults (<? (ledger-defaults defaults))
@@ -96,7 +96,7 @@
                                 ;; if default ns, and returns exception, throw - connection fails
                                 ;; (likely due to unreachable server with websocket request)
                                 (<? (default-remote-nameservice server-state state))))
-          cache-size      (conn-cache/memory->cache-size memory)
+          cache-size      (conn-cache/memory->cache-size cache-max-mb)
           lru-cache-atom  (or lru-cache-atom (atom (conn-cache/create-lru-cache
                                                      cache-size)))]
       (map->RemoteConnection {:id              conn-id


### PR DESCRIPTION
The default LRU cache for storing index segments defaulted to 10, and recent changes to fluree/server was also not picking up the correct options key name and was being ignored - so regardless of the config settings LRU cache was always 10.

This significantly slowed down queries/transactions for any but the smallest dbs.

This changes the default if no settings exist to 100Mb of memory for the cache (1,000 LRU cache items)

This also renames the setting into connection creation from `memory` to the better named `cache-max-mb`, which is what the new fluree/server settings is used - so it will now pick up the fluree/server config settings.