### PR TITLE
Add `Catalog` implementations of storage protocols

### DIFF
--- a/src/clj/fluree/db/commit/storage.cljc
+++ b/src/clj/fluree/db/commit/storage.cljc
@@ -35,7 +35,7 @@
 (defn read-data-jsonld
   [storage address]
   (go-try
-    (let [jsonld (<? (storage/read-catalog-json storage address)) ]
+    (let [jsonld (<? (storage/read-json storage address)) ]
       (-> jsonld
           (assoc "f:address" address)
           json-ld/expand))))
@@ -43,7 +43,7 @@
 (defn read-commit-jsonld
   [storage commit-address]
   (go-try
-    (let [commit-data   (<? (storage/read-catalog-json storage commit-address))
+    (let [commit-data   (<? (storage/read-json storage commit-address))
           addr-key-path (if (contains? commit-data "credentialSubject")
                           ["credentialSubject" "address"]
                           ["address"])]
@@ -99,7 +99,7 @@
 (defn write-jsonld
   [storage ledger-alias jsonld]
   (let [path (str/join "/" [ledger-alias "commit"])]
-    (storage/content-write-catalog-json storage path jsonld)))
+    (storage/content-write-json storage path jsonld)))
 
 (defn write-genesis-commit
   [storage ledger-alias branch publish-addresses init-time]

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -182,7 +182,7 @@
 (defn read-file-address
   [{:keys [commit-catalog] :as _conn} addr]
   (go-try
-    (let [json-data (<? (storage/read-catalog-json commit-catalog addr))]
+    (let [json-data (<? (storage/read-json commit-catalog addr))]
       (assoc json-data "address" addr))))
 
 (defn lookup-publisher-commit
@@ -454,7 +454,7 @@
 (defn write-transaction
   [storage ledger-alias txn]
   (let [path (str/join "/" [ledger-alias "txn"])]
-    (storage/content-write-catalog-json storage path txn)))
+    (storage/content-write-json storage path txn)))
 
 ;; TODO - as implemented the db handles 'staged' data as per below (annotation, raw txn)
 ;; TODO - however this is really a concern of "commit", not staging and I don' think the db should be handling any of it

--- a/src/clj/fluree/db/flake/history.cljc
+++ b/src/clj/fluree/db/flake/history.cljc
@@ -218,7 +218,7 @@
                    (let [txn-key     (json-ld/compact const/iri-txn compact)
                          txn-address (get commit-wrapper txn-key)
                          raw-txn     (when txn-address
-                                       (<? (storage/read-catalog-json commit-catalog txn-address)))]
+                                       (<? (storage/read-json commit-catalog txn-address)))]
                      (assoc {} txn-key raw-txn))
                    {})
            commit (-> (assoc commit-key commit-wrapper)

--- a/src/clj/fluree/db/flake/index/storage.cljc
+++ b/src/clj/fluree/db/flake/index/storage.cljc
@@ -40,7 +40,7 @@
   [storage ledger-alias index-type serialized-data]
   (let [index-name (name index-type)
         path       (str/join "/" [ledger-alias "index" index-name])]
-    (storage/content-write-catalog-json storage path serialized-data)))
+    (storage/content-write-json storage path serialized-data)))
 
 (defn write-leaf
   "Serializes and writes the index leaf node `leaf` to storage."
@@ -105,13 +105,13 @@
 (defn read-branch
   [{:keys [storage serializer] :as _idx-store} branch-address]
   (go-try
-    (when-let [data (<? (storage/read-catalog-json storage branch-address true))]
+    (when-let [data (<? (storage/read-json storage branch-address true))]
       (serdeproto/-deserialize-branch serializer data))))
 
 (defn read-leaf
   [{:keys [storage serializer] :as _idx-store} leaf-address]
   (go-try
-    (when-let [data (<? (storage/read-catalog-json storage leaf-address true))]
+    (when-let [data (<? (storage/read-json storage leaf-address true))]
       (serdeproto/-deserialize-leaf serializer data))))
 
 (defn reify-index-root
@@ -145,7 +145,7 @@
   "Returns garbage file data for a given index t."
   [{:keys [storage serializer] :as _idx-store} garbage-address]
   (go-try
-    (when-let [data (<? (storage/read-catalog-json storage garbage-address true))]
+    (when-let [data (<? (storage/read-json storage garbage-address true))]
       (serdeproto/-deserialize-garbage serializer data))))
 
 (defn delete-garbage-item
@@ -164,7 +164,7 @@
   "Returns all data for a db index root of a given t."
   [{:keys [storage serializer] :as _idx-store} idx-address]
   (go-try
-    (if-let [data (<? (storage/read-catalog-json storage idx-address true))]
+    (if-let [data (<? (storage/read-json storage idx-address true))]
       (let [{:keys [t] :as root-data}
             (serdeproto/-deserialize-db-root serializer data)]
         (-> root-data

--- a/src/clj/fluree/db/storage.cljc
+++ b/src/clj/fluree/db/storage.cljc
@@ -203,21 +203,29 @@
     (doto (async/chan)
       (async/put! ex))))
 
-(defn read-catalog-json
-  ([clg address]
-   (read-catalog-json clg address false))
-  ([clg address keywordize?]
-   (if-let [store (locate-address clg address)]
-     (read-json store address keywordize?)
-     (async-location-error address))))
+(extend-type Catalog
+  JsonArchive
+  (-read-json [clg address keywordize?]
+    (if-let [store (locate-address clg address)]
+     (-read-json store address keywordize?)
+     (async-location-error address)))
+
+  ContentAddressedStore
+  (-content-write-bytes [clg k v]
+    (let [store (get-content-store clg ::default)]
+      (-content-write-bytes store k v)))
+
+  EraseableStore
+  (delete [clg address]
+    (if-let [store (locate-address clg address)]
+      (delete store address)
+      (async-location-error location))))
 
 (defn content-write-catalog-json
-  ([clg path data]
-   (content-write-catalog-json clg ::default path data))
-  ([clg location path data]
-   (if-let [store (get-content-store clg location)]
-     (content-write-json store path data)
-     (async-location-error location))))
+  [clg location path data]
+  (if-let [store (get-content-store clg location)]
+    (content-write-json store path data)
+    (async-location-error location)))
 
 ;; TODO: Segregate content stores and byte stores if some catalog components
 ;;       don't implement both protocols
@@ -226,10 +234,4 @@
   (if-let [store (locate-address clg address)]
     (let [path (get-local-path address)]
       (write-bytes store path data))
-    (async-location-error location)))
-
-(defn delete-catalog
-  [clg address]
-  (if-let [store (locate-address clg address)]
-    (delete store address)
     (async-location-error location)))

--- a/src/clj/fluree/db/storage.cljc
+++ b/src/clj/fluree/db/storage.cljc
@@ -227,3 +227,9 @@
     (let [path (get-local-path address)]
       (write-bytes store path data))
     (async-location-error location)))
+
+(defn delete-catalog
+  [clg address]
+  (if-let [store (locate-address clg address)]
+    (delete store address)
+    (async-location-error location)))


### PR DESCRIPTION
This patch adds catalog implementations for the compatible storage protocols so that `Catalog` records can be used more interchangeably with the more primitive storage records. 