### PR TITLE
Favor regular json encoding instead of json-ld/normalize

### DIFF
--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -2,8 +2,8 @@
   (:require [fluree.crypto :as crypto]
             [fluree.db.flake :as flake]
             [fluree.db.util.core :as util :refer [get-first get-first-value try* catch*]]
+            [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
-            [fluree.json-ld :as json-ld]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.query.fql.parse :as q-parse]
@@ -247,14 +247,14 @@
 (defn commit-json->commit-id
   [jld]
   (let [b32-hash (-> jld
-                     json-ld/normalize-data
+                     json/stringify-UTF8
                      (crypto/sha2-256 :base32))]
     (str "fluree:commit:sha256:b" b32-hash)))
 
 (defn db-json->db-id
   [payload]
   (let [hsh (-> payload
-                json-ld/normalize-data
+                json/stringify-UTF8
                 (crypto/sha2-256 :base32))]
     (str "fluree:db:sha256:b" hsh)))
 

--- a/src/clj/fluree/db/storage.cljc
+++ b/src/clj/fluree/db/storage.cljc
@@ -5,6 +5,7 @@
             [clojure.pprint :as pprint]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.bytes :as bytes]
+            [fluree.db.util.json :as json]
             [fluree.json-ld :as json-ld])
   #?(:clj (:import (java.io Writer))))
 
@@ -115,7 +116,7 @@
 (defn content-write-json
   [store path data]
   (go-try
-    (let [json   (json-ld/normalize-data data)
+    (let [json   (json/stringify data)
           bytes  (bytes/string->UTF8 json)
           result (<? (-content-write-bytes store path bytes))]
       (assoc result :json json))))


### PR DESCRIPTION
Another performance boost comes from not `json-ld/normalize`(ing).

With the other performance gains making `stage` much faster, the `commit` process ended up taking longer than `stage`.

The biggest culprit of time is `json-ld/normalize`. By moving to a normal json/stringify, process this speeds up commits by more than 2x, and staging actually now takes longer again.

Indexing ended up using json-ld/normalize as well - and it turned out to be the real winner. In my prior large DB tests, the last indexing process took about 30 minutes. With this change, it takes about 5 minutes.

json-ld/normalize will be important for certain type of verifiable credential proofs - but we can implement that if/when we are writing out those proofs and only pay the penalty then.