### PR TITLE
Inline Transaction Filtering

### DIFF
--- a/src/clj/fluree/db/constants.cljc
+++ b/src/clj/fluree/db/constants.cljc
@@ -77,6 +77,7 @@
 (def ^:const iri-class "http://www.w3.org/2000/01/rdf-schema#Class")
 (def ^:const iri-lang-string "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
 (def ^:const iri-string "http://www.w3.org/2001/XMLSchema#string")
+(def ^:const iri-long "http://www.w3.org/2001/XMLSchema#long")
 
 ;; rdfs
 (def ^:const iri-rdfs:Class "http://www.w3.org/2000/01/rdf-schema#Class")
@@ -255,7 +256,7 @@
 ;; major types (a) ref, (b) string, (c) number, (d) boolean
 ;; xsd common types
 (def ^:const $xsd:anyURI (iri/iri->sid iri-anyURI))
-(def ^:const $xsd:string (iri/iri->sid "http://www.w3.org/2001/XMLSchema#string"))
+(def ^:const $xsd:string (iri/iri->sid iri-string))
 (def ^:const $xsd:boolean (iri/iri->sid "http://www.w3.org/2001/XMLSchema#boolean"))
 (def ^:const $xsd:date (iri/iri->sid "http://www.w3.org/2001/XMLSchema#date"))
 (def ^:const $xsd:dateTime (iri/iri->sid "http://www.w3.org/2001/XMLSchema#dateTime"))
@@ -263,7 +264,7 @@
 (def ^:const $xsd:decimal (iri/iri->sid "http://www.w3.org/2001/XMLSchema#decimal"))
 (def ^:const $xsd:double (iri/iri->sid "http://www.w3.org/2001/XMLSchema#double"))
 (def ^:const $xsd:integer (iri/iri->sid "http://www.w3.org/2001/XMLSchema#integer"))
-(def ^:const $xsd:long (iri/iri->sid "http://www.w3.org/2001/XMLSchema#long"))
+(def ^:const $xsd:long (iri/iri->sid iri-long))
 (def ^:const $xsd:int (iri/iri->sid "http://www.w3.org/2001/XMLSchema#int"))
 (def ^:const $xsd:short (iri/iri->sid "http://www.w3.org/2001/XMLSchema#short"))
 (def ^:const $xsd:float (iri/iri->sid "http://www.w3.org/2001/XMLSchema#float"))

--- a/src/clj/fluree/db/constants.cljc
+++ b/src/clj/fluree/db/constants.cljc
@@ -12,7 +12,7 @@
 (def ^:const iri-commit (fluree-iri "commit"))
 (def ^:const iri-DB (fluree-iri "DB"))
 (def ^:const iri-data (fluree-iri "data"))
-(def ^:const iri-t (fluree-iri "t"))
+(def ^:const iri-fluree-t (fluree-iri "t"))
 (def ^:const iri-address (fluree-iri "address"))
 (def ^:const iri-v (fluree-iri "v"))
 (def ^:const iri-flakes (fluree-iri "flakes"))
@@ -149,7 +149,7 @@
 (def ^:const $_commit:data (iri/iri->sid iri-data))
 (def ^:const $_commitdata:flakes (iri/iri->sid iri-flakes))
 (def ^:const $_commitdata:size (iri/iri->sid iri-size))
-(def ^:const $_commitdata:t (iri/iri->sid iri-t))
+(def ^:const $_commitdata:t (iri/iri->sid iri-fluree-t))
 
 (def ^:const $id (iri/iri->sid iri-id))
 

--- a/src/clj/fluree/db/constants.cljc
+++ b/src/clj/fluree/db/constants.cljc
@@ -70,6 +70,7 @@
 (def ^:const iri-language "@language")
 (def ^:const iri-type "@type")
 (def ^:const iri-filter "@filter")
+(def ^:const iri-t "@t")
 (def ^:const iri-json "http://www.w3.org/2001/XMLSchema#json")
 (def ^:const iri-anyURI "http://www.w3.org/2001/XMLSchema#anyURI")
 (def ^:const iri-rdf-type "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")

--- a/src/clj/fluree/db/datatype.cljc
+++ b/src/clj/fluree/db/datatype.cljc
@@ -353,8 +353,10 @@
       value)
 
     const/$xsd:anyURI
