### PR TITLE
Remove special assert syntax

### DIFF
--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -123,63 +123,14 @@
            :namespace-codes new-ns-codes
            :max-namespace-code max-namespace-code*)))
 
-(defn enrich-values
-  [id->node values]
-  (mapv (fn [{:keys [id type] :as v-map}]
-          (if id
-            (merge (get id->node id)
-                   (cond-> v-map
-                     (nil? type) (dissoc :type)))
-            v-map))
-        values))
-
-(defn enrich-node
-  [id->node node]
-  (reduce-kv
-   (fn [updated-node k v]
-     (assoc updated-node k (cond (= :id k) v
-                                 (:list (first v)) [{:list (enrich-values id->node (:list (first v)))}]
-                                 :else (enrich-values id->node v))))
-   {}
-   node))
-
-(defn enrich-assertion-values
-  "`asserts` is a json-ld flattened (ish) sequence of nodes. In order to properly generate
-  sids (or pids) for these nodes, we need the full node additional context for ref objects. This
-  function traverses the asserts and builds a map of node-id->node, then traverses the
-  asserts again and merges each ref object into the ref's node.
-
-  example input:
-  [{:id \"foo:bar\"
-    \"ex:key1\" {:id \"foo:ref-id\"}}
-  {:id \"foo:ref-id\"
-   :type \"some:type\"}]
-
-  example output:
-  [{:id \"foo:bar\"
-    \"ex:key1\" {:id \"foo:ref-id\"
-                 :type \"some:type\"}}
-  {:id \"foo:ref-id\"
-   :type \"some:type\"}]
-  "
-  [asserts]
-  (let [id->node (reduce (fn [id->node {:keys [id] :as node}] (assoc id->node id node))
-                         {}
-                         asserts)]
-    (mapv (partial enrich-node id->node)
-          asserts)))
 
 (defn db-assert
   [db-data]
-  (let [commit-assert (get db-data const/iri-assert)]
-    ;; TODO - any basic validation required
-    (enrich-assertion-values commit-assert)))
+  (get db-data const/iri-assert))
 
 (defn db-retract
   [db-data]
-  (let [commit-retract (get db-data const/iri-retract)]
-    ;; TODO - any basic validation required
-    commit-retract))
+  (get db-data const/iri-retract))
 
 (defn commit-error
   [message commit-data]


### PR DESCRIPTION
This code appears to create new flakes for `@type` values (classes) when being read from commits.

To my knowledge with the latest SID changes, this isn't needed and isn't done with initial transactions. At one point we did need a flake for every IRI, which is what I assume this was put in for.

I believe this would have the effect of a different db state for the same data when originally transacted vs read from commit files - as the latter would include flakes for every class, and the former would not.

After removing this code, all tests pass -  but definitely want more eyeballs in case I'm missing something.

For a large commit, this code does a decent amount of work, so will help performance by removing it as well.
