### PR TITLE
Feature/default policy

### DIFF
--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -231,11 +231,11 @@
    (ledger/-db ledger)))
 
 (defn wrap-policy
-  ([db policy default-allow?]
-   (wrap-policy db policy default-allow? nil))
-  ([db policy default-allow? values-map]
+  ([db policy]
+   (wrap-policy db policy nil))
+  ([db policy values-map]
    (promise-wrap
-    (policy/wrap-policy db policy default-allow? values-map))))
+    (policy/wrap-policy db policy values-map))))
 
 (defn wrap-identity-policy
   "For provided identity, locates specific property f:policyClass on
@@ -244,11 +244,11 @@
 
   With the policy classes, finds all policies containing that class
   declaration."
-  ([db identity default-allow?]
-   (wrap-identity-policy db identity default-allow? nil))
-  ([db identity default-allow? values-map]
+  ([db identity]
+   (wrap-identity-policy db identity nil))
+  ([db identity values-map]
    (promise-wrap
-    (policy/wrap-identity-policy db identity default-allow? values-map))))
+    (policy/wrap-identity-policy db identity values-map))))
 
 (defn dataset
   "Creates a composed dataset from multiple resolved graph databases.
@@ -291,14 +291,14 @@
   signing identity, which is then used by `wrap-identity-policy` to extract
   the policy classes and apply the policies to the query."
   ([ds cred-query] (credential-query ds cred-query {}))
-  ([ds cred-query {:keys [default-allow? values-map format] :as opts}]
+  ([ds cred-query {:keys [values-map format] :as opts}]
    (promise-wrap
     (go-try
       (let [{query :subject, identity :did} (if (= :sparql format)
                                               (cred/verify-jws cred-query)
                                               (<? (cred/verify cred-query)))]
        (log/debug "Credential query with identity: " identity " and query: " query)
-       (let [policy-db (<? (policy/wrap-identity-policy ds identity default-allow? values-map))]
+       (let [policy-db (<? (policy/wrap-identity-policy ds identity values-map))]
          (<? (query-api/query policy-db query opts))))))))
 
 (defn query-connection
@@ -327,12 +327,12 @@
    (let [latest-db (ledger/-db ledger)
          res-chan  (query-api/history latest-db query)]
      (promise-wrap res-chan)))
-  ([ledger query {:keys [policy identity default-allow? values-map] :as _opts}]
+  ([ledger query {:keys [policy identity values-map] :as _opts}]
    (promise-wrap
     (let [latest-db (ledger/-db ledger)
           policy-db (if identity
-                      (<? (policy/wrap-identity-policy latest-db identity default-allow? values-map))
-                      (<? (policy/wrap-policy latest-db policy default-allow? values-map)))]
+                      (<? (policy/wrap-identity-policy latest-db identity values-map))
+                      (<? (policy/wrap-policy latest-db policy values-map)))]
       (query-api/history policy-db query)))))
 
 (defn credential-history
@@ -343,7 +343,7 @@
   signing identity, which is then used by `wrap-identity-policy` to extract
   the policy classes and apply the policies to the query."
   ([ledger cred-query] (credential-history ledger cred-query {}))
-  ([ledger cred-query {:keys [default-allow? values-map] :as opts}]
+  ([ledger cred-query {:keys [values-map] :as _opts}]
    (promise-wrap
     (go-try
      (let [latest-db (ledger/-db ledger)
@@ -351,7 +351,7 @@
        (log/debug "Credential history query with identity: " identity " and query: " query)
        (cond
          (and query identity)
-         (let [policy-db (<? (policy/wrap-identity-policy latest-db identity default-allow? values-map))]
+         (let [policy-db (<? (policy/wrap-identity-policy latest-db identity values-map))]
            (<? (query-api/history policy-db query)))
 
          identity

--- a/src/clj/fluree/db/api/transact.cljc
+++ b/src/clj/fluree/db/api/transact.cljc
@@ -30,7 +30,7 @@
                          (:meta parsed-opts))
          identity    (:did parsed-opts)
          policy-db   (if identity
-                       (<? (policy/wrap-identity-policy db identity true nil))
+                       (<? (policy/wrap-identity-policy db identity nil))
                        db)]
      (if track-fuel?
        (let [start-time #?(:clj (System/nanoTime)

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -160,14 +160,14 @@
       commit-ch))
 
   policy/Restrictable
-  (wrap-policy [_ policy default-allow? values-map]
+  (wrap-policy [_ policy values-map]
     (go-try
      (let [db (<? db-chan)]
-       (<? (policy/wrap-policy db policy default-allow? values-map)))))
-  (wrap-identity-policy [_ identity default-allow? values-map]
+       (<? (policy/wrap-policy db policy values-map)))))
+  (wrap-identity-policy [_ identity values-map]
     (go-try
       (let [db (<? db-chan)]
-        (<? (policy/wrap-identity-policy db identity default-allow? values-map)))))
+        (<? (policy/wrap-identity-policy db identity values-map)))))
   (root [_]
     (let [root-ch (async/promise-chan)
           root-db (->AsyncDB alias branch commit t root-ch)]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -412,8 +412,7 @@
     (jld-format/reverse-property db iri reverse-spec compact-fn cache fuel-tracker error-ch))
 
   (-iri-visible? [db iri]
-    (let [sid (iri/encode-iri db iri)]
-      (qpolicy/allow-iri? db sid)))
+    (qpolicy/allow-iri? db iri))
 
   indexer/Indexable
   (index [db changes-ch]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -458,10 +458,10 @@
     (history/query-commits db context from-t to-t include error-ch))
 
   policy/Restrictable
-  (wrap-policy [db policy default-allow? values-map]
-    (policy-rules/wrap-policy db policy default-allow? values-map))
-  (wrap-identity-policy [db identity default-allow? values-map]
-    (policy-rules/wrap-identity-policy db identity default-allow? values-map))
+  (wrap-policy [db policy values-map]
+    (policy-rules/wrap-policy db policy values-map))
+  (wrap-identity-policy [db identity values-map]
+    (policy-rules/wrap-identity-policy db identity values-map))
   (root [db]
     (policy/root-db db))
 

--- a/src/clj/fluree/db/json_ld/api.cljc
+++ b/src/clj/fluree/db/json_ld/api.cljc
@@ -346,12 +346,12 @@
 (defn ^{:deprecated    "3.0"
         :superseded-by "fluree.db/wrap-policy"}
   wrap-policy
-  ([db policy default-allow?]
-   (wrap-policy db policy default-allow? nil))
-  ([db policy default-allow? values-map]
+  ([db policy]
+   (wrap-policy db policy nil))
+  ([db policy values-map]
    (log/warn "DEPRECATED function `wrap-policy` superseded by `fluree.db.api/wrap-policy`")
    (promise-wrap
-    (policy/wrap-policy db policy default-allow? values-map))))
+    (policy/wrap-policy db policy values-map))))
 
 (defn ^{:deprecated    "3.0"
         :superseded-by "fluree.db/wrap-identity-policy"}
@@ -362,12 +362,12 @@
 
   With the policy classes, finds all policies containing that class
   declaration."
-  ([db identity default-allow?]
-   (wrap-identity-policy db identity default-allow? nil))
-  ([db identity default-allow? values-map]
+  ([db identity]
+   (wrap-identity-policy db identity nil))
+  ([db identity values-map]
    (log/warn "DEPRECATED function `wrap-identity-policy` superseded by `fluree.db.api/wrap-identity-policy`")
    (promise-wrap
-    (policy/wrap-identity-policy db identity default-allow? values-map))))
+    (policy/wrap-identity-policy db identity values-map))))
 
 (defn ^{:deprecated    "3.0"
         :superseded-by "fluree.db/dataset"}
@@ -417,7 +417,7 @@
   signing identity, which is then used by `wrap-identity-policy` to extract
   the policy classes and apply the policies to the query."
   ([ds cred-query] (credential-query ds cred-query {}))
-  ([ds cred-query {:keys [default-allow? values-map] :as opts}]
+  ([ds cred-query {:keys [values-map] :as opts}]
    (log/warn "DEPRECATED function `credential-query` superseded by `fluree.db.api/credential-query`")
    (promise-wrap
     (go-try
@@ -425,7 +425,7 @@
        (log/debug "Credential query with identity: " identity " and query: " query)
        (cond
          (and query identity)
-         (let [policy-db (<? (policy/wrap-identity-policy ds identity default-allow? values-map))]
+         (let [policy-db (<? (policy/wrap-identity-policy ds identity values-map))]
            (<? (query-api/query policy-db query opts)))
 
          identity
@@ -456,13 +456,13 @@
    (let [latest-db (ledger/-db ledger)
          res-chan  (query-api/history latest-db query)]
      (promise-wrap res-chan)))
-  ([ledger query {:keys [policy identity default-allow? values-map] :as _opts}]
+  ([ledger query {:keys [policy identity values-map] :as _opts}]
    (log/warn "DEPRECATED function `history` superseded by `fluree.db.api/history`")
    (promise-wrap
      (let [latest-db (ledger/-db ledger)
            policy-db (if identity
-                       (<? (policy/wrap-identity-policy latest-db identity default-allow? values-map))
-                       (<? (policy/wrap-policy latest-db policy default-allow? values-map)))]
+                       (<? (policy/wrap-identity-policy latest-db identity values-map))
+                       (<? (policy/wrap-policy latest-db policy values-map)))]
       (query-api/history policy-db query)))))
 
 (defn ^{:deprecated    "3.0"
@@ -475,7 +475,7 @@
   signing identity, which is then used by `wrap-identity-policy` to extract
   the policy classes and apply the policies to the query."
   ([ledger cred-query] (credential-history ledger cred-query {}))
-  ([ledger cred-query {:keys [default-allow? values-map] :as opts}]
+  ([ledger cred-query {:keys [values-map] :as opts}]
    (log/warn "DEPRECATED function `credential-history` superseded by `fluree.db.api/credential-history`")
    (promise-wrap
     (go-try
@@ -484,7 +484,7 @@
        (log/debug "Credential history query with identity: " identity " and query: " query)
        (cond
          (and query identity)
-         (let [policy-db (<? (policy/wrap-identity-policy latest-db identity default-allow? values-map))]
+         (let [policy-db (<? (policy/wrap-identity-policy latest-db identity values-map))]
            (<? (query-api/history policy-db query)))
 
          identity

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -13,6 +13,6 @@
   (assoc db :policy root-policy-map))
 
 (defprotocol Restrictable
-  (wrap-policy [db policy-rules default-allow? values-map])
-  (wrap-identity-policy [db identity default-allow? values-map])
+  (wrap-policy [db policy-rules values-map])
+  (wrap-identity-policy [db identity values-map])
   (root [db]))

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -3,7 +3,6 @@
             [fluree.db.dbproto :as dbproto]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.iri :as iri]
-            [fluree.db.flake :as flake]
             [fluree.db.json-ld.policy :refer [root]]
             [fluree.db.util.log :as log]))
 
@@ -31,11 +30,10 @@
     (get-in policy [const/iri-modify :property])
     (get-in policy [const/iri-view :property])))
 
-
 (defn policies-for-classes
   "Returns sequence of policies that apply to the provided classes."
-  [policy-map modify? classes]
-  (let [class-policies (class-policy-map policy-map modify?)]
+  [policy modify? classes]
+  (let [class-policies (class-policy-map policy modify?)]
     (seq (apply concat (keep #(get class-policies %) classes)))))
 
 (defn policies-for-property
@@ -45,6 +43,12 @@
   (let [prop-policies (property-policy-map policy-map modify?)]
     (get prop-policies property)))
 
+(defn default-policies
+  "Returns default policies if they exist else nil"
+  [policy-map modify?]
+  (if modify?
+    (get-in policy-map [const/iri-modify :default])
+    (get-in policy-map [const/iri-view :default])))
 
 (defn policy-query
   [db sid values-map policy]
@@ -55,7 +59,7 @@
                    :TODO
                    [(into ["?$this"] (keys values-map))
                     [(into [{"@value" this-var
-                             "@type" const/iri-id}]
+                             "@type"  const/iri-id}]
                            (vals values-map))]])]
     (assoc query "values" values)))
 
@@ -65,15 +69,6 @@
                "Policy enforcement prevents modification.")
            {:status 403 :error :db/policy-exception}))
 
-(defn default-val
-  "Returns the default policy value if no policies are found. (true/false)
-  If false and a transactions/modification, an exception is thrown."
-  [{:keys [default-allow?] :as _policy} modify? policies]
-  (if (true? default-allow?)
-    true
-    (if modify?
-      (modify-exception policies)
-      false)))
 
 (defn policies-allow?
   "Once narrowed to a specific set of policies, execute and return
@@ -92,38 +87,3 @@
        (if modify?
          (modify-exception policies-to-eval)
          false)))))
-
-(defn class-allow?
-  "Evaluates if a class policy allows access to the provided subject.
-  Returns true if class policy allows, else false.
-  If no class policy exists, returns the value of `default-allow?`
-  Optional 'classes' argument is a list of class sids to check for policies.
-
-  If not passed in, the policy cache is checked for classes for the given
-  subject, or a query is executed to retrieve and cache them.
-
-  There is querying here that is expensive, so it should be checked
-  before here if class policies exist, if not, then there is no need
-  to utilize this function."
-  [{:keys [policy] :as db} sid modify? classes]
-  (go-try
-   (let [classes*   (or classes
-                        (get @(:cache policy) sid)
-                        (let [class-sids (<? (dbproto/-class-ids db sid))]
-                          (swap! (:cache policy) assoc sid class-sids)
-                          class-sids))
-         c-policies (policies-for-classes policy modify? classes*)]
-     (if c-policies
-       (<? (policies-allow? db modify? sid (:values-map policy) c-policies))
-       (default-val policy modify? c-policies)))))
-
-
-(defn property-allow?
-  [{:keys [policy] :as db} modify? flake]
-  (go-try
-   (let [pid        (flake/p flake)
-         sid        (flake/s flake)
-         p-policies (policies-for-property policy modify? pid)]
-     (if p-policies
-       (<? (policies-allow? db modify? sid (:values-map policy) p-policies))
-       (default-val policy modify? p-policies)))))

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -18,8 +18,8 @@
   (get-in policy [const/iri-view :property]))
 
 (defn unrestricted?
-  [{:keys [policy] :as _db}]
-  (enforce/unrestricted-view? policy))
+  [db]
+  (enforce/unrestricted-view? (:policy db)))
 
 (defn allow-flake?
   "Returns one of:

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -59,7 +59,7 @@
         (go (ex-info (str "Unexpected exception in allow-iri? checking permission for iri: " iri
                           "Exception encoding IRI to internal format.")
                      {:status 500
-                      :error :db/unexpected-error}))))
+                      :error :db/unexpected-error}))))))
 
 (defn filter-flakes
   "Iterates over multiple flakes and returns the allowed flakes from policy, or

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -33,7 +33,7 @@
      (enforce/unrestricted-view? policy)
      true
 
-     ;; currently property-restrictions override class restrictions if present
+     ;; property restrictions override class restrictions if present
      (property-restrictions? policy)
      (<? (enforce/property-allow? db false flake))
 

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -15,7 +15,11 @@
 
 (defn class-restriction?
   [restriction-map]
-  (nil? (:on-property restriction-map)))
+  (seq (:on-class restriction-map)))
+
+(defn default-restriction?
+  [restriction-map]
+  (:default? restriction-map))
 
 (defn view-restriction?
   [restriction-map]
@@ -24,15 +28,6 @@
 (defn modify-restriction?
   [restriction-map]
   (:modify? restriction-map))
-
-(defn extract-query
-  [restriction]
-  (let [query (util/get-first-value restriction const/iri-query)]
-    (if (map? query)
-      (assoc query "select" "?$this")
-      (throw (ex-info (str "Invalid policy, unable to extract query from restriction: " restriction)
-                      {:status 400
-                       :error :db/invalid-policy})))))
 
 (defn policy-cids
   "Returns class subject ids for a given policy restriction map.
@@ -44,53 +39,47 @@
          (map #(iri/encode-iri db %))
          set)))
 
