### PR TITLE
Feature/bm25 retractions

### DIFF
--- a/src/clj/fluree/db/virtual_graph/bm25/index.clj
+++ b/src/clj/fluree/db/virtual_graph/bm25/index.clj
@@ -196,7 +196,7 @@
                           result)]
             ;; note that query-result could be a single item if query used :selectOne, or a vector if not
             (async/>! results-ch (if (nil? result*)
-                                   [::bm25.update/retract next-iri]
+                                   [::bm25.update/retract {"@id" next-iri}]
                                    [::bm25.update/upsert result*]))
             (recur r))
           (async/close! results-ch))))

--- a/src/clj/fluree/db/virtual_graph/bm25/stemmer.clj
+++ b/src/clj/fluree/db/virtual_graph/bm25/stemmer.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.virtual-graph.bm25.stemmer
   (:import (org.tartarus.snowball SnowballStemmer)
-           (org.tartarus.snowball.ext englishStemmer)))
+           (org.tartarus.snowball.ext englishStemmer frenchStemmer)))
 
 (set! *warn-on-reflection* true)
 

--- a/src/clj/fluree/db/virtual_graph/bm25/update.clj
+++ b/src/clj/fluree/db/virtual_graph/bm25/update.clj
@@ -71,6 +71,46 @@
             (apply str all-text " " sentence)
             (str all-text " " sentence))))))
 
