### PR TITLE
offset and limit after projection

### DIFF
--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -63,14 +63,14 @@
         (group/combine q)
         (having/filter q error-ch)
         (select/modify q)
-        (order/arrange q)
-        (drop-offset q)
-        (take-limit q))))
+        (order/arrange q))))
 
 (defn execute
   [ds fuel-tracker q error-ch]
   (->> (execute* ds fuel-tracker q error-ch)
        (select/format ds q fuel-tracker error-ch)
+       (drop-offset q)
+       (take-limit q)
        (collect-results q)))
 
 ;; TODO: refactor namespace heirarchy so this isn't necessary
@@ -80,7 +80,9 @@
   [subquery]
   (fn [ds fuel-tracker error-ch]
     (->> (execute* ds fuel-tracker subquery error-ch)
-         (select/subquery-format ds subquery fuel-tracker error-ch))))
+         (select/subquery-format ds subquery fuel-tracker error-ch)
+         (drop-offset subquery)
+         (take-limit subquery))))
 
 (defn prep-subqueries
   "Takes a query and returns a query with all subqueries within replaced by a subquery

--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -35,6 +35,14 @@
     (async/take limit solution-ch)
     solution-ch))
 
+(defn paginate
+  "Returns a channel that contains a page-worth of results, according to `:offset` and
+  `:limit`."
+  [q solution-ch]
+  (->> solution-ch
+       (drop-offset q)
+       (take-limit q)))
+
 (defn collect-results
   "Returns a channel that will eventually contain the stream of results from the
   `result-ch` channel collected into a single vector, but handles the special cases.
@@ -69,8 +77,7 @@
   [ds fuel-tracker q error-ch]
   (->> (execute* ds fuel-tracker q error-ch)
        (select/format ds q fuel-tracker error-ch)
-       (drop-offset q)
-       (take-limit q)
+       (paginate q)
        (collect-results q)))
 
 ;; TODO: refactor namespace heirarchy so this isn't necessary
@@ -81,8 +88,7 @@
   (fn [ds fuel-tracker error-ch]
     (->> (execute* ds fuel-tracker subquery error-ch)
          (select/subquery-format ds subquery fuel-tracker error-ch)
-         (drop-offset subquery)
-         (take-limit subquery))))
+         (paginate subquery))))
 
 (defn prep-subqueries
   "Takes a query and returns a query with all subqueries within replaced by a subquery

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -137,22 +137,31 @@
                 "returns ordered results")))))))
 
 (deftest ^:integration select-distinct-test
-  (testing "Distinct queries"
-    (let [conn   (test-utils/create-conn)
-          people (test-utils/load-people conn)
-          db     (fluree/db people)
-          q      {:context         [test-utils/default-context
-                                    {:ex "http://example.org/ns/"}]
-                  :select-distinct '[?name ?email]
-                  :where           '{:schema/name  ?name
-                                     :schema/email ?email
-                                     :ex/favNums   ?favNum}
-                  :order-by        '?favNum}]
-      (is (= [["Cam" "cam@example.org"]
+  (let [conn   (test-utils/create-conn)
+        people (test-utils/load-people conn)
+        db     (fluree/db people)]
+    (testing "distinct results"
+      (is (= [["Alice" "alice@example.org"]
               ["Brian" "brian@example.org"]
-              ["Alice" "alice@example.org"]
+              ["Cam" "cam@example.org"]
               ["Liam" "liam@example.org"]]
-             @(fluree/query db q))
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select-distinct '[?name ?email]
+                                :where '{:schema/name ?name
+                                         :schema/email ?email
+                                         :ex/favNums ?favNum}}))
+          "return results without repeated entries"))
+    (testing "distinct results with limit and offset"
+      (is (= [["Brian" "brian@example.org"]
+              ["Cam" "cam@example.org"]]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select-distinct '[?name ?email]
+                                :where '{:schema/name ?name
+                                         :schema/email ?email
+                                         :ex/favNums ?favNum}
+                                :limit 2 :offset 1}))
           "return results without repeated entries"))))
 
 (deftest ^:integration select-one-test


### PR DESCRIPTION
We were applying `distinct` after offset and limit, which means users would have cases where they wouldn't receive desired results.

Closes https://github.com/fluree/core/issues/188