### PR TITLE
Fix/policy transact

### DIFF
--- a/src/clj/fluree/db/api/transact.cljc
+++ b/src/clj/fluree/db/api/transact.cljc
@@ -26,28 +26,29 @@
    internal Fluree triples format."
   [db parsed-txn parsed-opts]
   (go-try
-   (let [track-fuel? (or (:maxFuel parsed-opts)
-                         (:meta parsed-opts))
-         identity    (:did parsed-opts)
-         policy-db   (if identity
-                       (<? (policy/wrap-identity-policy db identity nil))
-                       db)]
-     (if track-fuel?
-       (let [start-time #?(:clj (System/nanoTime)
-                           :cljs (util/current-time-millis))
-             fuel-tracker       (fuel/tracker (:maxFuel parsed-opts))]
-         (try*
-          (let [result (<? (tx/stage policy-db fuel-tracker identity parsed-txn parsed-opts))]
-            {:status 200
-             :result result
-             :time   (util/response-time-formatted start-time)
-             :fuel   (fuel/tally fuel-tracker)})
-          (catch* e
-                  (throw (ex-info "Error staging database"
-                                  {:time (util/response-time-formatted start-time)
-                                   :fuel (fuel/tally fuel-tracker)}
-                                  e)))))
-       (<? (tx/stage policy-db identity parsed-txn parsed-opts))))))
+    (let [track-fuel? (or (:maxFuel parsed-opts)
+                          (:meta parsed-opts))
+          identity    (:did parsed-opts)
+          policy-db   (if (policy/policy-enforced-opts? parsed-opts)
+                        (let [parsed-context (:context parsed-opts)]
+                          (<? (policy/policy-enforce-db db parsed-context parsed-opts)))
+                        db)]
+      (if track-fuel?
+        (let [start-time #?(:clj (System/nanoTime)
+                            :cljs (util/current-time-millis))
+              fuel-tracker       (fuel/tracker (:maxFuel parsed-opts))]
+          (try*
+            (let [result (<? (tx/stage policy-db fuel-tracker identity parsed-txn parsed-opts))]
+              {:status 200
+               :result result
+               :time   (util/response-time-formatted start-time)
+               :fuel   (fuel/tally fuel-tracker)})
+            (catch* e
+                    (throw (ex-info "Error staging database"
+                                    {:time (util/response-time-formatted start-time)
+                                     :fuel (fuel/tally fuel-tracker)}
+                                    e)))))
+        (<? (tx/stage policy-db identity parsed-txn parsed-opts))))))
 
 (defn stage
   [db txn opts]
@@ -70,36 +71,42 @@
 (defn transact-ledger!
   [ledger txn {:keys [expanded? context triples?] :as opts}]
   (go-try
-   (let [txn-context (or (ctx-util/txn-context txn)
-                         context) ;; parent context might come from a Verifiable Credential's context
-         expanded    (if expanded?
-                       txn
-                       (json-ld/expand (ctx-util/use-fluree-context txn)))
-         triples     (if triples?
-                       txn
-                       (q-parse/parse-txn expanded txn-context))
-         parsed-opts (parse-opts expanded opts txn-context)
-         db          (<? (stage-triples (ledger/-db ledger) triples parsed-opts))
-         ;; commit API takes a did-map and parsed context as opts
-         ;; whereas stage API takes a did IRI and unparsed context.
-         ;; Dissoc them until deciding at a later point if they can carry through.
-         cmt-opts    (dissoc parsed-opts :context :did)] ;; possible keys at f.d.ledger.json-ld/enrich-commit-opts
-     (<? (ledger/-commit! ledger db cmt-opts)))))
+    (let [expanded    (if expanded?
+                        txn
+                        (json-ld/expand (ctx-util/use-fluree-context txn)))
+          txn-context (if expanded?
+                        context
+                        (or (ctx-util/txn-context txn)
+                            context)) ;; parent context might come from a Verifiable Credential's context
+          triples     (if triples?
+                        txn
+                        (q-parse/parse-txn expanded txn-context))
+          parsed-opts (parse-opts expanded opts txn-context)
+          db          (<? (stage-triples (ledger/-db ledger) triples parsed-opts))
+          ;; commit API takes a did-map and parsed context as opts
+          ;; whereas stage API takes a did IRI and unparsed context.
+          ;; Dissoc them until deciding at a later point if they can carry through.
+          cmt-opts    (dissoc parsed-opts :context :did)] ;; possible keys at f.d.ledger.json-ld/enrich-commit-opts
+      (<? (ledger/-commit! ledger db cmt-opts)))))
 
 (defn transact!
-  ([conn txn] (transact! conn txn {:raw-txn txn}))
+  ([conn txn] (transact! conn txn nil))
   ([conn txn opts]
    (go-try
-    (let [expanded  (json-ld/expand (ctx-util/use-fluree-context txn))
-          ledger-id (extract-ledger-id expanded)]
-      (<? (transact! conn ledger-id txn opts)))))
+     (let [expanded  (json-ld/expand (ctx-util/use-fluree-context txn))
+           ledger-id (extract-ledger-id expanded)
+           opts*     (assoc opts :expanded? true
+                                 :context (or (ctx-util/txn-context txn)
+                                              ;; parent context might come from a Verifiable Credential's context
+                                              (:context opts)))]
+       (<? (transact! conn ledger-id expanded opts*)))))
   ([conn ledger-id txn opts]
    (go-try
-    (let [address     (<? (nameservice/primary-address conn ledger-id nil))]
-      (if-not (<? (nameservice/exists? conn address))
-        (throw (ex-info "Ledger does not exist" {:ledger address}))
-        (let [ledger   (<? (jld-ledger/load conn address))]
-          (<? (transact-ledger! ledger txn opts))))))))
+     (let [address (<? (nameservice/primary-address conn ledger-id nil))]
+       (if-not (<? (nameservice/exists? conn address))
+         (throw (ex-info "Ledger does not exist" {:ledger address}))
+         (let [ledger (<? (jld-ledger/load conn address))]
+           (<? (transact-ledger! ledger txn opts))))))))
 
 (defn credential-transact!
   "Like transact!, but use when leveraging a Verifiable Credential or signed JWS.

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -1,8 +1,7 @@
 (ns fluree.db.query.api
   "Primary API ns for any user-invoked actions. Wrapped by language & use specific APIS
   that are directly exposed"
-  (:require [clojure.core.async :as async]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [fluree.db.util.context :as context]
             [fluree.json-ld :as json-ld]
             [fluree.db.fuel :as fuel]
@@ -16,13 +15,11 @@
             [fluree.db.query.sparql :as sparql]
             [fluree.db.query.fql.syntax :as syntax]
             [fluree.db.util.core :as util :refer [try* catch*]]
-            [fluree.db.util.async :as async-util :refer [<? go-try]]
+            [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.context :as ctx-util]
             [fluree.db.json-ld.policy :as perm]
-            [fluree.db.json-ld.credential :as cred]
             [fluree.db.nameservice.core :as nameservice]
-            [fluree.db.reasoner :as reasoner]
-            [fluree.db.validation :as v]))
+            [fluree.db.reasoner :as reasoner]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -52,52 +49,28 @@
          (recur (rest rule-sources) updated-rule-results))
        rule-results))))
 