+(defn retract-terms-docs
+  "Returns updated terms map with doc-id for sparce vec removed"
+  [terms id sparse-vec]
+  ;; set of term indexes as set we'll disj until empty
+  (let [retract-idxs (reduce #(conj %1 (first %2)) #{} sparse-vec)]
+    ;; iterate over terms until we retract all items
+    (loop [[[term-str term-map] & r] terms
+           retract-idxs retract-idxs
+           terms        (transient terms)]
+      (if (retract-idxs (:idx term-map)) ;; matches one of our retraction items?
+        (let [retract-idxs* (disj retract-idxs (:idx term-map))
+              terms*        (assoc! terms term-str (update term-map :items disj id))]
+          (if (empty? retract-idxs*) ;; no more restriction items, return updated terms map
+            (persistent! terms*)
+            (recur r retract-idxs* terms*)))
+        (recur r retract-idxs terms)))))
+
+(defn- retract-item
+  "Retracts item with id from index if exists in index, else returns original index."
+  [index id]
+  (if (contains? (:vectors index) id)
+    (let [{:keys [avg-length item-count terms vectors]} index
+          v           (get vectors id)
+          terms*      (retract-terms-docs terms id v)
+          vectors*    (dissoc vectors id)
+          doc-len     (reduce
+                       (fn [acc vec-tuple]
+                         (+ acc (second vec-tuple)))
+                       0
+                       v)
+          total-len   (* avg-length item-count)
+          total-len*  (- total-len doc-len)
+          item-count* (dec item-count)
+          avg-length* (/ total-len* item-count*)]
+      (assoc index :terms terms*
+                   :avg-length avg-length*
+                   :item-count item-count*
+                   :vectors vectors*))
+    index))
+
 (defn update-terms
   "Updates index's terms map with the new item's distinct terms
 
@@ -95,10 +135,8 @@
 
 (defn index-item
   "Returns updated bm25 index map after adding item to it"
-  [index stemmer stopwords iri-codec item]
+  [index stemmer stopwords id item]
   (let [{:keys [avg-length item-count terms dimensions vectors]} index
-        id             (->> (get item "@id")
-                            (iri/encode-iri iri-codec))
         item-terms     (-> (extract-text item)
                            (parse-sentence stemmer stopwords))
         doc-len        (count item-terms)
@@ -113,44 +151,6 @@
                  :item-count item-count*
                  :vectors (assoc vectors id item-vec))))
 
-(defn retract-terms-docs
-  "Returns updated terms map with doc-id for sparce vec removed"
-  [terms id sparse-vec]
-  ;; set of term indexes as set we'll disj until empty
-  (let [retract-idxs (reduce #(conj %1 (first %2)) #{} sparse-vec)]
-    ;; iterate over terms until we retract all items
-    (loop [[[term-str term-map] & r] terms
-           retract-idxs retract-idxs
-           terms        (transient terms)]
-      (if (retract-idxs (:idx term-map)) ;; matches one of our retraction items?
-        (let [retract-idxs* (disj retract-idxs (:idx term-map))
-              terms*        (assoc! terms term-str (update term-map :items disj id))]
-          (if (empty? retract-idxs*) ;; no more restriction items, return updated terms map
-            (persistent! terms*)
-            (recur r retract-idxs* terms*)))
-        (recur r retract-idxs terms)))))
-
-(defn- retract-item
-  [index iri-codec iri]
-  (let [{:keys [avg-length item-count terms vectors]} index
-        id          (iri/encode-iri iri-codec iri)
-        v           (get vectors id)
-        terms*      (retract-terms-docs terms id v)
-        vectors*    (dissoc vectors id)
-        doc-len     (reduce
-                     (fn [acc vec-tuple]
-                       (+ acc (second vec-tuple)))
-                     0
-                     v)
-        total-len   (* avg-length item-count)
-        total-len*  (- total-len doc-len)
-        item-count* (dec item-count)
-        avg-length* (/ total-len* item-count*)]
-    (assoc index :terms terms*
-                 :avg-length avg-length*
-                 :item-count item-count*
-                 :vectors vectors*)))
-
 (defn upsert-items
   "Asserts items into the bm25 index, returns updated state."
   [{:keys [stemmer stopwords] :as bm25} latest-index item-count items-ch status-update]
@@ -159,9 +159,12 @@
     (loop [i     1
            index latest-index]
       (if-let [[action item] (async/<! items-ch)]
-        (let [index* (if (= ::upsert action)
-                       (index-item index stemmer stopwords bm25 item)
-                       (retract-item index bm25 item))]
+        (let [id     (->> (get item "@id")
+                          (iri/encode-iri bm25))
+              index* (if (= ::upsert action)
+                       (-> (retract-item index id)
+                           (index-item stemmer stopwords id item))
+                       (retract-item index id))]
           ;; supply status for every 100 items for timeout reporting, etc.
           (when (zero? (mod i 100))
             (status-update [i item-count]))

--- a/test/fluree/db/vector/bm25_test.clj
+++ b/test/fluree/db/vector/bm25_test.clj
@@ -4,6 +4,21 @@
             [fluree.db.test-utils :as test-utils]
             [fluree.db.util.log :as log]))
 
+(defn full-text-search
+  "Performs a full text search and returns a couple attributes joined from the db
+  for use of tests below"
+  [db search-term]
+  @(fluree/query db {"@context" {"ex"   "http://example.org/ns/"
+                                 "fidx" "https://ns.flur.ee/index#"}
+                     "select"   ["?x", "?score", "?title"]
+                     "where"    [["graph" "##articleSearch" {"fidx:target" search-term
+                                                             "fidx:limit"  10,
+                                                             "fidx:sync"   true,
+                                                             "fidx:result" {"@id"        "?x"
+                                                                            "fidx:score" "?score"}}]
+                                 {"@id"      "?x"
+                                  "ex:title" "?title"}]}))
+
 (deftest ^:integration bm25-index-search
   (testing "Creating and using a bm25 index after inserting data"
     (let [conn   (test-utils/create-conn)
@@ -41,22 +56,11 @@
                                        "@value" {"@context" {"ex" "http://example.org/ns/"}
                                                  "where"    [{"@id"       "?x"
                                                               "ex:author" "?author"}]
-                                                 "select"   {"?x" ["@id" "ex:author" "ex:title" "ex:summary"]}}}}})
-
-          q1     @(fluree/query db-r {"@context" {"ex"   "http://example.org/ns/"
-                                                  "fidx" "https://ns.flur.ee/index#"}
-                                      "select"   ["?x", "?score", "?title"]
-                                      "where"    [["graph" "##articleSearch" {"fidx:target" "Apples for snacks for John"
-                                                                              "fidx:limit"  10,
-                                                                              "fidx:sync"   true,
-                                                                              "fidx:result" {"@id"        "?x"
-                                                                                             "fidx:score" "?score"}}]
-                                                  {"@id"      "?x"
-                                                   "ex:title" "?title"}]})]
+                                                 "select"   {"?x" ["@id" "ex:author" "ex:title" "ex:summary"]}}}}})]
 
       (is (= [["ex:hobby-article" 0.741011563872269 "This is an article about hobbies"]
               ["ex:food-article" 0.6510910594922633 "This is one title of a document about food"]]
-             q1)))))
+             (full-text-search db-r "Apples for snacks for John"))))))
 
 (deftest ^:integration bm25-index-search-before-data
   (testing "Creating and using a bm25 index before inserting data"
@@ -90,22 +94,11 @@
                      {"@id"        "ex:hobby-article"
                       "ex:author"  "John Doe"
                       "ex:title"   "This is an article about hobbies"
-                      "ex:summary" "Hobbies include reading and hiking"}]})
-
-          q1     @(fluree/query db-r {"@context" {"ex"   "http://example.org/ns/"
-                                                  "fidx" "https://ns.flur.ee/index#"}
-                                      "select"   ["?x", "?score", "?title"]
-                                      "where"    [["graph" "##articleSearch" {"fidx:target" "Apples for snacks for John"
-                                                                              "fidx:limit"  10,
-                                                                              "fidx:sync"   true,
-                                                                              "fidx:result" {"@id"        "?x"
-                                                                                             "fidx:score" "?score"}}]
-                                                  {"@id"      "?x"
-                                                   "ex:title" "?title"}]})]
+                      "ex:summary" "Hobbies include reading and hiking"}]})]
 
       (is (= [["ex:hobby-article" 0.741011563872269 "This is an article about hobbies"]
               ["ex:food-article" 0.6510910594922633 "This is one title of a document about food"]]
-             q1)))))
+             (full-text-search db-r "Apples for snacks for John"))))))
 
 (deftest ^:integration bm25-many-inserts-then-query
   (testing "Create a number of inserts, each will update off each other in the background - with pending query"
@@ -163,22 +156,63 @@
                      {"@id"        "ex:health-article2"
                       "ex:author"  "Amy Aetna"
                       "ex:title"   "Medical costs are at all time high"
-                      "ex:summary" "Medical costs are at all time high, and many people are struggling to pay for their healthcare"}]})
-
-          q1     @(fluree/query db-r3 {"@context" {"ex"   "http://example.org/ns/"
-                                                   "fidx" "https://ns.flur.ee/index#"}
-                                       "select"   ["?x", "?score", "?title"]
-                                       "where"    [["graph" "##articleSearch" {"fidx:target" "Bitcoin funding microplastics research"
-                                                                               "fidx:limit"  10,
-                                                                               "fidx:sync"   true,
-                                                                               "fidx:result" {"@id"        "?x"
-                                                                                              "fidx:score" "?score"}}]
-                                                   {"@id"      "?x"
-                                                    "ex:title" "?title"}]})]
+                      "ex:summary" "Medical costs are at all time high, and many people are struggling to pay for their healthcare"}]})]
 
       (is (= [["ex:tech-news2" 2.0901192626067044 "Cryptocurrency news - bitcoin at all time high"]
               ["ex:health-article" 1.9365594800478445 "Microplastics are in our food"]]
-             q1)))))
+             (full-text-search db-r3 "Bitcoin funding microplastics research"))))))
+
+(deftest ^:integration bm25-index-update-items
+  (testing "Ensuring that updates to indexed items are properly accounted for"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "bm25-item-updates")
+
+          db     @(fluree/stage
+                   (fluree/db ledger)
+                   {"insert"
+                    {"@context"       {"f"    "https://ns.flur.ee/ledger#"
+                                       "fvg"  "https://ns.flur.ee/virtualgraph#"
+                                       "fidx" "https://ns.flur.ee/index#"
+                                       "ex"   "http://example.org/"},
+                     "@id"            "ex:articleSearch"
+                     "@type"          ["f:VirtualGraph" "fidx:BM25"]
+                     "f:virtualGraph" "articleSearch"
+                     "f:query"        {"@type"  "@json"
+                                       "@value" {"@context" {"ex" "http://example.org/ns/"}
+                                                 "where"    [{"@id"       "?x"
+                                                              "ex:author" "?author"}]
+                                                 "select"   {"?x" ["@id" "ex:author" "ex:title" "ex:summary"]}}}}})
+
+          db-r   @(fluree/stage
+                   db
+                   {"@context" {"ex" "http://example.org/ns/"}
+                    "insert"
+                    [{"@id"        "ex:food-article"
+                      "ex:author"  "Jane Smith"
+                      "ex:title"   "This is one title of a document about food"
+                      "ex:summary" "This is a summary of the document about food including apples and oranges"}
+                     {"@id"        "ex:hobby-article"
+                      "ex:author"  "John Doe"
+                      "ex:title"   "This is an article about hobbies"
+                      "ex:summary" "Hobbies include reading and hiking"}]})
+
+          db-r2  @(fluree/stage
+                   db-r
+                   {"@context" {"ex" "http://example.org/ns/"}
+                    "where"    {"@id"        "ex:food-article"
+                                "ex:summary" "?summary"}
+                    "delete"   [{"@id"        "ex:food-article"
+                                 "ex:summary" "?summary"}]
+                    "insert"   [{"@id"        "ex:food-article"
+                                 "ex:summary" "This summary removes the fruit but adds travel like airplanes and taxis"}]})]
+
+      (is (= [["ex:hobby-article" 0.7549127709068711 "This is an article about hobbies"]]
+             (full-text-search db-r2 "Apples for snacks for John"))
+          "After updating the summary of the food article it no longer contains a reference to apples so won't show.")
+
+      (is (= [["ex:food-article" 0.64072428455121 "This is one title of a document about food"]]
+             (full-text-search db-r2 "Something about airplanes"))
+          "The article now talks about airplanes and should show up for the new search"))))
 
 (deftest ^:integration bm25-index-retractions
   (testing "Retracting data from a bm25 index"
@@ -220,26 +254,14 @@
                     "where"    {"@id" "ex:food-article"
                                 "?p"  "?o"}
                     "delete"   {"@id" "ex:food-article"
-                                "?p"  "?o"}})
-
-          q1     @(fluree/query db-r2 {"@context" {"ex"   "http://example.org/ns/"
-                                                   "fidx" "https://ns.flur.ee/index#"}
-                                       "select"   ["?x", "?score", "?title"]
-                                       "where"    [["graph" "##articleSearch" {"fidx:target" "Apples for snacks for John"
-                                                                               "fidx:limit"  10,
-                                                                               "fidx:sync"   true,
-                                                                               "fidx:result" {"@id"        "?x"
-                                                                                              "fidx:score" "?score"}}]
-                                                   {"@id"      "?x"
-                                                    "ex:title" "?title"}]})]
+                                "?p"  "?o"}})]
 
       (is (= [["ex:hobby-article" 0.28768207245178085 "This is an article about hobbies"]]
-             q1))
+             (full-text-search db-r2 "Apples for snacks for John")))
 
 
       (testing "Score after adding and retracting article is same as score with just one article"
-        (let [conn2   (test-utils/create-conn)
-              ledger2 @(fluree/create conn "bm25-retract-verify-same-score")
+        (let [ledger2 @(fluree/create conn "bm25-retract-verify-same-score")
 
               db2     @(fluree/stage
                         (fluree/db ledger2)
@@ -257,25 +279,16 @@
                                                                    "ex:author" "?author"}]
                                                       "select"   {"?x" ["@id" "ex:author" "ex:title" "ex:summary"]}}}}})
 
