### PR TITLE
use subquery :values to form initial solution

### DIFF
--- a/src/clj/fluree/db/query/exec.cljc
+++ b/src/clj/fluree/db/query/exec.cljc
@@ -74,7 +74,7 @@
   search."
   [subquery]
   (fn [ds fuel-tracker error-ch]
-    (->> (execute* ds fuel-tracker subquery error-ch (go {}))
+    (->> (execute* ds fuel-tracker subquery error-ch)
          (select/subquery-format ds subquery fuel-tracker error-ch))))
 
 (defn prep-subqueries

--- a/test/fluree/db/query/subquery_test.clj
+++ b/test/fluree/db/query/subquery_test.clj
@@ -140,3 +140,17 @@
                    :order-by '[?iri ?favNums]}]
           (is (= [["Alice" 42.33333333333333] ["Cam" 7.5]]
                  @(fluree/query db qry))))))))
+
+(deftest ^:integration subquery-values
+  (testing "Subquery with inline values"
+    (let [conn   @(fluree/connect-memory nil)
+          people (test-utils/load-people conn)
+          db     (fluree/db people)]
+      (testing "inline values filters subquery results"
+        (is (= [[:ex/alice] [:ex/liam]]
+               @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                  :select  '[?person]
+                                  :where   [[:query {:values          '[?name ["Alice" "Liam"]]
+                                                     :where           '[{:id ?person :schema/name ?name}
+                                                                        {:id ?person :ex/favNums ?num}]
+                                                     :select-distinct '[?person]}]]})))))))


### PR DESCRIPTION
We were explicitly supplying an empty initial solution instead of allowing the query executor to correctly derive the initial subquery solution from the subquery values clause.

Fixes https://github.com/fluree/core/issues/139. Because the subquery values clause wasn't being used to populate the initial subquery solution, the variables used in the query were bound to `nil`, which caused a incomparable datatypes error when executed.