### PR TITLE
Task/shacl explicit id tests

### DIFF
--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -1,7 +1,9 @@
 (ns fluree.db.shacl.shacl-basic-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [fluree.db.api :as fluree]
-            [fluree.db.test-utils :as test-utils :refer [pred-match?]]))
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.util.core :as util]))
 
 (deftest ^:integration using-pre-defined-types-as-classes
   (testing "Class not used as class initially can still be used as one."
@@ -35,25 +37,26 @@
                       :select  {'?s [:*]}
                       :where   {:id '?s, :type :ex/User}}
           db         @(fluree/stage
-                        (fluree/db ledger)
-                        {"@context" ["https://ns.flur.ee" context]
-                         "insert"
-                         {:id             :ex/UserShape
-                          :type           [:sh/NodeShape]
-                          :sh/targetClass :ex/User
-                          :sh/property    [{:sh/path     :schema/name
-                                            :sh/minCount 1
-                                            :sh/maxCount 1
-                                            :sh/datatype :xsd/string}]}})]
+                          (fluree/db ledger)
+                          {"@context" ["https://ns.flur.ee" context]
+                           "insert"
+                           {:id             :ex/UserShape
+                            :type           [:sh/NodeShape]
+                            :sh/targetClass :ex/User
+                            :sh/property    [{:id :ex/shape1
+                                              :sh/path     :schema/name
+                                              :sh/minCount 1
+                                              :sh/maxCount 1
+                                              :sh/datatype :xsd/string}]}})]
       (testing "cardinality ok"
         (let [db-ok @(fluree/stage
-                       db
-                       {"@context" ["https://ns.flur.ee" context]
-                        "insert"
-                        {:id              :ex/john
-                         :type            :ex/User
-                         :schema/name     "John"
-                         :schema/callSign "j-rock"}})]
+                              db
+                              {"@context" ["https://ns.flur.ee" context]
+                               "insert"
+                               {:id              :ex/john
+                                :type            :ex/User
+                                :schema/name     "John"
+                                :schema/callSign "j-rock"}})]
           (is (= [{:id              :ex/john,
                    :type            :ex/User,
                    :schema/name     "John",
@@ -62,28 +65,30 @@
               "basic rdf:type query response not correct")))
       (testing "cardinality less than"
         (let [db-no-names @(fluree/stage
-                             db
-                             {"@context" ["https://ns.flur.ee" context]
-                              "insert"
-                              {:id              :ex/john
-                               :type            :ex/User
-                               :schema/callSign "j-rock"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/minCount,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               0,
-                               :f/expectation          1,
-                               :sh/resultMessage       "count 0 is less than minimum count of 1",
-                               :sh/resultPath          [:schema/name]}]}}
-                           (ex-data db-no-names)))))
+                              db
+                              {"@context" ["https://ns.flur.ee" context]
+                               "insert"
+                               {:id              :ex/john
+                                :type            :ex/User
+                                :schema/callSign "j-rock"}})]
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/minCount,
+                     :sh/sourceShape         :ex/shape1
+                     :sh/value               0,
+                     :f/expectation          1,
+                     :sh/resultMessage       "count 0 is less than minimum count of 1",
+                     :sh/resultPath          [:schema/name]}]}}
+                 (ex-data db-no-names)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/minCount of shape :ex/shape1 - count 0 is less than minimum count of 1."
+                 (ex-message db-no-names)))))
       (testing "cardinality greater than"
         (let [db-two-names @(fluree/stage
                               db
@@ -93,22 +98,24 @@
                                 :type            :ex/User
                                 :schema/name     ["John", "Johnny"]
                                 :schema/callSign "j-rock"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/maxCount,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               2,
-                               :f/expectation          1,
-                               :sh/resultMessage       "count 2 is greater than maximum count of 1",
-                               :sh/resultPath          [:schema/name]}]}}
-                           (ex-data db-two-names))))))))
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/maxCount,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               2,
+                     :f/expectation          1,
+                     :sh/resultMessage       "count 2 is greater than maximum count of 1",
+                     :sh/resultPath          [:schema/name]}]}}
+                 (ex-data db-two-names)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/maxCount of shape :ex/shape1 - count 2 is greater than maximum count of 1."
+                 (ex-message db-two-names))))))))
 
 (deftest ^:integration shacl-datatype-constraints
   (testing "shacl datatype errors"
@@ -125,7 +132,8 @@
                          {:id             :ex/UserShape
                           :type           :sh/NodeShape
                           :sh/targetClass :ex/User
-                          :sh/property    [{:sh/path     :schema/name
+                          :sh/property    [{:id          :ex/shape1
+                                            :sh/path     :schema/name
                                             :sh/datatype :xsd/string}]}})]
       (testing "datatype ok"
         (let [db-ok @(fluree/stage
@@ -149,22 +157,24 @@
                                :type        :ex/User
                                ;; need to specify type inline in order to avoid coercion
                                :schema/name {:type :xsd/integer :value 42}}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/datatype,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               [:xsd/integer],
-                               :f/expectation          :xsd/string,
-                               :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42",
-                               :sh/resultPath          [:schema/name]}]}}
-                           (ex-data db-int-name)))))
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/datatype,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               [:xsd/integer],
+                     :f/expectation          :xsd/string,
+                     :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42",
+                     :sh/resultPath          [:schema/name]}]}}
+                 (ex-data db-int-name)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/datatype of shape :ex/shape1 - the following values do not have expected datatype :xsd/string: 42."
+                 (ex-message db-int-name)))))
       (testing "incorrect ref type"
         (let [db-bool-name @(fluree/stage
                               db
@@ -173,23 +183,25 @@
                                {:id          :ex/john
                                 :type        :ex/User
                                 :schema/name {:id :ex/john}}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/datatype,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               [:id],
-                               :f/expectation          :xsd/string,
-                               :sh/resultMessage       "the following values do not have expected datatype :xsd/string: :ex/john",
-                               :sh/resultPath          [:schema/name]}]}}
-                           (ex-data db-bool-name))
-              "Exception, because :schema/name is a boolean and not a string."))))))
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/datatype,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               [:id],
+                     :f/expectation          :xsd/string,
+                     :sh/resultMessage       "the following values do not have expected datatype :xsd/string: :ex/john",
+                     :sh/resultPath          [:schema/name]}]}}
+                 (ex-data db-bool-name))
+              "Exception, because :schema/name is a boolean and not a string.")
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/datatype of shape :ex/shape1 - the following values do not have expected datatype :xsd/string: :ex/john."
+                 (ex-message db-bool-name))))))))
 
 (deftest ^:integration shacl-closed-shape
   (testing "shacl closed shape"
@@ -266,7 +278,8 @@
                      {:id             :ex/EqualNamesShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:sh/path   :schema/name
+                      :sh/property    [{:id        :ex/shape1
+                                        :sh/path   :schema/name
                                         :sh/equals :ex/firstName}]}})
 
 
@@ -278,22 +291,24 @@
                                 :type         :ex/User
                                 :schema/name  "John"
                                 :ex/firstName "Jack"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/equals,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               ["John"],
-                               :f/expectation          ["Jack"],
-                               :sh/resultMessage       "path [:schema/name] values John do not equal :ex/firstName values Jack",
-                               :sh/resultPath          [:schema/name]}]}}
-                           (ex-data db-not-equal)))
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/equals,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               ["John"],
+                     :f/expectation          ["Jack"],
+                     :sh/resultMessage       "path [:schema/name] values John do not equal :ex/firstName values Jack",
+                     :sh/resultPath          [:schema/name]}]}}
+                 (ex-data db-not-equal)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/equals of shape :ex/shape1 - path [:schema/name] values John do not equal :ex/firstName values Jack."
+                 (ex-message db-not-equal)))
           (let [db-ok @(fluree/stage
                          db
                          {"@context" ["https://ns.flur.ee" context]
@@ -315,7 +330,8 @@
                      {:id             :ex/EqualNamesShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:sh/path   :ex/favNums
+                      :sh/property    [{:id        :ex/shape1
+                                        :sh/path   :ex/favNums
                                         :sh/equals :ex/luckyNums}]}})]
           (let [db-not-equal1 @(fluree/stage
                                  db
@@ -326,22 +342,24 @@
                                    :schema/name  "Brian"
                                    :ex/favNums   [11 17]
                                    :ex/luckyNums [13 18]}})]
-            (is (pred-match? {:status 422,
-                              :error  :shacl/violation,
-                              :report
-                              {:type        :sh/ValidationReport,
-                               :sh/conforms false,
-                               :sh/result
-                               [{:type                   :sh/ValidationResult,
-                                 :sh/resultSeverity      :sh/Violation
-                                 :sh/focusNode           :ex/brian,
-                                 :sh/constraintComponent :sh/equals,
-                                 :sh/sourceShape         test-utils/blank-node-id?,
-                                 :sh/value               [11 17],
-                                 :f/expectation          [13 18],
-                                 :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 13, 18",
-                                 :sh/resultPath          [:ex/favNums]}]}}
-                             (ex-data db-not-equal1))))
+            (is (= {:status 422,
+                    :error  :shacl/violation,
+                    :report
+                    {:type        :sh/ValidationReport,
+                     :sh/conforms false,
+                     :sh/result
+                     [{:type                   :sh/ValidationResult,
+                       :sh/resultSeverity      :sh/Violation
+                       :sh/focusNode           :ex/brian,
+                       :sh/constraintComponent :sh/equals,
+                       :sh/sourceShape         :ex/shape1
+                       :sh/value               [11 17],
+                       :f/expectation          [13 18],
+                       :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 13, 18",
+                       :sh/resultPath          [:ex/favNums]}]}}
+                   (ex-data db-not-equal1)))
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/shape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 13, 18."
+                   (ex-message db-not-equal1))))
           (let [db-not-equal2 @(fluree/stage
                                  db
                                  {"@context" ["https://ns.flur.ee" context]
@@ -351,22 +369,24 @@
                                    :schema/name  "Brian"
                                    :ex/favNums   [11 17]
                                    :ex/luckyNums [11]}})]
-            (is (pred-match? {:status 422,
-                              :error  :shacl/violation,
-                              :report
-                              {:type        :sh/ValidationReport,
-                               :sh/conforms false,
-                               :sh/result
-                               [{:type                   :sh/ValidationResult,
-                                 :sh/resultSeverity      :sh/Violation
-                                 :sh/focusNode           :ex/brian,
-                                 :sh/constraintComponent :sh/equals,
-                                 :sh/sourceShape         test-utils/blank-node-id?,
-                                 :sh/value               [11 17],
-                                 :f/expectation          [11],
-                                 :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11",
-                                 :sh/resultPath          [:ex/favNums]}]}}
-                             (ex-data db-not-equal2))))
+            (is (= {:status 422,
+                    :error  :shacl/violation,
+                    :report
+                    {:type        :sh/ValidationReport,
+                     :sh/conforms false,
+                     :sh/result
+                     [{:type                   :sh/ValidationResult,
+                       :sh/resultSeverity      :sh/Violation
+                       :sh/focusNode           :ex/brian,
+                       :sh/constraintComponent :sh/equals,
+                       :sh/sourceShape         :ex/shape1,
+                       :sh/value               [11 17],
+                       :f/expectation          [11],
+                       :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11",
+                       :sh/resultPath          [:ex/favNums]}]}}
+                   (ex-data db-not-equal2)))
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/shape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11."
+                   (ex-message db-not-equal2))))
           (let [db-not-equal3 @(fluree/stage
                                  db
                                  {"@context" ["https://ns.flur.ee" context]
@@ -376,22 +396,24 @@
                                    :schema/name  "Brian"
                                    :ex/favNums   [11 17]
                                    :ex/luckyNums [11 17 18]}})]
-            (is (pred-match? {:status 422,
-                              :error  :shacl/violation,
-                              :report
-                              {:type        :sh/ValidationReport,
-                               :sh/conforms false,
-                               :sh/result
-                               [{:type                   :sh/ValidationResult,
-                                 :sh/resultSeverity      :sh/Violation
-                                 :sh/focusNode           :ex/brian,
-                                 :sh/constraintComponent :sh/equals,
-                                 :sh/sourceShape         test-utils/blank-node-id?,
-                                 :sh/value               [11 17],
-                                 :f/expectation          [17 11 18],
-                                 :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17, 18",
-                                 :sh/resultPath          [:ex/favNums]}]}}
-                             (ex-data db-not-equal3))))
+            (is (= {:status 422,
+                    :error  :shacl/violation,
+                    :report
+                    {:type        :sh/ValidationReport,
+                     :sh/conforms false,
+                     :sh/result
+                     [{:type                   :sh/ValidationResult,
+                       :sh/resultSeverity      :sh/Violation
+                       :sh/focusNode           :ex/brian,
+                       :sh/constraintComponent :sh/equals,
+                       :sh/sourceShape         :ex/shape1,
+                       :sh/value               [11 17],
+                       :f/expectation          [17 11 18],
+                       :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17, 18",
+                       :sh/resultPath          [:ex/favNums]}]}}
+                   (ex-data db-not-equal3)))
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/shape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17, 18."
+                   (ex-message db-not-equal3))))
           (let [db-not-equal4 @(fluree/stage
                                  db
                                  {"@context" ["https://ns.flur.ee" context]
@@ -401,21 +423,21 @@
                                    :schema/name  "Brian"
                                    :ex/favNums   [11 17]
                                    :ex/luckyNums ["11" "17"]}})]
-            (is (pred-match? {:status 422,
-                              :error  :shacl/violation,
-                              :report
-                              {:type        :sh/ValidationReport,
-                               :sh/conforms false,
-                               :sh/result
-                               [{:type                   :sh/ValidationResult,
-                                 :sh/resultSeverity      :sh/Violation
-                                 :sh/focusNode           :ex/brian,
-                                 :sh/constraintComponent :sh/equals,
-                                 :sh/sourceShape         test-utils/blank-node-id?,
-                                 :sh/value               [11 17],
-                                 :f/expectation          ["17" "11"],
-                                 :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17",
-                                 :sh/resultPath          [:ex/favNums]}]}}
+            (is (= {:status 422,
+                    :error  :shacl/violation,
+                    :report
+                    {:type        :sh/ValidationReport,
+                     :sh/conforms false,
+                     :sh/result
+                     [{:type                   :sh/ValidationResult,
+                       :sh/resultSeverity      :sh/Violation
+                       :sh/focusNode           :ex/brian,
+                       :sh/constraintComponent :sh/equals,
+                       :sh/sourceShape         :ex/shape1
+                       :sh/value               [11 17],
+                       :f/expectation          ["17" "11"],
+                       :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17",
+                       :sh/resultPath          [:ex/favNums]}]}}
                    (ex-data db-not-equal4))))
           (let [db-ok @(fluree/stage
                          db
@@ -455,7 +477,8 @@
                      {:id             :ex/DisjointShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:sh/path     :ex/favNums
+                      :sh/property    [{:id          :ex/shape1
+                                        :sh/path     :ex/favNums
                                         :sh/disjoint :ex/luckyNums}]}})]
           (testing "disjoint values"
             (let [db-ok @(fluree/stage
@@ -483,21 +506,21 @@
                                         :schema/name  "Brian"
                                         :ex/favNums   11
                                         :ex/luckyNums 11}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/brian,
-                                   :sh/constraintComponent :sh/disjoint,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11],
-                                   :f/expectation          [11],
-                                   :sh/resultMessage       "path [:ex/favNums] values 11 are not disjoint with :ex/luckyNums values 11",
-                                   :sh/resultPath          [:ex/favNums]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/brian,
+                         :sh/constraintComponent :sh/disjoint,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11],
+                         :f/expectation          [11],
+                         :sh/resultMessage       "path [:ex/favNums] values 11 are not disjoint with :ex/luckyNums values 11",
+                         :sh/resultPath          [:ex/favNums]}]}}
                      (ex-data db-not-disjoint1)))))
           (testing "multiple disjoint tests"
             (let [db-not-disjoint2 @(fluree/stage
@@ -509,21 +532,21 @@
                                         :schema/name  "Brian"
                                         :ex/favNums   [11 17 31]
                                         :ex/luckyNums 11}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/brian,
-                                   :sh/constraintComponent :sh/disjoint,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17 31],
-                                   :f/expectation          [11],
-                                   :sh/resultMessage       "path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11",
-                                   :sh/resultPath          [:ex/favNums]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/brian,
+                         :sh/constraintComponent :sh/disjoint,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17 31],
+                         :f/expectation          [11],
+                         :sh/resultMessage       "path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11",
+                         :sh/resultPath          [:ex/favNums]}]}}
                      (ex-data db-not-disjoint2))
                   "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")))
           (testing "multiple non disjoint values"
@@ -536,21 +559,21 @@
                                         :schema/name  "Brian"
                                         :ex/favNums   [11 17 31]
                                         :ex/luckyNums [13 18 11]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/brian,
-                                   :sh/constraintComponent :sh/disjoint,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17 31],
-                                   :f/expectation          [13 11 18],
-                                   :sh/resultMessage       "path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11, 13, 18",
-                                   :sh/resultPath          [:ex/favNums]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/brian,
+                         :sh/constraintComponent :sh/disjoint,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17 31],
+                         :f/expectation          [13 11 18],
+                         :sh/resultMessage       "path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11, 13, 18",
+                         :sh/resultPath          [:ex/favNums]}]}}
                      (ex-data db-not-disjoint3))
                   "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")))))
       (testing "lessThan"
@@ -561,7 +584,8 @@
                          {:id             :ex/LessThanShape
                           :type           :sh/NodeShape
                           :sh/targetClass :ex/User
-                          :sh/property    [{:sh/path     :ex/p1
+                          :sh/property    [{:id          :ex/shape1
+                                            :sh/path     :ex/p1
                                             :sh/lessThan :ex/p2}]}})
               db-ok1 @(fluree/stage
                         db
@@ -605,21 +629,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [11 17]
                                 :ex/p2       17}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThan,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17],
