### PR TITLE
Fix/conn indexing opts

### DIFF
--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -63,3 +63,21 @@
                          (expand-idx child*))))
                    children)]
     (assoc branch "children" children*)))
+
+(defn idx-children
+  [root idx-type]
+  (let [branch (idx-branch root idx-type)]
+    (expand-idx branch)))
+
+(defn expand-addresses
+  [branch]
+  (let [children    (get branch "children")
+        child-addrs (mapv
+                     (fn [child]
+                       (let [child-addr (get child "id")
+                             leaf?      (true? (get child "leaf"))]
+                         (if leaf?
+                           child-addr
+                           [child-addr (expand-addresses (read-index-file child-addr))])))
+                     children)]
+    child-addrs))

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -92,3 +92,16 @@
   (let [branch-id   (get-in root [(name idx-type) "id"])
         branch-data (idx-branch root idx-type)]
     [branch-id (expand-addresses branch-data)]))
+
+(defn idx-depth
+  "Returns the depth of the index structure"
+  [root idx-type]
+  (let [addresses (idx-addresses root idx-type)]
+    (loop [branch addresses
+           depth 1]
+      ;; each level down it is of the structure [addr [child-addr [child-addr [leaf1, leaf2]]]]
+      (let [branch? (sequential? (first (second branch)))]
+        (if branch?
+          (recur (first (second branch))
+                 (inc depth))
+          depth)))))

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -48,3 +48,18 @@
   (let [idx*        (name idx-type)
         idx-address (get-in root [idx* "id"])]
     (read-index-file idx-address)))
+
+(defn expand-idx
+  [branch]
+  (let [children  (get branch "children")
+        children* (mapv
+                   (fn [child]
+                     (let [child-addr (get child "id")
+                           child-data (read-index-file child-addr)
+                           child*     (merge child child-data)
+                           leaf?      (true? (get child "leaf"))]
+                       (if leaf?
+                         child*
+                         (expand-idx child*))))
+                   children)]
+    (assoc branch "children" children*)))

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -42,3 +42,9 @@
 (defn latest-root
   [roots]
   (at-t (latest-t roots) roots))
+
+(defn idx-branch
+  [root idx-type]
+  (let [idx*        (name idx-type)
+        idx-address (get-in root [idx* "id"])]
+    (read-index-file idx-address)))

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -105,3 +105,4 @@
           (recur (first (second branch))
                  (inc depth))
           depth)))))
+(comment (def ledger-name "") ;; get latest index-root (-> (read-roots ledger-name)     (latest-root)) ;; get all nested addresses for :spot (-> (read-roots ledger-name)     (latest-root)     (idx-addresses :spot)) ;; get the depth (how many parents) of index type (-> (read-roots ledger-name)     (latest-root)     (idx-depth :spot)) )

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -32,3 +32,13 @@
           (when (= t (get r "t"))
             r))
         roots))
+
+(defn latest-t
+  [roots]
+  (->> roots
+       (map #(get % "t"))
+       (apply max)))
+
+(defn latest-root
+  [roots]
+  (at-t (latest-t roots) roots))

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -81,3 +81,14 @@
                            [child-addr (expand-addresses (read-index-file child-addr))])))
                      children)]
     child-addrs))
+
+(defn idx-addresses
+  "Reads all index address and puts in nested vector data structure
+  until reaching leafs.
+
+  e.g.
+  [root [child1 [child1-1 [child 1-1-1 child1-1-2...]"
+  [root idx-type]
+  (let [branch-id   (get-in root [(name idx-type) "id"])
+        branch-data (idx-branch root idx-type)]
+    [branch-id (expand-addresses branch-data)]))

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -3,7 +3,7 @@
             [fluree.db.util.json :as json]
             [fluree.db.storage :as storage]))
 
-(def data-directory "./data")
+(def data-directory "./dev/data")
 
 (defn set-data-dir!
   [data-dir]
@@ -28,6 +28,7 @@
 
 (defn at-t
   [t roots]
-  (filter (fn [r]
-            (= t (get r "t")))
-          roots))
+  (some (fn [r]
+          (when (= t (get r "t"))
+            r))
+        roots))

--- a/src/clj/fluree/db/conn/file.cljc
+++ b/src/clj/fluree/db/conn/file.cljc
@@ -97,10 +97,6 @@
      (binding [*out* w]
        (pr (connection/printer-map conn)))))
 