-
-(defn policy-restricted?
-  [query-opts]
-  (or (:did query-opts)
-      (:policyClass query-opts)
-      (:policy query-opts)))
-
-(defn policy-enforce-db
-  [db {:keys [opts] :as sanitized-query}]
-  (go-try
-   (let [context (context/extract sanitized-query)
-         {:keys [did policyClass policy policyValues]} opts]
-     (cond
-
-       did
-       (<? (perm/wrap-identity-policy db (json-ld/expand-iri did context) policyValues))
-
-       policyClass
-       (let [classes (map #(json-ld/expand-iri % context) (util/sequential policyClass))]
-         (<? (perm/wrap-class-policy db classes policyValues)))
-
-       policy
-       (let [expanded-policy (json-ld/expand policy context)]
-         (<? (perm/wrap-policy db expanded-policy policyValues)))))))
-
 (defn restrict-db
   ([db sanitized-query]
    (restrict-db db sanitized-query nil))
   ([db {:keys [t opts] :as sanitized-query} conn]
    (go-try
-    (let [{:keys [reasoner-methods rule-sources]} opts
-          processed-rule-sources (when rule-sources
-                                   (<? (load-aliased-rule-dbs conn rule-sources)))
-          policy-db              (if (policy-restricted? opts)
-                                   (<? (policy-enforce-db db sanitized-query))
-                                   db)
-          time-travel-db         (-> (if t
-                                       (<? (time-travel/as-of policy-db t))
-                                       policy-db))
-          reasoned-db            (if reasoner-methods
-                                   (<? (reasoner/reason time-travel-db
-                                                        reasoner-methods
-                                                        processed-rule-sources
-                                                        opts))
-                                   time-travel-db)]
-      (assoc-in reasoned-db [:policy :cache] (atom {}))))))
+     (let [{:keys [reasoner-methods rule-sources]} opts
+           processed-rule-sources (when rule-sources
+                                    (<? (load-aliased-rule-dbs conn rule-sources)))
+           policy-db              (if (perm/policy-enforced-opts? opts)
+                                    (let [parsed-context (context/extract sanitized-query)]
+                                      (<? (perm/policy-enforce-db db parsed-context opts)))
+                                    db)
+           time-travel-db         (-> (if t
+                                        (<? (time-travel/as-of policy-db t))
+                                        policy-db))
+           reasoned-db            (if reasoner-methods
+                                    (<? (reasoner/reason time-travel-db
+                                                         reasoner-methods
+                                                         processed-rule-sources
+                                                         opts))
+                                    time-travel-db)]
+       (assoc-in reasoned-db [:policy :cache] (atom {}))))))
 
 (defn track-query
   [ds max-fuel query]


### PR DESCRIPTION
This adds support for the `transact!` API to support the same policy options that were recently added to the `query-connection` API in this PR: https://github.com/fluree/db/pull/891

Now transact! "opts" can include the keys of `policyClass` or `policy` to pass along policy information, in addition to `did` which it already supported.