### PR TITLE
Fix/schema datatype

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,7 @@
          metosin/malli                   {:mvn/version "0.16.2"}
          nano-id/nano-id                 {:mvn/version "1.1.0"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :git/sha "97e5c713e1e9a2c833a509c71c615595ff5fcda0"}
+                                          :git/sha "452efeb51b6b7244de9dbbd461f068d62a33d53c"}
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.3.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,7 @@
          metosin/malli                   {:mvn/version "0.16.2"}
          nano-id/nano-id                 {:mvn/version "1.1.0"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
-                                          :git/sha "a27ddd5553d5f0dd0cc68bfc442d7b4bdedc0658"}
+                                          :git/sha "97e5c713e1e9a2c833a509c71c615595ff5fcda0"}
 
          ;; logging
          org.clojure/tools.logging       {:mvn/version "1.3.0"}

--- a/dev-resources/movies2-schema.json
+++ b/dev-resources/movies2-schema.json
@@ -32,12 +32,12 @@
       {
         "sh:path": { "@id": "https://example.com/population" },
         "sh:maxCount": 1,
-        "sh:datatype": { "@id": "xsd:float" }
+        "sh:datatype": { "@id": "xsd:integer" }
       },
       {
         "sh:path": { "@id": "https://example.com/area" },
         "sh:maxCount": 1,
-        "sh:datatype": { "@id": "xsd:float" },
+        "sh:datatype": { "@id": "xsd:integer" },
         "sh:description": "Area size in square miles"
 
       },
@@ -82,19 +82,19 @@
       {
         "sh:path": { "@id": "https://example.com/budget" },
         "sh:maxCount": 1,
-        "sh:datatype": { "@id": "xsd:float" },
+        "sh:datatype": { "@id": "xsd:integer" },
         "sh:description": "Budget in United States dollars ($)"
       },
       {
         "sh:path": { "@id": "https://example.com/revenue" },
         "sh:maxCount": 1,
-        "sh:datatype": { "@id": "xsd:float" },
+        "sh:datatype": { "@id": "xsd:integer" },
         "sh:description": "Revenue in United States dollars ($)"
       },
       {
         "sh:path": { "@id": "https://example.com/runtime" },
         "sh:maxCount": 1,
-        "sh:datatype": { "@id": "xsd:float" },
+        "sh:datatype": { "@id": "xsd:integer" },
         "sh:description": "Length of movie in minutes"
       },
       {

--- a/src/clj/fluree/db/datatype.cljc
+++ b/src/clj/fluree/db/datatype.cljc
@@ -117,7 +117,7 @@
      (string? x)  (if lang
                     const/$rdf:langString
                     const/$xsd:string)
-     (integer? x) const/$xsd:long ; infer to long to prevent overflow
+     (integer? x) const/$xsd:integer
      (number? x)  const/$xsd:double
      (boolean? x) const/$xsd:boolean)))
 

--- a/src/clj/fluree/db/dbproto.cljc
+++ b/src/clj/fluree/db/dbproto.cljc
@@ -2,8 +2,5 @@
 
 (defprotocol IFlureeDb
   (-query [db query] "Performs a query.")
-  ;; schema-related
-  (-p-prop [db property predicate] "Returns the property specified for the given predicate.")
-  ;; following return async chans
   (-class-ids [db subject-id] "For the provided subject-id (long int), returns a list of class subject ids it is a member of (long ints)")
   (-index-update [db commit-index] "Updates db to reflect a new index point described by commit-index metadata"))

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -372,7 +372,6 @@
                     max-namespace-code reindex-min-bytes reindex-max-bytes max-old-indexes]
   dbproto/IFlureeDb
   (-query [this query-map] (fql/query this query-map))
-  (-p-prop [_ meta-key property] (match/p-prop schema meta-key property))
   (-class-ids [this subject] (match/class-ids this subject))
   (-index-update [db commit-index] (index-update db commit-index))
 

--- a/src/clj/fluree/db/flake/match.cljc
+++ b/src/clj/fluree/db/flake/match.cljc
@@ -19,18 +19,9 @@
       (<? (query-range/index-range root :spot = [subject-id const/$rdf:type]
                                    {:flake-xf (map flake/o)})))))
 
