### PR TITLE
Feature/sid migration

### DIFF
--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -180,6 +180,10 @@
             (async/put! root-ch e))))
       root-db)))
 
+(defn db?
+  [x]
+  (instance? AsyncDB x))
+
 (def ^String label "#fluree/AsyncDB ")
 
 (defn display

--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -291,16 +291,15 @@
       (if (index/resolved? node)
         (let [updated-ids  (:updated-ids stats)
               written-node (<! (write-node db idx node updated-ids changes-ch error-ch))
-              stats*       (cond-> stats
-                             (not= old-id :empty) (update :garbage conj old-id)
-                             true                 (update :novel inc)
-                             true                 (assoc-in [:updated-ids (:id node)] (:id written-node)))]
+              stats*  (-> stats
+                          (update :novel inc)
+                          (assoc-in [:updated-ids (:id node)] (:id written-node))
+                          (cond-> (not= old-id :empty) (update :garbage conj old-id)))]
           (recur stats*
                  written-node))
         (recur (update stats :unchanged inc)
                node))
       (assoc stats :root (index/unresolve last-node)))))
-
 
 (defn refresh-index
   [{:keys [conn] :as db} changes-ch error-ch {::keys [idx t novelty root]}]

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -367,7 +367,7 @@
   Assumes commit is not yet created (but db is persisted), so
   commit-id and commit-address are added after finalizing and persisting commit."
   [{:keys [old-commit issuer message tag dbid t db-address flakes size author
-           txn-id annotation]
+           txn-id annotation time]
     :as   _commit}]
   (let [prev-data   (select-keys (data old-commit) [:id :address])
         data-commit (new-db-commit dbid t db-address prev-data flakes size)
@@ -377,7 +377,7 @@
                                 :prev-commit)
                         (assoc :address ""
                                :data data-commit
-                               :time (util/current-time-iso)))]
+                               :time time))]
     (cond-> commit
             txn-id (assoc :txn txn-id)
             author (assoc :author author)

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -275,7 +275,7 @@
 
 (defn blank-commit
   "Creates a skeleton blank commit map."
-  [alias branch ns-addresses]
+  [alias branch ns-addresses init-time]
   (let [commit-json  (->json-ld {:alias  alias
                                  :v      0
                                  :branch (if branch
@@ -284,7 +284,7 @@
                                  :data   {:t      0
                                           :flakes 0
                                           :size   0}
-                                 :time   (util/current-time-iso)
+                                 :time   init-time
                                  :ns     (mapv #(if (map? %)
                                                   %
                                                   {:id %})

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -10,6 +10,8 @@
             [fluree.db.query.exec.update :as update]
             [fluree.db.query.exec.where :as where]))
 
+(def commit-version 1)
+
 (comment
   ;; commit map - this map is what gets recorded in a few places:
   ;; - in a 'commit' file: (translated to JSON-LD, and optionally wrapped in a Verifiable Credential)
@@ -59,7 +61,7 @@
   "Note, key-val pairs are in vector form to preserve ordering of final commit map"
   [["@context" "https://ns.flur.ee/ledger/v1"]
    ["id" :id]
-   ["v" 0]
+   ["v" :v]
    ["address" :address]
    ["type" ["Commit"]]
    ["alias" :alias]
@@ -376,6 +378,7 @@
                         (dissoc :id :address :data :issuer :time :message :tag
                                 :prev-commit)
                         (assoc :address ""
+                               :v commit-version
                                :data data-commit
                                :time time))]
     (cond-> commit

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -4,7 +4,7 @@
             [fluree.db.async-db :as async-db]
             [fluree.db.connection :as connection]
             [fluree.db.constants :as const]
-            [fluree.db.flake.flake-db :as db]
+            [fluree.db.flake.flake-db :as flake-db]
             [fluree.db.flake.transact :as flake.transact]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.json-ld.iri :as iri]
@@ -46,17 +46,17 @@
                                  (get-first const/iri-data)
                                  (get-first-value const/iri-address))
 
-          db-data            (<? (db/read-db (:conn db) db-address))
-          t-new              (db/db-t db-data)
+          db-data            (<? (flake-db/read-db (:conn db) db-address))
+          t-new              (flake-db/db-t db-data)
           _ (log/info "Migrating commit " db-address " at t " t-new)
 
           ;; the ns-mapping has all the parts of the db necessary for create-flakes to encode iris properly
           ns-mapping         (db->namespace-mapping db)
 
-          assert             (db/db-assert db-data)
-          asserted-flakes    (db/create-flakes true ns-mapping t-new assert)
-          retract            (db/db-retract db-data)
-          retracted-flakes   (db/create-flakes false ns-mapping t-new retract)
+          assert             (flake-db/db-assert db-data)
+          asserted-flakes    (flake-db/create-flakes true ns-mapping t-new assert)
+          retract            (flake-db/db-retract db-data)
+          retracted-flakes   (flake-db/create-flakes false ns-mapping t-new retract)
 
           {:keys [previous issuer message data] :as commit-metadata}
           (commit-data/json-ld->map commit db)

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -131,11 +131,11 @@
            ledger-alias      (jld-ledger/commit->ledger-alias conn address first-commit)
            branch            (or (keyword (get-first-value first-commit const/iri-branch))
                                  :main)
-           ;; have to release the ledger so we can re-create a blank one with the same name
-           _                 (connection/release-ledger conn ledger-alias)
-           ledger            (<? (jld-ledger/create conn ledger-alias {:did      nil
-                                                                       :branch   branch
-                                                                       :indexing indexing-opts}))
+           ledger            (<? (jld-ledger/create* conn ledger-alias
+                                                     {:did nil
+                                                      :branch branch
+                                                      :indexing indexing-opts
+                                                      ::time (get-first-value first-commit const/iri-time)}))
            tuples-chans      (map (fn [commit-tuple]
                                     [commit-tuple (when changes-ch (async/chan))])
                                   all-commit-tuples)

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -96,7 +96,7 @@
           staged-db          (-> (<? (flake.transact/final-db db all-flakes tx-state))
                                  :db-after
                                  (set-namespaces ns-mapping))]
-      (<? (jld-ledger/commit! ledger staged-db nil)))))
+      (<? (jld-ledger/commit! ledger staged-db {:time (get-first-value commit const/iri-time)})))))
 
 (defn migrate-commits
   "Reduce over each commmit and integrate its data into the ledger's db."

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -1,17 +1,18 @@
 (ns fluree.db.json-ld.migrate.sid
-  (:require [fluree.db.constants :as const]
-            [fluree.db.query.exec.update :as update]
+  (:require [clojure.core.async :as async]
+            [clojure.string :as str]
+            [fluree.db.connection :as connection]
+            [fluree.db.constants :as const]
+            [fluree.db.flake.flake-db :as db]
+            [fluree.db.flake.transact :as flake.transact]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.json-ld.reify :as reify]
             [fluree.db.ledger.json-ld :as jld-ledger]
-            [fluree.db.indexer.default :as indexer]
-            [fluree.db.flake.flake-db :as db]
             [fluree.db.nameservice.core :as nameservice]
-            [fluree.db.util.core :as util :refer [get-first get-first-id get-first-value]]
+            [fluree.db.query.exec.update :as update]
             [fluree.db.util.async :refer [<? go-try]]
-            [fluree.db.util.log :as log :include-macros true]
-            [clojure.core.async :as async]))
+            [fluree.db.util.core :as util :refer [get-first get-first-id get-first-value]]))
 
 (defrecord NamespaceMapping [mapping]
   iri/IRICodec
@@ -21,6 +22,7 @@
     (iri/sid->iri sid (:namespace-codes @mapping))))
 
 (defn db->namespace-mapping
+  "Take only the parts of a db necessary to generate SIDs correctly."
   [db]
   (-> db
       (select-keys [:namespaces :namespace-codes])
@@ -28,102 +30,118 @@
       NamespaceMapping.))
 
 (defn set-namespaces
+  "Take a NamespaceMapping and a db and integrate the state."
   [db ns-mapping]
   (let [{:keys [namespaces namespace-codes]} @(:mapping ns-mapping)]
     (assoc db :namespaces namespaces, :namespace-codes namespace-codes)))
 
