### PR TITLE
support multiple shacl targets and larger target shapes

### DIFF
--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -260,52 +260,58 @@
             (recur r results))
           (not-empty results))))))
 
+(defn get-id [x]
+  (if (map? x)
+    (get x const/$id)
+    x))
+
 (defn target-node-target?
   "If a subject is the same as the targetNode target, it is targeted."
   [shape s-flakes]
   (let [sid        (some-> s-flakes first flake/s)
-        target-sids (->> (get shape const/sh_targetNode) (into #{}))]
+        target-sids (->> (get shape const/sh_targetNode) (into #{} (map get-id)))]
     (contains? target-sids sid)))
 
 (defn target-class-target?
   "If a subject has the targeted @type, then it is a targetClass target."
   [shape s-flakes]
-  (let [target-class (first (get shape const/sh_targetClass))]
+  (let [target-classes (->> (get shape const/sh_targetClass)
+                            (into #{} (map get-id)))]
     (some (fn [f]
             (and (flake/class-flake? f)
-                 (= (flake/o f) target-class)))
+                 (contains? target-classes (flake/o f))))
           s-flakes)))
 
 (defn target-subjects-of-target?
   "If a subject has the targeted predicate, then it is a targetSubjectsOf target."
   [shape s-flakes]
-  (let [target-pid (first (get shape const/sh_targetSubjectsOf))]
-    (some (fn [f] (= (flake/p f) target-pid))
+  (let [target-pids (->> (get shape const/sh_targetSubjectsOf) (into #{} (map get-id)))]
+    (some (fn [f] (contains? target-pids (flake/p f)))
           s-flakes)))
 
 (defn implicit-target?
   "If a sh:NodeShape has a class it implicitly targets nodes of that type."
   ;; https://www.w3.org/TR/shacl/#implicit-targetClass
   [shape s-flakes]
-  (let [shape-classes (-> (get shape const/$rdf:type) (set) (disj const/sh_NodeShape))]
+  (let [shape-classes (-> (into #{} (map get-id) (get shape const/$rdf:type)) (disj const/sh_NodeShape))]
     (some (fn [f] (and (flake/class-flake? f)
                        (contains? shape-classes (flake/o f))))
           s-flakes)))
 
 (defn target-objects-of-target?
   [shape]
-  (first (get shape const/sh_targetObjectsOf)))
+  (seq (get shape const/sh_targetObjectsOf)))
 
 (defn target-objects-of-focus-nodes
   "Returns the objects of any targeted predicate, plus the subject if it is referred to by
   the targeted predicate."
   [db shape s-flakes]
   (go-try
-    (let [target-pid (first (get shape const/sh_targetObjectsOf))]
+    (let [target-pids       (->> (get shape const/sh_targetObjectsOf) (into #{} (map get-id)))]
       (let [sid             (some-> s-flakes first flake/s)
             referring-pids  (not-empty (<? (query-range/index-range db :opst = [[sid const/$id]]
                                                                     {:flake-xf (map flake/p)})))
-            p-flakes        (filterv (fn [f] (= (flake/p f) target-pid)) s-flakes)
+            p-flakes        (filterv (fn [f] (contains? target-pids (flake/p f))) s-flakes)
             focus-nodes     (mapv object-node p-flakes)]
         ;; TODO: we assume that these objects are sids, but that assumption may not hold
         (cond-> (mapv flake/o p-flakes)

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -262,7 +262,7 @@
             (recur r results))
           (not-empty results))))))
 
-(defn get-id [x]
+(defn unpack-id [x]
   (if (map? x)
     (get x const/$id)
     x))
@@ -271,14 +271,13 @@
   "If a subject is the same as the targetNode target, it is targeted."
   [shape s-flakes]
   (let [sid        (some-> s-flakes first flake/s)
-        target-sids (->> (get shape const/sh_targetNode) (into #{} (map get-id)))]
+        target-sids (into #{} (map unpack-id) (get shape const/sh_targetNode))]
     (contains? target-sids sid)))
 
 (defn target-class-target?
   "If a subject has the targeted @type, then it is a targetClass target."
   [shape s-flakes]
-  (let [target-classes (->> (get shape const/sh_targetClass)
-                            (into #{} (map get-id)))]
+  (let [target-classes (into #{} (map unpack-id) (get shape const/sh_targetClass))]
     (some (fn [f]
             (and (flake/class-flake? f)
                  (contains? target-classes (flake/o f))))
@@ -287,7 +286,7 @@
 (defn target-subjects-of-target?
   "If a subject has the targeted predicate, then it is a targetSubjectsOf target."
   [shape s-flakes]
-  (let [target-pids (->> (get shape const/sh_targetSubjectsOf) (into #{} (map get-id)))]
+  (let [target-pids (into #{} (map unpack-id) (get shape const/sh_targetSubjectsOf))]
     (some (fn [f] (contains? target-pids (flake/p f)))
           s-flakes)))
 
@@ -295,7 +294,7 @@
   "If a sh:NodeShape has a class it implicitly targets nodes of that type."
   ;; https://www.w3.org/TR/shacl/#implicit-targetClass
   [shape s-flakes]
-  (let [shape-classes (-> (into #{} (map get-id) (get shape const/$rdf:type)) (disj const/sh_NodeShape))]
+  (let [shape-classes (-> (into #{} (map unpack-id) (get shape const/$rdf:type)) (disj const/sh_NodeShape))]
     (some (fn [f] (and (flake/class-flake? f)
                        (contains? shape-classes (flake/o f))))
           s-flakes)))
@@ -309,7 +308,7 @@
   the targeted predicate."
   [db shape s-flakes]
   (go-try
-    (let [target-pids       (->> (get shape const/sh_targetObjectsOf) (into #{} (map get-id)))]
+    (let [target-pids       (into #{} (map unpack-id) (get shape const/sh_targetObjectsOf))]
       (let [sid             (some-> s-flakes first flake/s)
             referring-pids  (not-empty (<? (query-range/index-range db :opst = [[sid const/$id]]
                                                                     {:flake-xf (map flake/p)})))

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -2987,3 +2987,89 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                (ex-data db2)))
         (is (= "Subject ex:invalid path [{\"sh:alternativePath\" \"ex:property1\"}] violates constraint sh:minCount of shape _:fdb-3 - count 1 is less than minimum count of 2."
                (ex-message db2)))))))
+
+(deftest multiple-and-encumbered-targets
+  (let [conn   @(fluree/connect {:method :memory})
+        ledger @(fluree/create conn "encumbered-targets")
+        db0    (fluree/db ledger)]
+    (testing "targetClass"
+      (testing "with multiple targets"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetClass" [{"@id" "ex:Assertion"} {"@id" "ex:Fact"}]}]})]
+          (is (not (nil? @(fluree/stage db1 {"@type" "ex:Assertion" "ex:term" 123}))))
+          (is (not (nil? @(fluree/stage db1 {"@type" "ex:Fact" "ex:term" 123}))))))
+      (testing "with extra data"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetClass" {"@id" "ex:Assertion" "ex:extra" "data"}}]})]
+          (is (not (nil? @(fluree/stage db1 {"@type" "ex:Assertion" "ex:term" 123})))))))
+    (testing "targetNode"
+      (testing "with multiple targets"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetNode" [{"@id" "ex:foo"}
+                                                         {"@id" "ex:bar"}]}]})]
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:foo" "ex:term" 123}))))
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:bar" "ex:term" 123}))))))
+      (testing "with extra data"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetNode" {"@id" "ex:foo" "ex:extra" "data"}}]})]
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:foo" "ex:term" 123})))))))
+    (testing "targetObjectsOf"
+      (testing "with multiple targets"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:datatype" {"@id" "xsd:string"},
+                                        "sh:targetObjectsOf" [{"@id" "ex:foo"}
+                                                              {"@id" "ex:bar"}]}]})]
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:foo" 123}))))
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:bar" 123}))))))
+      (testing "with extra data"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetObjectsOf" {"@id" "ex:foo" "@type" "rdf:Property"}}]})]
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:foo" "ex:term" 123})))))))
+    (testing "targetSubjectsof"
+      (testing "with multiple targets"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetSubjectsOf" [{"@id" "ex:foo"}
+                                                               {"@id" "ex:bar"}]}]})]
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:foo" "foo" "ex:term" 123}))))
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:bar" "bar" "ex:term" 123}))))))
+      (testing "with extra data"
+        (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
+                                      "insert"
+                                      [{"@type" "sh:NodeShape",
+                                        "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                                                        "sh:maxCount" 1,
+                                                        "sh:path" {"@id" "ex:term"}}],
+                                        "sh:targetSubjectsOf" {"@id" "ex:foo" "ex:extra" "data"}}]})]
+          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:foo" "foo" "ex:term" 123})))))))))


### PR DESCRIPTION
When we build shapes with `build-shape-node`, we do it greedily - we keep recursing until we find the "leaves" of the graph. The code assumed that a constructed shape would have a structure like this:

```
{"@id" "ex:MyShape"
 "sh:targetClass" ["ex:SomeClass"]}
```

But because of greedy construction, it very well could have a shape like this:
```
{"@id" "ex:MyShape"
 "sh:targetClass" [{"@id" "ex:SomeClass" "ex:foo" "some-other-data"}]}
```

Also, most of the targets assumed that there would only be a single target, when according to the spec there could be multiple.

This commit regularizes the shape structure to handle multiple targets and also additional data on the target subject.

fixes https://github.com/fluree/core/issues/132