### PR TITLE
Fix/single select aggregates

### DIFF
--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -78,12 +78,6 @@
   (where/->typed-val
     (apply clojure.core/min (mapv :value coll))))
 
-(defn ceil
-  [{n :value}]
-  (where/->typed-val (cond (= n (int n)) n
-                           (> n 0) (-> n int inc)
-                           (< n 0) (-> n int))))
-
 (defn count-distinct
   [coll]
   (where/->typed-val
@@ -92,12 +86,6 @@
 (defn -count
   [coll]
   (where/->typed-val (count coll)))
-
-(defn floor
-  [{n :value}]
-  (where/->typed-val (cond (= n (int n)) n
-                           (> n 0) (-> n int)
-                           (< n 0) (-> n int dec))))
 
 (def groupconcat clojure.core/concat)
 
@@ -124,6 +112,18 @@
       (if (nil? (:value res#))
         (coalesce ~@args)
         res#))))
+
+(defn ceil
+  [{n :value}]
+  (where/->typed-val (cond (= n (int n)) n
+                           (> n 0) (-> n int inc)
+                           (< n 0) (-> n int))))
+
+(defn floor
+  [{n :value}]
+  (where/->typed-val (cond (= n (int n)) n
+                           (> n 0) (-> n int)
+                           (< n 0) (-> n int dec))))
 
 (defn bound
   [{x :value}]

--- a/src/clj/fluree/db/query/exec/group.cljc
+++ b/src/clj/fluree/db/query/exec/group.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async]
             [fluree.db.query.exec.select :as select]
             [fluree.db.query.exec.where :as where]
+            [fluree.db.util.core :as util]
             [fluree.db.util.log :as log :include-macros true]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -49,7 +50,7 @@
 
 (defn implicit-grouping
   [select]
-  (when (some select/implicit-grouping? select)
+  (when (some select/implicit-grouping? (util/sequential select))
     [nil]))
 
 (defmethod select/display ::grouping

--- a/src/clj/fluree/db/query/exec/select.cljc
+++ b/src/clj/fluree/db/query/exec/select.cljc
@@ -166,7 +166,7 @@
   (let [selectors           (or (:select q)
                                 (:select-one q)
                                 (:select-distinct q))
-        modifying-selectors (filter #(satisfies? SolutionModifier %) selectors)
+        modifying-selectors (filter #(satisfies? SolutionModifier %) (util/sequential selectors))
         mods-xf             (map (fn [solution]
                                    (reduce
                                      (fn [sol sel]

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -45,4 +45,14 @@
                    :order-by '?count
                    :select   '[?name (as (count ?favNums) ?count)]}]
           (is (= [["Brian" 1] ["Cam" 2] ["Liam" 2] ["Alice" 3]]
-                 @(fluree/query db qry))))))))
+                 @(fluree/query db qry)))))
+      (testing "with non-sequential select with implicit grouping"
+        (is (= [8]
+               @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                  :where ['{:id ?s :ex/favNums ?favNums}]
+                                  :select '(count ?favNums)}))))
+      (testing "with sequential select with implicit grouping"
+        (is (= [[8]]
+               @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                  :where ['{:id ?s :ex/favNums ?favNums}]
+                                  :select ['(count ?favNums)]})))))))

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -155,6 +155,38 @@
              @(fluree/query db q))
           "return results without repeated entries"))))
 
+(deftest ^:integration select-one-test
+  (let [conn   (test-utils/create-conn)
+        people (test-utils/load-people conn)
+        db     (fluree/db people)]
+    (testing "select-one"
+      (testing "with result"
+        (testing "with sequential select"
+          (is (= [9]
+                 @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                    :selectOne '[?favNum]
+                                    :where '[{:id ?s :schema/name "Alice"}
+                                             {:id ?s :ex/favNums ?favNum}]
+                                    :order-by '?favNum}))))
+        (testing "with single select"
+          (is (= 9
+                 @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                    :selectOne '?favNum
+                                    :where '[{:id ?s :schema/name "Alice"}
+                                             {:id ?s :ex/favNums ?favNum}]
+                                    :order-by '?favNum})))))
+      (testing "with no result"
+        (testing "with sequential select"
+          (is (= nil
+                 @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                    :selectOne '[?s]
+                                    :where '{:id ?s :schema/name "Bob"}}))))
+        (testing "with single select"
+          (is (= nil
+                 @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                    :selectOne '?s
+                                    :where '{:id ?s :schema/name "Bob"}}))))))))
+
 (deftest ^:integration values-test
   (testing "Queries with pre-specified values"
     (let [conn   (test-utils/create-conn)


### PR DESCRIPTION
We were getting some strange behavior when calling `count` in a single select:
```
{:where [{:id '?s :ex/nums '?num}]
 :select '(count ?num)}
```
Turns out we weren't properly checking for non-sequential selectors when deciding when to aggregate and when deciding to modify solutions.

This fixes that.