### PR TITLE
Implement vector flat ranking in terms of the `Matcher` protocol

### DIFF
--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -73,7 +73,7 @@
   (-aliases [_]
     [alias])
 
-  (-finalize [_ _ solution-ch]
+  (-finalize [_ _ _ solution-ch]
     solution-ch)
 
   subject/SubjectFormatter

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -73,6 +73,9 @@
   (-aliases [_]
     [alias])
 
+  (-finalize [_ _ solution-ch]
+    solution-ch)
+
   subject/SubjectFormatter
   (-forward-properties [_ iri select-spec context compact-fn cache fuel-tracker error-ch]
     (let [prop-ch (async/chan)]

--- a/src/clj/fluree/db/dataset.cljc
+++ b/src/clj/fluree/db/dataset.cljc
@@ -85,6 +85,9 @@
   (-aliases [ds]
     (names ds))
 
+  (-finalize [_ _ solution-ch]
+    solution-ch)
+
 
   subject/SubjectFormatter
   (-forward-properties [ds iri select-spec context compact-fn cache fuel-tracker error-ch]

--- a/src/clj/fluree/db/dataset.cljc
+++ b/src/clj/fluree/db/dataset.cljc
@@ -85,7 +85,7 @@
   (-aliases [ds]
     (names ds))
 
-  (-finalize [_ _ solution-ch]
+  (-finalize [_ _ _ solution-ch]
     solution-ch)
 
 

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -337,7 +337,7 @@
   (-aliases [_]
     [alias])
 
-  (-finalize [_ _ solution-ch]
+  (-finalize [_ _ _ solution-ch]
     solution-ch)
 
   transact/Transactable

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -24,7 +24,7 @@
             [fluree.db.flake.index.novelty :as novelty]
             [fluree.db.query.fql :as fql]
             [fluree.db.flake.index.storage :as index-storage]
-            [fluree.db.vector.index-graph :as index-graph :refer [index-graph]]
+            [fluree.db.vector.flat-rank :as flat-rank]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.json-ld.policy :as policy]
             [fluree.db.json-ld.policy.query :as qpolicy]
@@ -328,7 +328,7 @@
   (-activate-alias [db alias']
     (cond
       (= alias alias')              db
-      (where/virtual-graph? alias') (index-graph db alias')))
+      (where/virtual-graph? alias') (flat-rank/index-graph db alias')))
 
   (-aliases [_]
     [alias])

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -323,11 +323,11 @@
   (-match-id [db fuel-tracker solution s-mch error-ch]
     (match/match-id db fuel-tracker solution s-mch error-ch))
 
-  (-match-triple [db fuel-tracker solution s-mch error-ch]
-    (match/match-triple db fuel-tracker solution s-mch error-ch))
+  (-match-triple [db fuel-tracker solution triple-mch error-ch]
+    (match/match-triple db fuel-tracker solution triple-mch error-ch))
 
-  (-match-class [db fuel-tracker solution s-mch error-ch]
-    (match/match-class db fuel-tracker solution s-mch error-ch))
+  (-match-class [db fuel-tracker solution class-mch error-ch]
+    (match/match-class db fuel-tracker solution class-mch error-ch))
 
   (-activate-alias [db alias']
     (cond

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -24,7 +24,7 @@
             [fluree.db.flake.index.novelty :as novelty]
             [fluree.db.query.fql :as fql]
             [fluree.db.flake.index.storage :as index-storage]
-            [fluree.db.vector.index-graph :as index-graph]
+            [fluree.db.vector.index-graph :as index-graph :refer [index-graph]]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.json-ld.policy :as policy]
             [fluree.db.json-ld.policy.query :as qpolicy]
@@ -331,25 +331,14 @@
 
   (-activate-alias [db alias']
     (cond
-      (= alias alias')
-      db
-
-      (virtual-graph? alias')
-      db
-
-      :else
-      (throw (ex-info (str "Unknown graph alias: " alias')
-                      {:status 400 :error :db/invalid-query}))))
+      (= alias alias')        db
+      (virtual-graph? alias') (index-graph db alias')))
 
   (-aliases [_]
     [alias])
 
   (-finalize [_ _ solution-ch]
     solution-ch)
-
-  where/Searcher
-  (-search [s fuel-tracker solution index-alias search-graph error-ch]
-    (index-graph/search s fuel-tracker solution index-alias search-graph error-ch))
 
   transact/Transactable
   (-stage-txn [db fuel-tracker context identity author annotation raw-txn parsed-txn]
@@ -379,15 +368,15 @@
       (log/debug "datetime->t db:" (pr-str db))
       (let [epoch-datetime (util/str->epoch-ms datetime)
             current-time   (util/current-time-millis)
-            [start end] (if (< epoch-datetime current-time)
+            [start end]    (if (< epoch-datetime current-time)
                           [epoch-datetime current-time]
                           [current-time epoch-datetime])
             flakes         (-> db
                                policy/root
                                (query-range/index-range
-                                :post
-                                > [const/$_commit:time start]
-                                < [const/$_commit:time end])
+                                 :post
+                                 > [const/$_commit:time start]
+                                 < [const/$_commit:time end])
                                <?)]
         (log/debug "datetime->t index-range:" (pr-str flakes))
         (if (empty? flakes)

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -344,6 +344,9 @@
   (-aliases [_]
     [alias])
 
+  (-finalize [_ _ solution-ch]
+    solution-ch)
+
   where/Searcher
   (-search [s fuel-tracker solution index-alias search-graph error-ch]
     (index-graph/search s fuel-tracker solution index-alias search-graph error-ch))

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -300,10 +300,6 @@
           (merge-flakes t-new all-flakes)
           (assoc :commit commit-metadata)))))
 
-(defn virtual-graph?
-  [graph-alias]
-  (str/starts-with? graph-alias "##"))
-
 (defrecord FlakeDB [index-catalog commit-catalog alias branch commit t tt-id stats
                     spot post opst tspo schema comparators staged novelty policy
                     namespaces namespace-codes max-namespace-code
@@ -331,8 +327,8 @@
 
   (-activate-alias [db alias']
     (cond
-      (= alias alias')        db
-      (virtual-graph? alias') (index-graph db alias')))
+      (= alias alias')              db
+      (where/virtual-graph? alias') (index-graph db alias')))
 
   (-aliases [_]
     [alias])

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -369,8 +369,8 @@
       (let [epoch-datetime (util/str->epoch-ms datetime)
             current-time   (util/current-time-millis)
             [start end]    (if (< epoch-datetime current-time)
-                          [epoch-datetime current-time]
-                          [current-time epoch-datetime])
+                             [epoch-datetime current-time]
+                             [current-time epoch-datetime])
             flakes         (-> db
                                policy/root
                                (query-range/index-range

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -565,10 +565,10 @@
   [{x :value}]
   (where/->typed-val (nil? x)))
 
-(defn dotproduct
+(defn dot-product
   [{v1 :value} {v2 :value}]
   (where/->typed-val
-    (score/dotproduct v1 v2)))
+    (score/dot-product v1 v2)))
 
 (defn cosine-similarity
   [{v1 :value} {v2 :value}]
@@ -659,7 +659,7 @@
     max            fluree.db.query.exec.eval/max
     min            fluree.db.query.exec.eval/min
 
-    dotproduct         fluree.db.query.exec.eval/dotproduct
+    dot-product         fluree.db.query.exec.eval/dot-product
     cosine-similarity  fluree.db.query.exec.eval/cosine-similarity
     euclidian-distance fluree.db.query.exec.eval/euclidean-distance})
 
@@ -689,7 +689,7 @@
      str-lang str-dt bnode
 
      ;; vector scoring fns
-     dotproduct cosine-similarity euclidian-distance})
+     dot-product cosine-similarity euclidian-distance})
 
 (def allowed-symbols
   (set/union allowed-aggregate-fns allowed-scalar-fns))

--- a/src/clj/fluree/db/query/exec/eval.cljc
+++ b/src/clj/fluree/db/query/exec/eval.cljc
@@ -565,17 +565,17 @@
   [{x :value}]
   (where/->typed-val (nil? x)))
 
-(defn dot-product
+(defn dotProduct
   [{v1 :value} {v2 :value}]
   (where/->typed-val
     (score/dot-product v1 v2)))
 
-(defn cosine-similarity
+(defn cosineSimilarity
   [{v1 :value} {v2 :value}]
   (where/->typed-val
     (score/cosine-similarity v1 v2 )))
 
-(defn euclidean-distance
+(defn euclideanDistance
   [{v1 :value} {v2 :value}]
   (where/->typed-val
     (score/euclidian-distance v1 v2 )))
@@ -659,9 +659,9 @@
     max            fluree.db.query.exec.eval/max
     min            fluree.db.query.exec.eval/min
 
-    dot-product         fluree.db.query.exec.eval/dot-product
-    cosine-similarity  fluree.db.query.exec.eval/cosine-similarity
-    euclidian-distance fluree.db.query.exec.eval/euclidean-distance})
+    dotProduct         fluree.db.query.exec.eval/dotProduct
+    cosineSimilarity  fluree.db.query.exec.eval/cosineSimilarity
+    euclidianDistance fluree.db.query.exec.eval/euclideanDistance})
 
 (def allowed-aggregate-fns
   '#{avg ceil count count-distinct distinct floor groupconcat
@@ -689,7 +689,7 @@
      str-lang str-dt bnode
 
      ;; vector scoring fns
-     dot-product cosine-similarity euclidian-distance})
+     dotProduct cosineSimilarity euclidianDistance})
 
 (def allowed-symbols
   (set/union allowed-aggregate-fns allowed-scalar-fns))

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -282,9 +282,6 @@
   (-aliases [s])
   (-finalize [s error-ch solution-ch]))
 
-(defprotocol Searcher
-  (-search [s fuel-tracker solution graph-alias search-graph error-ch]))
-
 (defn matcher?
   [x]
   (satisfies? Matcher x))
@@ -625,10 +622,7 @@
   [ds alias fuel-tracker solution clause error-ch]
   (try*
     (let [alias-ds (-activate-alias ds alias)]
-      (if (virtual-graph? alias)
-        (let [graph-pattern (->pattern :index-graph [alias clause])]
-          (match-pattern alias-ds fuel-tracker solution graph-pattern error-ch))
-        (match-clause alias-ds fuel-tracker solution clause error-ch)))
+      (match-clause alias-ds fuel-tracker solution clause error-ch))
     (catch* e
             (if (ex-data e)
               (async/offer! error-ch e)
@@ -695,11 +689,6 @@
                                 alias-ch)
           out-ch))
       (match-alias ds g fuel-tracker solution clause error-ch))))