-    (when (string? value)
-      value)
+    (if (iri/iri? value)
+      value
+      (when (string? value)
+        (iri/string->iri value)))
 
     const/$xsd:boolean
     (coerce-boolean value)

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -190,7 +190,7 @@
 (defn db-t
   "Returns 't' value from commit data."
   [db-data]
-  (let [t (get-first-value db-data const/iri-t)]
+  (let [t (get-first-value db-data const/iri-fluree-t)]
     (when-not (pos-int? t)
       (commit-error
        (str "Invalid, or non existent 't' value inside commit: " t) db-data))
@@ -589,7 +589,7 @@
                          indexed-db)
            commit-t    (-> commit-jsonld
                            (get-first const/iri-data)
-                           (get-first-value const/iri-t))
+                           (get-first-value const/iri-fluree-t))
            index-t     (:t indexed-db*)]
        (if (= commit-t index-t)
          indexed-db*
@@ -723,7 +723,7 @@
   "Creates the JSON-LD map containing a new ledger update"
   [{:keys [t commit stats staged] :as db}
    {:keys [type-key compact ctx-used-atom id-key] :as commit-opts}]
-  (let [prev-dbid   (commit-data/data-id commit)
+  (let [prev-dbid (commit-data/data-id commit)
 
         {:keys [assert retract refs-ctx]}
         (generate-commit db commit-opts)
@@ -732,20 +732,20 @@
         assert-key  (compact const/iri-assert)
         retract-key (compact const/iri-retract)
         refs-ctx*   (cond-> refs-ctx
-                      prev-dbid (assoc-in [prev-db-key "@type"] "@id")
-                      (seq assert) (assoc-in [assert-key "@container"] "@graph")
+                      prev-dbid     (assoc-in [prev-db-key "@type"] "@id")
+                      (seq assert)  (assoc-in [assert-key "@container"] "@graph")
                       (seq retract) (assoc-in [retract-key "@container"] "@graph"))
         nses        (new-namespaces db)
         db-json     (cond-> {id-key                nil ;; comes from hash later
                              type-key              [(compact const/iri-DB)]
-                             (compact const/iri-t) t
+                             (compact const/iri-fluree-t) t
                              (compact const/iri-v) data-version}
-                      prev-dbid (assoc prev-db-key prev-dbid)
-                      (seq assert) (assoc assert-key assert)
-                      (seq retract) (assoc retract-key retract)
-                      (seq nses) (assoc (compact const/iri-namespaces) nses)
+                      prev-dbid       (assoc prev-db-key prev-dbid)
+                      (seq assert)    (assoc assert-key assert)
+                      (seq retract)   (assoc retract-key retract)
+                      (seq nses)      (assoc (compact const/iri-namespaces) nses)
                       (:flakes stats) (assoc (compact const/iri-flakes) (:flakes stats))
-                      (:size stats) (assoc (compact const/iri-size) (:size stats)))
+                      (:size stats)   (assoc (compact const/iri-size) (:size stats)))
         ;; TODO - this is re-normalized below, can try to do it just once
         dbid        (commit-data/db-json->db-id db-json)
         db-json*    (-> db-json

--- a/src/clj/fluree/db/flake/history.cljc
+++ b/src/clj/fluree/db/flake/history.cljc
@@ -62,7 +62,7 @@
                          (group-by flake/t)
                          (vals)
                          (async/to-chan!))
-        t-key       (json-ld/compact const/iri-t compact)
+        t-key       (json-ld/compact const/iri-fluree-t compact)
         assert-key  (json-ld/compact const/iri-assert compact)
         retract-key (json-ld/compact const/iri-retract compact)]
 
@@ -209,7 +209,7 @@
 
            assert-key          (json-ld/compact const/iri-assert compact)
            retract-key         (json-ld/compact const/iri-retract compact)
-           t-key               (json-ld/compact const/iri-t compact)
+           t-key               (json-ld/compact const/iri-fluree-t compact)
            data-key            (json-ld/compact const/iri-data compact)
            commit-key          (json-ld/compact const/iri-commit compact)
            annotation-key      (json-ld/compact const/iri-annotation compact)]
@@ -279,7 +279,7 @@
   Chunks together history results with consecutive `t`s to reduce `time-range`
   calls. "
   [db context include error-ch history-results-ch]
-  (let [t-key      (json-ld/compact const/iri-t context)
+  (let [t-key      (json-ld/compact const/iri-fluree-t context)
         out-ch     (async/chan 2 cat)
         chunked-ch (async/chan 2 (with-consecutive-ts t-key))]
     (async/pipe history-results-ch chunked-ch)

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -168,7 +168,7 @@
 (defn parse-db-data
   [data]
   {:id      (:id data)
-   :t       (get-first-value data const/iri-t)
+   :t       (get-first-value data const/iri-fluree-t)
    :address (get-first-value data const/iri-address)
    :flakes  (get-first-value data const/iri-flakes)
    :size    (get-first-value data const/iri-size)})

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -2,6 +2,7 @@
   (:require [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
             [fluree.db.util.bytes :as bytes]
+            [fluree.json-ld :as json-ld]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.set :refer [map-invert]]
@@ -50,6 +51,12 @@
 
 (defmethod pprint/simple-dispatch IRI [^IRI iri]
   (pr iri))
+
+(defn expand
+  [compact-string context]
+  (-> compact-string
+      (json-ld/expand-iri context)
+      string->iri))
 
 (def ^:const f-ns "https://ns.flur.ee/ledger#")
 (def ^:const f-t-ns "https://ns.flur.ee/ledger/transaction#")

--- a/src/clj/fluree/db/json_ld/reify.cljc
+++ b/src/clj/fluree/db/json_ld/reify.cljc
@@ -62,7 +62,7 @@
                                  (get-first-value const/iri-address))
             commit-t         (-> commit
                                  (get-first const/iri-data)
-                                 (get-first-value const/iri-t))
+                                 (get-first-value const/iri-fluree-t))
             commit-tuples*   (conj commit-tuples [commit proof])]
         (when (or (nil? commit-t)
                   (and last-t (not= (dec last-t) commit-t)))

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -239,7 +239,7 @@
                          keyword)
           commit-t   (-> expanded-commit
                          (get-first const/iri-data)
-                         (get-first-value const/iri-t))
+                         (get-first-value const/iri-fluree-t))
           current-db (current-db ledger branch)
           current-t  (:t current-db)]
       (log/debug "notify of new commit for ledger:" (:alias ledger) "at t value:" commit-t

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -301,9 +301,7 @@
 
 (defmacro iri
   [s]
-  `(-> ~s
-       (json-ld/expand-iri ~context-var)
-       iri/string->iri))
+  `(iri/expand ~s ~context-var))
 
 (def allowed-scalar-fns
   '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang
@@ -329,8 +327,7 @@
   (set/union allowed-aggregate-fns allowed-scalar-fns))
 
 (def qualified-symbols
-  '{
-    !              fluree.db.query.exec.eval/!
+  '{!              fluree.db.query.exec.eval/!
     ||             fluree.db.query.exec.eval/||
     &&             fluree.db.query.exec.eval/&&
     abs            clojure.core/abs

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -169,7 +169,7 @@
     (let [lang* (if (variable? lang)
                   (-> soln (get lang) get-value)
                   lang)]
-      (-> mch ::meta :lang (= lang*)))))
+      (-> mch get-meta :lang (= lang*)))))
 
 (defn datatype-matcher
   "Return a function that returns true if the datatype of a matched pattern equals
@@ -182,6 +182,14 @@
       (-> mch
           get-datatype-iri
           (= type*)))))
