### PR TITLE
only store an unwrapped db in ledger state

### DIFF
--- a/src/fluree/db/branch.cljc
+++ b/src/fluree/db/branch.cljc
@@ -4,6 +4,7 @@
             [fluree.db.dbproto :as dbproto]
             [fluree.db.indexer :as indexer]
             [fluree.db.json-ld.commit-data :as commit-data]
+            [fluree.db.json-ld.policy :as policy]
             [fluree.db.nameservice :as nameservice]
             [fluree.db.util.async :refer [<?]]
             [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]]
@@ -193,7 +194,7 @@
   't' should be the same (if just updating an index) or after the db's 't' value."
   [{:keys [state index-queue] :as branch-map} new-db index-files-ch]
   (let [updated-db (-> state
-                       (swap! update-commit new-db)
+                       (swap! update-commit (policy/root-db new-db))
                        :current-db)]
     (enqueue-index! index-queue updated-db index-files-ch)
     branch-map))


### PR DESCRIPTION
Storing a policy wrapped db in the ledger branch state as :current-db can lead to situations where policy is applied to operations where it is not called for. In operations that should be wrapped we always call `wrap-policy` before conducting those operations, so clearing the policy before storage is just fine.

https://github.com/fluree/flhubee/issues/1432