### PR TITLE
Fix SPARQL :InlineDataFull Bug

### DIFF
--- a/src/clj/fluree/db/query/sparql/translator.cljc
+++ b/src/clj/fluree/db/query/sparql/translator.cljc
@@ -1,8 +1,7 @@
 (ns fluree.db.query.sparql.translator
   (:require #?(:cljs [cljs.tools.reader :refer [read-string]])
             [clojure.string :as str]
-            [fluree.db.constants :as const]
-            [fluree.db.util.log :as log]))
+            [fluree.db.constants :as const]))
 
 (defn rule?
   [x]

--- a/src/clj/fluree/db/query/sparql/translator.cljc
+++ b/src/clj/fluree/db/query/sparql/translator.cljc
@@ -1,7 +1,8 @@
 (ns fluree.db.query.sparql.translator
-  (:require [fluree.db.constants :as const]
+  (:require #?(:cljs [cljs.tools.reader :refer [read-string]])
             [clojure.string :as str]
-            #?(:cljs [cljs.tools.reader :refer [read-string]])))
+            [fluree.db.constants :as const]
+            [fluree.db.util.log :as log]))
 
 (defn rule?
   [x]
@@ -509,7 +510,7 @@
 (defmethod parse-term :InlineDataFull
   ;; InlineDataFull ::= ( NIL | VarList ) WS <'{'> WS ( ValueList WS | NIL )* <'}'>
   [[_ vars & data]]
-  [:values [(parse-term vars)] (mapv parse-term data)])
+  [:values [(parse-term vars) (mapv parse-term data)]])
 
 (defmethod parse-term :InlineDataOneVar
   ;; InlineDataOneVar ::= Var <'{'> WS DataBlockValue* <'}'>

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -329,25 +329,17 @@
                 {"@id" "?person", "person:handle" "?handle"}]
                (:where (sparql/->fql query)))
             "where pattern: single var, multiple values"))
-      (let [query "SELECT * WHERE {
-                            VALUES (?str ?date1 ?date2) {
-                              ( \"a\" \"2023-09-01\"^^xsd:date \"2023-09-30\"^^xsd:date )
-                              ( \"b\" \"2023-09-01\"^^xsd:date \"2023-09-30\"^^xsd:date )
-                              ( \"c\" \"2023-09-01\"^^xsd:date \"2023-09-30\"^^xsd:date )
-                             }
-                         }"]
-        (is (= [[:values
-                 [["?str" "?date1" "?date2"]
-                  [["a"
-                    {"@value" "2023-09-01", "@type" "xsd:date"}
-                    {"@value" "2023-09-30", "@type" "xsd:date"}]
-                   ["b"
-                    {"@value" "2023-09-01", "@type" "xsd:date"}
-                    {"@value" "2023-09-30", "@type" "xsd:date"}]
-                   ["c"
-                    {"@value" "2023-09-01", "@type" "xsd:date"}
-                    {"@value" "2023-09-30", "@type" "xsd:date"}]]]]]
-               (:where (sparql/->fql query)))
+      (let [query "SELECT ?claim
+                   WHERE {
+                     ?claim ci:claimDate ?date .
+                     FILTER (?date >= ?stateDate && ?date <= ?endDate)
+                   }
+                   VALUES (?state ?startDate ?endDate) { 
+                      ( \"New York\" \"2023-03-01\"^^xsd:date \"2023-03-31\"^^xsd:date ) 
+                  }"]
+        (is (= [["?state" "?startDate" "?endDate"]
+                [["New York" {"@value" "2023-03-01", "@type" "xsd:date"} {"@value" "2023-03-31", "@type" "xsd:date"}]]]
+               (:values (sparql/->fql query)))
             "multiple vars with multiple types"))
       (let [query "SELECT * WHERE {
                      VALUES (?color ?direction) {

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -330,18 +330,38 @@
                (:where (sparql/->fql query)))
             "where pattern: single var, multiple values"))
       (let [query "SELECT * WHERE {
+                            VALUES (?str ?date1 ?date2) {
+                              ( \"a\" \"2023-09-01\"^^xsd:date \"2023-09-30\"^^xsd:date )
+                              ( \"b\" \"2023-09-01\"^^xsd:date \"2023-09-30\"^^xsd:date )
+                              ( \"c\" \"2023-09-01\"^^xsd:date \"2023-09-30\"^^xsd:date )
+                             }
+                         }"]
+        (is (= [[:values
+                 [["?str" "?date1" "?date2"]
+                  [["a"
+                    {"@value" "2023-09-01", "@type" "xsd:date"}
+                    {"@value" "2023-09-30", "@type" "xsd:date"}]
+                   ["b"
+                    {"@value" "2023-09-01", "@type" "xsd:date"}
+                    {"@value" "2023-09-30", "@type" "xsd:date"}]
+                   ["c"
+                    {"@value" "2023-09-01", "@type" "xsd:date"}
+                    {"@value" "2023-09-30", "@type" "xsd:date"}]]]]]
+               (:where (sparql/->fql query)))
+            "multiple vars with multiple types"))
+      (let [query "SELECT * WHERE {
                      VALUES (?color ?direction) {
                      ( dm:red  \"north\" )
                      ( dm:blue  \"west\" )
                    }}"]
         (is (= [[:values
-                 [["?color" "?direction"]]
+                 [["?color" "?direction"]
                  [[{"@type" "@id",
                     "@value" "dm:red"}
                    "north"]
                   [{"@type" "@id",
                     "@value" "dm:blue"}
-                   "west"]]]]
+                   "west"]]]]]
                (:where (sparql/->fql query)))
             "multiple vars, multiple values")))
     (testing "clause"


### PR DESCRIPTION
`parse-term :InlineDataFull` wasn't properly returning its `:values` vector.

A SPARQL statement like
```sparql
    VALUES (?state ?startDate) { 
        ( "New York" "2023-03-01"^^xsd:date ) 
        ( "Florida" "2023-04-01"^^xsd:date ) 
    }
```

Was getting returned as
```
[:values [
     [["?state" "?startDate"]]
     ...
  ]
]
```
instead of
```
[:values [
     ["?state" "?startDate"]
     ...
  ]
]
```

There was a test that was passing (but shouldn't have been). But the only reason it was passing was because it was (a) a VALUES statement within a WHERE and (b) it was only testing for a certain shape and not actually executing the query. As an aside, this false-positive test was also why inline VALUES maps were parsing to FQL correctly but SPARQL queries that used them would return `[]` result sets