### PR TITLE
Feature/policy execution report

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -11,6 +11,7 @@
             [fluree.db.json-ld.credential :as credential]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.json-ld.policy :as policy]
+            [fluree.db.json-ld.policy.rules :as policy.rules]
             [fluree.db.flake.flake-db :as flake-db]
             [fluree.db.nameservice :as nameservice]
             [fluree.db.transact :as transact]
@@ -604,25 +605,29 @@
    internal Fluree triples format."
   [db parsed-txn parsed-opts]
   (go-try
-    (let [identity    (:identity parsed-opts)
-          policy-db   (if (policy/policy-enforced-opts? parsed-opts)
-                        (let [parsed-context (:context parsed-opts)]
-                          (<? (policy/policy-enforce-db db parsed-context parsed-opts)))
-                        db)]
+    (let [identity  (:identity parsed-opts)
+          policy-db (if (policy/policy-enforced-opts? parsed-opts)
+                      (let [parsed-context (:context parsed-opts)]
+                        (<? (policy/policy-enforce-db db parsed-context parsed-opts)))
+                      db)]
       (if (track-fuel? parsed-opts)
-        (let [start-time #?(:clj (System/nanoTime)
+        (let [start-time   #?(:clj (System/nanoTime)
                             :cljs (util/current-time-millis))
-              fuel-tracker       (fuel/tracker (:max-fuel parsed-opts))]
+              fuel-tracker (fuel/tracker (:max-fuel parsed-opts))]
           (try*
-            (let [result (<? (transact/stage policy-db fuel-tracker identity parsed-txn parsed-opts))]
-              {:status 200
-               :result result
-               :time   (util/response-time-formatted start-time)
-               :fuel   (fuel/tally fuel-tracker)})
+            (let [result        (<? (transact/stage policy-db fuel-tracker identity parsed-txn parsed-opts))
+                  policy-report (policy.rules/enforcement-report result)]
+              (cond-> {:status 200
+                       :result result
+                       :time   (util/response-time-formatted start-time)
+                       :fuel   (fuel/tally fuel-tracker)}
+                policy-report (assoc :policy policy-report)))
             (catch* e
-                    (throw (ex-info "Error staging database"
-                                    {:time (util/response-time-formatted start-time)
-                                     :fuel (fuel/tally fuel-tracker)}
+                    (throw (ex-info (ex-message e)
+                                    (let [policy-report (policy.rules/enforcement-report policy-db)]
+                                      (cond-> {:time (util/response-time-formatted start-time)
+                                               :fuel (fuel/tally fuel-tracker)}
+                                        policy-report (assoc :policy policy-report)))
                                     e)))))
         (<? (transact/stage policy-db identity parsed-txn parsed-opts))))))
 

--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -595,7 +595,7 @@
    (go-try
      (:db (<? (apply-stage! ledger staged-db opts))))))
 
-(defn track-fuel?
+(defn track?
   [parsed-opts]
   (or (:max-fuel parsed-opts)
       (:meta parsed-opts)))
@@ -610,7 +610,7 @@
                       (let [parsed-context (:context parsed-opts)]
                         (<? (policy/policy-enforce-db db parsed-context parsed-opts)))
                       db)]
-      (if (track-fuel? parsed-opts)
+      (if (track? parsed-opts)
         (let [start-time   #?(:clj (System/nanoTime)
                             :cljs (util/current-time-millis))
               fuel-tracker (fuel/tracker (:max-fuel parsed-opts))]
@@ -641,7 +641,7 @@
           ;; whereas stage API takes a did IRI and unparsed context.
           ;; Dissoc them until deciding at a later point if they can carry through.
           cmt-opts (dissoc parsed-opts :context :identity)]
-      (if (track-fuel? parsed-opts)
+      (if (track? parsed-opts)
         (assoc staged :result (<? (commit! ledger (:result staged) cmt-opts)))
         (<? (commit! ledger staged cmt-opts))))))
 

--- a/src/clj/fluree/db/json_ld/policy.cljc
+++ b/src/clj/fluree/db/json_ld/policy.cljc
@@ -39,8 +39,8 @@
           t-p const/iri-targetProperty :as policy}]
       (cond-> policy
         q   (assoc const/iri-query {"@value" q "@type" "@json"})
-        t-s (assoc const/iri-targetSubject (if (get t-s "@id") t-s {"@value" t-s "@type" "@json"}))
-        t-p (assoc const/iri-targetProperty (if (get t-p "@id") t-p {"@value" t-p "@type" "@json"}))))
+        t-s (assoc const/iri-targetSubject  (mapv #(if (get % "@id") % {"@value" % "@type" "@json"}) (util/sequential t-s)))
+        t-p (assoc const/iri-targetProperty (mapv #(if (get % "@id") % {"@value" % "@type" "@json"}) (util/sequential t-p)))))
     query-results))
 
 (defn wrap-class-policy

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -80,16 +80,22 @@
   "Once narrowed to a specific set of policies, execute and return
   appropriate policy response."
   [db modify? sid policies-to-eval]
-  (go-try
-    (loop [[policy & r] policies-to-eval]
-      ;; return first truthy response, else false
-      (if policy
-        (let [query  (policy-query db sid policy)
-              result (<? (dbproto/-query (root db) query))]
-          (if (seq result)
-            true
-            (recur r)))
-        ;; no more policies left to evaluate - all returned false
-        (if modify?
-          (modify-exception policies-to-eval)
-          false)))))
+  (let [tracer (-> db :policy :trace)]
+    (go-try
+      (loop [[policy & r] policies-to-eval]
+        ;; return first truthy response, else false
+        (if policy
+          (let [{exec-counter :executed
+                 allowed-counter :allowed} (get tracer (:id policy))
+
+                query   (policy-query db sid policy)
+                result  (seq (<? (dbproto/-query (root db) query)))]
+            (swap! exec-counter inc)
+            (when result (swap! allowed-counter inc))
+            (if result
+              true
+              (recur r)))
+          ;; no more policies left to evaluate - all returned false
+          (if modify?
+            (modify-exception policies-to-eval)
+            false))))))

--- a/src/clj/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/clj/fluree/db/json_ld/policy/enforce.cljc
@@ -91,9 +91,9 @@
                 query   (policy-query db sid policy)
                 result  (seq (<? (dbproto/-query (root db) query)))]
             (swap! exec-counter inc)