-(defn add-view-prop-restriction
-  [restriction pid policy]
-  (update-in policy [const/iri-view :property pid] util/conjv restriction))
+(defn add-default-restriction
+  [restriction policy]
+  (cond-> policy
 
-(defn add-modify-prop-restriction
-  [restriction pid policy]
-  (update-in policy [const/iri-modify :property pid] util/conjv restriction))
+          (view-restriction? restriction)
+          (update-in [const/iri-view :default] util/conjv restriction)
 
-(defn add-view-class-restriction
-  [restriction cid policy]
-  (update-in policy [const/iri-view :class cid] util/conjv restriction))
+          (modify-restriction? restriction)
+          (update-in [const/iri-modify :default] util/conjv restriction)))
 
-(defn add-modify-class-restriction
-  [restriction cid policy]
-  (update-in policy [const/iri-modify :class cid] util/conjv restriction))
-
-(defn parse-class-restriction
+(defn add-class-restriction
   [restriction-map db policy-map]
   (let [cids (policy-cids db restriction-map)]
     (reduce
-     (fn [acc cid]
+     (fn [policy cid]
        (let [restriction-map* (assoc restriction-map :cid cid)]
-         (cond->> acc
+         (cond-> policy
 
-                  (view-restriction? restriction-map)
-                  (add-view-class-restriction restriction-map* cid)
+                 (view-restriction? restriction-map*)
+                 (update-in [const/iri-view :class cid] util/conjv restriction-map*)
 
-                  (modify-restriction? restriction-map)
-                  (add-modify-class-restriction restriction-map* cid))))
+                 (modify-restriction? restriction-map*)
+                 (update-in [const/iri-modify :class cid] util/conjv restriction-map*))))
      policy-map
      cids)))
 