-                                   :f/expectation          [17],
-                                   :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 17",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThan,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17],
+                         :f/expectation          [17],
+                         :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 17",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail1)))))
           (testing "values not comparable to other values"
             (let [db-fail2 @(fluree/stage
@@ -631,21 +655,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [11 17]
                                 :ex/p2       ["18" "19"]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThan,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17],
-                                   :f/expectation          ["19" "18"],
-                                   :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 18, 19",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThan,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17],
+                         :f/expectation          ["19" "18"],
+                         :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 18, 19",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail2)))))
           (testing "values not less than all other values"
             (let [db-fail3 @(fluree/stage
@@ -657,21 +681,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [12 17]
                                 :ex/p2       [10 18]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThan,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [12 17],
-                                   :f/expectation          [10 18],
-                                   :sh/resultMessage       "path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 18",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThan,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [12 17],
+                         :f/expectation          [10 18],
+                         :sh/resultMessage       "path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 18",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail3)))))
           (testing "values not less than all"
             (let [db-fail4 @(fluree/stage
@@ -683,21 +707,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [11 17]
                                 :ex/p2       [12 16]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThan,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17],
-                                   :f/expectation          [12 16],
-                                   :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThan,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17],
+                         :f/expectation          [12 16],
+                         :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail4)))))
           (testing "not comparable with iris"
             (let [db-iris @(fluree/stage
@@ -709,21 +733,21 @@
                                :schema/name "Alice"
                                :ex/p1       :ex/brian
                                :ex/p2       :ex/john}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThan,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [:ex/brian],
-                                   :f/expectation          [:ex/john],
-                                   :sh/resultMessage       "path [:ex/p1] values :ex/brian are not all comparable with :ex/p2 values :ex/john",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThan,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [:ex/brian],
+                         :f/expectation          [:ex/john],
+                         :sh/resultMessage       "path [:ex/p1] values :ex/brian are not all comparable with :ex/p2 values :ex/john",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-iris)))))))
       (testing "lessThanOrEquals"
         (let [db @(fluree/stage
@@ -733,7 +757,8 @@
                      {:id             :ex/LessThanOrEqualsShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:sh/path             :ex/p1
+                      :sh/property    [{:id                  :ex/shape1
+                                        :sh/path             :ex/p1
                                         :sh/lessThanOrEquals :ex/p2}]}})]
           (testing "all values less than or equal"
             (let [db-ok1 @(fluree/stage
@@ -777,21 +802,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [11 17]
                                 :ex/p2       10}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThanOrEquals,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17],
-                                   :f/expectation          [10],
-                                   :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 10",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThanOrEquals,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17],
+                         :f/expectation          [10],
+                         :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 10",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail1)))))
           (testing "all values not comparable with other values"
             (let [db-fail2 @(fluree/stage
@@ -803,21 +828,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [11 17]
                                 :ex/p2       ["17" "19"]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThanOrEquals,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17],
-                                   :f/expectation          ["19" "17"],
-                                   :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 17, 19",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThanOrEquals,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17],
+                         :f/expectation          ["19" "17"],
+                         :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 17, 19",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail2)))))
           (testing "all values not less than other values"
             (let [db-fail3 @(fluree/stage
@@ -829,21 +854,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [12 17]
                                 :ex/p2       [10 17]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThanOrEquals,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [12 17],
-                                   :f/expectation          [17 10],
-                                   :sh/resultMessage       "path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 17",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThanOrEquals,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [12 17],
+                         :f/expectation          [17 10],
+                         :sh/resultMessage       "path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 17",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail3)))))
           (testing "all values not less than all other values"
             (let [db-fail4 @(fluree/stage
@@ -855,21 +880,21 @@
                                 :schema/name "Alice"
                                 :ex/p1       [11 17]
                                 :ex/p2       [12 16]}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/lessThanOrEquals,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               [11 17],
-                                   :f/expectation          [12 16],
-                                   :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16",
-                                   :sh/resultPath          [:ex/p1]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/lessThanOrEquals,
+                         :sh/sourceShape         :ex/shape1
+                         :sh/value               [11 17],
+                         :f/expectation          [12 16],
+                         :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16",
+                         :sh/resultPath          [:ex/p1]}]}}
                      (ex-data db-fail4))))))))))
 
 (deftest ^:integration shacl-value-range
@@ -888,7 +913,8 @@
                      {:id             :ex/ExclusiveNumRangeShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:sh/path         :schema/age
+                      :sh/property    [{:id              :ex/shape1
+                                        :sh/path         :schema/age
                                         :sh/minExclusive 1
                                         :sh/maxExclusive 100}]}})]
           (testing "values in range"
@@ -911,21 +937,21 @@
                                  {:id         :ex/john
                                   :type       :ex/User
                                   :schema/age 1}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/john,
-                                   :sh/constraintComponent :sh/minExclusive,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               1,
-                                   :f/expectation          1,
-                                   :sh/resultMessage       "value 1 is less than exclusive minimum 1",
-                                   :sh/resultPath          [:schema/age]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/john,
+                         :sh/constraintComponent :sh/minExclusive,
+                         :sh/sourceShape         :ex/shape1,
+                         :sh/value               1,
+                         :f/expectation          1,
+                         :sh/resultMessage       "value 1 is less than exclusive minimum 1",
+                         :sh/resultPath          [:schema/age]}]}}
                      (ex-data db-too-low)))))
           (testing "values too high"
             (let [db-too-high @(fluree/stage
@@ -935,21 +961,21 @@
                                   {:id         :ex/john
                                    :type       :ex/User
                                    :schema/age 100}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/john,
-                                   :sh/constraintComponent :sh/maxExclusive,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               100,
-                                   :f/expectation          100,
-                                   :sh/resultMessage       "value 100 is greater than exclusive maximum 100",
-                                   :sh/resultPath          [:schema/age]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/john,
+                         :sh/constraintComponent :sh/maxExclusive,
+                         :sh/sourceShape         :ex/shape1,
+                         :sh/value               100,
+                         :f/expectation          100,
+                         :sh/resultMessage       "value 100 is greater than exclusive maximum 100",
+                         :sh/resultPath          [:schema/age]}]}}
                      (ex-data db-too-high)))))))
       (testing "inclusive constraints"
         (let [db @(fluree/stage
@@ -964,19 +990,19 @@
                                         :sh/maxInclusive 100}]}})]
           (testing "values at limit"
             (let [db-ok  @(fluree/stage
-                            db
-                            {"@context" ["https://ns.flur.ee" context]
-                             "insert"
-                             {:id         :ex/brian
-                              :type       :ex/User
-                              :schema/age 1}})
+                           db
+                           {"@context" ["https://ns.flur.ee" context]
+                            "insert"
+                            {:id         :ex/brian
+                             :type       :ex/User
+                             :schema/age 1}})
                   db-ok2 @(fluree/stage
-                            db-ok
-                            {"@context" ["https://ns.flur.ee" context]
-                             "insert"
-                             {:id         :ex/alice
-                              :type       :ex/User
-                              :schema/age 100}})]
+                                 db-ok
+                                 {"@context" ["https://ns.flur.ee" context]
+                                  "insert"
+                                  {:id         :ex/alice
+                                   :type       :ex/User
+                                   :schema/age 100}})]
               (is (= [{:id         :ex/alice
                        :type       :ex/User
                        :schema/age 100}
@@ -986,27 +1012,27 @@
                      @(fluree/query db-ok2 user-query)))))
           (testing "values below min"
             (let [db-too-low @(fluree/stage
-                                db
-                                {"@context" ["https://ns.flur.ee" context]
-                                 "insert"
-                                 {:id         :ex/alice
-                                  :type       :ex/User
-                                  :schema/age 0}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/minInclusive,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               0,
-                                   :f/expectation          1,
-                                   :sh/resultMessage       "value 0 is less than inclusive minimum 1",
-                                   :sh/resultPath          [:schema/age]}]}}
+                                 db
+                                 {"@context" ["https://ns.flur.ee" context]
+                                  "insert"
+                                  {:id         :ex/alice
+                                   :type       :ex/User
+                                   :schema/age 0}})]
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/minInclusive,
+                         :sh/sourceShape :ex/shape1
+                         :sh/value               0,
+                         :f/expectation          1,
+                         :sh/resultMessage       "value 0 is less than inclusive minimum 1",
+                         :sh/resultPath          [:schema/age]}]}}
                      (ex-data db-too-low)))))
           (testing "values above max"
             (let [db-too-high @(fluree/stage
@@ -1016,21 +1042,21 @@
                                   {:id         :ex/alice
                                    :type       :ex/User
                                    :schema/age 101}})]
-              (is (pred-match? {:status 422,
-                                :error  :shacl/violation,
-                                :report
-                                {:type        :sh/ValidationReport,
-                                 :sh/conforms false,
-                                 :sh/result
-                                 [{:type                   :sh/ValidationResult,
-                                   :sh/resultSeverity      :sh/Violation
-                                   :sh/focusNode           :ex/alice,
-                                   :sh/constraintComponent :sh/maxInclusive,
-                                   :sh/sourceShape         test-utils/blank-node-id?,
-                                   :sh/value               101,
-                                   :f/expectation          100,
-                                   :sh/resultMessage       "value 101 is greater than inclusive maximum 100",
-                                   :sh/resultPath          [:schema/age]}]}}
+              (is (= {:status 422,
+                      :error  :shacl/violation,
+                      :report
+                      {:type        :sh/ValidationReport,
+                       :sh/conforms false,
+                       :sh/result
+                       [{:type                   :sh/ValidationResult,
+                         :sh/resultSeverity      :sh/Violation
+                         :sh/focusNode           :ex/alice,
+                         :sh/constraintComponent :sh/maxInclusive,
+                         :sh/sourceShape :ex/shape1
+                         :sh/value               101,
+                         :f/expectation          100,
+                         :sh/resultMessage       "value 101 is greater than inclusive maximum 100",
+                         :sh/resultPath          [:schema/age]}]}}
                      (ex-data db-too-high)))))))
       (testing "non-numeric values"
         (let [db         @(fluree/stage
@@ -1056,38 +1082,38 @@
                              {:id         :ex/alice
                               :type       :ex/User
                               :schema/age "10"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/alice,
-                               :sh/constraintComponent :sh/minExclusive,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               :ex/brian,
-                               :f/expectation          0,
-                               :sh/resultMessage       "value :ex/brian is less than exclusive minimum 0",
-                               :sh/resultPath          [:schema/age]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/alice,
+                     :sh/constraintComponent :sh/minExclusive,
+                     :sh/sourceShape :ex/shape1
+                     :sh/value               :ex/brian,
+                     :f/expectation          0,
+                     :sh/resultMessage       "value :ex/brian is less than exclusive minimum 0",
+                     :sh/resultPath          [:schema/age]}]}}
                  (ex-data db-subj-id)))
 
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/alice,
-                               :sh/constraintComponent :sh/minExclusive,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               "10",
-                               :f/expectation          0,
-                               :sh/resultMessage       "value 10 is less than exclusive minimum 0",
-                               :sh/resultPath          [:schema/age]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/alice,
+                     :sh/constraintComponent :sh/minExclusive,
+                     :sh/sourceShape :ex/shape1
+                     :sh/value               "10",
+                     :f/expectation          0,
+                     :sh/resultMessage       "value 10 is less than exclusive minimum 0",
+                     :sh/resultPath          [:schema/age]}]}}
                  (ex-data db-string))))))))
 
 (deftest ^:integration shacl-string-length-constraints
@@ -1140,21 +1166,21 @@
                                    {:id          :ex/al
                                     :type        :ex/User
                                     :schema/name "Al"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/al,
-                               :sh/constraintComponent :sh/minLength,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               "Al",
-                               :f/expectation          4,
-                               :sh/resultMessage       "value \"Al\" has string length less than minimum length 4",
-                               :sh/resultPath          [:schema/name]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/al,
+                     :sh/constraintComponent :sh/minLength,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               "Al",
+                     :f/expectation          4,
+                     :sh/resultMessage       "value \"Al\" has string length less than minimum length 4",
+                     :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-too-short-str)))))
       (testing "string is too long"
         (let [db-too-long-str @(fluree/stage
@@ -1164,21 +1190,21 @@
                                   {:id          :ex/jean-claude
                                    :type        :ex/User
                                    :schema/name "Jean-Claude"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/jean-claude,
-                               :sh/constraintComponent :sh/maxLength,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               "Jean-Claude",
-                               :f/expectation          10,
-                               :sh/resultMessage       "value \"Jean-Claude\" has string length greater than maximum length 10",
-                               :sh/resultPath          [:schema/name]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/jean-claude,
+                     :sh/constraintComponent :sh/maxLength,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               "Jean-Claude",
+                     :f/expectation          10,
+                     :sh/resultMessage       "value \"Jean-Claude\" has string length greater than maximum length 10",
+                     :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-too-long-str)))))
       (testing "non-string literals are stringified"
         (let [db-too-long-non-str @(fluree/stage
@@ -1188,21 +1214,21 @@
                                       {:id          :ex/john
                                        :type        :ex/User
                                        :schema/name 12345678910}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/maxLength,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               12345678910,
-                               :f/expectation          10,
-                               :sh/resultMessage       "value \"12345678910\" has string length greater than maximum length 10",
-                               :sh/resultPath          [:schema/name]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/maxLength,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               12345678910,
+                     :f/expectation          10,
+                     :sh/resultMessage       "value \"12345678910\" has string length greater than maximum length 10",
+                     :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-too-long-non-str)))))
       (testing "non-literal values violate"
         (let [db-ref-value @(fluree/stage
@@ -1212,21 +1238,21 @@
                                {:id          :ex/john
                                 :type        :ex/User
                                 :schema/name :ex/ref}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/maxLength,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               #fluree/SID [101 "ref"],
-                               :f/expectation          10,
-                               :sh/resultMessage       "value :ex/ref is not a literal value",
-                               :sh/resultPath          [:schema/name]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/maxLength,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/value               #fluree/SID [101 "ref"],
+                     :f/expectation          10,
+                     :sh/resultMessage       "value :ex/ref is not a literal value",
+                     :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-ref-value))))))))
 
 (deftest ^:integration shacl-string-pattern-constraints
@@ -1244,10 +1270,12 @@
                          {:id             :ex/UserShape
                           :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
-                          :sh/property    [{:sh/path    :ex/greeting
+                          :sh/property    [{:id         :ex/pshape1
+                                            :sh/path    :ex/greeting
                                             :sh/pattern "hello   (.*?)world"
                                             :sh/flags   ["x" "s"]}
-                                           {:sh/path    :ex/birthYear
+                                           {:id         :ex/pshape2
+                                            :sh/path    :ex/birthYear
                                             :sh/pattern "(19|20)[0-9][0-9]"}]}})]
       (testing "string matches pattern"
         (let [db-ok-greeting @(fluree/stage
@@ -1281,25 +1309,25 @@
                                          {:id          :ex/alice
                                           :type        :ex/User
                                           :ex/greeting "HELLO\nWORLD!"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/alice,
-                               :sh/constraintComponent :sh/pattern,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               "HELLO
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/alice,
+                     :sh/constraintComponent :sh/pattern,
+                     :sh/sourceShape         :ex/pshape1,
+                     :sh/value               "HELLO
 WORLD!",
-                               :f/expectation          "hello   (.*?)world",
-                               :sh/resultMessage       (str "value "
-                                                            (pr-str "HELLO
+                     :f/expectation          "hello   (.*?)world",
+                     :sh/resultMessage       (str "value "
+                                                  (pr-str "HELLO
 WORLD!")
-                                                            " does not match pattern \"hello   (.*?)world\" with :sh/flags s, x")
-                               :sh/resultPath          [:ex/greeting]}]}}
+                                                  " does not match pattern \"hello   (.*?)world\" with :sh/flags s, x")
+                     :sh/resultPath          [:ex/greeting]}]}}
                  (ex-data db-wrong-case-greeting)))))
       (testing "stringified literal does not match pattern"
         (let [db-wrong-birth-year @(fluree/stage
@@ -1309,21 +1337,21 @@ WORLD!")
                                       {:id           :ex/alice
                                        :type         :ex/User
                                        :ex/birthYear 1776}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/focusNode           :ex/alice,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/constraintComponent :sh/pattern,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               1776,
-                               :f/expectation          "(19|20)[0-9][0-9]",
-                               :sh/resultMessage       "value \"1776\" does not match pattern \"(19|20)[0-9][0-9]\"",
-                               :sh/resultPath          [:ex/birthYear]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/focusNode           :ex/alice,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/constraintComponent :sh/pattern,
+                     :sh/sourceShape         :ex/pshape2
+                     :sh/value               1776,
+                     :f/expectation          "(19|20)[0-9][0-9]",
+                     :sh/resultMessage       "value \"1776\" does not match pattern \"(19|20)[0-9][0-9]\"",
+                     :sh/resultPath          [:ex/birthYear]}]}}
                  (ex-data db-wrong-birth-year)))))
       (testing "non-literal values automatically produce violation"
         (let [db-ref-value @(fluree/stage
@@ -1333,21 +1361,21 @@ WORLD!")
                                {:id           :ex/john
                                 :type         :ex/User
                                 :ex/birthYear :ex/ref}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/pattern,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/value               #fluree/SID [101 "ref"],
-                               :f/expectation          "(19|20)[0-9][0-9]",
-                               :sh/resultMessage       "value \":ex/ref\" does not match pattern \"(19|20)[0-9][0-9]\"",
-                               :sh/resultPath          [:ex/birthYear]}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/pattern,
+                     :sh/sourceShape         :ex/pshape2
+                     :sh/value               #fluree/SID [101 "ref"],
+                     :f/expectation          "(19|20)[0-9][0-9]",
+                     :sh/resultMessage       "value \":ex/ref\" does not match pattern \"(19|20)[0-9][0-9]\"",
+                     :sh/resultPath          [:ex/birthYear]}]}}
                  (ex-data db-ref-value))))))))
 
 (deftest language-constraints
@@ -1362,7 +1390,8 @@ WORLD!")
                                     {"@id"           "ex:langShape"
                                      "type"          "sh:NodeShape"
                                      "sh:targetNode" {"@id" "ex:a"}
-                                     "sh:property"   [{"sh:path"       {"@id" "ex:label"}
+                                     "sh:property"   [{"id"            "ex:pshape1"
+                                                       "sh:path"       {"@id" "ex:label"}
                                                        "sh:languageIn" ["en" "fr"]}]}})]
         (testing "no error when language conforms"
           (let [db2 @(fluree/stage db1 {"@context" context
@@ -1375,22 +1404,22 @@ WORLD!")
                                         "insert"
                                         {"@id"      "ex:a"
                                          "ex:label" {"@value" "foo" "@language" "cz"}}})]
-            (is (pred-match? {:status 422,
-                              :error  :shacl/violation,
-                              :report
-                              {"type"        "sh:ValidationReport",
-                               "sh:conforms" false,
-                               "sh:result"
-                               [{"sh:constraintComponent" "sh:languageIn",
-                                 "sh:focusNode"           "ex:a",
-                                 "sh:resultSeverity"      "sh:Violation",
-                                 "sh:value"               "foo",
-                                 "sh:resultPath"          ["ex:label"],
-                                 "type"                   "sh:ValidationResult",
-                                 "sh:resultMessage"
-                                 "value \"foo\" does not have language tag in [\"en\" \"fr\"]",
-                                 "sh:sourceShape"         test-utils/blank-node-id?,
-                                 "f:expectation"          ["en" "fr"]}]}}
+            (is (= {:status 422,
+                    :error  :shacl/violation,
+                    :report
+                    {"type"        "sh:ValidationReport",
+                     "sh:conforms" false,
+                     "sh:result"
+                     [{"sh:constraintComponent" "sh:languageIn",
+                       "sh:focusNode"           "ex:a",
+                       "sh:resultSeverity"      "sh:Violation",
+                       "sh:value"               "foo",
+                       "sh:resultPath"          ["ex:label"],
+                       "type"                   "sh:ValidationResult",
+                       "sh:resultMessage"
+                       "value \"foo\" does not have language tag in [\"en\" \"fr\"]",
+                       "sh:sourceShape"         "ex:pshape1"
+                       "f:expectation"          ["en" "fr"]}]}}
                    (ex-data db2)))))))
     (testing "unique-lang"
       (let [db1 @(fluree/stage db0 {"@context" context
@@ -1398,7 +1427,8 @@ WORLD!")
                                     {"@id"           "ex:langShape"
                                      "type"          "sh:NodeShape"
                                      "sh:targetNode" {"@id" "ex:a"}
-                                     "sh:property"   [{"sh:path"       {"@id" "ex:label"}
+                                     "sh:property"   [{"id"            "ex:pshape1"
+                                                       "sh:path"       {"@id" "ex:label"}
                                                        "sh:uniqueLang" true}]}})]
         (testing "no error when all langs unique"
           (let [db2 @(fluree/stage db1 {"@context" context
@@ -1413,21 +1443,21 @@ WORLD!")
                                         {"@id"      "ex:a"
                                          "ex:label" [{"@value" "foo" "@language" "en"}
                                                      {"@value" "bar" "@language" "en"}]}})]
-            (is (pred-match? {:status 422,
-                              :error  :shacl/violation,
-                              :report
-                              {"type"        "sh:ValidationReport",
-                               "sh:conforms" false,
-                               "sh:result"
-                               [{"sh:constraintComponent" "sh:uniqueLang",
-                                 "sh:focusNode"           "ex:a",
-                                 "sh:resultSeverity"      "sh:Violation",
-                                 "sh:value"               false,
-                                 "sh:resultPath"          ["ex:label"],
-                                 "type"                   "sh:ValidationResult",
-                                 "sh:resultMessage"       "values [\"bar\" \"foo\"] do not have unique language tags",
-                                 "sh:sourceShape"         test-utils/blank-node-id?,
-                                 "f:expectation"          true}]}}
+            (is (= {:status 422,
+                    :error  :shacl/violation,
+                    :report
+                    {"type"        "sh:ValidationReport",
+                     "sh:conforms" false,
+                     "sh:result"
+                     [{"sh:constraintComponent" "sh:uniqueLang",
+                       "sh:focusNode"           "ex:a",
+                       "sh:resultSeverity"      "sh:Violation",
+                       "sh:value"               false,
+                       "sh:resultPath"          ["ex:label"],
+                       "type"                   "sh:ValidationResult",
+                       "sh:resultMessage"       "values [\"bar\" \"foo\"] do not have unique language tags",
+                       "sh:sourceShape"         "ex:pshape1",
+                       "f:expectation"          true}]}}
                    (ex-data db2)))))))))
 
 (deftest ^:integration shacl-multiple-properties-test
@@ -1481,21 +1511,21 @@ WORLD!")
                               :type         :ex/User
                               :schema/age   40
                               :schema/email "john@example.org"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:sh/constraintComponent :sh/minCount,
-                               :type                   :sh/ValidationResult,
-                               :sh/resultMessage       "count 0 is less than minimum count of 1",
-                               :sh/resultPath          [:schema/name],
-                               :f/expectation          1,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/value               0,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/focusNode           :ex/john}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:sh/constraintComponent :sh/minCount,
+                     :type                   :sh/ValidationResult,
+                     :sh/resultMessage       "count 0 is less than minimum count of 1",
+                     :sh/resultPath          [:schema/name],
+                     :f/expectation          1,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/value               0,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/focusNode           :ex/john}]}}
                  (ex-data db-no-name)))))
       (testing "cardinality constraint violated"
         (let [db-two-names @(fluree/stage
@@ -1507,21 +1537,21 @@ WORLD!")
                                 :schema/name  ["John" "Billy"]
                                 :schema/age   40
                                 :schema/email "john@example.org"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:sh/constraintComponent :sh/maxCount,
-                               :type                   :sh/ValidationResult,
-                               :sh/resultMessage       "count 2 is greater than maximum count of 1",
-                               :sh/resultPath          [:schema/name],
-                               :f/expectation          1,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/value               2,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/focusNode           :ex/john}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:sh/constraintComponent :sh/maxCount,
+                     :type                   :sh/ValidationResult,
+                     :sh/resultMessage       "count 2 is greater than maximum count of 1",
+                     :sh/resultPath          [:schema/name],
+                     :f/expectation          1,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/value               2,
+                     :sh/sourceShape         :ex/shape1,
+                     :sh/focusNode           :ex/john}]}}
                  (ex-data db-two-names)))))
       (testing "max constraint violated"
         (let [db-too-old @(fluree/stage
@@ -1533,21 +1563,21 @@ WORLD!")
                               :schema/name  "John"
                               :schema/age   140
                               :schema/email "john@example.org"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:sh/constraintComponent :sh/maxInclusive,
-                               :type                   :sh/ValidationResult,
-                               :sh/resultMessage       "value 140 is greater than inclusive maximum 130",
-                               :sh/resultPath          [:schema/age],
-                               :f/expectation          130,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/value               140,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/focusNode           :ex/john}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:sh/constraintComponent :sh/maxInclusive,
+                     :type                   :sh/ValidationResult,
+                     :sh/resultMessage       "value 140 is greater than inclusive maximum 130",
+                     :sh/resultPath          [:schema/age],
+                     :f/expectation          130,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/value               140,
+                     :sh/sourceShape         "_:fdb-3",
+                     :sh/focusNode           :ex/john}]}}
                  (ex-data db-too-old)))))
       (testing "second cardinality constraint violated"
         (let [db-two-ages @(fluree/stage
@@ -1559,21 +1589,21 @@ WORLD!")
                                :schema/name  "John"
                                :schema/age   [40 21]
                                :schema/email "john@example.org"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:sh/constraintComponent :sh/maxCount,
-                               :type                   :sh/ValidationResult,
-                               :sh/resultMessage       "count 2 is greater than maximum count of 1",
-                               :sh/resultPath          [:schema/age],
-                               :f/expectation          1,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/value               2,
-                               :sh/sourceShape         test-utils/blank-node-id?,
-                               :sh/focusNode           :ex/john}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:sh/constraintComponent :sh/maxCount,
+                     :type                   :sh/ValidationResult,
+                     :sh/resultMessage       "count 2 is greater than maximum count of 1",
+                     :sh/resultPath          [:schema/age],
+                     :f/expectation          1,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/value               2,
+                     :sh/sourceShape         "_:fdb-3",
+                     :sh/focusNode           :ex/john}]}}
                  (ex-data db-two-ages)))))
       (testing "datatype constraint violated"
         (let [db-num-email @(fluree/stage
@@ -1585,19 +1615,19 @@ WORLD!")
                                 :schema/name  "John"
                                 :schema/age   40
                                 :schema/email 42}})]
-          (is (pred-match? {:error  :shacl/violation
-                            :report {:sh/conforms false
-                                     :sh/result   [{:f/expectation          :xsd/string
-                                                    :sh/constraintComponent :sh/datatype
-                                                    :sh/focusNode           :ex/john
-                                                    :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42"
-                                                    :sh/resultPath          [:schema/email]
-                                                    :sh/resultSeverity      :sh/Violation
-                                                    :sh/sourceShape         test-utils/blank-node-id?
-                                                    :sh/value               [:xsd/integer]
-                                                    :type                   :sh/ValidationResult}]
-                                     :type        :sh/ValidationReport}
-                            :status 422}
+          (is (= {:error  :shacl/violation
+                  :report {:sh/conforms false
+                           :sh/result   [{:f/expectation          :xsd/string
+                                          :sh/constraintComponent :sh/datatype
+                                          :sh/focusNode           :ex/john
+                                          :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42"
+                                          :sh/resultPath          [:schema/email]
+                                          :sh/resultSeverity      :sh/Violation
+                                          :sh/sourceShape         "_:fdb-4"
+                                          :sh/value               [:xsd/integer]
+                                          :type                   :sh/ValidationResult}]
+                           :type        :sh/ValidationReport}
+                  :status 422}
                  (ex-data db-num-email))))))))
 
 (deftest ^:integration property-paths
@@ -1611,7 +1641,8 @@ WORLD!")
                                              "insert"   {"@type"          "sh:NodeShape"
                                                          "id"             "ex:ParentShape"
                                                          "sh:targetClass" {"@id" "ex:Parent"}
-                                                         "sh:property"    [{"sh:path"     {"sh:inversePath" {"id" "ex:parent"}}
+                                                         "sh:property"    [{"id" "ex:pshape1"
+                                                                            "sh:path"     {"sh:inversePath" {"id" "ex:parent"}}
                                                                             "sh:minCount" 1}]}})
             valid-parent @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                              "insert"   {"id"          "ex:Luke"
@@ -1631,21 +1662,21 @@ WORLD!")
                @(fluree/query valid-parent {"@context" context
                                             "select"   {"ex:Luke" ["*" {"ex:parent" ["*"]}]}})))
 
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:minCount",
-                             "sh:focusNode"           "ex:bad-parent",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               0,
-                             "sh:resultPath"          [{"sh:inversePath" "ex:parent"}],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       "count 0 is less than minimum count of 1",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          1}]}}
+        (is (= {:status 422,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:minCount",
+                   "sh:focusNode" "ex:bad-parent",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:value" 0,
+                   "sh:resultPath" [{"sh:inversePath" "ex:parent"}],
+                   "type" "sh:ValidationResult",
+                   "sh:resultMessage" "count 0 is less than minimum count of 1",
+                   "sh:sourceShape" "ex:pshape1"
+                   "f:expectation" 1}]}}
                (ex-data invalid-pal)))))
     (testing "sequence paths"
       (let [ ;; a valid Pal is anybody who has a pal with a name
@@ -1653,7 +1684,8 @@ WORLD!")
                                             "insert"   {"@type"          "sh:NodeShape"
                                                         "sh:targetClass" {"@id" "ex:Pal"}
                                                         "sh:property"
-                                                        [{"sh:path"
+                                                        [{"id" "ex:pshape1"
+                                                          "sh:path"
                                                           {"@list" [{"id" "ex:pal"} {"id" "schema:name"}]}
                                                           "sh:minCount" 1}]}})
             valid-pal   @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
@@ -1667,109 +1699,114 @@ WORLD!")
                                                         "type"        "ex:Pal"
                                                         "schema:name" "Darth Vader"
                                                         "ex:pal"      {"ex:evil" "has no name"}}})]
