### PR TITLE
Feature/function refactor

### DIFF
--- a/src/clj/fluree/db/datatype.cljc
+++ b/src/clj/fluree/db/datatype.cljc
@@ -107,8 +107,7 @@
                     const/$xsd:string)
      (integer? x) const/$xsd:long ; infer to long to prevent overflow
      (number? x)  const/$xsd:decimal
-     (boolean? x) const/$xsd:boolean
-     (iri/iri? x) const/$id)))
+     (boolean? x) const/$xsd:boolean)))
 
 (defn infer-iri
   ([x]
@@ -368,12 +367,6 @@
      const/$rdf:langString)
     (when (string? value)
       value)
-
-    const/$id
-    (if (iri/iri? value)
-      value
-      (when (string? value)
-        (iri/string->iri value)))
 
     const/$xsd:boolean
     (coerce-boolean value)

--- a/src/clj/fluree/db/datatype.cljc
+++ b/src/clj/fluree/db/datatype.cljc
@@ -8,8 +8,8 @@
             [fluree.db.vector.scoring :as vector.score]
             #?(:clj  [fluree.db.util.clj-const :as uc]
                :cljs [fluree.db.util.cljs-const :as uc]))
-  #?(:clj (:import (java.time OffsetDateTime OffsetTime LocalDate LocalTime
-                              LocalDateTime ZoneOffset)
+  #?(:clj (:import (java.time LocalDate LocalTime LocalDateTime
+                              OffsetDateTime OffsetTime ZoneOffset)
                    (java.time.format DateTimeFormatter))))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -376,8 +376,14 @@
       (parse-iso8601-date value))
 
     const/$xsd:dateTime
-    (when (string? value)
-      (parse-iso8601-datetime value))
+    (cond (string? value)
+          (parse-iso8601-datetime value)
+          ;; these values don't need coercion
+          (or (instance? OffsetDateTime value)
+              (instance? LocalDateTime value))
+          value)
+
+
 
     const/$xsd:time
     (when (string? value)

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -12,48 +12,6 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defrecord IRI [^String s]
-  Object
-  (toString [_] s)
-  Comparable
-  (compareTo [_ o]
-    (compare s (str ^IRI o))))
-
-(defn iri?
-  [x]
-  (instance? IRI x))
-
-(defn string->iri
-  [s]
-  (->IRI s))
-
-(defn unwrap
-  [x]
-  (if (iri? x)
-    (str x)
-    x))
-
-(defn serialize-iri ^String
-  [iri]
-  (str "\"" iri "\""))
-
-#?(:clj (defmethod print-method IRI [^IRI iri ^java.io.Writer w]
-          (let [iri-str (serialize-iri iri)]
-            (doto w
-              (.write "#fluree/IRI ")
-              (.write iri-str))))
-   :cljs (extend-protocol IPrintWithWriter
-           IRI
-           (-pr-writer [iri writer _]
-             (write-all writer "#fluree/IRI " (serialize-iri iri)))))
-
-#?(:clj (defmethod print-dup IRI
-          [^IRI iri ^java.io.Writer w]
-          (let [iri-string (str iri)]
-            (.write w (str "#=" `(string->iri ~iri-string))))))
-
-(defmethod pprint/simple-dispatch IRI [^IRI iri]
-  (pr iri))
 
 (def ^:const f-ns "https://ns.flur.ee/ledger#")
 (def ^:const f-t-ns "https://ns.flur.ee/ledger/transaction#")

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -55,12 +55,6 @@
 (defmethod pprint/simple-dispatch IRI [^IRI iri]
   (pr iri))
 
-(defn expand
-  [compact-string context]
-  (-> compact-string
-      (json-ld/expand-iri context)
-      string->iri))
-
 (def ^:const f-ns "https://ns.flur.ee/ledger#")
 (def ^:const f-t-ns "https://ns.flur.ee/ledger/transaction#")
 (def ^:const f-did-ns "did:fluree:")

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -633,7 +633,7 @@
 
                     ;; literal
                     (not (sequential? x))
-                    (where/->TypedValue x (datatype/infer x) nil)
+                    (where/->TypedValue x (datatype/infer-iri x) nil)
 
                     :else
                     x))

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -678,4 +678,5 @@
     (eval `(fn [~soln-sym ~var]
              (-> ~soln-sym
                  (assoc (quote ~var) ~var)
-                 ~f)))))
+                 ~f
+                 :value)))))

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -640,8 +640,8 @@
             code))
 
 (defn mch->typed-val
-  [{::where/keys [val iri datatype-iri lang]}]
-  (where/->typed-val (or iri val) (if iri const/iri-id datatype-iri) lang))
+  [{::where/keys [val iri datatype-iri meta]}]
+  (where/->typed-val (or iri val) (if iri const/iri-id datatype-iri) (:lang meta)))
 
 (defn bind-variables
   [soln-sym var-syms ctx]

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -30,7 +30,7 @@
 (defn avg
   [coll]
   (let [coll (mapv :value coll)
-        res (/ (sum coll)
+        res (/ (reduce + coll)
                (count coll))]
     (where/->typed-val
       (if (ratio? res)

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -110,7 +110,7 @@
 
 (defn sample1
   [coll]
-  (->> coll (sample 1) first))
+  (->> coll (sample (where/->typed-val 1)) first))
 
 (defmacro coalesce
   "Evaluates args in order. The result of the first arg not to return error gets returned."

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -10,10 +10,10 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :refer [postwalk]]
-            [clojure.math]
             [fluree.db.datatype :as datatype]
             [fluree.crypto :as crypto]
-            [fluree.db.constants :as const])
+            [fluree.db.constants :as const]
+            [clojure.math :as math])
   #?(:clj (:import (java.time Instant OffsetDateTime LocalDateTime))))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -25,71 +25,84 @@
 
 (defn sum
   [coll]
-  (reduce + coll))
+  (where/->typed-val (reduce + (mapv :value coll))))
 
 (defn avg
   [coll]
-  (let [res (/ (sum coll)
+  (let [coll (mapv :value coll)
+        res (/ (sum coll)
                (count coll))]
-    (if (ratio? res)
-      (double res)
-      res)))
+    (where/->typed-val
+      (if (ratio? res)
+        (double res)
+        res))))
 
 (defn median
   [coll]
-  (let [terms (sort coll)
+  (let [terms (sort (mapv :value coll))
         size  (count coll)
         med   (bit-shift-right size 1)
         res   (cond-> (nth terms med)
-                      (even? size)
-                      (-> (+ (nth terms (dec med)))
-                          (/ 2)))]
-    (if (ratio? res)
-      (double res)
-      res)))
+                (even? size)
+                (-> (+ (nth terms (dec med)))
+                    (/ 2)))]
+    (where/->typed-val
+      (if (ratio? res)
+        (double res)
+        res))))
 
 (defn variance
   [coll]
-  (let [mean (avg coll)
+  (let [mean (avg (mapv :value coll))
         sum  (sum (for [x coll
                         :let [delta (- x mean)]]
                     (* delta delta)))
         res  (/ sum (count coll))]
-    (if (ratio? res)
-      (double res)
-      res)))
+    (where/->typed-val
+      (if (ratio? res)
+        (double res)
+        res))))
 
 (defn stddev
   [coll]
-  (Math/sqrt (variance coll)))
+  (where/->typed-val
+    (Math/sqrt (:value (variance coll)))))
 
 (defn max
   [coll]
-  (apply clojure.core/max coll))
+  (where/->typed-val
+    (apply clojure.core/max (mapv :value coll))))
 
 (defn min
   [coll]
-  (apply clojure.core/min coll))
+  (where/->typed-val
+    (apply clojure.core/min (mapv :value coll))))
 
 (defn ceil
-  [n]
-  (cond (= n (int n)) n
-        (> n 0) (-> n int inc)
-        (< n 0) (-> n int)))
+  [{n :value}]
+  (where/->typed-val (cond (= n (int n)) n
+                           (> n 0) (-> n int inc)
+                           (< n 0) (-> n int))))
 
