### PR TITLE
Allow environment variables in connection configs

### DIFF
--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -7,7 +7,6 @@
             [fluree.db.util.context :as context]
             [fluree.json-ld :as json-ld]
             [fluree.db.json-ld.iri :as iri]
-            [fluree.db.platform :as platform]
             [clojure.core.async :as async :refer [go <!]]
             [fluree.db.query.api :as query-api]
             [fluree.db.api.transact :as transact-api]
@@ -59,7 +58,7 @@
   ;; TODO - do some validation
   (promise-wrap
     (go-try
-      (let [system-map (-> config config/parse system/initialize)
+      (let [system-map (system/initialize config)
             conn       (reduce-kv (fn [x k v]
                                     (if (isa? k :fluree.db/connection)
                                       (reduced v)

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -2,7 +2,8 @@
   (:require [clojure.string :as str]
             [fluree.db.connection.vocab :as conn-vocab]
             [fluree.db.json-ld.iri :as iri]
-            [fluree.db.util.core :as util :refer [get-id get-first]]
+            [fluree.db.util.core :as util :refer [get-id get-first get-first-value
+                                                  get-value]]
             [fluree.db.util.json :as json]
             [fluree.json-ld :as json-ld]))
 
@@ -67,28 +68,6 @@
   [node]
   (and (storage? node)
        (contains? node conn-vocab/ipfs-endpoint)))
-
-(defn env-var-datatype?
-  [node]
-  (-> node util/get-datatype (= conn-vocab/env-var-datatype)))
-
-(defn get-value
-  [node]
-  (let [v (util/get-value node)]
-    (if (env-var-datatype? node)
-      #?(:clj (or (System/getenv v)
-                  (throw (ex-info (str "Environment variable " v " unset.")
-                                  {:status 400 :error :db/missing-env-var})))
-         ;; TODO: Support environment variable overrides in cljs
-         :cljs (throw (ex-info "Environment variables are not supported on this platform"
-                               {:status 400 :error :db/unsupported-config})))
-      v)))
-
-(defn get-first-value
-  [node k]
-  (-> node
-      (get-first k)
-      get-value))
 
 (defn get-integer
   [x]

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -61,6 +61,24 @@
   (and (storage? node)
        (contains? node conn-vocab/ipfs-endpoint)))
 
+(defn env-var-datatype?
+  [node]
+  (-> node util/get-datatype (= conn-vocab/env-var-datatype)))
+
+(defn get-value
+  [node]
+  (let [v (util/get-value node)]
+    (if (env-var-datatype? node)
+      #?(:clj (System/getenv v)
+         :cljs nil) ; TODO: Support environment variable overrides in cljs
+      v)))
+
+(defn get-first-value
+  [jsonld k]
+  (-> jsonld
+      (get-first k)
+      get-value))
+
 (defn derive-node-id
   [node]
   (let [id (get-id node)]

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -69,7 +69,9 @@
   [node]
   (let [v (util/get-value node)]
     (if (env-var-datatype? node)
-      #?(:clj (System/getenv v)
+      #?(:clj (or (System/getenv v)
+                  (throw (ex-info (str "Environment variable " v " unset.")
+                                  {:status 400 :error :db/missing-env-var})))
          :cljs nil) ; TODO: Support environment variable overrides in cljs
       v)))
 

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -108,6 +108,19 @@
   [node k]
   (mapv get-string (get node k)))
 
+(defn get-boolean
+  [x]
+  (if (string? x)
+    #?(:clj (Boolean/parseBoolean x)
+       :cljs (js/Boolean x))
+    (boolean x)))
+
+(defn get-first-boolean
+  [node k]
+  (some-> node
+          (get-first-value k)
+          get-boolean))
+
 (defn derive-node-id
   [node]
   (let [id (get-id node)]

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -12,6 +12,13 @@
   [node kind]
   (-> node (get-first :type) (= kind)))
 
+(defn config-value?
+  [node]
+  (or (contains? node conn-vocab/env-var)
+      (contains? node conn-vocab/java-prop)
+      (contains? node conn-vocab/default-val)
+      (type? node conn-vocab/config-val-type)))
+
 (defn connection?
   [node]
   (type? node conn-vocab/connection-type))

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [fluree.db.connection.vocab :as conn-vocab]
             [fluree.db.json-ld.iri :as iri]
-            [fluree.db.util.core :as util :refer [get-id get-first get-first-value get-values]]
+            [fluree.db.util.core :as util :refer [get-id get-first]]
             [fluree.db.util.json :as json]
             [fluree.json-ld :as json-ld]))
 
