### PR TITLE
Feature/policy values

### DIFF
--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -272,19 +272,19 @@
   policy restrictions"
   ([db policy]
    (wrap-policy db policy nil))
-  ([db policy values-map]
+  ([db policy policy-values]
    (promise-wrap
     (let [policy* (json-ld/expand policy)]
-      (policy/wrap-policy db policy* values-map)))))
+      (policy/wrap-policy db policy* policy-values)))))
 
 (defn wrap-class-policy
   "Restricts the provided db with policies in the db
   which have a class @type of the provided class(es)."
   ([db policy-classes]
    (wrap-class-policy db policy-classes nil))
-  ([db policy-classes values-map]
+  ([db policy-classes policy-values]
    (promise-wrap
-    (policy/wrap-class-policy db policy-classes values-map))))
+    (policy/wrap-class-policy db policy-classes policy-values))))
 
 (defn wrap-identity-policy
   "For provided identity, locates specific property f:policyClass on
@@ -295,9 +295,9 @@
   declaration."
   ([db identity]
    (wrap-identity-policy db identity nil))
-  ([db identity values-map]
+  ([db identity policy-values]
    (promise-wrap
-    (policy/wrap-identity-policy db identity values-map))))
+    (policy/wrap-identity-policy db identity policy-values))))
 
 (defn dataset
   "Creates a composed dataset from multiple resolved graph databases.

--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -163,10 +163,10 @@
       commit-ch))
 
   policy/Restrictable
-  (wrap-policy [_ policy values-map]
+  (wrap-policy [_ policy policy-values]
     (go-try
      (let [db (<? db-chan)]
-       (<? (policy/wrap-policy db policy values-map)))))
+       (<? (policy/wrap-policy db policy policy-values)))))
   (root [_]
     (let [root-ch (async/promise-chan)
           root-db (->AsyncDB alias branch commit t root-ch)]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -390,8 +390,8 @@
     (history/query-commits db context from-t to-t include error-ch))
 
   policy/Restrictable
-  (wrap-policy [db policy values-map]
-    (policy-rules/wrap-policy db policy values-map))
+  (wrap-policy [db policy policy-values]
+    (policy-rules/wrap-policy db policy policy-values))
   (root [db]
     (policy/root-db db))
 

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -1,7 +1,8 @@
 (ns fluree.db.json-ld.policy
   (:require [clojure.core.async :refer [go <!]]
-            [fluree.db.dbproto :as dbproto]
             [fluree.db.constants :as const]
+            [fluree.db.dbproto :as dbproto]
+            [fluree.db.query.fql.parse :as parse]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
@@ -10,7 +11,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defprotocol Restrictable
-  (wrap-policy [db policy-rules values-map])
+  (wrap-policy [db policy-rules policy-values])
   (root [db]))
 
 (def root-policy-map
@@ -42,7 +43,7 @@
 (defn wrap-class-policy
   "Given one or more policy classes, queries for policies
   containing those classes and calls `wrap-policy`"
-  [db classes values-map]
+  [db classes policy-values]
   (go
     (let [c-values  (->> classes ;; for passing in classes as query `values`
                          util/sequential
@@ -62,33 +63,32 @@
                       " with error: " (ex-message policies*))
                  {:status 400 :error :db/policy-exception}
                  policies*)
-        (<! (wrap-policy db (json-ld/expand policies*) values-map))))))
-
+        (<! (wrap-policy db (json-ld/expand policies*) policy-values))))))
 
 (defn wrap-identity-policy
   "Given an identity (@id) that exists in the db which contains a
   property `f:policyClass` listing policy classes associated with
   that identity, queries for those classes and calls `wrap-policy`"
-  [db identity values-map]
+  [db identity policy-values]
   (go
-   (let [policies  (<! (dbproto/-query db {"select" {"?policy" ["*"]}
-                                           "where"  [{"@id"                 identity
-                                                      const/iri-policyClass "?classes"}
-                                                     {"@id"   "?policy"
-                                                      "@type" "?classes"}]}))
-         policies* (if (util/exception? policies)
-                     policies
-                     (policy-from-query policies))
-         val-map   (assoc values-map "?$identity" {"@value" identity
-                                                   "@type"  const/iri-id})]
-     (log/trace "wrap-identity-policy - extracted policy from identity: " identity
-                " policy: " policies*)
-     (if (util/exception? policies*)
-       (ex-info (str "Unable to extract policies for identity: " identity
-                     " with error: " (ex-message policies*))
-                {:status 400 :error :db/policy-exception}
-                policies*)
-       (<! (wrap-policy db (json-ld/expand policies*) val-map))))))
+    (let [policies  (<! (dbproto/-query db {"select" {"?policy" ["*"]}
+                                            "where"  [{"@id"                 identity
+                                                       const/iri-policyClass "?classes"}
+                                                      {"@id"   "?policy"
+                                                       "@type" "?classes"}]}))
+          policies* (if (util/exception? policies)
+                      policies
+                      (policy-from-query policies))
+
+          policy-values* (-> (parse/normalize-values policy-values)
+                             (parse/inject-value-binding "?$identity" {"@value" identity "@type" const/iri-id}))]
+      (log/trace "wrap-identity-policy - extracted policy from identity: " identity " policy: " policies*)
+      (if (util/exception? policies*)
+        (ex-info (str "Unable to extract policies for identity: " identity
+                      " with error: " (ex-message policies*))
+                 {:status 400 :error :db/policy-exception}
+                 policies*)
+        (<! (wrap-policy db (json-ld/expand policies*) policy-values*))))))
 
 (defn policy-enforced-opts?
   "Tests 'options' for a query or transaction to see if the options request

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -5,6 +5,7 @@
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
+            [fluree.db.util.parse :as util.parse]
             [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -64,14 +65,6 @@
                  policies*)
         (<! (wrap-policy db (json-ld/expand policies*) policy-values))))))
 