+
+(defn transaction-matcher
+  [t]
+  (fn [soln mch]
+    (let [t* (if (variable? t)
+                  (-> soln (get t) get-value)
+                  t)]
+      (-> mch get-transaction (= t*)))))
 
 (defn with-filter
   [mch f]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -24,10 +24,12 @@
   (assoc unmatched ::var var-sym))
 
 (defn match-value
-  [mch x dt-iri]
-  (assoc mch
-         ::val x
-         ::datatype-iri dt-iri))
+  ([mch x]
+   (assoc mch ::val x))
+  ([mch x dt-iri]
+   (-> mch
+       (match-value x)
+       (assoc ::datatype-iri dt-iri))))
 
 (defn matched-value?
   [match]
@@ -129,6 +131,10 @@
   "Returns true if the triple pattern component `match` represents a variable
   without an associated value."
   (complement matched?))
+
+(defn untyped-value
+  [v]
+  (match-value unmatched v))
 
 (defn anonymous-value
   "Build a pattern that already matches an explicit value."

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -96,7 +96,7 @@
   [mch value lang]
   (-> mch
       (match-value value const/iri-lang-string)
-      (match-meta {:lang lang})))
+      (update ::meta assoc :lang lang)))
 
 (defn get-lang
   [mch]
@@ -148,6 +148,34 @@
   [match]
   (and (contains? match ::var)
        (unmatched? match)))
