### PR TITLE
update load process for parallel data loads, commit meta updates

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -481,7 +481,7 @@
         (assoc :commit new-commit
                :prev-commit prev-commit
                :max-namespace-code max-ns-code)
-        (commit-data/add-commit-flakes prev-commit))))
+        (commit-data/add-commit-flakes))))
 
 (defn sanitize-commit-options
   "Parses the commit options and removes non-public opts."

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -461,84 +461,52 @@
   "Builds and returns the commit metadata flakes for the given commit, t, and
   db-sid. Used when committing to an in-memory ledger value and when reifying
   a ledger from storage on load."
-  [{:keys [address alias branch data time v author] :as _commit} t commit-sid db-sid]
-  (let [{db-t :t db-address :address :keys [flakes size]} data]
-    [;; commit flakes
-     ;; address
-     (flake/create commit-sid const/$_address address const/$xsd:string t true nil)
-     ;; alias
-     (flake/create commit-sid const/$_ledger:alias alias const/$xsd:string t true nil)
-     ;; branch
-     (flake/create commit-sid const/$_ledger:branch branch const/$xsd:string t true nil)
-     ;; v
-     (flake/create commit-sid const/$_v v const/$xsd:int t true nil)
-     ;; time
-     (flake/create commit-sid const/$_commit:time (util/str->epoch-ms time) const/$xsd:long t true nil)
-     ;; data
-     (flake/create commit-sid const/$_commit:data db-sid const/$id t true nil)
+  [db t commit]
+  (let [{:keys [id address alias branch data time v previous author issuer message txn]} commit
+        {db-t :t, db-address :address, data-id :id, :keys [flakes size]} data
+        commit-sid (iri/encode-iri db id)
+        db-sid     (iri/encode-iri db data-id)]
+    (cond->
+     [;; commit flakes
+      ;; address
+      (flake/create commit-sid const/$_address address const/$xsd:string t true nil)
+      ;; alias
+      (flake/create commit-sid const/$_ledger:alias alias const/$xsd:string t true nil)
+      ;; branch
+      (flake/create commit-sid const/$_ledger:branch branch const/$xsd:string t true nil)
+      ;; v
+      (flake/create commit-sid const/$_v v const/$xsd:int t true nil)
+      ;; time
+      (flake/create commit-sid const/$_commit:time (util/str->epoch-ms time) const/$xsd:long t true nil)
+      ;; data
+      (flake/create commit-sid const/$_commit:data db-sid const/$id t true nil)
 
-     ;; db flakes
-     ;; t
-     (flake/create db-sid const/$_commitdata:t db-t const/$xsd:int t true nil)
-     ;; address
-     (flake/create db-sid const/$_address db-address const/$xsd:string t true nil)
-     ;; size
-     (flake/create db-sid const/$_commitdata:size size const/$xsd:int t true nil)
-     ;; flakes
-     (flake/create db-sid const/$_commitdata:flakes flakes const/$xsd:int t true nil)]))
+      ;; db flakes
+      ;; t
+      (flake/create db-sid const/$_commitdata:t db-t const/$xsd:int t true nil)
+      ;; address
+      (flake/create db-sid const/$_address db-address const/$xsd:string t true nil)
+      ;; size
+      (flake/create db-sid const/$_commitdata:size size const/$xsd:int t true nil)
+      ;; flakes
+      (flake/create db-sid const/$_commitdata:flakes flakes const/$xsd:int t true nil)]
 
-(defn prev-commit-flakes
-  "Builds and returns a channel containing the previous commit flakes for the
-  given db, t, and previous-id (the id of a commit's previous commit). Used when
-  committing to an in-memory ledger and when reifying a ledger from storage on
-  load."
-  [db t commit-sid previous-id]
-  (let [prev-sid (iri/encode-iri db previous-id)]
-    [(flake/create commit-sid const/$_previous prev-sid const/$id t true nil)]))
+     (:id previous)
+     (conj (flake/create commit-sid const/$_previous (iri/encode-iri db (:id previous)) const/$id t true nil))
 
-(defn prev-data-flakes
-  "Builds and returns a channel containing the previous data flakes for the
-  given db, db-sid, t, and prev-data-id (the id of commit's data section's
-  previous pointer). Used when committing to an in-memory ledger value and when
-  reifying a ledger from storage on load."
-  [db db-sid t prev-data-id]
-  (let [prev-sid (iri/encode-iri db prev-data-id)]
-    [(flake/create db-sid const/$_previous prev-sid const/$id t true nil)]))
+     (:id issuer)
+     (conj (flake/create commit-sid const/$_commit:signer (iri/encode-iri db (:id issuer)) const/$id t true nil))
 
-(defn issuer-flakes
-  "Builds and returns a channel containing the credential issuer's flakes for
-  the given db, t, next-sid, and issuer-iri. next-sid should be a zero-arity fn
-  that returns the next subject id to use if the issuer doesn't already exist in
-  the db and that updates some internal state to reflect that this one is now
-  used. It will only be called if needed. Used when committing to an in-memory
-  ledger value and when reifying a ledger from storage on load."
-  [db t commit-sid issuer-iri]
-  (if-let [issuer-sid (iri/encode-iri db issuer-iri)]
-    ;; create reference to existing issuer
-    [(flake/create commit-sid const/$_commit:signer issuer-sid const/$id t true
-                   nil)]
-    ;; create new issuer flake and a reference to it
-    (let [new-issuer-sid (iri/encode-iri db issuer-iri)]
-      [(flake/create commit-sid const/$_commit:signer new-issuer-sid const/$id t
-                     true nil)])))
+     message
+     (conj (flake/create commit-sid const/$_commit:message message const/$xsd:string t true nil))
 
-(defn message-flakes
-  "Builds and returns the commit message flakes for the given t and message.
-  Used when committing to an in-memory ledger value and when reifying a ledger
-  from storage on load."
-  [t commit-sid message]
-  [(flake/create commit-sid const/$_commit:message message const/$xsd:string t true nil)])
+     ;; TODO - author should really be an IRI, not a string
+     author
+     (conj (flake/create commit-sid const/$_commit:author author const/$xsd:string t true nil))
 
-;; TODO - txn should really be an IRI, not a string
-(defn txn-flake
-  "Builds and returns the commit txn flake for the given t and transaction id."
-  [t commit-sid txn]
-  (flake/create commit-sid const/$_commit:txn txn const/$xsd:string t true nil))
-
-(defn author-flake
-  "Builds and returns the commit txn flake for the given t and transaction id."
-  [t commit-sid author]
-  (flake/create commit-sid const/$_commit:author author const/$xsd:string t true nil))
+     ;; TODO - txn should really be an IRI, not a string
+     txn
+     (conj (flake/create commit-sid const/$_commit:txn txn const/$xsd:string t true nil)))))
 
 (defn annotation-flakes
   [db t commit-sid annotation]
@@ -555,35 +523,17 @@
 
 (defn add-commit-flakes
   "Translate commit metadata into flakes and merge them into novelty."
-  [{:keys [commit] :as db} prev-commit]
-  (let [{:keys [data id issuer message annotation txn author]} commit
-        {db-t :t, db-id :id} data
-        {previous-id :id prev-data :data} prev-commit
-        prev-data-id       (:id prev-data)
-
-        t                  db-t
+  [{:keys [commit] :as db}]
+  (let [{:keys [data id annotation]} commit
+        t (:t data)
         commit-sid         (iri/encode-iri db id)
-        db-sid             (iri/encode-iri db db-id)
-        base-flakes        (commit-metadata-flakes commit t commit-sid db-sid)
-        prev-commit-flakes (when previous-id
-                             (prev-commit-flakes db t commit-sid previous-id))
-        prev-db-flakes     (when prev-data-id
-                             (prev-data-flakes db db-sid t prev-data-id))
-        issuer-flakes      (when-let [issuer-iri (:id issuer)]
-                             (issuer-flakes db t commit-sid issuer-iri))
-        message-flakes     (when message
-                             (message-flakes t commit-sid message))
+        base-flakes        (commit-metadata-flakes db t commit)
 
+        ;; TODO - if annotation flakes exist, do they also need to get created when doing a `load`?
         [db* annotation-flakes] (annotation-flakes db t commit-sid annotation)
 
         commit-flakes      (cond-> base-flakes
-                                   prev-commit-flakes (into prev-commit-flakes)
-                                   prev-db-flakes (into prev-db-flakes)
-                                   issuer-flakes (into issuer-flakes)
-                                   annotation-flakes (into annotation-flakes)
-                                   message-flakes (into message-flakes)
-                                   author (conj (author-flake t commit-sid author))
-                                   txn (conj (txn-flake t commit-sid txn)))]
+                                   annotation-flakes (into annotation-flakes))]
     (-> db*
         (update-novelty commit-flakes)
         add-tt-id)))

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -818,7 +818,8 @@
               conn        @(fluree/connect-file {:storage-path storage-path
                                                  :defaults     {:identity (did/private->did-map
                                                                             test-utils/default-private-key)}})
-              context     [test-utils/default-context {:ex "http://example.org/ns/"}]
+              context     [test-utils/default-context {:ex   "http://example.org/ns/"
+                                                       :cred "https://www.w3.org/2018/credentials#"}]
 
               a             @(fluree/create-with-txn conn {"@context" ["https://ns.flur.ee"
                                                                        context]
@@ -865,8 +866,7 @@
                             [#:f{:assert  [{:ex/x "foo-3"
                                             :ex/y "bar-3"
                                             :id   :ex/alice}]
-                                 :commit  {"https://www.w3.org/2018/credentials#issuer"
-                                           {:id test-utils/did?}
+                                 :commit  {:cred/issuer {:id test-utils/did?}
                                            :f/address  test-utils/address?
                                            :f/alias    ledger-name
                                            :f/branch   "main"
@@ -874,8 +874,7 @@
                                                         :f/assert   [{:ex/x "foo-3"
                                                                       :ex/y "bar-3"
                                                                       :id   :ex/alice}]
-                                                        :f/flakes   36
-                                                        :f/previous {:id test-utils/db-id?}
+                                                        :f/flakes   34
                                                         :f/retract  [{:ex/x "foo-2"
                                                                       :ex/y "bar-2"
                                                                       :id   :ex/alice}]
@@ -893,8 +892,7 @@
                              #:f{:assert  [{:ex/x "foo-cat"
                                             :ex/y "bar-cat"
                                             :id   :ex/alice}]
-                                 :commit  {"https://www.w3.org/2018/credentials#issuer"
-                                           {:id test-utils/did?}
+                                 :commit  {:cred/issuer {:id test-utils/did?}
                                            :f/address  test-utils/address?
                                            :f/alias    ledger-name
                                            :f/branch   "main"
@@ -902,8 +900,7 @@
                                                         :f/assert   [{:ex/x "foo-cat"
                                                                       :ex/y "bar-cat"
                                                                       :id   :ex/alice}]
-                                                        :f/flakes   68
-                                                        :f/previous {:id test-utils/db-id?}
+                                                        :f/flakes   64
                                                         :f/retract  [{:ex/x "foo-3"
                                                                       :ex/y "bar-3"
                                                                       :id   :ex/alice}]

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -177,9 +177,6 @@
                    :f/address
                    "fluree:memory://8845433666a9ff813ed629b2083ca337bfb15bb9969ef2ab6a6ee660014963e9"]
                   ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt" :f/flakes 11]
-                  ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt"
-                   :f/previous
-                   "fluree:db:sha256:beuoec4c6zqxfjglld3evwjdtavsdktncoh6bbxiz677cc4zz3qr"]
                   ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt" :f/size 1076]
                   ["fluree:db:sha256:bvktsmao5ivreittrb4scd3hkc4qkefhqg42va3npk64dbmss4qt" :f/t 1]
                   ["fluree:commit:sha256:bbvoxchxdfwg2u7ukcf7bxstzvyhp4aq62spuvusvygmijsojwucj"


### PR DESCRIPTION
When doing a db `load` from disk, this now traces just the commits to find the first commit after index, but doesn't yet load the db 'data' in that first pass.

The db 'data' is then loaded for each new commit processed.

This accomplishes two things:
1) we don't need to hold as much data in memory at once, which has a significant memory impact for large commits
2) We can load the data and json-ld/expand in parallel using an async chan... so this parallelizes some of the work and reduces db load times in my tests by about 15-20%.

In addition, I consolidated much of the 'commit metadata flake' generation. This was called from 3 places, each doing much of the same work and was not all done consistently.

Lastly, I removed the "prev-data" flake. We were storing `:f/previous` for both the commit ID and the db-data ID. The latter is not necessary as you can get to it easy enough from  the previous commit (and commits always points to its data).

In our load processing, creating this flake was doing another redundant commit load from disk, further adding time to load process for no obvious value.
