### PR TITLE
Feature - Required Policy

### DIFF
--- a/src/clj/fluree/db/constants.cljc
+++ b/src/clj/fluree/db/constants.cljc
@@ -59,6 +59,7 @@
 (def ^:const iri-rule (fluree-iri "rule"))
 (def ^:const iri-query (fluree-iri "query"))
 (def ^:const iri-onClass (fluree-iri "onClass"))
+(def ^:const iri-required (fluree-iri "required"))
 (def ^:const iri-onProperty (fluree-iri "onProperty"))
 (def ^:const iri-exMessage (fluree-iri "exMessage"))
 (def ^:const iri-policyClass (fluree-iri "policyClass"))

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -69,7 +69,6 @@
                "Policy enforcement prevents modification.")
            {:status 403 :error :db/policy-exception}))
 
-
 (defn policies-allow?
   "Once narrowed to a specific set of policies, execute and return
   appropriate policy response."

--- a/src/clj/fluree/db/json_ld/policy/modify.cljc
+++ b/src/clj/fluree/db/json_ld/policy/modify.cljc
@@ -30,14 +30,13 @@
        (loop [[flake & r] add]
          (if flake
            (let [sid (flake/s flake)]
-             (if-let [p-policies (enforce/policies-for-property policy true (flake/p flake))]
-               (<? (enforce/policies-allow? db-after true sid p-policies))
-               (if-let [c-policies (->> (classes-for-sid sid mods db-after)
-                                        (enforce/policies-for-classes policy true))]
-                 (<? (enforce/policies-allow? db-after true sid c-policies))
-                 (if-let [d-policies (enforce/default-policies policy true)]
-                   (<? (enforce/policies-allow? db-after true sid d-policies))
-                   false)))
+             (or (when-let [p-policies (enforce/policies-for-property policy true (flake/p flake))]
+                   (<? (enforce/policies-allow? db-after true sid p-policies)))
+                 (when-let [c-policies (->> (classes-for-sid sid mods db-after)
+                                            (enforce/policies-for-classes policy true))]
+                   (<? (enforce/policies-allow? db-after true sid c-policies)))
+                 (when-let [d-policies (enforce/default-policies policy true)]
+                   (<? (enforce/policies-allow? db-after true sid d-policies))))
 
              (recur r))
            ;; no more flakes, all passed so return final db

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -40,16 +40,15 @@
   hits this fn."
   [{:keys [policy] :as db} flake]
   (go-try
-   (let [pid     (flake/p flake)
-         sid     (flake/s flake)]
-     (if-let [p-policies (enforce/policies-for-property policy false pid)]
-       (<? (enforce/policies-allow? db false sid p-policies))
-       (if-let [c-policies (or (cached-class-policies policy sid)
-                               (<? (class-policies db sid)))]
-         (<? (enforce/policies-allow? db false sid c-policies))
-         (if-let [d-policies (enforce/default-policies policy false)]
-           (<? (enforce/policies-allow? db false sid d-policies))
-           false))))))
+   (let [pid (flake/p flake)
+         sid (flake/s flake)]
+     (or (when-let [p-policies (enforce/policies-for-property policy false pid)]
+           (<? (enforce/policies-allow? db false sid p-policies)))
+         (when-let [c-policies (or (cached-class-policies policy sid)
+                                   (<? (class-policies db sid)))]
+           (<? (enforce/policies-allow? db false sid c-policies)))
+         (when-let [d-policies (enforce/default-policies policy false)]
+           (<? (enforce/policies-allow? db false sid d-policies)))))))
 
 (defn allow-iri?
   "Returns async channel with truthy value if iri is visible for query results"

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -44,7 +44,9 @@
           sid      (flake/s flake)
           policies (concat (enforce/policies-for-property policy false pid)
                            (or (cached-class-policies policy sid)
-                               (<? (class-policies db sid)))
+                               (when (-> policy (get const/iri-view) :class not-empty)
+                                 ;; only do range scan if we have /any/ class policies
+                                 (<? (class-policies db sid))))
                            (enforce/default-policies policy false))]
       (if-some [required-policies (not-empty (filter :required? policies))]
         (<? (enforce/policies-allow? db false sid required-policies))

--- a/src/clj/fluree/db/json_ld/policy/query.cljc
+++ b/src/clj/fluree/db/json_ld/policy/query.cljc
@@ -40,15 +40,15 @@
   hits this fn."
   [{:keys [policy] :as db} flake]
   (go-try
-   (let [pid (flake/p flake)
-         sid (flake/s flake)]
-     (or (when-let [p-policies (enforce/policies-for-property policy false pid)]
-           (<? (enforce/policies-allow? db false sid p-policies)))
-         (when-let [c-policies (or (cached-class-policies policy sid)
-                                   (<? (class-policies db sid)))]
-           (<? (enforce/policies-allow? db false sid c-policies)))
-         (when-let [d-policies (enforce/default-policies policy false)]
-           (<? (enforce/policies-allow? db false sid d-policies)))))))
+    (let [pid      (flake/p flake)
+          sid      (flake/s flake)
+          policies (concat (enforce/policies-for-property policy false pid)
+                           (or (cached-class-policies policy sid)
+                               (<? (class-policies db sid)))
+                           (enforce/default-policies policy false))]
+      (if-some [required-policies (not-empty (filter :required? policies))]
+        (<? (enforce/policies-allow? db false sid required-policies))
+        (<? (enforce/policies-allow? db false sid policies))))))
 
 (defn allow-iri?
   "Returns async channel with truthy value if iri is visible for query results"

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -93,7 +93,7 @@
                       (set classes))
         src-query   (util/get-first-value restriction const/iri-query)
         query       (if (map? src-query)
-                      (assoc src-query "select" "?$this")
+                      (assoc src-query "select" "?$this" "limit" 1)
                       (throw (ex-info (str "Invalid policy, unable to extract query from f:query. "
                                            "Did you forget @context?. Parsed restriction: " restriction)
                                       {:status 400

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -124,7 +124,7 @@
   [db policy-rules]
   (reduce
    (fn [acc rule]
-     (let [parsed-restriction (restriction-map rule)] ;; will return nil if formatting is not valid
+     (let [parsed-restriction (restriction-map rule)] ;; will throw if formatting is not valid
        (cond
 
          (property-restriction? parsed-restriction)

--- a/src/clj/fluree/db/json_ld/policy/rules.cljc
+++ b/src/clj/fluree/db/json_ld/policy/rules.cljc
@@ -107,6 +107,7 @@
       {:id          id
        :on-property on-property
        :on-class    on-class
+       :required?   (util/get-first-value restriction const/iri-required)
        :default?    (and (nil? on-property) (nil? on-class)) ;; with no class or property restrictions, becomes a default policy
        :ex-message  (util/get-first-value restriction const/iri-exMessage)
        :view?       view?

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -573,16 +573,10 @@
   (go
     (let [f (pattern-data pattern)]
       (try*
-        (def solution solution)
         (let [result (f solution)]
           (when result
             solution))
         (catch* e (>! error-ch (filter-exception e solution f)))))))
-
-(comment
-  solution
-  {?s #:fluree.db.query.exec.where{:var ?s, :sids {"non-serializable-values" #fluree/SID [101 "2"]}, :iri "ex:2"},
-   ?date #:fluree.db.query.exec.where{:var ?date, :t 1, :meta nil, :val #time/date "2022-12-12", :datatype-iri "http://www.w3.org/2001/XMLSchema#date"}})
 
 (defn with-constraint
   "Return a channel of all solutions from the data set `ds` that extend from the

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -244,21 +244,21 @@
                   (crypto/create-jws sparql (:private auth))
                   {:format :sparql}))
              "SPARQL query credential - allowing access")
-         
+
          (is (= []
                 @(fluree/credential-query
                   (fluree/db ledger)
                   (crypto/create-jws sparql (:private pleb-auth))
                   {:format :sparql}))
              "SPARQL query credential - forbidding access")
-         
+
          (is (= [["D"]]
                 @(fluree/credential-query-connection
                   conn
                   (crypto/create-jws sparql (:private auth))
                   {:format :sparql}))
              "SPARQL query connection credential - allowing access")
-         
+
          (is (= []
                 @(fluree/credential-query-connection
                   conn

--- a/test/fluree/db/json_ld/credential_test.cljc
+++ b/test/fluree/db/json_ld/credential_test.cljc
@@ -136,6 +136,7 @@
                                      "ct" "ledger:credentialtest/"}
                       "@id"         "ct:userPolicy"
                       "@type"       ["f:AccessPolicy" "ct:DefaultUserPolicy"]
+                      "f:required"  true
                       "f:onClass"   [{"@id" "ct:User"}]
                       "f:action"    [{"@id" "f:view"}, {"@id" "f:modify"}]
                       "f:exMessage" "Users can only manage their own data."

--- a/test/fluree/db/policy/identity_based_test.clj
+++ b/test/fluree/db/policy/identity_based_test.clj
@@ -40,6 +40,7 @@
                                    ;; embedded policy
                                    {"@id"          "ex:ssnRestriction"
                                     "@type"        ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                    "f:required"   true
                                     "f:onProperty" [{"@id" "schema:ssn"}]
                                     "f:action"     {"@id" "f:view"}
                                     "f:query"      {"@type"  "@json"

--- a/test/fluree/db/policy/policy_class_test.clj
+++ b/test/fluree/db/policy/policy_class_test.clj
@@ -40,6 +40,7 @@
                                    ;; embedded policy
                                    {"@id"          "ex:ssnRestriction"
                                     "@type"        ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                    "f:required"   true
                                     "f:onProperty" [{"@id" "schema:ssn"}]
                                     "f:action"     {"@id" "f:view"}
                                     "f:query"      {"@type"  "@json"

--- a/test/fluree/db/policy/query_test.clj
+++ b/test/fluree/db/policy/query_test.clj
@@ -43,6 +43,7 @@
                                  "f"      "https://ns.flur.ee/ledger#"}
                      "@graph"   [{"@id"          "ex:ssnRestriction"
                                   "@type"        ["f:AccessPolicy"]
+                                  "f:required"   true
                                   "f:onProperty" [{"@id" "schema:ssn"}]
                                   "f:action"     {"@id" "f:view"}
                                   "f:query"      {"@type"  "@json"
@@ -148,6 +149,7 @@
                                        "f"      "https://ns.flur.ee/ledger#"}
                            "@graph"   [{"@id"       "ex:productPropertyRestriction"
                                         "@type"     ["f:AccessPolicy"]
+                                        "f:required" true
                                         "f:onClass" [{"@id" "ex:Product"}]
                                         "f:action"  {"@id" "f:view"}
                                         "f:query"   {"@type"  "@json"
@@ -230,6 +232,7 @@
                                       "f"  "https://ns.flur.ee/ledger#"}
                          "@id"       "ex:unclassRestriction"
                          "@type"     ["f:AccessPolicy", "ex:UnclassPolicy"]
+                         "f:required" true
                          "f:onClass" [{"@id" "ex:Data"}]
                          "f:action"  [{"@id" "f:view"}, {"@id" "f:modify"}]
                          "f:query"   {"@type"  "@json"

--- a/test/fluree/db/policy/tx_test.clj
+++ b/test/fluree/db/policy/tx_test.clj
@@ -46,6 +46,7 @@
                                          "f"      "https://ns.flur.ee/ledger#"}
                              "@graph"   [{"@id"          "ex:emailPropertyRestriction"
                                           "@type"        ["f:AccessPolicy"]
+                                          "f:required"   true
                                           "f:onProperty" [{"@id" "schema:email"}]
                                           "f:action"     [{"@id" "f:view"}, {"@id" "f:modify"}]
                                           "f:exMessage"  "Only users can update their own emails."
@@ -142,6 +143,7 @@
                                          "f"      "https://ns.flur.ee/ledger#"}
                              "@graph"   [{"@id"         "ex:productClassRestriction"
                                           "@type"       ["f:AccessPolicy"]
+                                          "f:required"  true
                                           "f:onClass"   [{"@id" "ex:Product"}]
                                           "f:action"    [{"@id" "f:view"}, {"@id" "f:modify"}]
                                           "f:exMessage" "Only products managed by the user can be modified."
@@ -228,6 +230,7 @@
                                                    "f"  "https://ns.flur.ee/ledger#"}
                                     "@id"         "ex:defaultAllowViewModify"
                                     "@type"       ["f:AccessPolicy"]
+                                    "f:required"  true
                                     "f:action"    [{"@id" "f:modify"}]
                                     "f:exMessage" "Sample policy always returns false - denied!"
                                     "f:query"     {"@type"  "@json"


### PR DESCRIPTION
## What's changed in this PR:

The execution semantics of when a policy is evaluated changed. We segregate policies into three groups:
1. "property" policies - have an `f:onProperty` constraint
2. "class" policies - have an `f:onClass` constraint
3. "default" policies - have neither `f:onClass` nor `f:onProperty` constraints

Before, we would only evaluate the policies in a single group, checked in the order specified above. This had the effect that if a "property" policy existed we would never check the "class" policies.

Now, we will check every policy regardless of its grouping, as outlined below.

This PR also introduces the `f:required` property, the semantics of which are outlined below.

I spent a lot of time making sure I understood how policies worked before I made changes, so below is a detailed description of how they work now.

## Authorization Policies

A Policy is a document that is used to decide which flakes can be viewed or modified. We use this vocabulary:

- `f:query`
  This is a Fluree query is used to determine if a policy allows access to a flake. It is the only required property on a policy. It is stored as an `@type` `@json` blob with its own `@context` that is separate from the query or transaction context.
- `@id` (optional)
- `@type` (optional)
- `f:onProperty` (optional)
  This is used to constrain when a policy is evaluated - only when a flake has a predicate that matches the properties specified here.
- `f:onClass` (optional)
  This is used to constrain when a policy is evaluated - only when a flake's subject has an @type that matches the classes specified here. This is more expensive because we need to look up the flake's subject's @type refs in order to find the policies that are relevant before we can evaluate the policy.
- `f:action` (optional)
  This is used to constrain when a policy is evaluated:
  `f:view` - during a query
  `f:modify` - during a transaction
  If no `f:action` is specified then a policy is applied for both.
- `f:required` (optional)
  If true, all non-required policies will be ignored. All required policies must evaluate to true to permit access.
- `f:exMessage` (optional)
  A custom error message to return if a policy prevents modification during a transaction.

At a conceptual level, policies are processed in this way for each flake that will be returned:
1. All `f:required` policies must evaluate to `true` to permit access the flake. Non required policies are ignored.
2. If no policies are "required", then all the policies are checked in sequence. The first one to evaluate to `true` permits access. If no policy evaluates to true, access to the flake is denied.

During policy evaluation, the `f:query` is executed with certain variables bound:
`?$this` - the subject of the flake being tested
`?$identity` - the identity of the principal performing the action

The query returns an authorization result:
- 1+ results: flake is allowed
- 0 results: flake is not allowed
- error: action is unwound

In order to have policies enforced at all, the correct opts need to be supplied: `identity`, `policyClass`, or `policy`. When present, we "wrap" the db in the applicable policies:
- `identity`: all policies with an `@type` found in the `f:policyClasses` specified on the `<identity>` subject.
- `policyClass`: all the policies with an `@type` that matches any of the supplied values
- `policy`: just the policies provided by this property.

The `credential-*` api functions derive the identity from the signed action and supply the `identity` opt.
