### PR TITLE
Track metadata in result maps

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -217,13 +217,6 @@
    (promise-wrap
     (transact-api/stage db json-ld opts))))
 
-(defn apply-stage!
-  ([ledger staged-db]
-   (apply-stage! ledger staged-db {}))
-  ([ledger staged-db opts]
-   (promise-wrap
-    (connection/apply-stage! ledger staged-db opts))))
-
 (defn format-txn
   "Reformats the transaction `txn` as JSON-QL if it is formatted as SPARQL,
   returning it unchanged otherwise."

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -563,12 +563,12 @@
       (->> (parse-keypair ledger))
       parse-data-helpers))
 
-(defn apply-stage!
+(defn commit!
   "Finds all uncommitted transactions and wraps them in a Commit document as the subject
   of a VerifiableCredential. Persists according to the :ledger :conn :method and
   returns a db with an updated :commit."
   ([ledger db]
-   (apply-stage! ledger db {}))
+   (commit! ledger db {}))
   ([{:keys [conn] ledger-alias :alias, :as ledger}
     {:keys [branch t stats commit] :as staged-db}
     opts]
@@ -614,19 +614,13 @@
 
        (<? (publish-commit conn commit-jsonld))
 
-       (-> write-result
-           (select-keys [:address :hash :size])
-           (assoc :ledger-id ledger-alias, :t t, :db db*))))))
-
-(defn commit!
-  ([ledger staged-db]
-   (commit! ledger staged-db {}))
-  ([ledger staged-db opts]
-   (go-try
-     (let [commit-result (<? (apply-stage! ledger staged-db opts))]
        (if (track? opts)
-         commit-result
-         (:db commit-result))))))
+         (-> write-result
+             (select-keys [:address :hash :size])
+             (assoc :ledger-id ledger-alias
+                    :t t
+                    :db db*))
+         db*)))))
 
 (defn stage-triples
   "Stages a new transaction that is already parsed into the

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -630,7 +630,7 @@
     (let [parsed-opts    (:opts parsed-txn)
           parsed-context (:context parsed-opts)
           identity       (:identity parsed-opts)]
-      (if (track? parsed-opts)
+      (if (track/track? parsed-opts)
         (let [start-time   #?(:clj (System/nanoTime)
                               :cljs (util/current-time-millis))
               track-fuel?  (track/track-fuel? parsed-opts)
@@ -673,7 +673,7 @@
           ;; whereas stage API takes a did IRI and unparsed context.
           ;; Dissoc them until deciding at a later point if they can carry through.
           cmt-opts (dissoc parsed-opts :context :identity)]
-      (if (track? parsed-opts)
+      (if (track/track? parsed-opts)
         (let [staged-db     (:db staged)
               commit-result (<? (commit! ledger staged-db cmt-opts))]
           (merge staged commit-result))

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -16,7 +16,7 @@
             [fluree.db.nameservice :as nameservice]
             [fluree.db.serde.json :refer [json-serde]]
             [fluree.db.storage :as storage]
-            [fluree.db.track :as track :refer [track?]]
+            [fluree.db.track :as track]
             [fluree.db.track.fuel :as fuel]
             [fluree.db.transact :as transact]
             [fluree.db.util.async :refer [<? go-try]]
@@ -614,7 +614,7 @@
 
        (<? (publish-commit conn commit-jsonld))
 
-       (if (track? opts)
+       (if (track/track? opts)
          (-> write-result
              (select-keys [:address :hash :size])
              (assoc :ledger-id ledger-alias

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -650,9 +650,10 @@
             (catch* e
               (throw (ex-info (ex-message e)
                               (let [policy-report (policy.rules/enforcement-report policy-db)]
-                                (cond-> {:time (util/response-time-formatted start-time)}
+                                (cond-> (ex-data e)
                                   track-fuel?   (assoc :fuel (fuel/tally fuel-tracker))
-                                  policy-report (assoc :policy policy-report)))
+                                  policy-report (assoc :policy policy-report)
+                                  true          (assoc :time (util/response-time-formatted start-time))))
                               e)))))
         (let [policy-db (if (policy/policy-enforced-opts? parsed-opts)
                           (<? (policy/policy-enforce-db db parsed-context parsed-opts))

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -670,7 +670,8 @@
           ;; Dissoc them until deciding at a later point if they can carry through.
           cmt-opts (dissoc parsed-opts :context :identity)]
       (if (track? parsed-opts)
-        (assoc staged :result (<? (commit! ledger (:result staged) cmt-opts)))
+        (let [commit-result (<? (commit! ledger (:result staged) cmt-opts))]
+          (merge staged commit-result))
         (<? (commit! ledger staged cmt-opts))))))
 
 (defn not-found?

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -650,8 +650,8 @@
             (catch* e
               (throw (ex-info (ex-message e)
                               (let [policy-report (policy.rules/enforcement-report policy-db)]
-                                (cond-> {:time (util/response-time-formatted start-time)
-                                         :fuel (fuel/tally fuel-tracker)}
+                                (cond-> {:time (util/response-time-formatted start-time)}
+                                  track-fuel?   (assoc :fuel (fuel/tally fuel-tracker))
                                   policy-report (assoc :policy policy-report)))
                               e)))))
         (<? (transact/stage policy-db identity parsed-txn parsed-opts))))))

--- a/src/fluree/db/json_ld/credential.cljc
+++ b/src/fluree/db/json_ld/credential.cljc
@@ -127,6 +127,15 @@
   (and (string? x)
        (re-matches #"(^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$)" x)))
 
+(defn signed-credential?
+  [x]
+  (some? (get-in x ["proof" "jws"])))
+
+(defn signed?
+  [command]
+  (or (jws? command)
+      (signed-credential? command)))
+
 (defn verify
   "Verifies a signed query/transaction. Returns keys:
   {:subject <original tx/cmd> :did <did>}

--- a/src/fluree/db/track.cljc
+++ b/src/fluree/db/track.cljc
@@ -8,17 +8,17 @@
   [{:keys [max-fuel meta] :as opts}]
   (or max-fuel
       (track-all? opts)
-      (:fuel meta)))
+      (-> meta :fuel true?)))
 
 (defn track-file?
   [{:keys [meta] :as opts}]
   (or (track-all? opts)
-      (:file meta)))
+      (-> meta :file true?)))
 
 (defn track-policy?
   [{:keys [meta] :as opts}]
   (or (track-all? opts)
-      (:policy meta)))
+      (-> meta :policy true?)))
 
 (defn track?
   [opts]

--- a/src/fluree/db/track.cljc
+++ b/src/fluree/db/track.cljc
@@ -4,18 +4,24 @@
   [{:keys [meta] :as _opts}]
   (true? meta))
 
