### PR TITLE
add support for functions as data

### DIFF
--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -595,9 +595,9 @@
                      :list-fn (if (= 'as (first s))
                                 (parse-select-as-fn s context)
                                 (parse-select-aggregate s context))
-                     :data-fn (if (= "as" (first s))
-                                (parse-select-as-fn s context)
-                                (parse-select-aggregate s context)))
+                     :vector-fn (if (= "as" (first s))
+                                  (parse-select-as-fn s context)
+                                  (parse-select-aggregate s context)))
         :select-map (parse-select-map s depth context)))))
 
 (defn parse-select-clause

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -247,7 +247,7 @@
 (defn parse-code
   [x]
   (cond (list? x)   x
-        (vector? x) (parse-code-data x)
+        (vector? x) (parse-code-data (second x))
         :else       (safe-read x)))
 
 (defn parse-filter-function

--- a/src/clj/fluree/db/validation.cljc
+++ b/src/clj/fluree/db/validation.cljc
@@ -249,7 +249,7 @@
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]
-                            [:data-fn [:and vector? [:cat [:enum :expr] [:* any?]]]]]
+                            [:vector-fn [:and vector? [:cat [:enum :expr] [:* any?]]]]]
     ::as-function          [:orn {:error/message "subquery aggregates must be bound to a variable with 'as' e.g. '(as (sum ?x) ?x-sum)"}
                             [:string-fn [:and :string [:re #"^\(as .+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]]

--- a/src/clj/fluree/db/validation.cljc
+++ b/src/clj/fluree/db/validation.cljc
@@ -249,7 +249,7 @@
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]
-                            [:data-fn [:and vector? [:cat :string [:* any?]]]]]
+                            [:data-fn [:and vector? [:cat [:enum :expr] [:* any?]]]]]
     ::as-function          [:orn {:error/message "subquery aggregates must be bound to a variable with 'as' e.g. '(as (sum ?x) ?x-sum)"}
                             [:string-fn [:and :string [:re #"^\(as .+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]]

--- a/src/clj/fluree/db/validation.cljc
+++ b/src/clj/fluree/db/validation.cljc
@@ -248,7 +248,8 @@
     ::subject              ::iri
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
-                            [:list-fn [:and list? [:cat :symbol [:* any?]]]]]
+                            [:list-fn [:and list? [:cat :symbol [:* any?]]]]
+                            [:data-fn [:and vector? [:cat :string [:* any?]]]]]
     ::as-function          [:orn {:error/message "subquery aggregates must be bound to a variable with 'as' e.g. '(as (sum ?x) ?x-sum)"}
                             [:string-fn [:and :string [:re #"^\(as .+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]]

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -22,10 +22,10 @@
       (testing "with data function syntax"
         (let [qry     {:context  [test-utils/default-str-context
                                   {"ex" "http://example.org/ns/"}]
-                       :select   ["?upperName" ["count" "?favNums"]]
+                       :select   ["?upperName" ["expr" ["count" "?favNums"]]]
                        :where    [{"schema:name" "?name"
                                    "ex:favNums"  "?favNums"}
-                                  ["bind" "?upperName" ["ucase" "?name"]]]
+                                  ["bind" "?upperName" ["expr" ["ucase" "?name"]]]]
                        :group-by "?upperName"}
               subject @(fluree/query db qry)]
           (is (= [["ALICE" 3] ["BRIAN" 1] ["CAM" 2] ["LIAM" 2]]

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -19,6 +19,18 @@
           (is (= [["Alice" 3] ["Brian" 1] ["Cam" 2] ["Liam" 2]]
                  subject)
               "aggregates bindings within each group")))
+      (testing "with data function syntax"
+        (let [qry     {:context  [test-utils/default-str-context
+                                  {"ex" "http://example.org/ns/"}]
+                       :select   ["?upperName" ["count" "?favNums"]]
+                       :where    [{"schema:name" "?name"
+                                   "ex:favNums"  "?favNums"}
+                                  ["bind" "?upperName" ["ucase" "?name"]]]
+                       :group-by "?upperName"}
+              subject @(fluree/query db qry)]
+          (is (= [["ALICE" 3] ["BRIAN" 1] ["CAM" 2] ["LIAM" 2]]
+                 subject)
+              "aggregates bindings within each group")))
       (testing "with singular function selector"
         (let [qry     {:context  [test-utils/default-context
                                   {:ex "http://example.org/ns/"}]

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -222,7 +222,7 @@
                                 :where   '[{:type        :ex/User
                                             :schema/age  ?age
                                             :schema/name ?name}
-                                           [:filter [">" "?age" ["/" ["+" "?age" 47] 2]]]]}))
+                                           [:filter ["expr" [">" "?age" ["/" ["+" "?age" 47] 2]]]]]}))
           "string atoms")
 
       (is (= [["Brian" 50]]
@@ -232,7 +232,7 @@
                                 :where   '[{:type        :ex/User
                                             :schema/age  ?age
                                             :schema/name ?name}
-                                           [:filter ["in" "?age" [50 2 3]]]]}))
+                                           [:filter ["expr" ["in" "?age" [50 2 3]]]]]}))
           "in expression")
       (is (= [{:type         :ex/User
                :schema/email "cam@example.org"
@@ -247,7 +247,7 @@
                                           {:ex "http://example.org/ns/"}]
                                 :select  {"?s" ["*"]}
                                 :where   [{:id "?s", :ex/favColor "?color"}
-                                          [:filter ["strStarts" "?color" "B"]]]}))
+                                          [:filter ["expr" ["strStarts" "?color" "B"]]]]}))
           "no quoting necessary")
       (is (= [{:type         :ex/User
                :schema/email "cam@example.org"
@@ -262,5 +262,5 @@
                                           {:ex "http://example.org/ns/"}]
                                 :select  {"?s" ["*"]}
                                 :where   [{:id "?s", :ex/favColor "?color"}
-                                          [:filter ["strStarts" "?color" {"@value" "B" "@language" "en"}]]]}))
+                                          [:filter ["expr" ["strStarts" "?color" {"@value" "B" "@language" "en"}]]]]}))
           "with value maps"))))

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -213,4 +213,54 @@
                                           {:ex "http://example.org/ns/"}]
                                 :select  {"?s" ["*"]}
                                 :where   [{:id "?s", :ex/favColor "?color"}
-                                          [:filter "(strStarts ?color \"B\")"]]}))))))
+                                          [:filter "(strStarts ?color \"B\")"]]}))))
+    (testing "data expression"
+      (is (= [["Brian" 50]]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '[?name ?age]
+                                :where   '[{:type        :ex/User
+                                            :schema/age  ?age
+                                            :schema/name ?name}
+                                           [:filter [">" "?age" ["/" ["+" "?age" 47] 2]]]]}))
+          "string atoms")
+
+      (is (= [["Brian" 50]]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '[?name ?age]
+                                :where   '[{:type        :ex/User
+                                            :schema/age  ?age
+                                            :schema/name ?name}
+                                           [:filter ["in" "?age" [50 2 3]]]]}))
+          "in expression")
+      (is (= [{:type         :ex/User
+               :schema/email "cam@example.org"
+               :ex/favNums   [5 10]
+               :schema/age   34
+               :ex/last      "Jones"
+               :schema/name  "Cam"
+               :id           :ex/cam
+               :ex/friend    [{:id :ex/alice} {:id :ex/brian}]
+               :ex/favColor  "Blue"}]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  {"?s" ["*"]}
+                                :where   [{:id "?s", :ex/favColor "?color"}
+                                          [:filter ["strStarts" "?color" "B"]]]}))
+          "no quoting necessary")
+      (is (= [{:type         :ex/User
+               :schema/email "cam@example.org"
+               :ex/favNums   [5 10]
+               :schema/age   34
+               :ex/last      "Jones"
+               :schema/name  "Cam"
+               :id           :ex/cam
+               :ex/friend    [{:id :ex/alice} {:id :ex/brian}]
+               :ex/favColor  "Blue"}]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  {"?s" ["*"]}
+                                :where   [{:id "?s", :ex/favColor "?color"}
+                                          [:filter ["strStarts" "?color" {"@value" "B" "@language" "en"}]]]}))
+          "with value maps"))))


### PR DESCRIPTION
When a user needs to write a function as a string all literal strings within the expression need to be escaped, which is difficult to read and prone to frustrating errors.

example:
```
  {"where" [{"@id" "?s" "ex:name" "?name"}
            ["filter" "(strStarts ?name \"B\")"]]
   ...}
```

This allows users who need to use json to express their functions as nested arrays:

```
  {"where" [{"@id" "?s" "ex:name" "?name"}
            ["filter" ["strStarts" "?name" "B"]]
   ...}
```
I tossed this off because I've been bothered by this for ages and I recently had to do a lot of work with a function like this:
```
"(and (>= ?date {\"@value\" \"2023-08-01\", \"@type\" \"xsd:date\"}) (<= ?date {\"@value\" \"2023-08-31\", \"@type\" \"xsd:date\"}))"
```
Which looks a lot nicer written like this:
```
["and"
  [">=" "?date" {"@value" "2023-08-01" "@type" "xsd:date"}]
  ["<=" "?date" {"@value" "2023-08-31" "@type" "xsd:date"}]]
```
  