-        (is (pred-match? [{"id"          "ex:good-pal"
-                           "type"        "ex:Pal"
-                           "schema:name" "J.D."
-                           "ex:pal"      (test-utils/set-matcher [{"schema:name" "Rowdy"}
-                                                                  {"schema:name" "Turk"}])}]
-                         @(fluree/query valid-pal {"@context" context
-                                                   "select"   {"ex:good-pal" ["*" {"ex:pal" ["schema:name"]}]}})))
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:minCount",
-                             "sh:focusNode"           "ex:bad-pal",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               0,
-                             "sh:resultPath"          ["ex:pal" "schema:name"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       "count 0 is less than minimum count of 1",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          1}]}}
+        (is (= {"id"          "ex:good-pal"
+                "type"        "ex:Pal"
+                "schema:name" "J.D."
+                "ex:pal"      #{{"schema:name" "Rowdy"}
+                                {"schema:name" "Turk"}}}
+               (-> @(fluree/query valid-pal {"@context" context
+                                             "select"   {"ex:good-pal" ["*" {"ex:pal" ["schema:name"]}]}})
+                   first
+                   (update "ex:pal" set))))
+        (is (= {:status 422,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:minCount",
+                   "sh:focusNode" "ex:bad-pal",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:value" 0,
+                   "sh:resultPath" ["ex:pal" "schema:name"],
+                   "type" "sh:ValidationResult",
+                   "sh:resultMessage" "count 0 is less than minimum count of 1",
+                   "sh:sourceShape" "ex:pshape1",
+                   "f:expectation" 1}]}}
                (ex-data invalid-pal)))))
     (testing "sequence paths"
-      (let [db1       @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
-                                          "insert"   [{"@type"          "sh:NodeShape"
-                                                       "sh:targetClass" {"@id" "ex:Pal"}
-                                                       "sh:property"
-                                                       [{"sh:path"
-                                                         {"@list" [{"id" "ex:pal"} {"id" "ex:name"}]}
-                                                         "sh:minCount" 1}]}]})
-            valid-pal @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
-                                          "insert"   {"id"      "ex:jd"
-                                                      "type"    "ex:Pal"
-                                                      "ex:name" "J.D."
-                                                      "ex:pal"  [{"ex:name" "Turk"}
-                                                                 {"ex:name" "Rowdy"}]}})
+      (let [db1         @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
+                                            "insert"   [{"@type"          "sh:NodeShape"
+                                                         "sh:targetClass" {"@id" "ex:Pal"}
+                                                         "sh:property"
+                                                         [{"id" "ex:pshape1"
+                                                           "sh:path"
+                                                           {"@list" [{"id" "ex:pal"} {"id" "ex:name"}]}
+                                                           "sh:minCount" 1}]}]})
+            valid-pal   @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
+                                            "insert"   {"id"      "ex:jd"
+                                                        "type"    "ex:Pal"
+                                                        "ex:name" "J.D."
+                                                        "ex:pal"  [{"ex:name" "Turk"}
+                                                                   {"ex:name" "Rowdy"}]}})
 
 
             invalid-pal @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                             "insert"   {"id"      "ex:jd"
                                                         "type"    "ex:Pal"
                                                         "ex:name" "J.D."
-                                                        "ex:pal"  [{"id"          "ex:not-pal"
+                                                        "ex:pal"  [{"id" "ex:not-pal"
                                                                     "ex:not-name" "noname"}
-                                                                   {"id"      "ex:turk"
+                                                                   {"id" "ex:turk"
                                                                     "ex:name" "Turk"}
-                                                                   {"id"      "ex:rowdy"
+                                                                   {"id" "ex:rowdy"
                                                                     "ex:name" "Rowdy"}]}})]
 
-        (is (pred-match? [{"id"      "ex:jd",
-                           "type"    "ex:Pal",
-                           "ex:name" "J.D.",
-                           "ex:pal"  (test-utils/set-matcher[{"ex:name" "Rowdy"}
-                                                             {"ex:name" "Turk"}])}]
-                         @(fluree/query valid-pal {"@context" context
-                                                   "select"   {"ex:jd" ["*" {"ex:pal" ["ex:name"]}]}})))
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:minCount",
-                             "sh:focusNode"           "ex:jd",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               0,
-                             "sh:resultPath"          ["ex:pal" "ex:name"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       "count 0 is less than minimum count of 1",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          1}]}}
+        (is (= {"id" "ex:jd",
+                "type" "ex:Pal",
+                "ex:name" "J.D.",
+                "ex:pal" [{"ex:name" "Rowdy"} {"ex:name" "Turk"}]}
+               (-> @(fluree/query valid-pal {"@context" context
+                                             "select"   {"ex:jd" ["*" {"ex:pal" ["ex:name"]}]}})
+                   (first)
+                   (update "ex:pal" #(sort-by first %)))))
+        (is (= {:status 422,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:minCount",
+                   "sh:focusNode" "ex:jd",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:value" 0,
+                   "sh:resultPath" ["ex:pal" "ex:name"],
+                   "type" "sh:ValidationResult",
+                   "sh:resultMessage" "count 0 is less than minimum count of 1",
+                   "sh:sourceShape" "ex:pshape1",
+                   "f:expectation" 1}]}}
                (ex-data invalid-pal)))))
 
     (testing "predicate-path"
-      (let [db1         @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
-                                            "insert"   [{"@type"          "sh:NodeShape"
-                                                         "sh:targetClass" {"@id" "ex:Named"}
-                                                         "sh:property"
-                                                         [{"sh:path"
-                                                           {"@list" [{"id" "ex:name"}]}
-                                                           "sh:datatype" {"id" "xsd:string"}}]}]})
-            valid-named @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
-                                            "insert"   {"id"      "ex:good-pal"
-                                                        "type"    "ex:Named"
-                                                        "ex:name" {"@value" 123
-                                                                   "@type"  "xsd:integer"}}})]
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:datatype",
-                             "sh:focusNode"           "ex:good-pal",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               ["xsd:integer"],
-                             "sh:resultPath"          ["ex:name"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"
-                             "the following values do not have expected datatype xsd:string: 123",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          "xsd:string"}]}}
+      (let [db1 @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
+                                    "insert" [{"@type" "sh:NodeShape"
+                                               "sh:targetClass" {"@id" "ex:Named"}
+                                               "sh:property"
+                                               [{"id" "ex:pshape1"
+                                                 "sh:path"
+                                                 {"@list" [{"id" "ex:name"}]}
+                                                 "sh:datatype" {"id" "xsd:string"}}]}]})
+            valid-named   @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
+                                              "insert"   {"id"      "ex:good-pal"
+                                                          "type"    "ex:Named"
+                                                          "ex:name" {"@value" 123
+                                                                     "@type" "xsd:integer"}}})]
+        (is (= {:status 422,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:datatype",
+                   "sh:focusNode" "ex:good-pal",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:value" ["xsd:integer"],
+                   "sh:resultPath" ["ex:name"],
+                   "type" "sh:ValidationResult",
+                   "sh:resultMessage"
+                   "the following values do not have expected datatype xsd:string: 123",
+                   "sh:sourceShape" "ex:pshape1",
+                   "f:expectation" "xsd:string"}]}}
                (ex-data valid-named)))))
     (testing "inverse sequence path"
       (let [ ;; a valid Princess is anybody who is the child of someone's queen
@@ -1777,7 +1814,8 @@ WORLD!")
                                                  "insert"   {"@type"          "sh:NodeShape"
                                                              "id"             "ex:PrincessShape"
                                                              "sh:targetClass" {"@id" "ex:Princess"}
-                                                             "sh:property"    [{"sh:path"
+                                                             "sh:property"    [{"id" "ex:pshape1"
+                                                                                "sh:path"
                                                                                 {"@list"
                                                                                  [{"sh:inversePath"
                                                                                    {"id" "ex:child"}}
@@ -1802,22 +1840,22 @@ WORLD!")
                @(fluree/query valid-princess {"@context" context
                                               "select"   {"ex:Mork" ["*"]}})))
 
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:minCount",
-                             "sh:focusNode"           "ex:Gerb",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               0,
-                             "sh:resultPath"
-                             [{"sh:inversePath" "ex:child"} {"sh:inversePath" "ex:queen"}],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       "count 0 is less than minimum count of 1",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          1}]}}
+        (is (= {:status 422,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:minCount",
+                   "sh:focusNode" "ex:Gerb",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:value" 0,
+                   "sh:resultPath"
+                   [{"sh:inversePath" "ex:child"} {"sh:inversePath" "ex:queen"}],
+                   "type" "sh:ValidationResult",
+                   "sh:resultMessage" "count 0 is less than minimum count of 1",
+                   "sh:sourceShape" "ex:pshape1",
+                   "f:expectation" 1}]}}
                (ex-data invalid-princess)))))))
 
 (deftest ^:integration shacl-class-test
@@ -1829,18 +1867,21 @@ WORLD!")
                                     "insert"   [{"@type"          "sh:NodeShape"
                                                  "sh:targetClass" {"@id" "https://example.com/Country"}
                                                  "sh:property"
-                                                 [{"sh:path"     {"@id" "https://example.com/name"}
+                                                 [{"id"          "ex:pshape1"
+                                                   "sh:path"     {"@id" "https://example.com/name"}
                                                    "sh:datatype" {"@id" "xsd:string"}
                                                    "sh:minCount" 1
                                                    "sh:maxCount" 1}]}
                                                 {"@type"          "sh:NodeShape"
                                                  "sh:targetClass" {"@id" "https://example.com/Actor"}
                                                  "sh:property"
-                                                 [{"sh:path"        {"@id" "https://example.com/country"}
+                                                 [{"id"             "ex:pshape2"
+                                                   "sh:path"        {"@id" "https://example.com/country"}
                                                    "sh:class"       {"@id" "https://example.com/Country"}
                                                    "sh:maxCount"    1
                                                    "sh:description" "Birth country"}
-                                                  {"sh:path"     {"@id" "https://example.com/name"}
+                                                  {"id"          "ex:pshape3"
+                                                   "sh:path"     {"@id" "https://example.com/name"}
                                                    "sh:minCount" 1
                                                    "sh:maxCount" 1
                                                    "sh:datatype" {"@id" "xsd:string"}}]}]})
@@ -1891,39 +1932,39 @@ WORLD!")
                                                  "@type"                       "https://example.com/Actor"
                                                  "https://example.com/name"    "Rindsey Rohan"}]})]
         (is (not (ex-data db3)))))
-    (is (pred-match? {:status 422,
-                      :error  :shacl/violation,
-                      :report
-                      {"type"        "sh:ValidationReport",
-                       "sh:conforms" false,
-                       "sh:result"
-                       [{"sh:constraintComponent" "sh:class",
-                         "sh:focusNode"           "https://example.com/Actor/1001",
-                         "sh:resultSeverity"      "sh:Violation",
-                         "sh:value"               ["https://example.com/FakeCountry"],
-                         "sh:resultPath"          ["https://example.com/country"],
-                         "type"                   "sh:ValidationResult",
-                         "sh:resultMessage"
-                         "missing required class https://example.com/Country",
-                         "sh:sourceShape"         test-utils/blank-node-id?,
-                         "f:expectation"          "https://example.com/Country"}]}}
+    (is (= {:status 422,
+            :error  :shacl/violation,
+            :report
+            {"type"        "sh:ValidationReport",
+             "sh:conforms" false,
+             "sh:result"
+             [{"sh:constraintComponent" "sh:class",
+               "sh:focusNode"           "https://example.com/Actor/1001",
+               "sh:resultSeverity"      "sh:Violation",
+               "sh:value"               ["https://example.com/FakeCountry"],
+               "sh:resultPath"          ["https://example.com/country"],
+               "type"                   "sh:ValidationResult",
+               "sh:resultMessage"
+               "missing required class https://example.com/Country",
+               "sh:sourceShape"         "ex:pshape2",
+               "f:expectation"          "https://example.com/Country"}]}}
            (ex-data db4)))
-    (is (pred-match? {:status 422,
-                      :error  :shacl/violation,
-                      :report
-                      {"type"        "sh:ValidationReport",
-                       "sh:conforms" false,
-                       "sh:result"
-                       [{"sh:constraintComponent" "sh:class",
-                         "sh:focusNode"           "https://example.com/Actor/8675309",
-                         "sh:resultSeverity"      "sh:Violation",
-                         "sh:value"               ["https://example.com/FakeCountry"],
-                         "sh:resultPath"          ["https://example.com/country"],
-                         "type"                   "sh:ValidationResult",
-                         "sh:resultMessage"
-                         "missing required class https://example.com/Country",
-                         "sh:sourceShape"         test-utils/blank-node-id?,
-                         "f:expectation"          "https://example.com/Country"}]}}
+    (is (= {:status 422,
+            :error  :shacl/violation,
+            :report
+            {"type"        "sh:ValidationReport",
+             "sh:conforms" false,
+             "sh:result"
+             [{"sh:constraintComponent" "sh:class",
+               "sh:focusNode"           "https://example.com/Actor/8675309",
+               "sh:resultSeverity"      "sh:Violation",
+               "sh:value"               ["https://example.com/FakeCountry"],
+               "sh:resultPath"          ["https://example.com/country"],
+               "type"                   "sh:ValidationResult",
+               "sh:resultMessage"
+               "missing required class https://example.com/Country",
+               "sh:sourceShape"         "ex:pshape2",
+               "f:expectation"          "https://example.com/Country"}]}}
            (ex-data db5)))))
 
 (deftest ^:integration shacl-in-test
@@ -1935,28 +1976,29 @@ WORLD!")
           db1     @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                       "insert"   [{"type"           ["sh:NodeShape"]
                                                    "sh:targetClass" {"id" "ex:Pony"}
-                                                   "sh:property"    [{"sh:path" {"id" "ex:color"}
+                                                   "sh:property"    [{"id" "ex:pshape1"
+                                                                      "sh:path" {"id" "ex:color"}
                                                                       "sh:in"   '("cyan" "magenta")}]}]})
           db2     @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                       "insert"   {"id"       "ex:YellowPony"
                                                   "type"     "ex:Pony"
                                                   "ex:color" "yellow"}})]
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         [{"sh:constraintComponent" "sh:in",
-                           "sh:focusNode"           "ex:YellowPony",
-                           "sh:resultSeverity"      "sh:Violation",
-                           "sh:value"               "yellow",
-                           "sh:resultPath"          ["ex:color"],
-                           "type"                   "sh:ValidationResult",
-                           "sh:resultMessage"
-                           "value \"yellow\" is not in [\"cyan\" \"magenta\"]",
-                           "sh:sourceShape"         test-utils/blank-node-id?,
-                           "f:expectation"          ["cyan" "magenta"]}]}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:in",
+                 "sh:focusNode"           "ex:YellowPony",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               "yellow",
+                 "sh:resultPath"          ["ex:color"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "value \"yellow\" is not in [\"cyan\" \"magenta\"]",
+                 "sh:sourceShape"         "ex:pshape1",
+                 "f:expectation"          ["cyan" "magenta"]}]}}
              (ex-data db2)))))
   (testing "node refs"
     (let [conn    @(fluree/connect-memory)
@@ -1966,7 +2008,8 @@ WORLD!")
           db1     @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                       "insert"   [{"type"           ["sh:NodeShape"]
                                                    "sh:targetClass" {"id" "ex:Pony"}
-                                                   "sh:property"    [{"sh:path" {"id" "ex:color"}
+                                                   "sh:property"    [{"id"      "ex:pshape1"
+                                                                      "sh:path" {"id" "ex:color"}
                                                                       "sh:in"   '({"id" "ex:Pink"}
                                                                                   {"id" "ex:Purple"})}]}]})
           db2     @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
@@ -1985,22 +2028,22 @@ WORLD!")
                                                    "type"     "ex:Pony"
                                                    "ex:color" [{"id" "ex:Pink"}
                                                                {"id" "ex:Purple"}]}]})]
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         [{"sh:constraintComponent" "sh:in",
-                           "sh:focusNode"           "ex:RainbowPony",
-                           "sh:resultSeverity"      "sh:Violation",
-                           "sh:value"               "ex:Green"
-                           "sh:resultPath"          ["ex:color"],
-                           "type"                   "sh:ValidationResult",
-                           "sh:resultMessage"
-                           "value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\"]",
-                           "sh:sourceShape"         test-utils/blank-node-id?,
-                           "f:expectation"          ["ex:Pink" "ex:Purple"]}]}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:in",
+                 "sh:focusNode"           "ex:RainbowPony",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               "ex:Green"
+                 "sh:resultPath"          ["ex:color"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\"]",
+                 "sh:sourceShape"         "ex:pshape1",
+                 "f:expectation"          ["ex:Pink" "ex:Purple"]}]}}
              (ex-data db2)))
 
       (is (not (ex-data db3)))
@@ -2021,7 +2064,8 @@ WORLD!")
           db1     @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                       "insert"   [{"type"           ["sh:NodeShape"]
                                                    "sh:targetClass" {"id" "ex:Pony"}
-                                                   "sh:property"    [{"sh:path" {"id" "ex:color"}
+                                                   "sh:property"    [{"id"      "ex:pshape1"
+                                                                      "sh:path" {"id" "ex:color"}
                                                                       "sh:in"   '({"id" "ex:Pink"}
                                                                                   {"id" "ex:Purple"}
                                                                                   "green")}]}]})