+
+(defn link-var
+  [mch var-type var]
+  (assoc-in mch [::linked-vars var-type] var))
+
+(defn get-linked-vars
+  [mch]
+  (::linked-vars mch))
+
+(defn linked-vars?
+  [mch]
+  (contains? mch ::linked-vars))
+
+(defn unlink-vars
+  [mch]
+  (dissoc mch ::linked-vars))
+
+(defn link-lang-var
+  [mch var]
+  (link-var mch :lang var))
+
+(defn link-dt-var
+  [mch var]
+  (link-var mch :dt var))
+
+(defn link-t-var
+  [mch var]
+  (link-var mch :t var))
 
 (defn sanitize-match
   [match]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -96,6 +96,10 @@
       (match-value value const/iri-lang-string)
       (match-meta {:lang lang})))
 
+(defn get-lang
+  [mch]
+  (-> mch get-meta (get :lang)))
+
 (defn match-transaction
   [mch t]
   (assoc mch ::t t))

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -349,19 +349,19 @@
   "Matches the object, data type, and metadata of the supplied `flake` to the
   triple object pattern component `o-match`."
   [o-match db flake]
-  (let [dt (flake/dt flake)]
+  (let [o-match* (-> o-match
+                     (match-transaction (flake/t flake))
+                     (match-meta (flake/m flake)))
+        dt (flake/dt flake)]
     (if (= const/$xsd:anyURI dt)
       (let [alias (:alias db)
             oid   (flake/o flake)
             o-iri (iri/decode-sid db oid)]
-        (-> o-match
+        (-> o-match*
             (match-sid alias oid)
             (match-iri o-iri)))
       (let [dt-iri (iri/decode-sid db dt)]
-        (-> o-match
-            (match-value (flake/o flake) dt-iri)
-            (match-transaction (flake/t flake))
-            (match-meta (flake/m flake)))))))
+        (match-value o-match* (flake/o flake) dt-iri)))))
 
 (defn match-linked-datatype
   [var db flake]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -24,14 +24,10 @@
   (assoc unmatched ::var var-sym))
 
 (defn match-value
-  ([mch x dt-iri]
-   (assoc mch
-     ::val x
-     ::datatype-iri dt-iri))
-  ([mch x dt-iri m]
-   (-> mch
-       (match-value x dt-iri)
-       (assoc ::meta m))))
+  [mch x dt-iri]
+  (assoc mch
+         ::val x
+         ::datatype-iri dt-iri))
 
 (defn matched-value?
   [match]
@@ -86,6 +82,20 @@
   (let [db-alias (:alias db)]
     (get-in iri-mch [::sids db-alias])))
 