@@ -65,14 +65,14 @@
   [node]
   (let [id (get-id node)]
     (cond
-      (connection? node)           (derive id :fluree.db/connection)
-      (system? node)               (derive id :fluree.db/remote-system)
-      (memory-storage? node)       (derive id :fluree.db.storage/memory)
-      (file-storage? node)         (derive id :fluree.db.storage/file)
-      (s3-storage? node)           (derive id :fluree.db.storage/s3)
-      (ipfs-storage? node)         (derive id :fluree.db.storage/ipfs)
-      (ipns-nameservice? node)     (derive id :fluree.db.nameservice/ipns)
-      (storage-nameservice? node)  (derive id :fluree.db.nameservice/storage))
+      (connection? node)          (derive id :fluree.db/connection)
+      (system? node)              (derive id :fluree.db/remote-system)
+      (memory-storage? node)      (derive id :fluree.db.storage/memory)
+      (file-storage? node)        (derive id :fluree.db.storage/file)
+      (s3-storage? node)          (derive id :fluree.db.storage/s3)
+      (ipfs-storage? node)        (derive id :fluree.db.storage/ipfs)
+      (ipns-nameservice? node)    (derive id :fluree.db.nameservice/ipns)
+      (storage-nameservice? node) (derive id :fluree.db.nameservice/storage))
     node))
 
 (def component-exclusions

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -116,6 +116,7 @@
   [node]
   (let [id (get-id node)]
     (cond
+      (config-value? node)        (derive id :fluree.db/config-value)
       (connection? node)          (derive id :fluree.db/connection)
       (system? node)              (derive id :fluree.db/remote-system)
       (memory-storage? node)      (derive id :fluree.db.storage/memory)

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -94,7 +94,10 @@
 
 (defn get-strings
   [node k]
-  (mapv get-string (get node k)))
+  (into []
+        (comp (map get-string)
+              (remove nil?))
+        (get node k)))
 
 (defn get-boolean
   [x]

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -75,6 +75,10 @@
          :cljs nil) ; TODO: Support environment variable overrides in cljs
       v)))
 
+(defn get-values
+  [node k]
+  (mapv get-value (get node k)))
+
 (defn get-first-value
   [jsonld k]
   (-> jsonld

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -75,15 +75,38 @@
          :cljs nil) ; TODO: Support environment variable overrides in cljs
       v)))
 
-(defn get-values
-  [node k]
-  (mapv get-value (get node k)))
-
 (defn get-first-value
-  [jsonld k]
-  (-> jsonld
+  [node k]
+  (-> node
       (get-first k)
       get-value))
+
+(defn get-integer
+  [x]
+  (if (string? x)
+    #?(:clj (Integer/parseInt x)
+       :cljs (js/parseInt x))
+    (int x)))
+
+(defn get-first-integer
+  [node k]
+  (some-> node
+          (get-first-value k)
+          get-integer))
+
+(defn get-first-string
+  [node k]
+  (some-> node
+          (get-first-value k)
+          str))
+
+(defn get-string
+  [node]
+  (some-> node get-value str))
+
+(defn get-strings
+  [node k]
+  (mapv get-string (get node k)))
 
 (defn derive-node-id
   [node]

--- a/src/clj/fluree/db/connection/config.cljc
+++ b/src/clj/fluree/db/connection/config.cljc
@@ -72,7 +72,9 @@
       #?(:clj (or (System/getenv v)
                   (throw (ex-info (str "Environment variable " v " unset.")
                                   {:status 400 :error :db/missing-env-var})))