@@ -2030,22 +2074,22 @@ WORLD!")
                                                   "type"     "ex:Pony"
                                                   "ex:color" [{"id" "ex:Pink"}
                                                               {"id" "ex:Green"}]}})]
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         [{"sh:constraintComponent" "sh:in",
-                           "sh:focusNode"           "ex:RainbowPony",
-                           "sh:resultSeverity"      "sh:Violation",
-                           "sh:value"               "ex:Green",
-                           "sh:resultPath"          ["ex:color"],
-                           "type"                   "sh:ValidationResult",
-                           "sh:resultMessage"
-                           "value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\" \"green\"]",
-                           "sh:sourceShape"         test-utils/blank-node-id?,
-                           "f:expectation"          ["ex:Pink" "ex:Purple" "green"]}]}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:in",
+                 "sh:focusNode"           "ex:RainbowPony",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               "ex:Green",
+                 "sh:resultPath"          ["ex:color"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\" \"green\"]",
+                 "sh:sourceShape"         "ex:pshape1",
+                 "f:expectation"          ["ex:Pink" "ex:Purple" "green"]}]}}
              (ex-data db2))))))
 
 (deftest ^:integration shacl-targetobjectsof-test
@@ -2061,7 +2105,8 @@ WORLD!")
                                                  {"@id"                "ex:friendShape"
                                                   "type"               ["sh:NodeShape"]
                                                   "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                                  "sh:property"        [{"sh:path"     {"@id" "ex:name"}
+                                                  "sh:property"        [{"id"          "ex:pshape1"
+                                                                         "sh:path"     {"@id" "ex:name"}
                                                                          "sh:datatype" {"@id" "xsd:string"}}]}})
               db-bad-friend-name @(fluree/stage db1
                                                 {"@context" ["https://ns.flur.ee" context]
@@ -2081,7 +2126,8 @@ WORLD!")
                                             {"@id"                "ex:friendShape"
                                              "type"               ["sh:NodeShape"]
                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                             "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
+                                             "sh:property"        [{"id"          "ex:pshape1"
+                                                                    "sh:path"     {"@id" "ex:ssn"}
                                                                     "sh:maxCount" 1}]}})
               db-excess-ssn @(fluree/stage db1
                                            {"@context" ["https://ns.flur.ee" context]
@@ -2094,21 +2140,21 @@ WORLD!")
                                               "ex:ssn" ["111-11-1111"
                                                         "222-22-2222"]
                                               "type"   "ex:User"}]})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {"type"        "sh:ValidationReport",
-                             "sh:conforms" false,
-                             "sh:result"
-                             [{"sh:constraintComponent" "sh:maxCount",
-                               "sh:focusNode"           "ex:Bob",
-                               "sh:resultSeverity"      "sh:Violation",
-                               "sh:value"               2,
-                               "sh:resultPath"          ["ex:ssn"],
-                               "type"                   "sh:ValidationResult",
-                               "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                               "sh:sourceShape"         test-utils/blank-node-id?,
-                               "f:expectation"          1}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {"type"        "sh:ValidationReport",
+                   "sh:conforms" false,
+                   "sh:result"
+                   [{"sh:constraintComponent" "sh:maxCount",
+                     "sh:focusNode"           "ex:Bob",
+                     "sh:resultSeverity"      "sh:Violation",
+                     "sh:value"               2,
+                     "sh:resultPath"          ["ex:ssn"],
+                     "type"                   "sh:ValidationResult",
+                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                     "sh:sourceShape"         "ex:pshape1",
+                     "f:expectation"          1}]}}
                  (ex-data db-excess-ssn)))))
       (testing "required properties"
         (let [db1           @(fluree/stage db0
@@ -2117,7 +2163,8 @@ WORLD!")
                                             [{"@id"                "ex:friendShape"
                                               "type"               ["sh:NodeShape"]
                                               "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
+                                              "sh:property"        [{"id"          "ex:pshape1"
+                                                                     "sh:path"     {"@id" "ex:ssn"}
                                                                      "sh:minCount" 1}]}]})
               db-just-alice @(fluree/stage db1
                                            {"@context" ["https://ns.flur.ee" context]
@@ -2126,21 +2173,21 @@ WORLD!")
                                               "ex:name"   "Alice"
                                               "type"      "ex:User"
                                               "ex:friend" {"@id" "ex:Bob"}}]})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {"type"        "sh:ValidationReport",
-                             "sh:conforms" false,
-                             "sh:result"
-                             [{"sh:constraintComponent" "sh:minCount",
-                               "sh:focusNode"           "ex:Bob",
-                               "sh:resultSeverity"      "sh:Violation",
-                               "sh:value"               0,
-                               "sh:resultPath"          ["ex:ssn"],
-                               "type"                   "sh:ValidationResult",
-                               "sh:resultMessage"       "count 0 is less than minimum count of 1",
-                               "sh:sourceShape"         test-utils/blank-node-id?,
-                               "f:expectation"          1}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {"type"        "sh:ValidationReport",
+                   "sh:conforms" false,
+                   "sh:result"
+                   [{"sh:constraintComponent" "sh:minCount",
+                     "sh:focusNode"           "ex:Bob",
+                     "sh:resultSeverity"      "sh:Violation",
+                     "sh:value"               0,
+                     "sh:resultPath"          ["ex:ssn"],
+                     "type"                   "sh:ValidationResult",
+                     "sh:resultMessage"       "count 0 is less than minimum count of 1",
+                     "sh:sourceShape"         "ex:pshape1",
+                     "f:expectation"          1}]}}
                  (ex-data db-just-alice)))))
       (testing "combined with `sh:targetClass`"
         (let [db1           @(fluree/stage db0
@@ -2149,12 +2196,14 @@ WORLD!")
                                             [{"@id"            "ex:UserShape"
                                               "type"           ["sh:NodeShape"]
                                               "sh:targetClass" {"@id" "ex:User"}
-                                              "sh:property"    [{"sh:path"     {"@id" "ex:ssn"}
+                                              "sh:property"    [{"id"          "ex:pshape1"
+                                                                 "sh:path"     {"@id" "ex:ssn"}
                                                                  "sh:maxCount" 1}]}
                                              {"@id"                "ex:friendShape"
                                               "type"               ["sh:NodeShape"]
                                               "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"sh:path"     {"@id" "ex:name"}
+                                              "sh:property"        [{"id"          "ex:pshape2"
+                                                                     "sh:path"     {"@id" "ex:name"}
                                                                      "sh:maxCount" 1}]}]})
               db-bad-friend @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                                 "insert"   [{"id"        "ex:Alice"
@@ -2165,21 +2214,21 @@ WORLD!")
                                                              "ex:name" ["Bob" "Robert"]
                                                              "ex:ssn"  "111-11-1111"
                                                              "type"    "ex:User"}]})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {"type"        "sh:ValidationReport",
-                             "sh:conforms" false,
-                             "sh:result"
-                             [{"sh:constraintComponent" "sh:maxCount",
-                               "sh:focusNode"           "ex:Bob",
-                               "sh:resultSeverity"      "sh:Violation",
-                               "sh:value"               2,
-                               "sh:resultPath"          ["ex:name"],
-                               "type"                   "sh:ValidationResult",
-                               "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                               "sh:sourceShape"         test-utils/blank-node-id?,
-                               "f:expectation"          1}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {"type"        "sh:ValidationReport",
+                   "sh:conforms" false,
+                   "sh:result"
+                   [{"sh:constraintComponent" "sh:maxCount",
+                     "sh:focusNode"           "ex:Bob",
+                     "sh:resultSeverity"      "sh:Violation",
+                     "sh:value"               2,
+                     "sh:resultPath"          ["ex:name"],
+                     "type"                   "sh:ValidationResult",
+                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                     "sh:sourceShape"         "ex:pshape2",
+                     "f:expectation"          1}]}}
                  (ex-data db-bad-friend))))))
     (testing "separate txns"
       (testing "maxCount"
@@ -2189,7 +2238,8 @@ WORLD!")
                                                      [{"@id"                "ex:friendShape"
                                                        "type"               ["sh:NodeShape"]
                                                        "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                                       "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
+                                                       "sh:property"        [{"id"          "ex:pshape1"
+                                                                              "sh:path"     {"@id" "ex:ssn"}
                                                                               "sh:maxCount" 1}]}]})
               db2                    @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                                          "insert"   [{"id"     "ex:Bob"
@@ -2202,21 +2252,21 @@ WORLD!")
                                                       "type"      "ex:User"
                                                       "ex:friend" {"@id" "ex:Bob"}}})]
 
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {"type"        "sh:ValidationReport",
-                             "sh:conforms" false,
-                             "sh:result"
-                             [{"sh:constraintComponent" "sh:maxCount",
-                               "sh:focusNode"           "ex:Bob",
-                               "sh:resultSeverity"      "sh:Violation",
-                               "sh:value"               2,
-                               "sh:resultPath"          ["ex:ssn"],
-                               "type"                   "sh:ValidationResult",
-                               "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                               "sh:sourceShape"         test-utils/blank-node-id?,
-                               "f:expectation"          1}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {"type"        "sh:ValidationReport",
+                   "sh:conforms" false,
+                   "sh:result"
+                   [{"sh:constraintComponent" "sh:maxCount",
+                     "sh:focusNode"           "ex:Bob",
+                     "sh:resultSeverity"      "sh:Violation",
+                     "sh:value"               2,
+                     "sh:resultPath"          ["ex:ssn"],
+                     "type"                   "sh:ValidationResult",
+                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                     "sh:sourceShape"         "ex:pshape1",
+                     "f:expectation"          1}]}}
                  (ex-data db-db-forbidden-friend))))
         (let [db1           @(fluree/stage db0
                                            {"@context" ["https://ns.flur.ee" context]
@@ -2224,7 +2274,8 @@ WORLD!")
                                             [{"@id"                "ex:friendShape"
                                               "type"               ["sh:NodeShape"]
                                               "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"sh:path"     {"@id" "ex:ssn"}
+                                              "sh:property"        [{"id"          "ex:pshape1"
+                                                                     "sh:path"     {"@id" "ex:ssn"}
                                                                      "sh:maxCount" 1}]}]})
               db2           @(fluree/stage db1
                                            {"@context" ["https://ns.flur.ee" context]
@@ -2242,21 +2293,21 @@ WORLD!")
                                             {"id"     "ex:Bob"
                                              "ex:ssn" ["111-11-1111"
                                                        "222-22-2222"]}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {"type"        "sh:ValidationReport",
-                             "sh:conforms" false,
-                             "sh:result"
-                             [{"sh:constraintComponent" "sh:maxCount",
-                               "sh:focusNode"           "ex:Bob",
-                               "sh:resultSeverity"      "sh:Violation",
-                               "sh:value"               2,
-                               "sh:resultPath"          ["ex:ssn"],
-                               "type"                   "sh:ValidationResult",
-                               "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                               "sh:sourceShape"         test-utils/blank-node-id?,
-                               "f:expectation"          1}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {"type"        "sh:ValidationReport",
+                   "sh:conforms" false,
+                   "sh:result"
+                   [{"sh:constraintComponent" "sh:maxCount",
+                     "sh:focusNode"           "ex:Bob",
+                     "sh:resultSeverity"      "sh:Violation",
+                     "sh:value"               2,
+                     "sh:resultPath"          ["ex:ssn"],
+                     "type"                   "sh:ValidationResult",
+                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                     "sh:sourceShape"         "ex:pshape1",
+                     "f:expectation"          1}]}}
                  (ex-data db-excess-ssn)))))
       (testing "datatype"
         (let [db1 @(fluree/stage db0
@@ -2264,7 +2315,8 @@ WORLD!")
                                   "insert"   {"@id"                "ex:friendShape"
                                               "type"               ["sh:NodeShape"]
                                               "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"sh:path"     {"@id" "ex:name"}
+                                              "sh:property"        [{"id"          "ex:pshape1"
+                                                                     "sh:path"     {"@id" "ex:name"}
                                                                      "sh:datatype" {"@id" "xsd:string"}}]}})
 
               ;; need to specify type in order to avoid sh:datatype coercion
@@ -2278,22 +2330,22 @@ WORLD!")
                                                   {"id"        "ex:Alice"
                                                    "type"      "ex:User"
                                                    "ex:friend" {"@id" "ex:Bob"}}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {"type"        "sh:ValidationReport",
-                             "sh:conforms" false,
-                             "sh:result"
-                             [{"sh:constraintComponent" "sh:datatype",
-                               "sh:focusNode"           "ex:Bob",
-                               "sh:resultSeverity"      "sh:Violation",
-                               "sh:value"               ["xsd:integer"],
-                               "sh:resultPath"          ["ex:name"],
-                               "type"                   "sh:ValidationResult",
-                               "sh:resultMessage"
-                               "the following values do not have expected datatype xsd:string: 123",
-                               "sh:sourceShape"         test-utils/blank-node-id?,
-                               "f:expectation"          "xsd:string"}]}}
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {"type"        "sh:ValidationReport",
+                   "sh:conforms" false,
+                   "sh:result"
+                   [{"sh:constraintComponent" "sh:datatype",
+                     "sh:focusNode"           "ex:Bob",
+                     "sh:resultSeverity"      "sh:Violation",
+                     "sh:value"               ["xsd:integer"],
+                     "sh:resultPath"          ["ex:name"],
+                     "type"                   "sh:ValidationResult",
+                     "sh:resultMessage"
+                     "the following values do not have expected datatype xsd:string: 123",
+                     "sh:sourceShape"         "ex:pshape1",
+                     "f:expectation"          "xsd:string"}]}}
                  (ex-data db-forbidden-friend))))))))
 
 (deftest ^:integration shape-based-constraints
@@ -2306,12 +2358,14 @@ WORLD!")
           db1            @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                              "insert"   [{"id"          "ex:AddressShape"
                                                           "type"        "sh:NodeShape"
-                                                          "sh:property" [{"sh:path"     {"id" "ex:postalCode"}
+                                                          "sh:property" [{"id"          "ex:pshape1"
+                                                                          "sh:path"     {"id" "ex:postalCode"}
                                                                           "sh:maxCount" 1}]}
                                                          {"id"             "ex:PersonShape"
                                                           "type"           "sh:NodeShape"
                                                           "sh:targetClass" {"id" "ex:Person"}
-                                                          "sh:property"    [{"sh:path"     {"id" "ex:address"}
+                                                          "sh:property"    [{"id"          "ex:pshape2"
+                                                                             "sh:path"     {"id" "ex:address"}
                                                                              "sh:node"     {"id" "ex:AddressShape"}
                                                                              "sh:minCount" 1}]}]})
           valid-person   @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
@@ -2321,27 +2375,29 @@ WORLD!")
           invalid-person @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                              "insert"   {"id"         "ex:Reto"
                                                          "type"       "ex:Person"
-                                                         "ex:address" {"ex:postalCode" ["12345" "45678"]}}})]
+                                                         "ex:address" {"id"            "ex:1"
+                                                                       "ex:postalCode" ["12345" "45678"]}}})]
       (is (= [{"id"         "ex:Bob",
                "type"       "ex:Person",
                "ex:address" {"ex:postalCode" "12345"}}]
              @(fluree/query valid-person {"@context" context
                                           "select"   {"ex:Bob" ["*" {"ex:address" ["ex:postalCode"]}]}})))
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         [{"sh:constraintComponent" "sh:node",
-                           "sh:focusNode"           "ex:Reto",
-                           "sh:resultSeverity"      "sh:Violation",
-                           "sh:value"               test-utils/blank-node-id?,
-                           "sh:resultPath"          ["ex:address"],
-                           "type"                   "sh:ValidationResult",
-                           "sh:resultMessage"       string?,
-                           "sh:sourceShape"         test-utils/blank-node-id?,
-                           "f:expectation"          ["ex:AddressShape"]}]}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:node",
+                 "sh:focusNode"           "ex:Reto",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               "ex:1",
+                 "sh:resultPath"          ["ex:address"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "node ex:1 does not conform to shapes [\"ex:AddressShape\"]",
+                 "sh:sourceShape"         "ex:pshape2",
+                 "f:expectation"          ["ex:AddressShape"]}]}}
              (ex-data invalid-person)))))
 
   (testing "sh:qualifiedValueShape property shape"
@@ -2354,10 +2410,12 @@ WORLD!")
                                                        "type"           "sh:NodeShape"
                                                        "sh:targetClass" {"id" "ex:Kid"}
                                                        "sh:property"
-                                                       [{"sh:path"                {"id" "ex:parent"}
+                                                       [{"id"                     "ex:pshape1"
+                                                         "sh:path"                {"id" "ex:parent"}
                                                          "sh:minCount"            2
                                                          "sh:maxCount"            2
-                                                         "sh:qualifiedValueShape" {"sh:path"    {"id" "ex:gender"}
+                                                         "sh:qualifiedValueShape" {"id"         "ex:qshape1"
+                                                                                   "sh:path"    {"id" "ex:gender"}
                                                                                    "sh:pattern" "female"}
                                                          "sh:qualifiedMinCount"   1}]}
                                                       {"id"        "ex:Bob"
@@ -2382,21 +2440,22 @@ WORLD!")
                                            "select"   {"ex:ValidKid" ["*"]}})
                  first
                  (update "ex:parent" (partial sort-by #(get % "id"))))))
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         [{"sh:constraintComponent" "sh:qualifiedValueShape",
-                           "sh:focusNode"           "ex:InvalidKid",
-                           "sh:resultSeverity"      "sh:Violation",
-                           "sh:value"               ["ex:Bob" "ex:Zorba"],
-                           "sh:resultPath"          ["ex:parent"],
-                           "type"                   "sh:ValidationResult",
-                           "sh:resultMessage"       string?,
-                           "sh:sourceShape"         test-utils/blank-node-id?,
-                           "f:expectation"          test-utils/blank-node-id?}]}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:qualifiedValueShape",
+                 "sh:focusNode"           "ex:InvalidKid",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               ["ex:Bob" "ex:Zorba"],
+                 "sh:resultPath"          ["ex:parent"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:qshape1 less than sh:qualifiedMinCount 1 times",
+                 "sh:sourceShape"         "ex:pshape1",
+                 "f:expectation"          "ex:qshape1"}]}}
              (ex-data invalid-kid)))))
   (testing "sh:qualifiedValueShape node shape"
     (let [conn   @(fluree/connect-memory)
@@ -2409,7 +2468,8 @@ WORLD!")
                                                        "type"           "sh:NodeShape"
                                                        "sh:targetClass" {"id" "ex:Kid"}
                                                        "sh:property"
-                                                       [{"sh:path"              {"id" "ex:parent"}
+                                                       [{"id"                   "ex:pshape1"
+                                                         "sh:path"              {"id" "ex:parent"}
                                                          "sh:minCount"          2
                                                          "sh:maxCount"          2
                                                          "sh:qualifiedValueShape"
@@ -2442,22 +2502,22 @@ WORLD!")
                             {"id" "ex:Mom"}]}]
              @(fluree/query valid-kid {"@context" context
                                        "select"   {"ex:ValidKid" ["*"]}})))
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         [{"sh:constraintComponent" "sh:qualifiedValueShape",
-                           "sh:focusNode"           "ex:InvalidKid",
-                           "sh:resultSeverity"      "sh:Violation",
-                           "sh:value"               ["ex:Bob" "ex:Zorba"],
-                           "sh:resultPath"          ["ex:parent"],
-                           "type"                   "sh:ValidationResult",
-                           "sh:resultMessage"
-                           "values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:ParentShape less than sh:qualifiedMinCount 1 times",
-                           "sh:sourceShape"         test-utils/blank-node-id?,
-                           "f:expectation"          "ex:ParentShape"}]}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:qualifiedValueShape",
+                 "sh:focusNode"           "ex:InvalidKid",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               ["ex:Bob" "ex:Zorba"],
+                 "sh:resultPath"          ["ex:parent"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:ParentShape less than sh:qualifiedMinCount 1 times",
+                 "sh:sourceShape"         "ex:pshape1",
+                 "f:expectation"          "ex:ParentShape"}]}}
              (ex-data invalid-kid)))))
   (testing "sh:qualifiedValueShapesDisjoint"
     (let [conn   @(fluree/connect-memory)
@@ -2473,16 +2533,19 @@ WORLD!")
                                         "type"           "sh:NodeShape"
                                         "sh:targetClass" {"id" "ex:Hand"}
                                         "sh:property"
-                                        [{"sh:path"     {"id" "ex:digit"}
+                                        [{"id"          "ex:pshape1"
+                                          "sh:path"     {"id" "ex:digit"}
                                           "sh:maxCount" 5}
-                                         {"sh:path"                         {"id" "ex:digit"}
+                                         {"id"                              "ex:pshape2"
+                                          "sh:path"                         {"id" "ex:digit"}
                                           "sh:qualifiedValueShape"          {"id"          "ex:thumbshape"
                                                                              "sh:path"     {"id" "ex:name"}
                                                                              "sh:hasValue" "Thumb"}
                                           "sh:qualifiedMinCount"            1
                                           "sh:qualifiedMaxCount"            1
                                           "sh:qualifiedValueShapesDisjoint" true}
-                                         {"sh:path"                         {"id" "ex:digit"}
+                                         {"id"                              "ex:pshape3"
+                                          "sh:path"                         {"id" "ex:digit"}
                                           "sh:qualifiedValueShape"          {"id"          "ex:fingershape"
                                                                              "sh:path"     {"id" "ex:name"}
                                                                              "sh:hasValue" "Finger"}
@@ -2518,33 +2581,32 @@ WORLD!")
                 {"ex:name" "Thumb"}]}]
              @(fluree/query valid-hand {"@context" context
                                         "select"   {"ex:ValidHand" ["*" {"ex:digit" ["ex:name"]}]}})))
-      (is (pred-match? {:status 422,
-                        :error  :shacl/violation,
-                        :report
-                        {"type"        "sh:ValidationReport",
-                         "sh:conforms" false,
-                         "sh:result"
-                         (test-utils/set-matcher
-                           [{"sh:constraintComponent" "sh:qualifiedValueShape",
-                             "sh:focusNode"           "ex:InvalidHand",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               "ex:finger4andthumb",
-                             "sh:resultPath"          ["ex:digit"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"
-                             "value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:fingershape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          "ex:thumbshape"}
-                            {"sh:constraintComponent" "sh:qualifiedValueShape",
-                             "sh:focusNode"           "ex:InvalidHand",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               "ex:finger4andthumb",
-                             "sh:resultPath"          ["ex:digit"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"
-                             "value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:thumbshape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          "ex:fingershape"}])}}
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:qualifiedValueShape",
+                 "sh:focusNode"           "ex:InvalidHand",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               "ex:finger4andthumb",
+                 "sh:resultPath"          ["ex:digit"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:fingershape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint",
+                 "sh:sourceShape"         "ex:pshape2",
+                 "f:expectation"          "ex:thumbshape"}
+                {"sh:constraintComponent" "sh:qualifiedValueShape",
+                 "sh:focusNode"           "ex:InvalidHand",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               "ex:finger4andthumb",
+                 "sh:resultPath"          ["ex:digit"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"
+                 "value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:thumbshape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint",
+                 "sh:sourceShape"         "ex:pshape3",
+                 "f:expectation"          "ex:fingershape"}]}}
              (ex-data invalid-hand))))))
 
 (deftest ^:integration post-processing-validation
@@ -2559,7 +2621,8 @@ WORLD!")
                                                 {"@id"                "ex:friendShape"
                                                  "type"               ["sh:NodeShape"]
                                                  "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                                 "sh:property"        [{"sh:path"     {"@id" "ex:name"}
+                                                 "sh:property"        [{"id"          "ex:pshape1"
+                                                                        "sh:path"     {"@id" "ex:name"}
                                                                         "sh:datatype" {"@id" "xsd:string"}}]}})
             ;; need to specify type in order to avoid sh:datatype coercion
             db2                 @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
@@ -2572,35 +2635,37 @@ WORLD!")
                                                 {"id"        "ex:Alice"
                                                  "type"      "ex:User"
                                                  "ex:friend" {"@id" "ex:Bob"}}})]
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:datatype",
-                             "sh:focusNode"           "ex:Bob",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               ["xsd:integer"],
-                             "sh:resultPath"          ["ex:name"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"
-                             "the following values do not have expected datatype xsd:string: 123",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          "xsd:string"}]}}
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:datatype",
+                   "sh:focusNode"           "ex:Bob",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               ["xsd:integer"],
+                   "sh:resultPath"          ["ex:name"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"
+                   "the following values do not have expected datatype xsd:string: 123",
+                   "sh:sourceShape"         "ex:pshape1"
+                   "f:expectation"          "xsd:string"}]}}
                (ex-data db-forbidden-friend)))))
     (testing "shape constraints"
       (let [db1            @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                                "insert"
                                                [{"id"          "ex:CoolShape"
                                                  "type"        "sh:NodeShape"
-                                                 "sh:property" [{"sh:path"     {"id" "ex:isCool"}
+                                                 "sh:property" [{"id"          "ex:pshape1"
+                                                                 "sh:path"     {"id" "ex:isCool"}
                                                                  "sh:hasValue" true
                                                                  "sh:minCount" 1}]}
                                                 {"id"             "ex:PersonShape"
                                                  "type"           "sh:NodeShape"
                                                  "sh:targetClass" {"id" "ex:Person"}
-                                                 "sh:property"    [{"sh:path"     {"id" "ex:cool"}
+                                                 "sh:property"    [{"id"          "ex:pshape2"
+                                                                    "sh:path"     {"id" "ex:cool"}
                                                                     "sh:node"     {"id" "ex:CoolShape"}
                                                                     "sh:minCount" 1}]}]})
             valid-person   @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
@@ -2610,34 +2675,37 @@ WORLD!")
             invalid-person @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
                                                "insert"   {"id"      "ex:Reto"
                                                            "type"    "ex:Person"
-                                                           "ex:cool" {"ex:isCool" false}}})]
+                                                           "ex:cool" {"id"        "ex:1"
+                                                                      "ex:isCool" false}}})]
         (is (= [{"id"      "ex:Bob",
                  "type"    "ex:Person",
                  "ex:cool" {"ex:isCool" true}}]
                @(fluree/query valid-person {"@context" context
                                             "select"   {"ex:Bob" ["*" {"ex:cool" ["ex:isCool"]}]}})))
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:node",
-                             "sh:focusNode"           "ex:Reto",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               test-utils/blank-node-id?,
-                             "sh:resultPath"          ["ex:cool"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       string?,
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          ["ex:CoolShape"]}]}}
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:node",
+                   "sh:focusNode"           "ex:Reto",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               "ex:1",
+                   "sh:resultPath"          ["ex:cool"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"
+                   "node ex:1 does not conform to shapes [\"ex:CoolShape\"]",
+                   "sh:sourceShape"         "ex:pshape2",
+                   "f:expectation"          ["ex:CoolShape"]}]}}
                (ex-data invalid-person)))))
     (testing "extended path constraints"
       (let [db1            @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                                "insert"   {"id"             "ex:PersonShape"
                                                            "type"           "sh:NodeShape"
                                                            "sh:targetClass" {"id" "ex:Person"}
-                                                           "sh:property"    [{"sh:path"
+                                                           "sh:property"    [{"id"          "ex:pshape1"
+                                                                              "sh:path"
                                                                               {"@list" [{"id" "ex:cool"}
                                                                                         {"id" "ex:dude"}]}
                                                                               "sh:nodeKind" {"id" "sh:BlankNode"}
@@ -2656,21 +2724,21 @@ WORLD!")
                  "ex:cool" {"ex:dude" {"ex:isBlank" true}}}]
                @(fluree/query valid-person {"@context" context
                                             "select"   {"ex:Bob" ["*" {"ex:cool" [{"ex:dude" ["ex:isBlank"]}]}]}})))
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:nodeKind",
-                             "sh:focusNode"           "ex:Reto",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               "ex:Dude",
-                             "sh:resultPath"          ["ex:cool" "ex:dude"],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       "value ex:Dude is is not of kind sh:BlankNode",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          "sh:BlankNode"}]}}
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:nodeKind",
+                   "sh:focusNode"           "ex:Reto",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               "ex:Dude",
+                   "sh:resultPath"          ["ex:cool" "ex:dude"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"       "value ex:Dude is is not of kind sh:BlankNode",
+                   "sh:sourceShape"         "ex:pshape1",
+                   "f:expectation"          "sh:BlankNode"}]}}
                (ex-data invalid-person)))))))
 
 (deftest validation-report
@@ -2813,7 +2881,8 @@ WORLD!")
                                 "insert"
                                 {"type"           "sh:NodeShape"
                                  "sh:targetClass" {"@id" "ex:Alt"}
-                                 "sh:property"    [{"sh:path"     {"sh:alternativePath"
+                                 "sh:property"    [{"id"          "ex:pshape1"
+                                                    "sh:path"     {"sh:alternativePath"
                                                                    [{"@id" "ex:property1"} {"@id" "ex:property2"}]}
                                                     "sh:minCount" 2}]}})]
     (testing "constraint is satisfied when constrained by sh:alternativePath"
@@ -2831,21 +2900,21 @@ WORLD!")
                                      "type"         "ex:Alt"
                                      "ex:property1" "One"
                                      "ex:property3" "Three"}})]
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"sh:constraintComponent" "sh:minCount",
-                             "sh:focusNode"           "ex:invalid",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:value"               1,
-                             "sh:resultPath"          [{"sh:alternativePath" "ex:property1"}],
-                             "type"                   "sh:ValidationResult",
-                             "sh:resultMessage"       "count 1 is less than minimum count of 2",
-                             "sh:sourceShape"         test-utils/blank-node-id?,
-                             "f:expectation"          2}]}}
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:minCount",
+                   "sh:focusNode"           "ex:invalid",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               1,
+                   "sh:resultPath"          [{"sh:alternativePath" "ex:property1"}],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"       "count 1 is less than minimum count of 2",
+                   "sh:sourceShape"         "ex:pshape1",
+                   "f:expectation"          2}]}}
                (ex-data db2)))))))
 
 (deftest multiple-and-encumbered-targets

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -43,7 +43,7 @@
                            {:id             :ex/UserShape
                             :type           [:sh/NodeShape]
                             :sh/targetClass :ex/User
-                            :sh/property    [{:id :ex/shape1
+                            :sh/property    [{:id :ex/pshape1
                                               :sh/path     :schema/name
                                               :sh/minCount 1
                                               :sh/maxCount 1
@@ -81,13 +81,13 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/minCount,
-                     :sh/sourceShape         :ex/shape1
+                     :sh/sourceShape         :ex/pshape1
                      :sh/value               0,
                      :f/expectation          1,
                      :sh/resultMessage       "count 0 is less than minimum count of 1",
                      :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-no-names)))
-          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/minCount of shape :ex/shape1 - count 0 is less than minimum count of 1."
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/minCount of shape :ex/pshape1 - count 0 is less than minimum count of 1."
                  (ex-message db-no-names)))))
       (testing "cardinality greater than"
         (let [db-two-names @(fluree/stage
@@ -108,13 +108,13 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/maxCount,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               2,
                      :f/expectation          1,
                      :sh/resultMessage       "count 2 is greater than maximum count of 1",
                      :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-two-names)))
-          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/maxCount of shape :ex/shape1 - count 2 is greater than maximum count of 1."
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/maxCount of shape :ex/pshape1 - count 2 is greater than maximum count of 1."
                  (ex-message db-two-names))))))))
 
 (deftest ^:integration shacl-datatype-constraints
@@ -132,7 +132,7 @@
                          {:id             :ex/UserShape
                           :type           :sh/NodeShape
                           :sh/targetClass :ex/User
-                          :sh/property    [{:id          :ex/shape1
+                          :sh/property    [{:id          :ex/pshape1
                                             :sh/path     :schema/name
                                             :sh/datatype :xsd/string}]}})]
       (testing "datatype ok"
@@ -167,13 +167,13 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/datatype,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               [:xsd/integer],
                      :f/expectation          :xsd/string,
                      :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42",
                      :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-int-name)))
