### PR TITLE
don't tally fuel unless a limit is supplied

### DIFF
--- a/src/clj/fluree/db/fuel.cljc
+++ b/src/clj/fluree/db/fuel.cljc
@@ -28,13 +28,13 @@
 
         ([result next]
          (vswap! counter inc)
-         (let [tly   (tally trkr)
-               limit (:limit trkr)]
-           (when (< 0 limit tly)
-             (log/error "Fuel limit of" limit "exceeded:" tly)
-             (put! error-ch
-                   (ex-info "Fuel limit exceeded" {:used tly, :limit limit})))
-           (rf result next)))
+         (when-let [limit (:limit trkr)]
+           (let [tly (tally trkr)]
+             (when (< 0 limit tly)
+               (log/error "Fuel limit of" limit "exceeded:" tly)
+               (put! error-ch
+                     (ex-info "Fuel limit exceeded" {:used tly, :limit limit})))))
+         (rf result next))
 
         ([result]
          (rf result))))))


### PR DESCRIPTION
Just a quick PR for a minor perf improvement I found.

If we don't have a fuel `:limit`, there's no reason to tally the fuel cost of every concurrent range scan. This should save a little bit of work on every flake when we have a fuel tracker.