### PR TITLE
Refactor/lru cache

### DIFF
--- a/dev/remote_conn.clj
+++ b/dev/remote_conn.clj
@@ -13,8 +13,12 @@
 
   (def db (fluree/db ledger))
 
-  @(fluree/query db {:select {"?s" ["*"]}
-                     :where  [["?s" "ex:name" nil]]})
+
+
+  @(fluree/query db {"@context" {"ex" "http://example.org/"}
+                     "select"   {"?s" ["*"]}
+                     "where"    {"@id"     "?s"
+                                 "ex:name" nil}})
 
 
   )

--- a/src/clj/fluree/db/conn/cache.cljc
+++ b/src/clj/fluree/db/conn/cache.cljc
@@ -2,6 +2,7 @@
   "A simple default connection-level cache."
   (:require [#?(:cljs cljs.cache :clj clojure.core.cache) :as cache]
             [clojure.core.async :as async]
+            [fluree.db.util.log :as log]
             [fluree.db.util.core :as util :refer [exception?]]))
 
 (defn create-lru-cache

--- a/src/clj/fluree/db/conn/cache.cljc
+++ b/src/clj/fluree/db/conn/cache.cljc
@@ -26,16 +26,18 @@
   function that accepts `k` as its only argument and returns an async channel) to
   produce the value and add it to the cache."
   [cache-atom k value-fn]
-  (let [out (async/chan)]
-    (if-let [v (get @cache-atom k)]
-      (do (swap! cache-atom cache/hit k)
-          (async/put! out v))
+  (if-let [v (get @cache-atom k)]
+    (do (swap! cache-atom cache/hit k)
+        v)
+    (let [c (async/promise-chan)]
+      (swap! cache-atom cache/miss k c)
       (async/go
         (let [v (async/<! (value-fn k))]
-          (when-not (exception? v)
-            (swap! cache-atom cache/miss k v))
-          (async/put! out v))))
-    out))
+          (async/put! c v)
+          (when (exception? v)
+            (log/error v "Error resolving cache value for key: " k "with exception:" (ex-message v))
+            (swap! cache-atom cache/evict k))))
+      c)))
 
 (defn lru-evict
   "Evict the key `k` from the cache."

--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -81,16 +81,8 @@
 
   index/Resolver
   (resolve
-    [conn {:keys [id leaf tempid] :as node}]
-    (let [cache-key [::resolve id tempid]]
-      (if (= :empty id)
-        (index-storage/resolve-empty-node node)
-        (conn-cache/lru-lookup
-          lru-cache-atom
-          cache-key
-          (fn [_]
-            (index-storage/resolve-index-node conn node
-                                        (fn [] (conn-cache/lru-evict lru-cache-atom cache-key)))))))))
+    [conn node]
+    (index-storage/index-resolver conn lru-cache-atom node)))
 
 #?(:cljs
    (extend-type FileConnection

--- a/src/clj/fluree/db/conn/ipfs.cljc
+++ b/src/clj/fluree/db/conn/ipfs.cljc
@@ -58,16 +58,8 @@
 
   index/Resolver
   (resolve
-    [conn {:keys [id leaf tempid] :as node}]
-    (let [cache-key [::resolve id tempid]]
-      (if (= :empty id)
-        (index-storage/resolve-empty-node node)
-        (conn-cache/lru-lookup
-          lru-cache-atom
-          cache-key
-          (fn [_]
-            (index-storage/resolve-index-node conn node
-                                        (fn [] (conn-cache/lru-evict lru-cache-atom cache-key)))))))))
+    [conn node]
+    (index-storage/index-resolver conn lru-cache-atom node)))
 
 #?(:cljs
    (extend-type IPFSConnection

--- a/src/clj/fluree/db/conn/remote.cljc
+++ b/src/clj/fluree/db/conn/remote.cljc
@@ -1,6 +1,6 @@
 (ns fluree.db.conn.remote
   (:require [clojure.core.async :as async :refer [go]]
-            [fluree.db.indexer.storage :as storage]
+            [fluree.db.indexer.storage :as index-storage]
             [fluree.db.index :as index]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log :include-macros true]
@@ -43,16 +43,8 @@
 
   index/Resolver
   (resolve
-    [conn {:keys [id leaf tempid] :as node}]
-    (let [cache-key [::resolve id tempid]]
-      (if (= :empty id)
-        (storage/resolve-empty-node node)
-        (conn-cache/lru-lookup
-          lru-cache-atom
-          cache-key
-          (fn [_]
-            (storage/resolve-index-node conn node
-                                        (fn [] (conn-cache/lru-evict lru-cache-atom cache-key)))))))))
+    [conn node]
+    (index-storage/index-resolver conn lru-cache-atom node)))
 
 #?(:cljs
    (extend-type RemoteConnection

--- a/src/clj/fluree/db/conn/s3.clj
+++ b/src/clj/fluree/db/conn/s3.clj
@@ -82,16 +82,8 @@
   (-state [_ ledger] (get @state ledger))
 
   index/Resolver
-  (resolve [conn {:keys [id leaf tempid] :as node}]
-    (let [cache-key [::resolve id tempid]]
-      (if (= :empty id)
-        (index-storage/resolve-empty-node node)
-        (conn-cache/lru-lookup lru-cache-atom cache-key
-                               (fn [_]
-                                 (index-storage/resolve-index-node
-                                   conn node
-                                   (fn [] (conn-cache/lru-evict lru-cache-atom
-                                                               cache-key)))))))))
+  (resolve [conn node]
+    (index-storage/index-resolver conn lru-cache-atom node)))
 
 
 (defmethod print-method S3Connection [^S3Connection conn, ^Writer w]


### PR DESCRIPTION
This makes the following changes:
1) consolidates the index-resolver code which was identical across all connections
2) change the LRU cache to store promise-chans and not values. This has two effects:
  a) Concurrent requests for the same uncached resource are highly likely to share the same request now, whereas they were highly likely previously to do the same work multiple times.
  b) index-resolver is called a lot, and it creates a new chan every time to put the ultimate value on (even if cached). Now we don't need to create new chans for every call that don't serve much of a purpose.
3) Moves exception-handling when caching to the cache. It was not handled consistently before.