### PR TITLE
Optimize time travel and novelty resolution

### DIFF
--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -62,7 +62,7 @@
     (let [cleared (reduce (fn [db* idx]
                             (update-in db* [:novelty idx]
                                        (fn [flakes]
-                                         (index/flakes-after t flakes))))
+                                         (index/filter-after t flakes))))
                           db index/types)
           size    (flake/size-bytes (get-in cleared [:novelty :spot]))]
       (assoc-in cleared [:novelty :size] size))

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -220,7 +220,8 @@
   (comp flake/hash-meta flake/m))
 
 (def fact-content
-  "Function to extract the content being asserted or retracted by a flake."
+  "Function to extract the fact being asserted or retracted by a flake, ignoring
+  the `t` value."
   (juxt flake/s flake/p flake/o flake/dt meta-hash))
 
 (defn same-fact?

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -87,18 +87,6 @@
                       flake/maximum)]
     (assoc new-leaf :first new-first)))
 
-(defn rem-flakes
-  [leaf flakes]
-  (let [new-leaf (-> leaf
-                     (update :flakes flake/disj-all flakes)
-                     (update :size (fn [size]
-                                     (->> flakes
-                                          (map flake/size-flake)
-                                          (reduce - size)))))
-        new-first (or (some-> new-leaf :flakes first)
-                      flake/maximum)]
-    (assoc new-leaf :first new-first)))
-
 (defn empty-leaf
   "Returns a blank leaf node map for the provided `ledger-alias` and index
   comparator `cmp`."

--- a/src/clj/fluree/db/flake/index.cljc
+++ b/src/clj/fluree/db/flake/index.cljc
@@ -185,6 +185,10 @@
   [t flakes]
   (filter-by-t after-t? t flakes))
 
+(defn flakes-from
+  [t flakes]
+  (filter-after (flake/prev-t t) flakes))
+
 (defn filter-before
   [t flakes]
   (filter-by-t before-t? t flakes))
@@ -298,15 +302,10 @@
 (defn history-t-range
   "Returns a sorted set of flakes between the transactions `from-t` and `to-t`."
   [{:keys [flakes] leaf-t :t :as leaf} novelty-t novelty from-t to-t]
-  (let [latest       (if (> to-t leaf-t)
-                       (into flakes (novelty-subrange leaf to-t novelty-t novelty))
-                       flakes)
-        ;; flakes that happen after to-t
-        subsequent   (filter-after to-t latest)
-        ;; flakes that happen before from-t
-        previous     (filter (partial before-t? from-t) latest)
-        out-of-range (concat subsequent previous)]
-    (flake/disj-all latest out-of-range)))
+  (let [latest (if (> to-t leaf-t)
+                 (into flakes (novelty-subrange leaf to-t novelty-t novelty))
+                 (flakes-through to-t flakes))]
+    (flakes-from from-t latest)))
 
 (defrecord CachedHistoryRangeResolver [node-resolver novelty-t novelty from-t to-t lru-cache-atom]
   Resolver


### PR DESCRIPTION
This patch has a few optimizations of how flake sets are manipulated when resolving index nodes to specific `t` values. The optimizations here avoid multiple traversals of flake sets where possible and makes better use of transient sets.