### PR TITLE
Feature/sparql group concat

### DIFF
--- a/resources/sparql.bnf
+++ b/resources/sparql.bnf
@@ -202,13 +202,14 @@ SubstringExpression   ::=   <'SUBSTR'> <'('> Expression <','> Expression ( <','>
 StrReplaceExpression    ::=   <'REPLACE'> <'('> Expression <','> Expression <','> Expression ( <','> Expression )? <')'>
 ExistsFunc    ::=   <'EXISTS'> GroupGraphPattern
 NotExistsFunc   ::=   <'NOT'> WS <'EXISTS'> GroupGraphPattern
+Separator ::= ( <';'> WS <('SEPARATOR' | 'separator')> WS <'='> String )
 Aggregate   ::=     'COUNT' WS <'('> WS 'DISTINCT'? WS ( '*' | Expression ) WS <')'> WS
 | 'SUM' WS <'('> WS 'DISTINCT'? Expression <')'>
 | 'MIN' <'('>  WS 'DISTINCT'? Expression <')'>
 | 'MAX' <'('>  WS 'DISTINCT'? Expression <')'>
 | 'AVG' <'('>  WS 'DISTINCT'? Expression <')'>
 | 'SAMPLE' <'('>  WS 'DISTINCT'? Expression? Expression <')'>
-| 'GROUP_CONCAT' <'('> WS 'DISTINCT'? Expression ( <';'> WS 'SEPARATOR' WS <'='> WS String WS )? <')'>
+| 'GROUP_CONCAT' <'('> WS 'DISTINCT'? Expression Separator? <')'>
 iriOrFunction	  ::=  	iri ArgList?
 RDFLiteral	  ::=  	String WS ( LANGTAG | ( '^^' iri ) )? WS
 NumericLiteral	  ::=  	NumericLiteralUnsigned WS | NumericLiteralPositive WS | NumericLiteralNegative WS

--- a/src/fluree/db/query/exec/eval.cljc
+++ b/src/fluree/db/query/exec/eval.cljc
@@ -84,7 +84,18 @@
   [coll]
   (where/->typed-val (count coll)))
 
-(def groupconcat clojure.core/concat)
+(defn groupconcat
+  "GroupConcat is a set function which performs a string concatenation across the values
+  of an expression with a group. The order of the strings is not specified. The
+  separator character used in the concatenation may be given with the scalar argument
+  SEPARATOR.
+
+  If the separator scalar argument is absent from GROUP_CONCAT then it is taken to be
+  the space character, unicode codepoint U+0020."
+  ([coll]
+   (groupconcat coll (where/->typed-val " ")))
+  ([coll separator]
+   (where/->typed-val (str/join (:value separator) (mapv :value coll)))))
 
 (defn sample
   [{n :value} coll]

--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -37,13 +37,18 @@
   [[_ & var]]
   (str "?" (str/join var)))
 
+(defmethod parse-term :Separator
+  [[_ & separator-chars]]
+  (apply str separator-chars))
+
 (def supported-aggregate-functions
   {"MAX"       "max"
    "MIN"       "min"
    "SAMPLE"    "sample1"
    "COUNT"     "count"
    "SUM"       "sum"
-   "AVG"       "avg"})
+   "AVG"       "avg"
+   "GROUP_CONCAT" "groupconcat"})
 
 (defmethod parse-term :Aggregate
   ;; Aggregate ::= 'COUNT' WS <'('> WS 'DISTINCT'? WS ( '*' | Expression ) WS <')'> WS
@@ -65,8 +70,8 @@
 
                   :else
                   f)
-          body (if distinct? (second body) (first body))]
-      (str "(" f " " (parse-term body) ")"))
+          [mset scalarvals] (if distinct? (rest body) body)]
+      (str "(" f " " (parse-term mset) (when scalarvals (str " " (literal-quote (parse-term scalarvals)))) ")"))
     (throw (ex-info (str "Unsupported aggregate function: " func)
                     {:status 400 :error :db/invalid-query}))))
 

