### PR TITLE
Return full commits from remote nameservices

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -197,10 +197,9 @@
 (defn read-publisher-commit
   [conn ledger-address]
   (go-try
-    (if-let [commit-addr (<? (lookup-publisher-commit conn ledger-address))]
-      (<? (read-file-address conn commit-addr))
-      (throw (ex-info (str "No published commits exists for: " ledger-address)
-                      {:status 404 :error :db/commit-not-found})))))
+    (or (<? (lookup-publisher-commit conn ledger-address))
+        (throw (ex-info (str "No published commits exist for: " ledger-address)
+                        {:status 404 :error, :db/commit-not-found})))))
 
 (defn published-addresses
   [conn ledger-alias]
@@ -363,7 +362,7 @@
   [{:keys [commit-catalog index-catalog] :as conn}
    ledger-chan address]
   (go-try
-    (let [commit  (<? (lookup-commit conn address))
+    (let [commit       (<? (lookup-commit conn address))
           _            (if-not commit
                          (throw (ex-info (str "Unable to load. No record of ledger exists: " address)
                                          {:status 400 :error :db/invalid-db}))

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -492,7 +492,7 @@
                             3)] ;; default of 3 maximum old indexes not garbage collected
     (when-not (and (int? max-old-indexes)
                    (>= max-old-indexes 0))
-      (throw (ex-info (str "Invalid max-old-indexes value. Must be a non-negative integer.")
+      (throw (ex-info "Invalid max-old-indexes value. Must be a non-negative integer."
                       {:status 400, :error :db/invalid-config})))
     (assoc root-map :reindex-min-bytes reindex-min-bytes
                     :reindex-max-bytes reindex-max-bytes

--- a/src/clj/fluree/db/json_ld/credential.cljc
+++ b/src/clj/fluree/db/json_ld/credential.cljc
@@ -127,14 +127,6 @@
   (and (string? x)
        (re-matches #"(^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$)" x)))
 
-(defn verifiable-credential?
-  [x]
-  (and (map? x) (contains? x "proof")))
-
-(defn credential?
-  [x]
-  (or (jws? x) (verifiable-credential? x)))
-
 (defn verify
   "Verifies a signed query/transaction. Returns keys:
   {:subject <original tx/cmd> :did <did>}

--- a/src/clj/fluree/db/nameservice.cljc
+++ b/src/clj/fluree/db/nameservice.cljc
@@ -52,13 +52,16 @@
       (boolean (<? (lookup nsv addr))))))
 
 (defn commit-from-record
-  [record branch]
-  (let [branch-iri (if branch
-                     (str (get record "@id") "(" branch ")")
-                     (get record "defaultBranch"))]
-    (some #(when (= (get % "@id") branch-iri)
-             (get % "commit"))
-          (get record "branches"))))
+  ([record]
+   (commit-from-record record nil))
+  ([record branch]
+   (log/info "Fetching commit from record:" record)
+   (let [branch-iri (if branch
+                      (str (get record "@id") "(" branch ")")
+                      (get record "defaultBranch"))]
+     (some #(when (= (get % "@id") branch-iri)
+              (get % "commit"))
+           (get record "branches")))))
 
 (defn commit-address-from-record
   [record branch]

--- a/src/clj/fluree/db/nameservice.cljc
+++ b/src/clj/fluree/db/nameservice.cljc
@@ -56,11 +56,9 @@
   (let [branch-iri (if branch
                      (str (get record "@id") "(" branch ")")
                      (get record "defaultBranch"))]
-    (->> (get record "branches")
-         (some #(when (= (get % "@id") branch-iri)
-                  (-> %
-                      (get "commit")
-                      (json-ld/expand)))))))
+    (some #(when (= (get % "@id") branch-iri)
+             (get % "commit"))
+          (get record "branches"))))
 
 (defn commit-address-from-record
   [record branch]

--- a/src/clj/fluree/db/nameservice/ipns.cljc
+++ b/src/clj/fluree/db/nameservice/ipns.cljc
@@ -66,8 +66,7 @@
   nameservice/iNameService
   (lookup [_ ledger-alias]
     (when-let [address (lookup-address ipfs-endpoint ipns-key ledger-alias)]
-      (some-> (ipfs/read ipfs-endpoint address)
-              (json-ld/expand))))
+      (ipfs/read ipfs-endpoint address)))
   (alias [_ ledger-address]
     (let [[_ _ alias] (address-parts ledger-address)]
       alias)))

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -51,7 +51,7 @@
             filename                (local-filename alias)]
         (when-let [record-bytes (<? (storage/read-bytes store filename))]
           (let [record (json/parse record-bytes false)]
-            (nameservice/commit-from-record record))
+            (nameservice/commit-from-record record))))))
 
   (alias [_ ledger-address]
     ;; TODO: need to validate that the branch doesn't have a slash?

--- a/src/clj/fluree/db/nameservice/storage.cljc
+++ b/src/clj/fluree/db/nameservice/storage.cljc
@@ -51,7 +51,7 @@
             filename                (local-filename alias)]
         (when-let [record-bytes (<? (storage/read-bytes store filename))]
           (let [record (json/parse record-bytes false)]
-            (nameservice/commit-from-record record nil))))))
+            (nameservice/commit-from-record record))
 
   (alias [_ ledger-address]
     ;; TODO: need to validate that the branch doesn't have a slash?

--- a/src/clj/fluree/db/remote_system.cljc
+++ b/src/clj/fluree/db/remote_system.cljc
@@ -78,10 +78,9 @@
   (let [server-host (pick-server system-state)]
     (go-try
       (try*
-        (let [head-commit (<? (xhttp/post-json (latest-commit-endpoint server-host)
-                                               {:resource ledger-address}
-                                               {:keywordize-keys false}))]
-          (get head-commit "address"))
+        (<? (xhttp/post-json (latest-commit-endpoint server-host)
+                             {:resource ledger-address}
+                             {:keywordize-keys false}))
         (catch* e
           (when-not (not-found-error? e) ; Return `nil` when the ledger isn't
                                          ; found in the remote system

--- a/src/clj/fluree/db/remote_system.cljc
+++ b/src/clj/fluree/db/remote_system.cljc
@@ -69,12 +69,16 @@
   [e]
   (-> e ex-data :status (= 404)))
 
+(defn latest-commit-endpoint
+  [host]
+  (str host "/fluree/remote/latestCommit"))
+
 (defn remote-lookup
   [system-state ledger-address]
   (let [server-host (pick-server system-state)]
     (go-try
       (try*
-        (let [head-commit (<? (xhttp/post-json (str server-host "/fluree/remote/latestCommit")
+        (let [head-commit (<? (xhttp/post-json (latest-commit-endpoint server-host)
                                                {:resource ledger-address}
                                                {:keywordize-keys false}))]
           (get head-commit "address"))


### PR DESCRIPTION
#965 changed the `lookup-commit` nameservice api method to return the full latest commit document instead of just the address of the latest commit.  However, the commit document returned was expanded in our proprietary format instead of expanded or compact jsonld, and this change wasn't implemented for remote nameservices. 

This patch extends on #965 to return compact jsonld from the `lookup-commit` api method, and it changes the behavior of remote nameservices to match storage-based and ipns based nameservices.

I thought about fixing these issues while keeping the original goal of #965 by making changes to stop storing the index in the commit document, and instead store indexes and commits separately while adding another nameservice api method to retrieve the latest index. I think this is what we should do eventually as it will simplify the system and prevent other issues, but I chose to do the most expedient thing right now to fix the immediate problem. 