### PR TITLE
Capture policy parsing/rule exceptions

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -336,7 +336,9 @@
   ([ds q]
    (query ds q {}))
   ([ds q opts]
-   (promise-wrap (query-api/query ds q opts))))
+   (if (util/exception? ds)
+     (throw ds)
+     (promise-wrap (query-api/query ds q opts)))))
 
 (defn credential-query
   "Issues a policy-enforced query to the specified dataset/db as a verifiable

--- a/src/fluree/db/json_ld/policy/rules.cljc
+++ b/src/fluree/db/json_ld/policy/rules.cljc
@@ -4,10 +4,9 @@
             [fluree.db.dbproto :as dbproto]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.json-ld.policy :as policy]
-            [fluree.db.util.async :refer [go-try <?]]
+            [fluree.db.util.async :refer [<?]]
             [fluree.db.util.core :as util :refer [try* catch*]]
-            [fluree.db.util.log :as log]
-            [fluree.json-ld :as json-ld]))
+            [fluree.db.util.log :as log]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/fluree/db/json_ld/policy/rules.cljc
+++ b/src/fluree/db/json_ld/policy/rules.cljc
@@ -5,7 +5,8 @@
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.json-ld.policy :as policy]
             [fluree.db.util.async :refer [go-try <?]]
-            [fluree.db.util.core :as util]
+            [fluree.db.util.core :as util :refer [try* catch*]]
+            [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -78,22 +79,25 @@
   (map? target-expr))
 
 (defn parse-targets
-  [db fuel-tracker policy-values target-exprs]
+  [db fuel-tracker error-ch policy-values target-exprs]
   (let [in-ch  (async/to-chan! target-exprs)
         out-ch (async/chan 2 (map (fn [iri] (iri/iri->sid iri (:namespaces db)))))]
     (async/pipeline-async 2
                           out-ch
                           (fn [target-expr ch]
-                            (if (query-target? target-expr)
-                              (let [context (json-ld/parse-context (get target-expr "@context"))
-                                    sid-xf  (map #(json-ld/expand-iri % context))
-                                    target-q (cond-> (assoc target-expr "select" "?$target")
-                                               policy-values (policy/inject-where-pattern ["values" policy-values]))]
-                                (-> (dbproto/-query db fuel-tracker target-q)
-                                    (async/pipe (async/chan 2 (comp cat sid-xf)))
-                                    (async/pipe ch)))
-                              ;; non-maps are literals
-                              (async/onto-chan! ch [target-expr])))
+                            (async/go
+                              (try*
+                                (if (query-target? target-expr)
+                                  (let [target-q (cond-> (assoc target-expr
+                                                                "select" "?$target"
+                                                                :selection-context {}) ;; don't compact selection results
+                                                   policy-values (policy/inject-where-pattern ["values" policy-values]))]
+                                    (->> (<? (dbproto/-query db fuel-tracker target-q))
+                                         (async/onto-chan! ch)))
+                                 ;; non-maps are literals
+                                  (async/onto-chan! ch [target-expr]))
+                                (catch* e
+                                  (async/>! error-ch e)))))
                           in-ch)
     (async/into #{} out-ch)))
 
@@ -102,61 +106,66 @@
   (not-empty (mapv #(or (util/get-id %) (util/get-value %)) targets)))
 
 (defn parse-policy
-  [db fuel-tracker policy-values policy-doc]
-  (go-try
-    (let [id (util/get-id policy-doc) ;; @id name of policy-doc
+  [db fuel-tracker error-ch policy-values policy-doc]
+  (async/go
+    (try*
+      (let [id (util/get-id policy-doc) ;; @id name of policy-doc
 
-          target-subject      (unwrap (get policy-doc const/iri-targetSubject))
-          subject-targets-ch  (when target-subject
-                                (parse-targets db fuel-tracker policy-values target-subject))
-          target-property     (unwrap (get policy-doc const/iri-targetProperty))
-          property-targets-ch (when target-property
-                                (parse-targets db fuel-tracker policy-values target-property))
+            target-subject      (unwrap (get policy-doc const/iri-targetSubject))
+            subject-targets-ch  (when target-subject
+                                  (parse-targets db fuel-tracker error-ch policy-values target-subject))
+            target-property     (unwrap (get policy-doc const/iri-targetProperty))
+            property-targets-ch (when target-property
+                                  (parse-targets db fuel-tracker error-ch policy-values target-property))
 
-          on-property (when-let [p-iris (util/get-all-ids policy-doc const/iri-onProperty)]
-                        (set p-iris))
-          on-class    (when-let [classes (util/get-all-ids policy-doc const/iri-onClass)]
-                        (set classes))
+            on-property (when-let [p-iris (util/get-all-ids policy-doc const/iri-onProperty)]
+                          (set p-iris))
+            on-class    (when-let [classes (util/get-all-ids policy-doc const/iri-onClass)]
+                          (set classes))
 
-          src-query (util/get-first-value policy-doc const/iri-query)
-          query     (if (map? src-query)
-                      (assoc src-query "select" "?$this" "limit" 1)
-                      (throw (ex-info (str "Invalid policy, unable to extract query from f:query. "
-                                           "Did you forget @context?. Parsed restriction: " policy-doc)
-                                      {:status 400
-                                       :error  :db/invalid-policy})))
-          actions   (set (util/get-all-ids policy-doc const/iri-action))
-          view?     (or (empty? actions) ;; if actions is not specified, default to all actions
-                        (contains? actions const/iri-view))
-          modify?   (or (empty? actions)
-                        (contains? actions const/iri-modify))
+            src-query (util/get-first-value policy-doc const/iri-query)
+            query     (if (map? src-query)
+                        (assoc src-query "select" "?$this" "limit" 1)
+                        (throw (ex-info (str "Invalid policy, unable to extract query from f:query. "
+                                             "Did you forget @context?. Parsed restriction: " policy-doc)
+                                        {:status 400
+                                         :error  :db/invalid-policy})))
+            actions   (set (util/get-all-ids policy-doc const/iri-action))
+            view?     (or (empty? actions) ;; if actions is not specified, default to all actions
+                          (contains? actions const/iri-view))
+            modify?   (or (empty? actions)
+                          (contains? actions const/iri-modify))
 
-          subject-targets  (when subject-targets-ch (<? subject-targets-ch))
-          property-targets (when property-targets-ch (<? property-targets-ch))]
-      (if (or view? modify?)
-        (cond-> {:id          id
-                 :on-property on-property
-                 :on-class    on-class
-                 :required?   (util/get-first-value policy-doc const/iri-required)
+            subject-targets  (when subject-targets-ch (<? subject-targets-ch))
+            property-targets (when property-targets-ch (<? property-targets-ch))]
+        (log/warn "subject-targets: " subject-targets
+                  " property-targets: " property-targets)
+        (if (or view? modify?)
+          (cond-> {:id          id
+                   :on-property on-property
+                   :on-class    on-class
+                   :required?   (util/get-first-value policy-doc const/iri-required)
                  ;; with no class or property restrictions, becomes a default policy-doc
-                 :default?    (and (nil? on-property)
-                                   (nil? on-class)
-                                   (nil? subject-targets)
-                                   (nil? property-targets))
-                 :ex-message  (util/get-first-value policy-doc const/iri-exMessage)
-                 :view?       view?
-                 :modify?     modify?
-                 :query       query}
-          target-subject               (assoc :target-subject target-subject)
-          target-property              (assoc :target-property target-property)
-          (not-empty subject-targets)  (assoc :s-targets subject-targets)
-          (not-empty property-targets) (assoc :p-targets property-targets))
+                   :default?    (and (nil? on-property)
+                                     (nil? on-class)
+                                     (nil? subject-targets)
+                                     (nil? property-targets))
+                   :ex-message  (util/get-first-value policy-doc const/iri-exMessage)
+                   :view?       view?
+                   :modify?     modify?
+                   :query       query}
+            target-subject               (assoc :target-subject target-subject)
+            target-property              (assoc :target-property target-property)
+            (not-empty subject-targets)  (assoc :s-targets subject-targets)
+            (not-empty property-targets) (assoc :p-targets property-targets))
         ;; policy-doc has incorrectly formatted view? and/or modify?
         ;; this might allow data through that was intended to be restricted, so throw.
-        (throw (ex-info (str "Invalid policy definition. Policies must have f:action of {@id: f:view} or {@id: f:modify}. "
-                             "Policy data that failed: " policy-doc)
-                        {:status 400
-                         :error  :db/invalid-policy}))))))
+          (throw (ex-info (str "Invalid policy definition. Policies must have f:action of {@id: f:view} or {@id: f:modify}. "
+                               "Policy data that failed: " policy-doc)
+                          {:status 400
+                           :error  :db/invalid-policy}))))
+      (catch* e
+        (async/put! error-ch e)))))
 
 (defn enforcement-report
   [db]
@@ -191,21 +200,28 @@
         wrapper*))))
 
 (defn parse-policies
-  [db fuel-tracker policy-values policy-docs]
-  (let [policy-ch     (async/chan)
-        policy-doc-ch (async/to-chan! policy-docs)]
-    (async/pipeline-async 2
-                          policy-ch
-                          (fn [policy-doc ch]
-                            (-> (parse-policy db fuel-tracker policy-values policy-doc)
-                                (async/pipe ch)))
-                          policy-doc-ch)
+  [db fuel-tracker error-ch policy-values policy-docs]
+  (let [policy-ch     (async/chan)]
+    ;; parse policies and put them on the policy-ch, output to error-ch in case of error
+    (->> policy-docs
+         async/to-chan!
+         (async/pipeline-async 2
+                               policy-ch
+                               (fn [policy-doc ch]
+                                 (-> (parse-policy db fuel-tracker error-ch policy-values policy-doc)
+                                     (async/pipe ch)))))
+
+    ;; build policy wrapper attached to db containing parsed policies
     (async/reduce (build-wrapper db) {:trace {}} policy-ch)))
 
 (defn wrap-policy
   ([db policy-rules policy-values]
    (wrap-policy db nil policy-rules policy-values))
   ([db fuel-tracker policy-rules policy-values]
-   (go-try
-     (let [wrapper (<? (parse-policies db fuel-tracker policy-values (util/sequential policy-rules)))]
-       (assoc db :policy (assoc wrapper :cache (atom {}) :policy-values policy-values))))))
+   (async/go
+     (let [error-ch (async/chan)
+           [wrapper _] (async/alts! [error-ch
+                                     (parse-policies db fuel-tracker error-ch policy-values (util/sequential policy-rules))])]
+       (if (util/exception? wrapper)
+         wrapper
+         (assoc db :policy (assoc wrapper :cache (atom {}), :policy-values policy-values)))))))

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -40,6 +40,7 @@
    [:where {:optional true} ::where]
    [:t {:optional true} ::t]
    [:context {:optional true} ::context]
+   [:selection-context {:optional true} ::context]
    [:order-by {:optional true} ::order-by]
    [:group-by {:optional true} ::group-by]
    [:having {:optional true} ::function]


### PR DESCRIPTION
Exceptions with policy rules were being swallowed, and would effect act like the policy doesn't exist - usually not what you'd want.

This introduces an `error-ch` strategy in policy parsing and execution which will now throw when calling `wrap-policy` or related APIs.

Also (fluree/query ...) will check that its DB object is not an exception before executing. When the db is an exception, it is difficult to know the issue as you'll get a cryptical 'cannot assoc ... to Exception' error.