-(defn parse-property-restriction
+(defn add-property-restriction
   [restriction-map db policy-map]
   (let [cids (policy-cids db restriction-map)]
     (reduce
-     (fn [acc property]
+     (fn [policy property]
        (let [pid              (iri/encode-iri db property)
              restriction-map* (assoc restriction-map :pid pid
                                                      :cids cids)]
-         (cond->> acc
+         (cond-> policy
 
-                  (view-restriction? restriction-map)
-                  (add-view-prop-restriction restriction-map* pid)
+                 (view-restriction? restriction-map*)
+                 (update-in [const/iri-view :property pid] util/conjv restriction-map*)
 
-                  (modify-restriction? restriction-map)
-                  (add-modify-prop-restriction restriction-map* pid))))
+                 (modify-restriction? restriction-map*)
+                 (update-in [const/iri-modify :property pid] util/conjv restriction-map*))))
      policy-map
      (:on-property restriction-map))))
 
@@ -100,35 +89,32 @@
         on-property (util/get-all-ids restriction const/iri-onProperty) ;; can be multiple properties
         on-class    (when-let [classes (util/get-all-ids restriction const/iri-onClass)]
                       (set classes))
-        query       (extract-query restriction)
+        query       (when-let [q (util/get-first-value restriction const/iri-query)]
+                      (if (map? q)
+                        (assoc q "select" "?$this")
+                        (throw (ex-info (str "Invalid policy, unable to extract query from restriction: " restriction)
+                                        {:status 400
+                                         :error  :db/invalid-policy}))))
         actions     (set (util/get-all-ids restriction const/iri-action))
         view?       (or (empty? actions) ;; if actions is not specified, default to all actions
                         (contains? actions const/iri-view))
         modify?     (or (empty? actions)
                         (contains? actions const/iri-modify))]
-    (cond
-      ;; valid restriction must have at least one of view or modify, and on-property or on-class
-      (and (or view? modify?)
-           (or on-property on-class))
+    (if (or view? modify?)
       {:id          id
        :on-property on-property
        :on-class    on-class
+       :default?    (and (nil? on-property) (nil? on-class)) ;; with no class or property restrictions, becomes a default policy
        :ex-message  (util/get-first-value restriction const/iri-exMessage)
        :view?       view?
        :modify?     modify?
        :query       query}
-
-      ;; no property or class specified
-      (or on-property on-class)
-      (do
-        (log/warn "Policy Restriction contain f:on-property or f:on-class, ignoring restriction: " id)
-        ;; log returns nil, but explicit here to show intended nil value for downstream checks
-        nil)
-
-      :else ;; no view or modify specified
-      (do
-        (log/warn "Policy Restriction must be of type view or modify, ignoring restriction: " id)
-        nil))))
+      ;; policy has incorrectly formatted view? and/or modify?
+      ;; this might allow data through that was intended to be restricted, so throw.
+      (throw (ex-info (str "Invalid policy definition. Policies must have f:action of {@id: f:view} or {@id: f:modify}. "
+                           "Policy restriction data that failed: " restriction)
+                      {:status 400
+                       :error  :db/invalid-policy})))))
 
 (defn parse-policy-rules
   [db policy-rules]
@@ -138,10 +124,13 @@
        (cond
 
          (property-restriction? parsed-restriction)
-         (parse-property-restriction parsed-restriction db acc)
+         (add-property-restriction parsed-restriction db acc)
 
          (class-restriction? parsed-restriction)
-         (parse-class-restriction parsed-restriction db acc)
+         (add-class-restriction parsed-restriction db acc)
+
+         (default-restriction? parsed-restriction)
+         (add-default-restriction parsed-restriction acc)
 
          :else
          acc)))

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -52,13 +52,13 @@
        rule-results))))
 
 (defn restrict-db
-  ([db t {:keys [did default-allow? reasoner-methods rule-sources] :as opts}]
+  ([db t {:keys [did reasoner-methods rule-sources] :as opts}]
    (restrict-db db t opts nil))
-  ([db t {:keys [did default-allow? reasoner-methods rule-sources] :as opts} conn]
+  ([db t {:keys [did reasoner-methods rule-sources] :as opts} conn]
    (go-try
     (let [processed-rule-sources (<? (load-aliased-rule-dbs conn rule-sources))
           policy-db              (if did
-                                   (<? (perm/wrap-identity-policy db did default-allow? nil))
+                                   (<? (perm/wrap-identity-policy db did nil))
                                    db)
           time-travel-db         (-> (if t
                                        (<? (time-travel/as-of policy-db t))

--- a/test/fluree/db/policy/identity_based_test.clj
+++ b/test/fluree/db/policy/identity_based_test.clj
@@ -45,9 +45,14 @@
                                     "f:query"      {"@type"  "@json"
                                                     "@value" {"@context" {"ex" "http://example.org/ns/"}
                                                               "where"    {"@id"     "?$identity"
-                                                                          "ex:user" {"@id" "?$this"}}}}}]})
+                                                                          "ex:user" {"@id" "?$this"}}}}}
+                                   {"@id"      "ex:defaultAllowView"
+                                    "@type"    ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                    "f:action" {"@id" "f:view"}
+                                    "f:query"  {"@type"  "@json"
+                                                "@value" {}}}]})
 
