### PR TITLE
Feature/integrated server

### DIFF
--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -222,8 +222,7 @@
 
 (defn apply-stage!
   ([ledger staged-db]
-   (promise-wrap
-    (apply-stage! ledger staged-db {})))
+   (apply-stage! ledger staged-db {}))
   ([ledger staged-db opts]
    (promise-wrap
     (connection/apply-stage! ledger staged-db opts))))

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -220,13 +220,13 @@
    (let [result-ch (transact-api/stage db json-ld opts)]
      (promise-wrap result-ch))))
 
-(defn actualize!
+(defn apply-stage!
   ([ledger staged-db]
    (promise-wrap
-    (actualize! ledger staged-db {})))
+    (apply-stage! ledger staged-db {})))
   ([ledger staged-db opts]
    (promise-wrap
-    (connection/actualize! ledger staged-db opts))))
+    (connection/apply-stage! ledger staged-db opts))))
 
 (defn commit!
   "Commits a staged database to the ledger with all changes since the last commit

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -220,6 +220,13 @@
    (let [result-ch (transact-api/stage db json-ld opts)]
      (promise-wrap result-ch))))
 
+(defn actualize!
+  ([ledger staged-db]
+   (promise-wrap
+    (actualize! ledger staged-db {})))
+  ([ledger staged-db opts]
+   (promise-wrap
+    (connection/actualize! ledger staged-db opts))))
 
 (defn commit!
   "Commits a staged database to the ledger with all changes since the last commit

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -523,7 +523,7 @@
     {:message opts}
     (select-keys opts [:context :did :private :message :tag :file-data? :index-files-ch])))
 
-(defn actualize!
+(defn apply-stage!
   [{:keys [conn] ledger-alias :alias, :as ledger}
    {:keys [branch t stats commit] :as staged-db}
    opts]

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -523,6 +523,62 @@
     {:message opts}
     (select-keys opts [:context :did :private :message :tag :file-data? :index-files-ch])))
 
+(defn actualize!
+  [{:keys [conn] ledger-alias :alias, :as ledger}
+   {:keys [branch t stats commit] :as staged-db}
+   opts]
+  (go-try
+    (let [{:keys [commit-catalog]} conn
+
+          {:keys [tag time message index-files-ch]
+           :or   {time (util/current-time-iso)}}
+          (parse-commit-options opts)
+
+          {commit-data-opts      :commit-data-helpers
+           {:keys [did private]} :commit-opts}
+          (enrich-commit-opts ledger opts)
+
+          {:keys [dbid db-jsonld staged-txns]}
+          (flake-db/db->jsonld staged-db commit-data-opts)
+
+          ;; TODO - we do not support multiple "transactions" in a single
+          ;; commit (although other code assumes we do which needs cleaning)
+          [[txn-id author annotation] :as _txns]
+          (<? (write-transactions! commit-catalog ledger-alias staged-txns))
+
+          data-write-result (<? (commit-storage/write-jsonld commit-catalog ledger-alias db-jsonld))
+          db-address        (:address data-write-result) ; may not have address (e.g. IPFS) until after writing file
+          keypair           {:did did :private private}
+
+          new-commit (commit-data/new-db-commit-map
+                      {:old-commit commit
+                       :issuer     did
+                       :message    message
+                       :tag        tag
+                       :dbid       dbid
+                       :t          t
+                       :time       time
+                       :db-address db-address
+                       :author     author
+                       :annotation annotation
+                       :txn-id     txn-id
+                       :flakes     (:flakes stats)
+                       :size       (:size stats)})
+
+          {:keys [commit-map commit-jsonld write-result]}
+          (<? (write-commit commit-catalog ledger-alias keypair new-commit))
+
+          db  (formalize-commit staged-db commit-map)
+          db* (ledger/update-commit! ledger branch db index-files-ch)]
+
+      (log/debug "Committing t" t "at" time)
+
+      (<? (publish-commit conn commit-jsonld))
+
+      (-> write-result
+          (select-keys [:address :hash :size])
+          (assoc :t t, :db db*)))))
+
 (defn commit!
   "Finds all uncommitted transactions and wraps them in a Commit document as the subject
   of a VerifiableCredential. Persists according to the :ledger :conn :method and

--- a/src/clj/fluree/db/connection/system.cljc
+++ b/src/clj/fluree/db/connection/system.cljc
@@ -248,9 +248,13 @@
                          :serializer           serializer
                          :defaults             defaults})))
 
+(defn prepare
+  [parsed-config]
+  (-> parsed-config convert-references ig/expand))
+
 (defn parsed-initialize
   [parsed-config]
-  (-> parsed-config convert-references ig/expand ig/init))
+  (-> parsed-config prepare ig/init))
 
 (defn initialize
   [config]


### PR DESCRIPTION
This small patch separates the `commit!` api function by adding a new `apply-stage!` function that returns a map of commit metadata including the commit address, hash, size, new t value, and the new db record. The pre-existing `commit!` function now only returns the updated db. These two pieces of functionality used to be complected within the same `commit!` function distinguished with the `file-data?` option. Having two separate functions leads to less complexity than handling control flow with opaque options.

This patch also includes a `prepare` function for parsing and expanding json-ld configuration documents into internal integrand config maps that's useful for repl sessions in dependent applications. 