### PR TITLE
Feature/policy classes

### DIFF
--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -237,7 +237,8 @@
    (wrap-policy db policy nil))
   ([db policy values-map]
    (promise-wrap
-    (policy/wrap-policy db policy values-map))))
+    (let [policy* (json-ld/expand policy)]
+      (policy/wrap-policy db policy* values-map)))))
 
 (defn wrap-class-policy
   "Restricts the provided db with policies in the db

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -231,6 +231,8 @@
    (ledger/-db ledger)))
 
 (defn wrap-policy
+  "Restricts the provided db with the provided json-ld
+  policy restrictions"
   ([db policy]
    (wrap-policy db policy nil))
   ([db policy values-map]

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -239,6 +239,15 @@
    (promise-wrap
     (policy/wrap-policy db policy values-map))))
 
+(defn wrap-class-policy
+  "Restricts the provided db with policies in the db
+  which have a class @type of the provided class(es)."
+  ([db policy-classes]
+   (wrap-class-policy db policy-classes nil))
+  ([db policy-classes values-map]
+   (promise-wrap
+    (policy/wrap-class-policy db policy-classes values-map))))
+
 (defn wrap-identity-policy
   "For provided identity, locates specific property f:policyClass on
   the identity containing a list of class IRIs that identity the policies

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -164,10 +164,6 @@
     (go-try
      (let [db (<? db-chan)]
        (<? (policy/wrap-policy db policy values-map)))))
-  (wrap-identity-policy [_ identity values-map]
-    (go-try
-      (let [db (<? db-chan)]
-        (<? (policy/wrap-identity-policy db identity values-map)))))
   (root [_]
     (let [root-ch (async/promise-chan)
           root-db (->AsyncDB alias branch commit t root-ch)]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -460,8 +460,6 @@
   policy/Restrictable
   (wrap-policy [db policy values-map]
     (policy-rules/wrap-policy db policy values-map))
-  (wrap-identity-policy [db identity values-map]
-    (policy-rules/wrap-identity-policy db identity values-map))
   (root [db]
     (policy/root-db db))
 

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -1,7 +1,15 @@
 (ns fluree.db.json-ld.policy
-  (:require [fluree.db.constants :as const]))
+  (:require [clojure.core.async :refer [go <!]]
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.constants :as const]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.log :as log]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+(defprotocol Restrictable
+  (wrap-policy [db policy-rules values-map])
+  (root [db]))
 
 (def root-policy-map
   "Base policy (permissions) map that will give access to all flakes."
@@ -12,7 +20,45 @@
   [db]
   (assoc db :policy root-policy-map))
 
-(defprotocol Restrictable
-  (wrap-policy [db policy-rules values-map])
-  (wrap-identity-policy [db identity values-map])
-  (root [db]))
+;; TODO - For now, extracting a policy from a `select` clause does not retain the
+;  @value: 'x', @type: '@json' structure for the value of `f:query` which
+;  then creates an issue with JSON-LD parsing. This adds back the
+;  explicit @type declaration for the query itself. Once there is a way
+;  to have the query result come back as raw json-ld, then this step can
+;  be removed.
+(defn policy-from-query
+  "Recasts @type: @json from a raw query result which
+  would looses the @type information."
+  [query-results]
+  (mapv
+   #(if-let [query (get % const/iri-query)]
+      (assoc % const/iri-query {"@value" query
+                                "@type"  "@json"})
+      %)
+   query-results))
+
+
+(defn wrap-identity-policy
+  "Given an identity (@id) that exists in the db which contains a
+  property `f:policyClass` listing policy classes associated with
+  that identity, queries for those classes and calls `wrap-policy`"
+  [db identity values-map]
+  (go
+   (let [policies  (<! (dbproto/-query db {"select" {"?policy" ["*"]}
+                                           "where"  [{"@id"                 identity
+                                                      const/iri-policyClass "?classes"}
+                                                     {"@id"   "?policy"
+                                                      "@type" "?classes"}]}))
+         policies* (if (util/exception? policies)
+                     policies
+                     (policy-from-query policies))
+         val-map   (assoc values-map "?$identity" {"@value" identity
+                                                   "@type"  const/iri-id})]
+     (log/trace "wrap-identity-policy - extracted policy from identity: " identity
+                " policy: " policies*)
+     (if (util/exception? policies*)
+       (ex-info (str "Unable to extract policies for identity: " identity
+                     " with error: " (ex-message policies*))
+                {:status 400 :error :db/policy-exception}
+                policies*)
+       (<! (wrap-policy db policies* val-map))))))

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -3,7 +3,8 @@
             [fluree.db.dbproto :as dbproto]
             [fluree.db.constants :as const]
             [fluree.db.util.core :as util]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -60,7 +61,7 @@
                       " with error: " (ex-message policies*))
                  {:status 400 :error :db/policy-exception}
                  policies*)
