### PR TITLE
Fix existing ledger instantiation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -59,7 +59,7 @@
    :ns-default build}
 
   :dev
-  {:extra-paths ["dev" "dev-resources" "src-cljs" "src-nodejs" "src-docs"]
+  {:extra-paths ["dev" "dev-resources"]
    :extra-deps  {org.clojure/tools.namespace       {:mvn/version "1.5.0"}
                  criterium/criterium               {:mvn/version "0.4.6"}
                  figwheel-sidecar/figwheel-sidecar {:mvn/version "0.5.20"}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -52,8 +52,8 @@
 
 (comment
 
-  (def file-conn @(fluree/connect {:storage-path "dev/data"
-                                   :defaults     {:did did}}))
+  (def file-conn @(fluree/connect-file {:storage-path "dev/data"
+                                        :defaults     {:did did}}))
 
   (def ledger-alias "user/test")
 

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -1,7 +1,6 @@
 (ns fluree.db.api
   (:require [camel-snake-kebab.core :refer [->camelCaseString]]
             [clojure.walk :refer [postwalk]]
-            [fluree.db.connection.config :as config]
             [fluree.db.connection.system :as system]
             [fluree.db.connection :as connection :refer [notify-ledger]]
             [fluree.db.util.context :as context]

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -163,7 +163,6 @@
 
   Options map (opts) can include:
   - did - DId information to use, if storing blocks as verifiable credentials"
-  ([conn] (create conn nil nil))
   ([conn ledger-alias] (create conn ledger-alias nil))
   ([conn ledger-alias opts]
    (promise-wrap

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -521,7 +521,7 @@
   [opts]
   (if (string? opts)
     {:message opts}
-    (select-keys opts [:context :did :private :message :tag :file-data? :index-files-ch])))
+    (select-keys opts [:context :did :private :message :tag :index-files-ch])))
 
 (defn apply-stage!
   [{:keys [conn] ledger-alias :alias, :as ledger}

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -377,7 +377,7 @@
 
           pubs   (publishers conn)
           ledger (ledger/instantiate conn ledger-alias address branch commit-catalog
-                                     index-catalog pubs did indexing commit)]
+                                     index-catalog pubs indexing did commit)]
       (subscribe-ledger conn ledger-alias)
       (async/put! ledger-chan ledger)
       ledger)))

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -405,9 +405,8 @@
         (<? ledger-chan)
         (loop [[addr & r] (<? (current-addresses conn alias))]
           (if addr
-            (do (log/info "trying to load address:" addr)
-                (or (<? (try-load-address conn ledger-chan alias addr))
-                    (recur r)))
+            (or (<? (try-load-address conn ledger-chan alias addr))
+                (recur r))
             (do (release-ledger conn alias)
                 (let [ex (ex-info (str "Load for " alias " failed due to failed address lookup.")
                                   {:status 404 :error :db/unknown-address}

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -422,37 +422,6 @@
 
 (def f-context {"f" "https://ns.flur.ee/ledger#"})
 
-(defn parse-commit-context
-  [context]
-  (let [parsed-context (if context
-                         (-> context
-                             json-ld/parse-context
-                             (json-ld/parse-context f-context))
-                         (json-ld/parse-context f-context))]
-    (context/stringify parsed-context)))
-
-(defn enrich-commit-opts
-  [ledger {:keys [context did private] :as _opts}]
-  (let [context*      (parse-commit-context context)
-        private*      (or private
-                          (:private did)
-                          (-> ledger :did :private))
-        did*          (or (some-> private* did/private->did)
-                          did
-                          (:did ledger))
-        ctx-used-atom (atom {})
-        compact-fn    (json-ld/compact-fn context* ctx-used-atom)]
-    {:commit-opts
-     {:private private*
-      :did did*}
-
-     :commit-data-helpers
-     {:compact-fn compact-fn
-      :compact (fn [iri] (json-ld/compact iri compact-fn))
-      :id-key (json-ld/compact "@id" compact-fn)
-      :type-key (json-ld/compact "@type" compact-fn)
-      :ctx-used-atom ctx-used-atom}}))
-
 (defn write-transaction
   [storage ledger-alias txn]
   (let [path (str/join "/" [ledger-alias "txn"])]
@@ -516,12 +485,49 @@
                :max-namespace-code max-ns-code)
         (commit-data/add-commit-flakes prev-commit))))
 
-(defn parse-commit-options
+(defn sanitize-commit-options
   "Parses the commit options and removes non-public opts."
   [opts]
   (if (string? opts)
     {:message opts}
     (select-keys opts [:context :did :private :message :tag :index-files-ch])))
+
+(defn parse-commit-context
+  [context]
+  (let [parsed-context (if context
+                         (-> context
+                             json-ld/parse-context
+                             (json-ld/parse-context f-context))
+                         (json-ld/parse-context f-context))]
+    (context/stringify parsed-context)))
+
+(defn parse-keypair
+  [ledger {:keys [did private] :as opts}]
+  (let [private* (or private
+                     (:private did)
+                     (-> ledger :did :private))
+        did*     (or (some-> private* did/private->did)
+                     did
+                     (:did ledger))]
+    (assoc opts :did did*, :private private*)))
+
+(defn parse-data-helpers
+  [{:keys [context] :as opts}]
+  (let [ctx-used-atom (atom {})
+        compact-fn    (json-ld/compact-fn context ctx-used-atom)]
+    (assoc opts
+           :commit-data-opts {:compact-fn    compact-fn
+                              :compact       (fn [iri] (json-ld/compact iri compact-fn))
+                              :id-key        (json-ld/compact "@id" compact-fn)
+                              :type-key      (json-ld/compact "@type" compact-fn)
+                              :ctx-used-atom ctx-used-atom})))
+
+(defn parse-commit-opts
+  [ledger opts]
+  (-> opts
+      (update :context parse-commit-context)
+      (->> (parse-keypair ledger))
+      parse-data-helpers))
 
 (defn apply-stage!
   [{:keys [conn] ledger-alias :alias, :as ledger}
@@ -530,13 +536,9 @@
   (go-try
     (let [{:keys [commit-catalog]} conn
 
-          {:keys [tag time message index-files-ch]
+          {:keys [tag time message did private commit-data-opts index-files-ch]
            :or   {time (util/current-time-iso)}}
-          (parse-commit-options opts)
-
-          {commit-data-opts      :commit-data-helpers
-           {:keys [did private]} :commit-opts}
-          (enrich-commit-opts ledger opts)
+          (parse-commit-opts ledger opts)
 
           {:keys [dbid db-jsonld staged-txns]}
           (flake-db/db->jsonld staged-db commit-data-opts)
@@ -548,22 +550,21 @@
 
           data-write-result (<? (commit-storage/write-jsonld commit-catalog ledger-alias db-jsonld))
           db-address        (:address data-write-result) ; may not have address (e.g. IPFS) until after writing file
-          keypair           {:did did :private private}
+          keypair           {:did did, :private private}
 
-          new-commit (commit-data/new-db-commit-map
-                      {:old-commit commit
-                       :issuer     did
-                       :message    message
-                       :tag        tag
-                       :dbid       dbid
-                       :t          t
-                       :time       time
-                       :db-address db-address
-                       :author     author
-                       :annotation annotation
-                       :txn-id     txn-id
-                       :flakes     (:flakes stats)
-                       :size       (:size stats)})
+          new-commit (commit-data/new-db-commit-map {:old-commit commit
+                                                     :issuer     did
+                                                     :message    message
+                                                     :tag        tag
+                                                     :dbid       dbid
+                                                     :t          t
+                                                     :time       time
+                                                     :db-address db-address
+                                                     :author     author
+                                                     :annotation annotation
+                                                     :txn-id     txn-id
+                                                     :flakes     (:flakes stats)
+                                                     :size       (:size stats)})
 
           {:keys [commit-map commit-jsonld write-result]}
           (<? (write-commit commit-catalog ledger-alias keypair new-commit))

--- a/src/clj/fluree/db/connection/system.cljc
+++ b/src/clj/fluree/db/connection/system.cljc
@@ -237,7 +237,7 @@
         primary-publisher    (get-first config conn-vocab/primary-publisher)
         secondary-publishers (get config conn-vocab/secondary-publishers)
         remote-systems       (get config conn-vocab/remote-systems)
-        defaults      (parse-defaults config)]
+        defaults             (parse-defaults config)]
     (connection/connect {:parallelism          parallelism
                          :cache                cache
                          :commit-catalog       commit-catalog

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [load vswap!])
   (:require [#?(:clj clojure.pprint, :cljs cljs.pprint) :as pprint :refer [pprint]]
             [clojure.core.async :as async :refer [go]]
-            [clojure.string :as str]
             [clojure.set :refer [map-invert]]
             [fluree.db.datatype :as datatype]
             [fluree.db.dbproto :as dbproto]

--- a/src/clj/fluree/db/ledger.cljc
+++ b/src/clj/fluree/db/ledger.cljc
@@ -126,8 +126,8 @@
                     " however, latest t is more current: " current-t)
           false)))))
 
-(defrecord Ledger [conn id address alias did state cache commit-storage
-                   index-storage reasoner])
+(defrecord Ledger [conn id address alias did state cache commit-catalog
+                   index-catalog reasoner])
 
 (defn initial-state
   [branches current-branch]

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -34,13 +34,12 @@
 (defrecord StorageNameService [store]
   nameservice/Publisher
   (publish [_ commit-jsonld]
-    (go-try
-      (let [ledger-alias (get commit-jsonld "alias")
-            ns-address   (publishing-address store ledger-alias)
-            record       (ns-record ns-address commit-jsonld)
-            record-bytes (json/stringify-UTF8 record)
-            filename     (local-filename ledger-alias)]
-        (<? (storage/write-bytes store filename record-bytes)))))
+    (let [ledger-alias (get commit-jsonld "alias")
+          ns-address   (publishing-address store ledger-alias)
+          record       (ns-record ns-address commit-jsonld)
+          record-bytes (json/stringify-UTF8 record)
+          filename     (local-filename ledger-alias)]
+      (storage/write-bytes store filename record-bytes)))
 
   (publishing-address [_ ledger-alias]
     (go (publishing-address store ledger-alias)))

--- a/src/clj/fluree/db/query/fql/syntax.cljc
+++ b/src/clj/fluree/db/query/fql/syntax.cljc
@@ -139,7 +139,6 @@
                          [:private {:optional true} :string]
                          [:message {:optional true} :string]
                          [:tag {:optional true} :string]
-                         [:file-data? {:optional true} :boolean]
                          [:index-files-ch {:optional true} :any]
                          [:time {:optional true} :string]]
     ::ledger-opts       [:map


### PR DESCRIPTION
This patch fixes an error instantiating existing ledgers that caused indexing options to be treated as identity keypairs. The fix is in commit 23ab9284f55a66626c97833de6a12536d8fffe1b, and the rest of the changes here are just cleanup for things I came across when looking for the source of this bug.

I guess this is another point in favor of statically typed languages 🤷🏾‍♂️ 