+(defn track-fuel?
+  [{:keys [max-fuel meta] :as opts}]
+  (or max-fuel
+      (track-all? opts)
+      (:fuel meta)))
+
 (defn track-file?
   [{:keys [meta] :as opts}]
   (or (track-all? opts)
       (:file meta)))
 
-(defn track-fuel?
-  [{:keys [max-fuel meta] :as _opts}]
-  (or max-fuel
-      (true? meta)
-      (:fuel meta)))
-
 (defn track-policy?
   [{:keys [meta] :as opts}]
   (or (track-all? opts)
       (:policy meta)))
+
+(defn track?
+  [opts]
+  (or (track-fuel? opts)
+      (track-file? opts)
+      (track-policy? opts)))

--- a/test/fluree/db/policy/target_test.clj
+++ b/test/fluree/db/policy/target_test.clj
@@ -150,7 +150,7 @@
                                                      "a:name"    "Burt's Birthday"
                                                      "a:summary" "My birthday wishlist"}}
                                                    "opts"     {"meta" true}})
-              authorized (:result txn-result)
+              authorized (:db txn-result)
               result     @(fluree/query authorized {"@context" {"a" "http://a.co/"}
                                                     "where"    [{"@id" (:id burt) "a:wishlist" "?wishlist"}]
                                                     "select"   "?wishlist"
@@ -222,7 +222,7 @@
                                                                 "a:description" "flying car, basically"
                                                                 "a:rank"        1}}
                                                      "opts"     {"meta" true}})
-                authorized (:result txn-result)
+                authorized (:db txn-result)
                 result     @(fluree/query authorized {"@context" {"a" "http://a.co/"}
                                                       "select"   {"a:burt-wish1-1" ["*"]}
                                                       "opts"     {"meta" true}})]

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -361,8 +361,8 @@
                               :id         :ex/alice
                               :quux/corge "grault"}]}
             committed  @(fluree/transact! conn txn {:meta true})]
-        (is (= [:fuel :result :status :time]
-               (sort (keys committed))))))
+        (is (= #{:address :db :fuel :hash :ledger-id :result :size :status :t :time}
+               (set (keys committed))))))
 
     (testing "Throws on invalid txn"
       (let [txn {"@context" ["" {:quux "http://quux.com/"}]

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -361,7 +361,7 @@
                               :id         :ex/alice
                               :quux/corge "grault"}]}
             committed  @(fluree/transact! conn txn {:meta true})]
-        (is (= #{:address :db :fuel :hash :ledger-id :result :size :status :t :time}
+        (is (= #{:address :db :fuel :hash :ledger-id :size :status :t :time}
                (set (keys committed))))))
 
     (testing "Throws on invalid txn"

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -769,7 +769,7 @@
                                                                             test-utils/default-context
                                                                             {:ex "http://example.org/ns/"}]
                                                                 "insert"   test-utils/people} {:meta true}))
-                            db          (:result response)
+                            db          (:db response)
                             flake-total (- (-> db :stats :flakes)
                                            (-> db0 :stats :flakes))]
                         (is (= flake-total (:fuel response))

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -702,7 +702,7 @@
                                                                {:ex "http://example.org/ns/"}]
                                                    "insert"   test-utils/people}
                                               {:meta true})
-                   db          (:result response)
+                   db          (:db response)
                    flake-total (- (-> db :stats :flakes)
                                   (-> db0 :stats :flakes))]
 


### PR DESCRIPTION
This patch begins to unify fuel, policy, and file metadata tracking under a track- api (more to come on that in subsequent prs). It also cleans up some of the `commit!` process by removing the `apply-stage!` function which was made redundant by the new tracking apis. Now commits will contain any fuel, policy, or file metadata directly within the returned commit result if the tracking was turned on.