-        (<! (wrap-policy db policies* values-map))))))
+        (<! (wrap-policy db (json-ld/expand policies*) values-map))))))
 
 
 (defn wrap-identity-policy
@@ -86,4 +87,4 @@
                      " with error: " (ex-message policies*))
                 {:status 400 :error :db/policy-exception}
                 policies*)
-       (<! (wrap-policy db policies* val-map))))))
+       (<! (wrap-policy db (json-ld/expand policies*) val-map))))))

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -140,22 +140,6 @@
    {}
    policy-rules))
 
-;; TODO - For now, extracting a policy from a `select` clause does not retain the
-;  @value: 'x', @type: '@json' structure for the value of `f:query` which
-;  then creates an issue with JSON-LD parsing. This adds back the
-;  explicit @type declaration for the query itself. Once there is a way
-;  to have the query result come back as raw json-ld, then this step can
-;  be removed.
-(defn policy-from-query
-  "Recasts @type: @json from a raw query result which
-  would looses the @type information."
-  [query-results]
-  (mapv
-   #(if-let [query (get % const/iri-query)]
-      (assoc % const/iri-query {"@value" query
-                                "@type"  "@json"})
-      %)
-   query-results))
 
 (defn wrap-policy
   [db policy-rules values-map]
@@ -165,25 +149,3 @@
      (log/trace "policy-rules: " policy-rules)
      (assoc db :policy (assoc policy-rules :cache (atom {})
                                            :values-map values-map)))))
-
-(defn wrap-identity-policy
-  [db identity values-map]
-  (go
-   (let [policies  (<! (dbproto/-query db {"select" {"?policy" ["*"]}
-                                           "where"  [{"@id"                 identity
-                                                      const/iri-policyClass "?classes"}
-                                                     {"@id"   "?policy"
-                                                      "@type" "?classes"}]}))
-         policies* (if (util/exception? policies)
-                     policies
-                     (policy-from-query policies))
-         val-map   (assoc values-map "?$identity" {"@value" identity
-                                                   "@type"  const/iri-id})]
-     (log/trace "wrap-identity-policy - extracted policy from identity: " identity
-                " policy: " policies*)
-     (if (util/exception? policies*)
-       (ex-info (str "Unable to extract policies for identity: " identity
-                     " with error: " (ex-message policies*))
-                {:status 400 :error :db/policy-exception}
-                policies*)
-       (<! (wrap-policy db policies* val-map))))))

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -140,10 +140,18 @@
    {}
    policy-rules))
 
+(defn validate-values-map
+  [values-map]
+  (or (map? values-map)
+      (throw (ex-info (str "Invalid policy values map. Must be a map. Received: " values-map)
+                      {:status 400
+                       :error  :db/invalid-values-map}))))
 
 (defn wrap-policy
   [db policy-rules values-map]
   (go-try
+   (when values-map
+     (validate-values-map values-map))
    (let [policy-rules (->> (parse-rules-graph policy-rules)
                            (parse-policy-rules db))]
      (log/trace "policy-rules: " policy-rules)

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -147,23 +147,13 @@
                       {:status 400
                        :error  :db/invalid-values-map}))))
 