-          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/datatype of shape :ex/shape1 - the following values do not have expected datatype :xsd/string: 42."
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/datatype of shape :ex/pshape1 - the following values do not have expected datatype :xsd/string: 42."
                  (ex-message db-int-name)))))
       (testing "incorrect ref type"
         (let [db-bool-name @(fluree/stage
@@ -193,14 +193,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/datatype,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               [:id],
                      :f/expectation          :xsd/string,
                      :sh/resultMessage       "the following values do not have expected datatype :xsd/string: :ex/john",
                      :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-bool-name))
               "Exception, because :schema/name is a boolean and not a string.")
-          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/datatype of shape :ex/shape1 - the following values do not have expected datatype :xsd/string: :ex/john."
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/datatype of shape :ex/pshape1 - the following values do not have expected datatype :xsd/string: :ex/john."
                  (ex-message db-bool-name))))))))
 
 (deftest ^:integration shacl-closed-shape
@@ -278,7 +278,7 @@
                      {:id             :ex/EqualNamesShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:id        :ex/shape1
+                      :sh/property    [{:id        :ex/pshape1
                                         :sh/path   :schema/name
                                         :sh/equals :ex/firstName}]}})
 
@@ -301,13 +301,13 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/equals,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               ["John"],
                      :f/expectation          ["Jack"],
                      :sh/resultMessage       "path [:schema/name] values John do not equal :ex/firstName values Jack",
                      :sh/resultPath          [:schema/name]}]}}
                  (ex-data db-not-equal)))
-          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/equals of shape :ex/shape1 - path [:schema/name] values John do not equal :ex/firstName values Jack."
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/equals of shape :ex/pshape1 - path [:schema/name] values John do not equal :ex/firstName values Jack."
                  (ex-message db-not-equal)))
           (let [db-ok @(fluree/stage
                          db
@@ -330,7 +330,7 @@
                      {:id             :ex/EqualNamesShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:id        :ex/shape1
+                      :sh/property    [{:id        :ex/pshape1
                                         :sh/path   :ex/favNums
                                         :sh/equals :ex/luckyNums}]}})]
           (let [db-not-equal1 @(fluree/stage
@@ -352,13 +352,13 @@
                        :sh/resultSeverity      :sh/Violation
                        :sh/focusNode           :ex/brian,
                        :sh/constraintComponent :sh/equals,
-                       :sh/sourceShape         :ex/shape1
+                       :sh/sourceShape         :ex/pshape1
                        :sh/value               [11 17],
                        :f/expectation          [13 18],
                        :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 13, 18",
                        :sh/resultPath          [:ex/favNums]}]}}
                    (ex-data db-not-equal1)))
-            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/shape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 13, 18."
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/pshape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 13, 18."
                    (ex-message db-not-equal1))))
           (let [db-not-equal2 @(fluree/stage
                                  db
@@ -379,13 +379,13 @@
                        :sh/resultSeverity      :sh/Violation
                        :sh/focusNode           :ex/brian,
                        :sh/constraintComponent :sh/equals,
-                       :sh/sourceShape         :ex/shape1,
+                       :sh/sourceShape         :ex/pshape1,
                        :sh/value               [11 17],
                        :f/expectation          [11],
                        :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11",
                        :sh/resultPath          [:ex/favNums]}]}}
                    (ex-data db-not-equal2)))
-            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/shape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11."
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/pshape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11."
                    (ex-message db-not-equal2))))
           (let [db-not-equal3 @(fluree/stage
                                  db
@@ -406,13 +406,13 @@
                        :sh/resultSeverity      :sh/Violation
                        :sh/focusNode           :ex/brian,
                        :sh/constraintComponent :sh/equals,
-                       :sh/sourceShape         :ex/shape1,
+                       :sh/sourceShape         :ex/pshape1,
                        :sh/value               [11 17],
                        :f/expectation          [17 11 18],
                        :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17, 18",
                        :sh/resultPath          [:ex/favNums]}]}}
                    (ex-data db-not-equal3)))
-            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/shape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17, 18."
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/pshape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17, 18."
                    (ex-message db-not-equal3))))
           (let [db-not-equal4 @(fluree/stage
                                  db
@@ -433,12 +433,14 @@
                        :sh/resultSeverity      :sh/Violation
                        :sh/focusNode           :ex/brian,
                        :sh/constraintComponent :sh/equals,
-                       :sh/sourceShape         :ex/shape1
+                       :sh/sourceShape         :ex/pshape1
                        :sh/value               [11 17],
                        :f/expectation          ["17" "11"],
                        :sh/resultMessage       "path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17",
                        :sh/resultPath          [:ex/favNums]}]}}
-                   (ex-data db-not-equal4))))
+                   (ex-data db-not-equal4)))
+            (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/equals of shape :ex/pshape1 - path [:ex/favNums] values 11, 17 do not equal :ex/luckyNums values 11, 17."
+                   (ex-message db-not-equal4))))
           (let [db-ok @(fluree/stage
                          db
                          {"@context" ["https://ns.flur.ee" context]
@@ -477,7 +479,7 @@
                      {:id             :ex/DisjointShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:id          :ex/shape1
+                      :sh/property    [{:id          :ex/pshape1
                                         :sh/path     :ex/favNums
                                         :sh/disjoint :ex/luckyNums}]}})]
           (testing "disjoint values"
@@ -516,12 +518,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/brian,
                          :sh/constraintComponent :sh/disjoint,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11],
                          :f/expectation          [11],
                          :sh/resultMessage       "path [:ex/favNums] values 11 are not disjoint with :ex/luckyNums values 11",
                          :sh/resultPath          [:ex/favNums]}]}}
-                     (ex-data db-not-disjoint1)))))
+                     (ex-data db-not-disjoint1)))
+              (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/disjoint of shape :ex/pshape1 - path [:ex/favNums] values 11 are not disjoint with :ex/luckyNums values 11."
+                     (ex-message db-not-disjoint1)))))
           (testing "multiple disjoint tests"
             (let [db-not-disjoint2 @(fluree/stage
                                       db
@@ -542,13 +546,15 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/brian,
                          :sh/constraintComponent :sh/disjoint,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17 31],
                          :f/expectation          [11],
                          :sh/resultMessage       "path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11",
                          :sh/resultPath          [:ex/favNums]}]}}
                      (ex-data db-not-disjoint2))
-                  "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")))
+                  "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")
+              (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/disjoint of shape :ex/pshape1 - path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11."
+                     (ex-message db-not-disjoint2)))))
           (testing "multiple non disjoint values"
             (let [db-not-disjoint3 @(fluree/stage
                                       db
@@ -569,13 +575,15 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/brian,
                          :sh/constraintComponent :sh/disjoint,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17 31],
                          :f/expectation          [13 11 18],
                          :sh/resultMessage       "path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11, 13, 18",
                          :sh/resultPath          [:ex/favNums]}]}}
                      (ex-data db-not-disjoint3))
-                  "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")))))
+                  "Exception, because :ex/favNums is not disjoint from :ex/luckyNums")
+              (is (= "Subject :ex/brian path [:ex/favNums] violates constraint :sh/disjoint of shape :ex/pshape1 - path [:ex/favNums] values 11, 17, 31 are not disjoint with :ex/luckyNums values 11, 13, 18."
+                     (ex-message db-not-disjoint3)))))))
       (testing "lessThan"
         (let [db     @(fluree/stage
                         (fluree/db ledger)
@@ -584,7 +592,7 @@
                          {:id             :ex/LessThanShape
                           :type           :sh/NodeShape
                           :sh/targetClass :ex/User
-                          :sh/property    [{:id          :ex/shape1
+                          :sh/property    [{:id          :ex/pshape1
                                             :sh/path     :ex/p1
                                             :sh/lessThan :ex/p2}]}})
               db-ok1 @(fluree/stage
@@ -639,12 +647,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThan,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17],
                          :f/expectation          [17],
                          :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 17",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail1)))))
+                     (ex-data db-fail1)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThan of shape :ex/pshape1 - path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 17."
+                     (ex-message db-fail1)))))
           (testing "values not comparable to other values"
             (let [db-fail2 @(fluree/stage
                               db
@@ -665,12 +675,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThan,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17],
                          :f/expectation          ["19" "18"],
                          :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 18, 19",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail2)))))
+                     (ex-data db-fail2)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThan of shape :ex/pshape1 - path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 18, 19."
+                     (ex-message db-fail2)))))
           (testing "values not less than all other values"
             (let [db-fail3 @(fluree/stage
                               db
@@ -691,12 +703,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThan,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [12 17],
                          :f/expectation          [10 18],
                          :sh/resultMessage       "path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 18",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail3)))))
+                     (ex-data db-fail3)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThan of shape :ex/pshape1 - path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 18."
+                     (ex-message db-fail3)))))
           (testing "values not less than all"
             (let [db-fail4 @(fluree/stage
                               db
@@ -717,12 +731,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThan,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17],
                          :f/expectation          [12 16],
                          :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail4)))))
+                     (ex-data db-fail4)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThan of shape :ex/pshape1 - path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16."
+                     (ex-message db-fail4)))))
           (testing "not comparable with iris"
             (let [db-iris @(fluree/stage
                              db
@@ -743,12 +759,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThan,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [:ex/brian],
                          :f/expectation          [:ex/john],
                          :sh/resultMessage       "path [:ex/p1] values :ex/brian are not all comparable with :ex/p2 values :ex/john",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-iris)))))))
+                     (ex-data db-iris)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThan of shape :ex/pshape1 - path [:ex/p1] values :ex/brian are not all comparable with :ex/p2 values :ex/john."
+                     (ex-message db-iris)))))))
       (testing "lessThanOrEquals"
         (let [db @(fluree/stage
                     (fluree/db ledger)
@@ -757,7 +775,7 @@
                      {:id             :ex/LessThanOrEqualsShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:id                  :ex/shape1
+                      :sh/property    [{:id                  :ex/pshape1
                                         :sh/path             :ex/p1
                                         :sh/lessThanOrEquals :ex/p2}]}})]
           (testing "all values less than or equal"
@@ -812,12 +830,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThanOrEquals,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17],
                          :f/expectation          [10],
                          :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 10",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail1)))))
+                     (ex-data db-fail1)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThanOrEquals of shape :ex/pshape1 - path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 10."
+                     (ex-message db-fail1)))))
           (testing "all values not comparable with other values"
             (let [db-fail2 @(fluree/stage
                               db
@@ -838,12 +858,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThanOrEquals,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17],
                          :f/expectation          ["19" "17"],
                          :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 17, 19",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail2)))))
+                     (ex-data db-fail2)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThanOrEquals of shape :ex/pshape1 - path [:ex/p1] values 11, 17 are not all comparable with :ex/p2 values 17, 19."
+                     (ex-message db-fail2)))))
           (testing "all values not less than other values"
             (let [db-fail3 @(fluree/stage
                               db
@@ -864,12 +886,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThanOrEquals,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [12 17],
                          :f/expectation          [17 10],
                          :sh/resultMessage       "path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 17",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail3)))))
+                     (ex-data db-fail3)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThanOrEquals of shape :ex/pshape1 - path [:ex/p1] values 12, 17 are not all less than :ex/p2 values 10, 17."
+                     (ex-message db-fail3)))))
           (testing "all values not less than all other values"
             (let [db-fail4 @(fluree/stage
                               db
@@ -890,12 +914,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/lessThanOrEquals,
-                         :sh/sourceShape         :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               [11 17],
                          :f/expectation          [12 16],
                          :sh/resultMessage       "path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16",
                          :sh/resultPath          [:ex/p1]}]}}
-                     (ex-data db-fail4))))))))))
+                     (ex-data db-fail4)))
+              (is (= "Subject :ex/alice path [:ex/p1] violates constraint :sh/lessThanOrEquals of shape :ex/pshape1 - path [:ex/p1] values 11, 17 are not all less than :ex/p2 values 12, 16."
+                     (ex-message db-fail4))))))))))
 
 (deftest ^:integration shacl-value-range
   (testing "shacl value range constraints"
@@ -913,7 +939,7 @@
                      {:id             :ex/ExclusiveNumRangeShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:id              :ex/shape1
+                      :sh/property    [{:id              :ex/pshape1
                                         :sh/path         :schema/age
                                         :sh/minExclusive 1
                                         :sh/maxExclusive 100}]}})]
@@ -947,12 +973,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/john,
                          :sh/constraintComponent :sh/minExclusive,
-                         :sh/sourceShape         :ex/shape1,
+                         :sh/sourceShape         :ex/pshape1,
                          :sh/value               1,
                          :f/expectation          1,
                          :sh/resultMessage       "value 1 is less than exclusive minimum 1",
                          :sh/resultPath          [:schema/age]}]}}
-                     (ex-data db-too-low)))))
+                     (ex-data db-too-low)))
+              (is (= "Subject :ex/john path [:schema/age] violates constraint :sh/minExclusive of shape :ex/pshape1 - value 1 is less than exclusive minimum 1."
+                     (ex-message db-too-low)))))
           (testing "values too high"
             (let [db-too-high @(fluree/stage
                                  db
@@ -971,12 +999,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/john,
                          :sh/constraintComponent :sh/maxExclusive,
-                         :sh/sourceShape         :ex/shape1,
+                         :sh/sourceShape         :ex/pshape1,
                          :sh/value               100,
                          :f/expectation          100,
                          :sh/resultMessage       "value 100 is greater than exclusive maximum 100",
                          :sh/resultPath          [:schema/age]}]}}
-                     (ex-data db-too-high)))))))
+                     (ex-data db-too-high)))
+              (is (= "Subject :ex/john path [:schema/age] violates constraint :sh/maxExclusive of shape :ex/pshape1 - value 100 is greater than exclusive maximum 100."
+                     (ex-message db-too-high)))))))
       (testing "inclusive constraints"
         (let [db @(fluree/stage
                     (fluree/db ledger)
@@ -985,24 +1015,25 @@
                      {:id             :ex/InclusiveNumRangeShape
                       :type           :sh/NodeShape
                       :sh/targetClass :ex/User
-                      :sh/property    [{:sh/path         :schema/age
+                      :sh/property    [{:id              :ex/pshape1
+                                        :sh/path         :schema/age
                                         :sh/minInclusive 1
                                         :sh/maxInclusive 100}]}})]
           (testing "values at limit"
             (let [db-ok  @(fluree/stage
-                           db
-                           {"@context" ["https://ns.flur.ee" context]
-                            "insert"
-                            {:id         :ex/brian
-                             :type       :ex/User
-                             :schema/age 1}})
+                            db
+                            {"@context" ["https://ns.flur.ee" context]
+                             "insert"
+                             {:id         :ex/brian
+                              :type       :ex/User
+                              :schema/age 1}})
                   db-ok2 @(fluree/stage
-                                 db-ok
-                                 {"@context" ["https://ns.flur.ee" context]
-                                  "insert"
-                                  {:id         :ex/alice
-                                   :type       :ex/User
-                                   :schema/age 100}})]
+                            db-ok
+                            {"@context" ["https://ns.flur.ee" context]
+                             "insert"
+                             {:id         :ex/alice
+                              :type       :ex/User
+                              :schema/age 100}})]
               (is (= [{:id         :ex/alice
                        :type       :ex/User
                        :schema/age 100}
@@ -1012,12 +1043,12 @@
                      @(fluree/query db-ok2 user-query)))))
           (testing "values below min"
             (let [db-too-low @(fluree/stage
-                                 db
-                                 {"@context" ["https://ns.flur.ee" context]
-                                  "insert"
-                                  {:id         :ex/alice
-                                   :type       :ex/User
-                                   :schema/age 0}})]
+                                db
+                                {"@context" ["https://ns.flur.ee" context]
+                                 "insert"
+                                 {:id         :ex/alice
+                                  :type       :ex/User
+                                  :schema/age 0}})]
               (is (= {:status 422,
                       :error  :shacl/violation,
                       :report
@@ -1028,12 +1059,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/minInclusive,
-                         :sh/sourceShape :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               0,
                          :f/expectation          1,
                          :sh/resultMessage       "value 0 is less than inclusive minimum 1",
                          :sh/resultPath          [:schema/age]}]}}
-                     (ex-data db-too-low)))))
+                     (ex-data db-too-low)))
+              (is (= "Subject :ex/alice path [:schema/age] violates constraint :sh/minInclusive of shape :ex/pshape1 - value 0 is less than inclusive minimum 1."
+                     (ex-message db-too-low)))))
           (testing "values above max"
             (let [db-too-high @(fluree/stage
                                  db
@@ -1052,12 +1085,14 @@
                          :sh/resultSeverity      :sh/Violation
                          :sh/focusNode           :ex/alice,
                          :sh/constraintComponent :sh/maxInclusive,
-                         :sh/sourceShape :ex/shape1
+                         :sh/sourceShape         :ex/pshape1
                          :sh/value               101,
                          :f/expectation          100,
                          :sh/resultMessage       "value 101 is greater than inclusive maximum 100",
                          :sh/resultPath          [:schema/age]}]}}
-                     (ex-data db-too-high)))))))
+                     (ex-data db-too-high)))
+              (is (= "Subject :ex/alice path [:schema/age] violates constraint :sh/maxInclusive of shape :ex/pshape1 - value 101 is greater than inclusive maximum 100."
+                     (ex-message db-too-high)))))))
       (testing "non-numeric values"
         (let [db         @(fluree/stage
                             (fluree/db ledger)
@@ -1066,7 +1101,8 @@
                              {:id             :ex/NumRangeShape
                               :type           :sh/NodeShape
                               :sh/targetClass :ex/User
-                              :sh/property    [{:sh/path         :schema/age
+                              :sh/property    [{:id              :ex/pshape1
+                                                :sh/path         :schema/age
                                                 :sh/minExclusive 0}]}})
               db-subj-id @(fluree/stage
                             db
@@ -1092,12 +1128,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/alice,
                      :sh/constraintComponent :sh/minExclusive,
-                     :sh/sourceShape :ex/shape1
+                     :sh/sourceShape         :ex/pshape1
                      :sh/value               :ex/brian,
                      :f/expectation          0,
                      :sh/resultMessage       "value :ex/brian is less than exclusive minimum 0",
                      :sh/resultPath          [:schema/age]}]}}
                  (ex-data db-subj-id)))
+          (is (= "Subject :ex/alice path [:schema/age] violates constraint :sh/minExclusive of shape :ex/pshape1 - value :ex/brian is less than exclusive minimum 0."
+                 (ex-message db-subj-id)))
 
           (is (= {:status 422,
                   :error  :shacl/violation,
@@ -1109,12 +1147,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/alice,
                      :sh/constraintComponent :sh/minExclusive,
-                     :sh/sourceShape :ex/shape1
+                     :sh/sourceShape         :ex/pshape1
                      :sh/value               "10",
                      :f/expectation          0,
                      :sh/resultMessage       "value 10 is less than exclusive minimum 0",
                      :sh/resultPath          [:schema/age]}]}}
