### PR TITLE
Refactor stale flake removal from idx node

### DIFF
--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -223,41 +223,35 @@
   "Function to extract the content being asserted or retracted by a flake."
   (juxt flake/s flake/p flake/o flake/dt meta-hash))
 
-(defn stale-by
-  "Returns a vector of flakes from the sorted set `flakes` that are out of date by
-  the transaction `from-t` because `flakes` contains another flake with the same
-  subject and predicate and a t-value later than that flake but on or before
-  `from-t`."
+(defn remove-stale-flakes
   [flakes]
-  (->> flakes
-       (flake/partition-by fact-content)
-       (mapcat (fn [flakes]
-                 ;; if the last flake pertaining to a unique
-                 ;; fact is an assert, then every flake before
-                 ;; that is stale. If that item is a retract,
-                 ;; then all the flakes are stale.
-                 (let [last-flake (flake/last flakes)]
-                   (if (flake/op last-flake)
-                     (disj flakes last-flake)
-                     flakes))))))
+  (loop [to-check (reverse flakes)
+         flakes*  (transient flakes)]
+    (if-let [next-flake (peek to-check)]
+      (if (flake/op next-flake)
+        (recur (pop to-check) flakes*)
+        (let [r            (pop to-check)
+              cmp          (fact-content next-flake)
+              assert-flake (some #(when (= cmp (fact-content %)) %) r)]
+          (recur r (-> flakes*
+                       (disj! next-flake)
+                       (disj! assert-flake)))))
+      (persistent! flakes*))))
 
 (defn t-range
   "Returns a sorted set of flakes that are not out of date between the
   transactions `from-t` and `to-t`."
   ([{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty to-t]
-   (let [latest       (cond
-                        (> to-t leaf-t)
-                        (into flakes (novelty-subrange leaf to-t novelty-t novelty))
+   (let [latest (cond
+                  (> to-t leaf-t)
+                  (into flakes (novelty-subrange leaf to-t novelty-t novelty))
 
-                        (= to-t leaf-t)
-                        flakes
+                  (= to-t leaf-t)
+                  flakes
 
-                        (< to-t leaf-t)
-                        (flake/disj-all flakes (filter-after to-t flakes)))
-         stale-flakes (stale-by latest)]
-     (if (seq stale-flakes)
-       (flake/disj-all latest stale-flakes)
-       latest))))
+                  (< to-t leaf-t)
+                  (flake/disj-all flakes (filter-after to-t flakes)))]
+     (remove-stale-flakes latest))))
 
 (defn resolve-t-range
   [resolver node novelty-t novelty to-t]


### PR DESCRIPTION
This builds on https://github.com/fluree/db/pull/931 and https://github.com/fluree/db/pull/929.

This PR refactors the approach to remove retraction/assertion pairs in an index node when resolving a node to a specific "t" value.

Based on the original 1M flake txn and the same cold query used in the prior two PRs, the cold query now finishes in 2.9s after this change, a 40% speed improvement over the last PR.

For the three PRs, the query time has gone from 6.6s -> 5.2s -> 4.8s -> 2.9s (here).

In total, almost 60% performance increase.