-(defn p-prop
-  [schema property predicate]
-  (assert (#{:id :iri :subclassOf :parentProps :childProps :datatype}
-           property)
-          (str "Invalid predicate property: " (pr-str property)))
-  (get-in schema [:pred predicate property]))
-
-(defn class-prop
-  [{:keys [schema] :as _db} meta-key class]
-  (if (= :subclasses meta-key)
-    (get @(:subclasses schema) class)
-    (p-prop schema meta-key class)))
+(defn subclasses
+  [{:keys [schema] :as _db} class]
+  (get @(:subclasses schema) class))
 
 (defn match-id
   [db fuel-tracker solution s-mch error-ch]
@@ -116,7 +107,7 @@
                              (comp (map (fn [cls]
                                           (where/match-sid sub-obj db-alias cls)))
                                    (remove nil?))
-                             (class-prop db :subclasses cls))
+                             (subclasses db cls))
             class-ch   (async/to-chan! class-objs)]
         (async/pipeline-async 2
                               matched-ch

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -37,7 +37,7 @@
    #{{:id #fluree/SID[8 'address'],
       :iri 'http://schema.org/Patient',
       :subclassOf #{#fluree/SID[8 'location']}
-      :datatype nil} ...}
+      ...} ...}
    "
   [pred-items]
   (let [subclass-map (reduce
@@ -74,8 +74,7 @@
    :iri         nil
    :subclassOf  #{}
    :parentProps #{}
-   :childProps  #{}
-   :datatype    nil})
+   :childProps  #{}})
 
 (defn initial-property-map*
   [iri sid]
@@ -190,12 +189,10 @@
       :else pred-map)))
 
 (def initial-type-map
-  (assoc (initial-property-map* const/iri-type const/$rdf:type)
-         :datatype const/$id))
+  (initial-property-map* const/iri-type const/$rdf:type))
 
 (def initial-class-map
-  (assoc (initial-property-map* const/iri-class const/$rdfs:Class)
-         :datatype const/$id))
+  (initial-property-map* const/iri-class const/$rdfs:Class))
 
 (defn with-vocab-flakes
   [pred-map db vocab-flakes]
@@ -269,50 +266,9 @@
                           (not (contains? pred-map pid)))))
           flakes)))
 
-(defn datatype-constraint?
-  [f]
-  (-> f flake/p (= const/sh_datatype)))
-
 (defn descending
   [x y]
   (compare y x))
-
-(defn list-index
-  [f]
-  (-> f flake/op :i))
-
-(defn pred-dt-constraints
-  "Collect any shacl datatype constraints and the predicates they apply to."
-  [new-flakes]
-  (loop [[s-flakes & r] (partition-by flake/s new-flakes)
-         res []]
-    (if s-flakes
-      (if-let [dt-constraints (->> s-flakes
-                                   (filter datatype-constraint?)
-                                   (map flake/o)
-                                   first)]
-        (let [path (->> s-flakes
-                        (filter #(= const/sh_path (flake/p %)))
-                        (sort-by list-index descending)
-                        (map flake/o)
-                        first)]
-          (recur r (conj res [path dt-constraints])))
-        (recur r res))
-      res)))
-
-(defn add-pred-datatypes
-  "Add a :datatype key to the pred meta map for any predicates with a sh:datatype
-  constraint. Only one datatype constraint can be valid for a given datatype, most
-  recent wins."
-  [{:keys [pred] :as schema} pred-tuples]
-  (reduce (fn [schema [pid dt]]
-            (let [{:keys [iri] :as pred-meta} (-> pred
-                                                  (get pid)
-                                                  (assoc :datatype dt))]
-              (-> schema
-                  (assoc-in [:pred pid] pred-meta)
-                  (assoc-in [:pred iri] pred-meta))))
-          schema pred-tuples))
 
 (defn add-pid
   [preds db pid]
@@ -345,10 +301,7 @@
                                         (or (contains? pred-sids (flake/s f))
                                             (contains? jld-ledger/predicate-refs (flake/p f)))))
                               new-flakes)
