### PR TITLE
Feature/query perf

### DIFF
--- a/src/clj/fluree/db/flake.cljc
+++ b/src/clj/fluree/db/flake.cljc
@@ -471,19 +471,6 @@
   [comparator & entries]
   (apply avl/sorted-map-by comparator entries))
 
-(defn conj-all
-  "Adds all flakes in the `to-add` collection from the AVL-backed sorted flake set
-  `sorted-set`. This function uses transients for intermediate set values for
-  better performance because of the slower batched update performance of
-  AVL-backed sorted sets."
-  [ss to-add]
-  (loop [trans (transient ss)
-         add   to-add]
-    (if-let [f (first add)]
-      (recur (conj! trans f)
-             (rest add))
-      (persistent! trans))))
-
 (defn disj-all
   "Removes all flakes in the `to-remove` collection from the AVL-backed sorted
   flake set `sorted-set`. This function uses transients for intermediate set

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -78,7 +78,7 @@
 (defn add-flakes
   [leaf flakes]
   (let [new-leaf (-> leaf
-                     (update :flakes flake/conj-all flakes)
+                     (update :flakes into flakes)
                      (update :size (fn [size]
                                      (->> flakes
                                           (map flake/size-flake)
@@ -245,7 +245,7 @@
   transactions `from-t` and `to-t`."
   ([{:keys [flakes] leaf-t :t :as leaf} novelty from-t to-t]
    (let [latest       (if (> to-t leaf-t)
-                        (flake/conj-all flakes (novelty-subrange leaf to-t novelty))
+                        (into flakes (novelty-subrange leaf to-t novelty))
                         flakes)
          stale-flakes (stale-by from-t latest)
          subsequent   (filter-after to-t latest)
@@ -289,7 +289,7 @@
   "Returns a sorted set of flakes between the transactions `from-t` and `to-t`."
   [{:keys [flakes] leaf-t :t :as leaf} novelty from-t to-t]
   (let [latest       (if (> to-t leaf-t)
-                       (flake/conj-all flakes (novelty-subrange leaf to-t novelty))
+                       (into flakes (novelty-subrange leaf to-t novelty))
                        flakes)
         ;; flakes that happen after to-t
         subsequent   (filter-after to-t latest)

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -194,7 +194,7 @@
        (flake/disj-all flakes)))
 
 (defn novelty-subrange
-  [{:keys [rhs leftmost?], first-flake :first, :as _node} through-t novelty]
+  [{:keys [rhs leftmost?], first-flake :first, :as _node} through-t novelty-t novelty]
   (log/trace "novelty-subrange: first-flake:" first-flake "\nrhs:" rhs "\nleftmost?" leftmost?)
   (let [subrange (cond
                    ;; standard case: both left and right boundaries
@@ -212,7 +212,9 @@
                    ;; no boundary
                    (and (nil? rhs) leftmost?)
                    novelty)]
-    (flakes-through through-t subrange)))
+    (if (= novelty-t through-t)
+      subrange
+      (flakes-through through-t subrange))))
 
 (def meta-hash
   (comp flake/hash-meta flake/m))
@@ -243,9 +245,9 @@
 (defn t-range
   "Returns a sorted set of flakes that are not out of date between the
   transactions `from-t` and `to-t`."
-  ([{:keys [flakes] leaf-t :t :as leaf} novelty from-t to-t]
+  ([{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty from-t to-t]
    (let [latest       (if (> to-t leaf-t)
-                        (into flakes (novelty-subrange leaf to-t novelty))
+                        (into flakes (novelty-subrange leaf to-t novelty-t novelty))
                         flakes)
          stale-flakes (stale-by from-t latest)
          subsequent   (filter-after to-t latest)
@@ -253,24 +255,24 @@
      (flake/disj-all latest out-of-range))))
 
 (defn resolve-t-range
-  [resolver node novelty from-t to-t]
+  [resolver node novelty-t novelty from-t to-t]
   (go-try
     (let [resolved (<? (resolve resolver node))
-          flakes   (t-range resolved novelty from-t to-t)]
+          flakes   (t-range resolved novelty-t novelty from-t to-t)]
       (-> resolved
           (dissoc :t)
           (assoc :from-t from-t
                  :to-t   to-t
                  :flakes  flakes)))))
 
-(defrecord TRangeResolver [node-resolver novelty from-t to-t]
+(defrecord TRangeResolver [node-resolver novelty-t novelty from-t to-t]
   Resolver
   (resolve [_ node]
     (if (branch? node)
       (resolve node-resolver node)
-      (resolve-t-range node-resolver node novelty from-t to-t))))
+      (resolve-t-range node-resolver node novelty-t novelty from-t to-t))))
 
-(defrecord CachedTRangeResolver [node-resolver novelty from-t to-t cache]
+(defrecord CachedTRangeResolver [node-resolver novelty-t novelty from-t to-t cache]
   Resolver
   (resolve [_ {:keys [id tempid tt-id] :as node}]
     (if (branch? node)
@@ -279,17 +281,17 @@
         cache
         [::t-range id tempid tt-id from-t to-t]
         (fn [_]
-          (resolve-t-range node-resolver node novelty from-t to-t))))))
+          (resolve-t-range node-resolver node novelty-t novelty from-t to-t))))))
 
 (defn index-catalog->t-range-resolver
-  [{:keys [cache] :as idx-store} novelty from-t to-t]
-  (->CachedTRangeResolver idx-store novelty from-t to-t cache))
+  [{:keys [cache] :as idx-store} novelty-t novelty from-t to-t]
+  (->CachedTRangeResolver idx-store novelty-t novelty from-t to-t cache))
 
 (defn history-t-range
   "Returns a sorted set of flakes between the transactions `from-t` and `to-t`."
-  [{:keys [flakes] leaf-t :t :as leaf} novelty from-t to-t]
+  [{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty from-t to-t]
   (let [latest       (if (> to-t leaf-t)
-                       (into flakes (novelty-subrange leaf to-t novelty))
+                       (into flakes (novelty-subrange leaf to-t novelty-t novelty))
                        flakes)
         ;; flakes that happen after to-t
         subsequent   (filter-after to-t latest)
@@ -298,7 +300,7 @@
         out-of-range (concat subsequent previous)]
     (flake/disj-all latest out-of-range)))
 
-(defrecord CachedHistoryRangeResolver [node-resolver novelty from-t to-t lru-cache-atom]
+(defrecord CachedHistoryRangeResolver [node-resolver novelty-t novelty from-t to-t lru-cache-atom]
   Resolver
   (resolve [_ {:keys [id tempid tt-id] :as node}]
     (if (branch? node)
@@ -309,29 +311,12 @@
         (fn [_]
           (go-try
             (let [resolved (<? (resolve node-resolver node))
-                  flakes   (history-t-range resolved novelty from-t to-t)]
+                  flakes   (history-t-range resolved novelty-t novelty from-t to-t)]
               (-> resolved
                   (dissoc :t)
                   (assoc :from-t from-t
                          :to-t   to-t
                          :flakes  flakes)))))))))
-
-(defn at-t
-  "Find the value of `leaf` at transaction `t` by adding new flakes from
-  `idx-novelty` to `leaf` if `t` is newer than `leaf`, or removing flakes later
-  than `t` from `leaf` if `t` is older than `leaf`."
-  [{:keys [rhs leftmost? flakes], leaf-t :t, :as leaf} t idx-novelty]
-  (if (= leaf-t t)
-    leaf
-    (cond-> leaf
-      (< leaf-t t)
-      (add-flakes (novelty-subrange leaf t idx-novelty))
-
-      (> leaf-t t)
-      (rem-flakes (filter-after t flakes))
-
-      true
-      (assoc :t t))))
 
 (defn- mark-expanded
   [node]

--- a/src/clj/fluree/db/flake/index/novelty.cljc
+++ b/src/clj/fluree/db/flake/index/novelty.cljc
@@ -142,7 +142,7 @@
 (defn update-leaf
   [leaf t novelty]
   (if-let [new-flakes (-> leaf
-                          (index/novelty-subrange t novelty)
+                          (index/novelty-subrange t t novelty)
                           not-empty)]
     (let [new-leaves (-> leaf
                          (dissoc :id)
@@ -340,7 +340,7 @@
   (let [refresh-xf (comp (map preserve-id)
                          (integrate-novelty t novelty))
         novel?     (fn [node]
-                     (seq (index/novelty-subrange node t novelty)))]
+                     (seq (index/novelty-subrange node t t novelty)))]
     (->> (index/tree-chan index-catalog root novel? 1 refresh-xf error-ch)
          (write-resolved-nodes db idx changes-ch error-ch))))
 

--- a/src/clj/fluree/db/query/range.cljc
+++ b/src/clj/fluree/db/query/range.cljc
@@ -151,11 +151,11 @@
   "Returns a channel that will contain a stream of chunked flake collections that
   contain the flakes between `start-flake` and `end-flake` and are within the
   transaction range starting at `from-t` and ending at `to-t`."
-  [{:keys [index-catalog] :as db} idx error-ch
+  [{:keys [index-catalog t] :as db} idx error-ch
    {:keys [from-t to-t start-flake end-flake] :as opts}]
   (let [root      (get db idx)
         novelty   (get-in db [:novelty idx])
-        resolver  (index/index-catalog->t-range-resolver index-catalog novelty from-t to-t)
+        resolver  (index/index-catalog->t-range-resolver index-catalog t novelty from-t to-t)
         query-xf  (extract-query-flakes opts)]
     (->> (index/tree-chan resolver root start-flake end-flake any? 1 query-xf error-ch)
          (filter-authorized db error-ch))))
@@ -239,7 +239,7 @@
 
          ;; resolve-flake-slices
          {:keys [cache]} index-catalog
-         resolver        (index/->CachedHistoryRangeResolver index-catalog novelty from-t to-t cache)
+         resolver        (index/->CachedHistoryRangeResolver index-catalog t novelty from-t to-t cache)
          range-set       (flake/sorted-set-by idx-cmp start-flake end-flake)
          in-range?       (fn [node] (intersects-range? node range-set))
          query-xf        (extract-query-flakes {:idx         idx

--- a/src/clj/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/subject.cljc
@@ -36,7 +36,7 @@
                           cat
                           (map flake/s)
                           (distinct))
-        resolver    (index/index-catalog->t-range-resolver (:index-catalog conn) novelty t t)]
+        resolver    (index/index-catalog->t-range-resolver (:index-catalog conn) t novelty t t)]
     (index/tree-chan resolver idx-root first-flake last-flake any? 10 query-xf error-ch)))
 
 (defn flakes-xf


### PR DESCRIPTION
This aims to improve cold query performance by reducing work done needed to generate a cached index node for a given 't'. Once cached, query performance is fast.

There is some more to be had, but wanted to get this smaller piece out since it is ready. This achieves a ~20% improvement in speed for cold queries.

In a test with ~1 million flakes in novelty after a large transaction, a simple cold query takes 6.6 seconds, whereas the same query once cached takes 8ms. This aims to reduce the 6.6 seconds, and with the following changes the query now takes 5.2 seconds.

This should also improve new index creation by a similar amount, however I didn't test it. I also noted this improved transaction times by a small percentage.

Changes:
- novelty-t arg - `novelty-subrange` filters out any flake values later than the requested 't' - however in most cases the novelty is at the same 't' as the requested 't', in which case the filter work is unnecessary. By passing in the db's t (and therefore novelty's t) we can check if these are equal and if so, avoid doing that work. This reduces cold queries by 15%.
- flake/conj-all -> into - conj-all performed the same function as into, which also uses transients. This resulted in negligible, but tiny improvement in speed (~1 ms for larger novelty).