-                 (ex-data db-string))))))))
+                 (ex-data db-string)))
+          (is (= "Subject :ex/alice path [:schema/age] violates constraint :sh/minExclusive of shape :ex/pshape1 - value 10 is less than exclusive minimum 0."
+                 (ex-message db-string))))))))
 
 (deftest ^:integration shacl-string-length-constraints
   (testing "shacl string length constraint errors"
@@ -1131,7 +1171,8 @@
                          {:id             :ex/UserShape
                           :type           :sh/NodeShape
                           :sh/targetClass :ex/User
-                          :sh/property    [{:sh/path      :schema/name
+                          :sh/property    [{:id           :ex/pshape1
+                                            :sh/path      :schema/name
                                             :sh/minLength 4
                                             :sh/maxLength 10}]}})]
       (testing "string is correct length"
@@ -1176,12 +1217,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/al,
                      :sh/constraintComponent :sh/minLength,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               "Al",
                      :f/expectation          4,
                      :sh/resultMessage       "value \"Al\" has string length less than minimum length 4",
                      :sh/resultPath          [:schema/name]}]}}
-                 (ex-data db-too-short-str)))))
+                 (ex-data db-too-short-str)))
+          (is (= "Subject :ex/al path [:schema/name] violates constraint :sh/minLength of shape :ex/pshape1 - value \"Al\" has string length less than minimum length 4."
+                 (ex-message db-too-short-str)))))
       (testing "string is too long"
         (let [db-too-long-str @(fluree/stage
                                  db
@@ -1200,12 +1243,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/jean-claude,
                      :sh/constraintComponent :sh/maxLength,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               "Jean-Claude",
                      :f/expectation          10,
                      :sh/resultMessage       "value \"Jean-Claude\" has string length greater than maximum length 10",
                      :sh/resultPath          [:schema/name]}]}}
-                 (ex-data db-too-long-str)))))
+                 (ex-data db-too-long-str)))
+          (is (= "Subject :ex/jean-claude path [:schema/name] violates constraint :sh/maxLength of shape :ex/pshape1 - value \"Jean-Claude\" has string length greater than maximum length 10."
+                 (ex-message db-too-long-str)))))
       (testing "non-string literals are stringified"
         (let [db-too-long-non-str @(fluree/stage
                                      db
@@ -1224,12 +1269,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/maxLength,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               12345678910,
                      :f/expectation          10,
                      :sh/resultMessage       "value \"12345678910\" has string length greater than maximum length 10",
                      :sh/resultPath          [:schema/name]}]}}
-                 (ex-data db-too-long-non-str)))))
+                 (ex-data db-too-long-non-str)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/maxLength of shape :ex/pshape1 - value \"12345678910\" has string length greater than maximum length 10."
+                 (ex-message db-too-long-non-str)))))
       (testing "non-literal values violate"
         (let [db-ref-value @(fluree/stage
                               db
@@ -1248,12 +1295,14 @@
                      :sh/resultSeverity      :sh/Violation
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/maxLength,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/value               #fluree/SID [101 "ref"],
                      :f/expectation          10,
                      :sh/resultMessage       "value :ex/ref is not a literal value",
                      :sh/resultPath          [:schema/name]}]}}
-                 (ex-data db-ref-value))))))))
+                 (ex-data db-ref-value)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/maxLength of shape :ex/pshape1 - value :ex/ref is not a literal value."
+                 (ex-message db-ref-value))))))))
 
 (deftest ^:integration shacl-string-pattern-constraints
   (testing "shacl string regex constraint errors"
@@ -1328,7 +1377,12 @@ WORLD!",
 WORLD!")
                                                   " does not match pattern \"hello   (.*?)world\" with :sh/flags s, x")
                      :sh/resultPath          [:ex/greeting]}]}}
-                 (ex-data db-wrong-case-greeting)))))
+                 (ex-data db-wrong-case-greeting)))
+          (is (= (str "Subject :ex/alice path [:ex/greeting] violates constraint :sh/pattern of shape :ex/pshape1 - value "
+                      (pr-str "HELLO
+WORLD!")
+                      " does not match pattern \"hello   (.*?)world\" with :sh/flags s, x.")
+                 (ex-message db-wrong-case-greeting)))))
       (testing "stringified literal does not match pattern"
         (let [db-wrong-birth-year @(fluree/stage
                                      db
@@ -1352,7 +1406,9 @@ WORLD!")
                      :f/expectation          "(19|20)[0-9][0-9]",
                      :sh/resultMessage       "value \"1776\" does not match pattern \"(19|20)[0-9][0-9]\"",
                      :sh/resultPath          [:ex/birthYear]}]}}
-                 (ex-data db-wrong-birth-year)))))
+                 (ex-data db-wrong-birth-year)))
+          (is (= "Subject :ex/alice path [:ex/birthYear] violates constraint :sh/pattern of shape :ex/pshape2 - value \"1776\" does not match pattern \"(19|20)[0-9][0-9]\"."
+                 (ex-message db-wrong-birth-year)))))
       (testing "non-literal values automatically produce violation"
         (let [db-ref-value @(fluree/stage
                               db
@@ -1376,7 +1432,9 @@ WORLD!")
                      :f/expectation          "(19|20)[0-9][0-9]",
                      :sh/resultMessage       "value \":ex/ref\" does not match pattern \"(19|20)[0-9][0-9]\"",
                      :sh/resultPath          [:ex/birthYear]}]}}
-                 (ex-data db-ref-value))))))))
+                 (ex-data db-ref-value)))
+          (is (= "Subject :ex/john path [:ex/birthYear] violates constraint :sh/pattern of shape :ex/pshape2 - value \":ex/ref\" does not match pattern \"(19|20)[0-9][0-9]\"."
+                 (ex-message db-ref-value))))))))
 
 (deftest language-constraints
   (let [conn    @(fluree/connect-memory)
@@ -1420,7 +1478,9 @@ WORLD!")
                        "value \"foo\" does not have language tag in [\"en\" \"fr\"]",
                        "sh:sourceShape"         "ex:pshape1"
                        "f:expectation"          ["en" "fr"]}]}}
-                   (ex-data db2)))))))
+                   (ex-data db2)))
+            (is (= "Subject ex:a path [\"ex:label\"] violates constraint sh:languageIn of shape ex:pshape1 - value \"foo\" does not have language tag in [\"en\" \"fr\"]."
+                   (ex-message db2)))))))
     (testing "unique-lang"
       (let [db1 @(fluree/stage db0 {"@context" context
                                     "insert"
@@ -1458,7 +1518,9 @@ WORLD!")
                        "sh:resultMessage"       "values [\"bar\" \"foo\"] do not have unique language tags",
                        "sh:sourceShape"         "ex:pshape1",
                        "f:expectation"          true}]}}
-                   (ex-data db2)))))))))
+                   (ex-data db2)))
+            (is (= "Subject ex:a path [\"ex:label\"] violates constraint sh:uniqueLang of shape ex:pshape1 - values [\"bar\" \"foo\"] do not have unique language tags."
+                   (ex-message db2)))))))))
 
 (deftest ^:integration shacl-multiple-properties-test
   (testing "multiple properties works"
@@ -1475,16 +1537,19 @@ WORLD!")
                          {:id             :ex/UserShape
                           :type           :sh/NodeShape
                           :sh/targetClass :ex/User
-                          :sh/property    [{:sh/path     :schema/name
+                          :sh/property    [{:id          :ex/pshape1
+                                            :sh/path     :schema/name
                                             :sh/datatype :xsd/string
                                             :sh/minCount 1
                                             :sh/maxCount 1}
-                                           {:sh/path         :schema/age
+                                           {:id              :ex/pshape2
+                                            :sh/path         :schema/age
                                             :sh/minCount     1
                                             :sh/maxCount     1
                                             :sh/minInclusive 0
                                             :sh/maxInclusive 130}
-                                           {:sh/path     :schema/email
+                                           {:id          :ex/pshape3
+                                            :sh/path     :schema/email
                                             :sh/datatype :xsd/string}]}})]
       (testing "all constraints satisfied"
         (let [db-ok @(fluree/stage
@@ -1524,9 +1589,11 @@ WORLD!")
                      :f/expectation          1,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/value               0,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/focusNode           :ex/john}]}}
-                 (ex-data db-no-name)))))
+                 (ex-data db-no-name)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/minCount of shape :ex/pshape1 - count 0 is less than minimum count of 1."
+                 (ex-message db-no-name)))))
       (testing "cardinality constraint violated"
         (let [db-two-names @(fluree/stage
                               db
@@ -1550,9 +1617,11 @@ WORLD!")
                      :f/expectation          1,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/value               2,
-                     :sh/sourceShape         :ex/shape1,
+                     :sh/sourceShape         :ex/pshape1,
                      :sh/focusNode           :ex/john}]}}
-                 (ex-data db-two-names)))))
+                 (ex-data db-two-names)))
+          (is (= "Subject :ex/john path [:schema/name] violates constraint :sh/maxCount of shape :ex/pshape1 - count 2 is greater than maximum count of 1."
+                 (ex-message db-two-names)))))
       (testing "max constraint violated"
         (let [db-too-old @(fluree/stage
                             db
@@ -1576,9 +1645,11 @@ WORLD!")
                      :f/expectation          130,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/value               140,
-                     :sh/sourceShape         "_:fdb-3",
+                     :sh/sourceShape         :ex/pshape2
                      :sh/focusNode           :ex/john}]}}
-                 (ex-data db-too-old)))))
+                 (ex-data db-too-old)))
+          (is (= "Subject :ex/john path [:schema/age] violates constraint :sh/maxInclusive of shape :ex/pshape2 - value 140 is greater than inclusive maximum 130."
+                 (ex-message db-too-old)))))
       (testing "second cardinality constraint violated"
         (let [db-two-ages @(fluree/stage
                              db
@@ -1602,9 +1673,11 @@ WORLD!")
                      :f/expectation          1,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/value               2,
-                     :sh/sourceShape         "_:fdb-3",
+                     :sh/sourceShape         :ex/pshape2
                      :sh/focusNode           :ex/john}]}}
-                 (ex-data db-two-ages)))))
+                 (ex-data db-two-ages)))
+          (is (= "Subject :ex/john path [:schema/age] violates constraint :sh/maxCount of shape :ex/pshape2 - count 2 is greater than maximum count of 1."
+                 (ex-message db-two-ages)))))
       (testing "datatype constraint violated"
         (let [db-num-email @(fluree/stage
                               db
@@ -1623,12 +1696,14 @@ WORLD!")
                                           :sh/resultMessage       "the following values do not have expected datatype :xsd/string: 42"
                                           :sh/resultPath          [:schema/email]
                                           :sh/resultSeverity      :sh/Violation
-                                          :sh/sourceShape         "_:fdb-4"
+                                          :sh/sourceShape         :ex/pshape3
                                           :sh/value               [:xsd/integer]
                                           :type                   :sh/ValidationResult}]
                            :type        :sh/ValidationReport}
                   :status 422}
-                 (ex-data db-num-email))))))))
+                 (ex-data db-num-email)))
+          (is (= "Subject :ex/john path [:schema/email] violates constraint :sh/datatype of shape :ex/pshape3 - the following values do not have expected datatype :xsd/string: 42."
+                 (ex-message db-num-email))))))))
 
 (deftest ^:integration property-paths
   (let [conn    @(fluree/connect-memory)
@@ -1677,7 +1752,9 @@ WORLD!")
                    "sh:resultMessage" "count 0 is less than minimum count of 1",
                    "sh:sourceShape" "ex:pshape1"
                    "f:expectation" 1}]}}
-               (ex-data invalid-pal)))))
+               (ex-data invalid-pal)))
+        (is (= "Subject ex:bad-parent path [{\"sh:inversePath\" \"ex:parent\"}] violates constraint sh:minCount of shape ex:pshape1 - count 0 is less than minimum count of 1."
+               (ex-message invalid-pal)))))
     (testing "sequence paths"
       (let [ ;; a valid Pal is anybody who has a pal with a name
             db1         @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
@@ -1723,7 +1800,9 @@ WORLD!")
                    "sh:resultMessage" "count 0 is less than minimum count of 1",
                    "sh:sourceShape" "ex:pshape1",
                    "f:expectation" 1}]}}
-               (ex-data invalid-pal)))))
+               (ex-data invalid-pal)))
+        (is (= "Subject ex:bad-pal path [\"ex:pal\" \"schema:name\"] violates constraint sh:minCount of shape ex:pshape1 - count 0 is less than minimum count of 1."
+               (ex-message invalid-pal)))))
     (testing "sequence paths"
       (let [db1         @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                             "insert"   [{"@type"          "sh:NodeShape"
@@ -1775,7 +1854,9 @@ WORLD!")
                    "sh:resultMessage" "count 0 is less than minimum count of 1",
                    "sh:sourceShape" "ex:pshape1",
                    "f:expectation" 1}]}}
-               (ex-data invalid-pal)))))
+               (ex-data invalid-pal)))
+        (is (= "Subject ex:jd path [\"ex:pal\" \"ex:name\"] violates constraint sh:minCount of shape ex:pshape1 - count 0 is less than minimum count of 1."
+               (ex-message invalid-pal)))))
 
     (testing "predicate-path"
       (let [db1 @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
@@ -1856,7 +1937,9 @@ WORLD!")
                    "sh:resultMessage" "count 0 is less than minimum count of 1",
                    "sh:sourceShape" "ex:pshape1",
                    "f:expectation" 1}]}}
-               (ex-data invalid-princess)))))))
+               (ex-data invalid-princess)))
+        (is (= "Subject ex:Gerb path [{\"sh:inversePath\" \"ex:child\"} {\"sh:inversePath\" \"ex:queen\"}] violates constraint sh:minCount of shape ex:pshape1 - count 0 is less than minimum count of 1."
+               (ex-message invalid-princess)))))))
 
 (deftest ^:integration shacl-class-test
   (let [conn    @(fluree/connect-memory)
@@ -1949,23 +2032,28 @@ WORLD!")
                "sh:sourceShape"         "ex:pshape2",
                "f:expectation"          "https://example.com/Country"}]}}
            (ex-data db4)))
+    (is (= "Subject https://example.com/Actor/1001 path [\"https://example.com/country\"] violates constraint sh:class of shape ex:pshape2 - missing required class https://example.com/Country."
+                   (ex-message db4)))
     (is (= {:status 422,
             :error  :shacl/violation,
             :report
-            {"type"        "sh:ValidationReport",
+            {"type" "sh:ValidationReport",
              "sh:conforms" false,
              "sh:result"
              [{"sh:constraintComponent" "sh:class",
-               "sh:focusNode"           "https://example.com/Actor/8675309",
-               "sh:resultSeverity"      "sh:Violation",
-               "sh:value"               ["https://example.com/FakeCountry"],
-               "sh:resultPath"          ["https://example.com/country"],
-               "type"                   "sh:ValidationResult",
+               "sh:focusNode" "https://example.com/Actor/8675309",
+               "sh:resultSeverity" "sh:Violation",
+               "sh:value" ["https://example.com/FakeCountry"],
+               "sh:resultPath" ["https://example.com/country"],
+               "type" "sh:ValidationResult",
                "sh:resultMessage"
                "missing required class https://example.com/Country",
-               "sh:sourceShape"         "ex:pshape2",
-               "f:expectation"          "https://example.com/Country"}]}}
-           (ex-data db5)))))
+               "sh:sourceShape" "ex:pshape2",
+               "f:expectation" "https://example.com/Country"}]}}
+               (ex-data db5)))
+        (is (= "Subject https://example.com/Actor/8675309 path [\"https://example.com/country\"] violates constraint sh:class of shape ex:pshape2 - missing required class https://example.com/Country."
+               (ex-message db5)))))
+
 
 (deftest ^:integration shacl-in-test
   (testing "value nodes"
@@ -1976,7 +2064,7 @@ WORLD!")
           db1     @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                       "insert"   [{"type"           ["sh:NodeShape"]
                                                    "sh:targetClass" {"id" "ex:Pony"}
-                                                   "sh:property"    [{"id" "ex:pshape1"
+                                                   "sh:property"    [{"id"      "ex:pshape1"
                                                                       "sh:path" {"id" "ex:color"}
                                                                       "sh:in"   '("cyan" "magenta")}]}]})
           db2     @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
@@ -1999,7 +2087,9 @@ WORLD!")
                  "value \"yellow\" is not in [\"cyan\" \"magenta\"]",
                  "sh:sourceShape"         "ex:pshape1",
                  "f:expectation"          ["cyan" "magenta"]}]}}
-             (ex-data db2)))))
+             (ex-data db2)))
+      (is (= "Subject ex:YellowPony path [\"ex:color\"] violates constraint sh:in of shape ex:pshape1 - value \"yellow\" is not in [\"cyan\" \"magenta\"]."
+             (ex-message db2)))))
   (testing "node refs"
     (let [conn    @(fluree/connect-memory)
           ledger  @(fluree/create conn "shacl-in-test")
@@ -2045,6 +2135,8 @@ WORLD!")
                  "sh:sourceShape"         "ex:pshape1",
                  "f:expectation"          ["ex:Pink" "ex:Purple"]}]}}
              (ex-data db2)))
+      (is (= "Subject ex:RainbowPony path [\"ex:color\"] violates constraint sh:in of shape ex:pshape1 - value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\"]."
+             (ex-message db2)))
 
       (is (not (ex-data db3)))
       (is (= {"id"       "ex:PastelPony"
@@ -2090,7 +2182,9 @@ WORLD!")
                  "value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\" \"green\"]",
                  "sh:sourceShape"         "ex:pshape1",
                  "f:expectation"          ["ex:Pink" "ex:Purple" "green"]}]}}
-             (ex-data db2))))))
+             (ex-data db2)))
+      (is (= "Subject ex:RainbowPony path [\"ex:color\"] violates constraint sh:in of shape ex:pshape1 - value \"ex:Green\" is not in [\"ex:Pink\" \"ex:Purple\" \"green\"]."
+             (ex-message db2))))))
 
 (deftest ^:integration shacl-targetobjectsof-test
   (let [conn    @(fluree/connect-memory)
@@ -2118,6 +2212,7 @@ WORLD!")
                                                   {"id"      "ex:Bob"
                                                    "ex:name" 123
                                                    "type"    "ex:User"}]})]
+
           (is (test-utils/shacl-error? db-bad-friend-name))))
       (testing "maxCount"
         (let [db1           @(fluree/stage db0
@@ -2155,198 +2250,210 @@ WORLD!")
                      "sh:resultMessage"       "count 2 is greater than maximum count of 1",
                      "sh:sourceShape"         "ex:pshape1",
                      "f:expectation"          1}]}}
