### PR TITLE
order-by syntax wasn't parsing correctly

### DIFF
--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -603,11 +603,18 @@
            ensure-vector
            (mapv parse-var-name)))
 
+(defn wrap-order-statement
+  [order-by]
+  (if (syntax/order-by-tuple? order-by)
+    [order-by]
+    order-by))
+
 (defn parse-ordering
   [q]
   (some->> (or (:order-by q)
                (:orderBy q))
            ensure-vector
+           wrap-order-statement
            (mapv (fn [ord]
                    (if-let [v (parse-var-name ord)]
                      [v :asc]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -14,11 +14,11 @@
 
 (defn asc?
   [x]
-  (boolean (#{'asc "asc" :asc} x)))
+  (boolean (#{'asc "asc" "ASC" :asc} x)))
 
 (defn desc?
   [x]
-  (boolean (#{'desc "desc" :desc} x)))
+  (boolean (#{'desc "desc" "DESC" :desc} x)))
 
 (defn one-select-key-present?
   [q]
@@ -165,7 +165,7 @@
                          [:desc [:fn desc?]]]
     ::ordering          [:orn {:error/message "Ordering must be a var or two-tuple formatted ['ASC' or 'DESC', var]"}
                          [:scalar ::var]
-                         [:vector [:and list?
+                         [:vector [:and sequential?
                                    [:catn
                                     [:direction ::direction]
                                     [:dimension ::var]]]]]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -20,6 +20,12 @@
   [x]
   (boolean (#{'desc "desc" "DESC" :desc} x)))
 
+(defn order-by-tuple?
+  [x]
+  (and (sequential? x)
+       (or (-> x first desc?)
+           (-> x first asc?))))
+
 (defn one-select-key-present?
   [q]
   (log/trace "one-select-key-present? q:" q)


### PR DESCRIPTION
`order-by` parsing had the following problems, which didn't allow for specifying "DESC" ordering:
1) when a direction was specified, e.g. [:desc ?myvar] - it was checking for `list?` which would fail for a vector, and therefore fail for parsed JSON. This is now changed to use `sequential?`.
2) Our docs specify using `"DESC"` and `"ASC"` - however we were only checking for `"desc"` and `"asc"`.

As an additional note for comment, the ordering needs to include the direction first, then the variable. This seems a bit counterintuitive to me.. perhaps that is the way its always been. It seems more natural to specify the variable first, then the direction... eg:
`[?score "DESC"]`
instead of how it currently needs to be:
`["DESC" ?score]`

Thoughts?