-;; (defn merge-commit
-;;   "Process a new commit map, converts commit into flakes, updates
-;;   respective indexes and returns updated db"
-;;   [conn {:keys [alias] :as db} [commit _proof]]
-;;   (go-try
-;;     (let [db-address (-> commit
-;;                          (get-first const/iri-data)
-;;                          (get-first-value const/iri-address))
-;;           _          (log/info "Migrating commit at address:" db-address)
-;;           db-data    (<? (reify/read-db conn db-address))
-;;           t-new      (reify/db-t db-data)
-;;           ns-mapping (db->namespace-mapping db)
+(defn migrate-commit
+  "Turns the data from the commit into flakes and re-generates the commit to include all
+  the necessary information."
+  [ledger db [commit _proof]]
+  (go-try
+    (let [db-address         (-> commit
+                                 (get-first const/iri-data)
+                                 (get-first-value const/iri-address))
 
-;;           assert           (reify/db-assert db-data)
-;;           asserted-flakes  (reify/assert-flakes ns-mapping t-new assert)
-;;           retract          (reify/db-retract db-data)
-;;           retracted-flakes (reify/retract-flakes ns-mapping t-new retract)
-;;           db*              (set-namespaces db ns-mapping)
+          db-data            (<? (db/read-db (:conn db) db-address))
+          t-new              (db/db-t db-data)
 
-;;           {:keys [previous issuer message data] :as commit-metadata}
-;;           (commit-data/json-ld->map commit db*)
+          ;; the ns-mapping has all the parts of the db necessary for create-flakes to encode iris properly
+          ns-mapping         (db->namespace-mapping db)
 
-;;           commit-id          (:id commit-metadata)
-;;           commit-sid         (iri/encode-iri db* commit-id)
-;;           [prev-commit _]    (some->> previous :address (reify/read-commit conn) <?)
-;;           db-sid             (iri/encode-iri db* (:id data))
-;;           metadata-flakes    (commit-data/commit-metadata-flakes commit-metadata
-;;                                                                  t-new commit-sid db-sid)
-;;           previous-id        (when prev-commit (:id prev-commit))
-;;           prev-commit-flakes (when previous-id
-;;                                (commit-data/prev-commit-flakes db* t-new commit-sid
-;;                                                                previous-id))
-;;           prev-data-id       (get-first-id prev-commit const/iri-data)
-;;           prev-db-flakes     (when prev-data-id
-;;                                (commit-data/prev-data-flakes db* db-sid t-new
-;;                                                              prev-data-id))
-;;           issuer-flakes      (when-let [issuer-iri (:id issuer)]
-;;                                (commit-data/issuer-flakes db* t-new commit-sid issuer-iri))
-;;           message-flakes     (when message
-;;                                (commit-data/message-flakes t-new commit-sid message))
-;;           all-flakes         (-> db*
-;;                                  (get-in [:novelty :spot])
-;;                                  empty
-;;                                  (into metadata-flakes)
-;;                                  (into retracted-flakes)
-;;                                  (into asserted-flakes)
-;;                                  (cond->
-;;                                      prev-commit-flakes (into prev-commit-flakes)
-;;                                      prev-db-flakes (into prev-db-flakes)
-;;                                      issuer-flakes  (into issuer-flakes)
-;;                                      message-flakes (into message-flakes)))]
-;;       (when (empty? all-flakes)
-;;         (reify/commit-error "Commit has neither assertions or retractions!"
-;;                       commit-metadata))
-;;       (-> db*
-;;           (reify/merge-flakes t-new all-flakes)
-;;           (assoc :previous (:commit db*))
-;;           (assoc :commit commit-metadata)))))
+          assert             (db/db-assert db-data)
+          asserted-flakes    (db/create-flakes true ns-mapping t-new assert)
+          retract            (db/db-retract db-data)
+          retracted-flakes   (db/create-flakes false ns-mapping t-new retract)
 
-;; (defn merge-commits
-;;   [{:keys [conn indexer] :as ledger} commit-opts tuples-chans]
-;;   (go-try
-;;     (loop [[[commit-tuple ch] & r] tuples-chans
-;;            db                      (db/create ledger)]
-;;       (if commit-tuple
-;;         (let [merged-db     (<? (merge-commit conn db commit-tuple))
-;;               update-commit (commit/update-commit-fn ledger merged-db commit-opts)
-;;               indexed-db    (<? (indexer/do-index indexer merged-db
-;;                                                   {:changes-ch    ch
-;;                                                    :update-commit update-commit}))]
-;;           (recur r indexed-db))
-;;         db))))
+          {:keys [previous issuer message data] :as commit-metadata}
+          (commit-data/json-ld->map commit db)
 
-;; (defn migrate
-;;   [conn address commit-opts changes-ch]
-;;   (go-try
-;;     (let [last-commit-addr  (<? (nameservice/lookup-commit conn address))
-;;           last-commit-tuple (<? (reify/read-commit conn last-commit-addr))
-;;           all-commit-tuples (<? (reify/trace-commits conn last-commit-tuple 1))
-;;           first-commit      (ffirst all-commit-tuples)
-;;           ledger-alias      (jld-ledger/commit->ledger-alias conn address first-commit)
-;;           branch            (or (keyword (get-first-value first-commit const/iri-branch))
-;;                                 :main)
-;;           ledger            (<? (jld-ledger/->ledger conn ledger-alias {:branch branch}))
-;;           commit-opts*      (assoc commit-opts :branch branch)
-;;           tuples-chans      (map (fn [commit-tuple]
-;;                                    [commit-tuple (async/chan)])
-;;                                  all-commit-tuples)
-;;           changes-chs       (map second tuples-chans)
-;;           _                 (-> changes-chs
-;;                                 async/merge
-;;                                 (async/pipe changes-ch))
-;;           db                (<? (merge-commits ledger commit-opts* tuples-chans))]
-;;       (jld-ledger/db-update ledger db)
-;;       ledger)))
+          commit-id          (:id commit-metadata)
+          commit-sid         (iri/encode-iri ns-mapping commit-id)
+
+          db-sid             (iri/encode-iri ns-mapping (:id data))
+          metadata-flakes    (commit-data/commit-metadata-flakes commit-metadata
+                                                                 t-new commit-sid db-sid)
+
+          previous-id        (when previous (:id previous))
+          prev-commit-flakes (when previous-id
+                               (commit-data/prev-commit-flakes db t-new commit-sid
+                                                               previous-id))
+          prev-data-id       (get-first-id previous const/iri-data)
+          prev-db-flakes     (when prev-data-id
+                               (commit-data/prev-data-flakes db db-sid t-new
+                                                             prev-data-id))
+          issuer-flakes      (when-let [issuer-iri (:id issuer)]
+                               (commit-data/issuer-flakes db t-new commit-sid issuer-iri))
+          message-flakes     (when message
+                               (commit-data/message-flakes t-new commit-sid message))
+          all-flakes         (-> db
+                                 (get-in [:novelty :spot])
+                                 empty
+                                 (into metadata-flakes)
+                                 (into retracted-flakes)
+                                 (into asserted-flakes)
+                                 (cond-> prev-commit-flakes (into prev-commit-flakes)
+                                         prev-db-flakes (into prev-db-flakes)
+                                         issuer-flakes (into issuer-flakes)
+                                         message-flakes (into message-flakes)))
+          tx-state           (flake.transact/->tx-state
+                               :db db
+                               :txn (get-first-value commit const/iri-txn)
+                               :author-did (let [author (get-first-value commit const/iri-author)]
+                                             (when-not (str/blank? author) author))
+                               :annotation (get-first-value commit const/iri-annotation))
+          staged-db          (-> (<? (flake.transact/final-db db all-flakes tx-state))
+                                 :db-after
+                                 (set-namespaces ns-mapping))]
+      (<? (jld-ledger/commit! ledger staged-db nil)))))
+
+(defn migrate-commits
+  "Reduce over each commmit and integrate its data into the ledger's db."
+  [ledger branch tuples-chans]
+  (go-try
+    (loop [[[commit-tuple ch] & r] tuples-chans
+           ;; need a FlakeDb, not an AsyncDb
+           db                      (-> (jld-ledger/current-db ledger)
+                                       :db-chan
+                                       <?)]
+      (if commit-tuple
+        (recur r (<? (migrate-commit ledger db commit-tuple)))
+        db))))
+
+(defn migrate
+  "Migrate the ledger at the designated address. changes-ch, if provided, will return a
+  stream of updated index nodes.
+
+  Old commits are lacking the f:namespaces key in the commit data file, and also lack a
+  link to the genesis commit from t1. Also, the flakes stored in the index files are not
+  compact SIDs. This migration traverses the commit chain and holds them all in memory,
+  then processes each one, properly generating the necessary namespace codes for SIDs
+  along the way and rewriting the commit chain to use the newer commit structure."
+  ([conn address indexing-opts]
+   (migrate conn address indexing-opts nil))
+  ([conn address indexing-opts changes-ch]
+   (go-try
+     (let [last-commit-addr  (<? (nameservice/lookup-commit conn address))
+           last-commit-tuple (<? (reify/read-commit conn last-commit-addr))
+           all-commit-tuples (<? (reify/trace-commits conn last-commit-tuple 1))
+           first-commit      (ffirst all-commit-tuples)
+           ledger-alias      (jld-ledger/commit->ledger-alias conn address first-commit)
+           branch            (or (keyword (get-first-value first-commit const/iri-branch))
+                                 :main)
+           ;; have to release the ledger so we can re-create a blank one with the same name
+           _                 (connection/release-ledger conn ledger-alias)
+           ledger            (<? (jld-ledger/create conn ledger-alias {:did      nil
+                                                                       :branch   branch
+                                                                       :indexing indexing-opts}))
+           tuples-chans      (map (fn [commit-tuple]
+                                    [commit-tuple (when changes-ch (async/chan))])
+                                  all-commit-tuples)
+           indexed-db        (<? (migrate-commits ledger branch tuples-chans))]
+       (when changes-ch
+         (-> (map second tuples-chans)
+             async/merge
+             (async/pipe changes-ch)))
+       ledger))))

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -110,7 +110,10 @@
   [ledger branch tuples-chans]
   (go-try
     (loop [[[commit-tuple ch] & r] tuples-chans
-           db (<? (async-db/deref-async (jld-ledger/current-db ledger)))]
+           db (let [current-db (jld-ledger/current-db ledger)]
+                (if (async-db/db? current-db)
+                  (<? (async-db/deref-async current-db))
+                  current-db))]
       (if commit-tuple
         (recur r (<? (migrate-commit ledger db commit-tuple)))
         db))))