-              db-r2   @(fluree/stage
+              db2-r   @(fluree/stage
                         db2
                         {"@context" {"ex" "http://example.org/ns/"}
                          "insert"
                          [{"@id"        "ex:hobby-article"
                            "ex:author"  "John Doe"
                            "ex:title"   "This is an article about hobbies"
-                           "ex:summary" "Hobbies include reading and hiking"}]})
-              q2      @(fluree/query db-r2 {"@context" {"ex"   "http://example.org/ns/"
-                                                        "fidx" "https://ns.flur.ee/index#"}
-                                            "select"   ["?x", "?score", "?title"]
-                                            "where"    [["graph" "##articleSearch" {"fidx:target" "Apples for snacks for John"
-                                                                                    "fidx:limit"  10,
-                                                                                    "fidx:sync"   true,
-                                                                                    "fidx:result" {"@id"        "?x"
-                                                                                                   "fidx:score" "?score"}}]
-                                                        {"@id"      "?x"
-                                                         "ex:title" "?title"}]})]
-          (is (= q2 q1)))))))
+                           "ex:summary" "Hobbies include reading and hiking"}]})]
+          (is (= (full-text-search db2-r "Apples for snacks for John")
+                 (full-text-search db-r2 "Apples for snacks for John"))))))))
 
 (deftest ^:integration bm25-index-exceptions
   (testing "The query of bm25 index has specific formatting requirements"


### PR DESCRIPTION
This add retractions and updates to the initial BM25 search PR here https://github.com/fluree/db/pull/936

Now, when a new "document" needs to get indexed, it first checks if the document is already in in the index and if so, retracts it before adding the updated one.

Also full retractions are working - when you delete all the properties for an indexed document so there is nothing left for the given IRI, a full retraction is now applied.

Retractions don't attempt to reduce the dimensionality of the index, nor do I think it should. E.g. in the tests the words apples and oranges were part of the index, but then the document containing those words. With no other documents containing those words, the dimensionality could be reduced but it retains those terms as sparse vector positions. I think we'll want this for time travel, and the number of orphaned terms should be relatively low with any modest sized index.
