### PR TITLE
add log with-mdc

### DIFF
--- a/src/fluree/db/util/log.cljc
+++ b/src/fluree/db/util/log.cljc
@@ -135,4 +135,27 @@
      [msg c]
      `(debug-async->vals ~c ~msg)))
 
+#?(:clj
+   (defn with-mdc* [context f]
+     (let [original (org.slf4j.MDC/getCopyOfContextMap)]
+       (try
+         (doseq [[k v] context]
+           (org.slf4j.MDC/put (name k) (str v)))
+         (f)
+         (finally
+           (org.slf4j.MDC/clear)
+           (when original
+             (doseq [[k v] original]
+               (org.slf4j.MDC/put k v)))))))
 
+   :cljs
+   (defn with-mdc* [_context f]
+     (f)))
+
+#?(:clj
+   (defmacro with-mdc [context & body]
+     `(with-mdc* ~context (fn [] ~@body)))
+
+   :cljs
+   (defmacro with-mdc [_context & body]
+     `(do ~@body)))


### PR DESCRIPTION
This allows attaching arbitrary key value pairs to be written in log files.  When logs are emitted as json then these properties will show up in the json and then search on these properties in cloudwatch log insights. 

To display these properties in not json log fromat you can use %X{propname} eg %X{tx.id} or %X to dispaly all mdc properties.  I use this pattern locally:

```
<appender name="CONSOLE_TRACE_COLORS" class="ch.qos.logback.core.ConsoleAppender">
    <encoder>
      <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger %t %X)\n  %msg%n</pattern>
    </encoder>
  </appender>
```
which renders as follows 
<img width="1787" alt="Screenshot 2025-03-12 at 11 58 41 AM" src="https://github.com/user-attachments/assets/621a2fa2-8b7d-43c0-8d94-c759b68d2e97" />

Note that mdc properties are stored on thread locals and thus not copied to go blocks or background threads.  For this to work in practice you also need to require this file to monkey-patch core.async thread executor so that it saves and restores the thread locals when the thread changes. 

https://github.com/fluree/nexus-server/commit/8ba2d7d2228151939d32c837950afcf09e22d28b#diff-684bac090a01548d7d3450bb82c9336370e3bba2b9b645a956208d35ef6827dc

Perhaps the above change should also be moved to db.  However it also captures the otel context and requires additional dependencies, but maybe this isn't so bad if we also want to add tracing and spans in db code as well. 