--- a/src/clj/fluree/db/nameservice/filesystem.cljc
+++ b/src/clj/fluree/db/nameservice/filesystem.cljc
@@ -194,20 +194,6 @@ changes from different branches into existing metadata map"
 
         commit-address))))
 
-(defn legacy-lookup2
-  "Return the commit address from the given ledger's head. Only supports the 'main'
-  branch. Creates a nameservice record for the ledger and writes it to the ledger's head
-  address."
-  [local-path ledger-address]
-  (go-try
-    (let [ledger-path (address-path ledger-address)]
-      (when-let [commit-path (<? (fs/read-file (str local-path "/" ledger-path)))]
-        (let [ledger-alias   (subs ledger-path 0 (- (count ledger-path) 10 #_(count "/main/head")))
-              commit-address (str "fluree:file://" commit-path)]
-          ;; write out new nameservice record
-          (convert-legacy-ns-record ledger-alias commit-address local-path ledger-path)
-          commit-address)))))
-
 (defn lookup
   "Return the commit address from the nameservice record for the provided ledger
   address. If no nameservice record is found, throws an error."
@@ -220,8 +206,7 @@ changes from different branches into existing metadata map"
             (throw (ex-info (str "No nameservice record found for ledger alias: " ledger-address)
                             {:status 404 :error :db/ledger-not-found})))
         ;; Note, below is for leagacy conversion only, will get removed in v3 GA
-        (or (<? (try-legacy-ns-lookup local-path alias))
-            (<? (legacy-lookup2 local-path ledger-address)))))))
+        (<? (try-legacy-ns-lookup local-path alias))))))
 
 
 (defrecord FileNameService

--- a/src/clj/fluree/db/nameservice/filesystem.cljc
+++ b/src/clj/fluree/db/nameservice/filesystem.cljc
@@ -194,26 +194,41 @@ changes from different branches into existing metadata map"
 
         commit-address))))
 
