### PR TITLE
Feature/drop

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -184,10 +184,9 @@
    (connection/load-ledger conn alias-or-address)))
 
 (defn drop
-  ([conn ledger-alias-or-address] (drop conn ledger-alias-or-address nil))
-  ([conn ledger-alias-or-address opts]
-   (promise-wrap
-     (connection/drop-ledger conn ledger-alias-or-address opts))))
+  [conn ledger-alias]
+  (promise-wrap
+   (connection/drop-ledger conn ledger-alias)))
 
 (defn exists?
   "Returns a promise with true if the ledger alias or address exists, false

--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -17,7 +17,7 @@
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld])
-  (:refer-clojure :exclude [merge load range exists?]))
+  (:refer-clojure :exclude [merge load range exists? drop]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -182,6 +182,12 @@
   (validate-connection conn)
   (promise-wrap
    (connection/load-ledger conn alias-or-address)))
+
+(defn drop
+  ([conn ledger-alias-or-address] (drop conn ledger-alias-or-address nil))
+  ([conn ledger-alias-or-address opts]
+   (promise-wrap
+     (connection/drop-ledger conn ledger-alias-or-address opts))))
 
 (defn exists?
   "Returns a promise with true if the ledger alias or address exists, false

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -447,7 +447,7 @@
     (load-ledger-alias conn alias-or-address)))
 
 (defn drop-commit-artifacts
-  [{:keys [commit-catalog] :as conn} latest-commit]
+  [{:keys [commit-catalog] :as _conn} latest-commit]
   (let [error-ch  (async/chan)
         commit-ch (commit-storage/trace-commits commit-catalog latest-commit 0 error-ch)]
     (go-loop []
@@ -457,7 +457,7 @@
               data-address        (-> (util/get-first commit const/iri-data)
                                       (util/get-first-value const/iri-address))]
           (log/debug "Dropping commit" (-> (util/get-first commit const/iri-data)
-                                          (util/get-first-value const/iri-fluree-t)))
+                                           (util/get-first-value const/iri-fluree-t)))
           (when data-address
             (log/debug "Deleting data" data-address)
             (storage/delete commit-catalog data-address))