-         pred-datatypes (pred-dt-constraints new-flakes)
-         schema         (-> db
-                            (update-schema pred-sids vocab-flakes)
-                            (add-pred-datatypes pred-datatypes))]
+         schema         (update-schema db pred-sids vocab-flakes)]
      (invalidate-shape-cache! db mods)
      (assoc db :schema schema))))
 
@@ -366,12 +319,11 @@
         (-> db
             :schema
             (assoc :pred pred-map)
-            (update-with db t vocab-flakes)
-            (add-pred-datatypes (filterv #(> (count %) 1) preds)))))))
+            (update-with db t vocab-flakes))))))
 
 ;; schema serialization
 (def ^:const serialized-pred-keys
-  [:id :datatype :subclassOf :parentProps :childProps])
+  [:id :subclassOf :parentProps :childProps])
 
 (def ^:const serialized-pred-keys-reverse
   (reverse serialized-pred-keys))
@@ -438,16 +390,11 @@
                      :id (let [sid (iri/deserialize-sid raw-val)]
                            (assoc acc :id sid
                                       :iri (iri/sid->iri sid namespace-codes)))
-                     :datatype (assoc acc :datatype (iri/deserialize-sid raw-val))
                      :subclassOf (assoc acc :subclassOf (into (:subclassOf base-property-map) (map iri/deserialize-sid raw-val)))
                      :parentProps (assoc acc :parentProps (into (:parentProps base-property-map) (map iri/deserialize-sid raw-val)))
                      :childProps (assoc acc :childProps (into (:childProps base-property-map) (map iri/deserialize-sid raw-val)))
                      ;; else
-                     (throw (ex-info (str "Cannot deserialize schema from index root. "
-                                          "Unrecognized schema property key found: " k
-                                          "which contains a value of: " raw-val)
-                                     {:status 500
-                                      :error  :db/invalid-index})))
+                     acc)
                    acc)]
         (if (= idx max-idx)
           acc*

--- a/src/clj/fluree/db/query/exec/update.cljc
+++ b/src/clj/fluree/db/query/exec/update.cljc
@@ -74,7 +74,6 @@
         dt (or (some-> o-mch
                        where/get-datatype-iri
                        (->> (generate-sid! db-vol)))
-               (dbproto/-p-prop @db-vol :datatype p-iri)
                (datatype/infer v (:lang m)))
         v* (datatype/coerce-value v dt)]
     (flake/create sid pid v* dt t true m)))

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -446,7 +446,7 @@
                                     [:bind ?dt (datatype ?age)]]}
                 results @(fluree/query db query)]
             (is (= [["Bart" "forever 10" :xsd/string]
-                    ["Homer" 36 :xsd/long]
+                    ["Homer" 36 :xsd/integer]
                     ["Marge" 36 :xsd/int]]
                    results))))
         (testing "filtered with the datatype function"
@@ -456,9 +456,9 @@
                          :where   '[{:ex/name ?name
                                      :ex/age  ?age}
                                     [:bind ?dt (datatype ?age)]
-                                    [:filter (= (iri :xsd/long) ?dt)]]}
+                                    [:filter (= (iri :xsd/integer) ?dt)]]}
                 results @(fluree/query db query)]
-            (is (= [["Homer" 36 :xsd/long]]
+            (is (= [["Homer" 36 :xsd/integer]]
                    results)))))
       (testing "filtered in value maps"
         (testing "with explicit type IRIs"

--- a/test/fluree/db/query/index_range_test.clj
+++ b/test/fluree/db/query/index_range_test.clj
@@ -59,9 +59,9 @@
                 alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
                 favNums-pid (fluree/encode-iri db favNums-iri)]
-            (is (= [[alice-sid favNums-pid 9 const/$xsd:long 1 true nil]
-                    [alice-sid favNums-pid 42 const/$xsd:long 1 true nil]
-                    [alice-sid favNums-pid 76 const/$xsd:long 1 true nil]]
+            (is (= [[alice-sid favNums-pid 9 const/$xsd:integer 1 true nil]
+                    [alice-sid favNums-pid 42 const/$xsd:integer 1 true nil]
+                    [alice-sid favNums-pid 76 const/$xsd:integer 1 true nil]]
                    (->> @(fluree/slice db :spot [alice-sid favNums-pid])
                         (mapv flake/Flake->parts)))
                 "Slice should only return Alice's favNums (multi-cardinality)")))
@@ -71,7 +71,7 @@
                 alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
                 favNums-pid (fluree/encode-iri db favNums-iri)]