-(defn lookup
-  "When provided a 'relative' ledger alias, looks in file system to see if
-  nameservice file exists and if so returns the latest commit address."
-  [ns-address local-path base-address {:keys [branch] :as _opts}]
+(defn legacy-lookup2
+  "Return the commit address from the given ledger's head. Only supports the 'main'
+  branch. Creates a nameservice record for the ledger and writes it to the ledger's head
+  address."
+  [local-path ledger-address]
   (go-try
-    (let [{:keys [alias branch* address]} (resolve-address base-address ns-address branch)
+    (let [ledger-path (address-path ledger-address)]
+      (when-let [commit-path (<? (fs/read-file (str local-path "/" ledger-path)))]
+        (let [ledger-alias   (subs ledger-path 0 (- (count ledger-path) 10 #_(count "/main/head")))
+              commit-address (str "fluree:file://" commit-path)]
+          ;; write out new nameservice record
+          (convert-legacy-ns-record ledger-alias commit-address local-path ledger-path)
+          commit-address)))))
+
+(defn lookup
+  "Return the commit address from the nameservice record for the provided ledger
+  address. If no nameservice record is found, throws an error."
+  [ledger-address local-path base-address {:keys [branch] :as _opts}]
+  (go-try
+    (let [{:keys [alias branch* address]} (resolve-address base-address ledger-address branch)
           ns-record (<? (retrieve-ns-record local-path alias))]
       (if ns-record
         (or (commit-address-from-record ns-record branch*)
-            (throw (ex-info (str "No nameservice record found for ledger alias: " ns-address)
+            (throw (ex-info (str "No nameservice record found for ledger alias: " ledger-address)
                             {:status 404 :error :db/ledger-not-found})))
         ;; Note, below is for leagacy conversion only, will get removed in v3 GA
-        (<? (try-legacy-ns-lookup local-path alias))))))
+        (or (<? (try-legacy-ns-lookup local-path alias))
+            (<? (legacy-lookup2 local-path ledger-address)))))))
 
 
 (defrecord FileNameService
   [local-path sync? base-address]
   ns-proto/iNameService
-  (-lookup [_ ledger-alias] (lookup ledger-alias local-path base-address nil))
-  (-lookup [_ ledger-alias opts] (lookup ledger-alias local-path base-address opts))
+  (-lookup [_ ledger-address] (lookup ledger-address local-path base-address nil))
+  (-lookup [_ ledger-address opts] (lookup ledger-address local-path base-address opts))
   (-push [_ commit-data] (push! local-path base-address commit-data))
   (-subscribe [nameservice ledger-alias callback] (throw (ex-info "Unsupported FileNameService op: subscribe" {})))
   (-unsubscribe [nameservice ledger-alias] (throw (ex-info "Unsupported FileNameService op: unsubscribe" {})))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -322,7 +322,7 @@
                                       :f/previous {:id test-utils/db-id?}
                                       :id         test-utils/db-id?}
                           :f/time    720000
-                          :f/v       0
+                          :f/v       1
                           :id        test-utils/commit-id?}}]
              @(fluree/history ledger {:context        context
                                       :commit-details true
@@ -346,7 +346,7 @@
                                    :f/message                                   "meow"
                                    :f/previous                                  {:id test-utils/commit-id?}
                                    :f/time                                      720000
-                                   :f/v                                         0
+                                   :f/v                                         1
                                    :id                                          test-utils/commit-id?}}
               commit-4 {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                                    {:id test-utils/did?}
@@ -365,7 +365,7 @@
                                                 :id         test-utils/db-id?}
                                    :f/previous {:id test-utils/commit-id?}
                                    :f/time     720000