@@ -474,7 +474,7 @@
   [storage node-address]
   (go-try
     (loop [[address & r] [node-address]
-           addresses     (list )]
+           addresses     (list)]
       (if address
         (if-let [children (->> (:children (<? (storage/read-json storage address true)))
                                (mapv :id))]
@@ -488,8 +488,7 @@
 (defn drop-index-artifacts
   [{:keys [index-catalog] :as _conn} latest-commit]
   (go-try
-    (let [
-          storage       (:storage index-catalog)
+    (let [storage       (:storage index-catalog)
           index-address (some-> (util/get-first latest-commit const/iri-index)
                                 (util/get-first-value const/iri-address))]
       (when index-address
@@ -509,7 +508,7 @@
           (<? (storage/delete storage index-address)))))))
 
 (defn drop-ledger
-  [{:keys [commit-catalog index-catalog] :as conn} alias opts]
+  [conn alias]
   (go-try
     (let [alias (if (fluree-address? alias)
                   (nameservice/address-path alias)

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -7,6 +7,7 @@
             [fluree.db.constants :as const]
             [fluree.db.did :as did]
             [fluree.db.flake.flake-db :as flake-db]
+            [fluree.db.indexer.garbage :as garbage]
             [fluree.db.json-ld.commit-data :as commit-data]
             [fluree.db.json-ld.credential :as credential]
             [fluree.db.json-ld.iri :as iri]
@@ -444,6 +445,85 @@
   (if (fluree-address? alias-or-address)
     (load-ledger-address conn alias-or-address)
     (load-ledger-alias conn alias-or-address)))
+
+(defn drop-commit-artifacts
+  [{:keys [commit-catalog] :as conn} latest-commit]
+  (let [error-ch  (async/chan)
+        commit-ch (commit-storage/trace-commits commit-catalog latest-commit 0 error-ch)]
+    (go-loop []
+      (when-let [[commit _] (<! commit-ch)]
+        (let [txn-address         (util/get-first-value commit const/iri-txn)
+              commit-address      (util/get-first-value commit const/iri-address)
+              data-address        (-> (util/get-first commit const/iri-data)
+                                      (util/get-first-value const/iri-address))]
+          (log/debug "Dropping commit" (-> (util/get-first commit const/iri-data)
+                                          (util/get-first-value const/iri-fluree-t)))
+          (when data-address
+            (log/debug "Deleting data" data-address)
+            (storage/delete commit-catalog data-address))
+          (when commit-address
+            (log/debug "Deleting commit" commit-address)
+            (storage/delete commit-catalog commit-address))
+          (when txn-address
+            (log/debug "Deleting txn" txn-address)
+            (storage/delete commit-catalog txn-address))
+          (recur))))))
+
+(defn drop-index-nodes
+  "Build up a list of node addresses in leaf->root order, then delete them."
+  [storage node-address]
+  (go-try
+    (loop [[address & r] [node-address]
+           addresses     (list )]
+      (if address
+        (if-let [children (->> (:children (<? (storage/read-json storage address true)))
+                               (mapv :id))]
+          (recur (into r children) (conj addresses address))
+          (recur r (conj addresses address)))
+
+        (doseq [address addresses]
+          (log/debug "Dropping node" address)
+          (storage/delete storage address))))))
+
+(defn drop-index-artifacts
+  [{:keys [index-catalog] :as _conn} latest-commit]
+  (go-try
+    (let [
+          storage       (:storage index-catalog)
+          index-address (some-> (util/get-first latest-commit const/iri-index)
+                                (util/get-first-value const/iri-address))]
+      (when index-address
+        (log/debug "Dropping index" index-address)
+        (let [{:keys [spot opst post tspo]} (<? (storage/read-json storage index-address true))
+
+              garbage-ch (garbage/clean-garbage* index-catalog index-address 0)
+              spot-ch    (drop-index-nodes storage (:id spot))
+              post-ch    (drop-index-nodes storage (:id post))
+              tspo-ch    (drop-index-nodes storage (:id tspo))
+              opst-ch    (drop-index-nodes storage (:id opst))]
+          (<? garbage-ch)
+          (<? spot-ch)
+          (<? post-ch)
+          (<? tspo-ch)
+          (<? opst-ch)
+          (<? (storage/delete storage index-address)))))))
+
+(defn drop-ledger
+  [{:keys [commit-catalog index-catalog] :as conn} alias-or-address opts]
+  (go-try
+    (let [alias (if (fluree-address? alias-or-address)
+                  (nameservice/address-path alias-or-address)
+                  alias-or-address)]
+      (loop [[ledger-addr & r] (<? (current-addresses conn alias))]
+        (when ledger-addr
+          (log/debug "Dropping ledger" ledger-addr)
+          (let [latest-commit (-> (<? (lookup-commit conn ledger-addr))
+                                  json-ld/expand)
+                index-ch      (drop-index-artifacts conn latest-commit)
+                commit-ch     (drop-commit-artifacts conn latest-commit)]
+            (<? index-ch)
+            (<? commit-ch)
+            (recur r)))))))
 
 (def f-context {"f" "https://ns.flur.ee/ledger#"})
 

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -514,7 +514,7 @@
     (let [alias (if (fluree-address? alias)
                   (nameservice/address-path alias)
                   alias)]
-      (loop [[publisher & r] (all-nameservices conn)]
+      (loop [[publisher & r] (publishers conn)]
         (when publisher
           (let [ledger-addr   (<? (nameservice/publishing-address publisher alias))
                 _             (log/debug "Dropping ledger" ledger-addr)

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -509,22 +509,24 @@
           (<? (storage/delete storage index-address)))))))
 
 (defn drop-ledger
-  [{:keys [commit-catalog index-catalog] :as conn} alias-or-address opts]
+  [{:keys [commit-catalog index-catalog] :as conn} alias opts]
   (go-try
-    (let [alias (if (fluree-address? alias-or-address)
-                  (nameservice/address-path alias-or-address)
-                  alias-or-address)]
-      (loop [[ledger-addr & r] (<? (current-addresses conn alias))]
-        (when ledger-addr
-          (log/debug "Dropping ledger" ledger-addr)
-          (let [latest-commit (-> (<? (lookup-commit conn ledger-addr))
+    (let [alias (if (fluree-address? alias)
+                  (nameservice/address-path alias)
+                  alias)]
+      (loop [[publisher & r] (all-nameservices conn)]
+        (when publisher
+          (let [ledger-addr   (<? (nameservice/publishing-address publisher alias))
+                _             (log/debug "Dropping ledger" ledger-addr)
+                latest-commit (-> (<? (nameservice/lookup publisher ledger-addr))
                                   json-ld/expand)
                 index-ch      (drop-index-artifacts conn latest-commit)
                 commit-ch     (drop-commit-artifacts conn latest-commit)]
             (<? index-ch)
             (<? commit-ch)
+            (<? (nameservice/retract publisher alias))
             (recur r))))
-      (log/debug "Dropped ledger" alias-or-address)
+      (log/debug "Dropped ledger" alias)
       :dropped)))
 
 (def f-context {"f" "https://ns.flur.ee/ledger#"})

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -523,7 +523,9 @@
                 commit-ch     (drop-commit-artifacts conn latest-commit)]
             (<? index-ch)
             (<? commit-ch)
-            (recur r)))))))
+            (recur r))))
+      (log/debug "Dropped ledger" alias-or-address)
+      :dropped)))
 
 (def f-context {"f" "https://ns.flur.ee/ledger#"})
 

--- a/src/fluree/db/nameservice.cljc
+++ b/src/fluree/db/nameservice.cljc
@@ -20,6 +20,8 @@
 (defprotocol Publisher
   (publish [publisher commit-jsonld]
     "Publishes new commit.")
+  (retract [publisher ledger-alias]
+    "Remove the nameservice record for the ledger.")
   (publishing-address [publisher ledger-alias]
     "Returns full publisher address/iri which will get published in commit. If
     'private', return `nil`."))

--- a/src/fluree/db/nameservice/ipns.cljc
+++ b/src/fluree/db/nameservice/ipns.cljc
@@ -58,6 +58,8 @@
   nameservice/Publisher
   (publish [_ commit-jsonld]
     (ipfs/push! ipfs-endpoint commit-jsonld))
+  (retract [_ ledger-alias]
+    (ipfs/write ipfs-endpoint "null"))
   (publishing-address [_ ledger-alias]
     (ipns-address ipfs-endpoint ipns-key ledger-alias))
 

--- a/src/fluree/db/nameservice/ipns.cljc
+++ b/src/fluree/db/nameservice/ipns.cljc
@@ -58,7 +58,7 @@
   nameservice/Publisher
   (publish [_ commit-jsonld]
     (ipfs/push! ipfs-endpoint commit-jsonld))
-  (retract [_ ledger-alias]
+  (retract [_ _ledger-alias]
     (ipfs/write ipfs-endpoint "null"))
   (publishing-address [_ ledger-alias]
     (ipns-address ipfs-endpoint ipns-key ledger-alias))

--- a/src/fluree/db/nameservice/storage.cljc
+++ b/src/fluree/db/nameservice/storage.cljc
@@ -11,7 +11,7 @@
   [ledger-alias]
   (str ledger-alias ".json"))
 
-(defn publishing-address
+(defn publishing-address*
   [store ledger-alias]
   (-> store
       storage/location
@@ -47,14 +47,17 @@
   nameservice/Publisher
   (publish [_ commit-jsonld]
     (let [ledger-alias (get commit-jsonld "alias")
-          ns-address   (publishing-address store ledger-alias)
+          ns-address   (publishing-address* store ledger-alias)
           record       (ns-record ns-address commit-jsonld)
           record-bytes (json/stringify-UTF8 record)
           filename     (local-filename ledger-alias)]
       (storage/write-bytes store filename record-bytes)))
 
+  (retract [_ ledger-alias]
+    (storage/delete store (publishing-address* store (local-filename ledger-alias))))
+
   (publishing-address [_ ledger-alias]
-    (go (publishing-address store ledger-alias)))
+    (go (publishing-address* store ledger-alias)))
 
   nameservice/iNameService
   (lookup [_ ledger-address]

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -1,13 +1,14 @@
 (ns fluree.db-test
-  (:require #?@(:clj  [[clojure.test :refer [deftest is testing]]
+  (:require #?@(:clj  [[clojure.core.async :as async]
+                       [clojure.test :refer [deftest is testing]]
                        [fluree.db.did :as did]
-                       [test-with-files.tools :refer [with-tmp-dir] :as twf]
                        [fluree.db.async-db :as async-db]
-                       [clojure.core.async :as async]]
+                       [fluree.db.util.filesystem :as fs]
+                       [test-with-files.tools :refer [with-tmp-dir] :as twf]]
                 :cljs [[cljs.test :refer-macros [deftest is testing async]]
-                       [test-with-files.tools :as-alias twf]
                        [clojure.core.async :refer [go <!]]
-                       [clojure.core.async.interop :refer [<p!]]])
+                       [clojure.core.async.interop :refer [<p!]]
+                       [test-with-files.tools :as-alias twf]])
             [fluree.db.api :as fluree]
             [fluree.db.test-utils :as test-utils]
             [fluree.db.util.core :as util]))
@@ -1026,3 +1027,80 @@
                     "@type"    "Yeti",
                     "@id"      "freddy"}]
                   @(fluree/query-connection conn2 q))))))))
