### PR TITLE
allow value-maps in function expressions

### DIFF
--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -4,12 +4,13 @@
   (:require [fluree.db.query.exec.group :as group]
             [fluree.db.query.exec.where :as where]
             [fluree.db.vector.scoring :as score]
+            [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]
             [fluree.db.json-ld.iri :as iri]
             [clojure.set :as set]
             [clojure.string :as str]
-            [clojure.walk :refer [postwalk]]
+            [clojure.walk :as walk :refer [postwalk]]
             [fluree.db.datatype :as datatype]
             [fluree.crypto :as crypto]
             [fluree.db.constants :as const]
@@ -677,21 +678,37 @@
                         {:status 400, :error :db/invalid-query}))))))
 
 (defn coerce
-  [code allow-aggregates?]
-  (postwalk (fn [x]
-              (cond (where/variable? x)
-                    x
+  [allow-aggregates? ctx x]
+  (cond
+    ;; set literal (for "in")
+    (vector? x)
+    (mapv (partial coerce allow-aggregates? ctx) x)
 
-                    (symbol? x)
-                    (qualify x allow-aggregates?)
+    ;; function expression
+    (sequential? x)
+    (map (partial coerce allow-aggregates? ctx) x)
 
-                    ;; literal
-                    (not (sequential? x))
-                    (where/->TypedValue x (datatype/infer-iri x) nil)
+    ;; value map
+    (map? x)
+    (let [{:keys [id value type language]}
+          (-> (json-ld/expand {"f:v-map" x} ctx)
+              (util/get-first "f:v-map"))]
+      (if id
+        (where/->typed-val id const/iri-id)
+        (where/->typed-val value type language)))
 
-                    :else
-                    x))
-            code))
+    (where/variable? x)
+    x
+
+    (symbol? x)
+    (qualify x allow-aggregates?)
+
+    ;; simple literal
+    (not (sequential? x))
+    (where/->typed-val x)
+
+    :else
+    x))
 
 (defn mch->typed-val
   [{::where/keys [val iri datatype-iri meta]}]
@@ -710,7 +727,7 @@
 
 (defn compile*
   [code ctx allow-aggregates?]
-  (let [qualified-code (coerce code allow-aggregates?)
+  (let [qualified-code (coerce allow-aggregates? ctx code)
         vars           (variables qualified-code)
         soln-sym       'solution
         bdg            (bind-variables soln-sym vars ctx)]

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -117,6 +117,24 @@
                                            [:bind ?nameLength "(strLen ?name)"]
                                            [:filter "(> 4 ?nameLength)"]]}))))
 
+    (testing "filtering literal value-maps"
+      (is (= ["Cam"]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '?name
+                                :where   '[{:type        :ex/User
+                                            :schema/name ?name}
+                                           [:bind ?nameLength "(strLen ?name)"]
+                                           [:filter "(> {\"@value\" 4 :type :xsd/int} ?nameLength)"]]})))
+      (is (= ["Cam"]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '?name
+                                :where   '[{:type        :ex/User
+                                            :schema/name ?name}
+                                           [:bind ?nameLength "(strLen ?name)"]
+                                           [:filter "(in ?nameLength [2 3 {\"@value\" 4 :type :xsd/int}])"]]}))))
+
     (testing "filtering variables bound to iris"
       (let [db-dads @(fluree/stage
                        db


### PR DESCRIPTION
We ran into a problem when translating SPARQL into FQL - RDF tagged literals were being translated into json-ld value maps, but we did not support value maps inside of function expressions.

```
PREFIX ex: <http://example.com/ns#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT ?s
FROM <fluree-jld/369435906932736>
WHERE {
    ?s ex:dob ?date .
    FILTER (?date >= "2023-08-01"^^xsd:date && ?date <= "2023-08-31"^^xsd:date)
}
;; => translates to
{:context {"ex" "http://exmpale.com/ns#", "xsd" "http://www.w3.org/2001/XMLSchema#"},
   :select ["?s"],
   :from ["fluree-jld/369435906932736"],
   :where [{"@id" "?s", "ex:dob" "?date"}
           [:filter "(and (>= ?date {\"@value\" \"2023-08-01\", \"@type\" \"xsd:date\"}) (<= ?date {\"@value\" \"2023-08-31\", \"@type\" \"xsd:date\"}))"]]}
```

I started by trying to change the translator to detect datatype-tagged literals and move them to a :values pattern, but it turned out to be much easier, and in retrospect much more flexible, to add support for value maps within expressions.

The only tricky part was handling the `in` function, where we use a vector as a set literal notation.