-                                   :f/v        0
+                                   :f/v        1
                                    :id         test-utils/commit-id?}}]
           (is (pred-match?
                [commit-4 commit-5]
@@ -404,7 +404,7 @@
                                           :id         test-utils/db-id?}
                              :f/previous {:id test-utils/commit-id?}
                              :f/time     720000
-                             :f/v        0
+                             :f/v        1
                              :id         test-utils/commit-id?}}
                  c4)))
           (is (pred-match?
@@ -427,7 +427,7 @@
                                         :id         test-utils/db-id?}
                            :f/previous {:id test-utils/commit-id?}
                            :f/time     720000
-                           :f/v        0
+                           :f/v        1
                            :id         test-utils/commit-id?}}
                c3))
           (is (pred-match?
@@ -450,7 +450,7 @@
                                         :id         test-utils/db-id?}
                            :f/previous {:id test-utils/commit-id?}
                            :f/time     720000
-                           :f/v        0
+                           :f/v        1
                            :id         test-utils/commit-id?}}
                c2))))
 
@@ -473,7 +473,7 @@
                                        :id         test-utils/db-id?}
                           :f/previous {:id test-utils/commit-id?}
                           :f/time     720000
-                          :f/v        0
+                          :f/v        1
                           :id         test-utils/commit-id?}}
               {:f/commit {"https://www.w3.org/2018/credentials#issuer"
                           {:id test-utils/did?}
@@ -495,7 +495,7 @@
                           :f/message  "meow"
                           :f/previous {:id test-utils/commit-id?}
                           :f/time     720000
-                          :f/v        0
+                          :f/v        1
                           :id         test-utils/commit-id?}}]
              @(fluree/history ledger {:context        context
                                       :commit-details true
@@ -520,7 +520,7 @@
                                        :f/previous {:id test-utils/db-id?}
                                        :id         test-utils/db-id?}
                           :f/time     720000
-                          :f/v        0
+                          :f/v        1
                           :id         test-utils/commit-id?}}]
              @(fluree/history ledger {:context        context
                                       :commit-details true
@@ -550,7 +550,7 @@
                                          :id         test-utils/db-id?}
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/v        0
+                            :f/v        1
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-2"
                              :ex/y "bar-2"
@@ -579,7 +579,7 @@
                             :f/message  "meow"
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/v        0
+                            :f/v        1
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-3"
                              :ex/y "bar-3"
@@ -674,7 +674,7 @@
                                          :id         test-utils/db-id?}
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/v        0
+                            :f/v        1
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-2"
                              :ex/y "bar-2"