-(defn normalize-values
-  "Normalize the structure of the values clause to
-  [[vars...] [[val1..] [val2...] ...]], handling nil properly."
-  [values]
-  (let [[vars vals] values]
-    [(into [] (when vars (util/sequential vars)))
-     (mapv util/sequential vals)]))
-
 (defn inject-value-binding
   "Inject the given var and value into a normalized values clause."
   [values var v]
@@ -96,7 +89,7 @@
                       policies
                       (policy-from-query policies))
 
-          policy-values* (-> (normalize-values policy-values)
+          policy-values* (-> (util.parse/normalize-values policy-values)
                              (inject-value-binding "?$identity" {"@value" identity "@type" const/iri-id}))]
       (log/trace "wrap-identity-policy - extracted policy from identity: " identity " policy: " policies*)
       (if (util/exception? policies*)

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -5,7 +5,8 @@
             [fluree.db.json-ld.policy :as policy :refer [root]]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.db.util.parse :as util.parse]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -56,7 +57,7 @@
   (let [policy-values (-> db :policy :policy-values)
         query         (:query policy)
         this-val      (iri/decode-sid db sid)
-        values        (-> (policy/normalize-values policy-values)
+        values        (-> (util.parse/normalize-values policy-values)
                           (policy/inject-value-binding "?$this" {"@value" this-val "@type" const/iri-id}))]
     (update query "where" (fn [where-clause]
                             (into [["values" values]]

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -2,8 +2,7 @@
   (:require [fluree.db.constants :as const]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.json-ld.iri :as iri]
-            [fluree.db.json-ld.policy :refer [root]]
-            [fluree.db.query.fql.parse :as parse]
+            [fluree.db.json-ld.policy :as policy :refer [root]]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]))
@@ -58,8 +57,8 @@
   (let [query    (:query policy)
         this-val (iri/decode-sid db sid)
         ;; TODO: handle pre-existing :values clause on query
-        values   (-> (parse/normalize-values policy-values)
-                     (parse/inject-value-binding "?$this" {"@value" this-val "@type" const/iri-id}))]
+        values   (-> (policy/normalize-values policy-values)
+                     (policy/inject-value-binding "?$this" {"@value" this-val "@type" const/iri-id}))]
     (assoc query "values" values)))
 
 (defn modify-exception

--- a/src/clj/fluree/db/json_ld/policy/modify.cljc
+++ b/src/clj/fluree/db/json_ld/policy/modify.cljc
@@ -31,12 +31,12 @@
          (if flake
            (let [sid (flake/s flake)]
              (if-let [p-policies (enforce/policies-for-property policy true (flake/p flake))]
-               (<? (enforce/policies-allow? db-after true sid (:values-map policy) p-policies))
+               (<? (enforce/policies-allow? db-after true sid p-policies))
                (if-let [c-policies (->> (classes-for-sid sid mods db-after)
                                         (enforce/policies-for-classes policy true))]
-                 (<? (enforce/policies-allow? db-after true sid (:values-map policy) c-policies))
+                 (<? (enforce/policies-allow? db-after true sid c-policies))
                  (if-let [d-policies (enforce/default-policies policy true)]
-                   (<? (enforce/policies-allow? db-after true sid (:values-map policy) d-policies))
+                   (<? (enforce/policies-allow? db-after true sid d-policies))
                    false)))
 
              (recur r))

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -41,15 +41,14 @@
   [{:keys [policy] :as db} flake]
   (go-try
    (let [pid     (flake/p flake)
-         sid     (flake/s flake)
-         val-map (:values-map policy)]
+         sid     (flake/s flake)]
      (if-let [p-policies (enforce/policies-for-property policy false pid)]
-       (<? (enforce/policies-allow? db false sid val-map p-policies))
+       (<? (enforce/policies-allow? db false sid p-policies))
        (if-let [c-policies (or (cached-class-policies policy sid)
                                (<? (class-policies db sid)))]
-         (<? (enforce/policies-allow? db false sid val-map c-policies))
+         (<? (enforce/policies-allow? db false sid c-policies))
          (if-let [d-policies (enforce/default-policies policy false)]
-           (<? (enforce/policies-allow? db false sid val-map d-policies))
+           (<? (enforce/policies-allow? db false sid d-policies))
            false))))))
 
 (defn allow-iri?

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -140,19 +140,11 @@
    {}
    policy-rules))
 
