### PR TITLE
Feature/explain

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -87,6 +87,40 @@
                       :where   '{:id          ?e
                                  :schema/name ?n}})
 
+  @(fluree/explain db1 {:context default-context
+                        :select  '[?n ?f-name]
+                        :where   '[{:id ?e :schema/name ?n}
+                                   {:id ?e :ex/friend ?friend}
+                                   {:id ?friend :schema/name ?f-name}]})
+  {:status 200,
+   :result [["Cam" "Alice"] ["Cam" "Brian"]],
+   :explain
+   ;; map of [<idx> <start-flake> <end-flake>] -> flake count
+   {[:post
+     #fluree/Flake [nil #fluree/SID [17 "name"] nil nil nil nil -2147483647]
+     #fluree/Flake [nil #fluree/SID [17 "name"] nil nil nil nil 2147483647]] 3,
+    [:spot
+     #fluree/Flake [#fluree/SID [101 "alice"] #fluree/SID [101 "friend"] nil nil nil nil -2147483647]
+     #fluree/Flake [#fluree/SID [101 "alice"] #fluree/SID [101 "friend"] nil nil nil nil 2147483647]] 0,
+    [:spot
+     #fluree/Flake [#fluree/SID [101 "brian"] #fluree/SID [101 "friend"] nil nil nil nil -2147483647]
+     #fluree/Flake [#fluree/SID [101 "brian"] #fluree/SID [101 "friend"] nil nil nil nil 2147483647]] 0,
+    [:spot
+     #fluree/Flake [#fluree/SID [101 "cam"] #fluree/SID [101 "friend"] nil nil nil nil -2147483647]
+     #fluree/Flake [#fluree/SID [101 "cam"] #fluree/SID [101 "friend"] nil nil nil nil 2147483647]] 2,
+    [:spot
+     #fluree/Flake [#fluree/SID [101 "alice"] #fluree/SID [17 "name"] nil nil nil nil -2147483647]
+     #fluree/Flake [#fluree/SID [101 "alice"] #fluree/SID [17 "name"] nil nil nil nil 2147483647]] 1,
+    [:spot
+     #fluree/Flake [#fluree/SID [101 "brian"] #fluree/SID [17 "name"] nil nil nil nil -2147483647]
+     #fluree/Flake [#fluree/SID [101 "brian"] #fluree/SID [17 "name"] nil nil nil nil 2147483647]] 1},
+   :time "11.22ms",
+   :fuel 7}
+
+
+
+
+
   (def db2 @(fluree/commit! ledger db1 {:message "hi"}))
 
   (-> @(fluree/load file-conn ledger-alias)

--- a/src/clj/fluree/db/api.cljc
+++ b/src/clj/fluree/db/api.cljc
@@ -343,6 +343,12 @@
   ([named-graphs default-graphs]
    (query-api/dataset named-graphs default-graphs)))
 
+(defn explain
+  ([ds q]
+   (explain ds q nil))
+  ([ds q opts]
+   (promise-wrap (query-api/explain ds q opts))))
+
 (defn query
   "Queries a dataset or single db and returns a promise with the results."
   ([ds q]

--- a/src/clj/fluree/db/flake/format.cljc
+++ b/src/clj/fluree/db/flake/format.cljc
@@ -106,7 +106,7 @@
   (let [sid                     (iri/encode-iri db iri)
         [start-flake end-flake] (flake-bounds db :spot [sid])
         flake-xf                (when fuel-tracker
-                                  (comp (fuel/track fuel-tracker error-ch)))
+                                  (comp (fuel/track fuel-tracker :spot start-flake end-flake error-ch)))
         range-opts              {:to-t        t
                                  :start-flake start-flake
                                  :end-flake   end-flake
@@ -123,7 +123,7 @@
         pid                     (iri/encode-iri db p-iri)
         [start-flake end-flake] (flake-bounds db :opst [oid pid])
         flake-xf                (if fuel-tracker
-                                  (comp (fuel/track fuel-tracker error-ch)
+                                  (comp (fuel/track fuel-tracker :opst start-flake end-flake error-ch)
                                         (map flake/s))
                                   (map flake/s))
         range-opts              {:to-t        t

--- a/src/clj/fluree/db/query/exec/where.cljc
+++ b/src/clj/fluree/db/query/exec/where.cljc
@@ -459,7 +459,7 @@
         start-flake (flake/create s p o* o-dt nil nil util/min-integer)
         end-flake   (flake/create s p o* o-dt nil nil util/max-integer)
         track-fuel  (when fuel-tracker
-                      (fuel/track fuel-tracker error-ch))
+                      (fuel/track fuel-tracker idx start-flake end-flake error-ch))
         subj-filter (when s-fn
                       (filter (fn [f]
                                 (-> unmatched


### PR DESCRIPTION
Very rough and dirty implementation of an `explain` api.

Shows a map of each index range scan to the number of flakes it returned.

The changes to `fuel-tracker` were minimal and I don't think really change the performance characteristics of fuel accounting. The actual result structure was fully improvised just to have something I could use and is fully WIP