### PR TITLE
Feature/query perf 2

### DIFF
--- a/src/clj/fluree/db/flake.cljc
+++ b/src/clj/fluree/db/flake.cljc
@@ -502,6 +502,8 @@
     (persistent! added)))
 
 (defn remove
+  "Removes all flakes in the sorted-set where
+  applying function f to the element returns truthy."
   [f ss]
   (loop [trans (transient ss)
          items (seq ss)]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -434,7 +434,8 @@
      (assoc m idx (-> comparators
                       (get idx)
                       flake/sorted-set-by)))
-   {:size 0} index/types))
+   {:size 0
+    :t    0} index/types))
 
 (defn genesis-root-map
   [ledger-alias]

--- a/src/clj/fluree/db/flake/format.cljc
+++ b/src/clj/fluree/db/flake/format.cljc
@@ -107,8 +107,7 @@
         [start-flake end-flake] (flake-bounds db :spot [sid])
         flake-xf                (when fuel-tracker
                                   (comp (fuel/track fuel-tracker error-ch)))
-        range-opts              {:from-t      t
-                                 :to-t        t
+        range-opts              {:to-t        t
                                  :start-flake start-flake
                                  :end-flake   end-flake
                                  :flake-xf    flake-xf}
@@ -127,8 +126,7 @@
                                   (comp (fuel/track fuel-tracker error-ch)
                                         (map flake/s))
                                   (map flake/s))
-        range-opts              {:from-t      t
-                                 :to-t        t
+        range-opts              {:to-t        t
                                  :start-flake start-flake
                                  :end-flake   end-flake
                                  :flake-xf    flake-xf}

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -228,9 +228,8 @@
   the transaction `from-t` because `flakes` contains another flake with the same
   subject and predicate and a t-value later than that flake but on or before
   `from-t`."
-  [from-t flakes]
+  [flakes]
   (->> flakes
-       (flake/remove (partial after-t? from-t))
        (flake/partition-by fact-content)
        (mapcat (fn [flakes]
                  ;; if the last flake pertaining to a unique
@@ -245,47 +244,48 @@
 (defn t-range
   "Returns a sorted set of flakes that are not out of date between the
   transactions `from-t` and `to-t`."
-  ([{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty from-t to-t]
+  ([{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty to-t]
    (let [latest       (if (> to-t leaf-t)
                         (into flakes (novelty-subrange leaf to-t novelty-t novelty))
                         flakes)
-         stale-flakes (stale-by from-t latest)
+         stale-flakes (stale-by latest)
          subsequent   (filter-after to-t latest)
          out-of-range (concat stale-flakes subsequent)]
-     (flake/disj-all latest out-of-range))))
+     (if (seq out-of-range)
+       (flake/disj-all latest out-of-range)
+       latest))))
 
 (defn resolve-t-range
-  [resolver node novelty-t novelty from-t to-t]
+  [resolver node novelty-t novelty to-t]
   (go-try
     (let [resolved (<? (resolve resolver node))
-          flakes   (t-range resolved novelty-t novelty from-t to-t)]
+          flakes   (t-range resolved novelty-t novelty to-t)]
       (-> resolved
           (dissoc :t)
-          (assoc :from-t from-t
-                 :to-t   to-t
+          (assoc :to-t   to-t
                  :flakes  flakes)))))
 
-(defrecord TRangeResolver [node-resolver novelty-t novelty from-t to-t]
+(defrecord TRangeResolver [node-resolver novelty-t novelty to-t]
   Resolver
   (resolve [_ node]
     (if (branch? node)
       (resolve node-resolver node)
-      (resolve-t-range node-resolver node novelty-t novelty from-t to-t))))
+      (resolve-t-range node-resolver node novelty-t novelty to-t))))
 
-(defrecord CachedTRangeResolver [node-resolver novelty-t novelty from-t to-t cache]
+(defrecord CachedTRangeResolver [node-resolver novelty-t novelty to-t cache]
   Resolver
   (resolve [_ {:keys [id tempid tt-id] :as node}]
     (if (branch? node)
       (resolve node-resolver node)
       (cache/lru-lookup
         cache
-        [::t-range id tempid tt-id from-t to-t]
+        [::t-range id tempid tt-id to-t]
         (fn [_]
-          (resolve-t-range node-resolver node novelty-t novelty from-t to-t))))))
+          (resolve-t-range node-resolver node novelty-t novelty to-t))))))
 
 (defn index-catalog->t-range-resolver
-  [{:keys [cache] :as idx-store} novelty-t novelty from-t to-t]
-  (->CachedTRangeResolver idx-store novelty-t novelty from-t to-t cache))
+  [{:keys [cache] :as idx-store} novelty-t novelty to-t]
+  (->CachedTRangeResolver idx-store novelty-t novelty to-t cache))
 
 (defn history-t-range
   "Returns a sorted set of flakes between the transactions `from-t` and `to-t`."

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -245,14 +245,18 @@
   "Returns a sorted set of flakes that are not out of date between the
   transactions `from-t` and `to-t`."
   ([{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty to-t]
-   (let [latest       (if (> to-t leaf-t)
+   (let [latest       (cond
+                        (> to-t leaf-t)
                         (into flakes (novelty-subrange leaf to-t novelty-t novelty))
-                        flakes)
-         stale-flakes (stale-by latest)
-         subsequent   (filter-after to-t latest)
-         out-of-range (concat stale-flakes subsequent)]
-     (if (seq out-of-range)
-       (flake/disj-all latest out-of-range)
+
+                        (= to-t leaf-t)
+                        flakes
+
+                        (< to-t leaf-t)
+                        (flake/disj-all flakes (filter-after to-t flakes)))
+         stale-flakes (stale-by latest)]
+     (if (seq stale-flakes)
+       (flake/disj-all latest stale-flakes)
        latest))))
 
 (defn resolve-t-range

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -406,7 +406,7 @@
   ([db add]
    (update-novelty db add []))
 
-  ([db add rem]
+  ([{:keys [t] :as db} add rem]
    (try*
      (let [flake-count (cond-> 0
                                add (+ (count add))
@@ -427,6 +427,7 @@
                                          :cljs opst))
            (update-in [:novelty :size] + #?(:clj  @flake-size
                                             :cljs flake-size))
+           (assoc-in [:novelty :t] t)
            (update-in [:stats :size] + #?(:clj  @flake-size
                                           :cljs flake-size))
            (update-in [:stats :flakes] + flake-count)))

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -473,7 +473,6 @@
                         (remove nil?)
                         (apply comp))
         opts        {:idx         idx
-                     :from-t      t
                      :to-t        t
                      :start-flake start-flake
                      :end-flake   end-flake

--- a/src/clj/fluree/db/query/range.cljc
+++ b/src/clj/fluree/db/query/range.cljc
@@ -152,10 +152,10 @@
   contain the flakes between `start-flake` and `end-flake` and are within the
   transaction range starting at `from-t` and ending at `to-t`."
   [{:keys [index-catalog t] :as db} idx error-ch
-   {:keys [from-t to-t start-flake end-flake] :as opts}]
+   {:keys [to-t start-flake end-flake] :as opts}]
   (let [root      (get db idx)
         novelty   (get-in db [:novelty idx])
-        resolver  (index/index-catalog->t-range-resolver index-catalog t novelty from-t to-t)
+        resolver  (index/index-catalog->t-range-resolver index-catalog t novelty to-t)
         query-xf  (extract-query-flakes opts)]
     (->> (index/tree-chan resolver root start-flake end-flake any? 1 query-xf error-ch)
          (filter-authorized db error-ch))))
@@ -305,7 +305,6 @@
                                        error-ch
                                        (assoc opts
                                          :idx idx
-                                         :from-t t
                                          :to-t t
                                          :start-test start-test
                                          :start-flake start-flake

--- a/src/clj/fluree/db/query/range.cljc
+++ b/src/clj/fluree/db/query/range.cljc
@@ -155,7 +155,8 @@
    {:keys [to-t start-flake end-flake] :as opts}]
   (let [root      (get db idx)
         novelty   (get-in db [:novelty idx])
-        resolver  (index/index-catalog->t-range-resolver index-catalog t novelty to-t)
+        novelty-t (get-in db [:novelty :t])
+        resolver  (index/index-catalog->t-range-resolver index-catalog novelty-t novelty to-t)
         query-xf  (extract-query-flakes opts)]
     (->> (index/tree-chan resolver root start-flake end-flake any? 1 query-xf error-ch)
          (filter-authorized db error-ch))))

--- a/src/clj/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/subject.cljc
@@ -36,7 +36,7 @@
                           cat
                           (map flake/s)
                           (distinct))