+(defn match-meta
+  [mch m]
+  (assoc mch ::meta m))
+
+(defn get-meta
+  [match]
+  (::meta match))
+
+(defn match-lang
+  [mch value lang]
+  (-> mch
+      (match-value value const/iri-lang-string)
+      (match-meta {:lang lang})))
+
 (defn matched?
   [match]
   (or (matched-value? match)
@@ -114,18 +124,12 @@
    (let [dt-iri (datatype/infer-iri v)]
      (anonymous-value v dt-iri)))
   ([v dt-iri]
-   (match-value unmatched v dt-iri))
-  ([v dt-iri m]
-   (match-value unmatched v dt-iri m)))
+   (match-value unmatched v dt-iri)))
 
 (defn unmatched-var?
   [match]
   (and (contains? match ::var)
        (unmatched? match)))
-
-(defn get-meta
-  [match]
-  (::meta match))
 
 (defn sanitize-match
   [match]
@@ -286,7 +290,9 @@
             (match-sid alias oid)
             (match-iri o-iri)))
       (let [dt-iri (iri/decode-sid db dt)]
-        (match-value o-match (flake/o flake) dt-iri (flake/m flake))))))
+        (-> o-match
+            (match-value (flake/o flake) dt-iri)
+            (match-meta (flake/m flake)))))))
 
 (defn match-flake
   "Assigns the unmatched variables within the supplied `triple-pattern` to their

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -348,54 +348,50 @@
     [o o-fn]))
 
 (defn resolve-flake-range
-  ([db fuel-tracker error-ch components]
-   (resolve-flake-range db fuel-tracker nil error-ch components))
+  [{:keys [t] :as db} fuel-tracker error-ch [s-mch p-mch o-mch]]
+  (let [s    (get-sid s-mch db)
+        s-fn (::fn s-mch)
+        p    (get-sid p-mch db)
+        p-fn (::fn p-mch)
+        o    (or (get-value o-mch)
+                 (get-sid o-mch db))
+        o-fn (::fn o-mch)
+        o-dt (some->> o-mch get-datatype-iri (iri/encode-iri db))
 
-  ([{:keys [t] :as db} fuel-tracker flake-xf error-ch [s-mch p-mch o-mch]]
-   (let [s    (get-sid s-mch db)
-         s-fn (::fn s-mch)
-         p    (get-sid p-mch db)
-         p-fn (::fn p-mch)
-         o    (or (get-value o-mch)
-                  (get-sid o-mch db))
-         o-fn (::fn o-mch)
-         o-dt (some->> o-mch get-datatype-iri (iri/encode-iri db))
-
-         idx         (try* (index/for-components s p o o-dt)
-                           (catch* e
-                             (log/error e "Error resolving flake range")
-                             (async/put! error-ch e)))
-         [o* o-fn*]  (augment-object-fn db idx s p o o-fn)
-         start-flake (flake/create s p o* o-dt nil nil util/min-integer)
-         end-flake   (flake/create s p o* o-dt nil nil util/max-integer)
-         track-fuel  (when fuel-tracker
-                       (fuel/track fuel-tracker error-ch))
-         subj-filter (when s-fn
-                       (filter (fn [f]
-                                 (-> unmatched
-                                     (match-subject db f)
-                                     s-fn))))
-         pred-filter (when p-fn
-                       (filter (fn [f]
-                                 (-> unmatched
-                                     (match-predicate db f)
-                                     p-fn))))
-         obj-filter  (when o-fn*
-                       (filter (fn [f]
-                                 (-> unmatched
-                                     (match-object db f)
-                                     o-fn*))))
-         flake-xf*   (->> [subj-filter pred-filter obj-filter
-                           flake-xf track-fuel]
-                          (remove nil?)
-                          (apply comp))
-         opts        {:idx         idx
-                      :from-t      t
-                      :to-t        t
-                      :start-flake start-flake
-                      :end-flake   end-flake
-                      :flake-xf    flake-xf*}]
-     (query-range/resolve-flake-slices db idx error-ch opts))))
+        idx         (try* (index/for-components s p o o-dt)
+                          (catch* e
+                                  (log/error e "Error resolving flake range")
+                                  (async/put! error-ch e)))
+        [o* o-fn*]  (augment-object-fn db idx s p o o-fn)
+        start-flake (flake/create s p o* o-dt nil nil util/min-integer)
+        end-flake   (flake/create s p o* o-dt nil nil util/max-integer)
+        track-fuel  (when fuel-tracker
+                      (fuel/track fuel-tracker error-ch))
+        subj-filter (when s-fn
+                      (filter (fn [f]
+                                (-> unmatched
+                                    (match-subject db f)
+                                    s-fn))))
+        pred-filter (when p-fn
+                      (filter (fn [f]
+                                (-> unmatched
+                                    (match-predicate db f)
+                                    p-fn))))
+        obj-filter  (when o-fn*
+                      (filter (fn [f]
+                                (-> unmatched
+                                    (match-object db f)
+                                    o-fn*))))
+        flake-xf    (->> [subj-filter pred-filter obj-filter track-fuel]
+                        (remove nil?)
+                        (apply comp))
+        opts        {:idx         idx
+                     :from-t      t
+                     :to-t        t
+                     :start-flake start-flake
+                     :end-flake   end-flake
+                     :flake-xf    flake-xf}]
+    (query-range/resolve-flake-slices db idx error-ch opts)))
 
 
 (defn compute-sid

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -96,6 +96,14 @@
       (match-value value const/iri-lang-string)
       (match-meta {:lang lang})))
 