-
-(defmethod match-pattern :index-graph
-  [ds fuel-tracker solution pattern error-ch]
-  (let [[g clause] (pattern-data pattern)]
-    (-search ds fuel-tracker solution g clause error-ch)))
 
 (defmethod match-pattern :union
   [db fuel-tracker solution pattern error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -620,15 +620,9 @@
 
 (defn match-alias
   [ds alias fuel-tracker solution clause error-ch]
-  (try*
-    (let [alias-ds (-activate-alias ds alias)]
-      (match-clause alias-ds fuel-tracker solution clause error-ch))
-    (catch* e
-            (if (ex-data e)
-              (async/offer! error-ch e)
-              (async/offer! error-ch (ex-info (str "Error activating alias: " alias)
-                                              {:status 400
-                                               :error :db/invalid-query} e))))))
+  (-> ds
+      (-activate-alias alias)
+      (match-clause fuel-tracker solution clause error-ch)))
 
 (defmethod match-pattern :exists
   [ds fuel-tracker solution pattern error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -280,7 +280,7 @@
   (-match-class [s fuel-tracker solution triple error-ch])
   (-activate-alias [s alias])
   (-aliases [s])
-  (-finalize [s error-ch solution-ch]))
+  (-finalize [s fuel-tracker error-ch solution-ch]))
 
 (defn matcher?
   [x]
@@ -616,7 +616,7 @@
                           initial-ch
                           ;; process subqueries before other patterns
                           (into (vec subquery-patterns) other-patterns))]
-    (-finalize ds error-ch result-ch)))
+    (-finalize ds fuel-tracker error-ch result-ch)))
 
 (defn match-alias
   [ds alias fuel-tracker solution clause error-ch]

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -620,9 +620,9 @@
 
 (defn match-alias
   [ds alias fuel-tracker solution clause error-ch]
-  (-> ds
-      (-activate-alias alias)
-      (match-clause fuel-tracker solution clause error-ch)))
+  (if-let [graph (-activate-alias ds alias)]
+    (match-clause graph fuel-tracker solution clause error-ch)
+    nil-channel))
 
 (defmethod match-pattern :exists
   [ds fuel-tracker solution pattern error-ch]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -506,18 +506,23 @@
   [[_ patterns] vars context]
   [(where/->pattern :minus (parse-where-clause patterns vars context))])
 
+;; TODO: This function is only necessary because ledger aliases might not be
+;; valid IRIs but virtual graph aliases are. We should require that all ledger
+;; aliases/graph names be IRIs.
+(defn parse-graph-string
+  [graph context]
+  (when (string? graph)
+    (let [expanded (json-ld/expand-iri graph context)]
+      (if (where/virtual-graph? expanded)
+        expanded
+        graph))))
+
 (defmethod parse-pattern :graph
   [[_ graph where] vars context]
-  (let [graph*       (or (parse-variable graph)
-                         graph)
-        graph-iri    (when (string? graph*)
-                       (json-ld/expand-iri graph* context))
-        index-graph? (when graph-iri
-                       (where/virtual-graph? graph-iri))
-        where*       (parse-where-clause where vars context)]
-    (if index-graph?
-      [(where/->pattern :index-graph [graph-iri where*])]
-      [(where/->pattern :graph [graph* where*])])))
+  (let [graph* (or (parse-variable graph)
+                   (parse-graph-string graph context))
+        where* (parse-where-clause where vars context)]
+    [(where/->pattern :graph [graph* where*])]))
 
 (defn parse-where
   [q vars context]

--- a/src/clj/fluree/db/vector/flat_rank.cljc
+++ b/src/clj/fluree/db/vector/flat_rank.cljc
@@ -11,7 +11,7 @@
             [fluree.db.util.core :refer [try* catch*]]
             [fluree.db.util.log :as log]))
 