+
+#?(:clj
+   (deftest drop-test
+     (with-tmp-dir storage-path
+       (let [conn   @(fluree/connect-file {:storage-path storage-path})
+             alias  "destined-for-drop"
+             ledger @(fluree/create conn alias {:reindex-min-bytes 100 :max-old-indexes 3})
+             db0    (-> (fluree/db ledger)
+                        ;; wrap with a policy so we are storing txns
+                        (fluree/wrap-policy {"@context" {"ex" "http://example.org/ns/" "f" "https://ns.flur.ee/ledger#"}
+                                             "@id" "ex:defaultAllowViewModify"
+                                             "@type" ["f:AccessPolicy"]
+                                             "f:action" [{"@id" "f:view"},
+                                                         {"@id" "f:modify"}]
+                                             "f:query" {"@type" "@json" "@value" {}}})
+                        deref)
+             tx1    {"insert" [{"@id" "ex:foo" "ex:num1" (range 1000)}]}
+             tx2    {"insert" [{"@id" "ex:foo" "ex:num2" (range 1000)}]}
+             tx3    {"insert" [{"@id" "ex:foo" "ex:num3" (range 1000)}]}
+             db1    (->> @(fluree/stage db0 tx1 {:raw-txn tx1})
+                         (fluree/commit! ledger)
+                         deref)
+             db2    (->> @(fluree/stage (fluree/db ledger) tx2 {:raw-txn tx2})
+                         (fluree/commit! ledger)
+                         deref)
+             db3    (->> @(fluree/stage (fluree/db ledger) tx3 {:raw-txn tx3})
+                         (fluree/commit! ledger)
+                         deref)
+             tx-count 3]
+         ;; wait for everything to be written
+         (Thread/sleep 1000)
+         (testing "before drop"
+           (is (= ["destined-for-drop" "destined-for-drop.json"]
+                  (sort (async/<!! (fs/list-files storage-path)))))
+           (is (= ["commit" "index" "txn"]
+                  (sort (async/<!! (fs/list-files (str storage-path "/" alias))))))
+           ;; only store txns when signed
+           (is (= tx-count
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/txn"))))))
+           ;; initial create call generates an initial commit, each commit has two files
+           (is (= (* 2 (inc tx-count))
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/commit"))))))
+           (is (= ["garbage" "opst" "post" "root" "spot" "tspo"]
+                  (sort (async/<!! (fs/list-files (str storage-path "/" alias "/index"))))))
+           ;; one new index root per tx
+           (is (= tx-count
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/root"))))))
+           ;; one garbage file for each obsolete index root
+           (is (= (dec tx-count)
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/garbage"))))))
+           (is (= 6
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/spot"))))))
+           (is (= 6
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/post"))))))
+           (is (= 6
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/tspo"))))))
+           (is (= 6
+                  (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/opst")))))))
+         (testing "drop"
+           (is (= :dropped
+                  @(fluree/drop conn alias))))
+         (testing "after drop"
+           ;; directories are not removed
+           (is (= ["destined-for-drop"]
+                  (async/<!! (fs/list-files storage-path))))
+           (is (= ["commit" "index" "txn"]
+                  (sort (async/<!! (fs/list-files (str storage-path "/" alias))))))
+           (is (= ["garbage" "opst" "post" "root" "spot" "tspo"]
+                  (sort (async/<!! (fs/list-files (str storage-path "/" alias "/index"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/txn"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/commit"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/root"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/garbage"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/spot"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/post"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/tspo"))))))
+           (is (zero? (count (async/<!! (fs/list-files (str storage-path "/" alias "/index/opst")))))))))))

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -1046,13 +1046,13 @@
              tx1    {"insert" [{"@id" "ex:foo" "ex:num1" (range 1000)}]}
              tx2    {"insert" [{"@id" "ex:foo" "ex:num2" (range 1000)}]}
              tx3    {"insert" [{"@id" "ex:foo" "ex:num3" (range 1000)}]}
-             db1    (->> @(fluree/stage db0 tx1 {:raw-txn tx1})
+             _db1   (->> @(fluree/stage db0 tx1 {:raw-txn tx1})
                          (fluree/commit! ledger)
                          deref)
-             db2    (->> @(fluree/stage (fluree/db ledger) tx2 {:raw-txn tx2})
+             _db2   (->> @(fluree/stage (fluree/db ledger) tx2 {:raw-txn tx2})
                          (fluree/commit! ledger)
                          deref)
-             db3    (->> @(fluree/stage (fluree/db ledger) tx3 {:raw-txn tx3})
+             _db3   (->> @(fluree/stage (fluree/db ledger) tx3 {:raw-txn tx3})
                          (fluree/commit! ledger)
                          deref)
              tx-count 3]


### PR DESCRIPTION
Add initial support for the `drop` api, which deletes all of the persistent artifacts created for a ledger: 
- all commits
- all indexes
- all garbage
- all nameservice records