-         :cljs nil) ; TODO: Support environment variable overrides in cljs
+         ;; TODO: Support environment variable overrides in cljs
+         :cljs (throw (ex-info "Environment variables are not supported on this platform"
+                               {:status 400 :error :db/unsupported-config})))
       v)))
 
 (defn get-first-value

--- a/src/clj/fluree/db/connection/system.cljc
+++ b/src/clj/fluree/db/connection/system.cljc
@@ -209,7 +209,7 @@
 
 (defn initialize
   [config]
-  (-> config convert-references ig/expand ig/init))
+  (-> config config/parse convert-references ig/expand ig/init))
 
 (defn terminate
   [sys]

--- a/src/clj/fluree/db/connection/system.cljc
+++ b/src/clj/fluree/db/connection/system.cljc
@@ -103,16 +103,16 @@
   [_ component]
   component)
 
-(defn get-env
-  [env-var]
-  #?(:clj (System/getenv env-var)
-     :cljs (throw (ex-info "Environment variables are not supported on this platform"
-                           {:status 400, :error :db/unsupported-config}))))
-
 (defn get-java-prop
   [java-prop]
   #?(:clj (System/getProperty java-prop)
      :cljs (throw (ex-info "Java system properties are not supported on this platform"
+                           {:status 400, :error :db/unsupported-config}))))
+
+(defn get-env
+  [env-var]
+  #?(:clj (System/getenv env-var)
+     :cljs (throw (ex-info "Environment variables are not supported on this platform"
                            {:status 400, :error :db/unsupported-config}))))
 
 (defn missing-config-error
@@ -129,10 +129,10 @@
 
 (defn get-priority-value
   [env-var java-prop default-val]
-  (or (and env-var
-           (get-env env-var))
-      (and java-prop
+  (or (and java-prop
            (get-java-prop java-prop))
+      (and env-var
+           (get-env env-var))
       default-val
       (throw (missing-config-error env-var java-prop))))
 

--- a/src/clj/fluree/db/connection/system.cljc
+++ b/src/clj/fluree/db/connection/system.cljc
@@ -207,9 +207,13 @@
                          :serializer           serializer
                          :defaults             defaults})))
 
+(defn parsed-initialize
+  [parsed-config]
+  (-> parsed-config convert-references ig/expand ig/init))
+
 (defn initialize
   [config]
-  (-> config config/parse convert-references ig/expand ig/init))
+  (-> config config/parse parsed-initialize))
 
 (defn terminate
   [sys]

--- a/src/clj/fluree/db/connection/vocab.cljc
+++ b/src/clj/fluree/db/connection/vocab.cljc
@@ -11,7 +11,7 @@
   (str system-ns s))
 
 (def env-var-datatype
-  (system-iri "EnvVar"))
+  (system-iri "envVar"))
 
 (def connection-type
   (system-iri "Connection"))

--- a/src/clj/fluree/db/connection/vocab.cljc
+++ b/src/clj/fluree/db/connection/vocab.cljc
@@ -10,8 +10,8 @@
   [s]
   (str system-ns s))
 
-(def env-var-datatype
-  (system-iri "envVar"))
+(def config-val-type
+  (system-iri "ConfigurationValue"))
 
 (def connection-type
   (system-iri "Connection"))
@@ -24,6 +24,15 @@
 
 (def system-type
   (system-iri "System"))
+
+(def env-var
+  (system-iri "envVar"))
+
+(def java-prop
+  (system-iri "javaProp"))
+
+(def default-val
+  (system-iri "defaultVal"))
 
 (def address-identifier
   (system-iri "addressIdentifier"))

--- a/src/clj/fluree/db/connection/vocab.cljc
+++ b/src/clj/fluree/db/connection/vocab.cljc
@@ -10,6 +10,9 @@
   [s]
   (str system-ns s))
 
+(def env-var-datatype
+  (system-iri "EnvVar"))
+
 (def connection-type
   (system-iri "Connection"))
 

--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -1,6 +1,5 @@
 (ns fluree.db.util.core
   (:require [clojure.string :as str]
-            [fluree.db.constants :as const]
             #?@(:clj [[fluree.db.util.clj-exceptions :as clj-exceptions]
                       [fluree.db.util.cljs-exceptions :as cljs-exceptions]]))
   #?(:cljs (:require-macros [fluree.db.util.core :refer [case+]]))
