### PR TITLE
Take db-id, commit-id from storage write hash

### DIFF
--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -674,7 +674,7 @@
                       (seq assert)  (assoc-in [assert-key "@container"] "@graph")
                       (seq retract) (assoc-in [retract-key "@container"] "@graph"))
         nses        (new-namespaces db)
-        db-json     (cond-> {id-key                nil ;; comes from hash later
+        db-json     (cond-> {id-key                ""
                              type-key              [(compact const/iri-DB)]
                              (compact const/iri-fluree-t) t
                              (compact const/iri-v) data-version}
@@ -683,12 +683,7 @@
                       (seq retract)   (assoc retract-key retract)
                       (seq nses)      (assoc (compact const/iri-namespaces) nses)
                       (:flakes stats) (assoc (compact const/iri-flakes) (:flakes stats))
-                      (:size stats)   (assoc (compact const/iri-size) (:size stats)))
-        ;; TODO - this is re-normalized below, can try to do it just once
-        dbid        (commit-data/db-json->db-id db-json)
-        db-json*    (-> db-json
-                        (assoc id-key dbid)
-                        (assoc "@context" (merge-with merge @ctx-used-atom refs-ctx*)))]
-    {:dbid        dbid
-     :db-jsonld   db-json*
+                      (:size stats)   (assoc (compact const/iri-size) (:size stats))
+                      true            (assoc "@context" (merge-with merge @ctx-used-atom refs-ctx*)))]
+    {:db-jsonld   db-json
      :staged-txns staged}))

--- a/src/clj/fluree/db/flake/flake_db.cljc
+++ b/src/clj/fluree/db/flake/flake_db.cljc
@@ -689,4 +689,4 @@
                       (:size stats)   (assoc (compact const/iri-size) (:size stats))
                       true            (assoc "@context" (merge-with merge @ctx-used-atom refs-ctx*)))]
     {:db-jsonld   db-json
-     :staged-txns staged}))
+     :staged-txn  staged}))

--- a/src/clj/fluree/db/json_ld/commit_data.cljc
+++ b/src/clj/fluree/db/json_ld/commit_data.cljc
@@ -244,29 +244,27 @@
   [commit commit-id]
   (assoc commit :id commit-id))
 
+(defn hash->commit-id
+  [hsh]
+  (str "fluree:commit:sha256:b" hsh))
+
 (defn commit-json->commit-id
   [jld]
-  (let [b32-hash (-> jld
-                     json/stringify-UTF8
-                     (crypto/sha2-256 :base32))]
-    (str "fluree:commit:sha256:b" b32-hash)))
+  (-> jld
+      json/stringify-UTF8
+      (crypto/sha2-256 :base32)
+      hash->commit-id))
+
+(defn hash->db-id
+  [hsh]
+  (str "fluree:db:sha256:b" hsh))
 
 (defn db-json->db-id
   [payload]
-  (let [hsh (-> payload
-                json/stringify-UTF8
-                (crypto/sha2-256 :base32))]
-    (str "fluree:db:sha256:b" hsh)))
-
-(defn commit->jsonld
-  "Generates JSON-LD commit map, and hash to include the @id value.
-  Return a two-tuple of the updated commit map and the final json-ld document"
-  [commit]
-  (let [jld         (->json-ld commit)
-        commit-id   (commit-json->commit-id jld)
-        commit-map* (update-commit-id commit commit-id)
-        jld*        (assoc jld "id" commit-id)]
-    [commit-map* jld*]))
+  (-> payload
+      json/stringify-UTF8
+      (crypto/sha2-256 :base32)
+      hash->db-id))
 
 (defn blank-commit
   "Creates a skeleton blank commit map."
@@ -370,7 +368,8 @@
         commit      (-> old-commit
                         (dissoc :id :address :data :issuer :time :message :tag
                                 :prev-commit)
-                        (assoc :address ""
+                        (assoc :id ""
+                               :address ""
                                :v commit-version
                                :data data-commit
                                :time time))]

--- a/src/clj/fluree/db/storage/file.cljc
+++ b/src/clj/fluree/db/storage/file.cljc
@@ -51,7 +51,7 @@
                         {:root root
                          :path dir
                          :data data})))
