### PR TITLE
Feature: Static bindings in :bind clause

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
         byte-streams/byte-streams           {:mvn/version "0.2.4"}
         cheshire/cheshire                   {:mvn/version "5.13.0"}
         instaparse/instaparse               {:mvn/version "1.5.0"}
-        metosin/malli                       {:mvn/version "0.16.2"}
+        metosin/malli                       {:mvn/version "0.17.0"}
         nano-id/nano-id                     {:mvn/version "1.1.0"}
         integrant/integrant                 {:mvn/version "0.10.0"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -788,10 +788,6 @@
     :else
     x))
 
-(defn mch->typed-val
-  [{::where/keys [val iri datatype-iri meta]}]
-  (where/->typed-val (or iri val) (if iri const/iri-id datatype-iri) (:lang meta)))
-
 (defn bind-variables
   [soln-sym var-syms ctx]
   (into `[~context-var ~ctx]
@@ -799,8 +795,8 @@
                   `[mch# (get ~soln-sym (quote ~var))
                     ;; convert match to TypedValue
                     ~var (if (= ::group/grouping (where/get-datatype-iri mch#))
-                           (mapv mch->typed-val (where/get-binding mch#))
-                           (mch->typed-val mch#))]))
+                           (mapv where/mch->typed-val (where/get-binding mch#))
+                           (where/mch->typed-val mch#))]))
         var-syms))
 
 (defn compile*

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -286,7 +286,7 @@
         ;; id map
         (where/match-iri mch (json-ld/expand-iri iri context))
         ;; literal value
-        (where/match-value mch static-value)))))
+        (where/match-value mch static-value (datatype/infer-iri static-value))))))
 
 (defn parse-bind-expression
   [var-name expression context]

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -22,6 +22,10 @@
   [x]
   (boolean (#{'desc "desc" :desc} x)))
 
+(defn function?
+  [x]
+  (m/validate ::v/function x {:registry v/registry}))
+
 (defn one-select-key-present?
   [q]
   (log/trace "one-select-key-present? q:" q)

--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -493,7 +493,13 @@
   [[_ & bindings]]
   ;; bindings come in as val, var; need to be reversed to var, val.
   (into [:bind] (->> bindings
-                     (mapv parse-term)
+                     (mapv (fn [term]
+                             (let [terms (into #{} (flatten term))
+                                   parsed (parse-term term)]
+                               (if (and (terms :iriOrFunction) (not= \( (first parsed)))
+                                 ;; static iri
+                                 {const/iri-id parsed}
+                                 (parse-term term)))))
                      (partition-all 2)
                      (mapcat reverse))))
 

--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -610,7 +610,12 @@
 (defmethod parse-term :PathElt
   [[_ primary mod]]
   (if mod
-    (str "<" (parse-term primary) (parse-term mod) ">")
+    (let [term  (parse-term primary)
+          term* (if ((set (flatten primary)) :IRIREF)
+                  ;; expanded IRIs need to be wrapped in angle brackets in a transitive path
+                  (str "<" term ">")
+                  term)]
+      (str "<" term* (parse-term mod) ">"))
     (parse-term primary)))
 
 (defmethod parse-term :PathSequence

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -7,6 +7,10 @@
             [malli.error :as me]
             [malli.util :as mu]))
 
+(defn json-ld-keyword?
+  [x]
+  (and (string? x) (= \@ (first x))))
+
 (defn decode-json-ld-keyword
   [v]
   (if (string? v)
@@ -271,7 +275,7 @@
                             [:double :double]
                             [:iri ::iri]
                             ;; id/value map
-                            [:map-of ::json-ld-keyword [:ref ::literal]]]
+                            [:map [:map-of [:fn json-ld-keyword?] [:ref ::literal]]]]
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -264,6 +264,14 @@
                             variable?]
     ::val                  [:fn value?]
     ::subject              ::iri
+    ::literal              [:orn {:error/message "Invalid literal"}
+                            [:string :string]
+                            [:boolean :boolean]
+                            [:int :int]
+                            [:double :double]
+                            [:iri ::iri]
+                            ;; id/value map
+                            [:map-of ::json-ld-keyword [:ref ::literal]]]
     ::function             [:orn
                             [:string-fn [:and :string [:re #"^\(.+\)$"]]]
                             [:list-fn [:and list? [:cat :symbol [:* any?]]]]
@@ -283,7 +291,7 @@
                             [:schema [:ref ::where]]]
     ::bind                 [:+ {:error/message "bind values must be mappings from variables to functions"}
                             [:catn [:var ::var]
-                             [:binding ::function]]]
+                             [:binding [:or ::function ::literal]]]]
     ::where-op             [:and
                             :keyword
                             [:enum {:error/message "unrecognized where operation, must be one of: graph, filter, optional, union, bind, values, exists, not-exists, minus"}

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -304,6 +304,47 @@
                 ["L" "Liam" false]]
                res))))
 
+    (testing "with static binds"
+      (let [q   {:context  [test-utils/default-context
+                            {:ex "http://example.org/ns/"}]
+                 :construct '[{:id ?s
+                               :ex/firstLetter ?firstLetterOfName
+                               :ex/const ?const
+                               :ex/greeting ?langstring
+                               :ex/date     ?date}]
+                 :where    '[{:id ?s
+                              :schema/age  ?age
+                              :schema/name ?name}
+                             [:bind
+                              ?firstLetterOfName (subStr ?name 1 1)
+                              ?const             "const"
+                              ?langstring        {"@value" "hola" "@language" "es"}
+                              ?bool              false
+                              ?date              {"@value" "2020-01-10" "@type" "ex:mydate"}]]
+                 :order-by '?name}
+            res (-> @(fluree/query db q) (get "@graph"))]
+        (is (= [{:id :ex/alice,
+                 :ex/firstLetter ["A"],
+                 :ex/const ["const"],
+                 :ex/greeting [{"@value" "hola", "@language" "es"}],
+                 :ex/date [{"@value" "2020-01-10", :type "ex:mydate"}]}
+                {:id :ex/brian,
+                 :ex/firstLetter ["B"],
+                 :ex/const ["const"],
+                 :ex/greeting [{"@value" "hola", "@language" "es"}],
+                 :ex/date [{"@value" "2020-01-10", :type "ex:mydate"}]}
+                {:id :ex/cam,
+                 :ex/firstLetter ["C"],
+                 :ex/const ["const"],
+                 :ex/greeting [{"@value" "hola", "@language" "es"}],
+                 :ex/date [{"@value" "2020-01-10", :type "ex:mydate"}]}
+                {:id :ex/liam,
+                 :ex/firstLetter ["L"],
+                 :ex/const ["const"],
+                 :ex/greeting [{"@value" "hola", "@language" "es"}],
+                 :ex/date [{"@value" "2020-01-10", :type "ex:mydate"}]}]
+               res))))
+
     (testing "with invalid aggregate fn"
       (let [q {:context  [test-utils/default-context
                           {:ex "http://example.org/ns/"}]

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -202,17 +202,31 @@
              where))))
   (testing "transitive property path"
     (testing "one-or-more"
-      (let [query "SELECT ?uri ?broader
-                 WHERE {?uri (<http://www.w3.org/2004/02/skos/core#broader>)+ ?broader.}"]
+      (testing "compact IRI"
+        (let [query "SELECT ?uri ?broader
+                     WHERE {?uri skos:broader+ ?broader.}"]
 
-        (is (= [{"@id" "?uri", "<http://www.w3.org/2004/02/skos/core#broader+>" "?broader"}]
-               (:where (sparql/->fql query))))))
+          (is (= [{"@id" "?uri", "<skos:broader+>" "?broader"}]
+                 (:where (sparql/->fql query))))))
+      (testing "expanded IRI"
+        (let [query "SELECT ?uri ?broader
+                     WHERE {?uri (<http://www.w3.org/2004/02/skos/core#broader>)+ ?broader.}"]
+
+          (is (= [{"@id" "?uri", "<<http://www.w3.org/2004/02/skos/core#broader>+>" "?broader"}]
+                 (:where (sparql/->fql query)))))))
     (testing "zero-or-more"
-      (let [query "SELECT ?uri ?broader
+      (testing "compact IRI"
+        (let [query "SELECT ?uri ?broader
+                 WHERE {?uri (skos:broader)* ?broader.}"]
+
+          (is (= [{"@id" "?uri", "<skos:broader*>" "?broader"}]
+                 (:where (sparql/->fql query))))))
+      (testing "expanded IRI"
+        (let [query "SELECT ?uri ?broader
                  WHERE {?uri (<http://www.w3.org/2004/02/skos/core#broader>)* ?broader.}"]
 
-        (is (= [{"@id" "?uri", "<http://www.w3.org/2004/02/skos/core#broader*>" "?broader"}]
-               (:where (sparql/->fql query)))))))
+          (is (= [{"@id" "?uri", "<<http://www.w3.org/2004/02/skos/core#broader>*>" "?broader"}]
+                 (:where (sparql/->fql query))))))))
   (testing "UNION"
     (let [query "SELECT ?person ?age
                  WHERE {?person person:age 70 .

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -435,13 +435,63 @@
                (select-keys (sparql/->fql query) [:where :values]))
             "where pattern: single var, multiple values"))))
   (testing "BIND"
-    (let [query "SELECT ?person ?handle
+    (testing "static values"
+      (testing "string"
+        (let [query "SELECT ?person ?handle
                  WHERE {BIND (\"dsanchez\" AS ?handle)
                         ?person person:handle ?handle.}"
-          {:keys [where]} (sparql/->fql query)]
-      (is (= [[:bind "?handle" "dsanchez"]
-              {"@id" "?person", "person:handle" "?handle"}]
-             where)))
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?handle" "dsanchez"]
+                  {"@id" "?person", "person:handle" "?handle"}]
+                 where))))
+      (testing "langstring"
+        (let [query "SELECT ?person ?bound
+                 WHERE {BIND (\"dsanchez\"@en AS ?bound)
+                        ?person person:handle ?bound.}"
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?bound" {"@value" "dsanchez", "@language" "en"}]
+                  {"@id" "?person", "person:handle" "?bound"}]
+                 where))))
+      (testing "boolean"
+        (let [query "SELECT ?person ?bound
+                 WHERE {BIND (true AS ?bound)
+                        ?person person:handle ?bound.}"
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?bound" true]
+                  {"@id" "?person", "person:handle" "?bound"}]
+                 where))))
+      (testing "integer"
+        (let [query "SELECT ?person ?bound
+                 WHERE {BIND (1 AS ?bound)
+                        ?person person:handle ?bound.}"
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?bound" 1]
+                  {"@id" "?person", "person:handle" "?bound"}]
+                 where))))
+      (testing "float"
+        (let [query "SELECT ?person ?bound
+                 WHERE {BIND (1.0 AS ?bound)
+                        ?person person:handle ?bound.}"
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?bound" 1.0]
+                  {"@id" "?person", "person:handle" "?bound"}]
+                 where))))
+      (testing "IRI"
+        (let [query "SELECT ?person ?bound
+                 WHERE {BIND (<ex:foo> AS ?bound)
+                        ?person person:handle ?bound.}"
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?bound" {"@id" "ex:foo"}]
+                  {"@id" "?person", "person:handle" "?bound"}]
+                 where))))
+      (testing "compact IRI"
+        (let [query "SELECT ?person ?bound
+                 WHERE {BIND (ex:foo AS ?bound)
+                        ?person person:handle ?bound.}"
+              {:keys [where]} (sparql/->fql query)]
+          (is (= [[:bind "?bound" {"@id" "ex:foo"}]
+                  {"@id" "?person", "person:handle" "?bound"}]
+                 where)))))
     (let [query "SELECT ?person ?prefix ?foofix ?num1
                  WHERE {BIND (SUBSTR(?handle, 4) AS ?prefix)
                         BIND (REPLACE(?prefix, \"abc\", \"FOO\") AS ?foofix)


### PR DESCRIPTION
Adds SPARQL and JLD-Query support for binding static values in a `:bind` clause, in addition to function calls. This is a commonly used idiom in SPARQL queries, though you can also use a `:values` clause to achieve the same effect.

