### PR TITLE
Fix/base context in queries

### DIFF
--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -586,7 +586,7 @@
     (if (v/variable? subj)
       (let [var (parse-var-name subj)]
         (select/subgraph-selector var selection depth spec))
-      (let [iri (json-ld/expand-iri subj context)]
+      (let [iri (json-ld/expand-iri subj context false)]
         (select/subgraph-selector iri selection depth spec)))))
 
 (defn parse-selector

--- a/src/clj/fluree/db/query/fql/parse.cljc
+++ b/src/clj/fluree/db/query/fql/parse.cljc
@@ -269,10 +269,10 @@
         f    (eval/compile code context false)]
     (where/->var-filter var-name f)))
 
-(defn parse-iri
+(defn parse-subject-iri
   [x context]
   (-> x
-      (json-ld/expand-iri context)
+      (json-ld/expand-iri context false)
       where/->iri-ref))
 
 (defn parse-class
@@ -362,7 +362,7 @@
   [id context]
   (if (v/variable? id)
     (parse-variable id)
-    (parse-iri id context)))
+    (parse-subject-iri id context)))
 
 (defn parse-predicate
   [p context]

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -382,3 +382,16 @@
       (testing "do not become multicardinal result values"
         (is (= [{"ex:foo" 30, "@id" "ex:1"}]
                @(fluree/query db3 {"select" {"ex:1" ["*"]}})))))))
+
+(deftest ^:integration base-context
+  (let [conn @(fluree/connect-memory)
+        ledger @(fluree/create conn "base")
+        db0 (fluree/db ledger)
+        db1 @(fluree/stage db0 {"@context" {"@base" "https://flur.ee/" "ex" "http://example.com/"}
+                                "insert" [{"@id" "freddy" "@type" "Yeti" "name" "Freddy"}
+                                          {"@id" "ex:betty" "@type" "Yeti" "name" "Betty"}]})]
+    (is (= [["name" "Freddy"]
+            ["@type" "Yeti"]]
+           @(fluree/query db1 {"@context" {"@base" "https://flur.ee/"}
+                               "where" [{"@id" "freddy" "?p" "?o"}]
+                               "select" ["?p" "?o"]})))))

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -394,4 +394,9 @@
             ["@type" "Yeti"]]
            @(fluree/query db1 {"@context" {"@base" "https://flur.ee/"}
                                "where" [{"@id" "freddy" "?p" "?o"}]
-                               "select" ["?p" "?o"]})))))
+                               "select" ["?p" "?o"]})))
+    (is (= [{"@id" "freddy"
+             "@type" "Yeti"
+             "name" "Freddy"}]
+           @(fluree/query db1 {"@context" {"@base" "https://flur.ee/"}
+                               "select" {"freddy" ["*"]}})))))


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/88

This is a fix to support using `@base` in queries. Subject iris were not getting expanded with the `@base` context and this PR adds support.