-(defn validate-values-map
-  [values-map]
-  (or (map? values-map)
-      (throw (ex-info (str "Invalid policy values map. Must be a map. Received: " values-map)
-                      {:status 400
-                       :error  :db/invalid-values-map}))))
-
 (defn wrap-policy
-  [db policy-rules values-map]
+  [db policy-rules policy-values]
   (go-try
    (let [policy-rules (->> policy-rules
                            util/sequential
                            (parse-policy-rules db))]
      (log/trace "policy-rules: " policy-rules)
-     (assoc db :policy (assoc policy-rules :cache (atom {})
-                                           :values-map values-map)))))
+     (assoc db :policy (assoc policy-rules :cache (atom {}) :policy-values policy-values)))))

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -150,8 +150,6 @@
 (defn wrap-policy
   [db policy-rules values-map]
   (go-try
-   (when values-map
-     (validate-values-map values-map))
    (let [policy-rules (->> policy-rules
                            util/sequential
                            (parse-policy-rules db))]

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -5,7 +5,6 @@
             [fluree.db.constants :as const]
             [fluree.db.datatype :as datatype]
             [fluree.db.json-ld.iri :as iri]
-            [fluree.db.json-ld.policy :as policy]
             [fluree.db.query.exec.eval :as eval]
             [fluree.db.query.exec.select :as select]
             [fluree.db.query.exec.where :as where]
@@ -13,6 +12,7 @@
             [fluree.db.util.context :as context]
             [fluree.db.util.core :as util :refer [try* catch*]]
             [fluree.db.util.log :as log :include-macros true]
+            [fluree.db.util.parse :as util.parse]
             [fluree.db.validation :as v]
             [fluree.json-ld :as json-ld]))
 
@@ -146,7 +146,7 @@
 (defn parse-values
   [values context]
   (when values
-    (let [[vars vals] (policy/normalize-values values)
+    (let [[vars vals] (util.parse/normalize-values values)
           parsed-vars (keep parse-var-name vars)
           var-count   (count vars)]
       (if (every? (fn [binding] (= (count binding) var-count))

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -5,6 +5,7 @@
             [fluree.db.constants :as const]
             [fluree.db.datatype :as datatype]
             [fluree.db.json-ld.iri :as iri]
+            [fluree.db.json-ld.policy :as policy]
             [fluree.db.query.exec.eval :as eval]
             [fluree.db.query.exec.select :as select]
             [fluree.db.query.exec.where :as where]
@@ -142,27 +143,10 @@
                          var-matches vals)]
     (zipmap vars binding)))
 
-(defn normalize-values
-  "Normalize the structure of the values clause to
-  [[vars...] [[val1..] [val2...] ...]], handling nil properly."
-  [values]
-  (let [[vars vals] values]
-    [(into [] (when vars (util/sequential vars)))
-     (mapv util/sequential vals)]))
-
-(defn inject-value-binding
-  "Inject the given var and value into a normalized values clause."
-  [values var v]
-  (let [[vars vals] values]
-    [(into [var] (when vars (util/sequential vars)))
-     (if (seq vals)
-       (mapv (partial into [v]) vals)
-       [[v]])]))
-
 (defn parse-values
   [values context]
   (when values
-    (let [[vars vals] (normalize-values values)
+    (let [[vars vals] (policy/normalize-values values)
           parsed-vars (keep parse-var-name vars)
           var-count   (count vars)]
       (if (every? (fn [binding] (= (count binding) var-count))

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -116,6 +116,7 @@
                          [:issuer {:optional true} ::issuer]
                          [:role {:optional true} ::role]
                          [:identity {:optional true} ::identity]
+                         [:policy-values {:optional true} :any]
                          ;; deprecated
                          [:pretty-print {:optional true} ::pretty-print]
                          [:did {:optional true} ::identity]
@@ -128,7 +129,8 @@
                          [:did {:optional true} ::identity]
                          [:context {:optional true} ::context]
                          [:raw-txn {:optional true} :any]
-                         [:author {:optional true} ::identity]]
+                         [:author {:optional true} ::identity]
+                         [:policy-values {:optional true} :any]]
     ::commit-opts       [:map
                          [:identity {:optional true} ::identity]
                          [:context {:optional true} ::context]

--- a/src/clj/fluree/db/util/parse.cljc
+++ b/src/clj/fluree/db/util/parse.cljc
@@ -1,0 +1,10 @@
+(ns fluree.db.util.parse
+  (:require [fluree.db.util.core :as util]))
+
+(defn normalize-values
+  "Normalize the structure of the values clause to
+  [[vars...] [[val1..] [val2...] ...]], handling nil properly."
+  [values]
+  (let [[vars vals] values]
+    [(into [] (when vars (util/sequential vars)))
+     (mapv util/sequential vals)]))

--- a/test/fluree/db/policy/identity_based_test.clj
+++ b/test/fluree/db/policy/identity_based_test.clj
@@ -54,7 +54,7 @@
 
           policy-db @(fluree/wrap-identity-policy db alice-did)]
 
-      (testing " with direct select binding restricts"
+      (testing "with direct select binding restricts"
         (is (= [["ex:alice" "111-11-1111"]]
                @(fluree/query
                  policy-db
@@ -66,7 +66,7 @@
                               "schema:ssn" "?ssn"}}))
             "ex:john should not show up in results"))
 
-      (testing " with where-clause match of restricted data"
+      (testing "with where-clause match of restricted data"
         (is (= []
                @(fluree/query
                  policy-db
@@ -77,7 +77,7 @@
                               "schema:ssn" "888-88-8888"}}))
             "ex:john has ssn 888-88-8888, so should results should be empty"))
 
-      (testing " in a graph crawl restricts"
+      (testing "in a graph crawl restricts"
         (is (= [{"@id"              "ex:alice",
                  "@type"            "ex:User",
                  "schema:name"      "Alice"

--- a/test/fluree/db/policy/policy_class_test.clj
+++ b/test/fluree/db/policy/policy_class_test.clj
@@ -51,14 +51,14 @@
                                     "f:action" {"@id" "f:view"}
                                     "f:query"  {"@type"  "@json"
                                                 "@value" {}}}]})]
-      (testing " setting a policy class and passing a values-map with the user's identity"
+      (testing "setting a policy class and passing a values-map with the user's identity"
         (let [policy-db @(fluree/wrap-class-policy db
                                                    ["http://example.org/ns/EmployeePolicy"]
                                                    ;; presumably values like this would come from upstream
                                                    ;; application or identity provider
                                                    {"?$identity" alice-did})]
 
-          (testing " with direct select binding restricts"
+          (testing "with direct select binding restricts"
             (is (= [["ex:alice" "111-11-1111"]]
                    @(fluree/query
                      policy-db
@@ -70,7 +70,7 @@
                                   "schema:ssn" "?ssn"}}))
                 "ex:john should not show up in results"))
 
-          (testing " with where-clause match of restricted data"
+          (testing "with where-clause match of restricted data"
             (is (= []
                    @(fluree/query
                      policy-db
@@ -81,7 +81,7 @@
                                   "schema:ssn" "888-88-8888"}}))
                 "ex:john has ssn 888-88-8888, so should results should be empty"))
 
-          (testing " in a graph crawl restricts"
+          (testing "in a graph crawl restricts"
             (is (= [{"@id"              "ex:alice",
                      "@type"            "ex:User",
                      "schema:name"      "Alice"

--- a/test/fluree/db/policy/policy_class_test.clj
+++ b/test/fluree/db/policy/policy_class_test.clj
@@ -56,7 +56,7 @@
                                                    ["http://example.org/ns/EmployeePolicy"]
                                                    ;; presumably values like this would come from upstream
                                                    ;; application or identity provider
-                                                   {"?$identity" alice-did})]
+                                                   ["?$identity" [alice-did]])]
 
           (testing "with direct select binding restricts"
             (is (= [["ex:alice" "111-11-1111"]]

--- a/test/fluree/db/policy/query_test.clj
+++ b/test/fluree/db/policy/query_test.clj
@@ -58,7 +58,7 @@
           policy-db @(fluree/wrap-policy db policy {"?$identity" {"@value" alice-did
                                                                   "@type"  "@id"}})]
 
-      (testing " with direct select binding restricts"
+      (testing "with direct select binding restricts"
         (is (= [["ex:alice" "111-11-1111"]]
                @(fluree/query
                  policy-db
@@ -70,7 +70,7 @@
                               "schema:ssn" "?ssn"}}))
             "ex:john should not show up in results"))
 
-      (testing " with where-clause match of restricted data"
+      (testing "with where-clause match of restricted data"
         (is (= []
                @(fluree/query
                  policy-db
@@ -81,7 +81,7 @@
                               "schema:ssn" "888-88-8888"}}))
             "ex:john has ssn 888-88-8888, so should results should be empty"))
 
-      (testing " in a graph crawl restricts"
+      (testing "in a graph crawl restricts"
         (is (= [{"@id"              "ex:alice",
                  "@type"            "ex:User",
                  "schema:name"      "Alice"
@@ -170,7 +170,7 @@
                             {"?$identity" {"@value" alice-did
                                            "@type"  "@id"}})]
 
-      (testing " and values binding has user with policy relationship"
+      (testing "and values binding has user with policy relationship"
         (is (= [{"@id"                  "ex:widget",
                  "@type"                "ex:Product",
                  "schema:name"          "Widget"
@@ -188,7 +188,7 @@
                   "where"    {"@id"   "?s"
                               "@type" "ex:Product"}}))))
 
-      (testing " and values binding has user without policy relationship"
+      (testing "and values binding has user without policy relationship"
         (is (= []
                @(fluree/query
                  alice-policy-db
@@ -264,7 +264,7 @@
                                     "@type" "ex:Referrer"},
                         "select"   {"?s" ["*" {"ex:referData" ["*"]}]}}]
 
-      (testing " with policy default allow? set to true"
+      (testing "with policy default allow? set to true"
         (is (= [{"@id"               "ex:data-0",
                  "@type"             "ex:Data",
                  "ex:classification" 0}]
@@ -282,9 +282,9 @@
                                   "@type"             "ex:Data"
                                   "ex:classification" 0}]}]
                @(fluree/query policy-allow refer-query))
-            " in graph crawl ex:Data is still restricted"))
+            "in graph crawl ex:Data is still restricted"))
 
-      (testing " with policy default allow? set to false"
+      (testing "with policy default allow? set to false"
         (is (= [{"@id"               "ex:data-0",
                  "@type"             "ex:Data",
                  "ex:classification" 0}]

--- a/test/fluree/db/policy/query_test.clj
+++ b/test/fluree/db/policy/query_test.clj
@@ -367,4 +367,18 @@
                                                                "@type" "?type"
                                                                "ex:capitol" "?capitol"}]}}}
                                         "policyValues" [["?type" "?capitol"]
-                                                        [[{"@value" "usa:state" "@type" "@id"} "Madison"]]]}}))))))
+                                                        [[{"@value" "usa:state" "@type" "@id"} "Madison"]]]}}))))
+    (testing "pre-existing values clause"
+      (is (= ["Wisconsin"]
+             @(fluree/query db {"@context" test-utils/default-str-context
+                                "where" [{"@id" "?state" "ex:name" "?name"}]
+                                "select" "?name"
+                                "opts" {"policy"
+                                        {"f:action" {"@id" "f:view"}
+                                         "f:query" {"@type" "@json"
+                                                    "@value"
+                                                    {"where" [{"@id" "?$this"
+                                                               "@type" "?type"
+                                                               "ex:capitol" "?capitol"}]
+                                                     "values" ["?type" [{"@value" "usa:state" "@type" "@id"}]]}}}
+                                        "policyValues" ["?capitol" ["Madison"]]}}))))))

