### PR TITLE
Fix/subquery composition

### DIFF
--- a/src/clj/fluree/db/query/exec.cljc
+++ b/src/clj/fluree/db/query/exec.cljc
@@ -68,6 +68,7 @@
        (select/format ds q fuel-tracker error-ch)
        (collect-results q)))
 
+;; TODO: refactor namespace heirarchy so this isn't necessary
 (defn subquery-executor
   "Closes over a subquery to allow processing the whole query pipeline from within the
   search."

--- a/src/clj/fluree/db/query/exec.cljc
+++ b/src/clj/fluree/db/query/exec.cljc
@@ -72,8 +72,8 @@
   "Closes over a subquery to allow processing the whole query pipeline from within the
   search."
   [subquery]
-  (fn [ds fuel-tracker solution error-ch]
-    (->> (execute* ds fuel-tracker subquery error-ch (go solution))
+  (fn [ds fuel-tracker error-ch]
+    (->> (execute* ds fuel-tracker subquery error-ch (go {}))
          (select/subquery-format ds subquery fuel-tracker error-ch))))
 
 (defn prep-subqueries

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -643,7 +643,7 @@
   [ds fuel-tracker solution pattern error-ch]
   (let [subquery-fn (pattern-data pattern)
         out-ch (async/chan 2 (map (fn [soln] (merge solution soln))))]
-    (async/pipe (subquery-fn ds fuel-tracker solution error-ch) out-ch)))
+    (async/pipe (subquery-fn ds fuel-tracker error-ch) out-ch)))
 
 (defmethod match-pattern :graph
   [ds fuel-tracker solution pattern error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -634,6 +634,12 @@
                     (async/<!))
         solution))))
 
+(defmethod match-pattern :query
+  [ds fuel-tracker solution pattern error-ch]
+  (let [subquery-fn (pattern-data pattern)
+        out-ch (async/chan 2 (map (fn [soln] (merge solution soln))))]
+    (async/pipe (subquery-fn ds fuel-tracker solution error-ch) out-ch)))
+
 (defmethod match-pattern :graph
   [ds fuel-tracker solution pattern error-ch]
   (let [[g clause] (pattern-data pattern)]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -589,10 +589,15 @@
   dataset `ds` extending from `solution` that also match all the patterns in the
   parsed where clause collection `clause`."
   [ds fuel-tracker solution clause error-ch]
-  (let [initial-ch (async/to-chan! [solution])]
+  (let [initial-ch (async/to-chan! [solution])
+        {subquery-patterns true
+         other-patterns false}
+        (group-by (fn [pattern] (and (sequential? pattern) (= :query (first pattern)))) clause)]
     (reduce (fn [solution-ch pattern]
               (with-constraint ds fuel-tracker pattern error-ch solution-ch))
-            initial-ch clause)))
+            initial-ch
+            ;; process subqueries before other patterns
+            (into (vec subquery-patterns) other-patterns))))
 
 (defn match-alias
   [ds alias fuel-tracker solution clause error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -584,6 +584,11 @@
                           solution-ch)
     out-ch))
 
+(defn subquery?
+  [pattern]
+  (and (sequential? pattern)
+       (= :query (first pattern))))
+
 (defn match-clause
   "Returns a channel that will eventually contain all match solutions in the
   dataset `ds` extending from `solution` that also match all the patterns in the
@@ -591,8 +596,7 @@
   [ds fuel-tracker solution clause error-ch]
   (let [initial-ch (async/to-chan! [solution])
         {subquery-patterns true
-         other-patterns false}
-        (group-by (fn [pattern] (and (sequential? pattern) (= :query (first pattern)))) clause)]
+         other-patterns false} (group-by subquery? clause)]
     (reduce (fn [solution-ch pattern]
               (with-constraint ds fuel-tracker pattern error-ch solution-ch))
             initial-ch

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -669,7 +669,7 @@
   (let [sub-query* (-> sub-query
                        syntax/coerce-subquery
                        (parse-analytical-query context))]
-    [[:query sub-query*]]))
+    [(where/->pattern :query sub-query*)]))
 
 (defn parse-query
   [q]

--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -503,14 +503,3 @@
     (if (or (:max-fuel merged-opts) (:meta merged-opts))
       (assoc merged-opts ::track-fuel? true)
       merged-opts)))
-
-(defn cartesian-merge
-  "Like a cartesian product, but performs a map
-  merge across all possilble combinations
-  of collections."
-  [colls]
-  (if (empty? colls)
-    '(())
-    (for [more (cartesian-merge (rest colls))
-          x    (first colls)]
-      (merge x more))))

--- a/test/fluree/db/query/subquery_test.clj
+++ b/test/fluree/db/query/subquery_test.clj
@@ -67,11 +67,11 @@
         (let [qry {:context  [test-utils/default-context
                               {:ex "http://example.org/ns/"}]
                    :select   '[?iri ?favNums]
-                   :where    ['{:id         ?iri
+                   :where    '[{:id         ?iri
                                 :ex/favNums ?favNums}
-                              [:filter "(> ?favNums ?avgFavNum)"]
-                              [:query {:where  '{:ex/favNums ?favN}
-                                       :select '[(as (avg ?favN) ?avgFavNum)]}]]
+                              [:query {:where  {:ex/favNums ?favN}
+                                       :select [(as (avg ?favN) ?avgFavNum)]}]
+                              [:filter "(> ?favNums ?avgFavNum)"]]
                    :order-by '[?iri ?favNums]}]
           (is (= [[:ex/alice 42] [:ex/alice 76] [:ex/liam 42]]
                  @(fluree/query db qry))))))))

--- a/test/fluree/db/query/subquery_test.clj
+++ b/test/fluree/db/query/subquery_test.clj
@@ -63,15 +63,15 @@
           people (test-utils/load-people conn)
           db     (fluree/db people)]
 
-      (testing " calculate average in subquery and use it in parent query as filter"
+      (testing "calculate average in subquery and use it in parent query as filter"
         (let [qry {:context  [test-utils/default-context
                               {:ex "http://example.org/ns/"}]
                    :select   '[?iri ?favNums]
-                   :where    '[{:id         ?iri
+                   :where    '[{:id ?iri
                                 :ex/favNums ?favNums}
-                              [:query {:where  {:ex/favNums ?favN}
-                                       :select [(as (avg ?favN) ?avgFavNum)]}]
-                              [:filter "(> ?favNums ?avgFavNum)"]]
+                               [:filter "(> ?favNums ?avgFavNum)"]
+                               [:query {:where {:ex/favNums ?favN}
+                                        :select [(as (avg ?favN) ?avgFavNum)]}]]
                    :order-by '[?iri ?favNums]}]
           (is (= [[:ex/alice 42] [:ex/alice 76] [:ex/liam 42]]
                  @(fluree/query db qry))))))))


### PR DESCRIPTION
We were handling subqueries in isolation correctly by executing them beforehand, but when they are placed in the scope of another where pattern those semantics were not being respected.

This refactors our subquery support to process them along with the other types of where patterns in a search. It closes over the subquery and the query executor so we can initiate an entire query from within the search processing pipeline.