### PR TITLE
Old predefined shape cache prevented shacl speedup

### DIFF
--- a/src/clj/fluree/db/json_ld/vocab.cljc
+++ b/src/clj/fluree/db/json_ld/vocab.cljc
@@ -323,8 +323,7 @@
   (let [pred (build-pred-map [initial-type-map initial-class-map])]
     {:t          0
      :pred       pred
-     :shapes     (atom {:class {} ; TODO: Does this need to be an atom?
-                        :pred  {}})
+     :shapes     (atom {})
      :subclasses (delay {})}))
 
 


### PR DESCRIPTION
PR #966 unlocked great speed gains when SHACL wasn't defined, but an old pre-defining of the shape cache made it look like shapes were present where there were none.

This fixes that, and unlocks the speed.