-(def count-distinct
-  (comp count distinct))
+(defn count-distinct
+  [coll]
+  (where/->typed-val
+    (count (distinct coll))))
+
+(defn -count
+  [coll]
+  (where/->typed-val (count coll)))
 
 (defn floor
-  [n]
-  (cond (= n (int n)) n
-        (> n 0) (-> n int)
-        (< n 0) (-> n int dec)))
+  [{n :value}]
+  (where/->typed-val (cond (= n (int n)) n
+                           (> n 0) (-> n int)
+                           (< n 0) (-> n int dec))))
 
 (def groupconcat clojure.core/concat)
 
 (defn sample
-  [n coll]
+  [{n :value} coll]
   (->> coll
        shuffle
        (take n)
@@ -99,125 +112,115 @@
   [coll]
   (->> coll (sample 1) first))
 
-(def allowed-aggregate-fns
-  '#{avg ceil count count-distinct distinct floor groupconcat
-     median max min rand sample sample1 stddev str sum variance})
-
 (defmacro coalesce
   "Evaluates args in order. The result of the first arg not to return error gets returned."
   ([] (throw (ex-info "COALESCE evaluation failed on all forms." {:status 400 :error :db/invalid-query})))
   ([arg] `(let [res# (try ~arg (catch Exception e# nil))]
-            (if (nil? res#)
-              (throw (ex-info "Coalesce evaluation failed on all forms." {:status 400 :error :db/invalid-query})) res#)))
+            (if (nil? (:value res#))
+              (throw (ex-info "Coalesce evaluation failed on all forms." {:status 400 :error :db/invalid-query}))
+              res#)))
   ([arg & args]
    `(let [res# (try ~arg (catch Exception e# nil))]
-      (if (nil? res#)
-        (coalesce ~@args) res#))))
+      (if (nil? (:value res#))
+        (coalesce ~@args)
+        res#))))
 
-(def bound some?)
+(defn bound
+  [{x :value}]
+  (where/->typed-val (some? x)))
 
-(def ! not)
+(defn -not
+  [{x :value}]
+  (where/->typed-val (not x)))
 
-(defmacro &&
+(defmacro -and
   "Equivalent to and"
-  ([] true)
+  ([] (where/->typed-val true))
   ([x] x)
   ([x & next]
-   `(let [and# ~x]
-      (if and# (and ~@next) and#))))
+   `(let [and# (:value ~x)]
+      (where/->typed-val (if and# (and (:value ~@next)) and#)))))
 
-(defmacro ||
+(defmacro -or
   "Equivalent to or"
-  ([] nil)
+  ([] (where/->typed-val nil))
   ([x] x)
   ([x & next]
-   `(let [or# ~x]
-      (if or# or# (or ~@next)))))
+   `(let [or# (:value ~x)]
+      (where/->typed-val (if or# or# (or (:value ~@next)))))))
 
 (defn now
   []
-  #?(:clj  (Instant/now)
-     :cljs (js/Date.)))
+  (where/->typed-val #?(:clj (Instant/now)
+                        :cljs (js/Date.))
+                     const/iri-xsd-dateTime))
 
 (defn strStarts
-  [s substr]
-  (str/starts-with? s substr))
+  [{s :value} {substr :value}]
+  (where/->typed-val (str/starts-with? s substr)))
 
 (defn strEnds
-  [s substr]
-  (str/ends-with? s substr))
+  [{s :value} {substr :value}]
+  (where/->typed-val (str/ends-with? s substr)))
 
 (defn subStr
   ;; The index of the first character in a string is 1.
-  ([s start]
-   (subs s (dec start)))
-  ([s start length]
+  ([{s :value} {start :value}]
+   (where/->typed-val (subs s (dec start))))
+  ([{s :value} {start :value} {length :value}]
    (let [start (dec start)]
-     (subs s start (clojure.core/min (+ start length) (count s))))))
+     (where/->typed-val (subs s start (clojure.core/min (+ start length) (count s)))))))
 
 (defn strLen
-  [s]
-  (count s))
+  [{s :value}]
+  (where/->typed-val (count s)))
 
 (defn ucase
-  [s]
-  (str/upper-case s))
+  [{s :value}]
+  (where/->typed-val (str/upper-case s)))
 
 (defn lcase
-  [s]
-  (str/lower-case s))
+  [{s :value}]
+  (where/->typed-val (str/lower-case s)))
 
 (defn contains
-  [s substr]
-  (str/includes? s substr))
+  [{s :value} {substr :value}]
+  (where/->typed-val (str/includes? s substr)))
 
 (defn strBefore
-  [s substr]
+  [{s :value} {substr :value}]
   (let [[before :as split] (str/split s (re-pattern substr))]
-    (if (> (count split) 1)
-      before
-      "")))
+    (where/->typed-val
+      (if (> (count split) 1)
+        before
+        ""))))
 
 (defn strAfter
-  [s substr]
+  [{s :value} {substr :value}]
   (let [split (str/split s (re-pattern substr))]
-    (if (> (count split) 1)
-      (last split)
-      "")))
+    (where/->typed-val
+      (if (> (count split) 1)
+        (last split)
+        ""))))
 
 (defn concat
   [& strs]
-  (apply str strs))
+  (where/->typed-val (apply str (mapv :value strs))))
 
-(defn var->lang-var
-  [var]
-  (when (where/variable? var)
-    (-> var
-        (str "$-LANG")
-        symbol)))
+(defn lang
+  [tv]
+  (where/->typed-val (:lang tv) const/iri-string))
 
-(defn var->dt-var
-  [var]
-  (when (where/variable? var)
-    (-> var
-        (str "$-DATATYPE")
-        symbol)))
-
-(defmacro lang
-  [var]
-  (var->lang-var var))
-
-(defmacro datatype
-  [var]
-  (let [dt (var->dt-var var)]
-    `(where/->TypedValue ~dt const/iri-id)))
+(defn datatype
+  [tv]
+  (where/->typed-val (:datatype-iri tv) const/iri-id))
 
 (def context-var
   (symbol "$-CONTEXT"))
 
 (defmacro iri
-  [s]
-  `(where/->TypedValue (json-ld/expand-iri ~s ~context-var) const/iri-id))
+  [tv]
+  `(where/->typed-val (json-ld/expand-iri (:value ~tv) ~context-var) const/iri-id))
 
 (def numeric-datatypes
   #{const/iri-xsd-decimal
@@ -253,21 +256,10 @@
       const/iri-xsd-date
       const/iri-xsd-time}))
 
-(def dt-sid->iri
-  {const/$xsd:string  const/iri-string
-   const/$xsd:long    const/iri-long
-   const/$xsd:decimal const/iri-xsd-decimal
-   const/$xsd:boolean const/iri-xsd-boolean
-   const/$id          const/iri-id})
-
-(defn infer-dt-iri
-  [x]
-  (get dt-sid->iri (datatype/infer x)))
-
 (defn compare*
   [val-a dt-a val-b dt-b]
-  (let [dt-a (or dt-a (infer-dt-iri val-a))
-        dt-b (or dt-b (infer-dt-iri val-b))]
+  (let [dt-a (or dt-a (datatype/infer-iri val-a))
+        dt-b (or dt-b (datatype/infer-iri val-b))]
     (cond
       ;; can compare across types
       (or (and (contains? numeric-datatypes dt-a)
@@ -288,155 +280,224 @@
                        :status 400
                        :error  :db/invalid-query})))))
 
-(defmacro less-than
-  [var-a var-b]
-  (let [dt-a (var->dt-var var-a)
-        dt-b (var->dt-var var-b)]
-    `(neg? (compare* ~var-a ~dt-a ~var-b ~dt-b))))
+(defn less-than
+  [{a :value a-dt :datatype-iri}
+   {b :value b-dt :datatype-iri}]
+  (where/->typed-val (neg? (compare* a a-dt b b-dt))))
 
-(defmacro less-than-or-equal
-  [var-a var-b]
-  (let [dt-a (var->dt-var var-a)
-        dt-b (var->dt-var var-b)]
-    `(or (= ~var-a ~var-b)
-         (neg? (compare* ~var-a ~dt-a ~var-b ~dt-b)))))
+(defn less-than-or-equal
+  [{a :value a-dt :datatype-iri}
+   {b :value b-dt :datatype-iri}]
+  (where/->typed-val
+    (or (= a b)
+        (neg? (compare* a a-dt b b-dt)))))
 
-(defmacro greater-than
-  [var-a var-b]
-  (let [dt-a (var->dt-var var-a)
-        dt-b (var->dt-var var-b)]
-    `(pos? (compare* ~var-a ~dt-a ~var-b ~dt-b))))
+(defn greater-than
+  [{a :value a-dt :datatype-iri}
+   {b :value b-dt :datatype-iri}]
+  (where/->typed-val (pos? (compare* a a-dt b b-dt))))
 
-(defmacro greater-than-or-equal
-  [var-a var-b]
-  (let [dt-a (var->dt-var var-a)
-        dt-b (var->dt-var var-b)]
-    `(or (= ~var-a ~var-b)
-         (pos? (compare* ~var-a ~dt-a ~var-b ~dt-b)))))
+(defn greater-than-or-equal
+  [{a :value a-dt :datatype-iri}
+   {b :value b-dt :datatype-iri}]
+  (where/->typed-val
+    (or (= a b)
+        (pos? (compare* a a-dt b b-dt)))))
 
 (defn regex
-  [text pattern]
-  (boolean (re-find (re-pattern pattern) text)))
+  [{text :value} {pattern :value}]
+  (where/->typed-val (boolean (re-find (re-pattern pattern) text))))
 
 (defn replace
-  [s pattern replacement]
-  (str/replace s (re-pattern pattern) replacement))
+  [{s :value} {pattern :value} {replacement :value}]
+  (where/->typed-val (str/replace s (re-pattern pattern) replacement)))
 
 (defn rand
   []
-  (clojure.core/rand))
+  (where/->typed-val (clojure.core/rand)))
 
 (defn year
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.getYear ^LocalDateTime datetime)
        :cljs (.getFullYear datetime))))
 
 (defn month
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.getMonthValue ^LocalDateTime datetime)
        :cljs (.getMonth datetime))))
 
 (defn day
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.getDayOfMonth ^LocalDateTime datetime)
        :cljs (.getDate datetime))))
 
 (defn hours
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.getHour ^LocalDateTime datetime)
        :cljs (.getHours datetime))))
 
 (defn minutes
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.getMinute ^LocalDateTime datetime)
        :cljs (.getMinutes datetime))))
 
 (defn seconds
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.getSecond ^LocalDateTime datetime)
        :cljs (.getSeconds datetime))))
 
 (defn tz
-  [datetime-string]
-  (let [datetime (datatype/coerce datetime-string const/$xsd:dateTime)]
+  [{datetime :value}]
+  (where/->typed-val
     #?(:clj  (.toString (.getOffset ^OffsetDateTime datetime))
        :cljs (.getTimeZoneOffset ^js/Date datetime))))
 
 (defn sha256
-  [x]
-  (crypto/sha2-256 x))
+  [{x :value}]
+  (where/->typed-val (crypto/sha2-256 x)))
 
 (defn sha512
-  [x]
-  (crypto/sha2-512 x))
+  [{x :value}]
+  (where/->typed-val (crypto/sha2-512 x)))
 
 (defn uuid
   []
-  (str "urn:uuid:" (random-uuid)))
+  (where/->typed-val (str "urn:uuid:" (random-uuid)) const/iri-id))
 
 (defn struuid
   []
-  (str (random-uuid)))
+  (where/->typed-val (str (random-uuid))))
 
 (defn isNumeric
-  [x]
-  (number? x))
+  [{x :value}]
+  (where/->typed-val (number? x)))
 
 (defn isBlank
-  [x]
-  (and (string? x)
-       (str/starts-with? x "_:")))
+  [{x :value}]
+  (where/->typed-val
+    (and (string? x)
+         (str/starts-with? x "_:"))))
 
 (defn sparql-str
-  [x]
-  (str x))
+  [{x :value}]
+  (where/->typed-val (str x)))
 
 (defn in
-  [term expressions]
-  (contains? (set expressions) term))
+  [{term :value} expressions]
+  (where/->typed-val (contains? (set (mapv :value expressions)) term)))
 
-(def allowed-scalar-fns
-  '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang
-     nil? as not not= or re-find re-pattern in
+(defn as*
+  [val var]
+  (log/trace "as binding value:" val "to variable:" var)
+  (if (where/variable? var)
+    val ; only needs to return the value b/c we store the binding variable in the AsSelector
+    (throw
+     (ex-info
+      (str "second arg to `as` must be a query variable (e.g. ?foo); provided:"
+           (pr-str var))
+      {:status 400, :error :db/invalid-query}))))
 
-     ;; string fns
-     strStarts strEnds subStr strLen ucase lcase contains strBefore strAfter
-     concat regex replace
+(defmacro as
+  [val var]
+  `(as* ~val '~var))
 
-     ;; numeric fns
-     abs round ceil floor rand
+(defn plus
+  ([] (where/->typed-val 0))
+  ([{x :value}]  (where/->typed-val x))
+  ([{x :value} {y :value}] (where/->typed-val (+ x y)))
+  ([{x :value} {y :value} & more]
+   (where/->typed-val (reduce + (+ x y) (mapv :value more)))))
 
-     ;; datetime fns
-     now year month day hours minutes seconds tz
+(defn minus
+  ([{x :value}]  (where/->typed-val (- x)))
+  ([{x :value} {y :value}] (where/->typed-val (- x y)))
+  ([{x :value} {y :value} & more]
+   (where/->typed-val (reduce - (- x y) (mapv :value more)))))
 
-     ;; hash fns
-     sha256 sha512
+(defn multiply
+  ([] (where/->typed-val 1))
+  ([{x :value}]  (where/->typed-val x))
+  ([{x :value} {y :value}] (where/->typed-val (* x y)))
+  ([{x :value} {y :value} & more]
+   (where/->typed-val (reduce * (* x y) (mapv :value more)))))
 
-     ;; rdf term fns
-     uuid struuid isNumeric isBlank str
+(defn divide
+  ([{x :value}]  (where/->typed-val (/ 1 x)))
+  ([{x :value} {y :value}] (where/->typed-val (/ x y)))
+  ([{x :value} {y :value} & more]
+   (where/->typed-val (reduce / (/ x y) (mapv :value more)))))
 
-     ;; vector scoring fns
-     dotproduct cosine-similarity euclidian-distance})
+(defn quotient
+  [{num :value} {div :value}]
+  (where/->typed-val (quot num div)))
 
-(def allowed-symbols
-  (set/union allowed-aggregate-fns allowed-scalar-fns))
+(defn equal
+  ([{x :value}]  (where/->typed-val true))
+  ([{x :value} {y :value}] (where/->typed-val (= x y)))
+  ([{x :value} {y :value} & more]
+   (where/->typed-val (apply = x y (mapv :value more)))))
+
+(defn not-equal
+  ([{x :value}]  (where/->typed-val false))
+  ([{x :value} {y :value}] (where/->typed-val (not= x y)))
+  ([{x :value} {y :value} & more]
+   (where/->typed-val (apply not= x y (mapv :value more)))))
+
+(defn absolute-value
+  [{x :value}]
+  (where/->typed-val (abs x)))
+
+(defn round
+  [{a :value}]
+  (where/->typed-val (math/round a)))
+
+(defmacro -if
+  [test then else]
+  `(if (:value ~test)
+     ~then
+     ~else))
+
+(defn -nil?
+  [{x :value}]
+  (where/->typed-val (nil? x)))
+
+(defn dotproduct
+  [{v1 :value} {v2 :value}]
+  (where/->typed-val
+    (score/dotproduct v1 v2)))
+
+(defn cosine-similarity
+  [{v1 :value} {v2 :value}]
+  (where/->typed-val
+    (score/cosine-similarity v1 v2 )))
+
+(defn euclidean-distance
+  [{v1 :value} {v2 :value}]
+  (where/->typed-val
+    (score/euclidian-distance v1 v2 )))
 
 (def qualified-symbols
-  '{!              fluree.db.query.exec.eval/!
-    ||             fluree.db.query.exec.eval/||
-    &&             fluree.db.query.exec.eval/&&
+  '{!              fluree.db.query.exec.eval/-not
+    ||             fluree.db.query.exec.eval/-or
+    &&             fluree.db.query.exec.eval/-and
+    +              fluree.db.query.exec.eval/plus
+    -              fluree.db.query.exec.eval/minus
+    *              fluree.db.query.exec.eval/multiply
+    /              fluree.db.query.exec.eval/divide
+    =              fluree.db.query.exec.eval/equal
     <              fluree.db.query.exec.eval/less-than
     <=             fluree.db.query.exec.eval/less-than-or-equal
     >              fluree.db.query.exec.eval/greater-than
     >=             fluree.db.query.exec.eval/greater-than-or-equal
-    abs            clojure.core/abs
+    abs            fluree.db.query.exec.eval/absolute-value
     as             fluree.db.query.exec.eval/as
+    and            fluree.db.query.exec.eval/-and
     avg            fluree.db.query.exec.eval/avg
     bound          fluree.db.query.exec.eval/bound
     ceil           fluree.db.query.exec.eval/ceil
@@ -444,20 +505,26 @@
     concat         fluree.db.query.exec.eval/concat
     contains       fluree.db.query.exec.eval/contains
     count-distinct fluree.db.query.exec.eval/count-distinct
-    count          clojure.core/count
+    count          fluree.db.query.exec.eval/-count
     datatype       fluree.db.query.exec.eval/datatype
     floor          fluree.db.query.exec.eval/floor
     groupconcat    fluree.db.query.exec.eval/groupconcat
+    if             fluree.db.query.exec.eval/-if
     in             fluree.db.query.exec.eval/in
     iri            fluree.db.query.exec.eval/iri
     lang           fluree.db.query.exec.eval/lang
     lcase          fluree.db.query.exec.eval/lcase
     median         fluree.db.query.exec.eval/median
+    nil?           fluree.db.query.exec.eval/-nil?
+    not            fluree.db.query.exec.eval/-not
+    not=           fluree.db.query.exec.eval/not-equal
     now            fluree.db.query.exec.eval/now
+    or             fluree.db.query.exec.eval/-or
+    quot           fluree.db.query.exec.eval/quotient
     rand           fluree.db.query.exec.eval/rand
     regex          fluree.db.query.exec.eval/regex
     replace        fluree.db.query.exec.eval/replace
-    round          clojure.math/round
+    round          fluree.db.query.exec.eval/round
     sample         fluree.db.query.exec.eval/sample
     sample1        fluree.db.query.exec.eval/sample1
     stddev         fluree.db.query.exec.eval/stddev
@@ -487,24 +554,39 @@
     max            fluree.db.query.exec.eval/max
     min            fluree.db.query.exec.eval/min
 
-    dotproduct         fluree.db.vector.scoring/dotproduct
-    cosine-similarity  fluree.db.vector.scoring/cosine-similarity
-    euclidian-distance fluree.db.vector.scoring/euclidian-distance})
+    dotproduct         fluree.db.query.exec.eval/dotproduct
+    cosine-similarity  fluree.db.query.exec.eval/cosine-similarity
+    euclidian-distance fluree.db.query.exec.eval/euclidean-distance})
 
-(defn as*
-  [val var]
-  (log/trace "as binding value:" val "to variable:" var)
-  (if (where/variable? var)
-    val ; only needs to return the value b/c we store the binding variable in the AsSelector
-    (throw
-     (ex-info
-      (str "second arg to `as` must be a query variable (e.g. ?foo); provided:"
-           (pr-str var))
-      {:status 400, :error :db/invalid-query}))))
+(def allowed-aggregate-fns
+  '#{avg ceil count count-distinct distinct floor groupconcat
+     median max min rand sample sample1 stddev str sum variance})
 
-(defmacro as
-  [val var]
-  `(as* ~val '~var))
+(def allowed-scalar-fns
+  '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang
+     nil? as not not= or re-find re-pattern in
+
+     ;; string fns
+     strStarts strEnds subStr strLen ucase lcase contains strBefore strAfter
+     concat regex replace
+
+     ;; numeric fns
+     abs round ceil floor rand
+
+     ;; datetime fns
+     now year month day hours minutes seconds tz
+
+     ;; hash fns
+     sha256 sha512
+
+     ;; rdf term fns
+     uuid struuid isNumeric isBlank str
+
+     ;; vector scoring fns
+     dotproduct cosine-similarity euclidian-distance})
+
+(def allowed-symbols
+  (set/union allowed-aggregate-fns allowed-scalar-fns))
 
 (defn symbols
   [code]
@@ -543,38 +625,49 @@
 (defn coerce
   [code allow-aggregates?]
   (postwalk (fn [x]
-              (if (and (symbol? x)
-                       (not (where/variable? x)))
-                (qualify x allow-aggregates?)
-                x))
+              (cond (where/variable? x)
+                    x
+
+                    (symbol? x)
+                    (qualify x allow-aggregates?)
+
+                    ;; literal
+                    (not (sequential? x))
+                    (where/->TypedValue x (datatype/infer x) nil)
+
+                    :else
+                    x))
             code))
+
+(defn mch->typed-val
+  [{::where/keys [val iri datatype-iri lang]}]
+  (where/->typed-val (or iri val) (if iri const/iri-id datatype-iri) lang))
 
 (defn bind-variables
   [soln-sym var-syms ctx]
   (into `[~context-var ~ctx]
         (mapcat (fn [var]
-                  (let [dt-var   (var->dt-var var)
-                        lang-var (var->lang-var var)]
-                    `[mch#      (get ~soln-sym (quote ~var))
-                      ~dt-var   (where/get-datatype-iri mch#)
-                      ~lang-var (-> mch# ::where/meta :lang (or ""))
-                      ~var      (cond->> (where/get-binding mch#)
-                                  (= ~dt-var ::group/grouping)
-                                  (mapv where/get-value))])))
+                  `[mch# (get ~soln-sym (quote ~var))
+                    ;; convert match to TypedValue
+                    ~var (if (= ::group/grouping (::where/datatype-iri mch#))
+                           (mapv mch->typed-val (where/get-binding mch#))
+                           (mch->typed-val mch#))]))
         var-syms))
+
+(defn compile*
+  [code ctx allow-aggregates?]
+  (let [qualified-code (coerce code allow-aggregates?)
+        vars           (variables qualified-code)
+        soln-sym       'solution
+        bdg            (bind-variables soln-sym vars ctx)]
+    `(fn [~soln-sym]
+       (let ~bdg
+         ~qualified-code))))
 
 (defn compile
   ([code ctx] (compile code ctx true))
   ([code ctx allow-aggregates?]
-   (let [qualified-code (coerce code allow-aggregates?)
-         vars           (variables qualified-code)
-         soln-sym       'solution
-         bdg            (bind-variables soln-sym vars ctx)
-         fn-code        `(fn [~soln-sym]
-                           (log/trace "fn solution:" ~soln-sym)
-                           (log/trace "fn bindings:" (quote ~bdg))
-                           (let ~bdg
-                             ~qualified-code))]
+   (let [fn-code (compile* code ctx allow-aggregates?)]
      (log/trace "compiled fn:" fn-code)
      (eval fn-code))))
 

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -209,8 +209,15 @@
 
 (defmacro datatype
   [var]
-  (let [dt-var (var->dt-var var)]
-    `(iri/string->iri ~dt-var)))
+  (let [dt (var->dt-var var)]
+    `(where/->TypedValue ~dt const/iri-id)))
+
+(def context-var
+  (symbol "$-CONTEXT"))
+
+(defmacro iri
+  [s]
+  `(where/->TypedValue (json-ld/expand-iri ~s ~context-var) const/iri-id))
 
 (def numeric-datatypes
   #{const/iri-xsd-decimal
@@ -393,13 +400,6 @@
 (defn in
   [term expressions]
   (contains? (set expressions) term))
-
-(def context-var
-  (symbol "$-CONTEXT"))
-
-(defmacro iri
-  [s]
-  `(iri/expand ~s ~context-var))
 
 (def allowed-scalar-fns
   '#{&& || ! > < >= <= = + - * / quot and bound coalesce datatype if iri lang

--- a/src/clj/fluree/db/query/exec/having.cljc
+++ b/src/clj/fluree/db/query/exec/having.cljc
@@ -11,7 +11,7 @@
       (async/pipeline-async 2
                             filtered-ch
                             (fn [solution ch]
-                              (go (try* (when (filter-fn solution)
+                              (go (try* (when (:value (filter-fn solution))
                                           (>! ch solution))
                                         (async/close! ch)
                                         (catch* e

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -119,7 +119,7 @@
   (update-solution
     [_ solution]
     (log/trace "AsSelector update-solution solution:" solution)
-    (let [result (as-fn solution)
+    (let [result (:value (as-fn solution))
           dt     (datatype/infer-iri result)]
       (log/trace "AsSelector update-solution result:" result)
       (assoc solution bind-var (-> bind-var

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -101,7 +101,7 @@
   ValueSelector
   (format-value
     [_ _ _ _ _ _ error-ch solution]
-    (go (try* (agg-fn solution)
+    (go (try* (:value (agg-fn solution))
               (catch* e
                       (log/error e "Error applying aggregate selector")
                       (>! error-ch e))))))

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -32,7 +32,7 @@
 
 (defmethod display const/iri-id
   [match compact]
-  (some-> match where/get-iri iri/unwrap compact))
+  (some-> match where/get-iri compact))
 
 (defmethod display const/iri-vector
   [match _compact]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -48,7 +48,7 @@
   (if (or (contains? mch ::iri)
           (contains? mch ::sids))
     const/iri-id
-    (-> mch ::datatype-iri iri/unwrap)))
+    (::datatype-iri mch)))
 
 (defn match-sid
   [iri-mch db-alias sid]
@@ -224,7 +224,7 @@
   [type context]
   (fn [soln mch]
     (if (variable? type)
-      (if-let [dt-iri (some-> soln (get type) get-iri iri/unwrap)]
+      (if-let [dt-iri (some-> soln (get type) get-iri)]
         (matched-datatype? mch dt-iri)
         true)
       (let [dt-iri (json-ld/expand-iri type context)]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -567,7 +567,7 @@
     (let [f (pattern-data pattern)]
       (try*
         (let [result (f solution)]
-          (when (:value result)
+          (when result
             solution))
         (catch* e (>! error-ch (filter-exception e solution f)))))))
 

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -428,8 +428,8 @@
   [[_ & codes] _vars context]
   (let [f (->> codes
                (map parse-code)
-               (map (fn [code]
-                      (eval/compile code context)))
+               (map (fn [code] (comp (fn [tv] (:value tv))
+                                     (eval/compile code context))))
                (apply every-pred))]
     [(where/->pattern :filter (with-meta f {:fns codes}))]))
 

--- a/test/fluree/db/datatype_test.cljc
+++ b/test/fluree/db/datatype_test.cljc
@@ -11,8 +11,8 @@
     (is (= nil (coerce 42 const/$xsd:string))))
 
   (testing "@id"
-    (is (= #fluree/IRI "foo" (coerce "foo" const/$id)))
-    (is (= nil (coerce 42 const/$id))))
+    (is (= "foo" (coerce "foo" const/$id)))
+    (is (= 42 (coerce 42 const/$id))))
   (testing "boolean"
     (is (= true (coerce "true" const/$xsd:boolean)))
     (is (= false (coerce "false" const/$xsd:boolean)))

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -927,6 +927,7 @@
                           WHERE {?person person:favNums ?favNums.}
                           GROUP BY ?person"
                  results @(fluree/query db query {:format :sparql})]
+             (is (= 3 (count results)))
              (is (every? #(-> % first integer?) results))))
          (testing "SUM query works"
            (let [query   "PREFIX person: <http://example.org/Person#>

--- a/test/fluree/db/transact/update_test.clj
+++ b/test/fluree/db/transact/update_test.clj
@@ -2,7 +2,13 @@
   (:require [clojure.test :refer [deftest is testing]]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.api :as fluree]
-            [fluree.db.constants :as const]))
+            [fluree.db.constants :as const])
+  (:import [java.time OffsetDateTime]))
+
+(defn const-now
+  []
+  {:value (OffsetDateTime/parse "2024-06-13T19:53:57.000Z")
+   :datatype-iri const/iri-xsd-dateTime})
 
 (deftest ^:integration deleting-data
   (testing "Deletions of entire subjects."
@@ -164,7 +170,7 @@
         db1    (fluree/db ledger)]
 
     (testing "hash functions"
-      (with-redefs [fluree.db.query.exec.eval/now (fn [] "2023-06-13T19:53:57.234345Z")]
+      (with-redefs [fluree.db.query.exec.eval/now const-now]
         (let [updated (-> @(fluree/stage db1 {"@context" ["https://ns.flur.ee"
                                                           test-utils/default-str-context
                                                           {"ex" "http://example.com/"}]
@@ -190,60 +196,60 @@
                                                        {"ex" "http://example.com/"}]
                                           "selectOne" {"ex:hash-fns" ["ex:sha512" "ex:sha256"]}}))))))
     (testing "datetime functions"
-      (with-redefs [fluree.db.query.exec.eval/now (fn [] {:value (java.time.Instant/parse "2023-06-13T19:53:57.234345Z")
-                                                          :datatype-iri const/iri-xsd-dateTime})]
-        (let [updated (-> @(fluree/stage db1 {"@context" ["https://ns.flur.ee"
-                                                          test-utils/default-str-context
-                                                          {"ex" "http://example.com/"}]
-                                              "insert"
-                                              [{"id"         "ex:create-predicates"
-                                                "ex:now"     0 "ex:year"    0 "ex:month"    0 "ex:day" 0 "ex:hours" 0
-                                                "ex:minutes" 0 "ex:seconds" 0 "ex:timezone" 0 "ex:tz"  0}
-                                               {"id"                "ex:datetime-fns"
-                                                "ex:localdatetime"  {"@value" "2023-06-13T14:17:22.435"
-                                                                     "@type" const/iri-xsd-dateTime}
-                                                "ex:offsetdatetime" {"@value" "2023-06-13T14:17:22.435-05:00"
-                                                                     "@type" const/iri-xsd-dateTime}
-                                                "ex:utcdatetime"    {"@value" "2023-06-13T14:17:22.435Z"
-                                                                     "@type" const/iri-xsd-dateTime}}]})
-                          (fluree/stage {"@context" ["https://ns.flur.ee"
-                                                     test-utils/default-str-context
-                                                     {"ex" "http://example.com/"}]
-                                         "where"    [{"id"                "?s"
-                                                      "ex:localdatetime"  "?localdatetime"
-                                                      "ex:offsetdatetime" "?offsetdatetime"
-                                                      "ex:utcdatetime"    "?utcdatetime"}
-                                                     ["bind"
-                                                      "?now" "(now)"
-                                                      "?year" "(year ?localdatetime)"
-                                                      "?month" "(month ?localdatetime)"
-                                                      "?day" "(day ?localdatetime)"
-                                                      "?hours" "(hours ?localdatetime)"
-                                                      "?minutes" "(minutes ?localdatetime)"
-                                                      "?seconds" "(seconds ?localdatetime)"
-                                                      "?tz1" "(tz ?utcdatetime)"
-                                                      "?tz2" "(tz ?offsetdatetime)"
-                                                      "?comp=" "(= ?localdatetime (now))"
-                                                      "?comp<" "(< ?localdatetime (now))"
-                                                      "?comp<=" "(<= ?localdatetime (now))"
-                                                      "?comp>" "(> ?localdatetime (now))"
-                                                      "?comp>=" "(>= ?localdatetime (now))"]]
-                                         "insert"   [{"id"         "?s"
-                                                      "ex:now"     "?now"
-                                                      "ex:year"    "?year"
-                                                      "ex:month"   "?month"
-                                                      "ex:day"     "?day"
-                                                      "ex:hours"   "?hours"
-                                                      "ex:minutes" "?minutes"
-                                                      "ex:seconds" "?seconds"
-                                                      "ex:tz"      ["?tz1" "?tz2"]
-                                                      "ex:comp="   "?comp="
-                                                      "ex:comp<"   "?comp<"
-                                                      "ex:comp<="  "?comp<="
-                                                      "ex:comp>"   "?comp>"
-                                                      "ex:comp>="  "?comp>="}]
-                                         "values"   ["?s" ["ex:datetime-fns"]]}))]
-          (is (= {"ex:now"     "2023-06-13T19:53:57.234345Z"
+      (with-redefs [fluree.db.query.exec.eval/now const-now]
+        (let [db2 @(fluree/stage db1 {"@context" ["https://ns.flur.ee"
+                                                  test-utils/default-str-context
+                                                  {"ex" "http://example.com/"}]
+                                      "insert"
+                                      [{"id"         "ex:create-predicates"
+                                        "ex:now"     0 "ex:year"    0 "ex:month"    0 "ex:day" 0 "ex:hours" 0
+                                        "ex:minutes" 0 "ex:seconds" 0 "ex:timezone" 0 "ex:tz"  0}
+                                       {"id"                "ex:datetime-fns"
+                                        "ex:localdatetime"  {"@value" "2023-06-13T14:17:22.435"
+                                                             "@type" const/iri-xsd-dateTime}
+                                        "ex:offsetdatetime" {"@value" "2023-06-13T14:17:22.435-05:00"
+                                                             "@type" const/iri-xsd-dateTime}
+                                        "ex:utcdatetime"    {"@value" "2023-06-13T14:17:22.435Z"
+                                                             "@type" const/iri-xsd-dateTime}}]})
+              db3 @(fluree/stage db2 {"@context" ["https://ns.flur.ee"
+                                                  test-utils/default-str-context
+                                                  {"ex" "http://example.com/"}]
+                                      "values" ["?s" [{"@value" "ex:datetime-fns" "@type" "@id"}]]
+                                      "where" [{"id" "?s"
+                                                "ex:localdatetime" "?localdatetime"
+                                                "ex:offsetdatetime" "?offsetdatetime"
+                                                "ex:utcdatetime" "?utcdatetime"}
+                                               ["bind"
+                                                "?now" "(str (now))"
+                                                "?year" "(year ?localdatetime)"
+                                                "?month" "(month ?localdatetime)"
+                                                "?day" "(day ?localdatetime)"
+                                                "?hours" "(hours ?localdatetime)"
+                                                "?minutes" "(minutes ?localdatetime)"
+                                                "?seconds" "(seconds ?localdatetime)"
+                                                "?tz1" "(tz ?utcdatetime)"
+                                                "?tz2" "(tz ?offsetdatetime)"
+                                                "?comp=" "(= ?localdatetime (now))"
+                                                "?comp<" "(< ?localdatetime (now))"
+                                                "?comp<=" "(<= ?localdatetime (now))"
+                                                "?comp>" "(> ?localdatetime (now))"
+                                                "?comp>=" "(>= ?localdatetime (now))"]]
+                                      "insert" [{"id" "?s"
+                                                 "ex:now"     "?now"
+                                                 "ex:year" "?year"
+                                                 "ex:month" "?month"
+                                                 "ex:day" "?day"
+                                                 "ex:hours" "?hours"
+                                                 "ex:minutes" "?minutes"
+                                                 "ex:seconds" "?seconds"
+                                                 "ex:tz" ["?tz1" "?tz2"]
+                                                 "ex:comp=" "?comp="
+                                                 "ex:comp<" "?comp<"
+                                                 "ex:comp<="  "?comp<="
+                                                 "ex:comp>"   "?comp>"
+                                                 "ex:comp>="  "?comp>="}]
+                                      })]
+          (is (= {"ex:now"     "2024-06-13T19:53:57Z"
                   "ex:year"    2023
                   "ex:month"   6
                   "ex:day"     13
@@ -256,7 +262,7 @@
                   "ex:comp<="  true
                   "ex:comp>"   false
                   "ex:comp>="  false}
-                 @(fluree/query @updated
+                 @(fluree/query db3
                                 {"@context" [test-utils/default-str-context
                                              {"ex" "http://example.com/"}]
                                  "selectOne"
@@ -297,7 +303,7 @@
                                                    "ex:ceil"  "?ceil"
                                                    "ex:floor" "?floor"
                                                    "ex:rand"  "?rand"}
-                                       "values"   ["?s" ["ex:numeric-fns"]]}))]
+                                       "values"   ["?s" [{"@value" "ex:numeric-fns" "@type" "@id"}]]}))]
         (is (= {"ex:abs"   2
                 "ex:round" 1
                 "ex:ceil"  2
@@ -356,7 +362,7 @@
                                                     "ex:strAfter"  "?strAfter"
                                                     "ex:concat"    "?concatted"
                                                     "ex:regex"     "?matched"}]
-                                       "values"   ["?s" ["ex:string-fns"]]}))]
+                                       "values"   ["?s" [{"@value" "ex:string-fns" "@type" "@id"}]]}))]
         (is (= {"ex:strEnds"   false
                 "ex:strStarts" false
                 "ex:contains"  false
@@ -421,7 +427,7 @@
                                                       "ex:isNotNumeric" "?isNotNum"
                                                       "ex:isBlank"      "?isBlank"
                                                       "ex:isNotBlank"   "?isNotBlank"}]
-                                         "values"   ["?s" ["ex:rdf-term-fns"]]}))]
+                                         "values"   ["?s" [{"@value" "ex:rdf-term-fns" "@type" "@id"}]]}))]
           (is (= {"ex:str"          ["1" "Abcdefg"]
                   "ex:uuid"         {"id" "urn:uuid:34bdb25f-9fae-419b-9c50-203b5f306e47"}
                   "ex:struuid"      "34bdb25f-9fae-419b-9c50-203b5f306e47",
@@ -471,7 +477,7 @@
                                                    "ex:bound"  "?bound"
                                                    "ex:in"     "?in"
                                                    "ex:not-in" "?not-in"}
-                                       "values"   ["?s" ["ex:functional-fns"]]}))]
+                                       "values"   ["?s" [{"@value" "ex:functional-fns" "@type" "@id"}]]}))]
         (is (= {"ex:bound"  true
                 "ex:in"     true
                 "ex:not-in" false}
@@ -503,7 +509,7 @@
                                           "where"    [{"id" "?s", "ex:text" "?text"}
                                                       ["bind" "?err" "(foo ?text)"]]
                                           "insert"   {"id" "?s", "ex:text" "?err"}
-                                          "values"   ["?s" ["ex:error"]]})
+                                          "values"   ["?s" [{"@value" "ex:error" "@type" "@id"}]]})
 
             run-err @(fluree/stage db2 {"@context" ["https://ns.flur.ee"
                                                     test-utils/default-str-context
@@ -511,7 +517,7 @@
                                         "where"    [{"id" "?s", "ex:text" "?text"}
                                                     ["bind" "?err" "(abs ?text)"]]
                                         "insert"   {"id" "?s", "ex:error" "?err"}
-                                        "values"   ["?s" ["ex:error"]]})]
+                                        "values"   ["?s" [{"@value" "ex:error" "@type" "@id"}]]})]
         (is (= "Query function references illegal symbol: foo"
                (-> parse-err
                    Throwable->map


### PR DESCRIPTION
In the course of implementing support for polymorphic comparisons and the various rdf functions I had to make some changes to how we handle function evaluation in general. I ended up replacing the IRI records with a more general TypedValue record. The main problem was that there are cases were we need to know the datatype of a value when that datatype cannot be inferred. We can only infer datatypes of:
- boolean
- string
- long
- decimal

If we have a function that returns a datatype not in that set, we couldn't do it. The IRI record was meant to allow inference of IRI types (distinct from strings), but it wasn't a general approach, and we needed a general approach.

This PR converts all of our function implementations to take TypedValues and return TypedValues.