### PR TITLE
Policy nil query handled as false/deny

### DIFF
--- a/src/fluree/db/json_ld/policy/enforce.cljc
+++ b/src/fluree/db/json_ld/policy/enforce.cljc
@@ -89,7 +89,7 @@
 
                 query   (when-let [query (:query policy)]
                           (policy-query db sid query))
-                result  (if query 
+                result  (if query
                           (seq (<? (dbproto/-query (root db) fuel-tracker query)))
                           deny-query-result)]
             (swap! exec-counter inc)

--- a/src/fluree/db/json_ld/policy/rules.cljc
+++ b/src/fluree/db/json_ld/policy/rules.cljc
@@ -122,14 +122,14 @@
                           (set classes))
 
             src-query (util/get-first-value policy-doc const/iri-query)
-            query     (cond 
+            query     (cond
                         (map? src-query)
                         (assoc src-query "select" "?$this" "limit" 1)
-                        
-                        (nil? src-query) 
-                        nil 
-                        
-                        :else 
+
+                        (nil? src-query)
+                        nil
+
+                        :else
                         (throw (ex-info (str "Invalid policy query. Query must be a map, instead got: " src-query)
                                         {:status 400
                                          :error  :db/invalid-policy})))
@@ -141,9 +141,9 @@
 
             subject-targets  (when subject-targets-ch (<? subject-targets-ch))
             property-targets (when property-targets-ch (<? property-targets-ch))]
-        
+
         (when (and (nil? query)
-                   (nil? target-subject) 
+                   (nil? target-subject)
                    (nil? target-property)
                    (nil? on-property)
                    (nil? on-class))
@@ -151,7 +151,7 @@
                                "Did you forget @context?. Parsed restriction: " policy-doc)
                           {:status 400
                            :error  :db/invalid-policy})))
-        
+
         (if (or view? modify?)
           (cond-> {:id          id
                    :on-property on-property


### PR DESCRIPTION
This builds on #1012 

This allows for `f:query` in policy to now be optional, and when not included it acts as a false/deny response if a query had existed.

Previously, if you wanted an 'always deny' policy, you'd have to write a query that always returned false. The common example is this one:
```
...
"f:query":  {"@type" : "@json"
             "@value": {"where": [["filter", "(not= 1 1)"]]}}
...
```

This is difficult to explain and didn't seem very natural. In addition it required a pointless query execution processing step.

I believe this updated approach is easier to explain and is more efficient. The change is backwards compatible, so an 'always false' query will still work.
