### PR TITLE
Fix/bm25 empty string

### DIFF
--- a/src/fluree/db/virtual_graph/bm25/index.clj
+++ b/src/fluree/db/virtual_graph/bm25/index.clj
@@ -102,6 +102,10 @@
   (go
     (try*
       (let [{::vg-parse/keys [target limit timeout] :as search-params} (vg-parse/get-search-params solution)
+            _ (when-not target
+                (throw (ex-info "No search target for virtual graph. Did you forget @context in your query?"
+                                {:status 400 :error
+                                 :db/invalid-query})))
             {:keys [pending-ch index]} @index-state
 
             ;; TODO - check for "sync" options and don't wait for pending-ch if sync is false
@@ -129,8 +133,7 @@
              (vg-parse/limit-results limit)
              (vg-parse/process-sparse-results bm25 solution search-params)
              (async/onto-chan! out-ch)))
-      (catch* e
-        (log/error e "Error ranking vectors")
+      (catch* e 
         (>! error-ch e)))))
 
 (defn bm25-upsert*

--- a/src/fluree/db/virtual_graph/bm25/index.clj
+++ b/src/fluree/db/virtual_graph/bm25/index.clj
@@ -133,7 +133,7 @@
              (vg-parse/limit-results limit)
              (vg-parse/process-sparse-results bm25 solution search-params)
              (async/onto-chan! out-ch)))
-      (catch* e 
+      (catch* e
         (>! error-ch e)))))
 
 (defn bm25-upsert*

--- a/src/fluree/db/virtual_graph/bm25/update.clj
+++ b/src/fluree/db/virtual_graph/bm25/update.clj
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async]
             [clojure.string :as str]
             [fluree.db.json-ld.iri :as iri]
+            [fluree.db.util.log :as log]
             [fluree.db.virtual-graph.bm25.stemmer :as stm]))
 
 (set! *warn-on-reflection* true)
@@ -10,7 +11,9 @@
 
 (defn- split-text
   [text]
-  (str/split (str/lower-case text) SPACE_PATTERN))
+  (if (= "" text)
+    []
+    (str/split (str/lower-case text) SPACE_PATTERN)))
 
 (defn parse-sentence
   [sentence stemmer stopwords]
@@ -52,6 +55,9 @@
          (reduce
           (fn [all-text sentence]
             (cond
+              (string? sentence)
+              (str all-text " " sentence)
+
             ;; nested map is a referred node
               (map? sentence)
               (str all-text " " (extract-text sentence))
@@ -66,7 +72,7 @@
               (nil? sentence)
               all-text
 
-              :else ;; string, or stringify other data types
+              :else ;; stringify other data types
               (str all-text " " sentence))
             (if (sequential? sentence)
               (apply str all-text " " sentence)
@@ -141,21 +147,26 @@
 
 (defn index-item
   "Returns updated bm25 index map after adding item to it"
-  [index stemmer stopwords id item]
-  (let [{:keys [avg-length item-count terms dimensions vectors]} index
-        item-terms     (-> (extract-text item)
-                           (parse-sentence stemmer stopwords))
-        doc-len        (count item-terms)
-        [avg-length* item-count*] (update-avg-len avg-length item-count doc-len)
-        term-freq      (frequencies item-terms)
-        terms-distinct (keys term-freq)
-        [terms* dimensions*] (update-terms terms dimensions id terms-distinct)
-        item-vec       (vectorize-item terms* term-freq)]
-    (assoc index :terms terms*
-           :dimensions dimensions*
-           :avg-length avg-length*
-           :item-count item-count*
-           :vectors (assoc vectors id item-vec))))
+  [{:keys [avg-length item-count terms dimensions vectors] :as index} stemmer stopwords id item]
+  (try
+    (let [item-terms     (-> (extract-text item)
+                             (parse-sentence stemmer stopwords))
+          doc-len        (count item-terms)]
+      (if (pos? doc-len) ;; empty strings will have no indexing data
+        (let [[avg-length* item-count*] (update-avg-len avg-length item-count doc-len)
+              term-freq      (frequencies item-terms)
+              terms-distinct (keys term-freq)
+              [terms* dimensions*] (update-terms terms dimensions id terms-distinct)
+              item-vec       (vectorize-item terms* term-freq)]
+          (assoc index :terms terms*
+                 :dimensions dimensions*
+                 :avg-length avg-length*
+                 :item-count item-count*
+                 :vectors (assoc vectors id item-vec)))
+        index))
+    (catch Exception e
+      (log/warn "Cannot full-text (BM25) index item: " item " - " (ex-message e) ". Ignoring item.")
+      index)))
 
 (defn upsert-items
   "Asserts items into the bm25 index, returns updated state.


### PR DESCRIPTION
This address a BM25 issue when there is only an empty string `""` to index.

Now it will skip this scenario.
