### PR TITLE
Datatype filtering

### DIFF
--- a/src/clj/data_readers.cljc
+++ b/src/clj/data_readers.cljc
@@ -1,2 +1,3 @@
 {fluree/Flake fluree.db.flake/parts->Flake
- fluree/SID   fluree.db.json-ld.iri/deserialize-sid}
+ fluree/SID   fluree.db.json-ld.iri/deserialize-sid
+ fluree/IRI   fluree.db.json-ld.iri/string->iri}

--- a/src/clj/fluree/db/datatype.cljc
+++ b/src/clj/fluree/db/datatype.cljc
@@ -104,7 +104,8 @@
                     const/$xsd:string)
      (integer? x) const/$xsd:long ; infer to long to prevent overflow
      (number? x)  const/$xsd:decimal
-     (boolean? x) const/$xsd:boolean)))
+     (boolean? x) const/$xsd:boolean
+     (iri/iri? x) const/$xsd:anyURI)))
 
 (defn infer-iri
   ([x]

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -23,29 +23,30 @@
   [s]
   (->IRI s))
 
-(defn iri->string
-  [iri]
-  (:s iri))
-
 (defn unwrap
   [x]
   (if (iri? x)
-    (iri->string x)
+    (str x)
     x))
 
-(defn display-iri ^String
+(defn serialize-iri ^String
   [iri]
-  (str "<\"" iri "\">"))
+  (str "\"" iri "\""))
 
 #?(:clj (defmethod print-method IRI [^IRI iri ^java.io.Writer w]
-          (let [iri-str (display-iri iri)]
+          (let [iri-str (serialize-iri iri)]
             (doto w
               (.write "#fluree/IRI ")
               (.write iri-str))))
    :cljs (extend-protocol IPrintWithWriter
            IRI
            (-pr-writer [iri writer _]
-             (write-all writer "#fluree/IRI " (display-iri iri)))))
+             (write-all writer "#fluree/IRI " (serialize-iri iri)))))
+
+#?(:clj (defmethod print-dup IRI
+          [^IRI iri ^java.io.Writer w]
+          (let [iri-string (str iri)]
+            (.write w (str "#=" `(string->iri ~iri-string))))))
 
 (defmethod pprint/simple-dispatch IRI [^IRI iri]
   (pr iri))

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -2,6 +2,7 @@
   (:require [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
             [fluree.db.util.bytes :as bytes]
+            [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.set :refer [map-invert]]
             [nano-id.core :refer [nano-id]]
@@ -13,6 +14,23 @@
 (defrecord IRI [^String s]
   Object
   (toString [_] s))
+
+(defn display-iri ^String
+  [iri]
+  (str "<\"" iri "\">"))
+
+#?(:clj (defmethod print-method IRI [^IRI iri ^java.io.Writer w]
+          (let [iri-str (display-iri iri)]
+            (doto w
+              (.write "#fluree/IRI ")
+              (.write iri-str))))
+   :cljs (extend-protocol IPrintWithWriter
+           IRI
+           (-pr-writer [iri writer _]
+             (write-all writer "#fluree/IRI " (display-iri iri)))))
+
+(defmethod pprint/simple-dispatch IRI [^IRI iri]
+  (pr iri))
 
 (defn iri?
   [x]

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -15,6 +15,24 @@
   Object
   (toString [_] s))
 
+(defn iri?
+  [x]
+  (instance? IRI x))
+
+(defn string->iri
+  [s]
+  (->IRI s))
+
+(defn iri->string
+  [iri]
+  (:s iri))
+
+(defn unwrap
+  [x]
+  (if (iri? x)
+    (iri->string x)
+    x))
+
 (defn display-iri ^String
   [iri]
   (str "<\"" iri "\">"))
@@ -31,16 +49,6 @@
 
 (defmethod pprint/simple-dispatch IRI [^IRI iri]
   (pr iri))
-
-(defn iri?
-  [x]
-  (instance? IRI x))
-
-(defn unwrap
-  [x]
-  (if (iri? x)
-    (:s x)
-    x))
 
 (def ^:const f-ns "https://ns.flur.ee/ledger#")
 (def ^:const f-t-ns "https://ns.flur.ee/ledger/transaction#")

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -10,7 +10,9 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defrecord IRI [^String s])
+(defrecord IRI [^String s]
+  Object
+  (toString [_] s))
 
 (defn iri?
   [x]

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -10,6 +10,18 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+(defrecord IRI [^String s])
+
+(defn iri?
+  [x]
+  (instance? IRI x))
+
+(defn unwrap
+  [x]
+  (if (iri? x)
+    (:s x)
+    x))
+
 (def ^:const f-ns "https://ns.flur.ee/ledger#")
 (def ^:const f-t-ns "https://ns.flur.ee/ledger/transaction#")
 (def ^:const f-did-ns "did:fluree:")

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -5,6 +5,7 @@
             [fluree.db.query.exec.where :as where]
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]
+            [fluree.db.json-ld.iri :as iri]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :refer [postwalk]]
@@ -205,7 +206,8 @@
 
 (defmacro datatype
   [var]
-  (-> var var->dt-var where/match-iri))
+  (let [dt-var (var->dt-var var)]
+    `(iri/->IRI ~dt-var)))
 
 (defn regex
   [text pattern]
@@ -301,7 +303,7 @@
   [s]
   `(-> ~s
        (json-ld/expand-iri ~context-var)
-       where/match-iri))
+       iri/->IRI))
 
 (def allowed-scalar-fns
   '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -204,7 +204,7 @@
 
 (defmacro datatype
   [var]
-  (var->dt-var var))
+  (-> var var->dt-var where/match-iri))
 
 (defn regex
   [text pattern]

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -207,7 +207,7 @@
 (defmacro datatype
   [var]
   (let [dt-var (var->dt-var var)]
-    `(iri/->IRI ~dt-var)))
+    `(iri/string->iri ~dt-var)))
 
 (defn regex
   [text pattern]
@@ -303,7 +303,7 @@
   [s]
   `(-> ~s
        (json-ld/expand-iri ~context-var)
-       iri/->IRI))
+       iri/string->iri))
 
 (def allowed-scalar-fns
   '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -4,6 +4,7 @@
   (:require [fluree.db.query.exec.group :as group]
             [fluree.db.query.exec.where :as where]
             [fluree.db.util.log :as log]
+            [fluree.json-ld :as json-ld]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :refer [postwalk]]
@@ -296,9 +297,15 @@
 (def context-var
   (symbol "$-CONTEXT"))
 
+(defmacro iri
+  [s]
+  `(-> ~s
+       (json-ld/expand-iri ~context-var)
+       where/match-iri))
+
 (def allowed-scalar-fns
-  '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if lang nil?
-     as not not= or re-find re-pattern in
+  '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang
+     nil? as not not= or re-find re-pattern in
 
      ;; string fns
      strStarts strEnds subStr strLen ucase lcase contains strBefore strAfter
@@ -315,7 +322,6 @@
 
      ;; rdf term fns
      uuid struuid isNumeric isBlank str})
-
 
 (def allowed-symbols
   (set/union allowed-aggregate-fns allowed-scalar-fns))
@@ -339,6 +345,7 @@
     floor          fluree.db.query.exec.eval/floor
     groupconcat    fluree.db.query.exec.eval/groupconcat
     in             fluree.db.query.exec.eval/in
+    iri            fluree.db.query.exec.eval/iri
     lang           fluree.db.query.exec.eval/lang
     lcase          fluree.db.query.exec.eval/lcase
     median         fluree.db.query.exec.eval/median

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -450,12 +450,12 @@
         (mapcat (fn [var]
                   (let [dt-var   (var->dt-var var)
                         lang-var (var->lang-var var)]
-                    `[mch#         (get ~soln-sym (quote ~var))
-                      ~dt-var      (where/get-datatype-iri mch#)
-                      ~lang-var    (-> mch# ::where/meta :lang (or ""))
-                      ~var         (cond->> (where/get-binding mch#)
-                                     (= ~dt-var ::group/grouping)
-                                     (mapv where/get-value))])))
+                    `[mch#      (get ~soln-sym (quote ~var))
+                      ~dt-var   (where/get-datatype-iri mch#)
+                      ~lang-var (-> mch# ::where/meta :lang (or ""))
+                      ~var      (cond->> (where/get-binding mch#)
+                                  (= ~dt-var ::group/grouping)
+                                  (mapv where/get-value))])))
         var-syms))
 
 (defn compile

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -202,6 +202,10 @@
   [var]
   (var->lang-var var))
 
+(defmacro datatype
+  [var]
+  (var->dt-var var))
+
 (defn regex
   [text pattern]
   (boolean (re-find (re-pattern pattern) text)))
@@ -290,16 +294,22 @@
   (contains? (set expressions) term))
 
 (def allowed-scalar-fns
-  '#{&& || ! > < >= <= = + - * / quot and bound coalesce if lang nil? as
-     not not= or re-find re-pattern in
+  '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if lang nil?
+     as not not= or re-find re-pattern in
+
      ;; string fns
-     strStarts strEnds subStr strLen ucase lcase contains strBefore strAfter concat regex replace
+     strStarts strEnds subStr strLen ucase lcase contains strBefore strAfter
+     concat regex replace
+
      ;; numeric fns
      abs round ceil floor rand
+
      ;; datetime fns
      now year month day hours minutes seconds tz
+
      ;; hash fns
      sha256 sha512
+
      ;; rdf term fns
      uuid struuid isNumeric isBlank str})
 
@@ -322,6 +332,7 @@
     contains       fluree.db.query.exec.eval/contains
     count-distinct fluree.db.query.exec.eval/count-distinct
     count          clojure.core/count
+    datatype       fluree.db.query.exec.eval/datatype
     floor          fluree.db.query.exec.eval/floor
     groupconcat    fluree.db.query.exec.eval/groupconcat
     in             fluree.db.query.exec.eval/in

--- a/src/clj/fluree/db/query/exec/group.cljc
+++ b/src/clj/fluree/db/query/exec/group.cljc
@@ -53,12 +53,11 @@
     [nil]))
 
 (defmethod select/display ::grouping
-  [match compact error-ch]
+  [match compact]
   (let [group (where/get-value match)]
-    (->> group
-         (map (fn [grouped-val]
-                (select/display grouped-val compact error-ch)))
-         (async/map vector))))
+    (mapv (fn [grouped-val]
+            (select/display grouped-val compact))
+          group)))
 
 (defn combine
   "Returns a channel of solutions from `solution-ch` collected into groups defined

--- a/src/clj/fluree/db/query/exec/group.cljc
+++ b/src/clj/fluree/db/query/exec/group.cljc
@@ -53,11 +53,11 @@
     [nil]))
 
 (defmethod select/display ::grouping
-  [match db select-cache compact error-ch]
+  [match compact error-ch]
   (let [group (where/get-value match)]
     (->> group
          (map (fn [grouped-val]
-                (select/display grouped-val db select-cache compact error-ch)))
+                (select/display grouped-val compact error-ch)))
          (async/map vector))))
 
 (defn combine

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -32,8 +32,7 @@
 
 (defmethod display const/iri-anyURI
   [match compact]
-  (or (some-> match where/get-iri iri/unwrap compact)
-      (some-> match where/get-value iri/unwrap compact)))
+  (some-> match where/get-iri iri/unwrap compact))
 
 (defprotocol ValueSelector
   (format-value [fmt db iri-cache context compact fuel-tracker error-ch solution]

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -38,7 +38,8 @@
 (defmethod display const/iri-anyURI
   [match db iri-cache compact error-ch]
   (go
-    (or (some-> match ::where/iri compact)
+    (or (some-> match where/get-iri compact)
+        (some-> match where/get-value iri/unwrap compact)
         (let [db-alias (:alias db)
               v        (where/get-sid match db-alias)]
           (if-let [cached (-> @iri-cache (get v) :as)]

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -32,7 +32,7 @@
 
 (defmethod display const/iri-anyURI
   [match compact]
-  (or (some-> match where/get-iri compact)
+  (or (some-> match where/get-iri iri/unwrap compact)
       (some-> match where/get-value iri/unwrap compact)))
 
 (defprotocol ValueSelector

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -39,17 +39,7 @@
   [match db iri-cache compact error-ch]
   (go
     (or (some-> match where/get-iri compact)
-        (some-> match where/get-value iri/unwrap compact)
-        (let [db-alias (:alias db)
-              v        (where/get-sid match db-alias)]
-          (if-let [cached (-> @iri-cache (get v) :as)]
-            cached
-            (try* (let [iri (compact (iri/decode-sid db v))]
-                    (vswap! iri-cache assoc v {:as iri})
-                    iri)
-                  (catch* e
-                          (log/error e "Error displaying iri:" v)
-                          (>! error-ch e))))))))
+        (some-> match where/get-value iri/unwrap compact))))
 
 (defprotocol ValueSelector
   (format-value [fmt db iri-cache context compact fuel-tracker error-ch solution]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -56,7 +56,8 @@
 
 (defn matched-sid?
   [mch]
-  (contains? mch ::sids))
+  (and (map? mch)
+       (contains? mch ::sids)))
 
 (defn get-sid
   [iri-mch db]
@@ -591,11 +592,14 @@
 
 (defn bind-function-result
   [solution var-name result]
-  (let [dt  (datatype/infer-iri result)
-        mch (-> var-name
-                unmatched-var
-                (match-value result dt))]
-    (assoc solution var-name mch)))
+  (if (matched? result)
+    (let [mch (assoc result ::var var-name)]
+      (assoc solution var-name mch))
+    (let [dt  (datatype/infer-iri result)
+          mch (-> var-name
+                  unmatched-var
+                  (match-value result dt))]
+      (assoc solution var-name mch))))
 
 (defmethod match-pattern :bind
   [_db _fuel-tracker solution pattern error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -589,7 +589,7 @@
     (-> (match-clause db fuel-tracker solution clause error-ch)
         (async/pipe opt-ch))))
 
-(defn add-fn-result-to-solution
+(defn bind-function-result
   [solution var-name result]
   (let [dt  (datatype/infer-iri result)
         mch (-> var-name
@@ -606,8 +606,8 @@
                       (let [f        (::fn b)
                             var-name (::var b)]
                         (try*
-                          (->> (f solution)
-                               (add-fn-result-to-solution solution* var-name))
+                          (let [result (f solution)]
+                            (bind-function-result solution* var-name result))
                           (catch* e (update solution* ::errors conj e)))))
                     solution (vals bind))]
         (when-let [errors (::errors result)]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -162,11 +162,11 @@
 (defn datatype-matcher
   "Return a function that returns true if the datatype of a matched pattern equals
   the supplied datatype iri `type`."
-  [type]
+  [type context]
   (fn [soln mch]
     (let [type* (if (variable? type)
                   (-> soln (get type) get-iri)
-                  type)]
+                  (json-ld/expand-iri type context))]
       (-> mch
           get-datatype-iri
           (= type*)))))

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -69,7 +69,7 @@
   (if (or (matched-iri? mch)
           (matched-sid? mch))
     const/iri-anyURI
-    (::datatype-iri mch)))
+    (-> mch ::datatype-iri iri/unwrap)))
 
 (defn matched?
   [match]
@@ -151,6 +151,18 @@
                   (-> soln (get lang) get-value)
                   lang)]
       (-> mch ::meta :lang (= lang*)))))
+
+(defn datatype-matcher
+  "Return a function that returns true if the datatype of a matched pattern equals
+  the supplied datatype iri `type`."
+  [type]
+  (fn [soln mch]
+    (let [type* (if (variable? type)
+                  (-> soln (get type) get-iri)
+                  type)]
+      (-> mch
+          get-datatype-iri
+          (= type*)))))
 
 (defn with-filter
   [mch f]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -40,7 +40,7 @@
 
 (defn get-iri
   [match]
-  (::iri match))
+  (-> match ::iri iri/unwrap))
 
 (defn matched-iri?
   [match]
@@ -592,14 +592,11 @@
 
 (defn bind-function-result
   [solution var-name result]
-  (if (matched? result)
-    (let [mch (assoc result ::var var-name)]
-      (assoc solution var-name mch))
-    (let [dt  (datatype/infer-iri result)
-          mch (-> var-name
-                  unmatched-var
-                  (match-value result dt))]
-      (assoc solution var-name mch))))
+  (let [dt  (datatype/infer-iri result)
+        mch (-> var-name
+                unmatched-var
+                (match-value result dt))]
+    (assoc solution var-name mch)))
 
 (defmethod match-pattern :bind
   [_db _fuel-tracker solution pattern error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -452,7 +452,6 @@
   (go
     (let [f (pattern-data pattern)]
       (try*
-        (log/info "filtering" solution)
        (when (f solution)
          solution)
        (catch* e (>! error-ch (filter-exception e solution f)))))))

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -62,19 +62,19 @@
   ([mch iri]
    (assoc mch ::iri iri)))
 
-(defn get-iri
-  [match]
-  (cond
-    (contains? match ::iri)
-    (-> match ::iri iri/unwrap)
-
-    (-> match get-datatype-iri #{const/iri-anyURI})
-    (-> match get-value iri/unwrap)))
-
 (defn matched-iri?
   [match]
   (-> match ::iri some?))
 
+(defn iri-datatype?
+  [mch]
+  (-> mch get-datatype-iri (= const/iri-anyURI)))
+
+(defn get-iri
+  [match]
+  (cond
+    (matched-iri? match)  (-> match ::iri iri/unwrap)
+    (iri-datatype? match) (-> match get-value iri/unwrap)))
 
 (defn matched-sid?
   [mch]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -442,7 +442,7 @@
         syntax/coerce-where
         (parse-where-clause vars context))))
 
-(defn parse-as-fn
+(defn parse-select-as-fn
   [f]
   (let [parsed-fn  (parse-code f)
         fn-name    (some-> parsed-fn second first)
@@ -452,7 +452,7 @@
         eval/compile
         (select/as-selector bind-var aggregate?))))
 
-(defn parse-fn
+(defn parse-select-aggregate
   [f]
   (-> f parse-code eval/compile select/aggregate-selector))
 
@@ -512,11 +512,11 @@
         :var (-> selector-val symbol select/variable-selector)
         :aggregate (case (first selector-val)
                      :string-fn (if (re-find #"^\(as " s)
-                                  (parse-as-fn s)
-                                  (parse-fn s))
+                                  (parse-select-as-fn s)
+                                  (parse-select-aggregate s))
                      :list-fn (if (= 'as (first s))
-                                (parse-as-fn s)
-                                (parse-fn s)))
+                                (parse-select-as-fn s)
+                                (parse-select-aggregate s)))
         :select-map (parse-select-map s depth context)))))
 
 (defn parse-select-clause

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -181,14 +181,14 @@
 
 (defn parse-filter-function
   "Evals and returns filter function."
-  [fltr fltr-var vars]
+  [fltr fltr-var vars ctx]
   (let [code      (parse-code fltr)
         code-vars (or (not-empty (variables code))
                       (throw (ex-info (str "Filter function must contain a valid variable. Provided: " code)
                                       {:status 400 :error :db/invalid-query})))
         var-name  (find-filtered-var code-vars vars)]
     (if (= var-name fltr-var)
-      (eval/compile-filter code var-name)
+      (eval/compile-filter code var-name ctx)
       (throw (ex-info (str "Variable filter must only reference the variable bound in its value map: "
                            fltr-var
                            ". Provided:" code)
@@ -196,9 +196,9 @@
 
 (defn parse-bind-function
   "Evals and returns bind function."
-  [var-name fn-code]
+  [var-name fn-code context]
   (let [code (parse-code fn-code)
-        f    (eval/compile code false)]
+        f    (eval/compile code context false)]
     (where/->var-filter var-name f)))
 
 (defn parse-iri
@@ -218,12 +218,12 @@
     (v/where-pattern-type pattern)))
 
 (defn parse-bind-map
-  [binds]
+  [binds context]
   (into {}
         (comp (partition-all 2)
               (map (fn [[k v]]
                      (let [var (parse-var-name k)
-                           f   (parse-bind-function var v)]
+                           f   (parse-bind-function var v context)]
                        [var f]))))
         binds))
 
@@ -243,11 +243,11 @@
             fs)))
 
 (defn parse-variable-attributes
-  [var attrs vars]
+  [var attrs vars context]
   (let [lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
         filter-fn    (some-> attrs
                              (get const/iri-filter)
-                             (parse-filter-function var vars))]
+                             (parse-filter-function var vars context))]
     (if-let [f (some->> [lang-matcher filter-fn]
                         (remove nil?)
                         not-empty
@@ -294,9 +294,6 @@
         (where/->predicate const/iri-rdf-type reverse)
         (where/->predicate expanded reverse)))))
 
-(def id-predicate-match
-  (parse-predicate const/iri-id nil))
-
 (declare parse-statement parse-statements)
 
 (defn flip-reverse-pattern
@@ -311,7 +308,7 @@
     (if-let [v (get o* const/iri-value)]
       (let [attrs (dissoc o* const/iri-value)
             o-mch (if-let [var (parse-var-name v)]
-                    (parse-variable-attributes var attrs vars)
+                    (parse-variable-attributes var attrs vars context)
                     (parse-value-attributes v attrs context))]
         [(flip-reverse-pattern [s-mch p-mch o-mch])])
       ;; ref
@@ -384,10 +381,11 @@
   (parse-node-map m vars context))
 
 (defmethod parse-pattern :filter
-  [[_ & codes] _vars _context]
+  [[_ & codes] _vars context]
   (let [f (->> codes
                (map parse-code)
-               (map eval/compile)
+               (map (fn [code]
+                      (eval/compile code context)))
                (apply every-pred))]
     [(where/->pattern :filter (with-meta f {:fns codes}))]))
 
@@ -407,12 +405,12 @@
         optionals))
 
 (defmethod parse-pattern :bind
-  [[_ & binds] _vars _context]
-  (let [parsed (parse-bind-map binds)]
+  [[_ & binds] _vars context]
+  (let [parsed (parse-bind-map binds context)]
     [(where/->pattern :bind parsed)]))
 
 (defmethod parse-pattern :values
-  [[_ values] vars context]
+  [[_ values] _vars context]
   (let [[_vars solutions] (parse-values values context)]
     [(where/->pattern :values solutions)]))
 
@@ -443,18 +441,18 @@
         (parse-where-clause vars context))))
 
 (defn parse-select-as-fn
-  [f]
+  [f context]
   (let [parsed-fn  (parse-code f)
         fn-name    (some-> parsed-fn second first)
         bind-var   (last parsed-fn)
         aggregate? (when fn-name (eval/allowed-aggregate-fns fn-name))]
     (-> parsed-fn
-        eval/compile
+        (eval/compile context)
         (select/as-selector bind-var aggregate?))))
 
 (defn parse-select-aggregate
-  [f]
-  (-> f parse-code eval/compile select/aggregate-selector))
+  [f context]
+  (-> f parse-code (eval/compile context) select/aggregate-selector))
 
 (defn reverse?
   [context k]
@@ -512,11 +510,11 @@
         :var (-> selector-val symbol select/variable-selector)
         :aggregate (case (first selector-val)
                      :string-fn (if (re-find #"^\(as " s)
-                                  (parse-select-as-fn s)
-                                  (parse-select-aggregate s))
+                                  (parse-select-as-fn s context)
+                                  (parse-select-aggregate s context))
                      :list-fn (if (= 'as (first s))
-                                (parse-select-as-fn s)
-                                (parse-select-aggregate s)))
+                                (parse-select-as-fn s context)
+                                (parse-select-aggregate s context)))
         :select-map (parse-select-map s depth context)))))
 
 (defn parse-select-clause
@@ -577,9 +575,9 @@
                          [v :desc])))))))
 
 (defn parse-having
-  [q]
+  [q context]
   (if-let [code (some-> q :having parse-code)]
-    (assoc q :having (eval/compile code))
+    (assoc q :having (eval/compile code context))
     q))
 
 (defn parse-fuel
@@ -603,7 +601,7 @@
          (cond-> (seq values) (assoc :values values)
                  grouping (assoc :group-by grouping)
                  ordering (assoc :order-by ordering))
-         parse-having
+         (parse-having context)
          (parse-select context)
          parse-fuel))))
 

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -81,10 +81,7 @@
   [v attrs context]
   (let [mch          (parse-value-datatype v attrs context)
         lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
-        dt-matcher   (some-> attrs
-                             (get const/iri-type)
-                             (json-ld/expand-iri context)
-                             where/datatype-matcher)]
+        dt-matcher   (some-> attrs (get const/iri-type) (where/datatype-matcher context))]
     (if-let [f (combine-filters lang-matcher dt-matcher)]
       (where/with-filter mch f)
       mch)))
@@ -256,10 +253,7 @@
 (defn parse-variable-attributes
   [var attrs vars context]
   (let [lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
-        dt-matcher   (some-> attrs
-                             (get const/iri-type)
-                             (json-ld/expand-iri context)
-                             where/datatype-matcher)
+        dt-matcher   (some-> attrs (get const/iri-type) (where/datatype-matcher context))
         filter-fn    (some-> attrs
                              (get const/iri-filter)
                              (parse-filter-function var vars context))]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -353,7 +353,19 @@
             results @(fluree/query db query)]
         (is (= [[36 :xsd/long]]
                results))))
-    (testing "filtering query results with @type value map")))
+    (testing "filtering query results with @type value map"
+      (let [query   {:context [test-utils/default-context
+                               {:ex    "http://example.org/ns/"
+                                :value "@value"
+                                :type  "@type"}]
+                     :select  '[?name ?age]
+                     :where   '[{:ex/name ?name
+                                 :ex/age  {:value ?age
+                                           :type  :xsd/string}}]}
+            results @(fluree/query db query)]
+        (is (= [["Bart" "forever 10"]]
+               results))))
+    (testing "filtering query results with @type value map with variable type")))
 
 (deftest ^:integration subject-object-test
   (let [conn   (test-utils/create-conn)

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -343,7 +343,16 @@
             results @(fluree/query db query)]
         (is (= [[36 :xsd/long] ["forever 10" :xsd/string]]
                results))))
-    (testing "filtering query results with datatype fn")
+    (testing "filtering query results with datatype fn"
+      (let [query   {:context [test-utils/default-context
+                               {:ex "http://example.org/ns/"}]
+                     :select  '[?age ?dt]
+                     :where   '[{:ex/age ?age}
+                                [:bind ?dt (datatype ?age)]
+                                [:filter (= (iri :xsd/long) ?dt)]]}
+            results @(fluree/query db query)]
+        (is (= [[36 :xsd/long]]
+               results))))
     (testing "filtering query results with @type value map")))
 
 (deftest ^:integration subject-object-test

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -320,52 +320,67 @@
                 "returns correctly filtered results")))))))
 
 (deftest ^:integration datatype-test
-  (let [conn   (test-utils/create-conn)
-        ledger @(fluree/create conn "people")
-        db     @(fluree/stage
-                  (fluree/db ledger)
-                  {"@context" ["https://ns.flur.ee"
-                               test-utils/default-context
-                               {:ex "http://example.org/ns/"}]
-                   "insert"
-                   [{:id      :ex/homer
-                     :ex/name "Homer"
-                     :ex/age  36}
-                    {:id      :ex/bart
-                     :ex/name "Bart"
-                     :ex/age  "forever 10"}]})]
-    (testing "including datatype in query results"
-      (let [query   {:context [test-utils/default-context
-                               {:ex "http://example.org/ns/"}]
-                     :select  '[?age ?dt]
-                     :where   '[{:ex/age ?age}
-                                [:bind ?dt (datatype ?age)]]}
-            results @(fluree/query db query)]
-        (is (= [[36 :xsd/long] ["forever 10" :xsd/string]]
-               results))))
-    (testing "filtering query results with datatype fn"
-      (let [query   {:context [test-utils/default-context
-                               {:ex "http://example.org/ns/"}]
-                     :select  '[?age ?dt]
-                     :where   '[{:ex/age ?age}
-                                [:bind ?dt (datatype ?age)]
-                                [:filter (= (iri :xsd/long) ?dt)]]}
-            results @(fluree/query db query)]
-        (is (= [[36 :xsd/long]]
-               results))))
-    (testing "filtering query results with @type value map"
-      (let [query   {:context [test-utils/default-context
-                               {:ex    "http://example.org/ns/"
-                                :value "@value"
-                                :type  "@type"}]
-                     :select  '[?name ?age]
-                     :where   '[{:ex/name ?name
-                                 :ex/age  {:value ?age
-                                           :type  :xsd/string}}]}
-            results @(fluree/query db query)]
-        (is (= [["Bart" "forever 10"]]
-               results))))
-    (testing "filtering query results with @type value map with variable type")))
+  (testing "querying with datatypes"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "people")
+          db     @(fluree/stage
+                    (fluree/db ledger)
+                    {"@context" ["https://ns.flur.ee"
+                                 test-utils/default-context
+                                 {:ex "http://example.org/ns/"}]
+                     "insert"
+                     [{:id      :ex/homer
+                       :ex/name "Homer"
+                       :ex/age  36}
+                      {:id      :ex/bart
+                       :ex/name "Bart"
+                       :ex/age  "forever 10"}]})]
+      (testing "bound to variables in 'bind' patterns"
+        (testing "included datatype in query results"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex "http://example.org/ns/"}]
+                         :select  '[?age ?dt]
+                         :where   '[{:ex/age ?age}
+                                    [:bind ?dt (datatype ?age)]]}
+                results @(fluree/query db query)]
+            (is (= [[36 :xsd/long] ["forever 10" :xsd/string]]
+                   results))))
+        (testing "filtered with the datatype function"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex "http://example.org/ns/"}]
+                         :select  '[?age ?dt]
+                         :where   '[{:ex/age ?age}
+                                    [:bind ?dt (datatype ?age)]
+                                    [:filter (= (iri :xsd/long) ?dt)]]}
+                results @(fluree/query db query)]
+            (is (= [[36 :xsd/long]]
+                   results)))))
+      (testing "filtered in value maps"
+        (testing "with explicit type IRIs"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex    "http://example.org/ns/"
+                                    :value "@value"
+                                    :type  "@type"}]
+                         :select  '[?name ?age]
+                         :where   '[{:ex/name ?name
+                                     :ex/age  {:value ?age
+                                               :type  :xsd/string}}]}
+                results @(fluree/query db query)]
+            (is (= [["Bart" "forever 10"]]
+                   results))))
+        (testing "with variable types"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex    "http://example.org/ns/"
+                                    :value "@value"
+                                    :type  "@type"}]
+                         :select  '[?name ?age]
+                         :where   '[[:bind ?ageType (iri :xsd/string)]
+                                    {:ex/name ?name
+                                     :ex/age  {:value ?age
+                                               :type  ?ageType}}]}
+                results @(fluree/query db query)]
+            (is (= [["Bart" "forever 10"]]
+                   results))))))))
 
 (deftest ^:integration subject-object-test
   (let [conn   (test-utils/create-conn)

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -319,7 +319,7 @@
             (is (= [["ex:bob"]] sut)
                 "returns correctly filtered results")))))))
 
-(deftest ^:integration ^:pending datatype-test
+(deftest ^:integration datatype-test
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "people")
         db     @(fluree/stage
@@ -341,7 +341,7 @@
                      :where   '[{:ex/age ?age}
                                 [:bind ?dt (datatype ?age)]]}
             results @(fluree/query db query)]
-        (is (= [["forever 10" "xsd:string"] [36 "xsd:long"]]
+        (is (= [[36 :xsd/long] ["forever 10" :xsd/string]]
                results))))
     (testing "filtering query results with datatype fn")
     (testing "filtering query results with @type value map")))


### PR DESCRIPTION
This patch adds features for querying with datatypes. There are examples of the added features in the [datatype test](https://github.com/fluree/db/blob/933ced3e47f0df0c8934e586f3a77462e0d82b1b/test/fluree/db/query/fql_test.clj#L322-L383)

First, it adds a `datatype` function that users can use to bind the datatype of a matched object to a variable or for use in more complex functions. It also adds the ability to filter and restrict the datatype of a match in an `@value` map within a triple (similar to how users can set language tags with `@language`).

This patch also adds the `iri` function so that users can explicitly set a string to be an iri within functions because this was essential for allowing users to compare a datatype extracted from the database with one they included in code. More work needs to be done to extend the `iri` function to make it work everywhere a user would expect, but this is just a start.

As an implementation detail, this patch adds a new `IRI` record type that both the `iri` and `datatype` function returns. This enables the type inference code to detect datatypes automatically. I would like to eventually parse all of the iris into `IRI` records because that would unlock more functionality, but that's a monumental task that I think we should take on gradually. 

Beyond that, this patch includes some cleanup of select clause processing because we no longer need to rely on cached sids/iris while displaying values since we changed the way we manage and generate sids a while ago, so there was a lot of dead code that would never be reached. This cleanup also has the advantage of making the display multimethod no longer need to be async. 

I also would like to clean up query processing to unify both value matches and iri matches. This separation was a vestige of previous versions of the database when we couldn't easily compute an iri from an sid or vice versa. Now that we can, this separation is no longer necessary, and I think the code would be much simpler and less error prone without it. I started some of that unification here to deliver these features, but I think finishing it is beyond the scope of this pr. 