-          policy-db @(fluree/wrap-identity-policy db alice-did true)]
+          policy-db @(fluree/wrap-identity-policy db alice-did)]
 
       (testing " with direct select binding restricts"
         (is (= [["ex:alice" "111-11-1111"]]

--- a/test/fluree/db/policy/tx_test.clj
+++ b/test/fluree/db/policy/tx_test.clj
@@ -41,18 +41,23 @@
                                            {"@id"     john-did
                                             "ex:user" {"@id" "ex:john"}}]})
 
-          policy            {"@context"     {"ex"     "http://example.org/ns/"
-                                             "schema" "http://schema.org/"
-                                             "f"      "https://ns.flur.ee/ledger#"}
-                             "@id"          "ex:emailPropertyRestriction"
-                             "@type"        ["f:AccessPolicy"]
-                             "f:onProperty" [{"@id" "schema:email"}]
-                             "f:action"     [{"@id" "f:view"}, {"@id" "f:modify"}]
-                             "f:exMessage"  "Only users can update their own emails."
-                             "f:query"      {"@type"  "@json"
-                                             "@value" {"@context" {"ex" "http://example.org/ns/"}
-                                                       "where"    [{"@id"     "?$identity"
-                                                                    "ex:user" {"@id" "?$this"}}]}}}
+          policy            {"@context" {"ex"     "http://example.org/ns/"
+                                         "schema" "http://schema.org/"
+                                         "f"      "https://ns.flur.ee/ledger#"}
+                             "@graph"   [{"@id"          "ex:emailPropertyRestriction"
+                                          "@type"        ["f:AccessPolicy"]
+                                          "f:onProperty" [{"@id" "schema:email"}]
+                                          "f:action"     [{"@id" "f:view"}, {"@id" "f:modify"}]
+                                          "f:exMessage"  "Only users can update their own emails."
+                                          "f:query"      {"@type"  "@json"
+                                                          "@value" {"@context" {"ex" "http://example.org/ns/"}
+                                                                    "where"    [{"@id"     "?$identity"
+                                                                                 "ex:user" {"@id" "?$this"}}]}}}
+                                         {"@id"      "ex:defaultAllowViewModify"
+                                          "@type"    ["f:AccessPolicy"]
+                                          "f:action" [{"@id" "f:view"}, {"@id" "f:modify"}]
+                                          "f:query"  {"@type"  "@json"
+                                                      "@value" {}}}]}
 
           john-params       {"?$identity" {"@value" john-did
                                            "@type"  "@id"}}
@@ -61,7 +66,7 @@
                                            "@type"  "@id"}}
 
           john-allowed      @(fluree/stage
-                              @(fluree/wrap-policy db policy true john-params)
+                              @(fluree/wrap-policy db policy john-params)
                               {"@context" {"ex"     "http://example.org/ns/"
                                            "schema" "http://schema.org/"
                                            "f"      "https://ns.flur.ee/ledger#"}
@@ -73,7 +78,7 @@
                                            "schema:email" "updatedEmail@flur.ee"}})
 
           alice-not-allowed @(fluree/stage
-                              @(fluree/wrap-policy db policy true alice-params)
+                              @(fluree/wrap-policy db policy alice-params)
                               {"@context" {"ex"     "http://example.org/ns/"
                                            "schema" "http://schema.org/"
                                            "f"      "https://ns.flur.ee/ledger#"}
@@ -134,18 +139,23 @@
                                             "ex:user"           {"@id" "ex:john"}
                                             "ex:productManager" {"@id" "ex:widget"}}]})
 
-          policy            {"@context"    {"ex"     "http://example.org/ns/"
-                                            "schema" "http://schema.org/"
-                                            "f"      "https://ns.flur.ee/ledger#"}
-                             "@id"         "ex:productClassRestriction"
-                             "@type"       ["f:AccessPolicy"]
-                             "f:onClass"   [{"@id" "ex:Product"}]
-                             "f:action"    [{"@id" "f:view"}, {"@id" "f:modify"}]
-                             "f:exMessage" "Only products managed by the user can be modified."
-                             "f:query"     {"@type"  "@json"
-                                            "@value" {"@context" {"ex" "http://example.org/ns/"}
-                                                      "where"    [{"@id"               "?$identity"
-                                                                   "ex:productManager" {"@id" "?$this"}}]}}}
+          policy            {"@context" {"ex"     "http://example.org/ns/"
+                                         "schema" "http://schema.org/"
+                                         "f"      "https://ns.flur.ee/ledger#"}
+                             "@graph"   [{"@id"         "ex:productClassRestriction"
+                                          "@type"       ["f:AccessPolicy"]
+                                          "f:onClass"   [{"@id" "ex:Product"}]
+                                          "f:action"    [{"@id" "f:view"}, {"@id" "f:modify"}]
+                                          "f:exMessage" "Only products managed by the user can be modified."
+                                          "f:query"     {"@type"  "@json"
+                                                         "@value" {"@context" {"ex" "http://example.org/ns/"}
+                                                                   "where"    [{"@id"               "?$identity"
+                                                                                "ex:productManager" {"@id" "?$this"}}]}}}
+                                         {"@id"      "ex:defaultAllowViewModify"
+                                          "@type"    ["f:AccessPolicy"]
+                                          "f:action" [{"@id" "f:view"}, {"@id" "f:modify"}]
+                                          "f:query"  {"@type"  "@json"
+                                                      "@value" {}}}]}
 
           john-params       {"?$identity" {"@value" john-did
                                            "@type"  "@id"}}
