### PR TITLE
Feature/separate commit and index

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -501,9 +501,7 @@
   [{:keys [primary-publisher secondary-publishers] :as _conn} commit-jsonld]
   (go-try
     (let [result (<? (nameservice/publish-commit primary-publisher commit-jsonld))]
-      (dorun (map (fn [ns]
-                    (nameservice/publish-commit ns commit-jsonld)))
-             secondary-publishers)
+      (nameservice/publish-to-all commit-jsonld secondary-publishers)
       result)))
 
 (defn formalize-commit

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -503,7 +503,7 @@
   "Publishes commit to all nameservices registered with the ledger."
   [{:keys [primary-publisher secondary-publishers] :as _conn} commit-jsonld]
   (go-try
-    (let [result (<? (nameservice/publish-commit primary-publisher commit-jsonld))]
+    (let [result (<? (nameservice/publish primary-publisher commit-jsonld))]
       (nameservice/publish-to-all commit-jsonld secondary-publishers)
       result)))
 

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -330,13 +330,15 @@
                          :error  :db/ledger-exists}))
         (let [addr          (<? (primary-address conn ledger-alias))
               publish-addrs (<? (publishing-addresses conn ledger-alias))
+              pubs          (publishers conn)
               ledger-opts   (parse-ledger-options conn opts)
               ledger        (<! (ledger/create {:conn              conn
                                                 :alias             ledger-alias
                                                 :address           addr
                                                 :publish-addresses publish-addrs
                                                 :commit-catalog    commit-catalog
-                                                :index-catalog     index-catalog}
+                                                :index-catalog     index-catalog
+                                                :publishers        pubs}
                                                ledger-opts))]
           (when (util/exception? ledger)
             (release-ledger conn ledger-alias))
@@ -373,8 +375,9 @@
 
           {:keys [did branch indexing]} (parse-ledger-options conn {:branch branch})
 
-          ledger   (ledger/instantiate conn ledger-alias address branch commit-catalog
-                                       index-catalog did indexing commit)]
+          pubs   (publishers conn)
+          ledger (ledger/instantiate conn ledger-alias address branch commit-catalog
+                                     index-catalog pubs did indexing commit)]
       (subscribe-ledger conn ledger-alias)
       (async/put! ledger-chan ledger)
       ledger)))

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -500,9 +500,9 @@
   "Publishes commit to all nameservices registered with the ledger."
   [{:keys [primary-publisher secondary-publishers] :as _conn} commit-jsonld]
   (go-try
-    (let [result (<? (nameservice/publish primary-publisher commit-jsonld))]
+    (let [result (<? (nameservice/publish-commit primary-publisher commit-jsonld))]
       (dorun (map (fn [ns]
-                    (nameservice/publish ns commit-jsonld)))
+                    (nameservice/publish-commit ns commit-jsonld)))
              secondary-publishers)
       result)))
 

--- a/src/clj/fluree/db/json_ld/branch.cljc
+++ b/src/clj/fluree/db/json_ld/branch.cljc
@@ -6,7 +6,8 @@
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
             [fluree.db.util.async :refer [<?]]
             [fluree.db.util.log :as log :include-macros true]
-            [clojure.core.async :as async :refer [<! go-loop]]))
+            [clojure.core.async :as async :refer [<! go-loop]]
+            [fluree.db.nameservice :as nameservice]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -86,8 +87,12 @@
           (if-let [indexed-db (try* (<? (indexer/index db* index-files-ch))
                                     (catch* e
                                       (log/error e "Error updating index")))]
-            (do (swap! branch-state update-index indexed-db)
-                (recur (:commit indexed-db)))
+            (let [[{prev-commit :commit} {indexed-commit :commit}]
+                  (swap-vals! branch-state update-index indexed-db)]
+              (when (not= prev-commit indexed-commit)
+                (let [commit-jsonld (commit-data/->json-ld indexed-commit)]
+                  (nameservice/publish-to-all commit-jsonld publishers)))
+              (recur indexed-commit))
             (recur last-index-commit)))))
     queue))
 