-(def iri-search (str iri/f-idx-ns "search"))
+(def iri-search (str iri/f-idx-ns "target"))
 (def iri-property (str iri/f-idx-ns "property"))
 (def iri-limit (str iri/f-idx-ns "limit"))
 (def iri-id (str iri/f-idx-ns "id"))
@@ -20,7 +20,7 @@
 (def iri-vector (str iri/f-idx-ns "vector"))
 (def iri-xsd-float "http://www.w3.org/2001/XMLSchema#float")
 
-(def flatrank-vg-re (re-pattern "##Flatrank-(.*)"))
+(def flatrank-vg-re (re-pattern "##FlatRank-(.*)"))
 
 (defn result-sort
   [a b]
@@ -56,7 +56,7 @@
   (let [p-iri (prop-iri triple)]
     (cond
       (= iri-search p-iri)
-      (assoc-in solution [::flat-rank ::search] (obj-val triple solution))
+      (assoc-in solution [::flat-rank ::target] (obj-val triple solution))
 
       (= iri-property p-iri)
       (assoc-in solution [::flat-rank ::property] (obj-iri triple))
@@ -130,11 +130,11 @@
   [db score-fn sort-fn solution error-ch out-ch]
   (go
     (try*
-      (let [{::keys [property search limit] :as search-params}
+      (let [{::keys [property target limit] :as search-params}
             (get-search-params solution)
 
             pid       (iri/encode-iri db property)
-            score-opt {:flake-xf (comp (map (partial score-flake score-fn search))
+            score-opt {:flake-xf (comp (map (partial score-flake score-fn target))
                                        (remove nil?))}
             ;; For now, pulling all matching values from full index once hitting
             ;; the actual vector index, we'll only need to pull matches out of

--- a/src/clj/fluree/db/vector/flat_rank.cljc
+++ b/src/clj/fluree/db/vector/flat_rank.cljc
@@ -11,7 +11,7 @@
             [fluree.db.util.core :refer [try* catch*]]
             [fluree.db.util.log :as log]))
 
-(def iri-search (str iri/f-idx-ns "target"))
+(def iri-target (str iri/f-idx-ns "target"))
 (def iri-property (str iri/f-idx-ns "property"))
 (def iri-limit (str iri/f-idx-ns "limit"))
 (def iri-id (str iri/f-idx-ns "id"))
@@ -56,7 +56,7 @@
   (go
     (let [p-iri (prop-iri triple)]
       (cond
-        (= iri-search p-iri)
+        (= iri-target p-iri)
         (assoc-in solution [::flat-rank ::target] (obj-val triple solution))
 
         (= iri-property p-iri)

--- a/src/clj/fluree/db/vector/flat_rank.cljc
+++ b/src/clj/fluree/db/vector/flat_rank.cljc
@@ -82,12 +82,12 @@
   (dissoc solution ::flat-rank))
 
 (defn finalize
-  [rank-af error-ch solution-ch]
+  [search-af error-ch solution-ch]
   (let [out-ch (async/chan 1 (map clear-search-params))]
     (async/pipeline-async 2
                           out-ch
                           (fn [solution ch]
-                            (rank-af solution error-ch ch))
+                            (search-af solution error-ch ch))
                           solution-ch)
     out-ch))
 

--- a/src/clj/fluree/db/vector/flat_rank.cljc
+++ b/src/clj/fluree/db/vector/flat_rank.cljc
@@ -53,25 +53,26 @@
 
 (defn match-search-triple
   [solution triple]
-  (let [p-iri (prop-iri triple)]
-    (cond
-      (= iri-search p-iri)
-      (assoc-in solution [::flat-rank ::target] (obj-val triple solution))
+  (go
+    (let [p-iri (prop-iri triple)]
+      (cond
+        (= iri-search p-iri)
+        (assoc-in solution [::flat-rank ::target] (obj-val triple solution))
 
-      (= iri-property p-iri)
-      (assoc-in solution [::flat-rank ::property] (obj-iri triple))
+        (= iri-property p-iri)
+        (assoc-in solution [::flat-rank ::property] (obj-iri triple))
 
-      (= iri-limit p-iri)
-      (assoc-in solution [::flat-rank ::limit] (obj-val triple solution))
+        (= iri-limit p-iri)
+        (assoc-in solution [::flat-rank ::limit] (obj-val triple solution))
 
-      (= iri-result p-iri)
-      (assoc-in solution [::flat-rank ::result ::id] (obj-var triple))
+        (= iri-result p-iri)
+        (assoc-in solution [::flat-rank ::result ::id] (obj-var triple))
 
-      (= iri-score p-iri)
-      (assoc-in solution [::flat-rank ::result ::score] (obj-var triple))
+        (= iri-score p-iri)
+        (assoc-in solution [::flat-rank ::result ::score] (obj-var triple))
 
-      (= iri-vector p-iri)
-      (assoc-in solution [::flat-rank ::result ::vector] (obj-var triple)))))
+        (= iri-vector p-iri)
+        (assoc-in solution [::flat-rank ::result ::vector] (obj-var triple))))))
 
 (defn get-search-params
   [solution]
@@ -152,7 +153,7 @@
 (defrecord DotProductFlatRankGraph [db]
   where/Matcher
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
-    (go (match-search-triple solution triple)))
+    (match-search-triple solution triple))
 
   (-finalize [_ _ error-ch solution-ch]
     (finalize (partial search db dot-product reverse-result-sort) error-ch solution-ch))
@@ -176,7 +177,7 @@
 (defrecord CosineFlatRankGraph [db]
   where/Matcher
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
-    (go (match-search-triple solution triple)))
+    (match-search-triple solution triple))
 
   (-finalize [_ _ error-ch solution-ch]
     (finalize (partial search db cosine-similarity reverse-result-sort) error-ch solution-ch))
@@ -200,7 +201,7 @@
 (defrecord EuclideanFlatRankGraph [db]
   where/Matcher
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
-    (go (match-search-triple solution triple)))
+    (match-search-triple solution triple))
 
   (-finalize [_ _ error-ch solution-ch]
     (finalize (partial search db euclidian-distance result-sort) error-ch solution-ch))

--- a/src/clj/fluree/db/vector/flat_rank.cljc
+++ b/src/clj/fluree/db/vector/flat_rank.cljc
@@ -1,4 +1,4 @@
-(ns fluree.db.vector.index-graph
+(ns fluree.db.vector.flat-rank
   (:require [camel-snake-kebab.core :refer [->kebab-case-keyword]]
             [clojure.core.async :as async :refer [>! go]]
             [fluree.db.constants :as const]

--- a/src/clj/fluree/db/vector/flat_rank.cljc
+++ b/src/clj/fluree/db/vector/flat_rank.cljc
@@ -150,7 +150,7 @@
         (log/error e "Error ranking vectors")
         (>! error-ch e)))))
 
-(defrecord DotProductFlatRankGraph [db]
+(defrecord DotProductGraph [db]
   where/Matcher
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
     (match-search-triple solution triple))
@@ -170,11 +170,11 @@
   (-aliases [_]
     (where/-aliases db)))
 
-(defn dot-product-flat-rank-graph
+(defn dot-product-graph
   [db]
-  (->DotProductFlatRankGraph db))
+  (->DotProductGraph db))
 
-(defrecord CosineFlatRankGraph [db]
+(defrecord CosineGraph [db]
   where/Matcher
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
     (match-search-triple solution triple))
@@ -194,11 +194,11 @@
   (-aliases [_]
     (where/-aliases db)))
 
-(defn cosine-flat-rank-graph
+(defn cosine-graph
   [db]
-  (->CosineFlatRankGraph db))
+  (->CosineGraph db))
 
-(defrecord EuclideanFlatRankGraph [db]
+(defrecord EuclideanGraph [db]
   where/Matcher
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
     (match-search-triple solution triple))
@@ -218,9 +218,9 @@
   (-aliases [_]
     (where/-aliases db)))
 
-(defn euclidean-flat-rank-graph
+(defn euclidean-graph
   [db]
-  (->EuclideanFlatRankGraph db))
+  (->EuclideanGraph db))
 
 (defn extract-metric
   "Takes the graph alias as a string and extracts the metric name from the
@@ -235,10 +235,10 @@
   (let [metric (extract-metric graph-alias)]
     (cond
       (= metric :cosine)
-      (cosine-flat-rank-graph db)
+      (cosine-graph db)
 
       (= metric :dot-product)
-      (dot-product-flat-rank-graph db)
+      (dot-product-graph db)
 
       (= metric :distance)
-      (euclidean-flat-rank-graph db))))
+      (euclidean-graph db))))

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -1,15 +1,16 @@
 (ns fluree.db.vector.index-graph
-  (:require [clojure.string :as str]
+  (:require [clojure.core.async :as async :refer [<! >! go]]
+            [clojure.string :as str]
             [fluree.db.constants :as const]
             [fluree.db.flake :as flake]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.query.exec.where :as where]
-            [clojure.core.async :as async]
-            [fluree.db.util.async :refer [<?]]
+            [fluree.db.util.async :refer [go-try <?]]
             [fluree.db.query.range :as query-range]
             [fluree.db.vector.scoring :as vector.score]
             [fluree.db.util.core :refer [try* catch*]]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.db.vector.index-graph :as index-graph]))
 
 (def iri-search (str iri/f-idx-ns "search"))
 (def iri-property (str iri/f-idx-ns "property"))
@@ -29,18 +30,6 @@
 (defn reverse-result-sort
   [a b]
   (compare (:score b) (:score a)))
-
-(def metrics
-  {:dotproduct {::score-fn vector.score/dotproduct
-                ::sort-fn  reverse-result-sort}
-   :cosine     {::score-fn vector.score/cosine-similarity
-                ::sort-fn  reverse-result-sort}
-   :distance   {::score-fn vector.score/euclidian-distance
-                ::sort-fn  result-sort}})
-
-(defn- subj-var
-  [triple]
-  (-> triple (nth 0) where/get-variable))
 
 (defn- prop-iri
   "Returns property IRI value from triple"
@@ -63,83 +52,59 @@
   [triple]
   (-> triple (nth 2) where/get-iri))
 
-(defn extract-metric
-  "Takes the graph alias as a string and extracts the metric name from the
-  end of the IRI"
-  [graph-alias]
-  (some-> (re-find flatrank-vg-re graph-alias)
-          second
-          str/lower-case
-          keyword))
+(defn match-search-triple
+  [solution triple]
+  (let [p-iri (prop-iri triple)]
+    (cond
+      (= iri-search p-iri)
+      (assoc-in solution [::flat-rank ::search] (obj-val triple solution))
 
-(defn parse-search-graph
-  [graph-alias solution graph-triples]
-  (try*
-    (let [metric (extract-metric graph-alias)]
-      (reduce
-       (fn [acc triple]
-         (let [p-iri (prop-iri triple)]
-           (cond
-             (= iri-search p-iri)
-             (assoc acc ::search (obj-val triple solution))
+      (= iri-property p-iri)
+      (assoc-in solution [::flat-rank ::property] (obj-iri triple))
 
-             (= iri-property p-iri)
-             (assoc acc ::property (obj-iri triple))
+      (= iri-limit p-iri)
+      (assoc-in solution [::flat-rank ::limit] (obj-val triple solution))
 
-             (= iri-limit p-iri)
-             (assoc acc ::limit (obj-val triple solution))
+      (= iri-result p-iri)
+      (assoc-in solution [::flat-rank ::result ::id] (obj-var triple))
 
-             (= iri-result p-iri)
-             (assoc-in acc [::result ::id] (obj-var triple))
+      (= iri-score p-iri)
+      (assoc-in solution [::flat-rank ::result ::score] (obj-var triple))
 
-             (= iri-score p-iri)
-             (assoc-in acc [::result ::score] (obj-var triple))
+      (= iri-vector p-iri)
+      (assoc-in solution [::flat-rank ::result ::vector] (obj-var triple)))))
 
-             (= iri-vector p-iri)
-             (assoc-in acc [::result ::vector] (obj-var triple))
+(defn get-search-params
+  [solution]
+  (::flat-rank solution))
 
-             :else
-             acc)))
-       {::metric metric}
-       graph-triples))
-    (catch* e
-            (throw (ex-info (str "Unable to parse search graph provided for index: " graph-alias)
-                            {:status 400
-                             :error  :db/invalid-query} e)))))
+(defn format-result
+  [f score]
+  {:id    (flake/s f)
+   :score score
+   :vec   (flake/o f)})
 
-(defn extract-vectors
-  [{::keys [property]} db]
-  (let [pid (iri/encode-iri db property)]
-    ;; For now, pulling all matching values from full index
-    ;; once hitting the actual vector index, we'll only need
-    ;; to pull matches out of novelty (if that)
-    (query-range/index-range db :post = [pid])))
+(defn rank
+  [db search-params score-fn sort-fn error-ch]
+  (go
+    (try*
+      (let [{::keys [property search limit]} search-params
 
-(defn score-vectors
-  [{::keys [search metric]} novelty]
-  (try*
-    (let [score-fn (get-in metrics [metric ::score-fn])]
-      (reduce
-       (fn [acc flake]
-         (let [vec   (flake/o flake)
-               score (score-fn vec search)]
-           (if score
-             (conj acc {:id    (flake/s flake)
-                        :score score
-                        :vec   vec})
-             acc)))
-       []
-       novelty))
-    (catch* e
-            (throw (ex-info (str "Unable to score vectors in vector index search.")
-                            {:status 500
-                             :error  :db/unexpected} e)))))
+            pid       (iri/encode-iri db property)
+            score-opt {:flake-xf (comp (map (partial score-fn search))
+                                       (remove nil?))}
 
-(defn result-candidates
-  [{::keys [metric limit]} vectors]
-  (let [sort-fn (get-in metrics [metric ::sort-fn])]
-    (cond->> (sort sort-fn vectors)
-             limit (take limit))))
+            ;; For now, pulling all matching values from full index
+            ;; once hitting the actual vector index, we'll only need
+            ;; to pull matches out of novelty (if that)
+            results (<? (query-range/index-range db :post = [pid] score-opt))
+            sorted  (sort sort-fn results)]
+        (if limit
+          (take limit sorted)
+          sorted))
+      (catch* e
+              (log/error e "Error ranking vectors")
+              (>! error-ch e)))))
 
 (defn process-results
   [db solution parsed-search search-results]
@@ -150,34 +115,162 @@
         db-alias        (:alias db)]
     (map (fn [result]
            (cond-> solution
-                   id-var (assoc id-var (-> (where/unmatched-var id-var)
-                                            (where/match-iri (iri/decode-sid db (:id result)))
-                                            (where/match-sid db-alias (:id result))))
-                   score-var (assoc score-var (-> (where/unmatched-var score-var)
-                                                  (where/match-value (:score result) iri-xsd-float)))
-                   vector-var (assoc vector-var (-> (where/unmatched-var vector-var)
-                                                    (where/match-value (:vec result) const/iri-vector)))))
+             id-var     (assoc id-var (-> (where/unmatched-var id-var)
+                                          (where/match-iri (iri/decode-sid db (:id result)))
+                                          (where/match-sid db-alias (:id result))))
+             score-var  (assoc score-var (-> (where/unmatched-var score-var)
+                                             (where/match-value (:score result) iri-xsd-float)))
+             vector-var (assoc vector-var (-> (where/unmatched-var vector-var)
+                                              (where/match-value (:vec result) const/iri-vector)))))
          search-results)))
 
