### PR TITLE
support whitespace in additive expressions

### DIFF
--- a/resources/sparql.bnf
+++ b/resources/sparql.bnf
@@ -120,7 +120,7 @@ RelationalExpression	  ::=  	NumericExpression WS ( '=' NumericExpression | '!='
 NumericExpression	  ::=  	WS AdditiveExpression WS
 As ::= WS <('AS' | 'as')> WS
 
-<AdditiveExpression>	  ::=  	MultiplicativeExpression ( '+' MultiplicativeExpression | '-' MultiplicativeExpression | ( NumericLiteralPositive | NumericLiteralNegative ) ( ( '*' UnaryExpression ) | ( '/' UnaryExpression ) )* )*
+<AdditiveExpression>	  ::=  	MultiplicativeExpression (WS '+' WS MultiplicativeExpression | WS '-' WS MultiplicativeExpression | ( NumericLiteralPositive | NumericLiteralNegative ) ( (WS '*' WS UnaryExpression ) | (WS '/' WS UnaryExpression ) )* )*
 
 
 MultiplicativeExpression ::= UnaryExpression ( '*' UnaryExpression | '/' UnaryExpression )*

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -226,6 +226,18 @@
           "filter by regex call"))
     (let [query "SELECT ?s
                  WHERE {
+                   ?product1 ex:numProp1 ?p1.
+                   ?product2 ex:numProp2 ?p2.
+                   FILTER (?p1 > (?p2 - 120) && ?p1 < (?p1 + 120))
+                 }"
+          {:keys [where]} (sparql/->fql query)]
+      (is (= [{"@id" "?product1", "ex:numProp1" "?p1"}
+              {"@id" "?product2", "ex:numProp2" "?p2"}
+              [:filter "(and (> ?p1 (- ?p2 120)) (< ?p1 (+ ?p1 120)))"]]
+             where)
+          "EXISTS expression parsing"))
+    (let [query "SELECT ?s
+                 WHERE {
                    ?s ?p ?o
                    FILTER EXISTS { ?s ex:name \"Larry\" }
                  }"


### PR DESCRIPTION
The grammar we were using didn't allow for whitespace around numeric operators, this updates the grammar to support that.