-            (is (= [[alice-sid favNums-pid 42 const/$xsd:long 1 true nil]]
+            (is (= [[alice-sid favNums-pid 42 const/$xsd:integer 1 true nil]]
                    (->> @(fluree/slice db :spot [alice-sid favNums-pid 42])
                         (mapv flake/Flake->parts)))
                 "Slice should only return the specified favNum value")))
@@ -81,8 +81,8 @@
                 alice-sid   (fluree/encode-iri db alice-iri)
                 favNums-iri (fluree/expand-iri context :ex/favNums)
                 favNums-pid (fluree/encode-iri db favNums-iri)]
-            (is (= [[alice-sid favNums-pid 42 const/$xsd:long 1 true nil]]
-                   (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 const/$xsd:long]])
+            (is (= [[alice-sid favNums-pid 42 const/$xsd:integer 1 true nil]]
+                   (->> @(fluree/slice db :spot [alice-sid favNums-pid [42 const/$xsd:integer]])
                         (mapv flake/Flake->parts)))
                 "Slice should only return the specified favNum value with matching datatype")))
 

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -173,43 +173,43 @@
                                                    {:ex "http://example.org/ns/"}]
                                          :select  ['?s '?p '?o]
                                          :where   {:id '?s, '?p '?o}})]
-          (is (= [["fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"
+          (is (= [["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
                    :f/address
-                   "fluree:memory://29f8788bdf21c7b8f19b15819f5f24bc71f2b2c045c1cb5f6e1233c21ccd798d"]
-                  ["fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"
+                   "fluree:memory://9269ae5eb352ef74fb9c78c0c8b18740f8ac497262e6dbb015fdec89e8bc7a1e"]
+                  ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
                    :f/flakes
                    11]
-                  ["fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"
+                  ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
                    :f/previous
                    "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"]
-                  ["fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"
+                  ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
                    :f/size
-                   1058]
-                  ["fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"
+                   1076]
+                  ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
                    :f/t
                    1]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    "https://www.w3.org/2018/credentials#issuer"
                    "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/address
-                   "fluree:memory://f27aaf853c6d8c3360b51101c966d30b1072cef6a99d7c6b317db39448f175c8"]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                   "fluree:memory://af10694c6008358ec9070a52dc8246c99981f82511f207f42dfd3990630f117b"]
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/alias
                    "query/everything"]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/branch
                    "main"]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/data
-                   "fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                   "fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"]
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/previous
                    "fluree:commit:sha256:bvvou3uvnd6ffhehsrw23mw4w3fux5jbpacko2ecosb2nzxkfu5v"]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/time
                    720000]
-                  ["fluree:commit:sha256:bbfbm6d5y4vyje5vgalfo4ho2osldck3ctzcuduq3rueisrvp4grs"
+                  ["fluree:commit:sha256:bccenzjhhlj634hgtkl6iamyxisxooxhw4xafoujdnsagituu3wr"
                    :f/v
                    1]
                   [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,14 +28,14 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:b7lmegwrinx56rv2rvikcipm6336q2omjkurdczz2744gpniz6iq"
+        (is (= "fluree:commit:sha256:bb5oiv3ppsasnxmhralghjf5q4ow3llo2nncn2ju47t3ttlh24sg5"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://1083d58f24aabed56f8c762c1ae9b67e930edc39b6db4aeffc65e5cc993ae3b2"
+        (is (= "fluree:memory://35087de56968027e9c6cdb1ecef6351e21e9252884210f3e84ad83f3fff64378"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
-        (is (= "fluree:db:sha256:bb2uy627whhmg66jhzqbncmwoc6wnjt6kboqzhmo6uomab53auug3"
+        (is (= "fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://29f8788bdf21c7b8f19b15819f5f24bc71f2b2c045c1cb5f6e1233c21ccd798d"
+        (is (= "fluree:memory://9269ae5eb352ef74fb9c78c0c8b18740f8ac497262e6dbb015fdec89e8bc7a1e"
                (get-in db1 [:commit :data :address])))))))

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1672,9 +1672,21 @@ WORLD!")
                                 :schema/name  "John"
                                 :schema/age   40
                                 :schema/email 42}})]
-          (is (= {:status 400, :error :db/value-coercion}
+          (is (= {:error  :shacl/violation
+                  :report {:sh/conforms false
+                           :sh/result   [{:f/expectation          :xsd/string
+                                          :sh/constraintComponent :sh/datatype
+                                          :sh/focusNode           :ex/john
+                                          :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42"
+                                          :sh/resultPath          [:schema/email]
+                                          :sh/resultSeverity      :sh/Violation
+                                          :sh/sourceShape         "_:fdb-4"
+                                          :sh/value               [:xsd/integer]
+                                          :type                   :sh/ValidationResult}]
+                           :type        :sh/ValidationReport}
+                  :status 400}
                  (ex-data db-num-email)))
-          (is (= "Value 42 cannot be coerced to provided datatype: http://www.w3.org/2001/XMLSchema#string."
+          (is (= "Subject :ex/john path [:schema/email] violates constraint :sh/datatype of shape _:fdb-4 - the following values do not have expected datatype :xsd/string: 42."
                  (ex-message db-num-email))))))))
 
 (deftest ^:integration property-paths
@@ -2169,7 +2181,7 @@ WORLD!")
                                                   {"id"      "ex:Bob"
                                                    "ex:name" 123
                                                    "type"    "ex:User"}]})]