-                 (ex-data db-excess-ssn)))))
-      (testing "required properties"
-        (let [db1           @(fluree/stage db0
-                                           {"@context" ["https://ns.flur.ee" context]
-                                            "insert"
-                                            [{"@id"                "ex:friendShape"
-                                              "type"               ["sh:NodeShape"]
-                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"id"          "ex:pshape1"
-                                                                     "sh:path"     {"@id" "ex:ssn"}
-                                                                     "sh:minCount" 1}]}]})
-              db-just-alice @(fluree/stage db1
-                                           {"@context" ["https://ns.flur.ee" context]
-                                            "insert"
-                                            [{"id"        "ex:Alice"
-                                              "ex:name"   "Alice"
-                                              "type"      "ex:User"
-                                              "ex:friend" {"@id" "ex:Bob"}}]})]
-          (is (= {:status 422,
-                  :error  :shacl/violation,
-                  :report
-                  {"type"        "sh:ValidationReport",
-                   "sh:conforms" false,
-                   "sh:result"
-                   [{"sh:constraintComponent" "sh:minCount",
-                     "sh:focusNode"           "ex:Bob",
-                     "sh:resultSeverity"      "sh:Violation",
-                     "sh:value"               0,
-                     "sh:resultPath"          ["ex:ssn"],
-                     "type"                   "sh:ValidationResult",
-                     "sh:resultMessage"       "count 0 is less than minimum count of 1",
-                     "sh:sourceShape"         "ex:pshape1",
-                     "f:expectation"          1}]}}
-                 (ex-data db-just-alice)))))
-      (testing "combined with `sh:targetClass`"
-        (let [db1           @(fluree/stage db0
-                                           {"@context" ["https://ns.flur.ee" context]
-                                            "insert"
-                                            [{"@id"            "ex:UserShape"
-                                              "type"           ["sh:NodeShape"]
-                                              "sh:targetClass" {"@id" "ex:User"}
-                                              "sh:property"    [{"id"          "ex:pshape1"
+                 (ex-data db-excess-ssn)))
+          (is (= "Subject ex:Bob path [\"ex:ssn\"] violates constraint sh:maxCount of shape ex:pshape1 - count 2 is greater than maximum count of 1."
+                 (ex-message db-excess-ssn)))))
+  (testing "required properties"
+    (let [db1           @(fluree/stage db0
+                                       {"@context" ["https://ns.flur.ee" context]
+                                        "insert"
+                                        [{"@id"                "ex:friendShape"
+                                          "type"               ["sh:NodeShape"]
+                                          "sh:targetObjectsOf" {"@id" "ex:friend"}
+                                          "sh:property"        [{"id"          "ex:pshape1"
                                                                  "sh:path"     {"@id" "ex:ssn"}
-                                                                 "sh:maxCount" 1}]}
-                                             {"@id"                "ex:friendShape"
-                                              "type"               ["sh:NodeShape"]
-                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"id"          "ex:pshape2"
-                                                                     "sh:path"     {"@id" "ex:name"}
-                                                                     "sh:maxCount" 1}]}]})
-              db-bad-friend @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
-                                                "insert"   [{"id"        "ex:Alice"
-                                                             "ex:name"   "Alice"
-                                                             "type"      "ex:User"
-                                                             "ex:friend" {"@id" "ex:Bob"}}
-                                                            {"id"      "ex:Bob"
-                                                             "ex:name" ["Bob" "Robert"]
-                                                             "ex:ssn"  "111-11-1111"
-                                                             "type"    "ex:User"}]})]
-          (is (= {:status 422,
-                  :error  :shacl/violation,
-                  :report
-                  {"type"        "sh:ValidationReport",
-                   "sh:conforms" false,
-                   "sh:result"
-                   [{"sh:constraintComponent" "sh:maxCount",
-                     "sh:focusNode"           "ex:Bob",
-                     "sh:resultSeverity"      "sh:Violation",
-                     "sh:value"               2,
-                     "sh:resultPath"          ["ex:name"],
-                     "type"                   "sh:ValidationResult",
-                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                     "sh:sourceShape"         "ex:pshape2",
-                     "f:expectation"          1}]}}
-                 (ex-data db-bad-friend))))))
-    (testing "separate txns"
-      (testing "maxCount"
-        (let [db1                    @(fluree/stage db0
-                                                    {"@context" ["https://ns.flur.ee" context]
-                                                     "insert"
-                                                     [{"@id"                "ex:friendShape"
-                                                       "type"               ["sh:NodeShape"]
-                                                       "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                                       "sh:property"        [{"id"          "ex:pshape1"
-                                                                              "sh:path"     {"@id" "ex:ssn"}
-                                                                              "sh:maxCount" 1}]}]})
-              db2                    @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
-                                                         "insert"   [{"id"     "ex:Bob"
-                                                                      "ex:ssn" ["111-11-1111" "222-22-2222"]
-                                                                      "type"   "ex:User"}]})
-              db-db-forbidden-friend @(fluree/stage db2
-                                                    {"@context" ["https://ns.flur.ee" context]
-                                                     "insert"
-                                                     {"id"        "ex:Alice"
-                                                      "type"      "ex:User"
-                                                      "ex:friend" {"@id" "ex:Bob"}}})]
+                                                                 "sh:minCount" 1}]}]})
+          db-just-alice @(fluree/stage db1
+                                       {"@context" ["https://ns.flur.ee" context]
+                                        "insert"
+                                        [{"id"        "ex:Alice"
+                                          "ex:name"   "Alice"
+                                          "type"      "ex:User"
+                                          "ex:friend" {"@id" "ex:Bob"}}]})]
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:minCount",
+                 "sh:focusNode"           "ex:Bob",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               0,
+                 "sh:resultPath"          ["ex:ssn"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage" "count 0 is less than minimum count of 1",
+                 "sh:sourceShape"   "ex:pshape1",
+                 "f:expectation"    1}]}}
+             (ex-data db-just-alice)))
+      (is (= "Subject ex:Bob path [\"ex:ssn\"] violates constraint sh:minCount of shape ex:pshape1 - count 0 is less than minimum count of 1."
+             (ex-message db-just-alice)))))
+  (testing "combined with `sh:targetClass`"
+    (let [db1           @(fluree/stage db0
+                                       {"@context" ["https://ns.flur.ee" context]
+                                        "insert"
+                                        [{"@id"            "ex:UserShape"
+                                          "type"           ["sh:NodeShape"]
+                                          "sh:targetClass" {"@id" "ex:User"}
+                                          "sh:property"    [{"id"          "ex:pshape1"
+                                                             "sh:path"     {"@id" "ex:ssn"}
+                                                             "sh:maxCount" 1}]}
+                                         {"@id"                "ex:friendShape"
+                                          "type"               ["sh:NodeShape"]
+                                          "sh:targetObjectsOf" {"@id" "ex:friend"}
+                                          "sh:property"        [{"id"          "ex:pshape2"
+                                                                 "sh:path"     {"@id" "ex:name"}
+                                                                 "sh:maxCount" 1}]}]})
+          db-bad-friend @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
+                                            "insert"   [{"id"        "ex:Alice"
+                                                         "ex:name"   "Alice"
+                                                         "type"      "ex:User"
+                                                         "ex:friend" {"@id" "ex:Bob"}}
+                                                        {"id"      "ex:Bob"
+                                                         "ex:name" ["Bob" "Robert"]
+                                                         "ex:ssn"  "111-11-1111"
+                                                         "type"    "ex:User"}]})]
+      (is (= {:status 422,
+              :error  :shacl/violation,
+              :report
+              {"type"        "sh:ValidationReport",
+               "sh:conforms" false,
+               "sh:result"
+               [{"sh:constraintComponent" "sh:maxCount",
+                 "sh:focusNode"           "ex:Bob",
+                 "sh:resultSeverity"      "sh:Violation",
+                 "sh:value"               2,
+                 "sh:resultPath"          ["ex:name"],
+                 "type"                   "sh:ValidationResult",
+                 "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                 "sh:sourceShape"         "ex:pshape2",
+                 "f:expectation"          1}]}}
+             (ex-data db-bad-friend)))
+      (is (= "Subject ex:Bob path [\"ex:name\"] violates constraint sh:maxCount of shape ex:pshape2 - count 2 is greater than maximum count of 1."
+             (ex-message db-bad-friend)))))
+  (testing "separate txns"
+    (testing "maxCount"
+      (let [db1                    @(fluree/stage db0
+                                                  {"@context" ["https://ns.flur.ee" context]
+                                                   "insert"
+                                                   [{"@id"                "ex:friendShape"
+                                                     "type"               ["sh:NodeShape"]
+                                                     "sh:targetObjectsOf" {"@id" "ex:friend"}
+                                                     "sh:property"        [{"id"          "ex:pshape1"
+                                                                            "sh:path"     {"@id" "ex:ssn"}
+                                                                            "sh:maxCount" 1}]}]})
+            db2                    @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
+                                                       "insert"   [{"id"     "ex:Bob"
+                                                                    "ex:ssn" ["111-11-1111" "222-22-2222"]
+                                                                    "type"   "ex:User"}]})
+            db-db-forbidden-friend @(fluree/stage db2
+                                                  {"@context" ["https://ns.flur.ee" context]
+                                                   "insert"
+                                                   {"id"        "ex:Alice"
+                                                    "type"      "ex:User"
+                                                    "ex:friend" {"@id" "ex:Bob"}}})]
 
-          (is (= {:status 422,
-                  :error  :shacl/violation,
-                  :report
-                  {"type"        "sh:ValidationReport",
-                   "sh:conforms" false,
-                   "sh:result"
-                   [{"sh:constraintComponent" "sh:maxCount",
-                     "sh:focusNode"           "ex:Bob",
-                     "sh:resultSeverity"      "sh:Violation",
-                     "sh:value"               2,
-                     "sh:resultPath"          ["ex:ssn"],
-                     "type"                   "sh:ValidationResult",
-                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                     "sh:sourceShape"         "ex:pshape1",
-                     "f:expectation"          1}]}}
-                 (ex-data db-db-forbidden-friend))))
-        (let [db1           @(fluree/stage db0
-                                           {"@context" ["https://ns.flur.ee" context]
-                                            "insert"
-                                            [{"@id"                "ex:friendShape"
-                                              "type"               ["sh:NodeShape"]
-                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"id"          "ex:pshape1"
-                                                                     "sh:path"     {"@id" "ex:ssn"}
-                                                                     "sh:maxCount" 1}]}]})
-              db2           @(fluree/stage db1
-                                           {"@context" ["https://ns.flur.ee" context]
-                                            "insert"
-                                            [{"id"        "ex:Alice"
-                                              "ex:name"   "Alice"
-                                              "type"      "ex:User"
-                                              "ex:friend" {"@id" "ex:Bob"}}
-                                             {"id"      "ex:Bob"
-                                              "ex:name" "Bob"
-                                              "type"    "ex:User"}]})
-              db-excess-ssn @(fluree/stage db2
-                                           {"@context" ["https://ns.flur.ee" context]
-                                            "insert"
-                                            {"id"     "ex:Bob"
-                                             "ex:ssn" ["111-11-1111"
-                                                       "222-22-2222"]}})]
-          (is (= {:status 422,
-                  :error  :shacl/violation,
-                  :report
-                  {"type"        "sh:ValidationReport",
-                   "sh:conforms" false,
-                   "sh:result"
-                   [{"sh:constraintComponent" "sh:maxCount",
-                     "sh:focusNode"           "ex:Bob",
-                     "sh:resultSeverity"      "sh:Violation",
-                     "sh:value"               2,
-                     "sh:resultPath"          ["ex:ssn"],
-                     "type"                   "sh:ValidationResult",
-                     "sh:resultMessage"       "count 2 is greater than maximum count of 1",
-                     "sh:sourceShape"         "ex:pshape1",
-                     "f:expectation"          1}]}}
-                 (ex-data db-excess-ssn)))))
-      (testing "datatype"
-        (let [db1 @(fluree/stage db0
-                                 {"@context" ["https://ns.flur.ee" context]
-                                  "insert"   {"@id"                "ex:friendShape"
-                                              "type"               ["sh:NodeShape"]
-                                              "sh:targetObjectsOf" {"@id" "ex:friend"}
-                                              "sh:property"        [{"id"          "ex:pshape1"
-                                                                     "sh:path"     {"@id" "ex:name"}
-                                                                     "sh:datatype" {"@id" "xsd:string"}}]}})
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:maxCount",
+                   "sh:focusNode"           "ex:Bob",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               2,
+                   "sh:resultPath"          ["ex:ssn"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                   "sh:sourceShape"         "ex:pshape1",
+                   "f:expectation"          1}]}}
+               (ex-data db-db-forbidden-friend)))
+        (is (= "Subject ex:Bob path [\"ex:ssn\"] violates constraint sh:maxCount of shape ex:pshape1 - count 2 is greater than maximum count of 1."
+               (ex-message db-db-forbidden-friend))))
+      (let [db1           @(fluree/stage db0
+                                         {"@context" ["https://ns.flur.ee" context]
+                                          "insert"
+                                          [{"@id"                "ex:friendShape"
+                                            "type"               ["sh:NodeShape"]
+                                            "sh:targetObjectsOf" {"@id" "ex:friend"}
+                                            "sh:property"        [{"id"          "ex:pshape1"
+                                                                   "sh:path"     {"@id" "ex:ssn"}
+                                                                   "sh:maxCount" 1}]}]})
+            db2           @(fluree/stage db1
+                                         {"@context" ["https://ns.flur.ee" context]
+                                          "insert"
+                                          [{"id"        "ex:Alice"
+                                            "ex:name"   "Alice"
+                                            "type"      "ex:User"
+                                            "ex:friend" {"@id" "ex:Bob"}}
+                                           {"id"      "ex:Bob"
+                                            "ex:name" "Bob"
+                                            "type"    "ex:User"}]})
+            db-excess-ssn @(fluree/stage db2
+                                         {"@context" ["https://ns.flur.ee" context]
+                                          "insert"
+                                          {"id"     "ex:Bob"
+                                           "ex:ssn" ["111-11-1111"
+                                                     "222-22-2222"]}})]
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:maxCount",
+                   "sh:focusNode"           "ex:Bob",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               2,
+                   "sh:resultPath"          ["ex:ssn"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"       "count 2 is greater than maximum count of 1",
+                   "sh:sourceShape"         "ex:pshape1",
+                   "f:expectation"          1}]}}
+               (ex-data db-excess-ssn)))
+        (is (= "Subject ex:Bob path [\"ex:ssn\"] violates constraint sh:maxCount of shape ex:pshape1 - count 2 is greater than maximum count of 1."
+               (ex-message db-excess-ssn)))))
+    (testing "datatype"
+      (let [db1 @(fluree/stage db0
+                               {"@context" ["https://ns.flur.ee" context]
+                                "insert"   {"@id"                "ex:friendShape"
+                                            "type"               ["sh:NodeShape"]
+                                            "sh:targetObjectsOf" {"@id" "ex:friend"}
+                                            "sh:property"        [{"id"          "ex:pshape1"
+                                                                   "sh:path"     {"@id" "ex:name"}
+                                                                   "sh:datatype" {"@id" "xsd:string"}}]}})
 
-              ;; need to specify type in order to avoid sh:datatype coercion
-              db2                 @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
-                                                      "insert"   {"id"      "ex:Bob"
-                                                                  "ex:name" {"@type" "xsd:integer" "@value" 123}
-                                                                  "type"    "ex:User"}})
-              db-forbidden-friend @(fluree/stage db2
-                                                 {"@context" ["https://ns.flur.ee" context]
-                                                  "insert"
-                                                  {"id"        "ex:Alice"
-                                                   "type"      "ex:User"
-                                                   "ex:friend" {"@id" "ex:Bob"}}})]
-          (is (= {:status 422,
-                  :error  :shacl/violation,
-                  :report
-                  {"type"        "sh:ValidationReport",
-                   "sh:conforms" false,
-                   "sh:result"
-                   [{"sh:constraintComponent" "sh:datatype",
-                     "sh:focusNode"           "ex:Bob",
-                     "sh:resultSeverity"      "sh:Violation",
-                     "sh:value"               ["xsd:integer"],
-                     "sh:resultPath"          ["ex:name"],
-                     "type"                   "sh:ValidationResult",
-                     "sh:resultMessage"
-                     "the following values do not have expected datatype xsd:string: 123",
-                     "sh:sourceShape"         "ex:pshape1",
-                     "f:expectation"          "xsd:string"}]}}
-                 (ex-data db-forbidden-friend))))))))
+            ;; need to specify type in order to avoid sh:datatype coercion
+            db2                 @(fluree/stage db1 {"@context" ["https://ns.flur.ee" context]
+                                                    "insert"   {"id"      "ex:Bob"
+                                                                "ex:name" {"@type" "xsd:integer" "@value" 123}
+                                                                "type"    "ex:User"}})
+            db-forbidden-friend @(fluree/stage db2
+                                               {"@context" ["https://ns.flur.ee" context]
+                                                "insert"
+                                                {"id"        "ex:Alice"
+                                                 "type"      "ex:User"
+                                                 "ex:friend" {"@id" "ex:Bob"}}})]
+        (is (= {:status 422,
+                :error  :shacl/violation,
+                :report
+                {"type"        "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"sh:constraintComponent" "sh:datatype",
+                   "sh:focusNode"           "ex:Bob",
+                   "sh:resultSeverity"      "sh:Violation",
+                   "sh:value"               ["xsd:integer"],
+                   "sh:resultPath"          ["ex:name"],
+                   "type"                   "sh:ValidationResult",
+                   "sh:resultMessage"
+                   "the following values do not have expected datatype xsd:string: 123",
+                   "sh:sourceShape"         "ex:pshape1",
+                   "f:expectation"          "xsd:string"}]}}
+               (ex-data db-forbidden-friend)))
+        (is (= "Subject ex:Bob path [\"ex:name\"] violates constraint sh:datatype of shape ex:pshape1 - the following values do not have expected datatype xsd:string: 123."
+               (ex-message db-forbidden-friend)))))))))
 
 (deftest ^:integration shape-based-constraints
   (testing "sh:node"
@@ -2398,7 +2505,9 @@ WORLD!")
                  "node ex:1 does not conform to shapes [\"ex:AddressShape\"]",
                  "sh:sourceShape"         "ex:pshape2",
                  "f:expectation"          ["ex:AddressShape"]}]}}
-             (ex-data invalid-person)))))
+             (ex-data invalid-person)))
+      (is (= "Subject ex:Reto path [\"ex:address\"] violates constraint sh:node of shape ex:pshape2 - node ex:1 does not conform to shapes [\"ex:AddressShape\"]."
+             (ex-message invalid-person)))))
 
   (testing "sh:qualifiedValueShape property shape"
     (let [conn        @(fluree/connect-memory)
@@ -2456,7 +2565,9 @@ WORLD!")
                  "values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:qshape1 less than sh:qualifiedMinCount 1 times",
                  "sh:sourceShape"         "ex:pshape1",
                  "f:expectation"          "ex:qshape1"}]}}
-             (ex-data invalid-kid)))))
+             (ex-data invalid-kid)))
+      (is (= "Subject ex:InvalidKid path [\"ex:parent\"] violates constraint sh:qualifiedValueShape of shape ex:pshape1 - values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:qshape1 less than sh:qualifiedMinCount 1 times."
+             (ex-message invalid-kid)))))
   (testing "sh:qualifiedValueShape node shape"
     (let [conn   @(fluree/connect-memory)
           ledger @(fluree/create conn "shape-constaints")
@@ -2518,7 +2629,9 @@ WORLD!")
                  "values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:ParentShape less than sh:qualifiedMinCount 1 times",
                  "sh:sourceShape"         "ex:pshape1",
                  "f:expectation"          "ex:ParentShape"}]}}
-             (ex-data invalid-kid)))))
+             (ex-data invalid-kid)))
+      (is (= "Subject ex:InvalidKid path [\"ex:parent\"] violates constraint sh:qualifiedValueShape of shape ex:pshape1 - values [\"ex:Bob\" \"ex:Zorba\"] conformed to ex:ParentShape less than sh:qualifiedMinCount 1 times."
+             (ex-message invalid-kid)))))
   (testing "sh:qualifiedValueShapesDisjoint"
     (let [conn   @(fluree/connect-memory)
           ledger @(fluree/create conn "shape-constraints")
@@ -2569,8 +2682,7 @@ WORLD!")
                                                                    {"id" "ex:finger2" "ex:name" "Finger"}
                                                                    {"id" "ex:finger3" "ex:name" "Finger"}
                                                                    {"id"      "ex:finger4andthumb"
-                                                                    "ex:name" ["Finger" "Thumb"]}]}})
-          ]
+                                                                    "ex:name" ["Finger" "Thumb"]}]}})]
       (is (= [{"id"   "ex:ValidHand",
                "type" "ex:Hand",
                "ex:digit"
@@ -2607,7 +2719,10 @@ WORLD!")
                  "value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:thumbshape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint",
                  "sh:sourceShape"         "ex:pshape3",
                  "f:expectation"          "ex:fingershape"}]}}
-             (ex-data invalid-hand))))))
+             (ex-data invalid-hand)))
+      (is (= "Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValueShape of shape ex:pshape2 - value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:fingershape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint.
+Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValueShape of shape ex:pshape3 - value ex:finger4andthumb conformed to a sibling qualified value shape [\"ex:thumbshape\"] in violation of the sh:qualifiedValueShapesDisjoint constraint."
+             (ex-message invalid-hand))))))
 
 (deftest ^:integration post-processing-validation
   (let [conn    @(fluree/connect-memory)
@@ -2651,7 +2766,9 @@ WORLD!")
                    "the following values do not have expected datatype xsd:string: 123",
                    "sh:sourceShape"         "ex:pshape1"
                    "f:expectation"          "xsd:string"}]}}
-               (ex-data db-forbidden-friend)))))
+               (ex-data db-forbidden-friend)))
+        (is (= "Subject ex:Bob path [\"ex:name\"] violates constraint sh:datatype of shape ex:pshape1 - the following values do not have expected datatype xsd:string: 123."
+               (ex-message db-forbidden-friend)))))
     (testing "shape constraints"
       (let [db1            @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                                "insert"
@@ -2698,7 +2815,9 @@ WORLD!")
                    "node ex:1 does not conform to shapes [\"ex:CoolShape\"]",
                    "sh:sourceShape"         "ex:pshape2",
                    "f:expectation"          ["ex:CoolShape"]}]}}
-               (ex-data invalid-person)))))
+               (ex-data invalid-person)))
+        (is (= "Subject ex:Reto path [\"ex:cool\"] violates constraint sh:node of shape ex:pshape2 - node ex:1 does not conform to shapes [\"ex:CoolShape\"]."
+               (ex-message invalid-person)))))
     (testing "extended path constraints"
       (let [db1            @(fluree/stage db0 {"@context" ["https://ns.flur.ee" context]
                                                "insert"   {"id"             "ex:PersonShape"
@@ -2739,7 +2858,9 @@ WORLD!")
                    "sh:resultMessage"       "value ex:Dude is is not of kind sh:BlankNode",
                    "sh:sourceShape"         "ex:pshape1",
                    "f:expectation"          "sh:BlankNode"}]}}
-               (ex-data invalid-person)))))))
+               (ex-data invalid-person)))
+        (is (= "Subject ex:Reto path [\"ex:cool\" \"ex:dude\"] violates constraint sh:nodeKind of shape ex:pshape1 - value ex:Dude is is not of kind sh:BlankNode."
+               (ex-message invalid-person)))))))
 
 (deftest validation-report
   (let [conn    @(fluree/connect-memory)
@@ -2872,55 +2993,58 @@ WORLD!")
                (:status (ex-data db2))))))))
 
 (deftest alternative-path
-  (let [conn    @(fluree/connect-memory)
-        ledger  @(fluree/create conn "validation-report")
+  (let [conn @(fluree/connect-memory)
+        ledger @(fluree/create conn "validation-report")
         context ["https://ns.flur.ee" test-utils/default-str-context {"ex" "http://example.com/ns/"}]
-        db0     (fluree/db ledger)
+        db0 (fluree/db ledger)
 
         db1 @(fluree/stage db0 {"@context" context
                                 "insert"
-                                {"type"           "sh:NodeShape"
+                                {"type" "sh:NodeShape"
                                  "sh:targetClass" {"@id" "ex:Alt"}
-                                 "sh:property"    [{"id"          "ex:pshape1"
-                                                    "sh:path"     {"sh:alternativePath"
-                                                                   [{"@id" "ex:property1"} {"@id" "ex:property2"}]}
-                                                    "sh:minCount" 2}]}})]
+                                 "sh:property" [{"id" "ex:pshape1"
+                                                 "sh:path" {"sh:alternativePath"
+                                                            [{"@id" "ex:property1"} {"@id" "ex:property2"}]}
+                                                 "sh:minCount" 2}]}})]
     (testing "constraint is satisfied when constrained by sh:alternativePath"
       (let [db2 @(fluree/stage db1 {"@context" context
                                     "insert"
-                                    {"id"           "ex:valid"
-                                     "type"         "ex:Alt"
+                                    {"id" "ex:valid"
+                                     "type" "ex:Alt"
                                      "ex:property1" "One"
                                      "ex:property2" "Two"}})]
         (is (nil? (ex-data db2)))))
     (testing "constraint is violated when constrained by sh:alternativePath"
       (let [db2 @(fluree/stage db1 {"@context" context
                                     "insert"
-                                    {"id"           "ex:invalid"
-                                     "type"         "ex:Alt"
+                                    {"id" "ex:invalid"
+                                     "type" "ex:Alt"
                                      "ex:property1" "One"
                                      "ex:property3" "Three"}})]
         (is (= {:status 422,
-                :error  :shacl/violation,
+                :error :shacl/violation,
                 :report
-                {"type"        "sh:ValidationReport",
+                {"type" "sh:ValidationReport",
                  "sh:conforms" false,
                  "sh:result"
                  [{"sh:constraintComponent" "sh:minCount",
-                   "sh:focusNode"           "ex:invalid",
-                   "sh:resultSeverity"      "sh:Violation",
-                   "sh:value"               1,
-                   "sh:resultPath"          [{"sh:alternativePath" "ex:property1"}],
-                   "type"                   "sh:ValidationResult",
-                   "sh:resultMessage"       "count 1 is less than minimum count of 2",
-                   "sh:sourceShape"         "ex:pshape1",
-                   "f:expectation"          2}]}}
-               (ex-data db2)))))))
+                   "sh:focusNode" "ex:invalid",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:value" 1,
+                   "sh:resultPath" [{"sh:alternativePath" "ex:property1"}],
+                   "type" "sh:ValidationResult",
+                   "sh:resultMessage" "count 1 is less than minimum count of 2",
+                   "sh:sourceShape" "ex:pshape1",
+                   "f:expectation" 2}]}}
+
+               (ex-data db2)))
+        (is (= "Subject ex:invalid path [{\"sh:alternativePath\" \"ex:property1\"}] violates constraint sh:minCount of shape ex:pshape1 - count 1 is less than minimum count of 2."
+               (ex-message db2)))))))
 
 (deftest multiple-and-encumbered-targets
-  (let [conn   @(fluree/connect-memory)
+  (let [conn @(fluree/connect-memory)
         ledger @(fluree/create conn "encumbered-targets")
-        db0    (fluree/db ledger)]
+        db0 (fluree/db ledger)]
     (testing "targetClass"
       (testing "with multiple targets"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.shacl.shacl-logical-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer :all]
             [fluree.db.api :as fluree]
-            [fluree.db.test-utils :as test-utils :refer [pred-match?]]))
+            [fluree.db.test-utils :as test-utils]))
 
 (deftest ^:integration shacl-not-test
   (testing "shacl basic not constraint works"
@@ -51,20 +51,22 @@
                                    :type               [:ex/User],
                                    :schema/companyName "WrongCo"
                                    :schema/callSign    "j-rock"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-company-name)))))
