### PR TITLE
large txn performance improvements

### DIFF
--- a/dev/customers/icebreakers.clj
+++ b/dev/customers/icebreakers.clj
@@ -1,1 +1,0 @@
-(ns icebreakers)

--- a/dev/customers/icebreakers.clj
+++ b/dev/customers/icebreakers.clj
@@ -1,0 +1,1 @@
+(ns icebreakers)

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -395,34 +395,47 @@
   [flakes]
   (filter ref? flakes))
 
+;; TODO - flakes-size takes considerable time for lg txns, see if can be optimized
+(defn calc-flake-size
+  [add rem]
+  (cond-> 0
+          add (+ (flake/size-bytes add))
+          rem (- (flake/size-bytes rem))))
+
 (defn update-novelty
   ([db add]
    (update-novelty db add []))
 
   ([db add rem]
    (try*
-    (let [ref-add     (ref-flakes add)
-          ref-rem     (ref-flakes rem)
-          flake-count (cond-> 0
-                              add (+ (count add))
-                              rem (- (count rem)))
-          flake-size  (cond-> 0
-                              add (+ (flake/size-bytes add))
-                              rem (- (flake/size-bytes rem)))]
-      (-> db
-          (update-in [:novelty :spot] flake/revise add rem)
-          (update-in [:novelty :post] flake/revise add rem)
-          (update-in [:novelty :opst] flake/revise ref-add ref-rem)
-          (update-in [:novelty :tspo] flake/revise add rem)
-          (update-in [:novelty :size] + flake-size)
-          (update-in [:stats :size] + flake-size)
-          (update-in [:stats :flakes] + flake-count)))
-    (catch* e
-            (log/error (str "Update novelty unexpected error while attempting to updated db: "
-                            (pr-str db) " due to exception: " (ex-message e))
-                       {:add-flakes add
-                        :rem-flakes rem})
-            (throw e)))))
+     (let [flake-count (cond-> 0
+                               add (+ (count add))
+                               rem (- (count rem)))
+           ;; launch futures for parallellism on JVM
+           flake-size  #?(:clj  (future (calc-flake-size add rem))
+                          :cljs (calc-flake-size add rem))
+           post        #?(:clj  (future (flake/revise (get-in db [:novelty :post]) add rem))
+                          :cljs (flake/revise (get-in db [:novelty :post]) add rem))
+           opst        #?(:clj  (future (flake/revise (get-in db [:novelty :opst]) (ref-flakes add) (ref-flakes rem)))
+                          :cljs (flake/revise (get-in db [:novelty :opst]) (ref-flakes add) (ref-flakes rem)))]
+       (-> db
+           (update-in [:novelty :spot] flake/revise add rem)
+           (update-in [:novelty :tspo] flake/revise add rem)
+           (assoc-in [:novelty :post] #?(:clj  @post
+                                         :cljs post))
+           (assoc-in [:novelty :opst] #?(:clj  @opst
+                                         :cljs opst))
+           (update-in [:novelty :size] + #?(:clj  @flake-size
+                                            :cljs flake-size))
+           (update-in [:stats :size] + #?(:clj  @flake-size
+                                          :cljs flake-size))
+           (update-in [:stats :flakes] + flake-count)))
+     (catch* e
+             (log/error (str "Update novelty unexpected error while attempting to updated db: "
+                             (pr-str db) " due to exception: " (ex-message e))
+                        {:add-flakes add
+                         :rem-flakes rem})
+       (throw e)))))
 
 (defn add-tt-id
   "Associates a unique tt-id for any in-memory staged db in their index roots.


### PR DESCRIPTION
This gives a significant boost in transaction times, although significant increases are most noticable with larger transactions.

This improved transaction time by > 30% in a transaction containing 1 million flakes / 15MB of data.

Txn time went from ~28 seconds to ~19 seconds.

The improvements are achieved by running some operations in parallel on the JVM that were coded as serial.

Notable:
1) Calculating flake-size (for db size) in commit data is much slower than I expected. Not sure what the bottleneck is, didn't investigate - but of original 28 seconds, this operation alone took 6 seconds. This is done in a background thread now.
2) post, opst updates takes about 4x longer than spot, tspo indexes. I think this makes sense because there are large numbers of the same 'p' in most data sets, so the first equivalency tests still will have a large number of secondary items to check. These two indexes only are updated in the background... spot & tspo will both finish before post, so left those as-is for now.