--- a/test/fluree/db/policy/query_test.clj
+++ b/test/fluree/db/policy/query_test.clj
@@ -55,8 +55,7 @@
                                   "f:query"  {"@type"  "@json"
                                               "@value" {}}}]}
 
-          policy-db @(fluree/wrap-policy db policy {"?$identity" {"@value" alice-did
-                                                                  "@type"  "@id"}})]
+          policy-db @(fluree/wrap-policy db policy ["?$identity" [{"@value" alice-did "@type"  "@id"}]])]
 
       (testing "with direct select binding restricts"
         (is (= [["ex:alice" "111-11-1111"]]
@@ -162,13 +161,11 @@
                                                     "@value" {}}}]}
           john-policy-db  @(fluree/wrap-policy
                             db policy
-                            {"?$identity" {"@value" john-did
-                                           "@type"  "@id"}})
+                            ["?$identity" [{"@value" john-did "@type"  "@id"}]])
 
           alice-policy-db @(fluree/wrap-policy
                             db policy
-                            {"?$identity" {"@value" alice-did
-                                           "@type"  "@id"}})]
+                            ["?$identity" [{"@value" alice-did "@type"  "@id"}]])]
 
       (testing "and values binding has user with policy relationship"
         (is (= [{"@id"                  "ex:widget",

--- a/test/fluree/db/policy/query_test.clj
+++ b/test/fluree/db/policy/query_test.clj
@@ -316,7 +316,7 @@
                                             "@type" "usa:territory"
                                             "ex:name" "Puerto Rico"
                                             "ex:capitol" "San Juan"}]})]
