### PR TITLE
honor @container @set on @reverse predicates

### DIFF
--- a/src/clj/fluree/db/async_db.cljc
+++ b/src/clj/fluree/db/async_db.cljc
@@ -90,13 +90,13 @@
             (>! error-ch e))))
       prop-ch))
 
-  (-reverse-property [_ iri reverse-spec compact-fn cache fuel-tracker error-ch]
+  (-reverse-property [_ iri reverse-spec context compact-fn cache fuel-tracker error-ch]
     (let [prop-ch (async/chan)]
       (go
         (try*
           (let [db (<? db-chan)]
             (-> db
-                (subject/-reverse-property iri reverse-spec compact-fn cache fuel-tracker error-ch)
+                (subject/-reverse-property iri reverse-spec context compact-fn cache fuel-tracker error-ch)
                 (async/pipe prop-ch)))
           (catch* e
             (log/error e "Error loading database")

--- a/src/clj/fluree/db/dataset.cljc
+++ b/src/clj/fluree/db/dataset.cljc
@@ -101,13 +101,13 @@
                             db-ch)
       (async/reduce merge-subgraphs {} prop-ch)))
 
-  (-reverse-property [ds iri reverse-spec compact-fn cache fuel-tracker error-ch]
+  (-reverse-property [ds iri reverse-spec context compact-fn cache fuel-tracker error-ch]
     (let [db-ch   (->> ds all async/to-chan!)
           prop-ch (async/chan)]
       (async/pipeline-async 2
                             prop-ch
                             (fn [db ch]
-                              (-> (subject/-reverse-property db iri reverse-spec compact-fn cache fuel-tracker error-ch)
+                              (-> (subject/-reverse-property db iri reverse-spec context compact-fn cache fuel-tracker error-ch)
                                   (async/pipe ch)))
                             db-ch)
       (async/reduce (fn [combined-prop db-prop]

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -346,8 +346,8 @@
   (-forward-properties [db iri spec context compact-fn cache fuel-tracker error-ch]
     (jld-format/forward-properties db iri spec context compact-fn cache fuel-tracker error-ch))
 
-  (-reverse-property [db iri reverse-spec compact-fn cache fuel-tracker error-ch]
-    (jld-format/reverse-property db iri reverse-spec compact-fn cache fuel-tracker error-ch))
+  (-reverse-property [db iri reverse-spec context compact-fn cache fuel-tracker error-ch]
+    (jld-format/reverse-property db iri reverse-spec context compact-fn cache fuel-tracker error-ch))
 
   (-iri-visible? [db iri]
     (qpolicy/allow-iri? db iri))

--- a/src/clj/fluree/db/flake/format.cljc
+++ b/src/clj/fluree/db/flake/format.cljc
@@ -118,7 +118,7 @@
          (async/transduce subj-xf (completing conj) {}))))
 
 (defn reverse-property
-  [{:keys [t] :as db} o-iri {:keys [as spec], p-iri :iri, :as reverse-spec} compact-fn cache fuel-tracker error-ch]
+  [{:keys [t] :as db} o-iri {:keys [as spec], p-iri :iri, :as reverse-spec} context compact-fn cache fuel-tracker error-ch]
   (let [oid                     (iri/encode-iri db o-iri)
         pid                     (iri/encode-iri db p-iri)
         [start-flake end-flake] (flake-bounds db :opst [oid pid])
@@ -138,7 +138,7 @@
          (async/transduce (comp cat sid-xf)
                           (completing conj
                                       (fn [result]
-                                        [as (util/unwrap-singleton result)]))
+                                        [as (util/unwrap-singleton as context result)]))
                           []))))
 
 (defn format-subject-flakes
@@ -152,7 +152,7 @@
                               (format-subject-xf db cache context compact-fn select-spec)
                               s-flakes)
           subject-ch    (if reverse
-                          (let [reverse-ch (subject/format-reverse-properties db s-iri reverse compact-fn cache fuel-tracker error-ch)]
+                          (let [reverse-ch (subject/format-reverse-properties db s-iri reverse context compact-fn cache fuel-tracker error-ch)]
                             (async/reduce conj subject-attrs reverse-ch))
                           (go subject-attrs))]
       (->> subject-ch

--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -30,6 +30,12 @@
              @(fluree/query db {:context   [context {:friended {:reverse :ex/friend}}]
                                 :selectOne {:ex/brian [:schema/name :friended]}})))
 
+      (is (= {:schema/name "Brian"
+              :friended    [:ex/cam]}
+             @(fluree/query db {:context   [context {:friended {:container :set
+                                                                :reverse :ex/friend}}]
+                                :selectOne {:ex/brian [:schema/name :friended]}})))
+
       (is (= {:schema/name "Alice"
               :friended    [:ex/brian :ex/cam]}
              @(fluree/query db {:context   [context {:friended {:reverse :ex/friend}}]


### PR DESCRIPTION
Derek discovered a bug where we were not honoring `@container @set` for reverse properties. This PR provides that support - we just needed to thread the context down to `reverse-property` in the same way we do for `forward-property`. The actual fix is in `fluree.db.flake.format/reverse-property`.