### PR TITLE
Fix/hydrate shape cache

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -268,8 +268,8 @@
 (defn db
   "Retrieves latest db, or optionally a db at a moment in time
   and/or permissioned to a specific identity."
-  ([ledger]
-   (ledger/current-db ledger)))
+  [ledger]
+  (ledger/current-db ledger))
 
 (defn wrap-policy
   "Restricts the provided db with the provided json-ld

--- a/src/fluree/db/async_db.cljc
+++ b/src/fluree/db/async_db.cljc
@@ -27,6 +27,10 @@
     (go-try
       (let [db (<? db-chan)]
         (<? (dbproto/-query db query-map)))))
+  (-class-ids [_ subject]
+    (go-try
+      (let [db (<? db-chan)]
+        (<? (dbproto/-class-ids db subject)))))
   (-index-update [_ commit-index]
     (let [commit* (assoc commit :index commit-index)
           updated-db (->async-db alias branch commit* t)]

--- a/src/fluree/db/flake.cljc
+++ b/src/fluree/db/flake.cljc
@@ -103,6 +103,7 @@
 
              IAssociative
              (-assoc [this k v] (assoc-flake this k v))
+             (-contains-key? [_ k] (boolean (#{:s :p :o :dt :t :op :m} k)))
 
              IMeta
              (-meta [_this] -clj-meta)

--- a/src/fluree/db/flake/flake_db.cljc
+++ b/src/fluree/db/flake/flake_db.cljc
@@ -560,11 +560,11 @@
            indexed-db* (if (nil? (:schema root-map)) ;; needed for legacy (v0) root index map
                          (<? (vocab/load-schema indexed-db (:preds root-map)))
                          indexed-db)
-           index-t     (:t indexed-db*)]
-       (<? (shacl/hydrate-shape-cache!
-            (if (= commit-t index-t)
-              indexed-db*
-              (<? (load-novelty commit-catalog indexed-db* index-t commit-jsonld)))))))))
+           index-t     (:t indexed-db*)
+           loaded-db   (if (= commit-t index-t)
+                         indexed-db*
+                         (<? (load-novelty commit-catalog indexed-db* index-t commit-jsonld)))]
+       (<? (shacl/hydrate-shape-cache! loaded-db))))))
 
 (defn get-s-iri
   "Returns a compact IRI from a subject id (sid)."

--- a/src/fluree/db/flake/flake_db.cljc
+++ b/src/fluree/db/flake/flake_db.cljc
@@ -23,6 +23,7 @@
             [fluree.db.json-ld.policy :as policy]
             [fluree.db.json-ld.policy.query :as qpolicy]
             [fluree.db.json-ld.policy.rules :as policy-rules]
+            [fluree.db.json-ld.shacl :as shacl]
             [fluree.db.json-ld.vocab :as vocab]
             [fluree.db.query.exec.select.subject :as subject]
             [fluree.db.query.exec.where :as where]
@@ -560,9 +561,10 @@
                          (<? (vocab/load-schema indexed-db (:preds root-map)))
                          indexed-db)
            index-t     (:t indexed-db*)]
-       (if (= commit-t index-t)
-         indexed-db*
-         (<? (load-novelty commit-catalog indexed-db* index-t commit-jsonld)))))))
+       (<? (shacl/hydrate-shape-cache!
+            (if (= commit-t index-t)
+              indexed-db*
+              (<? (load-novelty commit-catalog indexed-db* index-t commit-jsonld)))))))))
 
 (defn get-s-iri
   "Returns a compact IRI from a subject id (sid)."

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -1113,7 +1113,8 @@
 (defn reset-shape-cache!
   "resets the shape cache with new shapes."
   [db new-shapes]
-  (reset! (-> db :schema :shapes) new-shapes))
+  (reset! (-> db :schema :shapes) new-shapes)
+  db)
 
 (defn cached-shapes
   "Shapes stored as map, keyed to the shacl rule's SID"
@@ -1156,8 +1157,7 @@
   [db]
   (go-try
     (let [new-shapes (<? (rebuild-shapes db))]
-      (reset-shape-cache! db new-shapes)
-      db)))
+      (reset-shape-cache! db new-shapes))))
 
 (defn extract-shapes
   [db]

--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -1152,12 +1152,18 @@
   (let [p-ns (property-ns-code flake)]
     (= p-ns shacl-ns-code)))
 
-(defn extract-shapes
+(defn hydrate-shape-cache!
   [db]
   (go-try
     (let [new-shapes (<? (rebuild-shapes db))]
-      (reset-shape-cache! db new-shapes) ;; TODO - there is really no reason this needs to be an atom any longer
-      (vals new-shapes))))
+      (reset-shape-cache! db new-shapes)
+      db)))
+
+(defn extract-shapes
+  [db]
+  (go-try
+    (let [db* (<? (hydrate-shape-cache! db))]
+      (-> db* :schema :shapes deref vals))))
 
 (defn validate!
   "Will throw an exception if any of the modified subjects fails to conform to a shape that targets it.


### PR DESCRIPTION
When loading an existing ledger we need to hydrate the SHACL shape cache. If no cached shapes are found in a transaction that has no shape flakes, no validation will be performed.