-    (testing "no policyValues"
+    (testing "no policyValues returns all results"
       (is (= ["Colorado" "New York" "North Carolina" "Puerto Rico" "Wisconsin"]
              @(fluree/query db {"@context" test-utils/default-str-context
                                 "where" [{"@id" "?state" "ex:name" "?name"}]
@@ -328,7 +328,7 @@
                                          "f:query" {"@type" "@json"
                                                     "@value"
                                                     {"where" [{"@id" "?$this" "ex:capitol" "?capitol"}]}}}}}))))
-    (testing "a single policyValues value"
+    (testing "a single policyValues value constrains results to corresponding value"
       (is (= ["Wisconsin"]
              @(fluree/query db {"@context" test-utils/default-str-context
                                 "where" [{"@id" "?state" "ex:name" "?name"}]
@@ -341,7 +341,7 @@
                                                     "@value"
                                                     {"where" [{"@id" "?$this" "ex:capitol" "?capitol"}]}}}
                                         "policyValues" ["?capitol" ["Madison"]]}}))))
-    (testing "multiple policyValues values"
+    (testing "multiple policyValues values constrains results to corresponding values"
       (is (= ["Puerto Rico" "Wisconsin"]
              @(fluree/query db {"@context" test-utils/default-str-context
                                 "where" [{"@id" "?state" "ex:name" "?name"}]
@@ -354,7 +354,7 @@
                                                     "@value"
                                                     {"where" [{"@id" "?$this" "ex:capitol" "?capitol"}]}}}
                                         "policyValues" ["?capitol" ["Madison" "San Juan"]]}}))))
