### PR TITLE
Optimize Stale Flake Removal

### DIFF
--- a/dev/indexing_test.clj
+++ b/dev/indexing_test.clj
@@ -22,7 +22,7 @@
                     {:server   nil                          ;; use default
                      ;; ledger defaults used for newly created ledgers
                      :defaults {:ipns    {:key "self"}      ;; publish to ipns by default using the provided key/profile
-                                :indexer {:reindex-min-bytes 9000
+                                :indexing {:reindex-min-bytes 9000
                                           :reindex-max-bytes 10000000}
                                 :did     (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c")}}))
 

--- a/dev/json_ld.clj
+++ b/dev/json_ld.clj
@@ -57,7 +57,7 @@
                     {:server   nil                          ;; use default
                      ;; ledger defaults used for newly created ledgers
                      :defaults {:ipns    {:key "self"}      ;; publish to ipns by default using the provided key/profile
-                                :indexer {:reindex-min-bytes 100
+                                :indexing {:reindex-min-bytes 100
                                           :reindex-max-bytes 10000000}
                                 :did     (did/private->did-map "8ce4eca704d653dec594703c81a84c403c39f262e54ed014ed857438933a2e1c")}}))
 

--- a/src/clj/fluree/db/connection/system.cljc
+++ b/src/clj/fluree/db/connection/system.cljc
@@ -229,7 +229,7 @@
           index-options (parse-index-options defaults)]
       (cond-> nil
         identity      (assoc :identity identity)
-        index-options (assoc :index-options index-options)))))
+        index-options (assoc :indexing index-options)))))
 
 (defmethod ig/init-key :fluree.db/connection
   [_ {:keys [cache commit-catalog index-catalog serializer] :as config}]

--- a/src/clj/fluree/db/connection/vocab.cljc
+++ b/src/clj/fluree/db/connection/vocab.cljc
@@ -98,7 +98,7 @@
   (system-iri "privateKey"))
 
 (def index-options
-  (system-iri "indexOptions"))
+  (system-iri "indexing"))
 
 (def reindex-min-bytes
   (system-iri "reindexMinBytes"))

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -224,16 +224,18 @@
   (juxt flake/s flake/p flake/o flake/dt meta-hash))
 
 (defn remove-stale-flakes
-  "Removes all flake retractions, along with the flakes they retract, from the sorted set.
+  "Removes all flake retractions, along with the flakes they retract, from the
+  sorted set.
 
-  Approach is to iterate through the flakes in reverse order, and for each retraction, find the
-  corresponding assertion and remove both from the set.
+  Approach is to iterate through the flakes in reverse order, and for each
+  retraction, find the corresponding assertion and remove both from the set.
 
-  Note, with 'spo' not consisting of full uniqueness (e.g. lang, datatype, or duplicate @list value),
-  the 'next flake' is from a retraction is not guaranteed to be the corresponding assertion, however
-  it should be very close. For this reason, a scan over the remaining flakes using `some` is done below."
+  Note, with 'spo' not consisting of full uniqueness (e.g. lang, datatype, or
+  duplicate @list value), the 'next flake' is from a retraction is not
+  guaranteed to be the corresponding assertion, however it should be very close.
+  For this reason, a scan over the remaining flakes using `some` is done below."
   [flakes]
-  (loop [to-check (reverse flakes)
+  (loop [to-check (rseq flakes)
          flakes*  (transient flakes)]
     (if-let [next-flake (first to-check)]
       (let [r   (rest to-check)
@@ -242,7 +244,7 @@
           (do
             ;; remove flakes with same content but different t values (quickly!)
             (loop [check-flakes r]
-              (if-let [f (first check-flakes)]
+              (when-let [f (first check-flakes)]
                 (if (= cmp (fact-content (first check-flakes)))
                   (do (disj! flakes* f)
                       (recur (rest check-flakes)))

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -223,6 +223,10 @@
   "Function to extract the content being asserted or retracted by a flake."
   (juxt flake/s flake/p flake/o flake/dt meta-hash))
 
+(defn same-fact?
+  [fact f]
+  (-> f fact-content (= fact)))
+
 (defn remove-stale-flakes
   "Removes all flake retractions, along with the flakes they retract, from the
   sorted set.
@@ -239,13 +243,13 @@
          checked  #{}
          flakes*  (transient flakes)]
     (if-let [next-flake (first to-check)]
-      (let [r   (rest to-check)
-            cmp (fact-content next-flake)]
+      (let [r    (rest to-check)
+            fact (fact-content next-flake)]
         (if (flake/op next-flake)
-          (if (contains? checked cmp)
+          (if (contains? checked fact)
             (recur r checked (disj! flakes* next-flake))
-            (recur r (conj checked cmp) flakes*))
-          (let [assert-flake (some #(when (= cmp (fact-content %)) %) r)]
+            (recur r (conj checked fact) flakes*))
+          (let [assert-flake (some #(when (same-fact? fact %) %) r)]
             (recur r checked (-> flakes*
                                  (disj! next-flake)
                                  (disj! assert-flake))))))

--- a/test/fluree/db/flake/index/novelty_test.clj
+++ b/test/fluree/db/flake/index/novelty_test.clj
@@ -9,7 +9,7 @@
     (with-tmp-dir storage-path
       (let [conn    @(fluree/connect-file {:storage-path storage-path
                                            :defaults
-                                           {:indexer {:reindex-min-bytes 12
+                                           {:indexing {:reindex-min-bytes 12
                                                       :reindex-max-bytes 10000000}}})
             context (merge test-utils/default-str-context {"ex" "http://example.org/ns/"})
             ledger  @(fluree/create conn "index/datetimes")


### PR DESCRIPTION
This patch brings ins @aaj3f 's fix for inconsistent indexing configuration options and includes an optimization for removing repeated equivalent facts from query results by maintaining a set of previously checked facts to avoid traversing the list of flakes in a node multiple times. 