@@ -154,7 +164,7 @@
                                            "@type"  "@id"}}
 
           john-allowed      @(fluree/stage
-                              @(fluree/wrap-policy db policy true john-params)
+                              @(fluree/wrap-policy db policy john-params)
                               {"@context" {"ex"     "http://example.org/ns/"
                                            "schema" "http://schema.org/"
                                            "f"      "https://ns.flur.ee/ledger#"}
@@ -165,7 +175,7 @@
                                "insert"   {"@id"         "ex:widget",
                                            "schema:name" "Widget - Updated"}})
           alice-not-allowed @(fluree/stage
-                              @(fluree/wrap-policy db policy true alice-params)
+                              @(fluree/wrap-policy db policy alice-params)
                               {"@context" {"ex"     "http://example.org/ns/"
                                            "schema" "http://schema.org/"
                                            "f"      "https://ns.flur.ee/ledger#"}

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -934,54 +934,53 @@
     (let [conn         @(fluree/connect {:method :memory})
           ledger-name  "authortest"
           ledger       @(fluree/create conn ledger-name)
-          context      [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
+          context      [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"
+                                                                             "f"  "https://ns.flur.ee/ledger#"}]
           root-privkey "89e0ab9ac36fb82b172890c89e9e231224264c7c757d58cfd8fcd6f3d4442199"
           root-did     (:id (did/private->did-map root-privkey))
 
-          db0 (fluree/db ledger)
-          db1 @(fluree/stage db0 {"@context" context
-                                  "insert"   [{"@id"         "ex:betty"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Betty"
-                                               "schema:age"  55}
-                                              {"@id"         "ex:freddy"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Freddy"
-                                               "schema:age"  1002}
-                                              {"@id"         "ex:letty"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Leticia"
-                                               "schema:age"  38}
-                                              {"@id"    root-did
-                                               "f:role" {"@id" "ex:rootRole"}}]})
-          db2 (->> @(fluree/stage db1 {"@context" context
-                                       "insert"   {"@id"          "ex:rootPolicy"
-                                                   "@type"        ["f:Policy"]
-                                                   "f:targetNode" {"@id" "f:allNodes"}
-                                                   "f:allow"      [{"@id"          "ex:rootAccessAllow"
-                                                                    "f:targetRole" {"@id" "ex:rootRole"}
-                                                                    "f:action"     [{"@id" "f:view"}
-                                                                                    {"@id" "f:modify"}]}]}})
-                   (fluree/commit! ledger)
-                   (deref))
+          db0          (fluree/db ledger)
+          db1          @(fluree/stage db0 {"@context" context
+                                           "insert"   [{"@id"         "ex:betty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Betty"
+                                                        "schema:age"  55}
+                                                       {"@id"         "ex:freddy"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Freddy"
+                                                        "schema:age"  1002}
+                                                       {"@id"         "ex:letty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Leticia"
+                                                        "schema:age"  38}
+                                                       {"@id"           root-did
+                                                        "f:policyClass" [{"@id" "ex:RootPolicy"}]}]})
+          db2          (->> @(fluree/stage db1 {"@context" context
+                                                "insert"   [{"@id"      "ex:defaultAllowViewModify"
+                                                             "@type"    ["f:AccessPolicy" "ex:RootPolicy"]
+                                                             "f:action" [{"@id" "f:view"}, {"@id" "f:modify"}]
+                                                             "f:query"  {"@type"  "@json"
+                                                                         "@value" {}}}]})
+                            (fluree/commit! ledger)
+                            (deref))
 
-          db3  @(fluree/credential-transact! conn (crypto/create-jws
-                                                    (json/stringify {"@context" context
-                                                                     "ledger" ledger-name
-                                                                     "insert" {"ex:foo" 3}})
-                                                    root-privkey))
+          db3          @(fluree/credential-transact! conn (crypto/create-jws
+                                                           (json/stringify {"@context" context
+                                                                            "ledger"   ledger-name
+                                                                            "insert"   {"ex:foo" 3}})
+                                                           root-privkey))
 
-          db4  @(fluree/credential-transact! conn (crypto/create-jws
-                                                    (json/stringify {"@context" context
-                                                                     "ledger" ledger-name
-                                                                     "insert" {"ex:foo" 5}})
-                                                    root-privkey))]
+          db4          @(fluree/credential-transact! conn (crypto/create-jws
+                                                           (json/stringify {"@context" context
+                                                                            "ledger"   ledger-name
+                                                                            "insert"   {"ex:foo" 5}})
+                                                           root-privkey))]
       (is (= [{"f:data" {"f:t" 1}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn"    "fluree:memory://cba3a98584459b25115f12e11b30f504f6f985d82979f1f16fb1e2d3158ff659",
+               "f:txn"    "fluree:memory://fd7c5b8ed7ad1e0369f75b2504f18826d915b471832ece2397f0ff9dbbc76750",
                "f:data"   {"f:t" 2}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-               "f:txn"    "fluree:memory://69063190b0a67fc6352ce405a28a76617bacfdd976a6d98eccd6dd0b78cf6f37",
+               "f:txn"    "fluree:memory://1944819c19e00d6266a79fdb7074d20fb8609476a6e3bd1083eb91b954e34dbd",
                "f:data"   {"f:t" 3}}]
              (->> @(fluree/history ledger {:context        context
                                            :commit-details true
@@ -996,50 +995,50 @@
     (let [conn         @(fluree/connect {:method :memory})
           ledger-name  "authortest"
           ledger       @(fluree/create conn ledger-name)
-          context      [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
+          context      [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"
+                                                                             "f"  "https://ns.flur.ee/ledger#"}]
           root-privkey "89e0ab9ac36fb82b172890c89e9e231224264c7c757d58cfd8fcd6f3d4442199"
           root-did     (:id (did/private->did-map root-privkey))
 
-          db0 (fluree/db ledger)
-          db1 @(fluree/stage db0 {"@context" context
-                                  "insert"   [{"@id"         "ex:betty"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Betty"
-                                               "schema:age"  55}
-                                              {"@id"         "ex:freddy"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Freddy"
-                                               "schema:age"  1002}
-                                              {"@id"         "ex:letty"
-                                               "@type"       "ex:Yeti"
-                                               "schema:name" "Leticia"
-                                               "schema:age"  38}
-                                              {"@id"    root-did
-                                               "f:role" {"@id" "ex:rootRole"}}]})
-          db2 (->> @(fluree/stage db1 {"@context" context
-                                       "insert"   {"@id"          "ex:rootPolicy"
-                                                   "@type"        ["f:Policy"]
-                                                   "f:targetNode" {"@id" "f:allNodes"}
-                                                   "f:allow"      [{"@id"          "ex:rootAccessAllow"
-                                                                    "f:targetRole" {"@id" "ex:rootRole"}
-                                                                    "f:action"     [{"@id" "f:view"}
-                                                                                    {"@id" "f:modify"}]}]}})
-                   (fluree/commit! ledger)
-                   (deref))
+          db0          (fluree/db ledger)
+          db1          @(fluree/stage db0 {"@context" context
+                                           "insert"   [{"@id"         "ex:betty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Betty"
+                                                        "schema:age"  55}
+                                                       {"@id"         "ex:freddy"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Freddy"
+                                                        "schema:age"  1002}
+                                                       {"@id"         "ex:letty"
+                                                        "@type"       "ex:Yeti"
+                                                        "schema:name" "Leticia"
+                                                        "schema:age"  38}
+                                                       {"@id"           root-did
+                                                        "f:policyClass" [{"@id" "ex:RootPolicy"}]}]})
+          db2          (->> @(fluree/stage db1 {"@context" context
+                                                "insert"   [{"@id"      "ex:defaultAllowViewModify"
+                                                             "@type"    ["f:AccessPolicy" "ex:RootPolicy"]
+                                                             "f:action" [{"@id" "f:view"}, {"@id" "f:modify"}]
+                                                             "f:query"  {"@type"  "@json"
+                                                                         "@value" {}}}]})
+                            (fluree/commit! ledger)
+                            (deref))
 
-          jws1 (crypto/create-jws
-                 (json/stringify {"@context" context
-                                  "ledger"   ledger-name
-                                  "insert"   {"ex:foo" 3}})
-                 root-privkey)
-          db3  @(fluree/credential-transact! conn jws1)
+          jws1         (crypto/create-jws
+                        (json/stringify {"@context" context
+                                         "ledger"   ledger-name
+                                         "insert"   {"ex:foo" 3}})
+                        root-privkey)
+          db3          @(fluree/credential-transact! conn jws1)
 
-          jws2 (crypto/create-jws
-                 (json/stringify {"@context" context
-                                  "ledger"   ledger-name
-                                  "insert"   {"ex:foo" 5}})
-                 root-privkey)
-          db4  @(fluree/credential-transact! conn jws2)]
+          jws2         (crypto/create-jws
+                        (json/stringify {"@context" context
+                                         "ledger"   ledger-name
+                                         "insert"   {"ex:foo" 5}})
+                        root-privkey)
+          db4          @(fluree/credential-transact! conn jws2)]
+
       (testing ":txn returns the raw transaction"
         (is (= [{"f:txn" nil}
                 {"f:txn" jws1}
@@ -1047,86 +1046,80 @@
                @(fluree/history ledger {:context context
                                         :txn     true
                                         :t       {:from 1 :to :latest}}))))
+
       (testing ":commit returns just the commit wrapper"
         (is (pred-match?
-              [{"f:commit"
-                {"f:alias"    "authortest",
-                 "f:time"     720000,
-                 "f:previous" {"id" test-utils/commit-id?},
-                 "id"         test-utils/commit-id?
-                 "f:v"        1,
-                 "f:branch"   "main",
-                 "f:address"  test-utils/address?
-                 "f:data"
-                 {"f:address"  test-utils/address?
-                  "f:flakes"   16,
-                  "f:previous" {"id" test-utils/db-id?},
-                  "f:size"     pos-int?,
-                  "f:t"        1,
-                  "id"         test-utils/db-id?}}}
-               {"f:commit"
-                {"f:alias"    "authortest",
-                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                 "f:time"     720000,
-                 "f:txn"      test-utils/address?
-                 "f:previous" {"id" test-utils/commit-id?}
-                 "id"         test-utils/commit-id?
-                 "f:v"        1,
-                 "f:branch"   "main",
-                 "f:address"  test-utils/address?
-                 "f:data"
-                 {"f:address"  test-utils/address?
-                  "f:flakes"   29,
-                  "f:previous" {"id" test-utils/db-id?},
-                  "f:size"     pos-int?
-                  "f:t"        2,
-                  "id"         test-utils/db-id?}}}
-               {"f:commit"
-                {"f:alias"    "authortest",
-                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                 "f:time"     720000,
-                 "f:txn"      test-utils/address?
-                 "f:previous" {"id" test-utils/commit-id?},
-                 "id"         test-utils/commit-id?
-                 "f:v"        1,
-                 "f:branch"   "main",
-                 "f:address"  test-utils/address?
-                 "f:data"
-                 {"f:address"  test-utils/address?
-                  "f:flakes"   44,
-                  "f:previous" {"id" test-utils/db-id?},
-                  "f:size"     pos-int?,
-                  "f:t"        3,
-                  "id"         test-utils/db-id?}}}]
-              @(fluree/history ledger {:context context
-                                       :commit  true
-                                       :t       {:from 1 :to :latest}}))))
+             [{"f:commit"
+               {"f:alias"    "authortest",
+                "f:time"     720000,
+                "f:previous" {"id" test-utils/commit-id?},
+                "id"         test-utils/commit-id?
+                "f:v"        1,
+                "f:branch"   "main",
+                "f:address"  test-utils/address?
+                "f:data"     {"f:address"  test-utils/address?
+                              "f:flakes"   15,
+                              "f:previous" {"id" test-utils/db-id?},
+                              "f:size"     pos-int?,
+                              "f:t"        1,
+                              "id"         test-utils/db-id?}}}
+              {"f:commit"
+               {"f:alias"    "authortest",
+                "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                "f:time"     720000,
+                "f:txn"      test-utils/address?
+                "f:previous" {"id" test-utils/commit-id?}
+                "id"         test-utils/commit-id?
+                "f:v"        1,
+                "f:branch"   "main",
+                "f:address"  test-utils/address?
+                "f:data"     {"f:address"  test-utils/address?
+                              "f:flakes"   28,
+                              "f:previous" {"id" test-utils/db-id?},
+                              "f:size"     pos-int?
+                              "f:t"        2,
+                              "id"         test-utils/db-id?}}}
+              {"f:commit"
+               {"f:alias"    "authortest",
+                "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                "f:time"     720000,
+                "f:txn"      test-utils/address?
+                "f:previous" {"id" test-utils/commit-id?},
+                "id"         test-utils/commit-id?
+                "f:v"        1,
+                "f:branch"   "main",
+                "f:address"  test-utils/address?
+                "f:data"     {"f:address"  test-utils/address?
+                              "f:flakes"   43,
+                              "f:previous" {"id" test-utils/db-id?},
+                              "f:size"     pos-int?,
+                              "f:t"        3,
+                              "id"         test-utils/db-id?}}}]
+             @(fluree/history ledger {:context context
+                                      :commit  true
+                                      :t       {:from 1 :to :latest}}))))
+
       (testing ":data returns just the asserts and retracts"
-        (is (= [{"f:data"
-                 {"f:t"       1
-                  "f:assert"
-                  [{"f:role" {"id" "ex:rootRole"},
-                    "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                   {"type"        "ex:Yeti",
-                    "schema:age"  55,
-                    "schema:name" "Betty",
-                    "id"          "ex:betty"}
-                   {"type"        "ex:Yeti",
-                    "schema:age"  1002,
-                    "schema:name" "Freddy",
-                    "id"          "ex:freddy"}
-                   {"type"        "ex:Yeti",
-                    "schema:age"  38,
-                    "schema:name" "Leticia",
-                    "id"          "ex:letty"}
-                   {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
-                    "f:targetRole" {"id" "ex:rootRole"},
-                    "id"           "ex:rootAccessAllow"}
-                   {"type"         "f:Policy",
-                    "f:allow"      {"id" "ex:rootAccessAllow"},
-                    "f:targetNode" {"id" "f:allNodes"},
-                    "id"           "ex:rootPolicy"}],
-                  "f:retract" []}}
+        (is (= [{"f:data" {"f:t"       1
+                           "f:assert"  [{"id"            "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"
+                                         "f:policyClass" {"id" "ex:RootPolicy"}}
+                                        {"type"        "ex:Yeti",
+                                         "schema:age"  55,
+                                         "schema:name" "Betty",
+                                         "id"          "ex:betty"}
+                                        {"id"       "ex:defaultAllowViewModify"
+                                         "type"     ["f:AccessPolicy" "ex:RootPolicy"],
+                                         "f:action" [{"id" "f:modify"} {"id" "f:view"}],
+                                         "f:query"  {}}
+                                        {"id"          "ex:freddy"
+                                         "type"        "ex:Yeti",
+                                         "schema:age"  1002,
+                                         "schema:name" "Freddy",}
+                                        {"id"          "ex:letty"
+                                         "type"        "ex:Yeti",
+                                         "schema:age"  38,
+                                         "schema:name" "Leticia"}]
+                           "f:retract" []}}
                 {"f:data" {"f:t"       2
                            "f:assert"  [{"ex:foo" 3, "id" "_:fdb-4"}],
                            "f:retract" []}}
@@ -1136,213 +1129,209 @@
                @(fluree/history ledger {:context context
                                         :data    true
                                         :t       {:from 1 :to :latest}}))))
+
       (testing ":commit :data :and txn can be composed together"
         (is (pred-match?
-              [{"f:txn" nil
-                "f:commit"
-                {"f:alias"    "authortest",
-                 "f:time"     720000,
-                 "f:previous" {"id" test-utils/commit-id?},
-                 "id"         test-utils/commit-id?
-                 "f:v"        1,
-                 "f:branch"   "main",
-                 "f:address"  test-utils/address?
-                 "f:data"
-                 {"f:address"  test-utils/address?
-                  "f:flakes"   16,
-                  "f:previous" {"id" test-utils/db-id?},
-                  "f:size"     pos-int?
-                  "f:t"        1,
-                  "id"         test-utils/db-id?}},
-                "f:data"
-                {"f:t"       1,
-                 "f:assert"
-                 [{"f:role" {"id" "ex:rootRole"},
-                   "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                  {"type"        "ex:Yeti",
-                   "schema:age"  55,
-                   "schema:name" "Betty",
-                   "id"          "ex:betty"}
-                  {"type"        "ex:Yeti",
-                   "schema:age"  1002,
-                   "schema:name" "Freddy",
-                   "id"          "ex:freddy"}
-                  {"type"        "ex:Yeti",
-                   "schema:age"  38,
-                   "schema:name" "Leticia",
-                   "id"          "ex:letty"}
-                  {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
-                   "f:targetRole" {"id" "ex:rootRole"},
-                   "id"           "ex:rootAccessAllow"}
-                  {"type"         "f:Policy",
-                   "f:allow"      {"id" "ex:rootAccessAllow"},
-                   "f:targetNode" {"id" "f:allNodes"},
-                   "id"           "ex:rootPolicy"}],
-                 "f:retract" []}}
-               {"f:txn"  jws1
-                "f:commit"
-                {"f:alias"    "authortest",
-                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                 "f:time"     720000,
-                 "f:txn"      test-utils/address?
-                 "f:previous" {"id" test-utils/commit-id?},
-                 "id"         test-utils/commit-id?
-                 "f:v"        1,
-                 "f:branch"   "main",
-                 "f:address"  test-utils/address?
-                 "f:data"
-                 {"f:address"  test-utils/address?
-                  "f:flakes"   29,
-                  "f:previous" {"id" test-utils/db-id?},
-                  "f:size"     pos-int?
-                  "f:t"        2,
-                  "id"         test-utils/db-id?}},
-                "f:data" {"f:t"       2
-                          "f:assert"  [{"ex:foo" 3, "id" "_:fdb-4"}],
-                          "f:retract" []}}
-               {"f:txn"  jws2
-                "f:commit"
-                {"f:alias"    "authortest",
-                 "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
-                 "f:time"     720000,
-                 "f:txn"      test-utils/address?
-                 "f:previous" {"id" test-utils/commit-id?},
-                 "id"         test-utils/commit-id?
-                 "f:v"        1,
-                 "f:branch"   "main",
-                 "f:address"  test-utils/address?
-                 "f:data"
-                 {"f:address"  test-utils/address?
-                  "f:flakes"   44,
-                  "f:previous" {"id" test-utils/db-id?},
-                  "f:size"     pos-int?
-                  "f:t"        3,
-                  "id"         test-utils/db-id?}},
-                "f:data" {"f:t"       3
-                          "f:assert"  [{"ex:foo" 5, "id" "_:fdb-6"}],
-                          "f:retract" []}}]
-              @(fluree/history ledger {:context context
-                                       :txn     true
-                                       :data    true
-                                       :commit  true
-                                       :t       {:from 1 :to :latest}}))))
+             [{"f:txn"    nil
+               "f:commit" {"f:alias"    "authortest",
+                           "f:time"     720000,
+                           "f:previous" {"id" test-utils/commit-id?},
+                           "id"         test-utils/commit-id?
+                           "f:v"        1,
+                           "f:branch"   "main",
+                           "f:address"  test-utils/address?
+                           "f:data"
+                           {"f:address"  test-utils/address?
+                            "f:flakes"   15,
+                            "f:previous" {"id" test-utils/db-id?},
+                            "f:size"     pos-int?
+                            "f:t"        1,
+                            "id"         test-utils/db-id?}},
+               "f:data"   {"f:t"       1,
+                           "f:assert"
+                           [{"id"            "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"
+                             "f:policyClass" {"id" "ex:RootPolicy"}}
+                            {"type"        "ex:Yeti",
+                             "schema:age"  55,
+                             "schema:name" "Betty",
+                             "id"          "ex:betty"}
+                            {"id"       "ex:defaultAllowViewModify"
+                             "type"     ["f:AccessPolicy" "ex:RootPolicy"],
+                             "f:action" [{"id" "f:modify"} {"id" "f:view"}],
+                             "f:query"  {}}
+                            {"type"        "ex:Yeti",
+                             "schema:age"  1002,
+                             "schema:name" "Freddy",
+                             "id"          "ex:freddy"}
+                            {"type"        "ex:Yeti",
+                             "schema:age"  38,
+                             "schema:name" "Leticia",
+                             "id"          "ex:letty"}]
+                           "f:retract" []}}
+              {"f:txn"    jws1
+               "f:commit" {"f:alias"    "authortest",
+                           "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                           "f:time"     720000,
+                           "f:txn"      test-utils/address?
+                           "f:previous" {"id" test-utils/commit-id?},
+                           "id"         test-utils/commit-id?
+                           "f:v"        1,
+                           "f:branch"   "main",
+                           "f:address"  test-utils/address?
+                           "f:data"
+                           {"f:address"  test-utils/address?
+                            "f:flakes"   28,
+                            "f:previous" {"id" test-utils/db-id?},
+                            "f:size"     pos-int?
+                            "f:t"        2,
+                            "id"         test-utils/db-id?}},
+               "f:data"   {"f:t"       2
+                           "f:assert"  [{"ex:foo" 3, "id" "_:fdb-4"}],
+                           "f:retract" []}}
+              {"f:txn"    jws2
+               "f:commit" {"f:alias"    "authortest",
+                           "f:author"   "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
+                           "f:time"     720000,
+                           "f:txn"      test-utils/address?
+                           "f:previous" {"id" test-utils/commit-id?},
+                           "id"         test-utils/commit-id?
+                           "f:v"        1,
+                           "f:branch"   "main",
+                           "f:address"  test-utils/address?
+                           "f:data"
+                           {"f:address"  test-utils/address?
+                            "f:flakes"   43,
+                            "f:previous" {"id" test-utils/db-id?},
+                            "f:size"     pos-int?
+                            "f:t"        3,
+                            "id"         test-utils/db-id?}},
+               "f:data"   {"f:t"       3
+                           "f:assert"  [{"ex:foo" 5, "id" "_:fdb-6"}],
+                           "f:retract" []}}]
+             @(fluree/history ledger {:context context
+                                      :txn     true
+                                      :data    true
+                                      :commit  true
+                                      :t       {:from 1 :to :latest}}))))
+
       (testing ":commit :data :and txn can be composed together with history"
         (is (pred-match?
-              [{"f:t"       1,
-                "f:assert"  [{"type"        "ex:Yeti",
+             [{"f:t"       1,
+               "f:assert"  [{"type"        "ex:Yeti",
+                             "schema:age"  1002,
+                             "schema:name" "Freddy",
+                             "id"          "ex:freddy"}],
+               "f:retract" [],
+               "f:txn"     nil,
+               "f:commit"  {"f:alias"    "authortest",
+                            "f:time"     720000,
+                            "f:previous" {"id" test-utils/commit-id?},
+                            "id"         test-utils/commit-id?
+                            "f:v"        1,
+                            "f:branch"   "main",
+                            "f:address"  test-utils/address?
+                            "f:data"
+                            {"f:address"  test-utils/address?
+                             "f:flakes"   15,
+                             "f:previous" {"id" test-utils/db-id?},
+                             "f:size"     pos-int?,
+                             "f:t"        1,
+                             "id"         test-utils/db-id?}},
+               "f:data"    {"f:t"       1,
+                            "f:assert"
+                            [{"id"            "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"
+                              "f:policyClass" {"id" "ex:RootPolicy"}}
+                             {"type"        "ex:Yeti",
+                              "schema:age"  55,
+                              "schema:name" "Betty",
+                              "id"          "ex:betty"}
+                             {"id"       "ex:defaultAllowViewModify"
+                              "type"     ["f:AccessPolicy" "ex:RootPolicy"],
+                              "f:action" [{"id" "f:modify"} {"id" "f:view"}],
+                              "f:query"  {}}
+                             {"type"        "ex:Yeti",
                               "schema:age"  1002,
                               "schema:name" "Freddy",
-                              "id"          "ex:freddy"}],
-                "f:retract" [],
-                "f:txn"     nil,
-                "f:commit"  {"f:alias"    "authortest",
-                             "f:time"     720000,
-                             "f:previous" {"id" test-utils/commit-id?},
-                             "id"         test-utils/commit-id?
-                             "f:v"        1,
-                             "f:branch"   "main",
-                             "f:address"  test-utils/address?
-                             "f:data"
-                             {"f:address"  test-utils/address?
-                              "f:flakes"   16,
-                              "f:previous" {"id" test-utils/db-id?},
-                              "f:size"     pos-int?,
-                              "f:t"        1,
-                              "id"         test-utils/db-id?}},
-                "f:data"    {"f:t"       1,
-                             "f:assert"
-                             [{"f:role" {"id" "ex:rootRole"},
-                               "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                              {"type"        "ex:Yeti",
-                               "schema:age"  55,
-                               "schema:name" "Betty",
-                               "id"          "ex:betty"}
-                              {"type"        "ex:Yeti",
-                               "schema:age"  1002,
-                               "schema:name" "Freddy",
-                               "id"          "ex:freddy"}
-                              {"type"        "ex:Yeti",
-                               "schema:age"  38,
-                               "schema:name" "Leticia",
-                               "id"          "ex:letty"}
-                              {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
-                               "f:targetRole" {"id" "ex:rootRole"},
-                               "id"           "ex:rootAccessAllow"}
-                              {"type"         "f:Policy",
-                               "f:allow"      {"id" "ex:rootAccessAllow"},
-                               "f:targetNode" {"id" "f:allNodes"},
-                               "id"           "ex:rootPolicy"}],
-                             "f:retract" []}}]
-              @(fluree/history ledger {:context context
-                                       :history "ex:freddy"
-                                       :txn     true
-                                       :data    true
-                                       :commit  true
-                                       :t       {:from 1 :to :latest}}))))
+                              "id"          "ex:freddy"}
+                             {"type"        "ex:Yeti",
+                              "schema:age"  38,
+                              "schema:name" "Leticia",
+                              "id"          "ex:letty"}],
+                            "f:retract" []}}]
+             @(fluree/history ledger {:context context
+                                      :history "ex:freddy"
+                                      :txn     true
+                                      :data    true
+                                      :commit  true
+                                      :t       {:from 1 :to :latest}}))))
+
       (testing ":commit :data :and txn can be composed together with commit-details"
         (is (pred-match?
-              [{"f:t"       1,
-                "f:assert"  [{"type"        "ex:Yeti",
+             [{"f:t"       1,
+               "f:assert"  [{"type"        "ex:Yeti",
+                             "schema:age"  1002,
+                             "schema:name" "Freddy",
+                             "id"          "ex:freddy"}],
+               "f:retract" [],
+               "f:txn"     nil,
+               "f:commit"  {"f:alias"    "authortest",
+                            "f:time"     720000,
+                            "f:previous" {"id" test-utils/commit-id?},
+                            "id"         test-utils/commit-id?
+                            "f:v"        1,
+                            "f:branch"   "main",
+                            "f:address"  test-utils/address?
+                            "f:data"
+                            {"f:address"  test-utils/address?
+                             "f:flakes"   15,
+                             "f:previous" {"id" test-utils/db-id?},
+                             "f:size"     pos-int?
+                             "f:t"        1,
+                             "id"         test-utils/db-id?}}
+               "f:data"    {"f:t"       1,
+                            "f:assert"
+                            [{"id"            "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"
+                              "f:policyClass" {"id" "ex:RootPolicy"}}
+                             {"type"        "ex:Yeti",
+                              "schema:age"  55,
+                              "schema:name" "Betty",
+                              "id"          "ex:betty"}
+                             {"id"       "ex:defaultAllowViewModify"
+                              "type"     ["f:AccessPolicy" "ex:RootPolicy"],
+                              "f:action" [{"id" "f:modify"} {"id" "f:view"}],
+                              "f:query"  {}}
+                             {"type"        "ex:Yeti",
                               "schema:age"  1002,
                               "schema:name" "Freddy",
-                              "id"          "ex:freddy"}],
-                "f:retract" [],
-                "f:txn"     nil,
-                "f:commit"  {"f:alias"    "authortest",
-                             "f:time"     720000,
-                             "f:previous" {"id" test-utils/commit-id?},
-                             "id"         test-utils/commit-id?
-                             "f:v"        1,
-                             "f:branch"   "main",
-                             "f:address"  test-utils/address?
-                             "f:data"
-                             {"f:address"  test-utils/address?
-                              "f:flakes"   16,
-                              "f:previous" {"id" test-utils/db-id?},
-                              "f:size"     pos-int?
-                              "f:t"        1,
-                              "id"         test-utils/db-id?}}
-                "f:data"    {"f:t"       1,
-                             "f:assert"
-                             [{"f:role" {"id" "ex:rootRole"},
-                               "id"     "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb"}
-                              {"type"        "ex:Yeti",
-                               "schema:age"  55,
-                               "schema:name" "Betty",
-                               "id"          "ex:betty"}
-                              {"type"        "ex:Yeti",
-                               "schema:age"  1002,
-                               "schema:name" "Freddy",
-                               "id"          "ex:freddy"}
-                              {"type"        "ex:Yeti",
-                               "schema:age"  38,
-                               "schema:name" "Leticia",
-                               "id"          "ex:letty"}
-                              {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
-                               "f:targetRole" {"id" "ex:rootRole"},
-                               "id"           "ex:rootAccessAllow"}
-                              {"type"         "f:Policy",
-                               "f:allow"      {"id" "ex:rootAccessAllow"},
-                               "f:targetNode" {"id" "f:allNodes"},
-                               "id"           "ex:rootPolicy"}],
-                             "f:retract" []}}]
-              @(fluree/history ledger {:context        context
-                                       :history        "ex:freddy"
-                                       :commit-details true
-                                       :txn            true
-                                       :data           true
-                                       :commit         true
-                                       :t              {:from 1 :to :latest}})))))))
+                              "id"          "ex:freddy"}
+                             {"type"        "ex:Yeti",
+                              "schema:age"  38,
+                              "schema:name" "Leticia",
+                              "id"          "ex:letty"}
+                             {"f:action"     [{"id" "f:modify"} {"id" "f:view"}],
+                              "f:targetRole" {"id" "ex:rootRole"},
+                              "id"           "ex:rootAccessAllow"}
+                             {"type"         "f:Policy",
+                              "f:allow"      {"id" "ex:rootAccessAllow"},
+                              "f:targetNode" {"id" "f:allNodes"},
+                              "id"           "ex:rootPolicy"}],
+                            "f:retract" []}}]
+             @(fluree/history ledger {:context        context
+                                      :history        "ex:freddy"
+                                      :txn            true
+                                      :data           true
+                                      :commit         true
+                                      :t              {:from 1 :to :latest}})))))))
 
 (deftest ^:integration txn-annotation
   (let [bnode-counter (atom 0)
 
-        conn        @(fluree/connect {:method :memory})
-        ledger-name "annotationtest"
-        ledger      @(fluree/create conn ledger-name)
-        context     [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
+        conn          @(fluree/connect {:method :memory})
+        ledger-name   "annotationtest"
+        ledger        @(fluree/create conn ledger-name)
+        context       [test-utils/default-str-context "https://ns.flur.ee" {"ex" "http://example.org/ns/"}]
 
-        db0 (fluree/db ledger)]
+        db0           (fluree/db ledger)]
     (testing "valid annotations"
       (with-redefs [fluree.db.util.core/current-time-iso    (fn [] "1970-01-01T00:12:00.00000Z")
                     fluree.db.json-ld.iri/new-blank-node-id (fn [] (str "_:fdb-" (swap! bnode-counter inc)))]


### PR DESCRIPTION
Removes `default-allow?` policy flag in favor of default policies.

When looking at configuring fluree/server for zero-trust, it introduced the challenge of specifying a config for `default-allow?` on a per ledger basis. This made it clear that this behavior really belonged as part of the policy itself, and such a config shouldn't be needed.

Having the 'default' behavior part of the policy also offered these enhanced capabilities:
1) instead of true/false, any policy query could be defined as the 'default', allowing more granular control.
2) Different users/identities might have different default behavior
3) Default policy behavior is co-resident with other policy behavior
4) Default policies are defined the identical way as property or class policies, so one thing to explain

As we look to have zero-trust mode, this also makes it possible to create a 'root' policy (just a default policy that always returns truthy) and attach it to an identity, presumably the same identity that created the ledger. This is how v2 worked.

Creating a 'root' policy is just like any other policy, except there is *no* `f:onProperty` or `f:onClass` specified (thus, default). The following is the most permissive/simple example of a root policy:
```
{"@id"      "ex:defaultAllowViewModify"
 "@type"    ["f:AccessPolicy" "ex:RootPolicy"]
 "f:action" [{"@id" "f:view"}, {"@id" "f:modify"}]
 "f:query"  {"@type"  "@json"
                    "@value" {}}}
```

To attached an identity to the above policy, just use `f:policyClass` set to the `@type` in the policy define above (`ex:RootPolicy`):
```
{"@id"          <some-root-did-here>
 "f:policyClass" [{"@id" "ex:RootPolicy"}]}
```

While any query `where` condition can be specified for `f:query` - an empty map has no where condition, so it allows `?$this` to just flow through (truthy).