+(defn match-transaction
+  [mch t]
+  (assoc mch ::t t))
+
+(defn get-transaction
+  [mch]
+  (::t mch))
+
 (defn matched?
   [match]
   (or (matched-value? match)
@@ -292,6 +300,7 @@
       (let [dt-iri (iri/decode-sid db dt)]
         (-> o-match
             (match-value (flake/o flake) dt-iri)
+            (match-transaction (flake/t flake))
             (match-meta (flake/m flake)))))))
 
 (defn match-flake

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -80,9 +80,10 @@
 (defn parse-value-attributes
   [v attrs context]
   (let [mch          (parse-value-datatype v attrs context)
-        lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
-        dt-matcher   (some-> attrs (get const/iri-type) (where/datatype-matcher context))]
-    (if-let [f (combine-filters lang-matcher dt-matcher)]
+        t-matcher    (some-> attrs (get const/iri-t) (where/transaction-matcher))
+        dt-matcher   (some-> attrs (get const/iri-type) (where/datatype-matcher context))
+        lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)]
+    (if-let [f (combine-filters t-matcher lang-matcher dt-matcher)]
       (where/with-filter mch f)
       mch)))
 
@@ -252,12 +253,13 @@
 
 (defn parse-variable-attributes
   [var attrs vars context]
-  (let [lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
+  (let [t-matcher    (some-> attrs (get const/iri-t) (where/transaction-matcher))
         dt-matcher   (some-> attrs (get const/iri-type) (where/datatype-matcher context))
+        lang-matcher (some-> attrs (get const/iri-language) where/lang-matcher)
         filter-fn    (some-> attrs
                              (get const/iri-filter)
                              (parse-filter-function var vars context))]
-    (if-let [f (combine-filters lang-matcher dt-matcher filter-fn)]
+    (if-let [f (combine-filters t-matcher dt-matcher lang-matcher filter-fn)]
       (where/->var-filter var f)
       (where/unmatched-var var))))
 

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -60,7 +60,7 @@
           (where/anonymous-value dt-iri))
       (where/anonymous-value v dt-iri))
     (if-let [lang (get attrs const/iri-language)]
-      (where/anonymous-value v const/iri-lang-string {:lang lang})
+      (where/match-lang where/unmatched v lang)
       (where/anonymous-value v))))
 
 (defn every-binary-pred
@@ -97,7 +97,7 @@
           (where/match-iri var-match expanded))
         (where/match-value var-match val dt-iri))
       (if-let [lang (get attrs const/iri-language)]
-        (where/match-value var-match val const/iri-lang-string {:lang lang})
+        (where/match-lang var-match val lang)
         (let [dt (datatype/infer-iri val)]
           (where/match-value var-match val dt))))))
 
