### PR TITLE
Fix/query optimization

### DIFF
--- a/src/clj/fluree/db/query/exec.cljc
+++ b/src/clj/fluree/db/query/exec.cljc
@@ -62,9 +62,9 @@
        (having/filter q error-ch)
        (select/modify q)
        (order/arrange q)
-       (select/format ds q fuel-tracker error-ch)
        (drop-offset q)
        (take-limit q)
+       (select/format ds q fuel-tracker error-ch)
        (collect-results q)))
 
 (defn execute-subquery
@@ -74,9 +74,9 @@
        (having/filter q error-ch)
        (select/modify q)
        (order/arrange q)
-       (select/subquery-format ds q fuel-tracker error-ch)
        (drop-offset q)
-       (take-limit q)))
+       (take-limit q)
+       (select/subquery-format ds q fuel-tracker error-ch)))
 
 (defn collect-subqueries
   "With multiple subqueries each having its own solution channel,

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -218,7 +218,7 @@
         format-ch           (if (contains? q :select-distinct)
                               (chan 1 (distinct))
                               (chan))]
-    (async/pipeline-async 1
+    (async/pipeline-async 3
                           format-ch
                           (fn [solution ch]
                             (log/trace "select/format solution:" solution)


### PR DESCRIPTION
This does query offset/limit before query selection formatting in addition to increasing the parallelism to 3 for selection formatting.

These changes have a strong performance impact for queries that have large graph crawls in the 'select'.
