### PR TITLE
Allow `compare*` for Non-Numeric `min`/`max`

### DIFF
--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -322,16 +322,8 @@
                      (if (pos? (compare* (:value a) (:datatype-iri a)
                                          (:value b) (:datatype-iri b)))
                        a
-                       b))
-        ;; I think we should also return the datatype-iri here, 
-        ;; but currently for date-like values, that is java.time.LocalDate 
-        ;; or java.time.OffsetDateTime, which ought actually to be returned 
-        ;; as xsd:date or xsd:dateTime, respectively.
-        ;;
-        ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
-        ;; (where/->typed-val value datatype-iri)))
-        value      (:value (reduce compare-fn coll))]
-    (where/->typed-val value)))
+                       b))]
+    (reduce compare-fn coll)))
 
 (defn min
   [coll]
@@ -339,16 +331,8 @@
                      (if (neg? (compare* (:value a) (:datatype-iri a)
                                          (:value b) (:datatype-iri b)))
                        a
-                       b))
-        ;; I think we should also return the datatype-iri here, 
-        ;; but currently for date-like values, that is java.time.LocalDate 
-        ;; or java.time.OffsetDateTime, which ought actually to be returned 
-        ;; as xsd:date or xsd:dateTime, respectively.
-        ;;
-        ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
-        ;; (where/->typed-val value datatype-iri)))
-        value      (:value (reduce compare-fn coll))]
-    (where/->typed-val value)))
+                       b))]
+    (reduce compare-fn coll)))
 
 (defn regex
   [{text :value} {pattern :value}]

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -68,16 +68,6 @@
   (where/->typed-val
     (Math/sqrt (:value (variance coll)))))
 
-(defn max
-  [coll]
-  (where/->typed-val
-    (apply clojure.core/max (mapv :value coll))))
-
-(defn min
-  [coll]
-  (where/->typed-val
-    (apply clojure.core/min (mapv :value coll))))
-
 (defn ceil
   [{n :value}]
   (where/->typed-val (cond (= n (int n)) n
@@ -325,6 +315,42 @@
   (where/->typed-val
     (or (= a b)
         (pos? (compare* a a-dt b b-dt)))))
+
+(defn max
+  [coll]
+  (let [compare-fn (fn [a b]
+                     (if (pos? (compare* (:value a) (:datatype-iri a)
+                                         (:value b) (:datatype-iri b)))
+                       a
+                       b))
+        ;; I think we should also return the datatype-iri here, 
+        ;; but currently for date-like values, that is java.time.LocalDate 
+        ;; or java.time.OffsetDateTime, which ought actually to be returned 
+        ;; as xsd:date or xsd:dateTime, respectively.
+        ;;
+        ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
+        ;; (where/->typed-val value datatype-iri)))
+        value      (:value (reduce compare-fn coll))
+        _          (log/info "max value:" value)]
+    (where/->typed-val value)))
+
+(defn min
+  [coll]
+  (let [compare-fn (fn [a b]
+                     (if (neg? (compare* (:value a) (:datatype-iri a)
+                                         (:value b) (:datatype-iri b)))
+                       a
+                       b))
+        ;; I think we should also return the datatype-iri here, 
+        ;; but currently for date-like values, that is java.time.LocalDate 
+        ;; or java.time.OffsetDateTime, which ought actually to be returned 
+        ;; as xsd:date or xsd:dateTime, respectively.
+        ;;
+        ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
+        ;; (where/->typed-val value datatype-iri)))
+        value      (:value (reduce compare-fn coll))
+        _          (log/info "min value:" value)]
+    (where/->typed-val value)))
 
 (defn regex
   [{text :value} {pattern :value}]

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -330,8 +330,7 @@
         ;;
         ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
         ;; (where/->typed-val value datatype-iri)))
-        value      (:value (reduce compare-fn coll))
-        _          (log/info "max value:" value)]
+        value      (:value (reduce compare-fn coll))]
     (where/->typed-val value)))
 
 (defn min
@@ -348,8 +347,7 @@
         ;;
         ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
         ;; (where/->typed-val value datatype-iri)))
-        value      (:value (reduce compare-fn coll))
-        _          (log/info "min value:" value)]
+        value      (:value (reduce compare-fn coll))]
     (where/->typed-val value)))
 
 (defn regex

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -36,6 +36,21 @@
               subject @(fluree/query db qry)]
           (is (= [[4]] subject)
               "aggregates bindings for all results")))
+      (testing "with min and implicit grouping"
+        (let [qry     {:context [test-utils/default-context
+                                 {:ex "http://example.org/ns/"}]
+                       :select  '[(min ?nums)]
+                       :where   '{:ex/favNums ?nums}}
+              subject @(fluree/query db qry)]
+          (is (= [[5]] subject)
+              "aggregates bindings for all results")))
+      (testing "with implicit grouping and comparable data types"
+        (let [qry     {:context test-utils/default-context
+                       :select  ['(max ?birthDate)]
+                       :where   '{:schema/birthDate ?birthDate}}
+              subject @(fluree/query db qry)]
+          (is (= [[(java.time.LocalDate/parse "2011-09-26")]] subject)
+              "aggregates bindings for all results")))
       (testing "with ordering"
         (let [qry {:context  [test-utils/default-context
                               {:ex "http://example.org/ns/"}]

--- a/test/fluree/db/test_utils.cljc
+++ b/test/fluree/db/test_utils.cljc
@@ -95,7 +95,8 @@
     :schema/name  "Alice"
     :schema/email "alice@example.org"
     :schema/age   50
-    :ex/favNums   [42, 76, 9]}
+    :ex/favNums   [42, 76, 9]
+    :schema/birthDate { "@value" "1974-09-26" "@type" :xsd/date}}
    {:id           :ex/cam,
     :type         :ex/User,
     :schema/name  "Cam"
@@ -109,7 +110,8 @@
     :schema/email "liam@example.org"
     :schema/age   13
     :ex/favNums   [42, 11]
-    :ex/friend    [:ex/brian :ex/alice :ex/cam]}])
+    :ex/friend    [:ex/brian :ex/alice :ex/cam]
+    :schema/birthDate { "@value" "2011-09-26" "@type" :xsd/date }}])
 
 (def people-strings
   [{"@id"           "ex:brian",


### PR DESCRIPTION
@dpetran had updated `compare*` to allow `<`, `>`, etc comparisons between non-numeric-yet-comparator-friendly types like `LocalDate` and `OffsetDateTime`, but `min` and `max` were still using clojure.core defaults, disabling their use as aggregate functions for dates and dateTimes.

This just adds the use of `compare*` to those eval fns.

One small note, it seemed in the following that if the `coll` elements are `{ :value :datatype-iri }` that we should return both, but data that had been added as `xsd:date` or `xsd:dateTime` was returning `LocalDate` and `OffsetDateTime` data types, which I think would be more confusing than useful. As a result, I left the implementation for that commented out, and just returned the `:value` for now...

```clojure
(defn min
  [coll]
  (let [compare-fn (fn [a b]
                     (if (neg? (compare* (:value a) (:datatype-iri a)
                                         (:value b) (:datatype-iri b)))
                       a
                       b))
        ;; I think we should also return the datatype-iri here, 
        ;; but currently for date-like values, that is java.time.LocalDate 
        ;; or java.time.OffsetDateTime, which ought actually to be returned 
        ;; as xsd:date or xsd:dateTime, respectively.
        ;;
        ;;     {:keys [value datatype-iri]} (reduce compare-fn coll)]
        ;; (where/->typed-val value datatype-iri)))
        value      (:value (reduce compare-fn coll))]
    (where/->typed-val value)))
```