### PR TITLE
Load latest index from nameservice, not commit

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -362,18 +362,12 @@
   [{:keys [commit-catalog index-catalog] :as conn}
    ledger-chan address]
   (go-try
-    (let [commit-addr  (<? (lookup-commit conn address))
-          _            (log/debug "Attempting to load from address:" address
-                                  "with commit address:" commit-addr)
-          _            (when-not commit-addr
+    (let [commit  (<? (lookup-commit conn address))
+          _            (if-not commit
                          (throw (ex-info (str "Unable to load. No record of ledger exists: " address)
-                                         {:status 400 :error :db/invalid-commit-address})))
-          [commit _]   (<? (commit-storage/read-commit-jsonld commit-catalog commit-addr))
-          _            (when-not commit
-                         (throw (ex-info (str "Unable to load. Commit file for ledger: " address
-                                              " at location: " commit-addr " is not found.")
-                                         {:status 400 :error :db/invalid-db})))
-          _            (log/debug "load commit:" commit)
+                                         {:status 400 :error :db/invalid-db}))
+                         (log/debug "Attempting to load from address:" address
+                                    "with commit:" commit))
           ledger-alias (commit->ledger-alias conn address commit)
           branch       (keyword (get-first-value commit const/iri-branch))
 

--- a/src/clj/fluree/db/flake/index/storage.cljc
+++ b/src/clj/fluree/db/flake/index/storage.cljc
@@ -155,10 +155,9 @@
 
 (defn reify-schema
   [{:keys [namespace-codes v] :as root-map}]
-  (if (not= 1 v)
-    (update root-map :schema vocab/deserialize-schema namespace-codes)
-    ;; legacy, for now only v0
-    (update root-map :preds deserialize-preds)))
+  (if (or (nil? v) (= 0 v))
+    (update root-map :preds deserialize-preds) ;; legacy, for now only v0
+    (update root-map :schema vocab/deserialize-schema namespace-codes)))
 
 (defn read-db-root
   "Returns all data for a db index root of a given t."

--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -503,10 +503,10 @@
           (recur r acc*))))))
 
 (defn deserialize-preds
-  [namespace-codes pred-tuples]
-  (let [pred-keys      (mapv keyword (get pred-tuples "keys"))
-        pred-positions (map-indexed vector pred-keys)
-        pred-vals      (get pred-tuples "vals")
+  [namespace-codes serialized-pred-map]
+  (let [{pred-keys :keys
+         pred-vals :vals} serialized-pred-map
+        pred-positions (map-indexed #(vector %1 (keyword %2)) pred-keys)
         pred-maps      (map
                         (partial deserialize-pred-tuple namespace-codes pred-positions)
                         pred-vals)]
@@ -520,10 +520,9 @@
 (defn deserialize-schema
   "Deserializes the schema map from a semi-compact json."
   [serialized-schema namespace-codes]
-  (let [{pred-tuples "pred"
-         t           "t"} serialized-schema
-        pred (deserialize-preds namespace-codes pred-tuples)]
+  (let [{:keys [pred t]} serialized-schema
+        pred* (deserialize-preds namespace-codes pred)]
     (-> (base-schema)
         (assoc :t t
-               :pred pred)
+               :pred pred*)
         (refresh-subclasses))))

--- a/src/clj/fluree/db/nameservice/ipns.cljc
+++ b/src/clj/fluree/db/nameservice/ipns.cljc
@@ -5,8 +5,8 @@
             [fluree.db.method.ipfs :as ipfs]
             [fluree.db.method.ipfs.directory :as ipfs-dir]
             [fluree.db.method.ipfs.keys :as ipfs-keys]
-            [fluree.db.util.json :as json]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -65,7 +65,9 @@
 
   nameservice/iNameService
   (lookup [_ ledger-alias]
-    (lookup-address ipfs-endpoint ipns-key ledger-alias))
+    (when-let [address (lookup-address ipfs-endpoint ipns-key ledger-alias)]
+      (some-> (ipfs/read ipfs-endpoint address)
+              (json-ld/expand))))
   (alias [_ ledger-address]
     (let [[_ _ alias] (address-parts ledger-address)]
       alias)))

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -51,7 +51,7 @@
             filename                (local-filename alias)]
         (when-let [record-bytes (<? (storage/read-bytes store filename))]
           (let [record (json/parse record-bytes false)]
-            (nameservice/commit-address-from-record record nil))))))
+            (nameservice/commit-from-record record nil))))))
 
   (alias [_ ledger-address]
     ;; TODO: need to validate that the branch doesn't have a slash?


### PR DESCRIPTION
When loading an existing db, the index was always pulled from the latest commit file which did not reflect the latest index (if one was written since the latest commit).

The latest index is stored in the nameservice, and this now relies on the nameservice latest information rather than the latest commit file.

There were also some bugs I discovered in reading the serialized index file - not sure how things were working when relying on indexes on disk (my guess is they were not, if there were subclasses, etc.)
