### PR TITLE
Fix/opts refactor

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,7 @@
          instaparse/instaparse           {:mvn/version "1.5.0"}
          metosin/malli                   {:mvn/version "0.16.2"}
          nano-id/nano-id                 {:mvn/version "1.1.0"}
+         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
          com.fluree/json-ld              {:git/url "https://github.com/fluree/json-ld.git"
                                           :git/sha "7ae310b2d8c0aaf10e107e094607f69464ed3447"}
 

--- a/src/clj/fluree/db/api/transact.cljc
+++ b/src/clj/fluree/db/api/transact.cljc
@@ -18,10 +18,10 @@
   [expanded-txn override-opts txn-context]
   (let [txn-opts (some-> (util/get-first-value expanded-txn const/iri-opts)
                          util/keywordize-keys)
-        opts*    (merge txn-opts (util/keywordize-keys override-opts))]
-    (-> opts*
+        opts     (merge txn-opts (util/keywordize-keys override-opts))]
+    (-> opts
         (assoc :context txn-context)
-        (update :identity #(or % (:did opts*)))
+        (update :identity #(or % (:did opts)))
         (dissoc :did))))
 
 (defn track-fuel?

--- a/src/clj/fluree/db/api/transact.cljc
+++ b/src/clj/fluree/db/api/transact.cljc
@@ -26,8 +26,7 @@
 
 (defn track-fuel?
   [parsed-opts]
-  (or (:maxFuel parsed-opts)
-      (:max-fuel parsed-opts)
+  (or (:max-fuel parsed-opts)
       (:meta parsed-opts)))
 
 (defn stage-triples

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -105,10 +105,10 @@
         (<? (subject/-iri-visible? db iri)))))
 
   transact/Transactable
-  (-stage-txn [_ fuel-tracker context identity annotation raw-txn parsed-txn]
+  (-stage-txn [_ fuel-tracker context identity author annotation raw-txn parsed-txn]
     (go-try
       (let [db (<? db-chan)]
-        (<? (transact/-stage-txn db fuel-tracker context identity annotation raw-txn parsed-txn)))))
+        (<? (transact/-stage-txn db fuel-tracker context identity author annotation raw-txn parsed-txn)))))
   (-merge-commit [_ new-commit]
     (go-try
       (let [db (<? db-chan)]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -350,8 +350,8 @@
     [alias])
 
   transact/Transactable
-  (-stage-txn [db fuel-tracker context identity annotation raw-txn parsed-txn]
-    (flake.transact/stage db fuel-tracker context identity annotation raw-txn parsed-txn))
+  (-stage-txn [db fuel-tracker context identity author annotation raw-txn parsed-txn]
+    (flake.transact/stage db fuel-tracker context identity author annotation raw-txn parsed-txn))
   (-merge-commit [db new-commit proof] (merge-commit conn db [new-commit proof]))
   (-merge-commit [db new-commit] (merge-commit conn db [new-commit]))
 

--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -117,7 +117,7 @@
       allowed-db)))
 
 (defn stage
-  [db fuel-tracker context identity annotation raw-txn parsed-txn]
+  [db fuel-tracker context identity author annotation raw-txn parsed-txn]
   (go-try
     (when (policy.modify/deny-all? db)
       (throw (ex-info "Database policy denies all modifications."
@@ -125,7 +125,7 @@
     (let [tx-state   (->tx-state :db db
                                  :context context
                                  :txn raw-txn
-                                 :author identity
+                                 :author (or author identity)
                                  :annotation annotation)
           [db** new-flakes] (<? (generate-flakes db fuel-tracker parsed-txn tx-state))
           updated-db (<? (final-db db** new-flakes tx-state))]

--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -37,7 +37,7 @@
   "Generates a state map for transaction processing. When optional
   reasoned-from-IRI is provided, will mark any new flakes as reasoned from the
   provided value in the flake's metadata (.-m) as :reasoned key."
-  [& {:keys [db context txn author-did annotation reasoned-from-iri]}]
+  [& {:keys [db context txn author annotation reasoned-from-iri]}]
   (let [{:keys [policy], db-t :t} db
 
         commit-t  (-> db :commit commit-data/t)
@@ -47,7 +47,7 @@
      :context       context
      :txn           txn
      :annotation    annotation
-     :author-did    author-did
+     :author        author
      :policy        policy
      :stage-update? (= t db-t) ; if a previously staged db is getting updated again before committed
      :t             t
@@ -94,14 +94,14 @@
 (defn final-db
   "Returns map of all elements for a stage transaction required to create an
   updated db."
-  [db new-flakes {:keys [stage-update? policy t txn author-did annotation db-before context] :as _tx-state}]
+  [db new-flakes {:keys [stage-update? policy t txn author annotation db-before context] :as _tx-state}]
   (go-try
     (let [[add remove] (if stage-update?
                          (stage-update-novelty (get-in db [:novelty :spot]) new-flakes)
                          [new-flakes nil])
           mods         (<? (modified-subjects (policy/root db) add))
           db-after     (-> db
-                           (update :staged conj [txn author-did annotation])
+                           (update :staged conj [txn author annotation])
                            (assoc :t t
                                   :policy policy) ; re-apply policy to db-after
                            (commit-data/update-novelty add remove)
@@ -125,7 +125,7 @@
     (let [tx-state   (->tx-state :db db
                                  :context context
                                  :txn raw-txn
-                                 :author-did identity
+                                 :author identity
                                  :annotation annotation)
           [db** new-flakes] (<? (generate-flakes db fuel-tracker parsed-txn tx-state))
           updated-db (<? (final-db db** new-flakes tx-state))]

--- a/src/clj/fluree/db/json_ld/migrate/sid.cljc
+++ b/src/clj/fluree/db/json_ld/migrate/sid.cljc
@@ -93,8 +93,8 @@
           tx-state           (flake.transact/->tx-state
                                :db db
                                :txn (get-first-value commit const/iri-txn)
-                               :author-did (let [author (get-first-value commit const/iri-author)]
-                                             (when-not (str/blank? author) author))
+                               :author (let [author (get-first-value commit const/iri-author)]
+                                         (when-not (str/blank? author) author))
                                :annotation (get-first-value commit const/iri-annotation))
           staged-db          (-> (<? (flake.transact/final-db db all-flakes tx-state))
                                  :db-after

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -95,7 +95,6 @@
   policy enforcement."
   [opts]
   (or (:identity opts)
-      (:did opts)
       (:policyClass opts)
       (:policy opts)))
 
@@ -103,11 +102,11 @@
   "Policy enforces a db based on the query/transaction options"
   [db parsed-context opts]
   (go-try
-   (let [{:keys [identity did policyClass policy policyValues]} opts]
+    (let [{:keys [identity policyClass policy policyValues]} opts]
      (cond
 
-       (or identity did)
-       (<? (wrap-identity-policy db did policyValues))
+       identity
+       (<? (wrap-identity-policy db identity policyValues))
 
        policyClass
        (let [classes (map #(json-ld/expand-iri % parsed-context) (util/sequential policyClass))]

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -94,7 +94,8 @@
   "Tests 'options' for a query or transaction to see if the options request
   policy enforcement."
   [opts]
-  (or (:did opts)
+  (or (:identity opts)
+      (:did opts)
       (:policyClass opts)
       (:policy opts)))
 
@@ -102,10 +103,10 @@
   "Policy enforces a db based on the query/transaction options"
   [db parsed-context opts]
   (go-try
-   (let [{:keys [did policyClass policy policyValues]} opts]
+   (let [{:keys [identity did policyClass policy policyValues]} opts]
      (cond
 
-       did
+       (or identity did)
        (<? (wrap-identity-policy db did policyValues))
 
        policyClass

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -99,13 +99,13 @@
     (context/stringify parsed-context)))
 
 (defn- enrich-commit-opts
-  [ledger {:keys [context did private message tag file-data? index-files-ch time] :as _opts}]
+  [ledger {:keys [context identity private message tag file-data? index-files-ch time] :as _opts}]
   (let [context*      (parse-commit-context context)
         private*      (or private
-                          (:private did)
+                          (:private identity)
                           (-> ledger :did :private))
-        did*          (or (some-> private* did/private->did)
-                          did
+        identity*     (or (some-> private* did/private->did)
+                          identity
                           (:did ledger))
         ctx-used-atom (atom {})
         compact-fn    (json-ld/compact-fn context* ctx-used-atom)]
@@ -116,7 +116,7 @@
       :file-data? file-data? ;; if true, return the db as well as the written files (for consensus)
       :context context*
       :private private*
-      :did did*}
+      :did identity*}
 
      :commit-data-helpers
      {:compact-fn compact-fn

--- a/src/clj/fluree/db/ledger/json_ld.cljc
+++ b/src/clj/fluree/db/ledger/json_ld.cljc
@@ -136,10 +136,10 @@
    (loop [[next-staged & r] staged
           results []]
      (if next-staged
-       (let [[txn author-did annotation] next-staged
+       (let [[txn author annotation] next-staged
              results* (if txn
                         (let [{txn-id :address} (<? (connection/-txn-write conn alias txn))]
-                          (conj results [txn-id author-did annotation]))
+                          (conj results [txn-id author annotation]))
                         (conj results next-staged))]
          (recur r results*))
        results))))

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -240,11 +240,11 @@
         (dataset db-map defaults)))))
 
 (defn query-connection-fql
-  [conn query did]
+  [conn query override-opts]
   (go-try
     (let [{:keys [opts] :as sanitized-query} (-> query
                                                  syntax/coerce-query
-                                                 (sanitize-query-options {:identity did}))
+                                                 (sanitize-query-options override-opts))
 
           default-aliases (some-> sanitized-query :from util/sequential)
           named-aliases   (some-> sanitized-query :from-named util/sequential)]
@@ -260,14 +260,14 @@
                         {:status 400, :error :db/invalid-query}))))))
 
 (defn query-connection-sparql
-  [conn query did]
+  [conn query override-opts]
   (go-try
     (let [fql (sparql/->fql query)]
-      (log/debug "query-connection SPARQL fql: " fql "did:" did)
-      (<? (query-connection-fql conn fql did)))))
+      (log/debug "query-connection SPARQL fql: " fql "override-opts:" override-opts)
+      (<? (query-connection-fql conn fql override-opts)))))
 
 (defn query-connection
-  [conn query {:keys [format did] :as opts :or {format :fql}}]
+  [conn query {:keys [format] :as override-opts :or {format :fql}}]
   (case format
-    :fql (query-connection-fql conn query did)
-    :sparql (query-connection-sparql conn query did)))
+    :fql (query-connection-fql conn query override-opts)
+    :sparql (query-connection-sparql conn query override-opts)))

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -35,11 +35,13 @@
   [query {:keys [identity did issuer] :as override-opts}]
   (update query :opts (fn [{:keys [max-fuel meta] :as opts}]
                         ;; ensure :max-fuel key is present
-                        (cond-> (assoc opts :max-fuel max-fuel)
-                          (or max-fuel meta)       (assoc ::track-fuel? true)
-                          (or identity did issuer) (assoc :identity identity
-                                                          :did identity
-                                                          :issuer identity)))))
+                        (-> (assoc opts :max-fuel max-fuel)
+                            ;; get rid of :did, :issuer opts
+                            (update :identity #(or % (:did opts) (:issuer opts)))
+                            (dissoc :did :issuer)
+                            (cond->
+                                (or max-fuel meta)       (assoc ::track-fuel? true)
+                                (or identity did issuer) (assoc :identity (or identity did issuer)))))))
 
 (defn load-aliased-rule-dbs
   [conn rule-sources]

--- a/src/clj/fluree/db/query/api.cljc
+++ b/src/clj/fluree/db/query/api.cljc
@@ -107,17 +107,16 @@
   ([ds query] (query-fql ds query nil))
   ([ds query override-opts]
    (go-try
-    ;; TODO - verify if both 'did' and 'issuer' opts are still needed upstream
      (let [{:keys [opts] :as query*} (-> query
                                          syntax/coerce-query
                                          (sanitize-query-options override-opts))
 
-          ;; TODO - remove restrict-db from here, restriction should happen
-          ;;      - upstream if needed
-          ds*      (if (dataset? ds)
-                     ds
-                     (<? (restrict-db ds query*)))
-          query**  (update query* :opts dissoc :meta :max-fuel ::track-fuel?)
+           ;; TODO - remove restrict-db from here, restriction should happen
+           ;;      - upstream if needed
+           ds*      (if (dataset? ds)
+                      ds
+                      (<? (restrict-db ds query*)))
+           query**  (update query* :opts dissoc :meta :max-fuel ::track-fuel?)
            max-fuel (:max-fuel opts)]
       (if (track-fuel? query*)
         (<? (track-query ds* max-fuel query**))

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -621,7 +621,7 @@
 
 (defn parse-fuel
   [{:keys [opts] :as q}]
-  (if-let [max-fuel (or (:max-fuel opts) (:maxFuel opts))]
+  (if-let [max-fuel (:max-fuel opts)]
     (assoc q :fuel max-fuel)
     q))
 

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -582,23 +582,11 @@
   (let [depth      (or (:depth q) 0)
         select-key (some (fn [k]
                            (when (contains? q k) k))
-                         [:select :selectOne :select-one
-                          :selectDistinct :select-distinct])
+                         [:select :select-one :select-distinct])
         select     (-> q
                        (get select-key)
                        (parse-select-clause context depth))]
-    (case select-key
-      (:select
-       :select-one
-       :select-distinct) (assoc q select-key select)
-
-      :selectOne (-> q
-                     (dissoc :selectOne)
-                     (assoc :select-one select))
-
-      :selectDistinct (-> q
-                          (dissoc :selectDistinct)
-                          (assoc :select-distinct select)))))
+    (assoc q select-key select)))
 
 (defn ensure-vector
   [x]
@@ -608,15 +596,13 @@
 
 (defn parse-grouping
   [q]
-  (some->> (or (:groupBy q)
-               (:group-by q))
+  (some->> (:group-by q)
            ensure-vector
            (mapv parse-var-name)))
 
 (defn parse-ordering
   [q]
-  (some->> (or (:order-by q)
-               (:orderBy q))
+  (some->> (:order-by q)
            ensure-vector
            (mapv (fn [ord]
                    (if-let [v (parse-var-name ord)]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -27,8 +27,7 @@
   (log/trace "one-select-key-present? q:" q)
   (if (map? q)
     (let [skeys (->> q keys
-                     (map #{:select :selectOne :select-one :selectDistinct
-                            :select-distinct})
+                     (map #{:select :select-one :select-distinct})
                      (remove nil?))]
       (log/trace "one-select-key-present? skeys:" skeys)
       (= 1 (count skeys)))
@@ -41,19 +40,15 @@
    [:where {:optional true} ::where]
    [:t {:optional true} ::t]
    [:context {:optional true} ::context]
-   [:orderBy {:optional true} ::order-by]
    [:order-by {:optional true} ::order-by]
-   [:groupBy {:optional true} ::group-by]
    [:group-by {:optional true} ::group-by]
    [:having {:optional true} ::function]
    [:values {:optional true} ::values]
    [:limit {:optional true} ::limit]
    [:offset {:optional true} ::offset]
-   [:maxFuel {:optional true} ::max-fuel]
    [:max-fuel {:optional true} ::max-fuel]
    [:depth {:optional true} ::depth]
    [:opts {:optional true} ::opts]
-   [:prettyPrint {:optional true} ::pretty-print]
    [:pretty-print {:optional true} ::pretty-print]])
 
 (defn wrap-query-map-schema
@@ -77,9 +72,7 @@
   [extra-kvs]
   (-> common-query-schema
       (into [[:select {:optional true} ::select]
-             [:selectOne {:optional true} ::select]
              [:select-one {:optional true} ::select]
-             [:selectDistinct {:optional true} ::select]
              [:select-distinct {:optional true} ::select]])
       (into extra-kvs)
       wrap-query-map-schema))
@@ -88,9 +81,7 @@
   [extra-kvs]
   (-> common-query-schema
       (into [[:select {:optional true} ::subquery-select]
-             [:selectOne {:optional true} ::subquery-select]
              [:select-one {:optional true} ::subquery-select]
-             [:selectDistinct {:optional true} ::subquery-select]
              [:select-distinct {:optional true} ::subquery-select]])
       (into extra-kvs)
       wrap-query-map-schema))
@@ -120,21 +111,16 @@
     ::issuer            [:maybe string?]
     ::role              :any
     ::identity          :any
-    ::opts              [:and
-                         [:map-of :keyword :any]
-                         [:map
-                          [:maxFuel {:optional true} ::max-fuel]
-                          [:max-fuel {:optional true} ::max-fuel]
-                          [:parseJSON {:optional true} ::parse-json]
-                          [:parse-json {:optional true} ::parse-json]
-                          [:prettyPrint {:optional true} ::pretty-print]
-                          [:pretty-print {:optional true} ::pretty-print]
-                          [:default-allow? {:optional true} ::default-allow?]
-                          [:defaultAllow {:optional true} ::default-allow?]
-                          [:issuer {:optional true} ::issuer]
-                          [:role {:optional true} ::role]
-                          [:identity {:optional true} ::identity]
-                          [:did {:optional true} ::identity]]]
+    ::opts              [:map
+                         [:max-fuel {:optional true} ::max-fuel]
+                         [:issuer {:optional true} ::issuer]
+                         [:role {:optional true} ::role]
+                         [:identity {:optional true} ::identity]
+                         ;; deprecated
+                         [:pretty-print {:optional true} ::pretty-print]
+                         [:did {:optional true} ::identity]
+                         [:default-allow? {:optional true} ::default-allow?]
+                         [:parse-json {:optional true} ::parse-json]]
     ::function          ::v/function
     ::as-function       ::v/as-function
     ::wildcard          [:fn wildcard?]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -118,7 +118,7 @@
     ::parse-json        boolean?
     ::issuer            [:maybe string?]
     ::role              :any
-    ::did               :any
+    ::identity          :any
     ::opts              [:and
                          [:map-of :keyword :any]
                          [:map
@@ -132,7 +132,8 @@
                           [:defaultAllow {:optional true} ::default-allow?]
                           [:issuer {:optional true} ::issuer]
                           [:role {:optional true} ::role]
-                          [:did {:optional true} ::did]]]
+                          [:identity {:optional true} ::identity]
+                          [:did {:optional true} ::identity]]]
     ::function          ::v/function
     ::as-function       ::v/as-function
     ::wildcard          [:fn wildcard?]

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -3,6 +3,7 @@
             [fluree.db.util.log :as log]
             [fluree.db.validation :as v]
             [fluree.db.util.docs :as docs]
+            [camel-snake-kebab.core :as csk]
             [clojure.edn :as edn]
             [malli.core :as m]
             [malli.transform :as mt]))
@@ -199,8 +200,9 @@
 
 (def fql-transformer
   (mt/transformer
-   {:name     :fql
-    :decoders (mt/-json-decoders)}))
+    {:name     :fql
+     :decoders (mt/-json-decoders)}
+    (mt/key-transformer {:decode csk/->kebab-case-keyword})))
 
 (def coerce-query*
   (m/coercer ::query fql-transformer {:registry registry}))

--- a/src/clj/fluree/db/transact.cljc
+++ b/src/clj/fluree/db/transact.cljc
@@ -7,7 +7,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defprotocol Transactable
-  (-stage-txn [db fuel-tracker context identity annotation raw-txn parsed-txn])
+  (-stage-txn [db fuel-tracker context identity author annotation raw-txn parsed-txn])
   (-merge-commit [db commit] [db commit proof]))
 
 (defn nested-nodes?
@@ -48,7 +48,7 @@
    (stage db nil identity txn parsed-opts))
   ([db fuel-tracker identity parsed-txn parsed-opts]
    (go-try
-     (let [{:keys [context raw-txn]} parsed-opts
+     (let [{:keys [context raw-txn author]} parsed-opts
 
            annotation (extract-annotation context parsed-txn parsed-opts)]
-       (<? (-stage-txn db fuel-tracker context identity annotation raw-txn parsed-txn))))))
+       (<? (-stage-txn db fuel-tracker context identity author annotation raw-txn parsed-txn))))))

--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -495,15 +495,6 @@
            unwrap-list
            (keep get-id)))
 
-(defn parse-opts
-  [opts]
-  (let [other-keys    (->> opts keys (remove #{:max-fuel :maxFuel}))
-        max-fuel-opts {:max-fuel (or (:max-fuel opts) (:maxFuel opts))}
-        merged-opts   (merge max-fuel-opts (select-keys opts other-keys))]
-    (if (or (:max-fuel merged-opts) (:meta merged-opts))
-      (assoc merged-opts ::track-fuel? true)
-      merged-opts)))
-
 (defn cartesian-merge
   "Like a cartesian product, but performs a map
   merge across all possilble combinations

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -371,6 +371,18 @@
                                                        {:foo  "http://foo.com/"
                                                         :bar  "http://bar.com/"
                                                         :quux "http://quux.com/"}])))))))
+    (testing "fuel tracking works on transactions"
+      (let [txn {"@context" ["https://ns.flur.ee"
+                             {:f "https://ns.flur.ee/ledger#"}]
+                 "ledger"   ledger-name
+                 "insert"   [{:context    [context
+                                           {:ex "http://example.org/ns/"}
+                                           {:quux "http://quux.com/"}]
+                              :id         :ex/alice
+                              :quux/corge "grault"}]}
+            committed  @(fluree/transact! conn txn {:meta true})]
+        (is (= [:fuel :result :status :time]
+               (sort (keys committed))))))
 
     (testing "Throws on invalid txn"
       (let [txn {"@context" ["https://ns.flur.ee" "" {:quux "http://quux.com/"}]


### PR DESCRIPTION
In order to facilitate using `db` from `server`, I needed to make some changes to how we were handling opts. This PR makes opts more consistent across the various api functions, simplifies opt handling, enables new functionality (asserting the author), and fixes a couple bugs (history api).