-            (when result (swap! allowed-counter inc))
             (if result
-              true
+              (do (swap! allowed-counter inc)
+                  true)
               (recur r)))
           ;; no more policies left to evaluate - all returned false
           (if modify?

--- a/test/fluree/db/policy/target_test.clj
+++ b/test/fluree/db/policy/target_test.clj
@@ -140,6 +140,8 @@
                   "http://a.co/wishlistItemViewPolicy"   {:executed 0, :allowed 0},
                   "http://a.co/availableModifyPolicy"    {:executed 0, :allowed 0}}
                  (:policy (ex-data unauthorized))))
+          (is (= 3
+                 (:fuel (ex-data unauthorized))))))
       (testing "linked to user"
         (let [policy-db  @(fluree/wrap-policy db1 {"@graph" [wishlist-create wishlist-modify wishlist-view
                                                              item-create item-modify item-view available]}
@@ -166,6 +168,8 @@
                   "http://a.co/wishlistItemViewPolicy"   {:executed 0, :allowed 0},
                   "http://a.co/availableModifyPolicy"    {:executed 0, :allowed 0}}
                  (:policy txn-result)))
+          (is (= 3
+                 (:fuel txn-result)))
           (is (= ["a:burt-wish1"]
                  (:result result)))
           (is (= {"http://a.co/wishlistCreatePolicy"     {:executed 1, :allowed 1},
@@ -176,6 +180,8 @@
                   "http://a.co/wishlistItemViewPolicy"   {:executed 0, :allowed 0},
                   "http://a.co/availableModifyPolicy"    {:executed 0, :allowed 0}}
                  (:policy result)))
+          (is (= 1
+                 (:fuel result))))))
     (testing "wishlist item"
       (let [db2 @(fluree/stage db1 {"@context" {"a" "http://a.co/"}
                                     "insert"
@@ -233,6 +239,8 @@
                     "http://a.co/wishlistItemViewPolicy"   {:executed 0, :allowed 0},
                     "http://a.co/availableModifyPolicy"    {:executed 0, :allowed 0}}
                    (:policy txn-result)))
+            (is (= 4
+                   (:fuel txn-result)))
             (is (= [{"a:title"       "helicopter"
                      "a:description" "flying car, basically"
                      "a:rank"        1}]
@@ -244,7 +252,9 @@
                     "http://a.co/wishlistItemModifyPolicy" {:executed 3, :allowed 3},
                     "http://a.co/wishlistItemViewPolicy"   {:executed 3, :allowed 3},
                     "http://a.co/availableModifyPolicy"    {:executed 0, :allowed 0}}
-                   (:policy result)))))))
+                   (:policy result)))
+            (is (= 3
+                   (:fuel result)))))))
     (testing "item availability"
       (let [db2 @(fluree/stage db1 {"@context" {"a" "http://a.co/"}
                                     "insert"
@@ -300,7 +310,9 @@
                         "http://a.co/wishlistItemModifyPolicy" {:executed 0, :allowed 0},
                         "http://a.co/wishlistItemViewPolicy"   {:executed 3, :allowed 3},
                         "http://a.co/availableModifyPolicy"    {:executed 2, :allowed 0}}
-                       (:policy result)))))))
+                       (:policy result)))
+                (is (= 4
+                       (:fuel result)))))))
         (testing "non-owners item available status"
           (let [policy-db  @(fluree/wrap-policy db2 {"@graph" [wishlist-create wishlist-modify wishlist-view
                                                                item-create item-modify item-view available]}
@@ -326,4 +338,6 @@
                         "http://a.co/wishlistItemModifyPolicy" {:executed 0, :allowed 0},
                         "http://a.co/wishlistItemViewPolicy"   {:executed 3, :allowed 3},
                         "http://a.co/availableModifyPolicy"    {:executed 2, :allowed 2}}
-                       (:policy result)))))))))))
+                       (:policy result)))
+                (is (= 4
+                       (:fuel result)))))))))))


### PR DESCRIPTION
Closes https://github.com/fluree/core/issues/167

When a user adds the `meta: true` opt to a query or a transaction, we will now return a map of policy-id -> #times-executed, #times-flake-allowed. This is as much data as we can collect without much performance overhead, but should provide a couple of useful dimensions for analyzing policy performance.