### PR TITLE
SHACL - remove 'mods' dependency

### DIFF
--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -85,14 +85,14 @@
 
 (defn modified-subjects
   "Returns a map of sid to s-flakes for each modified subject."
-  [db flakes]
+  [db-after flakes]
   (go-try
     (loop [[s-flakes & r] (partition-by flake/s flakes)
            sid->s-flakes {}]
       (if s-flakes
-        (let [sid             (some-> s-flakes first flake/s)
-              existing-flakes (<? (query-range/index-range db :spot = [sid]))]
-          (recur r (assoc sid->s-flakes sid (into (set s-flakes) existing-flakes))))
+        (let [sid        (some-> s-flakes first flake/s)
+              sid-flakes (set (<? (query-range/index-range (policy/root db-after) :spot = [sid])))]
+          (recur r (assoc sid->s-flakes sid sid-flakes)))
         sid->s-flakes))))
 
 (defn new-virtual-graph
@@ -128,14 +128,13 @@
     (let [[add remove] (if stage-update?
                          (stage-update-novelty (get-in db [:novelty :spot]) new-flakes)
                          [new-flakes nil])
-          mods-ch      (modified-subjects (policy/root db) add) ;; kick off mods in background
           db-after     (-> db
                            (update :staged conj [txn author annotation])
                            (assoc :t t
                                   :policy policy) ; re-apply policy to db-after
                            (commit-data/update-novelty add remove)
                            (commit-data/add-tt-id))
-          mods         (<? mods-ch)
+          mods         (<? (modified-subjects db-after add))
           db-after*    (-> db-after
                            (vocab/hydrate-schema add mods)
                            (check-virtual-graph add remove))]

--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -147,9 +147,9 @@
        :context   context})))
 
 (defn validate-db-update
-  [{:keys [db-after db-before mods context] :as staged-map}]
+  [{:keys [db-after db-before add context] :as staged-map}]
   (go-try
-    (<? (shacl/validate! db-before (policy/root db-after) (vals mods) context))
+    (<? (shacl/validate! db-before (policy/root db-after) add context))
     (let [allowed-db (<? (policy.modify/allowed? staged-map))]
       allowed-db)))
 

--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -136,7 +136,7 @@
                            (commit-data/add-tt-id))
           mods         (<? (modified-subjects db-after add))
           db-after*    (-> db-after
-                           (vocab/hydrate-schema add mods)
+                           (vocab/hydrate-schema add)
                            (check-virtual-graph add remove))]
       {:add       add
        :remove    remove

--- a/src/clj/fluree/db/json_ld/iri.cljc
+++ b/src/clj/fluree/db/json_ld/iri.cljc
@@ -21,6 +21,8 @@
 (def ^:const f-ipfs-ns "fluree:ipfs://")
 (def ^:const f-s3-ns "fluree:s3://")
 
+(def ^:const shacl-ns "http://www.w3.org/ns/shacl#")
+
 (def ^:const type-iri "@type")
 (def ^:const json-iri "@json")
 (def ^:const rdf:type-iri "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
@@ -46,7 +48,7 @@
    "http://www.w3.org/2001/XMLSchema#"           2
    "http://www.w3.org/1999/02/22-rdf-syntax-ns#" 3
    "http://www.w3.org/2000/01/rdf-schema#"       4
-   "http://www.w3.org/ns/shacl#"                 5
+   shacl-ns                                      5
    "http://www.w3.org/2002/07/owl#"              6
    "https://www.w3.org/2018/credentials#"        7
    f-ns                                          8

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -311,8 +311,10 @@
     (let [target-pids       (into #{} (map unpack-id) (get shape const/sh_targetObjectsOf))]
       (let [sid             (some-> s-flakes first flake/s)
             referring-pids  (not-empty (<? (query-range/index-range db :opst = [[sid const/$id]]
-                                                                    {:flake-xf (map flake/p)})))
-            p-flakes        (filterv (fn [f] (contains? target-pids (flake/p f))) s-flakes)
+                                                                    {:flake-xf (comp
+                                                                                (map flake/p)
+                                                                                (filter target-pids))})))
+            p-flakes        (filter (fn [f] (contains? target-pids (flake/p f))) s-flakes)
             focus-nodes     (mapv object-node p-flakes)]
         (cond-> focus-nodes
           referring-pids (conj (sid-node sid)))))))

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -1114,12 +1114,12 @@
                  :context  context
                  :shape-db shape-db
                  :data-db  data-db}]