@@ -630,7 +630,8 @@
   (let [datatype* (iri/normalize datatype)]
     (if (= datatype* const/iri-id)
       (where/match-iri (json-ld/expand-iri v context))
-      (where/anonymous-value v datatype* metadata))))
+      (-> (where/anonymous-value v datatype*)
+          (where/match-meta metadata)))))
 
 (defn parse-obj-cmp
   [allowed-vars context subj-cmp pred-cmp m triples
@@ -717,7 +718,7 @@
     (catch* e
             (throw (ex-info (str "Parsing failure due to: " (ex-message e)
                                  ". Query: " expanded)
-                            (ex-data e)
+                            (or (ex-data e) {})
                             e)))))
 
 (defn parse-txn

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -58,9 +58,8 @@
       (throw (ex-info "Language tags are not allowed when the data type is specified."
                       {:status 400, :error :db/invalid-query}))
       (if (= const/iri-anyURI dt-iri)
-        (-> v
-            (json-ld/expand-iri context)
-            (where/anonymous-value dt-iri))
+        (let [expanded (json-ld/expand-iri v context)]
+          (where/match-iri where/unmatched expanded))
         (where/anonymous-value v dt-iri)))
     (if-let [lang (get attrs const/iri-language)]
       (where/match-lang where/unmatched v lang)

--- a/src/clj/fluree/db/validation.cljc
+++ b/src/clj/fluree/db/validation.cljc
@@ -240,9 +240,6 @@
    (m/predicate-schemas)
    {::iri                  [:or {:error/message "invalid iri"}
                             :string :keyword]
-    ::iri-key              [:fn iri-key?]
-    ::iri-map              [:map-of {:max 1}
-                            ::iri-key ::iri]
     ::json-ld-keyword      [:keyword {:decode/json decode-json-ld-keyword
                                       :decode/fql  decode-json-ld-keyword}]
     ::var                  [:fn {:error/message "variable should be one or more characters beginning with `?`"}

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -11,7 +11,7 @@
     (is (= nil (coerce 42 const/$xsd:string))))
 
   (testing "anyURI"
-    (is (= "foo" (coerce "foo" const/$xsd:anyURI)))
+    (is (= #fluree/IRI "foo" (coerce "foo" const/$xsd:anyURI)))
     (is (= nil (coerce 42 const/$xsd:anyURI))))
   (testing "boolean"
     (is (= true (coerce "true" const/$xsd:boolean)))

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -384,12 +384,13 @@
         (testing "filtered with the datatype function"
           (let [query   {:context [test-utils/default-context
                                    {:ex "http://example.org/ns/"}]
-                         :select  '[?age ?dt]
-                         :where   '[{:ex/age ?age}
+                         :select  '[?name ?age ?dt]
+                         :where   '[{:ex/name ?name
+                                     :ex/age  ?age}
                                     [:bind ?dt (datatype ?age)]
                                     [:filter (= (iri :xsd/long) ?dt)]]}
                 results @(fluree/query db query)]
-            (is (= [[36 :xsd/long]]
+            (is (= [["Homer" 36 :xsd/long]]
                    results)))))
       (testing "filtered in value maps"
         (testing "with explicit type IRIs"
@@ -417,6 +418,85 @@
                 results @(fluree/query db query)]
             (is (= [["Marge" 36 :xsd/int]]
                    results))))))))
