### PR TITLE
fix reify-schema version check

### DIFF
--- a/src/clj/fluree/db/flake/index/storage.cljc
+++ b/src/clj/fluree/db/flake/index/storage.cljc
@@ -152,7 +152,7 @@
 
 (defn reify-schema
   [{:keys [namespace-codes v] :as root-map}]
-  (if (not= 1 v)
+  (if (> v 0)
     (update root-map :schema vocab/deserialize-schema namespace-codes)
     ;; legacy, for now only v0
     (update root-map :preds deserialize-preds)))


### PR DESCRIPTION
I'm a little confused how this scooted by undetected for so long, but I think this condition was reversed. And it was also not forward compatible.

This manifested as the db :schema not having a :shapes cache, which causes validation to blow up.