### PR TITLE
External API - throw if invalid 'conn'

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -62,6 +62,10 @@
 (defmethod pprint/simple-dispatch Connection [^Connection conn]
   (pr conn))
 
+(defn connection?
+  [x]
+  (instance? Connection x))
+
 (defn connect
   [{:keys [parallelism commit-catalog index-catalog cache serializer
            primary-publisher secondary-publishers remote-systems defaults]


### PR DESCRIPTION
On many occasions when working with the API, I forget to deref @(fluree/connect ...).

It ends up throwing a Nil exception within an async call stack, and is worse than useless (to me) as it makes me start to think there is a weird bug.

This adds a check, and hopefully useful error to anyone doing this on what the issue likely is. This only affects the public API calls that take 'conn', which this extra check should have no impact on performance.