-          (is (= "Value 123 cannot be coerced to provided datatype: http://www.w3.org/2001/XMLSchema#string."
+          (is (= "Subject ex:Bob path [\"ex:name\"] violates constraint sh:datatype of shape _:fdb-2 - the following values do not have expected datatype xsd:string: 123."
                  (ex-message db-bad-friend-name)))))
       (testing "maxCount"
         (let [db1           @(fluree/stage db0

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -143,7 +143,7 @@
                           :sh/property    [{:sh/path     :schema/age
                                             :sh/minCount 1
                                             :sh/maxCount 1
-                                            :sh/datatype :xsd/long}]}})
+                                            :sh/datatype :xsd/integer}]}})
 
 
 

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -47,7 +47,7 @@
              (ex-message stage-id-only)))
       (is (= "Invalid transaction, insert or delete clause must contain nodes with objects."
              (ex-message stage-empty-txn)))
-      (is (= {:flakes 1, :size 88, :indexed 0}
+      (is (= {:flakes 1, :size 94, :indexed 0}
              (:stats stage-empty-node))
           "empty nodes are allowed as long as there is other data, they are just noops")
       (is (= [[:ex/alice :schema/age 42]]
@@ -260,7 +260,8 @@
             _       (assert (not (util/exception? db1)))
             db2     @(fluree/stage db0 {"@context" ["https://ns.flur.ee"
                                                     test-utils/default-str-context
-                                                    {"ex" "https://example.com/"}]
+                                                    {"ex"        "https://example.com/"
+                                                     "ex:rating" {"@type" "xsd:float"}}]
                                         "insert"   movies})
             _       (assert (not (util/exception? db2)))
             query   {"@context" [test-utils/default-str-context
@@ -531,6 +532,6 @@
            @(fluree/query db2 {"@context"  context
                                "selectOne" {"ex:freddy" ["schema:age"]}}))
         "8 is converted from a long to an int.")
-    (is (= "Value alot cannot be coerced to provided datatype: http://www.w3.org/2001/XMLSchema#integer."
+    (is (= "Subject ex:letti path [\"schema:age\"] violates constraint sh:datatype of shape ex:PropertyShape/age - the following values do not have expected datatype xsd:integer: alot."
            (ex-message db3))
         "datatype constraint is restored after a load")))


### PR DESCRIPTION
This finishes the move of inferred datatypes for integers, which are now cast to xsd:integer instead of xsd:long per spec. Tests adjusted.

After this change, I noticed `dbproto/-p-prop` shouldn't be used and was actually getting in the way of SHACL validation reporting. I removed this protocol.

Removal of the protocol obliviated the need to track `:datatype` in the `:schema`,s "preds" - so that was removed which also simplified some code and should offer a tiny boost in speed.