-    (testing "multiple vars and multiple values"
+    (testing "multiple vars and multiple values constrains results to corresponding values"
       (is (= ["Wisconsin"]
              @(fluree/query db {"@context" test-utils/default-str-context
                                 "where" [{"@id" "?state" "ex:name" "?name"}]
@@ -368,7 +368,7 @@
                                                                "ex:capitol" "?capitol"}]}}}
                                         "policyValues" [["?type" "?capitol"]
                                                         [[{"@value" "usa:state" "@type" "@id"} "Madison"]]]}}))))
-    (testing "pre-existing values clause"
+    (testing "pre-existing values clause compose with supplied policyValues"
       (is (= ["Wisconsin"]
              @(fluree/query db {"@context" test-utils/default-str-context
                                 "where" [{"@id" "?state" "ex:name" "?name"}]

--- a/test/fluree/db/policy/tx_test.clj
+++ b/test/fluree/db/policy/tx_test.clj
@@ -59,11 +59,9 @@
                                           "f:query"  {"@type"  "@json"
                                                       "@value" {}}}]}
 
-          john-params       {"?$identity" {"@value" john-did
-                                           "@type"  "@id"}}
+          john-params       ["?$identity" [{"@value" john-did "@type" "@id"}]]
 
-          alice-params      {"?$identity" {"@value" alice-did
-                                           "@type"  "@id"}}
+          alice-params      ["?$identity" [{"@value" alice-did "@type" "@id"}]]
 
           john-allowed      @(fluree/stage
                               @(fluree/wrap-policy db policy john-params)
@@ -157,11 +155,9 @@
                                           "f:query"  {"@type"  "@json"
                                                       "@value" {}}}]}
 
-          john-params       {"?$identity" {"@value" john-did
-                                           "@type"  "@id"}}
+          john-params       ["?$identity" [{"@value" john-did "@type" "@id"}]]
 
-          alice-params      {"?$identity" {"@value" alice-did
-                                           "@type"  "@id"}}
+          alice-params      ["?$identity" [{"@value" alice-did "@type" "@id"}]]
 
           john-allowed      @(fluree/stage
                               @(fluree/wrap-policy db policy john-params)

--- a/test/fluree/db/policy/tx_test.clj
+++ b/test/fluree/db/policy/tx_test.clj
@@ -204,7 +204,7 @@
                     "insert"   [{"@id"         "ex:alice"
                                  "schema:name" "Alice"}]})]
 
-      (testing " apply policy with only view action, no modify and transact"
+      (testing "apply policy with only view action, no modify and transact"
         (let [policy-wrapped @(fluree/wrap-policy
                                db {"@context" {"ex" "http://example.org/ns/"
                                                "f"  "https://ns.flur.ee/ledger#"}
@@ -225,7 +225,7 @@
           (is (= "Database policy denies all modifications."
                  (ex-message no-policy-ex)))))
 
-      (testing " apply policy with modify policy that will always return false"
+      (testing "apply policy with modify policy that will always return false"
         (let [policy-wrapped @(fluree/wrap-policy
                                db [;; falesy always modify
                                    {"@context"    {"ex" "http://example.org/ns/"


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/128

This change makes the `opts.policyValues` use the same syntax as an fql values clause or a values pattern.
```
["?a" [1 2]]
;; or
[["?a "?b] [["a1" "b1"] ["a2" "b2"]]]
```
It composes with an existing values clause on the policy query by adding the specified values as a values pattern in the where clause.