--- a/src/clj/fluree/db/json_ld/branch.cljc
+++ b/src/clj/fluree/db/json_ld/branch.cljc
@@ -77,7 +77,7 @@
     db))
 
 (defn index-queue
-  [alias branch branch-state]
+  [alias branch publishers branch-state]
   (let [buf   (async/sliding-buffer 1)
         queue (async/chan buf)]
     (go-loop [last-index-commit nil]
@@ -97,15 +97,15 @@
 
 (defn state-map
   "Returns a branch map for specified branch name at supplied commit"
-  ([ledger-alias branch-name commit-catalog index-catalog commit-jsonld]
-   (state-map ledger-alias branch-name commit-catalog index-catalog commit-jsonld nil))
-  ([ledger-alias branch-name commit-catalog index-catalog commit-jsonld indexing-opts]
+  ([ledger-alias branch-name commit-catalog index-catalog publishers commit-jsonld]
+   (state-map ledger-alias branch-name commit-catalog index-catalog publishers commit-jsonld nil))
+  ([ledger-alias branch-name commit-catalog index-catalog publishers commit-jsonld indexing-opts]
    (let [initial-db (async-db/load ledger-alias branch-name commit-catalog index-catalog
                                    commit-jsonld indexing-opts)
          commit-map (commit-data/jsonld->clj commit-jsonld)
          state      (atom {:commit     commit-map
                            :current-db initial-db})
-         idx-q      (index-queue ledger-alias branch-name state)]
+         idx-q      (index-queue ledger-alias branch-name publishers state)]
      {:name        branch-name
       :alias       ledger-alias
       :state       state

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -151,11 +151,10 @@
         (merge-template json-ld-data-template))))
 
 (defn ->json-ld
-  "Converts a clojure commit map to a JSON-LD version.
-  Uses the JSON-LD template, and only incorporates values
-  that exist in both the commit-map and the json-ld template,
-  except for some defaults (like rdf:type) which are not in
-  our internal commit map, but are part of json-ld."
+  "Converts a clojure commit map to a JSON-LD version. Uses the JSON-LD template,
+  and only incorporates values that exist in both the commit-map and the json-ld
+  template, except for some defaults (like rdf:type) which are not in our
+  internal commit map, but are part of json-ld."
   [{:keys [previous data ns index issuer] :as commit-map}]
   (let [commit-map*    (assoc commit-map
                               :previous (merge-template previous json-ld-prev-commit-template)

--- a/src/clj/fluree/db/ledger.cljc
+++ b/src/clj/fluree/db/ledger.cljc
@@ -139,10 +139,10 @@
 (defn instantiate
   "Creates a new ledger, optionally bootstraps it as permissioned or with default
   context."
-  [conn ledger-alias ledger-address branch commit-catalog index-catalog
+  [conn ledger-alias ledger-address branch commit-catalog index-catalog publishers
    indexing-opts did latest-commit]
   (let [branches {branch (branch/state-map ledger-alias branch commit-catalog index-catalog
-                                           latest-commit indexing-opts)}]
+                                           publishers latest-commit indexing-opts)}]
     (map->Ledger {:conn                 conn
                   :id                   (random-uuid)
                   :did                  did
@@ -165,7 +165,8 @@
 (defn create
   "Creates a new ledger, optionally bootstraps it as permissioned or with default
   context."
-  [{:keys [conn alias primary-address publish-addresses commit-catalog index-catalog]}
+  [{:keys [conn alias primary-address publish-addresses commit-catalog index-catalog
+           publishers]}
    {:keys [did branch indexing] :as opts}]
   (go-try
     (let [ledger-alias*  (normalize-alias alias)
@@ -175,4 +176,4 @@
           genesis-commit (<? (commit-storage/write-genesis-commit
                                commit-catalog alias branch publish-addresses init-time))]
       (instantiate conn ledger-alias* primary-address branch commit-catalog index-catalog
-                   indexing did genesis-commit))))
+                   publishers indexing did genesis-commit))))

--- a/src/clj/fluree/db/nameservice.cljc
+++ b/src/clj/fluree/db/nameservice.cljc
@@ -42,7 +42,6 @@
                     (catch* e
                       (log/warn e "Publisher failed to publish commit")
                       ::publishing-error)))))
-       doall
        async/merge))
 
 (defn published-ledger?

--- a/src/clj/fluree/db/nameservice.cljc
+++ b/src/clj/fluree/db/nameservice.cljc
@@ -18,7 +18,7 @@
     not avail"))
 
 (defprotocol Publisher
-  (publish-commit [publisher commit-jsonld]
+  (publish [publisher commit-jsonld]
     "Publishes new commit.")
   (publishing-address [publisher ledger-alias]
     "Returns full publisher address/iri which will get published in commit. If
@@ -38,7 +38,7 @@
        (map (fn [ns]
                 (go
                   (try*
-                    (<? (publish-commit ns commit-jsonld))
+                    (<? (publish ns commit-jsonld))
                     (catch* e
                       (log/warn e "Publisher failed to publish commit")
                       ::publishing-error)))))

--- a/src/clj/fluree/db/nameservice.cljc
+++ b/src/clj/fluree/db/nameservice.cljc
@@ -16,7 +16,7 @@
     not avail"))
 
 (defprotocol Publisher
-  (publish [publisher commit-data]
+  (publish-commit [publisher commit-data]
     "Publishes new commit.")
   (publishing-address [publisher ledger-alias]
     "Returns full publisher address/iri which will get published in commit. If

--- a/src/clj/fluree/db/nameservice.cljc
+++ b/src/clj/fluree/db/nameservice.cljc
@@ -50,20 +50,6 @@
     (let [addr (<? (publishing-address nsv ledger-alias))]
       (boolean (<? (lookup nsv addr))))))
 
-(defn ns-record
-  "Generates nameservice metadata map for JSON storage. For now, since we only
-  have a single branch possible, always sets default-branch. Eventually will
-  need to merge changes from different branches into existing metadata map"
-  [ns-address {address "address", alias "alias", branch "branch", :as commit-jsonld}]
-  (let [branch-iri (str ns-address "(" branch ")")]
-    {"@context"      "https://ns.flur.ee/ledger/v1"
-     "@id"           ns-address
-     "defaultBranch" branch-iri
-     "ledgerAlias"   alias
-     "branches"      [{"@id"     branch-iri
-                       "address" address
-                       "commit"  commit-jsonld}]}))
-
 (defn commit-address-from-record
   [record branch]
   (let [branch-iri (if branch

--- a/src/clj/fluree/db/nameservice/ipns.cljc
+++ b/src/clj/fluree/db/nameservice/ipns.cljc
@@ -5,6 +5,7 @@
             [fluree.db.method.ipfs :as ipfs]
             [fluree.db.method.ipfs.directory :as ipfs-dir]
             [fluree.db.method.ipfs.keys :as ipfs-keys]
+            [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -57,8 +58,12 @@
 
 (defrecord IpnsNameService [ipfs-endpoint ipns-key base-address?]
   nameservice/Publisher
-  (publish [_ commit-data]
-    (ipfs/push! ipfs-endpoint commit-data))
+  (publish [_ commit-jsonld]
+    (let [ledger-alias (get commit-jsonld "alias")
+          ns-address   (ipns-address ipfs-endpoint ipns-key ledger-alias)
+          record       (nameservice/ns-record ns-address commit-jsonld)
+          record-bytes (json/stringify-UTF8 record)]
+      (ipfs/push! ipfs-endpoint record-bytes)))
   (publishing-address [_ ledger-alias]
     (ipns-address ipfs-endpoint ipns-key ledger-alias))
 

--- a/src/clj/fluree/db/nameservice/ipns.cljc
+++ b/src/clj/fluree/db/nameservice/ipns.cljc
@@ -33,7 +33,7 @@
   "Given IPNS address, performs lookup and returns latest ledger address."
   [ipfs-endpoint ipns-profile ledger-name]
   (go-try
-    (let [ipns-address (if-let [[proto address ledger] (address-parts ledger-name)]
+    (let [ipns-address (if-let [[_proto address _ledger] (address-parts ledger-name)]
                          address
                          (<? (ipfs-keys/address ipfs-endpoint ipns-profile)))
           ipfs-address (str "/ipns/" ipns-address)
@@ -59,11 +59,7 @@
 (defrecord IpnsNameService [ipfs-endpoint ipns-key base-address?]
   nameservice/Publisher
   (publish [_ commit-jsonld]
-    (let [ledger-alias (get commit-jsonld "alias")
-          ns-address   (ipns-address ipfs-endpoint ipns-key ledger-alias)
-          record       (nameservice/ns-record ns-address commit-jsonld)
-          record-bytes (json/stringify-UTF8 record)]
-      (ipfs/push! ipfs-endpoint record-bytes)))
+    (ipfs/push! ipfs-endpoint commit-jsonld))
   (publishing-address [_ ledger-alias]
     (ipns-address ipfs-endpoint ipns-key ledger-alias))
 

--- a/src/clj/fluree/db/nameservice/ipns.cljc
+++ b/src/clj/fluree/db/nameservice/ipns.cljc
@@ -58,7 +58,7 @@
 
 (defrecord IpnsNameService [ipfs-endpoint ipns-key base-address?]
   nameservice/Publisher
-  (publish [_ commit-jsonld]
+  (publish-commit [_ commit-jsonld]
     (let [ledger-alias (get commit-jsonld "alias")
           ns-address   (ipns-address ipfs-endpoint ipns-key ledger-alias)
           record       (nameservice/ns-record ns-address commit-jsonld)

--- a/src/clj/fluree/db/nameservice/ipns.cljc
+++ b/src/clj/fluree/db/nameservice/ipns.cljc
@@ -58,7 +58,7 @@
 
 (defrecord IpnsNameService [ipfs-endpoint ipns-key base-address?]
   nameservice/Publisher
-  (publish-commit [_ commit-jsonld]
+  (publish [_ commit-jsonld]
     (let [ledger-alias (get commit-jsonld "alias")
           ns-address   (ipns-address ipfs-endpoint ipns-key ledger-alias)
           record       (nameservice/ns-record ns-address commit-jsonld)

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -19,7 +19,7 @@
 
 (defrecord StorageNameService [store]
   nameservice/Publisher
-  (publish-commit [_ commit-jsonld]
+  (publish [_ commit-jsonld]
     (go-try
       (let [ledger-alias (get commit-jsonld "alias")
             ns-address   (publishing-address store ledger-alias)

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -19,7 +19,7 @@
 
 (defrecord StorageNameService [store]
   nameservice/Publisher
-  (publish [_ commit-jsonld]
+  (publish-commit [_ commit-jsonld]
     (go-try
       (let [ledger-alias (get commit-jsonld "alias")
             ns-address   (publishing-address store ledger-alias)

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -17,13 +17,27 @@
       storage/location
       (storage/build-address ledger-alias)))
 
+(defn ns-record
+  "Generates nameservice metadata map for JSON storage. For now, since we only
+  have a single branch possible, always sets default-branch. Eventually will
+  need to merge changes from different branches into existing metadata map"
+  [ns-address {address "address", alias "alias", branch "branch", :as commit-jsonld}]
+  (let [branch-iri (str ns-address "(" branch ")")]
+    {"@context"      "https://ns.flur.ee/ledger/v1"
+     "@id"           ns-address
+     "defaultBranch" branch-iri
+     "ledgerAlias"   alias
+     "branches"      [{"@id"     branch-iri
+                       "address" address
+                       "commit"  commit-jsonld}]}))
+
 (defrecord StorageNameService [store]
   nameservice/Publisher
   (publish [_ commit-jsonld]
     (go-try
       (let [ledger-alias (get commit-jsonld "alias")
             ns-address   (publishing-address store ledger-alias)
-            record       (nameservice/ns-record ns-address commit-jsonld)
+            record       (ns-record ns-address commit-jsonld)
             record-bytes (json/stringify-UTF8 record)
             filename     (local-filename ledger-alias)]
         (<? (storage/write-bytes store filename record-bytes)))))
@@ -37,8 +51,8 @@
       (let [{:keys [alias _branch]} (nameservice/resolve-address (storage/location store) ledger-address nil)
             filename                (local-filename alias)]
         (when-let [record-bytes (<? (storage/read-bytes store filename))]
-          (let [ns-record (json/parse record-bytes false)]
-            (nameservice/commit-address-from-record ns-record nil))))))
+          (let [record (json/parse record-bytes false)]
+            (nameservice/commit-address-from-record record nil))))))
 
   (alias [_ ledger-address]
     ;; TODO: need to validate that the branch doesn't have a slash?


### PR DESCRIPTION
This patch makes a collection of publishers available to index queues so that they can publish commits with updated indexes after an index process finishes. This ensures that the latest commit as reported by the name services always has the most up to date indexes possible.