### PR TITLE
Ensure `leftmost?` is set for index nodes

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/dev/index_explore.clj
+++ b/dev/index_explore.clj
@@ -33,10 +33,16 @@
             r))
         roots))
 
-(defn latest-t
+(defn t-values
   [roots]
   (->> roots
        (map #(get % "t"))
+       sort))
+
+(defn latest-t
+  [roots]
+  (->> roots
+       t-values
        (apply max)))
 
 (defn latest-root

--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -101,15 +101,6 @@
                 (reconstruct-branch branch t kids)))
          update-sibling-leftmost)))
 
-(defn filter-predicates
-  [preds & flake-sets]
-  (if (seq preds)
-    (->> flake-sets
-         (apply concat)
-         (filter (fn [f]
-                   (contains? preds (flake/p f)))))
-    []))
-
 (defn rebalance-leaf
   "Splits leaf nodes if the combined size of its flakes is greater than
   `*overflow-bytes*`."

--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -67,6 +67,7 @@
         size        (->> child-nodes
                          (map :size)
                          (reduce +))
+        leftmost?   (->> children first val :leftmost? true?)
         first-flake (->> children first key)
         rhs         (->> children flake/last val :rhs)
         new-id      (random-uuid)]
@@ -75,6 +76,7 @@
            :t t
            :children children
            :size size
+           :leftmost? leftmost?
            :first first-flake
            :rhs rhs)))
 
@@ -118,8 +120,10 @@
                 last-leaf (-> leaf
                               (assoc :flakes subrange
                                      :first cur-first
-                                     :rhs rhs)
-                              (dissoc :id :leftmost?))]
+                                     :rhs rhs
+                                     :leftmost? (and (empty? leaves)
+                                                     leftmost?))
+                              (dissoc :id))]
             (conj leaves last-leaf))
           (let [new-size (-> f flake/size-flake (+ cur-size) long)]
             (if (> new-size target-size)

--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -228,7 +228,7 @@
                    (= (count remaining-nodes) 1))
              (xf result)
              (loop [child-nodes   remaining-nodes
-                    root-template (first remaining-nodes)
+                    root-template (peek remaining-nodes)
                     result*       result]
                (if (overflow-children? child-nodes)
                  (let [new-branches (rebalance-children root-template t child-nodes)


### PR DESCRIPTION
There were some situations where the `:leftmost?` key was not set for index nodes after they or their parent nodes overflowed. This caused the system to lose track of some of these nodes during ancestor checks in certain situations because *both* the `first-flake` and `leftmost?` keys are required for accurate ancestor checks. This patch sets the `leftmost?` key in each case a node or it's ancestors could be split.

This patch also contains an optimization to eagerly push index nodes downstream for writing during a reindexing process instead of pushing fully resolved nodes onto the stack to wait for their ancestor nodes to be processed. Their ancestor nodes needs to have access to all of it's child nodes to determine if and how it should update it's `children` key, but we don't need to keep fully resolved nodes in the stack waiting for this. Instead, we can write the fully resolved node immediately and push an unresolved node (the same node, but without the `flakes` or `children` keys) onto that stack that it's ancestor can access. This should result in a significant reduction in memory consumption while reindexing large databases. 