### PR TITLE
handle expanded IRIs in SPARQL property path expressions

### DIFF
--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -377,7 +377,7 @@
                      ;; translate back to string
                     (sparql.translator/parse-term)
                      ;; separate recursion modifier
-                    (split-at (dec (count path-expr)))
+                    (#(split-at (dec (count %)) %))
                      ;; turn back into strings
                     (map (partial apply str)))
         recur-mod   ({"+" :one+ "*" :zero+} mod)]

--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -610,7 +610,12 @@
 (defmethod parse-term :PathElt
   [[_ primary mod]]
   (if mod
-    (str "<" (parse-term primary) (parse-term mod) ">")
+    (let [term  (parse-term primary)
+          term* (if ((set (flatten primary)) :IRIREF)
+                  ;; expanded IRIs need to be wrapped in angle brackets in a transitive path
+                  (str "<" term ">")
+                  term)]
+      (str "<" term* (parse-term mod) ">"))
     (parse-term primary)))
 
 (defmethod parse-term :PathSequence

--- a/test/fluree/db/query/property_path_test.clj
+++ b/test/fluree/db/query/property_path_test.clj
@@ -45,7 +45,7 @@
           (testing "transitive"
             (testing "without cycle"
               (is (= ["ex:b" "ex:c" "ex:d" "ex:e"]
-                     @(fluree/query db1 {"where" [{"@id" "ex:a" "<ex:knows+>" "?who"}]
+                     @(fluree/query db1 {"where" [{"@id" "ex:a" "<<ex:knows>+>" "?who"}]
                                          "select" "?who"}))))
             (testing "with cycle"
               (let [db2 @(fluree/stage db1 {"insert" {"@id" "ex:e" "ex:knows" {"@id" "ex:a"}}})]

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -202,17 +202,31 @@
              where))))
   (testing "transitive property path"
     (testing "one-or-more"
-      (let [query "SELECT ?uri ?broader
-                 WHERE {?uri (<http://www.w3.org/2004/02/skos/core#broader>)+ ?broader.}"]
+      (testing "compact IRI"
+        (let [query "SELECT ?uri ?broader
+                     WHERE {?uri skos:broader+ ?broader.}"]
 
-        (is (= [{"@id" "?uri", "<http://www.w3.org/2004/02/skos/core#broader+>" "?broader"}]
-               (:where (sparql/->fql query))))))
+          (is (= [{"@id" "?uri", "<skos:broader+>" "?broader"}]
+                 (:where (sparql/->fql query))))))
+      (testing "expanded IRI"
+        (let [query "SELECT ?uri ?broader
+                     WHERE {?uri (<http://www.w3.org/2004/02/skos/core#broader>)+ ?broader.}"]
+
+          (is (= [{"@id" "?uri", "<<http://www.w3.org/2004/02/skos/core#broader>+>" "?broader"}]
+                 (:where (sparql/->fql query)))))))
     (testing "zero-or-more"
-      (let [query "SELECT ?uri ?broader
+      (testing "compact IRI"
+        (let [query "SELECT ?uri ?broader
+                 WHERE {?uri (skos:broader)* ?broader.}"]
+
+          (is (= [{"@id" "?uri", "<skos:broader*>" "?broader"}]
+                 (:where (sparql/->fql query))))))
+      (testing "expanded IRI"
+        (let [query "SELECT ?uri ?broader
                  WHERE {?uri (<http://www.w3.org/2004/02/skos/core#broader>)* ?broader.}"]
 
-        (is (= [{"@id" "?uri", "<http://www.w3.org/2004/02/skos/core#broader*>" "?broader"}]
-               (:where (sparql/->fql query)))))))
+          (is (= [{"@id" "?uri", "<<http://www.w3.org/2004/02/skos/core#broader>*>" "?broader"}]
+                 (:where (sparql/->fql query))))))))
   (testing "UNION"
     (let [query "SELECT ?person ?age
                  WHERE {?person person:age 70 .


### PR DESCRIPTION
Expanded IRIs need to wrapped in angle brackets to be valid SPARQL expressions. A bit awkward, since the rest of our translator is built to translate SPARQL into jld-query, and in this case we do not want to do that.

Closes https://github.com/fluree/db/issues/1006