-        resolver    (index/index-catalog->t-range-resolver (:index-catalog conn) t novelty t t)]
+        resolver    (index/index-catalog->t-range-resolver (:index-catalog conn) t novelty t)]
     (index/tree-chan resolver idx-root first-flake last-flake any? 10 query-xf error-ch)))
 
 (defn flakes-xf

--- a/src/clj/fluree/db/query/subject_crawl/subject.cljc
+++ b/src/clj/fluree/db/query/subject_crawl/subject.cljc
@@ -20,6 +20,7 @@
   [{:keys [conn novelty t] :as db} error-ch vars {:keys [p o] :as _where-clause}]
   (let [idx-root    (get db :post)
         novelty     (get novelty :post)
+        novelty-t   (get novelty :t)
         o*          (if-some [v (:value o)]
                       v
                       (when-let [variable (:variable o)]
@@ -36,7 +37,7 @@
                           cat
                           (map flake/s)
                           (distinct))
-        resolver    (index/index-catalog->t-range-resolver (:index-catalog conn) t novelty t)]
+        resolver    (index/index-catalog->t-range-resolver (:index-catalog conn) novelty-t novelty t)]
     (index/tree-chan resolver idx-root first-flake last-flake any? 10 query-xf error-ch)))
 
 (defn flakes-xf


### PR DESCRIPTION
This adds another performance enhancement on top of https://github.com/fluree/db/pull/929.

This takes the same referenced cold query (~1M flakes) to 4.8s (from original 6.6s, or 5.2s after the last PR). So this adds almost a 10% improvement in cold query speeds.

This also makes transactions and indexing incrementally faster.

The changes are:
- Track novelty-t, and eliminate `subsequent` calls except when time-traveling. Previously the code would evaluate the entire index for "future t value flakes" to eliminate them - but this situation only exists for time travel queries and now is only evaluated in the circumstance it is known to be relevant.
- remove :from-t for query range calls, this really has no impact on performance but wasn't being used. I assume this is legacy when history query ranges tried to use the same resolver code.