-      (let [hash     (crypto/sha2-256 data :hex)
+      (let [hash     (crypto/sha2-256 data :base32)
             filename (str hash ".json")
             path     (str/join "/" [dir filename])
             absolute (full-path root path)

--- a/src/clj/fluree/db/storage/localstorage.cljs
+++ b/src/clj/fluree/db/storage/localstorage.cljs
@@ -40,7 +40,7 @@
       (let [hashable (if (storage/hashable? v)
                        v
                        (pr-str v))
-            hash     (crypto/sha2-256 hashable)]
+            hash     (crypto/sha2-256 hashable :base32)]
         (.setItem js/localStorage k v)
         {:path    k
          :address (local-storage-address identifier k)

--- a/src/clj/fluree/db/storage/memory.cljc
+++ b/src/clj/fluree/db/storage/memory.cljc
@@ -38,7 +38,7 @@
       (let [hashable (if (storage/hashable? v)
                        v
                        (pr-str v))
-            hash     (crypto/sha2-256 hashable)]
+            hash     (crypto/sha2-256 hashable :base32)]
         (swap! contents assoc hash v)
         {:path    hash
          :address (memory-address identifier hash)

--- a/src/clj/fluree/db/storage/s3.clj
+++ b/src/clj/fluree/db/storage/s3.clj
@@ -115,7 +115,7 @@
   storage/ContentAddressedStore
   (-content-write-bytes [_ dir data]
     (go
-      (let [hash     (crypto/sha2-256 data)
+      (let [hash     (crypto/sha2-256 data :base32)
             bytes    (if (string? data)
                        (bytes/string->UTF8 data)
                        data)

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -973,10 +973,10 @@
       (is (= [{"f:data" {"f:t" 1}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
                "f:data" {"f:t" 2},
-               "f:txn" "fluree:memory://ecdb35e5136082b09f10c3627982e2e1be32af4d0cf50c48ec8ee7f32467e4b7"}
+               "f:txn" "fluree:memory://b3g3gxsrgyecwcprbq3cpgbofyn6gkxu2dhvbreozdxh6msgpzfx"}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
                "f:data" {"f:t" 3},
-               "f:txn" "fluree:memory://d9130edd136b368943868d086d53f058523f6ca839acfa44d763030a0beb32e5"}]
+               "f:txn" "fluree:memory://bwitb3org2zwrfbyndiinvj7awcsh5wkqonm7jcnoyydbif6wmxf"}]
              (->> @(fluree/history ledger {:context        context
                                            :commit-details true
                                            :t              {:from 1 :to :latest}})

--- a/test/fluree/db/query/history_test.clj
+++ b/test/fluree/db/query/history_test.clj
@@ -317,7 +317,6 @@
                                       :f/retract  []
                                       :f/size     pos-int?
                                       :f/t        1
-                                      :f/previous {:id test-utils/db-id?}
                                       :id         test-utils/db-id?}
                           :f/time    720000
                           :f/v       1
@@ -333,8 +332,7 @@
                                                                                  :f/assert   [{:ex/x "foo-cat"
                                                                                                :ex/y "bar-cat"
                                                                                                :id   :ex/alice}]
-                                                                                 :f/flakes   62
-                                                                                 :f/previous {:id test-utils/db-id?}
+                                                                                 :f/flakes   58
                                                                                  :f/retract  [#_{:ex/x "foo-3"
                                                                                                  :ex/y "bar-3"
                                                                                                  :id   :ex/alice}]
@@ -355,8 +353,7 @@
                                                 :f/assert   [{:ex/x "foo-cat"
                                                               :ex/y "bar-cat"
                                                               :id   :ex/cat}]
-                                                :f/flakes   47
-                                                :f/previous {:id test-utils/db-id?}
+                                                :f/flakes   44
                                                 :f/retract  []
                                                 :f/size     pos-int?
                                                 :f/t        4
@@ -394,8 +391,7 @@
                                           :f/assert   [{:ex/x "foo-cat"
                                                         :ex/y "bar-cat"
                                                         :id   :ex/cat}]
-                                          :f/flakes   47
-                                          :f/previous {:id test-utils/db-id?}
+                                          :f/flakes   44
                                           :f/retract  []
                                           :f/size     pos-int?
                                           :f/t        4
@@ -415,8 +411,7 @@
                                         :f/assert   [{:ex/x "foo-3"
                                                       :ex/y "bar-3"
                                                       :id   :ex/alice}]
-                                        :f/flakes   32
-                                        :f/previous {:id test-utils/db-id?}
+                                        :f/flakes   30
                                         :f/retract  [{:ex/x "foo-2"
                                                       :ex/y "bar-2"
                                                       :id   :ex/alice}]
@@ -438,8 +433,7 @@
                                         :f/assert   [{:ex/x "foo-2"
                                                       :ex/y "bar-2"
                                                       :id   :ex/alice}]
-                                        :f/flakes   17
-                                        :f/previous {:id test-utils/db-id?}
+                                        :f/flakes   16
                                         :f/retract  [{:ex/x "foo-1"
                                                       :ex/y "bar-1"
                                                       :id   :ex/alice}]
@@ -463,7 +457,7 @@
                                        :f/assert   [{:ex/x "foo-cat"
                                                      :ex/y "bar-cat"
                                                      :id   :ex/cat}]
-                                       :f/flakes   47
+                                       :f/flakes   44
                                        :f/previous {:id test-utils/db-id?}
                                        :f/retract  []
                                        :f/size     pos-int?
@@ -482,7 +476,7 @@
                                        :f/assert   [{:ex/x "foo-cat"
                                                      :ex/y "bar-cat"
                                                      :id   :ex/alice}]
-                                       :f/flakes   62
+                                       :f/flakes   58
                                        :f/previous {:id test-utils/db-id?}
                                        :f/retract  [{:ex/x "foo-3"
                                                      :ex/y "bar-3"
@@ -515,7 +509,6 @@
                                        :f/retract  []
                                        :f/size     pos-int?
                                        :f/t        1
-                                       :f/previous {:id test-utils/db-id?}
                                        :id         test-utils/db-id?}
                           :f/time     720000
                           :f/v        1
@@ -538,8 +531,7 @@
                                          :f/assert   [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
-                                         :f/flakes   32
-                                         :f/previous {:id test-utils/db-id?}
+                                         :f/flakes   30
                                          :f/retract  [{:ex/x "foo-2"
                                                        :ex/y "bar-2"
                                                        :id   :ex/alice}]
@@ -566,8 +558,7 @@
                                          :f/assert   [{:ex/x "foo-cat"
                                                        :ex/y "bar-cat"
                                                        :id   :ex/alice}]
-                                         :f/flakes   62
-                                         :f/previous {:id test-utils/db-id?}
+                                         :f/flakes   58
                                          :f/retract  [{:ex/x "foo-3"
                                                        :ex/y "bar-3"
                                                        :id   :ex/alice}]
@@ -955,10 +946,10 @@
       (is (= [{"f:data" {"f:t" 1}}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
                "f:data" {"f:t" 2},
-               "f:txn" "fluree:memory://b1e4f45002633e4778ad3136b3fd26fe606dbc9520c7af0116a9c4bc28d33493"}
+               "f:txn" "fluree:memory://bmpe6riaeyz6i54k2mjwwp6sn7tanw6jkighv4arnkoexqungnet"}
               {"f:author" "did:fluree:Tf8ziWxPPA511tcGtUHTLYihHSy2phNjrKb",
                "f:data" {"f:t" 3},
-               "f:txn" "fluree:memory://5080c4ab66cf7e0153d517a79269ab8408ef7c26fe4de12f6a71ec924cb3760b"}]
+               "f:txn" "fluree:memory://ueaysvwnt36afj5kf5hsju2xbai556cn7sn4exwu4pmsjglg5ql"}]
              (->> @(fluree/history ledger {:context        context
                                            :commit-details true
                                            :t              {:from 1 :to :latest}})

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -173,43 +173,43 @@
                                                    {:ex "http://example.org/ns/"}]
                                          :select  ['?s '?p '?o]
                                          :where   {:id '?s, '?p '?o}})]
-          (is (= [["fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"
+          (is (= [["fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                    :f/address
-                   "fluree:memory://1b2db88aa3b254e57ac5c1da9a4d5e5e091a67dd09fcc9bbeaf52093e9e9a3fe"]
-                  ["fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"
+                   "fluree:memory://tqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"]
+                  ["fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                    :f/flakes
                    11]
-                  ["fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"
+                  ["fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                    :f/previous
                    "fluree:db:sha256:bbktr7nvywjwtiamogekl3gfy57di3c5b7vob4gth3dm7hwmtw5k4"]
-                  ["fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"
+                  ["fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                    :f/size
                    1266]
-                  ["fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"
+                  ["fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                    :f/t
                    1]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    "https://www.w3.org/2018/credentials#issuer"
                    "did:fluree:TfCzWTrXqF16hvKGjcYiLxRoYJ1B8a6UMH6"]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/address
-                   "fluree:memory://5acc78bb89fa8619ab186a8a5aaba2c08531c1fae18309d944bf406c6129ed34"]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                   "fluree:memory://bs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"]
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/alias
                    "query/everything"]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/branch
                    "main"]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/data
-                   "fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                   "fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"]
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/previous
                    "fluree:commit:sha256:bb6dtkig73qu77wvwzpumlkmy2ftq3ikv2lhltti4eqvripnpqoqz"]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/time
                    720000]
-                  ["fluree:commit:sha256:bfx4zqi3vysp2aiyxuycwjldw22l2mcoszjfvpdda76a5vedx4mi"
+                  ["fluree:commit:sha256:bbs2ggy7vuaimeqgzstb35jmstqn63phlboetqnvvuatndgvigjii"
                    :f/v
                    1]
                   [:ex/alice :type :ex/User]

--- a/test/fluree/db/query/stable_hashes_test.clj
+++ b/test/fluree/db/query/stable_hashes_test.clj
@@ -28,14 +28,14 @@
                        :schema/age   30}]})
           db1    @(fluree/commit! ledger db0)]
       (testing "stable commit id"
-        (is (= "fluree:commit:sha256:bkmbeerzyxr2cu4tatl2mqj2uvz67t7ow4m36xgw6d7stbxzqljw"
+        (is (= "fluree:commit:sha256:bjz4dqtt66riynizxdwzljc5l34jp2qtmxgyae5dtshc5mmoowbh"
                (get-in db1 [:commit :id]))))
       (testing "stable commit address"
-        (is (= "fluree:memory://dc2c628dd6f75e54e4052372c85f3f0401e59da96380a8a22e72410db26ad32b"
+        (is (= "fluree:memory://jz4dqtt66riynizxdwzljc5l34jp2qtmxgyae5dtshc5mmoowbh"
                (get-in db1 [:commit :address]))))
       (testing "stable db id"
-        (is (= "fluree:db:sha256:bbzjpuyb7d4ah6yvqm677efrvjxyswtqglpj6pc6gwuuf3rdof3iy"
+        (is (= "fluree:db:sha256:btqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                (get-in db1 [:commit :data :id]))))
       (testing "stable db address"
-        (is (= "fluree:memory://1b2db88aa3b254e57ac5c1da9a4d5e5e091a67dd09fcc9bbeaf52093e9e9a3fe"
+        (is (= "fluree:memory://tqomzs3uzs7dspzbs5ht4e7af7qrahnvomx4s4id7apr5jm7dxn"
                (get-in db1 [:commit :data :address])))))))


### PR DESCRIPTION
In the commit process, we were serializing the JSON just to get a hash, then updating the data, then on writing to storage we get another hash.

This change skips the first step and only uses the latter has for the db-id, commit-id.

The JSON serialization is the the most time consuming part of the 'commit' process - and it was being done twice. Now, just once.

The storage serialization hash is in may ways the better hash, as one can verify just from bytes on disk. Before, you'd have to read the bytes, deserialize them, dissoc the @id, re-serialize, and re-hash for verification.

The downside is the @id value is no longer present in the written files - but they are present by anything wrapping them (e.g. db-id is present in the commit).

There are some proofs (some VC proofs) that require specific serialization rules where neither method would have worked anyhow - so if/when those are supported we can encode the logic and pay the penalty for those at that point. Regardless they'd always be optional, and people who preferred a faster DB vs a special proof wouldn't have to pay a penalty.