@@ -701,7 +701,7 @@
                             :f/message  "meow"
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/v        0
+                            :f/v        1
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-3"
                              :ex/y "bar-3"
@@ -774,7 +774,7 @@
                                          :id         test-utils/db-id?}
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/v        0
+                            :f/v        1
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-2"
                              :ex/y "bar-2"
@@ -803,7 +803,7 @@
                             :f/message  "meow"
                             :f/previous {:id test-utils/commit-id?}
                             :f/time     720000
-                            :f/v        0
+                            :f/v        1
                             :id         test-utils/commit-id?}
                   :retract [{:ex/x "foo-3"
                              :ex/y "bar-3"
@@ -889,7 +889,7 @@
                                                        :id         test-utils/db-id?}
                                           :f/previous {:id test-utils/commit-id?}
                                           :f/time     720000
-                                          :f/v        0
+                                          :f/v        1
                                           :id         test-utils/commit-id?}
                                 :retract [{:ex/x "foo-2"
                                            :ex/y "bar-2"
@@ -918,7 +918,7 @@
                                           :f/message  "meow"
                                           :f/previous {:id test-utils/commit-id?}
                                           :f/time     720000
-                                          :f/v        0
+                                          :f/v        1
                                           :id         test-utils/commit-id?}
                                 :retract [{:ex/x "foo-3"
                                            :ex/y "bar-3"
@@ -1054,7 +1054,7 @@
                  "f:time"     720000,
                  "f:previous" {"id" test-utils/commit-id?},
                  "id"         test-utils/commit-id?
-                 "f:v"        0,
+                 "f:v"        1,
                  "f:branch"   "main",
                  "f:address"  test-utils/address?
                  "f:data"
@@ -1071,7 +1071,7 @@
                  "f:txn"      test-utils/address?
                  "f:previous" {"id" test-utils/commit-id?}
                  "id"         test-utils/commit-id?
-                 "f:v"        0,
+                 "f:v"        1,
                  "f:branch"   "main",
                  "f:address"  test-utils/address?
                  "f:data"
@@ -1088,7 +1088,7 @@
                  "f:txn"      test-utils/address?
                  "f:previous" {"id" test-utils/commit-id?},
                  "id"         test-utils/commit-id?
-                 "f:v"        0,
+                 "f:v"        1,
                  "f:branch"   "main",
                  "f:address"  test-utils/address?
                  "f:data"
@@ -1144,7 +1144,7 @@
                  "f:time"     720000,
                  "f:previous" {"id" test-utils/commit-id?},
                  "id"         test-utils/commit-id?
-                 "f:v"        0,
+                 "f:v"        1,
                  "f:branch"   "main",
                  "f:address"  test-utils/address?
                  "f:data"
@@ -1187,7 +1187,7 @@
                  "f:txn"      test-utils/address?
                  "f:previous" {"id" test-utils/commit-id?},
                  "id"         test-utils/commit-id?
-                 "f:v"        0,
+                 "f:v"        1,
                  "f:branch"   "main",
                  "f:address"  test-utils/address?
                  "f:data"
@@ -1208,7 +1208,7 @@
                  "f:txn"      test-utils/address?
                  "f:previous" {"id" test-utils/commit-id?},
                  "id"         test-utils/commit-id?
-                 "f:v"        0,
+                 "f:v"        1,
                  "f:branch"   "main",
                  "f:address"  test-utils/address?
                  "f:data"
@@ -1239,7 +1239,7 @@
                              "f:time"     720000,
                              "f:previous" {"id" test-utils/commit-id?},
                              "id"         test-utils/commit-id?
-                             "f:v"        0,
+                             "f:v"        1,
                              "f:branch"   "main",
                              "f:address"  test-utils/address?
                              "f:data"
@@ -1292,7 +1292,7 @@
                              "f:time"     720000,
                              "f:previous" {"id" test-utils/commit-id?},
                              "id"         test-utils/commit-id?
-                             "f:v"        0,
+                             "f:v"        1,
                              "f:branch"   "main",
                              "f:address"  test-utils/address?
                              "f:data"

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -188,30 +188,30 @@
                  ["fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"
                   :f/t
                   1]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   "https://www.w3.org/2018/credentials#issuer"
                   "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/address
-                  "fluree:memory://322ca14416b1a885bd87c1d0be9b6bf2a56432fef2456b53e06a335d0aa5b7d5"]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                  "fluree:memory://cfd9757eacc9398a0b64217e96cdb7f9d629599b648090aff252b7a9f73c3a9c"]
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/alias
                   "query/everything"]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/branch
                   "main"]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/data
                   "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/previous
                   "fluree:commit:sha256:bvvou3uvnd6ffhehsrw23mw4w3fux5jbpacko2ecosb2nzxkfu5v"]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/time
                   720000]
