### PR TITLE
Ensure @type and rdfs:Class have complete schema property maps

### DIFF
--- a/src/clj/fluree/db/indexer/default.cljc
+++ b/src/clj/fluree/db/indexer/default.cljc
@@ -218,13 +218,17 @@
 
         ;; Completion: If there is only one node left in the stack, then it's
         ;; the root and we're done, so we call the nested transformer's
-        ;; completion arity. If there is more than one node left in the stack,
-        ;; then the root was split because it overflowed. We first make a new
-        ;; root that is the parent of the nodes resulting from the split, then
-        ;; we check if that new root overflows If the new root does overflow, we
-        ;; iterate all of the newly split nodes with the nested transformer and
-        ;; repeat the process. If the new root does not overflow, we iterate the
-        ;; new root before calling the nested transformer's completion arity.
+        ;; completion arity.
+        ;;
+        ;; If there is more than one node left in the stack, then the root was
+        ;; split because it overflowed. We first make a new root that is the
+        ;; parent of the nodes resulting from the split, then we check if that
+        ;; new root overflows.
+        ;;
+        ;; If the new root does overflow, we iterate all of the newly split
+        ;; nodes with the nested transformer and repeat the process. If the new
+        ;; root does not overflow, we iterate the new root before calling the
+        ;; nested transformer's completion arity.
         ([result]
          (let [remaining-nodes @stack]
            (vreset! stack [])

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -374,6 +374,18 @@
 (def ^:const serialized-pred-keys-reverse
   (reverse serialized-pred-keys))
 
+(defn serialize-property-set
+  [tuple st]
+  (if (seq st)
+    (conj tuple
+          (mapv #(if (iri/sid? %)
+                   (iri/serialize-sid %)
+                   %)
+                st))
+    (if (seq tuple) ; if 'tuple' is still empty, keep it that if nothing to add
+      (conj tuple nil)
+      tuple)))
+
 (defn schema-tuple
   [pred-map]
   (reduce
@@ -381,15 +393,7 @@
      (let [next-val (get pred-map next-key)]
        (cond
          (set? next-val)
-         (if (seq next-val) ;; non-empty?
-           (conj acc
-                 (mapv #(if (iri/sid? %)
-                          (iri/serialize-sid %)
-                          %)
-                       next-val))
-           (if (seq acc) ;; if 'acc' is still empty, keep it that if nothing to add
-             (conj acc nil)
-             acc))
+         (serialize-property-set acc next-val)
 
          (iri/sid? next-val)
          (conj acc (iri/serialize-sid next-val))

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -69,10 +69,6 @@
           (assoc acc iri subclasses)))
       subclass-map subclass-map)))
 
-(def property-sids #{const/$rdf:Property
-                     const/$owl:DatatypeProperty
-                     const/$owl:ObjectProperty})
-
 (def ^:const base-property-map
   {:id          nil
    :iri         nil
@@ -347,18 +343,6 @@
                             (add-pred-datatypes pred-datatypes))]
      (invalidate-shape-cache! db mods)
      (assoc db :schema schema))))
-
-(defn serialize-schema-predicates
-  [schema]
-  (reduce (fn [root [k {:keys [datatype]}]]
-            (if (iri/sid? k)
-              (let [sid (iri/serialize-sid k)]
-                (if datatype
-                  (conj root [sid (iri/serialize-sid datatype)])
-                  (conj root [sid])))
-              root))
-          []
-          (:pred schema)))
 
 (defn load-schema
   [{:keys [t] :as db} preds]

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -308,24 +308,25 @@
               (-> schema
                   (assoc-in [:pred pid] pred-meta)
                   (assoc-in [:pred iri] pred-meta))))
-          schema
-          pred-tuples))
+          schema pred-tuples))
 
 (defn add-pid
-  [db preds pid]
+  [preds db pid]
   (if (contains? preds pid)
     preds
     (let [{:keys [iri] :as p-map} (initial-property-map db pid)]
       (assoc preds pid p-map, iri p-map))))
 
 (defn add-predicates
-  [db pred-map pids]
-  (reduce (partial add-pid db) pred-map pids))
+  [pred-map db pids]
+  (reduce (fn [pred-map* pid]
+            (add-pid pred-map* db pid))
+          pred-map pids))
 
 (defn update-schema
   [{:keys [schema t] :as db} pids vocab-flakes]
   (-> schema
-      (update :pred (partial add-predicates db) pids)
+      (update :pred add-predicates db pids)
       (update-with db t vocab-flakes)))
 
 (defn hydrate-schema

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -1,4 +1,5 @@
 (ns fluree.db.json-ld.vocab
+  "Generates vocabulary/schema pre-cached maps."
   (:require [fluree.db.constants :as const]
             [fluree.db.flake :as flake]
             [fluree.db.json-ld.ledger :as jld-ledger]
@@ -8,8 +9,6 @@
             [fluree.db.json-ld.iri :as iri]))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-;; generates vocabulary/schema pre-cached maps.
 
 (defn map-pred-id+iri
   "In the schema map, we index properties by both integer :id and :iri for easy lookup of either."

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -10,8 +10,9 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defn map-pred-id+iri
-  "In the schema map, we index properties by both integer :id and :iri for easy lookup of either."
+(defn build-pred-map
+  "In the schema map, we index properties by both sid :id and :iri for easy
+  lookup of either."
   [properties]
   (reduce
     (fn [acc prop-map]
@@ -218,7 +219,7 @@
 
 (defn base-schema
   []
-  (let [pred (map-pred-id+iri [initial-type-map initial-class-map])]
+  (let [pred (build-pred-map [initial-type-map initial-class-map])]
     {:t          0
      :pred       pred
      :shapes     (atom {:class {} ; TODO: Does this need to be an atom?

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -378,8 +378,11 @@
             (add-pred-datatypes (filterv #(> (count %) 1) preds)))))))
 
 ;; schema serialization
-(def ^:const serialized-pred-keys [:id :datatype :subclassOf :parentProps :childProps])
-(def ^:const serialized-pred-keys-reverse (reverse serialized-pred-keys))
+(def ^:const serialized-pred-keys
+  [:id :datatype :subclassOf :parentProps :childProps])
+
+(def ^:const serialized-pred-keys-reverse
+  (reverse serialized-pred-keys))
 
 (defn schema-tuple
   [pred-map]
@@ -418,7 +421,9 @@
   [{:keys [t pred] :as _db-schema}]
   (let [pred-keys (mapv name serialized-pred-keys)
         pred-vals (->> pred
-                       (filter #(string? (key %))) ;; every pred map is duplicated for both keys iri, and sid - keep only 1
+                       (filter #(string? (key %))) ; every pred map is
+                                                   ; duplicated for both keys
+                                                   ; iri, and sid - keep only 1
                        vals
                        (mapv schema-tuple))]
     {"t"    t
@@ -477,4 +482,3 @@
         (assoc :t t
                :pred pred)
         (refresh-subclasses))))
-


### PR DESCRIPTION
The initial schema property maps for both the `@type` and `rdfs:Class` properties were incomplete. They did not include the `:subclassOf`, `:parentProps`, `:childProps`, or `:datatype` keys. This prevented the schema map from serializing correctly if any dataset had a fact involving one of those keys. This then would cause any attempts to load the database to fail with a json parsing error. This patch ensures that both these property maps are complete. The main fix is in bb5997ac12321e385648c3ef7327ae49d169cbc6. The rest is general code cleanup.