### PR TITLE
Allow ordering directions to be specified as string

### DIFF
--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -96,7 +96,6 @@
 
 (defn string->ordering
   [x]
-  (log/info "Decoding ordering:" x)
   (if (string? x)
     (edn/read-string x)
     x))

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -170,7 +170,7 @@
     ::direction         [:orn {:error/message "Direction must be \"asc\" or \"desc\""}
                          [:asc [:fn asc?]]
                          [:desc [:fn desc?]]]
-    ::ordering          [:orn {:error/message "Ordering must be a var or two-tuple formatted ['ASC' or 'DESC', var]"
+    ::ordering          [:orn {:error/message "Ordering must be a var or a direction function call such as '(asc ?var)' or '(desc ?var)'."
                                :decode/fql  string->ordering
                                :decode/json string->ordering}
                          [:scalar ::var]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -96,6 +96,7 @@
 
 (defn string->ordering
   [x]
+  (log/info "Decoding ordering:" x)
   (if (string? x)
     (edn/read-string x)
     x))
@@ -174,12 +175,11 @@
                                :decode/fql  string->ordering
                                :decode/json string->ordering}
                          [:scalar ::var]
-                         [:vector
-                          [:and
-                           list?
-                           [:catn
-                            [:direction ::direction]
-                            [:dimension ::var]]]]]
+                         [:vector [:and
+                                   list?
+                                   [:catn
+                                    [:direction ::direction]
+                                    [:dimension ::var]]]]]
     ::order-by          [:orn {:error/message "orderBy clause must be variable or two-tuple formatted ['ASC' or 'DESC', var]"}
                          [:clause ::ordering]
                          [:collection [:sequential ::ordering]]]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -175,8 +175,7 @@
                                :decode/fql  string->ordering
                                :decode/json string->ordering}
                          [:scalar ::var]
-                         [:vector [:and
-                                   list?
+                         [:vector [:and list?
                                    [:catn
                                     [:direction ::direction]
                                     [:dimension ::var]]]]]


### PR DESCRIPTION
This patch fixes a bug where string ordering direction weren't being parsed correctly. It uses a malli decoder to turn strings to edn in the ordering before trying to validate it. 