### PR TITLE
Policy removed dependency on 'mods'

### DIFF
--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -4,7 +4,6 @@
             [fluree.db.flake :as flake]
             [fluree.db.flake.index.novelty :as novelty]
             [fluree.db.query.exec.where :as where]
-            [fluree.db.query.range :as query-range]
             [fluree.db.json-ld.policy :as policy]
             [fluree.db.util.core :as util]
             [fluree.db.util.async :refer [<? go-try]]
@@ -82,18 +81,6 @@
                    (if (util/exception? result)
                      result
                      [@db-vol result]))))))
-
-(defn modified-subjects
-  "Returns a map of sid to s-flakes for each modified subject."
-  [db-after flakes]
-  (go-try
-    (loop [[s-flakes & r] (partition-by flake/s flakes)
-           sid->s-flakes {}]
-      (if s-flakes
-        (let [sid        (some-> s-flakes first flake/s)
-              sid-flakes (set (<? (query-range/index-range (policy/root db-after) :spot = [sid])))]
-          (recur r (assoc sid->s-flakes sid sid-flakes)))
-        sid->s-flakes))))
 
 (defn new-virtual-graph
   "Creates a new virtual graph. If the virtual graph is invalid, an

--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -134,7 +134,6 @@
                                   :policy policy) ; re-apply policy to db-after
                            (commit-data/update-novelty add remove)
                            (commit-data/add-tt-id))
-          mods         (<? (modified-subjects db-after add))
           db-after*    (-> db-after
                            (vocab/hydrate-schema add)
                            (check-virtual-graph add remove))]
@@ -142,7 +141,6 @@
        :remove    remove
        :db-after  db-after*
        :db-before db-before
-       :mods      mods
        :context   context})))
 
 (defn validate-db-update
@@ -167,5 +165,5 @@
                                  :author (or author identity)
                                  :annotation annotation)
           [db** new-flakes] (<? (generate-flakes db fuel-tracker parsed-txn tx-state))
-          updated-db (<? (final-db db** new-flakes tx-state))]
-      (<? (validate-db-update updated-db)))))
+          staged-map (<? (final-db db** new-flakes tx-state))]
+      (<? (validate-db-update staged-map)))))

--- a/src/clj/fluree/db/json_ld/policy/modify.cljc
+++ b/src/clj/fluree/db/json_ld/policy/modify.cljc
@@ -1,11 +1,11 @@
 (ns fluree.db.json-ld.policy.modify
   (:require [fluree.db.constants :as const]
-            [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.dbproto :as dbproto]
             [fluree.db.flake :as flake]
-            [fluree.db.util.core :as util]
-            [fluree.db.util.log :as log]
             [fluree.db.json-ld.policy.enforce :as enforce]
-            [fluree.db.json-ld.policy.rules :as policy.rules]))
+            [fluree.db.json-ld.policy.rules :as policy.rules]
+            [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.util.log :as log]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -39,15 +39,30 @@
               (recur r (conj refreshed policy))))
           (assoc-in db-after [:policy :modify :default] refreshed))))))
 
+(defn has-class-policies?
+  [policy]
+  (boolean (enforce/class-policy-map policy true)))
+
+(defn subject-class-policies
+  [db-after policy class-policy-cache sid]
+  (go-try
+    (let [classes (<? (dbproto/-class-ids db-after sid))
+          policies (or (enforce/policies-for-classes classes policy true)
+                       [])]
+      (swap! class-policy-cache assoc sid policies)
+      policies)))
+
 (defn allowed?
   "Checks if all 'adds' are allowed by the policy. If so
   returns final db.
 
   If encounters a policy error, will throw with policy error
   message (if available)."
-  [{:keys [db-after add mods]}]
+  [{:keys [db-after add]}]
   (go-try
-    (let [{:keys [policy]} (<? (refresh-modify-policies db-after))]
+    (let [{:keys [policy]} (<? (refresh-modify-policies db-after))
+          class-policies? (has-class-policies? policy)
+          class-policy-cache (atom {})]
       (if (enforce/unrestricted-modify? policy)
         db-after
         (loop [[flake & r] add]
@@ -55,8 +70,9 @@
             (let [sid      (flake/s flake)
                   pid      (flake/p flake)
                   policies (concat (enforce/policies-for-property policy true pid)
-                                   (->> (classes-for-sid sid mods db-after)
-                                        (enforce/policies-for-classes policy true))
+                                   (when class-policies?
+                                     (or (get @class-policy-cache sid)
+                                         (<? (subject-class-policies db-after policy class-policy-cache sid))))
                                    (enforce/policies-for-flake db-after flake true))]
               ;; policies-allow? will throw if access forbidden
               (if-some [required-policies (not-empty (filter :required? policies))]

--- a/src/clj/fluree/db/json_ld/policy/modify.cljc
+++ b/src/clj/fluree/db/json_ld/policy/modify.cljc
@@ -1,6 +1,5 @@
 (ns fluree.db.json-ld.policy.modify
-  (:require [fluree.db.constants :as const]
-            [fluree.db.dbproto :as dbproto]
+  (:require [fluree.db.dbproto :as dbproto]
             [fluree.db.flake :as flake]
             [fluree.db.json-ld.policy.enforce :as enforce]
             [fluree.db.json-ld.policy.rules :as policy.rules]
@@ -8,14 +7,6 @@
             [fluree.db.util.log :as log]))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-(defn classes-for-sid
-  [sid mods {:keys [schema] :as _db}]
-  ;; TODO - get parent classes
-  (->> (get mods sid)
-       (filter #(= const/$rdf:type (flake/p %)))
-       (map flake/o)
-       seq))
 
 (defn refresh-policy
   [db-after policy-values {:keys [target-subject target-property] :as policy}]
@@ -43,6 +34,7 @@
   [policy]
   (boolean (enforce/class-policy-map policy true)))
 
+;; TODO - get parent classes
 (defn subject-class-policies
   [db-after policy class-policy-cache sid]
   (go-try


### PR DESCRIPTION
This removes the policy enforcement dependency on 'mods' and complements the same being done for SHACL in #966 

The result is a substantial speed-up of transactions, particularly for large dbs where we saw a degree of exponential growth in transaction time - now transaction time is relatively stable even into the 10s of millions of triples, and the indexing background process is the only thing slowing you down.
