### PR TITLE
add support for a singular function selector

### DIFF
--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -563,9 +563,18 @@
 
 (defn parse-select-clause
   [clause context depth]
-  (if (sequential? clause)
+  (cond
+    ;; singular function call
+    (list? clause)
+    (parse-selector context depth clause)
+
+    ;; collection of selectors
+    (sequential? clause)
     (mapv (partial parse-selector context depth)
           clause)
+
+    ;; singular selector
+    :else
     (parse-selector context depth clause)))
 
 (defn parse-select

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -19,6 +19,16 @@
           (is (= [["Alice" 3] ["Brian" 1] ["Cam" 2] ["Liam" 2]]
                  subject)
               "aggregates bindings within each group")))
+      (testing "with singular function selector"
+        (let [qry     {:context  [test-utils/default-context
+                                  {:ex "http://example.org/ns/"}]
+                       :select   '(count ?favNums)
+                       :where    '{:schema/name ?name
+                                   :ex/favNums  ?favNums}
+                       :group-by '?name}
+              subject @(fluree/query db qry)]
+          (is (= [3 1 2 2] subject)
+              "aggregates bindings within each group")))
       (testing "with implicit grouping"
         (let [qry     {:context test-utils/default-context
                        :select  '[(count ?name)]


### PR DESCRIPTION
This allows users to use a singular function selector, just like a singular variable selector or a wildcard selector:
```
{
  "from": "graph",
  "where": {
    "@id": "?s",
    "favNum": "?favNum"
  },
  "select": "(count ?favNum)",
  "groupBy": "?s"
}
```