-(defn expanded?
-  "Checks if json-ld is already expanded by looking for Fluree's special keys.
-  In the case of query-connection calling wrap-policy, it will attempt to expand
-  the policy json-ld using the query's context, so we don't need to re-attempt
-  expansion here."
-  [json-ld]
-  (and (sequential? json-ld)
-       (contains? (first json-ld) :idx)))
-
 (defn wrap-policy
   [db policy-rules values-map]
   (go-try
    (when values-map
      (validate-values-map values-map))
-   (let [policy-rules (->> (if (expanded? policy-rules)
-                             policy-rules
-                             (parse-rules-graph policy-rules))
+   (let [policy-rules (->> policy-rules
+                           util/sequential
                            (parse-policy-rules db))]
      (log/trace "policy-rules: " policy-rules)
      (assoc db :policy (assoc policy-rules :cache (atom {})

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -3,6 +3,7 @@
   that are directly exposed"
   (:require [clojure.core.async :as async]
             [clojure.string :as str]
+            [fluree.db.util.context :as context]
             [fluree.json-ld :as json-ld]
             [fluree.db.fuel :as fuel]
             [fluree.db.ledger.json-ld :as jld-ledger]
@@ -51,14 +52,41 @@
          (recur (rest rule-sources) updated-rule-results))
        rule-results))))
 
+
+(defn policy-restricted?
+  [query-opts]
+  (or (:did query-opts)
+      (:policyClass query-opts)
+      (:policy query-opts)))
+
+(defn policy-enforce-db
+  [db {:keys [opts] :as sanitized-query}]
+  (go-try
+   (let [context (context/extract sanitized-query)
+         {:keys [did policyClass policy policyValues]} opts]
+     (cond
+
+       did
+       (<? (perm/wrap-identity-policy db (json-ld/expand-iri did context) policyValues))
+
+       policyClass
+       (let [classes (map #(json-ld/expand-iri % context) (util/sequential policyClass))]
+         (<? (perm/wrap-class-policy db classes policyValues)))
+
+       policy
+       (let [expanded-policy (json-ld/expand policy context)]
+         (<? (perm/wrap-policy db expanded-policy policyValues)))))))
+
 (defn restrict-db
-  ([db t {:keys [did reasoner-methods rule-sources] :as opts}]
-   (restrict-db db t opts nil))
-  ([db t {:keys [did reasoner-methods rule-sources] :as opts} conn]
+  ([db sanitized-query]
+   (restrict-db db sanitized-query nil))
+  ([db {:keys [t opts] :as sanitized-query} conn]
    (go-try
-    (let [processed-rule-sources (<? (load-aliased-rule-dbs conn rule-sources))
-          policy-db              (if did
-                                   (<? (perm/wrap-identity-policy db did nil))
+    (let [{:keys [reasoner-methods rule-sources]} opts
+          processed-rule-sources (when rule-sources
+                                   (<? (load-aliased-rule-dbs conn rule-sources)))
+          policy-db              (if (policy-restricted? opts)
+                                   (<? (policy-enforce-db db sanitized-query))
                                    db)
           time-travel-db         (-> (if t
                                        (<? (time-travel/as-of policy-db t))
@@ -102,7 +130,7 @@
           ;;      - upstream if needed
           ds*      (if (dataset? ds)
                      ds
-                     (<? (restrict-db ds t opts)))
+                     (<? (restrict-db ds query*)))
           query**  (update query* :opts dissoc :meta :max-fuel ::util/track-fuel?)
           max-fuel (:max-fuel opts)]
       (if (::util/track-fuel? opts)
@@ -174,25 +202,26 @@
       [alias nil])))
 
 (defn load-alias
-  [conn alias t opts]
+  [conn alias {:keys [t] :as sanitized-query}]
   (go-try
-    (try*
-      (let [[alias explicit-t] (extract-query-string-t alias)
-            address      (<? (nameservice/primary-address conn alias nil))
-            ledger       (<? (jld-ledger/load conn address))
-            db           (ledger/-db ledger)
-            t*           (or explicit-t t)]
-        (<? (restrict-db db t* opts conn)))
-      (catch* e
-              (throw (contextualize-ledger-400-error
-                       (str "Error loading ledger " alias ": ")
-                       e))))))
+   (try*
+     (let [[alias explicit-t] (extract-query-string-t alias)
+           address (<? (nameservice/primary-address conn alias nil))
+           ledger  (<? (jld-ledger/load conn address))
+           db      (ledger/-db ledger)
+           t*      (or explicit-t t)
+           query*  (assoc sanitized-query :t t*)]
+       (<? (restrict-db db query* conn)))
+     (catch* e
+             (throw (contextualize-ledger-400-error
+                     (str "Error loading ledger " alias ": ")
+                     e))))))
 
 (defn load-aliases
-  [conn aliases global-t opts]
-  (when (some? global-t)
+  [conn aliases sanitized-query]
+  (when (some? (:t sanitized-query))
     (try*
-      (util/str->epoch-ms global-t)
+      (util/str->epoch-ms (:t sanitized-query))
       (catch* e
         (throw
          (contextualize-ledger-400-error
@@ -204,7 +233,7 @@
           db-map      {}]
      (if alias
        ;; TODO: allow restricting federated dataset components individually by t
-       (let [db      (<? (load-alias conn alias global-t opts))
+       (let [db      (<? (load-alias conn alias sanitized-query))
              db-map* (assoc db-map alias db)]
          (recur r db-map*))
        db-map))))
@@ -218,16 +247,16 @@
     (dataset/combine named-graphs default-coll)))
 
 (defn load-dataset
-  [conn defaults named global-t opts]
+  [conn defaults named sanitized-query]
   (go-try
     (if (and (= (count defaults) 1)
              (empty? named))
       (let [alias (first defaults)]
-        (<? (load-alias conn alias global-t opts))) ; return an unwrapped db if
+        (<? (load-alias conn alias sanitized-query))) ; return an unwrapped db if
                                                     ; the data set consists of
                                                     ; one ledger
       (let [all-aliases (->> defaults (concat named) distinct)
-            db-map      (<? (load-aliases conn all-aliases global-t opts))]
+            db-map      (<? (load-aliases conn all-aliases sanitized-query))]
         (dataset db-map defaults)))))
 
 (defn query-connection-fql
@@ -241,7 +270,7 @@
           named-aliases   (some-> sanitized-query :from-named util/sequential)]
       (if (or (seq default-aliases)
               (seq named-aliases))
-        (let [ds            (<? (load-dataset conn default-aliases named-aliases t opts))
+        (let [ds            (<? (load-dataset conn default-aliases named-aliases sanitized-query))
               trimmed-query (update sanitized-query :opts dissoc :meta :max-fuel ::util/track-fuel?)
               max-fuel      (:max-fuel opts)]
           (if (::util/track-fuel? opts)

--- a/test/fluree/db/policy/policy_class_test.clj
+++ b/test/fluree/db/policy/policy_class_test.clj
@@ -1,0 +1,102 @@
+(ns fluree.db.policy.policy-class-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.did :as did]
+            [fluree.db.api :as fluree]
+            [fluree.db.test-utils :as test-utils]))
+
+(deftest ^:integration class-policy-query
+  (testing "Policy class based query tests."
+    (let [conn      (test-utils/create-conn)
+          ledger    @(fluree/create conn "policy/class-policy-query")
+          root-did  (:id (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c"))
+          alice-did (:id (did/private->did-map "c0459840c334ca9f20c257bed971da88bd9b1b5d4fca69d4e3f4b8504f981c07"))
+          db        @(fluree/stage
+                      (fluree/db ledger)
+                      {"@context" {"ex"     "http://example.org/ns/"
+                                   "schema" "http://schema.org/"
+                                   "f"      "https://ns.flur.ee/ledger#"}
+                       "insert"   [{"@id"              "ex:alice",
+                                    "@type"            "ex:User",
+                                    "schema:name"      "Alice"
+                                    "schema:email"     "alice@flur.ee"
+                                    "schema:birthDate" "2022-08-17"
+                                    "schema:ssn"       "111-11-1111"}
+                                   {"@id"              "ex:john",
+                                    "@type"            "ex:User",
+                                    "schema:name"      "John"
+                                    "schema:email"     "john@flur.ee"
+                                    "schema:birthDate" "2021-08-17"
+                                    "schema:ssn"       "888-88-8888"}
+                                   {"@id"                  "ex:widget",
+                                    "@type"                "ex:Product",
+                                    "schema:name"          "Widget"
+                                    "schema:price"         99.99
+                                    "schema:priceCurrency" "USD"}
+                                   {"@id" root-did}
+                                   ;; assign alice-did to "ex:EmployeePolicy" and also link the did to "ex:alice" via "ex:user"
+                                   {"@id"           alice-did
+                                    "f:policyClass" [{"@id" "ex:EmployeePolicy"}]
+                                    "ex:user"       {"@id" "ex:alice"}}
+                                   ;; embedded policy
+                                   {"@id"          "ex:ssnRestriction"
+                                    "@type"        ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                    "f:onProperty" [{"@id" "schema:ssn"}]
+                                    "f:action"     {"@id" "f:view"}
+                                    "f:query"      {"@type"  "@json"
+                                                    "@value" {"@context" {"ex" "http://example.org/ns/"}
+                                                              "where"    {"@id"     "?$identity"
+                                                                          "ex:user" {"@id" "?$this"}}}}}
+                                   {"@id"      "ex:defaultAllowView"
+                                    "@type"    ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                    "f:action" {"@id" "f:view"}
+                                    "f:query"  {"@type"  "@json"
+                                                "@value" {}}}]})]
+      (testing " setting a policy class and passing a values-map with the user's identity"
+        (let [policy-db @(fluree/wrap-class-policy db
+                                                   ["http://example.org/ns/EmployeePolicy"]
+                                                   ;; presumably values like this would come from upstream
+                                                   ;; application or identity provider
+                                                   {"?$identity" alice-did})]
+
+          (testing " with direct select binding restricts"
+            (is (= [["ex:alice" "111-11-1111"]]
+                   @(fluree/query
+                     policy-db
+                     {"@context" {"ex"     "http://example.org/ns/"
+                                  "schema" "http://schema.org/"}
+                      "select"   ["?s" "?ssn"]
+                      "where"    {"@id"        "?s"
+                                  "@type"      "ex:User"
+                                  "schema:ssn" "?ssn"}}))
+                "ex:john should not show up in results"))
+
+          (testing " with where-clause match of restricted data"
+            (is (= []
+                   @(fluree/query
+                     policy-db
+                     {"@context" {"ex"     "http://example.org/ns/"
+                                  "schema" "http://schema.org/"}
+                      "select"   "?s"
+                      "where"    {"@id"        "?s"
+                                  "schema:ssn" "888-88-8888"}}))
+                "ex:john has ssn 888-88-8888, so should results should be empty"))
+
+          (testing " in a graph crawl restricts"
+            (is (= [{"@id"              "ex:alice",
+                     "@type"            "ex:User",
+                     "schema:name"      "Alice"
+                     "schema:email"     "alice@flur.ee"
+                     "schema:birthDate" "2022-08-17"
+                     "schema:ssn"       "111-11-1111"}
+                    {"@id"              "ex:john",
+                     "@type"            "ex:User",
+                     "schema:name"      "John"
+                     "schema:email"     "john@flur.ee"
+                     "schema:birthDate" "2021-08-17"}]
+                   @(fluree/query
+                     policy-db
+                     {"@context" {"ex"     "http://example.org/ns/"
+                                  "schema" "http://schema.org/"}
+                      "select"   {"?s" ["*"]}
+                      "where"    {"@id"   "?s"
+                                  "@type" "ex:User"}})))))))))


### PR DESCRIPTION
Adds two features needed for Nexus (and generally useful)
1) Adds `wrap-class-policy` API to the existing `wrap-policy` and `wrap-identity-policy` for enforcing policy on a db. This addition allows you to pass one or more class IRIs to enforce policy, which will query the db for policies of those class(es) and apply them. This feature provides a similar capability to v2's 'roles' option.
2) Allows new policy features to be utilized from the `query-connection` API which Nexus primarily uses. In the 'opts' for a query, you can now include the following keys:
a) `policyClass` - which performs the feature as described in (1) above.
b) `policy` - which allows you to pass in any json-ld policy definitions and will call `wrap-policy` on your behalf
c) `policyValues` - which allows you to pass in a values map that policy enforcement will inject into the policy queries (via the policy query's `values` key).

*note - in the case of `policy` and `policyClass`, json-ld/expand will be called on them utilizing the query's `@context`. In the process added the expansion to the existing `did` option which previously was never attempted to expand.