+          (is (= {:status 422,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-2"}]}}
+                 (ex-data db-company-name)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
+                 (ex-message db-company-name)))))
       (testing "conforms to minCount"
         (let [db-two-names @(fluree/stage
                               db
@@ -74,20 +76,22 @@
                                 :type               [:ex/User],
                                 :schema/companyName ["John", "Johnny"]
                                 :schema/callSign    "j-rock"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-two-names)))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-2"}]}}
+                 (ex-data db-two-names)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
+                 (ex-message db-two-names)))))
       (testing "conforms to equals"
         (let [db-callsign-name @(fluree/stage
                                   db
@@ -97,20 +101,22 @@
                                     :type            [:ex/User]
                                     :schema/name     "Johnny Boy"
                                     :schema/callSign "Johnny Boy"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-callsign-name)))))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-3"}]}}
+                 (ex-data db-callsign-name)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-3."
+                 (ex-message db-callsign-name)))))))
 
   (testing "shacl not w/ value ranges works"
     (let [conn       (test-utils/create-conn)
@@ -177,27 +183,30 @@
                               :schema/companyName "WrongCo"
                               :schema/callSign    "j-rock"
                               :schema/age         131}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-too-old)))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-10"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                 (ex-data db-too-old)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+                 (ex-message db-too-old)))))
       (testing "conforms to max exclusive"
         (let [db-too-low @(fluree/stage
                             db
@@ -209,43 +218,48 @@
                               :schema/callSign    "j-rock"
                               :schema/age         27
                               :schema/favNums     [4 8 15 16 23 42]}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-too-low)))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                 (ex-data db-too-low)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+                 (ex-message db-too-low)))))
       (testing "conforms to min and max exclusive"
         (let []
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-two-probs)))))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-10"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                 (ex-data db-two-probs)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+                 (ex-message db-two-probs)))))))
 
   (testing "shacl not w/ string constraints works"
     (let [conn       (test-utils/create-conn)
@@ -291,34 +305,38 @@
                                     {:id          :ex/john,
                                      :type        [:ex/User],
                                      :schema/name "John"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-name-too-short)))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                 (ex-data db-name-too-short)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
+                 (ex-message db-name-too-short)))))
       (testing "tag conforms"
         (let [db-tag-too-long @(fluree/stage
                                  db
@@ -327,34 +345,38 @@
                                   {:id     :ex/john,
                                    :type   [:ex/User],
                                    :ex/tag 12345}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-tag-too-long)))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                 (ex-data db-tag-too-long)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
+                 (ex-message db-tag-too-long)))))
       (testing "greeting conforms"
         (let [db-greeting-incorrect @(fluree/stage
                                        db
@@ -363,34 +385,38 @@
                                         {:id          :ex/john,
                                          :type        [:ex/User],
                                          :ex/greeting "hello!"}})]
-          (is (pred-match? {:status 422,
-                            :error  :shacl/violation,
-                            :report
-                            {:type        :sh/ValidationReport,
-                             :sh/conforms false,
-                             :sh/result
-                             [{:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}
-                              {:type                   :sh/ValidationResult,
-                               :sh/resultSeverity      :sh/Violation,
-                               :sh/focusNode           :ex/john,
-                               :sh/constraintComponent :sh/not,
-                               :sh/sourceShape         :ex/UserShape,
-                               :sh/value               :ex/john,
-                               :sh/resultMessage       string?}]}}
-                           (ex-data db-greeting-incorrect))))))))
+          (is (= {:status 400,
+                  :error  :shacl/violation,
+                  :report
+                  {:type        :sh/ValidationReport,
+                   :sh/conforms false,
+                   :sh/result
+                   [{:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                    {:type                   :sh/ValidationResult,
+                     :sh/resultSeverity      :sh/Violation,
+                     :sh/focusNode           :ex/john,
+                     :sh/constraintComponent :sh/not,
+                     :sh/sourceShape         :ex/UserShape,
+                     :sh/value               :ex/john,
+                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                 (ex-data db-greeting-incorrect)))
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
+                 (ex-message db-greeting-incorrect))))))))
 
 (deftest ^:integration shacl-and-tests
   (let [conn    @(fluree/connect-memory)
@@ -418,20 +444,23 @@
     (testing "conforms to only two shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
                                     "insert" {"@id" "ex:a" "ex:height" 3}})]
-        (is (pred-match? {:status 422,
-                          :error :shacl/violation,
-                          :report
-                          {"type" "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"type" "sh:ValidationResult",
-                             "sh:resultSeverity" "sh:Violation",
-                             "sh:focusNode" "ex:a",
-                             "sh:constraintComponent" "sh:and",
-                             "sh:sourceShape" "ex:andShape",
-                             "sh:value" "ex:a",
-                             "sh:resultMessage" string?}]}}
-                         (ex-data db2)))))))
+        (is (= {:status 400,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"type" "sh:ValidationResult",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:focusNode" "ex:a",
+                   "sh:constraintComponent" "sh:and",
+                   "sh:sourceShape" "ex:andShape",
+                   "sh:value" "ex:a",
+                   "sh:resultMessage"
+                   "ex:a failed to conform to all sh:and shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\" \"_:fdb-5\"]"}]}}
+               (ex-data db2)))
+        (is (= "Subject ex:a violates constraint sh:and of shape ex:andShape - ex:a failed to conform to all sh:and shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\" \"_:fdb-5\"]."
+               (ex-message db2)))))))
 
 (deftest ^:integration shacl-or-tests
   (let [conn    @(fluree/connect-memory)
@@ -440,40 +469,42 @@
         db0     (fluree/db ledger)
         db1     @(fluree/stage db0 {"@context" context
                                     "insert"
-                                    {"@id"            "ex:orShape"
-                                     "@type"          "sh:NodeShape"
+                                    {"@id" "ex:orShape"
+                                     "@type" "sh:NodeShape"
                                      "sh:targetClass" {"@id" "ex:Dimensional"}
-                                     "sh:or"          [{"sh:path"     {"@id" "ex:height"}
-                                                        "sh:minCount" 1
-                                                        "sh:datatype" {"@id" "xsd:integer"}}
-                                                       {"sh:path"     {"@id" "ex:width"}
-                                                        "sh:minCount" 1
-                                                        "sh:datatype" {"@id" "xsd:integer"}}
-                                                       {"sh:path"     {"@id" "ex:depth"}
-                                                        "sh:minCount" 1
-                                                        "sh:datatype" {"@id" "xsd:integer"}}]}})]
+                                     "sh:or" [{"sh:path" {"@id" "ex:height"}
+                                               "sh:minCount" 1
+                                               "sh:datatype" {"@id" "xsd:integer"}}
+                                              {"sh:path" {"@id" "ex:width"}
+                                               "sh:minCount" 1
+                                               "sh:datatype" {"@id" "xsd:integer"}}
+                                              {"sh:path" {"@id" "ex:depth"}
+                                               "sh:minCount" 1
+                                               "sh:datatype" {"@id" "xsd:integer"}}]}})]
     (testing "conforms to one shape"
       (let [db2 @(fluree/stage db1 {"@context" context
-                                    "insert"   {"@type" "ex:Dimensional" "ex:height" 8}})]
+                                    "insert" {"@type" "ex:Dimensional" "ex:height" 8}})]
         (is (nil? (ex-data db2)))))
 
     (testing "conforms to no shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
-                                    "insert"   {"@type" "ex:Dimensional" "ex:bigness" "yup it's big"}})]
-        (is (pred-match? {:status 422,
-                          :error  :shacl/violation,
-                          :report
-                          {"type"        "sh:ValidationReport",
-                           "sh:conforms" false,
-                           "sh:result"
-                           [{"type"                   "sh:ValidationResult",
-                             "sh:resultSeverity"      "sh:Violation",
-                             "sh:focusNode"           test-utils/blank-node-id?,
-                             "sh:constraintComponent" "sh:or",
-                             "sh:sourceShape"         "ex:orShape",
-                             "sh:value"               test-utils/blank-node-id?,
-                             "sh:resultMessage"       string?}]}}
-                         (ex-data db2)))))))
+                                    "insert" {"@type" "ex:Dimensional" "ex:bigness" "yup it's big"}})]
+        (is (= {:status 400,
+                :error :shacl/violation,
+                :report
+                {"type" "sh:ValidationReport",
+                 "sh:conforms" false,
+                 "sh:result"
+                 [{"type" "sh:ValidationResult",
+                   "sh:resultSeverity" "sh:Violation",
+                   "sh:focusNode" "_:fdb-8",
+                   "sh:constraintComponent" "sh:or",
+                   "sh:sourceShape" "ex:orShape",
+                   "sh:value" "_:fdb-8",
+                   "sh:resultMessage" "_:fdb-8 failed to conform to any of the following shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\"]"}]}}
+               (ex-data db2)))
+        (is (= "Subject _:fdb-8 violates constraint sh:or of shape ex:orShape - _:fdb-8 failed to conform to any of the following shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\"]."
+               (ex-message db2)))))))
 
 (deftest ^:integration shacl-xone-tests
   (let [conn    @(fluree/connect-memory)
@@ -504,7 +535,7 @@
     (testing "conforms to no shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
                                     "insert"   {"@id" "ex:Named" "ex:nickname" "Father G"}})]
-        (is (= {:status 422,
+        (is (= {:status 400,
                 :error :shacl/violation,
                 :report
                 {"type" "sh:ValidationReport",
@@ -517,7 +548,9 @@
                    "sh:sourceShape" "ex:orShape",
                    "sh:value" ["Father G"],
                    "sh:resultMessage" "values conformed to 0 of the following sh:xone shapes: [\"ex:one-part\" \"ex:two-parts\"]; must only conform to one"}]}}
-               (ex-data db2)))))
+               (ex-data db2)))
+        (is (= "Subject ex:Named violates constraint sh:xone of shape ex:orShape - values conformed to 0 of the following sh:xone shapes: [\"ex:one-part\" \"ex:two-parts\"]; must only conform to one."
+               (ex-message db2)))))
 
     (testing "conforms to more than one shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
@@ -525,7 +558,7 @@
                                                 "ex:fullName"  "George Washington"
                                                 "ex:firstName" "George"
                                                 "ex:lastName"  "Washington"}})]
-        (is (= {:status 422,
+        (is (= {:status 400,
                 :error :shacl/violation,
                 :report
                 {"type" "sh:ValidationReport",
@@ -538,4 +571,6 @@
                    "sh:sourceShape" "ex:orShape",
                    "sh:value" ["Washington" "George Washington" "George"],
                    "sh:resultMessage" "values conformed to 2 of the following sh:xone shapes: [\"ex:one-part\" \"ex:two-parts\"]; must only conform to one"}]}}
-               (ex-data db2)))))))
+               (ex-data db2)))
+        (is (= "Subject ex:Named violates constraint sh:xone of shape ex:orShape - values conformed to 2 of the following sh:xone shapes: [\"ex:one-part\" \"ex:two-parts\"]; must only conform to one."
+               (ex-message db2)))))))

--- a/test/fluree/db/shacl/shacl_logical_test.clj
+++ b/test/fluree/db/shacl/shacl_logical_test.clj
@@ -18,11 +18,14 @@
                          {:id             :ex/UserShape
                           :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
-                          :sh/not         [{:sh/path     :schema/companyName
+                          :sh/not         [{:id          :ex/pshape1
+                                            :sh/path     :schema/companyName
                                             :sh/minCount 1}
-                                           {:sh/path   :schema/name
+                                           {:id        :ex/pshape2
+                                            :sh/path   :schema/name
                                             :sh/equals :schema/callSign}]
-                          :sh/property    [{:sh/path     :schema/callSign
+                          :sh/property    [{:id          :ex/pshape3
+                                            :sh/path     :schema/callSign
                                             :sh/minCount 1
                                             :sh/maxCount 1
                                             :sh/datatype :xsd/string}]}})]
@@ -63,9 +66,9 @@
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-2"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}]}}
                  (ex-data db-company-name)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1."
                  (ex-message db-company-name)))))
       (testing "conforms to minCount"
         (let [db-two-names @(fluree/stage
@@ -76,7 +79,7 @@
                                 :type               [:ex/User],
                                 :schema/companyName ["John", "Johnny"]
                                 :schema/callSign    "j-rock"}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -88,9 +91,9 @@
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-2"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}]}}
                  (ex-data db-two-names)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-2."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1."
                  (ex-message db-two-names)))))
       (testing "conforms to equals"
         (let [db-callsign-name @(fluree/stage
@@ -101,7 +104,7 @@
                                     :type            [:ex/User]
                                     :schema/name     "Johnny Boy"
                                     :schema/callSign "Johnny Boy"}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -113,9 +116,9 @@
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-3"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}]}}
                  (ex-data db-callsign-name)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-3."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2."
                  (ex-message db-callsign-name)))))))
 
   (testing "shacl not w/ value ranges works"
@@ -132,16 +135,17 @@
                          {:id             :ex/UserShape
                           :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
-                          :sh/not         [{:sh/path         :schema/age
+                          :sh/not         [{:id              :ex/pshape1
+                                            :sh/path         :schema/age
                                             :sh/minInclusive 130}
-                                           {:sh/path         :schema/favNums
+                                           {:id              :ex/pshape2
+                                            :sh/path         :schema/favNums
                                             :sh/maxExclusive 9000}]
-                          :sh/property    [{:sh/path     :schema/age
+                          :sh/property    [{:id          :ex/pshape3
+                                            :sh/path     :schema/age
                                             :sh/minCount 1
                                             :sh/maxCount 1
                                             :sh/datatype :xsd/integer}]}})
-
-
 
           db-two-probs @(fluree/stage
                           db
@@ -183,7 +187,7 @@
                               :schema/companyName "WrongCo"
                               :schema/callSign    "j-rock"
                               :schema/age         131}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -195,17 +199,17 @@
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-10"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}]}}
                  (ex-data db-too-old)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2."
                  (ex-message db-too-old)))))
       (testing "conforms to max exclusive"
         (let [db-too-low @(fluree/stage
@@ -218,7 +222,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                               :schema/callSign    "j-rock"
                               :schema/age         27
                               :schema/favNums     [4 8 15 16 23 42]}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -230,13 +234,13 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}]}}
                  (ex-data db-too-low)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2."
                  (ex-message db-too-low)))))
       (testing "conforms to min and max exclusive"
         (let []
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -248,17 +252,17 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-10"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-11"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}]}}
                  (ex-data db-two-probs)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-10.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-11."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2."
                  (ex-message db-two-probs)))))))
 
   (testing "shacl not w/ string constraints works"
@@ -275,11 +279,14 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                          {:id             :ex/UserShape
                           :type           [:sh/NodeShape]
                           :sh/targetClass :ex/User
-                          :sh/not         [{:sh/path      :ex/tag
+                          :sh/not         [{:id           :ex/pshape1
+                                            :sh/path      :ex/tag
                                             :sh/minLength 4}
-                                           {:sh/path      :schema/name
+                                           {:id           :ex/pshape2
+                                            :sh/path      :schema/name
                                             :sh/maxLength 10}
-                                           {:sh/path    :ex/greeting
+                                           {:id         :ex/pshape3
+                                            :sh/path    :ex/greeting
                                             :sh/pattern "hello.*"}]}})]
       (testing "no constraint violations"
         (let [db-ok @(fluree/stage
@@ -305,7 +312,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                                     {:id          :ex/john,
                                      :type        [:ex/User],
                                      :schema/name "John"}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -317,25 +324,25 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape3"}]}}
                  (ex-data db-name-too-short)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape3."
                  (ex-message db-name-too-short)))))
       (testing "tag conforms"
         (let [db-tag-too-long @(fluree/stage
@@ -345,7 +352,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                                   {:id     :ex/john,
                                    :type   [:ex/User],
                                    :ex/tag 12345}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -357,25 +364,25 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape3"}]}}
                  (ex-data db-tag-too-long)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape3."
                  (ex-message db-tag-too-long)))))
       (testing "greeting conforms"
         (let [db-greeting-incorrect @(fluree/stage
@@ -385,7 +392,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                                         {:id          :ex/john,
                                          :type        [:ex/User],
                                          :ex/greeting "hello!"}})]
-          (is (= {:status 400,
+          (is (= {:status 422,
                   :error  :shacl/violation,
                   :report
                   {:type        :sh/ValidationReport,
@@ -397,25 +404,25 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-18"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape1"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-19"}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape2"}
                     {:type                   :sh/ValidationResult,
                      :sh/resultSeverity      :sh/Violation,
                      :sh/focusNode           :ex/john,
                      :sh/constraintComponent :sh/not,
                      :sh/sourceShape         :ex/UserShape,
                      :sh/value               :ex/john,
-                     :sh/resultMessage       ":ex/john conforms to shape _:fdb-20"}]}}
+                     :sh/resultMessage       ":ex/john conforms to shape :ex/pshape3"}]}}
                  (ex-data db-greeting-incorrect)))
-          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-18.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-19.
-Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape _:fdb-20."
+          (is (= "Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape1.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape2.
+Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john conforms to shape :ex/pshape3."
                  (ex-message db-greeting-incorrect))))))))
 
 (deftest ^:integration shacl-and-tests
@@ -428,13 +435,17 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                                     {"@id" "ex:andShape"
                                      "@type" "sh:NodeShape"
                                      "sh:targetNode" {"@id" "ex:a"}
-                                     "sh:and" [{"sh:path" {"@id" "ex:width"}
+                                     "sh:and" [{"id" "ex:pshape1"
+                                                "sh:path" {"@id" "ex:width"}
                                                 "sh:minCount" 1}
-                                               {"sh:path" {"@id" "ex:width"}
+                                               {"id" "ex:pshape2"
+                                                "sh:path" {"@id" "ex:width"}
                                                 "sh:datatype" {"@id" "xsd:integer"}}
-                                               {"sh:path" {"@id" "ex:height"}
+                                               {"id" "ex:pshape3"
+                                                "sh:path" {"@id" "ex:height"}
                                                 "sh:minCount" 1}
-                                               {"sh:path" {"@id" "ex:height"}
+                                               {"id" "ex:pshape4"
+                                                "sh:path" {"@id" "ex:height"}
                                                 "sh:datatype" {"@id" "xsd:integer"}}]}})]
     (testing "conforms to all shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
@@ -444,7 +455,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
     (testing "conforms to only two shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
                                     "insert" {"@id" "ex:a" "ex:height" 3}})]
-        (is (= {:status 400,
+        (is (= {:status 422,
                 :error :shacl/violation,
                 :report
                 {"type" "sh:ValidationReport",
@@ -457,9 +468,9 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                    "sh:sourceShape" "ex:andShape",
                    "sh:value" "ex:a",
                    "sh:resultMessage"
-                   "ex:a failed to conform to all sh:and shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\" \"_:fdb-5\"]"}]}}
+                   "ex:a failed to conform to all sh:and shapes: [\"ex:pshape1\" \"ex:pshape2\" \"ex:pshape3\" \"ex:pshape4\"]"}]}}
                (ex-data db2)))
-        (is (= "Subject ex:a violates constraint sh:and of shape ex:andShape - ex:a failed to conform to all sh:and shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\" \"_:fdb-5\"]."
+        (is (= "Subject ex:a violates constraint sh:and of shape ex:andShape - ex:a failed to conform to all sh:and shapes: [\"ex:pshape1\" \"ex:pshape2\" \"ex:pshape3\" \"ex:pshape4\"]."
                (ex-message db2)))))))
 
 (deftest ^:integration shacl-or-tests
@@ -472,24 +483,27 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                                     {"@id" "ex:orShape"
                                      "@type" "sh:NodeShape"
                                      "sh:targetClass" {"@id" "ex:Dimensional"}
-                                     "sh:or" [{"sh:path" {"@id" "ex:height"}
+                                     "sh:or" [{"id" "ex:pshape1"
+                                               "sh:path" {"@id" "ex:height"}
                                                "sh:minCount" 1
                                                "sh:datatype" {"@id" "xsd:integer"}}
-                                              {"sh:path" {"@id" "ex:width"}
+                                              {"id" "ex:pshape2"
+                                               "sh:path" {"@id" "ex:width"}
                                                "sh:minCount" 1
                                                "sh:datatype" {"@id" "xsd:integer"}}
-                                              {"sh:path" {"@id" "ex:depth"}
+                                              {"id" "ex:pshape3"
+                                               "sh:path" {"@id" "ex:depth"}
                                                "sh:minCount" 1
                                                "sh:datatype" {"@id" "xsd:integer"}}]}})]
     (testing "conforms to one shape"
       (let [db2 @(fluree/stage db1 {"@context" context
-                                    "insert" {"@type" "ex:Dimensional" "ex:height" 8}})]
+                                    "insert" {"@id" "ex:1" "@type" "ex:Dimensional" "ex:height" 8}})]
         (is (nil? (ex-data db2)))))
 
     (testing "conforms to no shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
-                                    "insert" {"@type" "ex:Dimensional" "ex:bigness" "yup it's big"}})]
-        (is (= {:status 400,
+                                    "insert" {"@id" "ex:2" "@type" "ex:Dimensional" "ex:bigness" "yup it's big"}})]
+        (is (= {:status 422,
                 :error :shacl/violation,
                 :report
                 {"type" "sh:ValidationReport",
@@ -497,13 +511,13 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                  "sh:result"
                  [{"type" "sh:ValidationResult",
                    "sh:resultSeverity" "sh:Violation",
-                   "sh:focusNode" "_:fdb-8",
+                   "sh:focusNode" "ex:2",
                    "sh:constraintComponent" "sh:or",
                    "sh:sourceShape" "ex:orShape",
-                   "sh:value" "_:fdb-8",
-                   "sh:resultMessage" "_:fdb-8 failed to conform to any of the following shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\"]"}]}}
+                   "sh:value" "ex:2",
+                   "sh:resultMessage" "ex:2 failed to conform to any of the following shapes: [\"ex:pshape1\" \"ex:pshape2\" \"ex:pshape3\"]"}]}}
                (ex-data db2)))
-        (is (= "Subject _:fdb-8 violates constraint sh:or of shape ex:orShape - _:fdb-8 failed to conform to any of the following shapes: [\"_:fdb-2\" \"_:fdb-3\" \"_:fdb-4\"]."
+        (is (= "Subject ex:2 violates constraint sh:or of shape ex:orShape - ex:2 failed to conform to any of the following shapes: [\"ex:pshape1\" \"ex:pshape2\" \"ex:pshape3\"]."
                (ex-message db2)))))))
 
 (deftest ^:integration shacl-xone-tests
@@ -535,7 +549,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
     (testing "conforms to no shapes"
       (let [db2 @(fluree/stage db1 {"@context" context
                                     "insert"   {"@id" "ex:Named" "ex:nickname" "Father G"}})]
-        (is (= {:status 400,
+        (is (= {:status 422,
                 :error :shacl/violation,
                 :report
                 {"type" "sh:ValidationReport",
@@ -558,7 +572,7 @@ Subject :ex/john violates constraint :sh/not of shape :ex/UserShape - :ex/john c
                                                 "ex:fullName"  "George Washington"
                                                 "ex:firstName" "George"
                                                 "ex:lastName"  "Washington"}})]
-        (is (= {:status 400,
+        (is (= {:status 422,
                 :error :shacl/violation,
                 :report
                 {"type" "sh:ValidationReport",


### PR DESCRIPTION
This PR does the tedious work of changing the SHACL tests to use explicit node identifiers to preserve the coverage and legibility of the tests without the brittleness of depending on either deterministic blank node ids or broad `pred-match?` style tests.