+
+(deftest ^:integration t-test
+  (testing "querying with t values"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "people")
+          db1    @(fluree/stage (fluree/db ledger)
+                                {"@context" ["https://ns.flur.ee"
+                                             test-utils/default-context
+                                             {:ex    "http://example.org/ns/"
+                                              :value "@value"
+                                              :type  "@type"}]
+                                 "insert"
+                                 [{:id      :ex/homer
+                                   :ex/name "Homer"
+                                   :ex/age  36}
+                                  {:id      :ex/marge
+                                   :ex/name "Marge"
+                                   :ex/age  {:value 36
+                                             :type  :xsd/int}}
+                                  {:id      :ex/bart
+                                   :ex/name "Bart"
+                                   :ex/age  "forever 10"}]})
+          db1*   @(fluree/commit! ledger db1)
+          db2    @(fluree/stage db1* {"@context" ["https://ns.flur.ee"
+                                                  test-utils/default-context
+                                                  {:ex    "http://example.org/ns/"
+                                                   :value "@value"
+                                                   :type  "@type"}]
+                                      "insert"
+                                      [{:id     :ex/homer
+                                        :ex/son {:id :ex/bart}}
+                                       {:id            :ex/bart
+                                        :ex/dad        {:id :ex/homer}
+                                        :ex/occupation "Getting into mischief"}]})
+          db2*   @(fluree/commit! ledger db2)
+          db3    @(fluree/stage db2* {"@context" ["https://ns.flur.ee"
+                                                  test-utils/default-context
+                                                  {:ex    "http://example.org/ns/"
+                                                   :value "@value"
+                                                   :type  "@type"}]
+                                      "insert"
+                                      [{:id     :ex/marge
+                                        :ex/son {:id :ex/bart}}
+                                       {:id     :ex/bart
+                                        :ex/mom {:id :ex/marge}}]})
+          db3*   @(fluree/commit! ledger db3)]
+      (testing "using a specific t"
+        (let [query   {:context [test-utils/default-context
+                                 {:ex    "http://example.org/ns/"
+                                  :value "@value"
+                                  :type  "@type"
+                                  :t     "@t"}]
+                       :select  '[?p ?o]
+                       :where   '[{:id :ex/bart
+                                   ?p  {:value ?o
+                                        :t     2}}]}
+              results @(fluree/query db3* query)]
+          (is (= [[:ex/dad :ex/homer]
+                  [:ex/occupation "Getting into mischief"]]
+                 results)
+              "returns only data set in that transaction")))
+      (testing "using a variable t"
+        (let [query   {:context [test-utils/default-context
+                                 {:ex    "http://example.org/ns/"
+                                  :value "@value"
+                                  :type  "@type"
+                                  :t     "@t"}]
+                       :select  '[?p ?o ?t]
+                       :where   '[{:id :ex/bart
+                                   ?p  {:value ?o
+                                        :t     ?t}}]}
+              results @(fluree/query db3* query)]
+          (is (= [[:ex/age "forever 10" 1]
+                  [:ex/dad :ex/homer 2]
+                  [:ex/mom :ex/marge 3]
+                  [:ex/name "Bart" 1]
+                  [:ex/occupation "Getting into mischief" 2]]
+                 results)
+              "returns the correct transaction number for each result"))))))
 
 (deftest ^:integration subject-object-test
   (let [conn   (test-utils/create-conn)

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -409,13 +409,13 @@
                                    {:ex    "http://example.org/ns/"
                                     :value "@value"
                                     :type  "@type"}]
-                         :select  '[?name ?age]
-                         :where   '[[:bind ?ageType (iri :xsd/string)]
-                                    {:ex/name ?name
+                         :select  '[?name ?age ?ageType]
+                         :where   '[{:ex/name ?name
                                      :ex/age  {:value ?age
-                                               :type  ?ageType}}]}
+                                               :type  ?ageType}}
+                                    [:bind ?ageType (iri :xsd/int)]]}
                 results @(fluree/query db query)]
-            (is (= [["Bart" "forever 10"]]
+            (is (= [["Marge" 36 :xsd/int]]
                    results))))))))
 
 (deftest ^:integration subject-object-test


### PR DESCRIPTION
This patch adds support for specifying either explicit or variable transactions within a value map during a query, and you can see [examples for using this feature](https://github.com/fluree/db/compare/feature/inline-datatype-filtering...feature/inline-transaction-filtering?expand=1#diff-d9f2d68ae5213e13d8a2b9d402cc073f631b4eb0de343b6a4d85312b9306dd9cR422-R499) in the `fluree.db.query.fql-test/t-test`. 

This patch also fixes a number of bugs, including one with `:bind` patterns where solutions were still considered valid even if a bound variable was already set which didn't agree with the value from the binding, as well as a bug with language and data type matching when bound variables were already set. 

This patch builds on #857.