@@ -414,21 +413,21 @@
    (clojure.core/vswap! vol f arg1 arg2 arg3)))
 
 (defn get-first
-  [json-ld k]
-  (let [v (get json-ld k)]
+  [jsonld k]
+  (let [v (get jsonld k)]
     (if (sequential? v)
       (first v)
       v)))
 
 (defn get-types
-  [json-ld]
-  (or (:type json-ld)
-      (get json-ld "@type")))
+  [jsonld]
+  (or (:type jsonld)
+      (get jsonld "@type")))
 
 (defn of-type?
   "Returns true if the provided json-ld node is of the provided type."
-  [json-ld rdf-type]
-  (->> json-ld
+  [jsonld rdf-type]
+  (->> jsonld
        get-types
        (some #(= % rdf-type))))
 
@@ -441,31 +440,28 @@
 
 (defn get-datatype
   [node]
-  (if (or (contains? node :value)
-          (contains? node "@value"))
-    (get-types node)
-    (when (or (contains? node :id)
-              (contains? node "@id"))
-      const/iri-id)))
+  (when (or (contains? node :value)
+            (contains? node "@value"))
+    (get-types node)))
 
 (defn get-first-value
-  [json-ld k]
-  (-> json-ld
+  [jsonld k]
+  (-> jsonld
       (get-first k)
       get-value))
 
 (defn get-values
-  [json-ld k]
-  (mapv get-value (get json-ld k)))
+  [jsonld k]
+  (mapv get-value (get jsonld k)))
 
 (defn get-id
-  [json-ld]
-  (or (:id json-ld)
-      (get json-ld "@id")))
+  [jsonld]
+  (or (:id jsonld)
+      (get jsonld "@id")))
 
 (defn get-first-id
-  [json-ld k]
-  (-> json-ld
+  [jsonld k]
+  (-> jsonld
       (get-first k)
       get-id))
 
@@ -499,13 +495,13 @@
         vals)))
 
 (defn get-all-ids
-  "Returns all @id values for a given key in a json-ld node.
+  "Returns all @id values for a given key in a jsonld node.
 
   If values are contained in a @list, unwraps them.
 
   Elides any scalar values (those without an @id key)."
-  [json-ld k]
-  (some->> (get json-ld k)
+  [jsonld k]
+  (some->> (get jsonld k)
            unwrap-list
            (keep get-id)))
 

--- a/src/clj/fluree/db/util/core.cljc
+++ b/src/clj/fluree/db/util/core.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.util.core
   (:require [clojure.string :as str]
+            [fluree.db.constants :as const]
             #?@(:clj [[fluree.db.util.clj-exceptions :as clj-exceptions]
                       [fluree.db.util.cljs-exceptions :as cljs-exceptions]]))
   #?(:cljs (:require-macros [fluree.db.util.core :refer [case+]]))
@@ -437,6 +438,15 @@
     (or (:value val)
         (get val "@value"))
     val))
+
+(defn get-datatype
+  [node]
+  (if (or (contains? node :value)
+          (contains? node "@value"))
+    (get-types node)
+    (when (or (contains? node :id)
+              (contains? node "@id"))
+      const/iri-id)))
 
 (defn get-first-value
   [json-ld k]


### PR DESCRIPTION
This patch allows a user to specify environment variables in json-ld connection configs. The config system will then load the actual config values from the specified environment variable. Users specify the environment variable by setting the `"@type"` of a value map to "https://ns.flur.ee/system#envVar", as in the following example

```json
{
  "@context": {
    "@base": "https://ns.flur.ee/dev/config/",
    "@vocab": "https://ns.flur.ee/system#"
  },
  "@id": "testSystem",
  "@graph": [
    ...
    {
      "@id": "testConnection",
      "@type": "Connection",
      "parallelism": {
        "@value": "FLUREE_CONNECTION_PARALLELISM",
        "@type": "envVar"
      },
      "cacheMaxMb": {
        "@value": "FLUREE_CACHE_MAX_MB",
        "@type": "envVar"
      }
    }
  ]
}
```