### PR TITLE
fix @type handling in construct selectors

### DIFF
--- a/src/fluree/db/query/exec/select/json_ld.cljc
+++ b/src/fluree/db/query/exec/select/json_ld.cljc
@@ -45,8 +45,10 @@
 (defn json-ld-node
   [compact bnodes s-matches]
   (reduce (fn [node [_ p o]]
-            (let [pred (json-ld-predicate p)]
-              (assoc node (compact pred) (json-ld-object compact bnodes pred o))))
+            ;; There may be no p or o matches, e. from an :id pattern
+            (if-let [pred (json-ld-predicate p)]
+              (assoc node (compact pred) (json-ld-object compact bnodes pred o))
+              node))
           (json-ld-subject compact bnodes (ffirst s-matches))
           s-matches))
 

--- a/src/fluree/db/query/exec/select/json_ld.cljc
+++ b/src/fluree/db/query/exec/select/json_ld.cljc
@@ -5,14 +5,17 @@
             [fluree.db.validation :as v]))
 
 (defn json-ld-object
-  [compact bnodes o-match]
+  [compact bnodes p o-match]
   [(if (where/unmatched? o-match)
      (let [var (where/get-variable o-match)]
        ;; unbound non-bnode variable is an optional match.
        (when (v/bnode-variable? var)
          {(compact const/iri-id) (str var bnodes)}))
      (if-let [iri (where/get-iri o-match)]
-       {(compact const/iri-id) (compact iri)}
+       ;; don't wrap @type values
+       (if (= p const/iri-type)
+         (compact iri)
+         {(compact const/iri-id) (compact iri)})
        (let [v      (where/get-value o-match)
              dt-iri (where/get-datatype-iri o-match)
              lang   (where/get-lang o-match)]
@@ -21,6 +24,13 @@
            (cond-> {(compact const/iri-value) v}
              lang       (assoc (compact const/iri-language) lang)
              (not lang) (assoc (compact const/iri-type) (compact dt-iri)))))))])
+
+(defn json-ld-predicate
+  [p-match]
+  (let [p (where/get-iri p-match)]
+    (if (= p const/iri-rdf-type)
+      const/iri-type
+      p)))
 
 (defn json-ld-subject
   [compact bnodes s-match]
@@ -35,7 +45,8 @@
 (defn json-ld-node
   [compact bnodes s-matches]
   (reduce (fn [node [_ p o]]
-            (assoc node (compact (where/get-iri p)) (json-ld-object compact bnodes o)))
+            (let [pred (json-ld-predicate p)]
+              (assoc node (compact pred) (json-ld-object compact bnodes pred o))))
           (json-ld-subject compact bnodes (ffirst s-matches))
           s-matches))
 

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -553,12 +553,26 @@
         syntax/coerce-where
         (parse-where-clause vars context))))
 
+(defn unwrap-tuple-patterns
+  "Construct accepts ::v/node-map patterns, which can produce :tuple patterns, :class
+  patterns, or :id patterns. We only need the pattern components as a template for
+  construct, the :id and :class patterns are for optimized query execution, so this
+  function unwraps :id and :class patterns and only returns the underlying components."
+  [patterns]
+  (mapv (fn [[pattern-type component :as pattern]]
+          (case pattern-type
+            :class component
+            :id    [component]
+            pattern))
+        patterns))
+
 (defn parse-construct
   [q context]
   (when-let [construct (:construct q)]
     (-> construct
         syntax/coerce-where
         (parse-where-clause nil context)
+        unwrap-tuple-patterns
         select/construct-selector)))
 
 (defn parse-select-as-fn

--- a/test/fluree/db/query/construct_test.clj
+++ b/test/fluree/db/query/construct_test.clj
@@ -103,6 +103,16 @@
                                  "construct" [{"@id" "?s" "json" "?config"}
                                               {"@id" "?s" "name" "?name"}
                                               {"@id" "?s" "date" "?date"}]}))))
+    (testing "@type values are unwrapped"
+      (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}
+              "@graph" [{"@id" "ex:bbob", "@type" ["ex:Person"]}
+                        {"@id" "ex:fbueller", "@type" ["ex:Person"]}
+                        {"@id" "ex:jbob", "@type" ["ex:Person"]}
+                        {"@id" "ex:jdoe", "@type" ["ex:Person"]}]}
+             @(fluree/query db1 {"@context" context
+                                 "where" [{"@id" "?s" "@type" "?o"}]
+                                 "construct" [{"@id" "?s" "@type" "?o"}]}))))
+
     #_(testing "bnode template"
         (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}
                 "@graph"

--- a/test/fluree/db/query/construct_test.clj
+++ b/test/fluree/db/query/construct_test.clj
@@ -112,6 +112,26 @@
              @(fluree/query db1 {"@context" context
                                  "where" [{"@id" "?s" "@type" "?o"}]
                                  "construct" [{"@id" "?s" "@type" "?o"}]}))))
+    (testing ":class patterns are constructed correctly"
+      (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}
+              "@graph" [{"@id" "ex:bbob", "@type" ["ex:Human"]}
+                        {"@id" "ex:fbueller", "@type" ["ex:Human"]}
+                        {"@id" "ex:jbob", "@type" ["ex:Human"]}
+                        {"@id" "ex:jdoe", "@type" ["ex:Human"]}]}
+             @(fluree/query db1 {"@context" context
+                                 "where" [{"@id" "?s" "@type" "ex:Person"}]
+                                 ;; :class pattern in construct clause
+                                 "construct" [{"@id" "?s" "@type" "ex:Human"}]}))))
+    (testing ":id patterns are constructed correctly"
+      (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}
+              "@graph" [{"@id" "ex:bbob"}
+                        {"@id" "ex:fbueller"}
+                        {"@id" "ex:jbob"}
+                        {"@id" "ex:jdoe"}]}
+             @(fluree/query db1 {"@context" context
+                                 "where" [{"@id" "?s" "@type" "ex:Person"}]
+                                 ;; :id pattern in construct clause
+                                 "construct" [{"@id" "?s"}]}))))
 
     #_(testing "bnode template"
         (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}


### PR DESCRIPTION
@type values were being wrapped in id-maps like any other iri, instead of special cased. This adds the special casing for that predicate.

We translate "a" to "@type", which then gets interned on a flake as "rdf:type". So, when formatting as json-ld, we need to translate "rdf:type" to "@type".

Also addresses handling of `:id` and `:class` patterns in the construct clause.

Closes https://github.com/fluree/db/issues/1003
Closes https://github.com/fluree/db/issues/1004