### PR TITLE
Test for unicode chars in @id iri

### DIFF
--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -547,3 +547,38 @@
     (is (= "Subject ex:letti path [\"schema:age\"] violates constraint sh:datatype of shape ex:PropertyShape/age - the following values do not have expected datatype xsd:integer: alot."
            (ex-message db3))
         "datatype constraint is restored after a load")))
+
+(deftest ^:integration ^:json transaction-iri-special-char
+  (testing "transaction with special iri characters in @id"
+    (let [
+          conn      @(fluree/connect {:method :memory})
+          ledger-id "transaction-iri-special-char"
+          ledger    @(fluree/create conn ledger-id)
+          db0       (fluree/db ledger)
+          db1a      @(fluree/stage db0 {"@context" {"ex" "http://example.org/"}
+                                        "ledger"   ledger-id
+                                        "insert"   [{"@id"     "ex:aஃ",
+                                                     "@type"   "ex:Foo"
+                                                     "ex:desc" "try special ஃ as second iri char"}]})
+          ;; TODO - below doesn't work when first IRI char is unicode
+          ;db1b      @(fluree/stage db0 {"@context" {"ex" "http://example.org/"}
+          ;                              "ledger"   ledger-id
+          ;                              "insert"   [{"@id"     "ex:ஃb",
+          ;                                           "@type"   "ex:Foo"
+          ;                                           "ex:desc" "try special ஃ as first iri char"}]})
+          q1a       {"@context" {"ex" "http://example.org/"}
+                     "from"     ledger-id
+                     "select"   {"ex:aஃ" ["*"]}}
+          q1b       {"@context" {"ex" "http://example.org/"}
+                     "from"     ledger-id
+                     "select"   {"ex:ஃb" ["*"]}}]
+      (is (= [{"@id"     "ex:aஃ",
+               "@type"   "ex:Foo"
+               "ex:desc" "try special ஃ as second iri char"}]
+             @(fluree/query db1a q1a)))
+      ;; TODO - below test should pass once unicode as first IRI char supported above
+      #_(is (= [{"@id"     "ex:ஃb",
+               "@type"   "ex:Foo"
+               "ex:desc" "try special ஃ as first iri char"}]
+             @(fluree/query db1b q1b)))
+      )))

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -548,7 +548,8 @@
            (ex-message db3))
         "datatype constraint is restored after a load")))
 
-(deftest ^:integration ^:json transaction-iri-special-char
+;; TODO - below will brick the db when first IRI char is unicode, but the test where unicode comes second works
+(deftest ^:kaocha/pending ^:integration ^:json transaction-iri-special-char
   (testing "transaction with special iri characters in @id"
     (let [
           conn      @(fluree/connect {:method :memory})
@@ -560,12 +561,12 @@
                                         "insert"   [{"@id"     "ex:aஃ",
                                                      "@type"   "ex:Foo"
                                                      "ex:desc" "try special ஃ as second iri char"}]})
-          ;; TODO - below doesn't work when first IRI char is unicode
-          ;db1b      @(fluree/stage db0 {"@context" {"ex" "http://example.org/"}
-          ;                              "ledger"   ledger-id
-          ;                              "insert"   [{"@id"     "ex:ஃb",
-          ;                                           "@type"   "ex:Foo"
-          ;                                           "ex:desc" "try special ஃ as first iri char"}]})
+
+          db1b      @(fluree/stage db0 {"@context" {"ex" "http://example.org/"}
+                                        "ledger"   ledger-id
+                                        "insert"   [{"@id"     "ex:ஃb",
+                                                     "@type"   "ex:Foo"
+                                                     "ex:desc" "try special ஃ as first iri char"}]})
           q1a       {"@context" {"ex" "http://example.org/"}
                      "from"     ledger-id
                      "select"   {"ex:aஃ" ["*"]}}
@@ -576,9 +577,7 @@
                "@type"   "ex:Foo"
                "ex:desc" "try special ஃ as second iri char"}]
              @(fluree/query db1a q1a)))
-      ;; TODO - below test should pass once unicode as first IRI char supported above
-      #_(is (= [{"@id"     "ex:ஃb",
+      (is (= [{"@id"     "ex:ஃb",
                "@type"   "ex:Foo"
                "ex:desc" "try special ஃ as first iri char"}]
-             @(fluree/query db1b q1b)))
-      )))
+             @(fluree/query db1b q1b))))))


### PR DESCRIPTION
This adds a unicode IRI test along with a commented out test that bricks the db. I spent some time trying to identify the issue, but it will take more investigation.

Unicode is supported in iris, however this shows it doesn't work when a special character is the first char, only when it is a later character.

This works: 
{"@id": "ex:aஃ", ...}

This bricks the db:
{"@id": "ex:ஃb", ...}

I've written up a ticket here: 

This exploration was an effort to fix this issue here: https://github.com/fluree/db/issues/918
