### PR TITLE
fix match-id implementation

### DIFF
--- a/src/clj/fluree/db/flake/match.cljc
+++ b/src/clj/fluree/db/flake/match.cljc
@@ -35,7 +35,7 @@
                                                   (assoc solution var matched))
                                                 solution)))))
         s-mch*     (where/assign-matched-component s-mch solution)]
-    (if-let [s (where/compute-sid db s-mch*)]
+    (if-let [s (where/compute-sid s-mch* db)]
       (-> db
           (where/resolve-flake-range fuel-tracker error-ch [s])
           (async/pipe matched-ch))

--- a/test/fluree/db/query/values_test.clj
+++ b/test/fluree/db/query/values_test.clj
@@ -73,7 +73,13 @@
                                      "values" ["?friend" [{"@value" "ex:alice" "@type" "@id"}]]
                                      "where" [{"@id" "?s" "ex:friend" {"@id" "?friend"}}]
                                      "select" ["?s"]}))
-              "variable in id-map"))))
+              "variable in id-map")))
+      (testing "matching id only"
+        (is (= ["ex:brian"]
+               @(fluree/query db1 {"@context" context
+                                   "values" ["?s" [{"@type" "@id" "@value" "ex:brian"}]]
+                                   "where" [{"@id" "?s"}]
+                                   "select" "?s"})))))
     (testing "where pattern"
       (testing "single var"
         (is (= [["Brian" "brian@example.org"]


### PR DESCRIPTION
We were passing the args to `where/commit-sid` in the wrong order, causing the range scan to return all subjects, not just the one supplied.