--- a/test/fluree/db/query/aggregate_test.clj
+++ b/test/fluree/db/query/aggregate_test.clj
@@ -82,4 +82,23 @@
         (is (= [[8]]
                @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
                                   :where ['{:id ?s :ex/favNums ?favNums}]
-                                  :select ['(count ?favNums)]})))))))
+                                  :select ['(count ?favNums)]}))))
+      (testing "using groupconcat"
+        (testing "without explicit separator"
+          (is (= [[:ex/cam "5 10"]
+                  [:ex/brian "7"]
+                  [:ex/alice "9 42 76"]
+                  [:ex/liam "11 42"]]
+                 @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                    :where ['{:id ?s :ex/favNums ?favNums}]
+                                    :group-by '?s
+                                    :select ['?s '(groupconcat ?favNums)]}))))
+        (testing "with explicit separator"
+          (is (= [[:ex/cam "5, 10"]
+                  [:ex/brian "7"]
+                  [:ex/alice "9, 42, 76"]
+                  [:ex/liam "11, 42"]]
+                 @(fluree/query db {:context [test-utils/default-context {:ex "http://example.org/ns/"}]
+                                    :where ['{:id ?s :ex/favNums ?favNums}]
+                                    :group-by '?s
+                                    :select ['?s '(groupconcat ?favNums ", ")]}))))))))

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -1459,6 +1459,22 @@
                            "type" "literal",
                            "datatype" "http://www.w3.org/2001/XMLSchema#integer"}}]}}
                       @(fluree/query db query {:format :sparql :output :sparql}))))))
+         (testing "GROUP_CONCAT aggregate fn query works"
+           (let [query   "PREFIX person: <http://example.org/Person#>
+                          SELECT (GROUP_CONCAT(?favNums; separator=\", \") AS ?nums)
+                          WHERE {?person person:favNums ?favNums.}
+                          GROUP BY ?person"]
+             (testing "output :fql"
+               (is (= [["0, 3, 5, 6, 7, 8, 9"] ["3, 7, 42, 99"] ["23"]]
+                      @(fluree/query db query {:format :sparql}))))
+             (testing "output :sparql"
+               (is (= {"head" {"vars" ["nums"]},
+                       "results"
+                       {"bindings"
+                        [{"nums" {"value" "0, 3, 5, 6, 7, 8, 9", "type" "literal"}}
+                         {"nums" {"value" "3, 7, 42, 99", "type" "literal"}}
+                         {"nums" {"value" "23", "type" "literal"}}]}}
+                      @(fluree/query db query {:format :sparql :output :sparql}))))))
          (testing "aggregate fn w/ GROUP BY ... HAVING query works"
            (let [query   "PREFIX person: <http://example.org/Person#>
                           SELECT (AVG(?favNums) AS ?avgFav)

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -75,8 +75,15 @@
             {:keys [select]} (sparql/->fql query)]
         (is (= ["?fullName" "(as (sum ?favNums) ?sum)"]
                select))))
-    ;;TODO: not yet supported
-    #_(testing "GROUP_CONCAT")))
+    (testing "GROUP_CONCAT"
+      (let [query "SELECT ?author (GROUP_CONCAT(?title; separator=\", \") AS ?books)
+                   WHERE {
+                     ?book dc:creator ?author .
+                     ?book dc:title ?title .
+                   }
+                   GROUP BY ?author"]
+        (is (= ["?author" "(as (groupconcat ?title \", \") ?books)"]
+               (:select (sparql/->fql query))))))))
 
 (deftest parse-construct
   (testing "basic construct"


### PR DESCRIPTION
Adds [GROUP_CONCAT](https://www.w3.org/TR/sparql11-query/#defn_aggGroupConcat) support for SPARQL queries and fixes our non-functional `groupconcat` function in JLD-Query.

Closes https://github.com/fluree/core/issues/186