### PR TITLE
Fix/target objects of literals

### DIFF
--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -342,7 +342,7 @@
      (loop [[[s _dt :as focus-node] & r] (<? (resolve-focus-nodes data-db shape s-flakes))
             results          []]
        (if focus-node
-         (let [value-nodes (cond (= (some-> s-flakes first flake/s) s)
+         (let [value-nodes (cond (some-> s-flakes first flake/s (= s))
                                  (mapv object-node s-flakes)
 
                                  (iri/sid? s)

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -3054,8 +3054,8 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:maxCount" 1,
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetClass" [{"@id" "ex:Assertion"} {"@id" "ex:Fact"}]}]})]
-          (is (not (nil? @(fluree/stage db1 {"@type" "ex:Assertion" "ex:term" 123}))))
-          (is (not (nil? @(fluree/stage db1 {"@type" "ex:Fact" "ex:term" 123}))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@type" "ex:Assertion" "ex:term" 123}})))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@type" "ex:Fact" "ex:term" 123}})))))
       (testing "with extra data"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
                                       "insert"
@@ -3064,7 +3064,7 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:maxCount" 1,
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetClass" {"@id" "ex:Assertion" "ex:extra" "data"}}]})]
-          (is (not (nil? @(fluree/stage db1 {"@type" "ex:Assertion" "ex:term" 123})))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@type" "ex:Assertion" "ex:term" 123}}))))))
     (testing "targetNode"
       (testing "with multiple targets"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
@@ -3075,8 +3075,8 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetNode" [{"@id" "ex:foo"}
                                                          {"@id" "ex:bar"}]}]})]
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:foo" "ex:term" 123}))))
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:bar" "ex:term" 123}))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:foo" "ex:term" 123}})))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:bar" "ex:term" 123}})))))
       (testing "with extra data"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
                                       "insert"
@@ -3085,7 +3085,7 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:maxCount" 1,
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetNode" {"@id" "ex:foo" "ex:extra" "data"}}]})]
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:foo" "ex:term" 123})))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:foo" "ex:term" 123}}))))))
     (testing "targetObjectsOf"
       (testing "with multiple targets"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
@@ -3094,8 +3094,8 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                         "sh:datatype" {"@id" "xsd:string"},
                                         "sh:targetObjectsOf" [{"@id" "ex:foo"}
                                                               {"@id" "ex:bar"}]}]})]
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:foo" 123}))))
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:bar" 123}))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:me" "ex:foo" 123}})))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:me" "ex:bar" 123}})))))
       (testing "with extra data"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
                                       "insert"
@@ -3104,7 +3104,7 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:maxCount" 1,
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetObjectsOf" {"@id" "ex:foo" "@type" "rdf:Property"}}]})]
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:foo" "ex:term" 123})))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:foo" "ex:term" 123}}))))))
     (testing "targetSubjectsof"
       (testing "with multiple targets"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
@@ -3115,8 +3115,8 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetSubjectsOf" [{"@id" "ex:foo"}
                                                                {"@id" "ex:bar"}]}]})]
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:foo" "foo" "ex:term" 123}))))
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:bar" "bar" "ex:term" 123}))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:me" "ex:foo" "foo" "ex:term" 123}})))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:me" "ex:bar" "bar" "ex:term" 123}})))))
       (testing "with extra data"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context
                                       "insert"
@@ -3125,4 +3125,4 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:maxCount" 1,
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetSubjectsOf" {"@id" "ex:foo" "ex:extra" "data"}}]})]
-          (is (not (nil? @(fluree/stage db1 {"@id" "ex:me" "ex:foo" "foo" "ex:term" 123})))))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:me" "ex:foo" "foo" "ex:term" 123}}))))))))


### PR DESCRIPTION
Fixes the shacl target tests - they weren't testing for the specific error that we were looking for, and so were
missing the fact that no data was actually getting staged. Once fixed, they revealed that `targetObjectsOf` constraints were not working when the object was a literal value and not a ref.

Our implementation of `targetObjectsOf` targets presupposed that the objects in question would be subject references. This leaves a lot of utility for that target type on the table.

In order to enable it I needed to make a "focus-node" and a "value-node" structurally identical - in this case, a tuple of `[value dt lang]` (before, focus nodes were just sids). Then, in `validate-node-shape` in the case that the focus node is not  a member of the s-flakes nor a reference, it becomes the value node for the constraint.

As a note for future work, this is similar to a `where/TypedValue` record, we should investigate consolidating those abstractions, though one deals with datatype iris and the other with sids.