-                 ["fluree:commit:sha256:bbebuepz3rvtndg3ouopnpzuvwogygngg773ugln7twvzw4czyja7"
+                 ["fluree:commit:sha256:bu4jgqyidpq65yhjm3iz74qegosata3wdhy5frchfwsxtst4p2f"
                   :f/v
-                  0]
+                  1]
                  [:ex/alice :type :ex/User]
                  [:ex/alice :schema/age 42]
                  [:ex/alice :schema/email "alice@flur.ee"]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,10 +28,10 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bby2vwaws2jotvncr2s6f2h7xgoba5yzmbc2iiceryc6ib4xnyci4"
+        (is (= "fluree:commit:sha256:bbtmf2ndsyhnrhpozswy7asxrctv7bjedkx4re7c3zustebtwu5av"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://77de4933247471aaac184ae88aa510e2639d04316ec47c2e1dab4f370076f83c"
+        (is (= "fluree:memory://1680629d3d6699f7fa4c622f22870a30bac9f50e9d6c69164c153a712593c91e"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
         (is (= "fluree:db:sha256:bbsfu5hq2mkalfpirabumzsohpwwz3legce6hie6tpb6nlqwvzigc"


### PR DESCRIPTION
We've changed several things since v3, and this is a tool to bring existing v3 ledgers up to compatibility with main.

When this migration is run, it will:
1. generate a nameserver record for the ledger head
2. create a new genesis commit for the ledger
3. process each commit in order in order to:
    - generate index nodes that have correctly serialized SIDs
    - update commit data with new namespace codes
    - remove empty string author entries
    - correctly link to the previous commit, including the new genesis commit
 
Afterwards the old files will be left behind in the `<ledger>/<branch>` directory, which can be safely delete manually once everything is confirmed to be working correctly. We may write an additional migration in the future to delete the legacy data directory.