### PR TITLE
only return valid triples in :construct query

### DIFF
--- a/src/fluree/db/query/exec/select.cljc
+++ b/src/fluree/db/query/exec/select.cljc
@@ -125,7 +125,7 @@
       (go (->> (mapv #(where/assign-matched-values % solution) patterns)
                ;; partition by s-match
                (partition-by first)
-               (mapv (partial select.json-ld/json-ld-node compact bnodes)))))))
+               (keep (partial select.json-ld/format-node compact bnodes)))))))
 
 (defn construct-selector
   [patterns]

--- a/src/fluree/db/query/exec/select/json_ld.cljc
+++ b/src/fluree/db/query/exec/select/json_ld.cljc
@@ -4,53 +4,69 @@
             [fluree.db.query.exec.where :as where]
             [fluree.db.validation :as v]))
 
-(defn json-ld-object
-  [compact bnodes p o-match]
-  [(if (where/unmatched? o-match)
-     (let [var (where/get-variable o-match)]
-       ;; unbound non-bnode variable is an optional match.
-       (when (v/bnode-variable? var)
-         {(compact const/iri-id) (str var bnodes)}))
-     (if-let [iri (where/get-iri o-match)]
-       ;; don't wrap @type values
-       (if (= p const/iri-type)
-         (compact iri)
-         {(compact const/iri-id) (compact iri)})
-       (let [v      (where/get-value o-match)
-             dt-iri (where/get-datatype-iri o-match)
-             lang   (where/get-lang o-match)]
-         (if (datatype/inferable-iri? dt-iri)
-           v
-           (cond-> {(compact const/iri-value) v}
+(defn object
+  "Returns the formatted object if it is properly bound, or nil. The object formatted
+  'multicardinal' style in a vector, regardless of the number of values."
+  [bnodes compact p o-match]
+  (if (where/unmatched? o-match)
+    (let [var (where/get-variable o-match)]
+      ;; unbound non-bnode variable is an optional match, return nil
+      (when (v/bnode-variable? var)
+        [{(compact const/iri-id) (str var bnodes)}]))
+    (if-let [iri (where/get-iri o-match)]
+      ;; don't wrap @type values
+      (if (= p const/iri-type)
+        [(compact iri)]
+        [{(compact const/iri-id) (compact iri)}])
+      (let [v      (where/get-value o-match)
+            dt-iri (where/get-datatype-iri o-match)
+            lang   (where/get-lang o-match)]
+        (if (datatype/inferable-iri? dt-iri)
+          [v]
+          [(cond-> {(compact const/iri-value) v}
              lang       (assoc (compact const/iri-language) lang)
-             (not lang) (assoc (compact const/iri-type) (compact dt-iri)))))))])
+             (not lang) (assoc (compact const/iri-type) (compact dt-iri)))])))))
 
-(defn json-ld-predicate
-  [p-match]
-  (let [p (where/get-iri p-match)]
-    (if (= p const/iri-rdf-type)
-      const/iri-type
-      p)))
+(defn predicate
+  "Returns the predicate iri if it is properly bound, or nil."
+  [bnodes p-match]
+  (if (where/unmatched? p-match)
+    (let [var (where/get-variable p-match)]
+      (when (v/bnode-variable? var)
+        (str var bnodes)))
+    (let [p (where/get-iri p-match)]
+      (if (= p const/iri-rdf-type)
+        const/iri-type
+        p))))
 
-(defn json-ld-subject
-  [compact bnodes s-match]
-  (if (where/get-iri s-match)
-    {(compact const/iri-id) (compact (where/get-iri s-match))}
+(defn subject
+  "Returns the subject iri if it is properly bound, or nil."
+  [bnodes s-match]
+  (if (where/unmatched? s-match)
     (let [var (where/get-variable s-match)]
-      (if (v/bnode-variable? var)
-        {(compact const/iri-id) (str var bnodes)}
-        ;; unbound non-bnode variable is an optional match.
-        {(compact const/iri-id) nil}))))
+      (when (v/bnode-variable? var)
+        (str var bnodes)))
+    (where/get-iri s-match)))
 
-(defn json-ld-node
+(defn format-node
+  "Format a collection of subject matches into a json-ld object. If there is not at least
+  one valid triple, return an empty object which will be removed."
   [compact bnodes s-matches]
-  (reduce (fn [node [_ p o]]
-            ;; There may be no p or o matches, e. from an :id pattern
-            (if-let [pred (json-ld-predicate p)]
-              (assoc node (compact pred) (json-ld-object compact bnodes pred o))
-              node))
-          (json-ld-subject compact bnodes (ffirst s-matches))
-          s-matches))
+  (let [node (reduce (fn [node [_ p-match o-match]]
+                       (if node
+                         (if-let [p (predicate bnodes p-match)]
+                           (if-let [o (object bnodes compact p o-match)]
+                             (assoc node (compact p) o)
+                             node)
+                           node)
+                         ;; no bound subject, no valid triples
+                         (reduced nil)))
+                     (when-let [s (subject bnodes (ffirst s-matches))]
+                       {(compact const/iri-id) (compact s)})
+                     s-matches)]
+    ;; a valid node needs at least two entries, one for the subject and one for a pred/obj
+    (when (> (count node) 1)
+      node)))
 
 (defn nest-multicardinal-values
   "Aggregate unique values for the same predicate into a vector."

--- a/test/fluree/db/query/construct_test.clj
+++ b/test/fluree/db/query/construct_test.clj
@@ -122,16 +122,25 @@
                                  "where" [{"@id" "?s" "@type" "ex:Person"}]
                                  ;; :class pattern in construct clause
                                  "construct" [{"@id" "?s" "@type" "ex:Human"}]}))))
-    (testing ":id patterns are constructed correctly"
+    (testing ":id patterns cannot produce valid triples"
       (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}
-              "@graph" [{"@id" "ex:bbob"}
-                        {"@id" "ex:fbueller"}
-                        {"@id" "ex:jbob"}
-                        {"@id" "ex:jdoe"}]}
+              "@graph" []}
              @(fluree/query db1 {"@context" context
                                  "where" [{"@id" "?s" "@type" "ex:Person"}]
                                  ;; :id pattern in construct clause
                                  "construct" [{"@id" "?s"}]}))))
+    (testing "unbound vars are not included"
+      (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}
+              "@graph" [{"@id" "ex:alice", "ex:name" ["Alice"]}
+                        {"@id" "ex:bbob", "@type" ["ex:Person"]}
+                        {"@id" "ex:fbueller" "@type" ["ex:Person"]}
+                        {"@id" "ex:jbob" "@type" ["ex:Person"]}
+                        {"@id" "ex:jdoe" "@type" ["ex:Person"]}]}
+             @(fluree/query db1 {"@context" context
+                                 "where" [{"@id" "?s" "?p" "?o"}
+                                          ["optional" {"@id" "?s" "@type" "?type"}]
+                                          ["optional" {"@id" "?s" "foaf:givenname" "?name"}]]
+                                 "construct" [{"@id" "?s"  "ex:name" "?name" "@type" "?type"}]}))))
 
     #_(testing "bnode template"
         (is (= {"@context" {"person" "http://example.org/Person#", "ex" "http://example.org/"}


### PR DESCRIPTION
Per the spec:

> If any such instantiation produces a triple containing an unbound
variable or an illegal RDF construct, such as a literal in subject or predicate position, then that triple is not included in the output RDF graph.

Closes https://github.com/fluree/db/issues/1007