-(defn ledger-defaults
-  [{:keys [did]}]
-  {:did did})
-
 (defn default-file-nameservice
   "Returns file nameservice or will throw if storage-path generates an exception."
   [path]
@@ -122,7 +118,7 @@
       ;; TODO - need to set up monitor loops for async chans
       (map->FileConnection {:id              conn-id
                             :store           file-store
-                            :ledger-defaults (ledger-defaults defaults)
+                            :ledger-defaults defaults
                             :serializer      serializer
                             :parallelism     parallelism
                             :msg-in-ch       (async/chan)

--- a/src/clj/fluree/db/conn/ipfs.cljc
+++ b/src/clj/fluree/db/conn/ipfs.cljc
@@ -74,10 +74,6 @@
      (binding [*out* w]
        (pr (connection/printer-map conn)))))
 
-(defn ledger-defaults
-  [{:keys [did]}]
-  {:did did})
-
 (defn validate-http-url
   "Tests that URL starts with http:// or https://, returns exception or
   original url if passes. Appends a '/' at the end if not already present."
@@ -132,7 +128,6 @@
                              :sync?        true}}}]
   (go-try
     (let [ipfs-endpoint   (validate-http-url server)
-          ledger-defaults (ledger-defaults defaults)
           conn-id         (str (random-uuid))
           state           (connection/blank-state)
           nameservices*   (if nameservices ;; provided pre-configured nameservices to connection
@@ -157,7 +152,7 @@
       (map->IPFSConnection {:id              conn-id
                             :store           ipfs-store
                             :ipfs-endpoint   ipfs-endpoint
-                            :ledger-defaults ledger-defaults
+                            :ledger-defaults defaults
                             :serializer      serializer
                             :parallelism     parallelism
                             :msg-in-ch       (chan)

--- a/src/clj/fluree/db/conn/memory.cljc
+++ b/src/clj/fluree/db/conn/memory.cljc
@@ -87,12 +87,6 @@
      (binding [*out* w]
        (pr (connection/printer-map conn)))))
 
-(defn ledger-defaults
-  "Normalizes ledger defaults settings"
-  [{:keys [did] :as _defaults}]
-  (go
-    {:did did}))
-
 (defn default-memory-nameservice
   "Returns memory nameservice"
   [store]
@@ -102,8 +96,7 @@
   "Creates a new memory connection."
   [{:keys [parallelism lru-cache-atom cache-max-mb defaults nameservices]}]
   (go-try
-    (let [ledger-defaults (<? (ledger-defaults defaults))
-          conn-id         (str (random-uuid))
+    (let [conn-id         (str (random-uuid))
           state           (connection/blank-state)
           mem-store       (memory-storage/create)
           nameservices*   (util/sequential
@@ -122,7 +115,7 @@
           lru-cache-atom  (or lru-cache-atom (atom (conn-cache/create-lru-cache
                                                      cache-size)))]
       (map->MemoryConnection {:id              conn-id
-                              :ledger-defaults ledger-defaults
+                              :ledger-defaults defaults
                               :store           mem-store
                               :parallelism     parallelism
                               :msg-in-ch       (async/chan)

--- a/src/clj/fluree/db/conn/remote.cljc
+++ b/src/clj/fluree/db/conn/remote.cljc
@@ -59,12 +59,6 @@
      (binding [*out* w]
        (pr (connection/printer-map conn)))))
 
-(defn ledger-defaults
-  "Normalizes ledger defaults settings"
-  [{:keys [did] :as _defaults}]
-  (go
-    {:did did}))
-
 (defn default-remote-nameservice
   "Returns remote nameservice or will throw if generates an exception."
   [server-state state-atom]
@@ -76,8 +70,7 @@
   [{:keys [parallelism lru-cache-atom cache-max-mb defaults servers serializer nameservices]
     :or   {serializer (json-serde)}}]
   (go-try
-    (let [ledger-defaults (<? (ledger-defaults defaults))
-          servers*        (str/split servers #",")
+    (let [servers*        (str/split servers #",")
           server-state    (atom {:servers      servers*
                                  :connected-to nil
                                  :stats        {:connected-at nil}})
@@ -96,6 +89,6 @@
                               :state           state
                               :lru-cache-atom  lru-cache-atom
                               :serializer      serializer
-                              :ledger-defaults ledger-defaults
+                              :ledger-defaults defaults
                               :parallelism     parallelism
                               :nameservices    nameservices*}))))

--- a/src/clj/fluree/db/conn/s3.clj
+++ b/src/clj/fluree/db/conn/s3.clj
@@ -91,10 +91,6 @@
   (binding [*out* w]
     (pr (connection/printer-map conn))))
 
-(defn ledger-defaults
-  [{:keys [did]}]
-  {:did did})
-
 (defn default-S3-nameservice
   "Returns S3 nameservice or will throw if storage-path generates an exception."
   [s3-client s3-bucket s3-prefix]
@@ -120,7 +116,7 @@
       (map->S3Connection {:id              conn-id
                           :store           s3-store
                           :state           state
-                          :ledger-defaults (ledger-defaults defaults)
+                          :ledger-defaults defaults
                           :serializer      serializer
                           :parallelism     parallelism
                           :msg-in-ch       (async/chan)

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -322,10 +322,12 @@
 (defn parse-ledger-options
   [conn {:keys [did branch indexing]
          :or   {branch :main}}]
-  (let [did* (parse-did conn did)]
+  (let [did*           (parse-did conn did)
+        ledger-default (-> conn :ledger-defaults :indexing)
+        indexing*      (merge ledger-default indexing)]
     {:did      did*
      :branch   branch
-     :indexing indexing}))
+     :indexing indexing*}))
 
 (defn create*
   "Creates a new ledger, optionally bootstraps it as permissioned or with default context."


### PR DESCRIPTION
This addresses carrying :ledger-defaults on the conn as a default - specifically for indexing.

Previously, indexing default options were not being passed through.

This also adds some more functionality to the development index-explore namespace for troubleshooting indexing.