-      (loop [[next-shape-sid node-shape-sids*] (<? (all-node-shape-ids shape-db))]
-        (if next-shape-sid
+      (loop [[shape-sid & r] (<? (all-node-shape-ids shape-db))]
+        (if shape-sid
           (let [shape (<? (build-shape shape-db shape-sid))]
             (when (not (get shape const/sh_deactivated))
               (doseq [s-flakes modified-subjects]
                 (when-let [results (<? (validate-node-shape v-ctx shape s-flakes))]
                   (throw-shacl-violation context results))))
-            (recur node-shape-sids*))
+            (recur r))
           :valid)))))

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -1111,15 +1111,15 @@
   [shape-db data-db modified-subjects context]
   (go-try
     (if-let [node-shape-sids (seq (<? (all-node-shape-ids shape-db)))]
-      (doseq [s-flakes modified-subjects]
-        (doseq [shape-sid node-shape-sids]
-          (let [shape   (<? (build-shape shape-db shape-sid))
-                v-ctx   {:display  (make-display data-db context)
-                         :context  context
-                         :shape-db shape-db
-                         :data-db  data-db}]
-            ;; only enforce activated shapes
-            (when (not (get shape const/sh_deactivated))
-              (when-let [results (<? (validate-node-shape v-ctx shape s-flakes))]
-                (throw-shacl-violation context results))))))
+      (let [v-ctx {:display  (make-display data-db context)
+                   :context  context
+                   :shape-db shape-db
+                   :data-db  data-db}]
+        (doseq [s-flakes modified-subjects]
+          (doseq [shape-sid node-shape-sids]
+            (let [shape (<? (build-shape shape-db shape-sid))]
+              ;; only enforce activated shapes
+              (when (not (get shape const/sh_deactivated))
+                (when-let [results (<? (validate-node-shape v-ctx shape s-flakes))]
+                  (throw-shacl-violation context results)))))))
       :valid)))

--- a/src/clj/fluree/db/json_ld/shacl.cljc
+++ b/src/clj/fluree/db/json_ld/shacl.cljc
@@ -1110,7 +1110,7 @@
   `modified-subjects` is a sequence of s-flakes of modified subjects."
   [shape-db data-db modified-subjects context]
   (go-try
-    (when-let [node-shape-sids (seq (<? (all-node-shape-ids shape-db)))]
+    (if-let [node-shape-sids (seq (<? (all-node-shape-ids shape-db)))]
       (doseq [s-flakes modified-subjects]
         (doseq [shape-sid node-shape-sids]
           (let [shape   (<? (build-shape shape-db shape-sid))
@@ -1121,4 +1121,5 @@
             ;; only enforce activated shapes
             (when (not (get shape const/sh_deactivated))
               (when-let [results (<? (validate-node-shape v-ctx shape s-flakes))]
-                (throw-shacl-violation context results)))))))))
+                (throw-shacl-violation context results))))))
+      :valid)))

--- a/test/fluree/db/shacl/shacl_basic_test.clj
+++ b/test/fluree/db/shacl/shacl_basic_test.clj
@@ -3104,7 +3104,11 @@ Subject ex:InvalidHand path [\"ex:digit\"] violates constraint sh:qualifiedValue
                                                         "sh:maxCount" 1,
                                                         "sh:path" {"@id" "ex:term"}}],
                                         "sh:targetObjectsOf" {"@id" "ex:foo" "@type" "rdf:Property"}}]})]
-          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@id" "ex:foo" "ex:term" 123}}))))))
+          (is (test-utils/shacl-error? @(fluree/stage db1 {"insert" {"@context" test-utils/default-str-context
+                                                                     "@graph"   [{"@id" "ex:me"
+                                                                                  "ex:foo" {"@id" "ex:you"}}
+                                                                                 {"@id" "ex:you"
+                                                                                  "ex:term" ["hello", "there"]}]}}))))))
     (testing "targetSubjectsof"
       (testing "with multiple targets"
         (let [db1 @(fluree/stage db0 {"@context" test-utils/default-str-context


### PR DESCRIPTION
This PR removes SHACL's (and :schema) dependency on 'mods'. The reasoner still relies on 'mods', but will remove that depending in another PR.

This also:
- Fixes a bug in targetObjectsOf, where if it found a modified subject was the target of any property it would validate - where it should have ensured the target property was one defined in the SHACL shape
- Fixes a bad test that was passing incorrectly related to the above
- Focuses all SHACL validation on db-after... before it was mixing db-before with all new flakes... but this could lead to some incorrect validation. db-after is cleaner
- In some rudimentary tests, makes SHACL validation about 50% faster. There was a lot of work being duplicated that was unnecessary
- Makes it such that SHACL work is only done if SHACL is defined... before it was always performing SHACL related work. This will make DBs that have no SHACL run substantially faster

