### PR TITLE
Only a single 'staged' db per commit

### DIFF
--- a/src/clj/fluree/db/connection.cljc
+++ b/src/clj/fluree/db/connection.cljc
@@ -426,20 +426,15 @@
     (storage/content-write-json storage path txn)))
 
 ;; TODO - as implemented the db handles 'staged' data as per below (annotation, raw txn)
-;; TODO - however this is really a concern of "commit", not staging and I don' think the db should be handling any of it
-(defn write-transactions!
+;; TODO - however this is really a concern of "commit", not staging and I don't think the db should be handling any of it
+(defn write-transaction!
   [storage ledger-alias staged]
   (go-try
-   (loop [[next-staged & r] staged
-          results []]
-     (if next-staged
-       (let [[txn author-did annotation] next-staged
-             results* (if txn
-                        (let [{txn-id :address} (<? (write-transaction storage ledger-alias txn))]
-                          (conj results [txn-id author-did annotation]))
-                        (conj results next-staged))]
-         (recur r results*))
-       results))))
+    (let [[txn author-did annotation] staged]
+      (if txn
+        (let [{txn-id :address} (<? (write-transaction storage ledger-alias txn))]
+          [txn-id author-did annotation])
+        staged))))
 
 (defn update-commit-address
   "Once a commit address is known, which might be after the commit is written
@@ -477,8 +472,8 @@
   [{prev-commit :commit :as staged-db} new-commit]
   (let [max-ns-code (-> staged-db :namespace-codes iri/get-max-namespace-code)]
     (-> staged-db
-        (update :staged empty)
         (assoc :commit new-commit
+               :staged nil
                :prev-commit prev-commit
                :max-namespace-code max-ns-code)
         (commit-data/add-commit-flakes prev-commit))))
@@ -538,13 +533,11 @@
            :or   {time (util/current-time-iso)}}
           (parse-commit-opts ledger opts)
 
-          {:keys [dbid db-jsonld staged-txns]}
+          {:keys [dbid db-jsonld staged-txn]}
           (flake-db/db->jsonld staged-db commit-data-opts)
 
-          ;; TODO - we do not support multiple "transactions" in a single
-          ;; commit (although other code assumes we do which needs cleaning)
-          [[txn-id author annotation] :as _txns]
-          (<? (write-transactions! commit-catalog ledger-alias staged-txns))
+          [txn-id author annotation]
+          (<? (write-transaction! commit-catalog ledger-alias staged-txn))
 
           data-write-result (<? (commit-storage/write-jsonld commit-catalog ledger-alias db-jsonld))
           db-address        (:address data-write-result) ; may not have address (e.g. IPFS) until after writing file

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -518,7 +518,7 @@
                                   :commit commit-map
                                   :tt-id nil
                                   :comparators index/comparators
-                                  :staged []
+                                  :staged nil
                                   :novelty (new-novelty-map index/comparators)
                                   :max-namespace-code max-ns-code)
                            map->FlakeDB
@@ -691,4 +691,4 @@
                         (assoc "@context" (merge-with merge @ctx-used-atom refs-ctx*)))]
     {:dbid        dbid
      :db-jsonld   db-json*
-     :staged-txns staged}))
+     :staged-txn  staged}))

--- a/src/clj/fluree/db/flake/transact.cljc
+++ b/src/clj/fluree/db/flake/transact.cljc
@@ -116,17 +116,16 @@
                          (stage-update-novelty (get-in db [:novelty :spot]) new-flakes)
                          [new-flakes nil])
           db-after     (-> db
-                           (update :staged conj [txn author annotation])
                            (assoc :t t
+                                  :staged [txn author annotation]
                                   :policy policy) ; re-apply policy to db-after
                            (commit-data/update-novelty add remove)
-                           (commit-data/add-tt-id))
-          db-after*    (-> db-after
+                           (commit-data/add-tt-id)
                            (vocab/hydrate-schema add)
                            (check-virtual-graph add remove))]
       {:add       add
        :remove    remove
-       :db-after  db-after*
+       :db-after  db-after
        :db-before db-before
        :context   context})))
 


### PR DESCRIPTION
There was a partial assumption multiple staged dbs could be in a single commit - but this is not something we have supported (although v1/v2 supported multiple txns in a block).

It is the case that you can 'stage' multiple times, but those stages get merged into a single commit.

There were some code assumptions that multiple stages could exist..

This removes the code assumptions and cleans things up a little bit.