-(defn search
-  [db fuel-tracker solution index-alias search-graph error-ch]
-  (let [resp-ch (async/chan)]
+(defn dot-product-score
+  [v f]
+  (when-let [score (vector.score/dotproduct (flake/o f) v)]
+    (format-result f score)))
 
-    (async/go
-      (try*
-        (let [parsed-search (parse-search-graph index-alias solution search-graph)]
-          (->> (<? (extract-vectors parsed-search db))
-               (score-vectors parsed-search)
-               (result-candidates parsed-search)
-               (process-results db solution parsed-search)
-               (async/onto-chan! resp-ch)))
-        (catch* e
-                (let [e* (if (ex-data e)
-                           e
-                           (ex-info (str "Unexpected error processing index for results: " index-alias ".")
-                                    {:status 500
-                                     :error  :db/unexpected} e))]
-                  (async/offer! error-ch e*)
-                  (async/close! resp-ch)))))
+(defn dot-product-rank
+  [db solution error-ch out-ch]
+  (go
+    (let [search-params (get-search-params solution)]
+      (->> (<! (rank db search-params dot-product-score reverse-result-sort error-ch))
+           (process-results db solution search-params)
+           (async/onto-chan! out-ch)))))
 
-    resp-ch))
+(defrecord DotProductGraph [db]
+  where/Matcher
+  (-match-triple [_ _fuel-tracker solution triple _error-ch]
+    (go (match-search-triple solution triple)))
+
+  (-finalize [_ error-ch solution-ch]
+    (let [out-ch (async/chan)]
+      (async/pipeline-async 2
+                            out-ch
+                            (fn [solution ch]
+                              (dot-product-rank db solution error-ch ch))
+                            solution-ch)
+      out-ch))
+
+  (-match-id [_ _fuel-tracker _solution _s-mch _error-ch]
+    where/nil-channel)
+
+  (-match-class [_ _fuel-tracker _solution _s-mch _error-ch]
+    where/nil-channel)
+
+  (-activate-alias [_ alias']
+    (where/-activate-alias db alias'))
+
+  (-aliases [_]
+    (where/-aliases db)))
+
+(defn dot-product-graph
+  [db]
+  (->DotProductGraph db))
+
+(defn cosine-score
+  [v f]
+  (when-let [score (vector.score/cosine-similarity (flake/o f) v)]
+    (format-result f score)))
+
+(defn cosine-rank
+  [db solution error-ch out-ch]
+  (go
+    (let [search-params (get-search-params solution)]
+      (->> (<! (rank db search-params cosine-score reverse-result-sort error-ch))
+           (process-results db solution search-params)
+           (async/onto-chan! out-ch)))))
+
+(defrecord CosineGraph [db]
+  where/Matcher
+  (-match-triple [_ _fuel-tracker solution triple _error-ch]
+    (go (match-search-triple solution triple)))
+
+  (-finalize [_ error-ch solution-ch]
+    (let [out-ch (async/chan)]
+      (async/pipeline-async 2
+                            out-ch
+                            (fn [solution ch]
+                              (cosine-rank db solution error-ch ch))
+                            solution-ch)
+      out-ch))
+
+  (-match-id [_ _fuel-tracker _solution _s-mch _error-ch]
+    where/nil-channel)
+
+  (-match-class [_ _fuel-tracker _solution _s-mch _error-ch]
+    where/nil-channel)
+
+  (-activate-alias [_ alias']
+    (where/-activate-alias db alias'))
+
+  (-aliases [_]
+    (where/-aliases db)))
+
+(defn cosine-graph
+  [db]
+  (->CosineGraph db))
+
+(defn euclidean-score
+  [v f]
+  (when-let [score (vector.score/euclidian-distance (flake/o f) v)]
+    (format-result f score)))
+
+(defn euclidean-rank
+  [db solution error-ch out-ch]
+  (go
+    (let [search-params (get-search-params solution)]
+      (->> (<! (rank db search-params euclidean-score result-sort error-ch))
+           (process-results db solution search-params)
+           (async/onto-chan! out-ch)))))
+
+(defrecord EuclideanGraph [db]
+  where/Matcher
+  (-match-triple [_ _fuel-tracker solution triple _error-ch]
+    (go (match-search-triple solution triple)))
+
+  (-finalize [_ error-ch solution-ch]
+    (let [out-ch (async/chan)]
+      (async/pipeline-async 2
+                            out-ch
+                            (fn [solution ch]
+                              (euclidean-rank db solution error-ch ch))
+                            solution-ch)
+      out-ch))
+
+  (-match-id [_ _fuel-tracker _solution _s-mch _error-ch]
+    where/nil-channel)
+
+  (-match-class [_ _fuel-tracker _solution _s-mch _error-ch]
+    where/nil-channel)
+
+  (-activate-alias [_ alias']
+    (where/-activate-alias db alias'))
+
+  (-aliases [_]
+    (where/-aliases db)))
+
+(defn euclidean-graph
+  [db]
+  (->EuclideanGraph db))
+
+(defn extract-metric
+  "Takes the graph alias as a string and extracts the metric name from the
+  end of the IRI"
+  [graph-alias]
+  (some-> (re-find flatrank-vg-re graph-alias)
+          second
+          str/lower-case
+          keyword))
+
+(defn index-graph
+  [db graph-alias]
+  (let [metric (extract-metric graph-alias)]
+    (cond
+      (= metric :cosine)
+      (cosine-graph db)
+
+      (= metric :dotproduct)
+      (dot-product-graph db)
+
+      (= metric :distance)
+      (euclidean-graph db))))

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -22,8 +22,13 @@
 
 (def flatrank-vg-re (re-pattern "##Flatrank-(.*)"))
 
-(def result-sort (fn [a b] (compare (get a :score) (get b :score))))
-(def reverse-result-sort (fn [a b] (compare (get b :score) (get a :score))))
+(defn result-sort
+  [a b]
+  (compare (:score a) (:score b)))
+
+(defn reverse-result-sort
+  [a b]
+  (compare (:score b) (:score a)))
 
 (def metrics
   {:dotproduct {::score-fn vector.score/dotproduct

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -77,6 +77,10 @@
   [solution]
   (::flat-rank solution))
 
+(defn clear-search-params
+  [solution]
+  (dissoc solution ::flat-rank))
+
 (defn format-result
   [f score]
   {:id    (flake/s f)
@@ -142,7 +146,7 @@
     (go (match-search-triple solution triple)))
 
   (-finalize [_ error-ch solution-ch]
-    (let [out-ch (async/chan)]
+    (let [out-ch (async/chan 1 (map clear-search-params))]
       (async/pipeline-async 2
                             out-ch
                             (fn [solution ch]
@@ -185,7 +189,7 @@
     (go (match-search-triple solution triple)))
 
   (-finalize [_ error-ch solution-ch]
-    (let [out-ch (async/chan)]
+    (let [out-ch (async/chan 1 (map clear-search-params))]
       (async/pipeline-async 2
                             out-ch
                             (fn [solution ch]
@@ -228,7 +232,7 @@
     (go (match-search-triple solution triple)))
 
   (-finalize [_ error-ch solution-ch]
-    (let [out-ch (async/chan)]
+    (let [out-ch (async/chan 1 (map clear-search-params))]
       (async/pipeline-async 2
                             out-ch
                             (fn [solution ch]

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.vector.index-graph
-  (:require [clojure.core.async :as async :refer [<! >! go]]
+  (:require [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+            [clojure.core.async :as async :refer [<! >! go]]
             [clojure.string :as str]
             [fluree.db.constants :as const]
             [fluree.db.flake :as flake]
@@ -129,7 +130,7 @@
 
 (defn dot-product-score
   [v f]
-  (when-let [score (vector.score/dotproduct (flake/o f) v)]
+  (when-let [score (vector.score/dot-product (flake/o f) v)]
     (format-result f score)))
 
 (defn dot-product-rank
@@ -262,8 +263,7 @@
   [graph-alias]
   (some-> (re-find flatrank-vg-re graph-alias)
           second
-          str/lower-case
-          keyword))
+          ->kebab-case-keyword))
 
 (defn index-graph
   [db graph-alias]
@@ -272,7 +272,7 @@
       (= metric :cosine)
       (cosine-graph db)
 
-      (= metric :dotproduct)
+      (= metric :dot-product)
       (dot-product-graph db)
 
       (= metric :distance)

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -126,7 +126,7 @@
     (take limit results)
     results))
 
-(defn rank
+(defn search
   [db score-fn sort-fn solution error-ch out-ch]
   (go
     (try*
@@ -146,8 +146,8 @@
              (process-results db solution search-params)
              (async/onto-chan! out-ch)))
       (catch* e
-              (log/error e "Error ranking vectors")
-              (>! error-ch e)))))
+        (log/error e "Error ranking vectors")
+        (>! error-ch e)))))
 
 (defrecord DotProductFlatRankGraph [db]
   where/Matcher
@@ -155,7 +155,7 @@
     (go (match-search-triple solution triple)))
 
   (-finalize [_ _ error-ch solution-ch]
-    (finalize (partial rank db dot-product reverse-result-sort) error-ch solution-ch))
+    (finalize (partial search db dot-product reverse-result-sort) error-ch solution-ch))
 
   (-match-id [_ _fuel-tracker _solution _s-mch _error-ch]
     where/nil-channel)
@@ -179,7 +179,7 @@
     (go (match-search-triple solution triple)))
 
   (-finalize [_ _ error-ch solution-ch]
-    (finalize (partial rank db cosine-similarity reverse-result-sort) error-ch solution-ch))
+    (finalize (partial search db cosine-similarity reverse-result-sort) error-ch solution-ch))
 
   (-match-id [_ _fuel-tracker _solution _s-mch _error-ch]
     where/nil-channel)
@@ -203,7 +203,7 @@
     (go (match-search-triple solution triple)))
 
   (-finalize [_ _ error-ch solution-ch]
-    (finalize (partial rank db euclidian-distance result-sort) error-ch solution-ch))
+    (finalize (partial search db euclidian-distance result-sort) error-ch solution-ch))
 
   (-match-id [_ _fuel-tracker _solution _s-mch _error-ch]
     where/nil-channel)

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -5,7 +5,7 @@
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.query.exec.where :as where]
             [clojure.core.async :as async]
-            [fluree.db.util.async :refer [go-try <?]]
+            [fluree.db.util.async :refer [<?]]
             [fluree.db.query.range :as query-range]
             [fluree.db.vector.scoring :as vector.score]
             [fluree.db.util.core :refer [try* catch*]]
@@ -33,10 +33,14 @@
    :distance   {::score-fn vector.score/euclidian-distance
                 ::sort-fn  result-sort}})
 
+(defn- subj-var
+  [triple]
+  (-> triple (nth 0) where/get-variable))
+
 (defn- prop-iri
   "Returns property IRI value from triple"
   [triple]
-  (-> triple (nth 1) ::where/iri))
+  (-> triple (nth 1) where/get-iri))
 
 (defn- obj-val
   [triple solution]
@@ -48,11 +52,11 @@
 
 (defn- obj-var
   [triple]
-  (-> triple (nth 2) ::where/var))
+  (-> triple (nth 2) where/get-variable))
 
 (defn- obj-iri
   [triple]
-  (-> triple (nth 2) ::where/iri))
+  (-> triple (nth 2) where/get-iri))
 
 (defn extract-metric
   "Takes the graph alias as a string and extracts the metric name from the

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -5,12 +5,11 @@
             [fluree.db.flake :as flake]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.query.exec.where :as where]
-            [fluree.db.util.async :refer [go-try <?]]
+            [fluree.db.util.async :refer [<?]]
             [fluree.db.query.range :as query-range]
             [fluree.db.vector.scoring :as vector.score]
             [fluree.db.util.core :refer [try* catch*]]
-            [fluree.db.util.log :as log]
-            [fluree.db.vector.index-graph :as index-graph]))
+            [fluree.db.util.log :as log]))
 
 (def iri-search (str iri/f-idx-ns "search"))
 (def iri-property (str iri/f-idx-ns "property"))

--- a/src/clj/fluree/db/vector/index_graph.cljc
+++ b/src/clj/fluree/db/vector/index_graph.cljc
@@ -145,7 +145,7 @@
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
     (go (match-search-triple solution triple)))
 
-  (-finalize [_ error-ch solution-ch]
+  (-finalize [_ _ error-ch solution-ch]
     (let [out-ch (async/chan 1 (map clear-search-params))]
       (async/pipeline-async 2
                             out-ch
@@ -188,7 +188,7 @@
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
     (go (match-search-triple solution triple)))
 
-  (-finalize [_ error-ch solution-ch]
+  (-finalize [_ _ error-ch solution-ch]
     (let [out-ch (async/chan 1 (map clear-search-params))]
       (async/pipeline-async 2
                             out-ch
@@ -231,7 +231,7 @@
   (-match-triple [_ _fuel-tracker solution triple _error-ch]
     (go (match-search-triple solution triple)))
 
-  (-finalize [_ error-ch solution-ch]
+  (-finalize [_ _ error-ch solution-ch]
     (let [out-ch (async/chan 1 (map clear-search-params))]
       (async/pipeline-async 2
                             out-ch

--- a/src/clj/fluree/db/vector/scoring.cljc
+++ b/src/clj/fluree/db/vector/scoring.cljc
@@ -15,7 +15,7 @@
   #?(:clj  (v/vec? x)
      :cljs (vector? x)))
 
-(defn dotproduct*
+(defn dot-product*
   [v1 v2]
   #?(:clj  (v/dot v1 v2)
      :cljs (reduce + (map * v1 v2))))
@@ -23,17 +23,17 @@
 (defn- magnitude
   [v]
   #?(:clj  (v/magnitude v)
-     :cljs (Math/sqrt (dotproduct* v v))))
+     :cljs (Math/sqrt (dot-product* v v))))
 
-(defn dotproduct
+(defn dot-product
   [v1 v2]
   (when (and (vec? v1) (vec? v2))
-    (dotproduct* v1 v2)))
+    (dot-product* v1 v2)))
 
 (defn cosine-similarity
   [v1 v2]
   (when (and (vec? v1) (vec? v2))
-    (/ (dotproduct* v1 v2)
+    (/ (dot-product* v1 v2)
        (* (magnitude v1)
           (magnitude v2)))))
 
@@ -42,4 +42,3 @@
   (when (and (vec? v1) (vec? v2))
     #?(:clj  (v/distance v1 v2)
        :cljs (Math/sqrt (reduce + (map #(* % %) (map - v1 v2)))))))
-

--- a/test/fluree/db/vector/index_test.clj
+++ b/test/fluree/db/vector/index_test.clj
@@ -1,5 +1,5 @@
 (ns fluree.db.vector.index-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [fluree.db.api :as fluree]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.iri :as iri]
@@ -29,8 +29,8 @@
                                    "fidx" iri/f-idx-ns}
                        "select"   ["?x", "?score", "?vec"]
                        "where"    [["graph"
-                                    "##Flatrank-DotProduct"
-                                    {"fidx:search"   {"@value" [0.7, 0.6]
+                                    "##FlatRank-DotProduct"
+                                    {"fidx:target"   {"@value" [0.7, 0.6]
                                                       "@type"  const/iri-vector}
                                      "fidx:property" {"@id" "ex:xVec"}
                                      "fidx:limit"    10,
@@ -48,8 +48,8 @@
                                    "fidx" iri/f-idx-ns},
                        "select"   ["?x", "?score", "?vec"],
                        "where"    [["graph"
-                                    "##Flatrank-Cosine"
-                                    {"fidx:search"   {"@value" [0.7, 0.6]
+                                    "##FlatRank-Cosine"
+                                    {"fidx:target"   {"@value" [0.7, 0.6]
                                                       "@type"  const/iri-vector}
                                      "fidx:property" {"@id" "ex:xVec"}
                                      "fidx:limit"    10,
@@ -67,8 +67,8 @@
                                    "fidx" iri/f-idx-ns},
                        "select"   ["?x", "?score", "?vec"],
                        "where"    [["graph"
-                                    "##Flatrank-Distance"
-                                    {"fidx:search"   {"@value" [0.7, 0.6]
+                                    "##FlatRank-Distance"
+                                    {"fidx:target"   {"@value" [0.7, 0.6]
                                                       "@type"  const/iri-vector}
                                      "fidx:property" {"@id" "ex:xVec"}
                                      "fidx:limit"    10,
@@ -106,8 +106,8 @@
                                    "fidx" iri/f-idx-ns}
                        "select"   ["?x", "?title", "?score", "?vec"]
                        "where"    [["graph"
-                                    "##Flatrank-DotProduct"
-                                    {"fidx:search"   {"@value" [0.7, 0.6]
+                                    "##FlatRank-DotProduct"
+                                    {"fidx:target"   {"@value" [0.7, 0.6]
                                                       "@type"  const/iri-vector}
                                      "fidx:property" {"@id" "ex:xVec"}
                                      "fidx:limit"    10,
@@ -146,8 +146,8 @@
                                    "fidx" iri/f-idx-ns}
                        "select"   ["?x", "?targetVec", "?score", "?vec"]
                        "where"    [["graph"
-                                    "##Flatrank-DotProduct"
-                                    {"fidx:search"   "?targetVec"
+                                    "##FlatRank-DotProduct"
+                                    {"fidx:target"   "?targetVec"
                                      "fidx:property" {"@id" "ex:xVec"}
                                      "fidx:limit"    10,
                                      "fidx:result"   {"@id"         "?x"
@@ -174,8 +174,8 @@
                        "where"    [{"@id"     "?targetSubj"
                                     "ex:xVec" "?targetVec"}
                                    ["graph"
-                                    "##Flatrank-Cosine"
-                                    {"fidx:search"   "?targetVec"
+                                    "##FlatRank-Cosine"
+                                    {"fidx:target"   "?targetVec"
                                      "fidx:property" {"@id" "ex:xVec"}
                                      "fidx:limit"    10
                                      "fidx:result"   {"@id"        "?x"

--- a/test/fluree/db/vector/search_test.clj
+++ b/test/fluree/db/vector/search_test.clj
@@ -29,7 +29,7 @@
                                                 "@type"  const/iri-vector}]]
                      "where"    [{"@id"     "?x"
                                   "ex:xVec" "?vec"}
-                                 ["bind" "?score" "(dot-product ?vec ?targetVec)"]]}
+                                 ["bind" "?score" "(dotProduct ?vec ?targetVec)"]]}
             results @(fluree/query db query)]
         (is (= [["ex:bart" 0.61 [0.1, 0.9]]
                 ["ex:homer" 0.72 [0.6, 0.5]]]
@@ -43,7 +43,7 @@
                      "where"    [{"@id"     "?x"
                                   "ex:age"  36
                                   "ex:xVec" "?vec"}
-                                 ["bind" "?score" "(dot-product ?vec ?targetVec)"]]}
+                                 ["bind" "?score" "(dotProduct ?vec ?targetVec)"]]}
             results @(fluree/query db query)]
         (is (= [["ex:homer" 0.72 [0.6, 0.5]]]
                results))))
@@ -55,7 +55,7 @@
                                                 "@type"  const/iri-vector}]]
                      "where"    [{"@id"     "?x"
                                   "ex:xVec" "?vec"}
-                                 ["bind" "?score" "(dot-product ?vec ?targetVec)"]
+                                 ["bind" "?score" "(dotProduct ?vec ?targetVec)"]
                                  ["filter" "(> ?score 0.7)"]]}
             results @(fluree/query db query)]
         (is (= [["ex:homer" 0.72]]
@@ -85,7 +85,7 @@
                                                   "@type"  const/iri-vector}]]
                        "where"    [{"@id"     "?x"
                                     "ex:xVec" "?vec"}
-                                   ["bind" "?score" "(dot-product ?vec ?targetVec)"]]
+                                   ["bind" "?score" "(dotProduct ?vec ?targetVec)"]]
                        "orderBy"  "?score"}
               results @(fluree/query db query)]
           (is (= [["ex:bart" 0.61 [0.1, 0.9]]
@@ -100,7 +100,7 @@
                                                   "@type"  const/iri-vector}]]
                        "where"    [{"@id"     "?x"
                                     "ex:xVec" "?vec"}
-                                   ["bind" "?score" "(cosine-similarity ?vec ?targetVec)"]]
+                                   ["bind" "?score" "(cosineSimilarity ?vec ?targetVec)"]]
                        "orderBy"  "?score"}
               results @(fluree/query db query)]
           (is (= [["ex:bart" 0.7306568260253945 [0.1 0.9]]
@@ -108,14 +108,14 @@
                   ["ex:homer" 0.9999035633345558 [0.6 0.5]]]
                  results))))
 
-      (testing "Usine a euclidian-distance metric"
+      (testing "Usine a euclidianDistance metric"
         (let [query   {"@context" {"ex" "http://example.org/ns/"}
                        "select"   ["?x" "?score" "?vec"]
                        "values"   ["?targetVec" [{"@value" [0.7, 0.6]
                                                   "@type"  const/iri-vector}]]
                        "where"    [{"@id"     "?x"
                                     "ex:xVec" "?vec"}
-                                   ["bind" "?score" "(euclidian-distance ?vec ?targetVec)"]]
+                                   ["bind" "?score" "(euclidianDistance ?vec ?targetVec)"]]
                        "orderBy"  "?score"}
               results @(fluree/query db query)]
           (is (= [["ex:homer" 0.14142135623730956 [0.6 0.5]]
@@ -149,7 +149,7 @@
                                                   "@type"  const/iri-vector}]]
                        "where"    [{"@id"     "?x"
                                     "ex:xVec" "?vec"}
-                                   ["bind" "?score" "(dot-product ?vec ?targetVec)"]]
+                                   ["bind" "?score" "(dotProduct ?vec ?targetVec)"]]
                        "orderBy"  "?score"}
               results @(fluree/query db query)]
           (is (= [["ex:lucy" nil "Not a Vector"]

--- a/test/fluree/db/vector/search_test.clj
+++ b/test/fluree/db/vector/search_test.clj
@@ -29,7 +29,7 @@
                                                 "@type"  const/iri-vector}]]
                      "where"    [{"@id"     "?x"
                                   "ex:xVec" "?vec"}
-                                 ["bind" "?score" "(dotproduct ?vec ?targetVec)"]]}
+                                 ["bind" "?score" "(dot-product ?vec ?targetVec)"]]}
             results @(fluree/query db query)]
         (is (= [["ex:bart" 0.61 [0.1, 0.9]]
                 ["ex:homer" 0.72 [0.6, 0.5]]]
@@ -43,7 +43,7 @@
                      "where"    [{"@id"     "?x"
                                   "ex:age"  36
                                   "ex:xVec" "?vec"}
-                                 ["bind" "?score" "(dotproduct ?vec ?targetVec)"]]}
+                                 ["bind" "?score" "(dot-product ?vec ?targetVec)"]]}
             results @(fluree/query db query)]
         (is (= [["ex:homer" 0.72 [0.6, 0.5]]]
                results))))
@@ -55,7 +55,7 @@
                                                 "@type"  const/iri-vector}]]
                      "where"    [{"@id"     "?x"
                                   "ex:xVec" "?vec"}
-                                 ["bind" "?score" "(dotproduct ?vec ?targetVec)"]
+                                 ["bind" "?score" "(dot-product ?vec ?targetVec)"]
                                  ["filter" "(> ?score 0.7)"]]}
             results @(fluree/query db query)]
         (is (= [["ex:homer" 0.72]]
@@ -85,7 +85,7 @@
                                                   "@type"  const/iri-vector}]]
                        "where"    [{"@id"     "?x"
                                     "ex:xVec" "?vec"}
-                                   ["bind" "?score" "(dotproduct ?vec ?targetVec)"]]
+                                   ["bind" "?score" "(dot-product ?vec ?targetVec)"]]
                        "orderBy"  "?score"}
               results @(fluree/query db query)]
           (is (= [["ex:bart" 0.61 [0.1, 0.9]]
@@ -149,7 +149,7 @@
                                                   "@type"  const/iri-vector}]]
                        "where"    [{"@id"     "?x"
                                     "ex:xVec" "?vec"}
-                                   ["bind" "?score" "(dotproduct ?vec ?targetVec)"]]
+                                   ["bind" "?score" "(dot-product ?vec ?targetVec)"]]
                        "orderBy"  "?score"}
               results @(fluree/query db query)]
           (is (= [["ex:lucy" nil "Not a Vector"]


### PR DESCRIPTION
This patch changes #879 by adding a `-finalize` method to the `fluree.db.query.exec.where/Matcher` protocol which is called after all of the patterns in a clause is matched to complete any remaining computation or clean up any left over state. Then vector flat ranking is implemented in terms of the `Matcher` protocol by creating three new index graph records that wrap an underlying flake db and add comparisons based on the 3 metrics.