### PR TITLE
Add basic insert API

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -209,7 +209,7 @@
   (promise-wrap
    (connection/notify conn commit-address commit-hash)))
 
-(defn insert 
+(defn insert
   "Inserts a new set of data into the database if valid (does not commit).
    Multiple inserts and updates can be staged together and will be merged into a single
    transaction when committed.
@@ -240,7 +240,6 @@
   "Renamed to `update`, prefer that API instead."
   ([db json-ld] (update db json-ld nil))
   ([db json-ld opts] (update db json-ld opts)))
-
 
 (defn format-txn
   "Reformats the transaction `txn` as JSON-QL if it is formatted as SPARQL,

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -16,10 +16,8 @@
 (defn insert
   [db txn override-opts]
   (go-try
-    (let [context    (or (ctx-util/txn-context txn)
-                         (:context override-opts))
-          parsed-txn {:insert (parse/jld->parsed-triples txn nil context)}]
-      (<? (connection/stage-triples db parsed-txn)))))
+    (let [parsed-triples (parse/jld->parsed-triples txn nil (:context override-opts))]
+      (<? (connection/stage-triples db {:insert parsed-triples})))))
 
 (defn stage
   [db txn override-opts]

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -13,6 +13,14 @@
     (sparql/->fql txn)
     txn))
 
+(defn insert
+  [db txn override-opts]
+  (go-try
+    (let [context    (or (ctx-util/txn-context txn)
+                         (:context override-opts))
+          parsed-txn {:insert (parse/jld->parsed-triples txn nil context)}]
+      (<? (connection/stage-triples db parsed-txn)))))
+
 (defn stage
   [db txn override-opts]
   (go-try

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -898,13 +898,17 @@
 
 (defn jld->parsed-triples
   "Parses a JSON-LD document into a sequence of update triples. The document
-   should be expanded and contain a @graph key."
-  [txn bound-vars context]
-  (-> txn
-      (json-ld/expand context)
+   will be expanded using the context inside the txn merged with the 
+   provided parsed-context, if not nil.
+   
+   If bound-vars is non-nil, it will replace any variables in the document
+   assuming it is a valid variable placement, otherwise it will throw."
+  [jld bound-vars parsed-context]
+  (-> jld
+      (json-ld/expand parsed-context)
       util/get-graph
       util/sequential
-      (parse-triples bound-vars context)))
+      (parse-triples bound-vars parsed-context)))
 
 (defn parse-stage-txn
   ([txn]

--- a/test/fluree/db/transact/insert_test.clj
+++ b/test/fluree/db/transact/insert_test.clj
@@ -1,0 +1,51 @@
+(ns fluree.db.transact.insert-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.api :as fluree]
+            [fluree.db.test-utils :as test-utils]))
+
+(deftest ^:integration insert-data
+  (testing "Inserting data into a ledger using EDN"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "tx/insert")
+          db     @(fluree/insert
+                   (fluree/db ledger)
+                   {"@context" [test-utils/default-str-context
+                                {"ex" "http://example.org/ns/"}]
+                    "@graph"   [{"id"         "ex:alice",
+                                 "type"        "ex:User",
+                                 "schema:name" "Alice"
+                                 "schema:age"  42}
+                                {"id"         "ex:bob",
+                                 "type"        "ex:User",
+                                 "schema:name" "Bob"
+                                 "schema:age"  22}]})]
+      (is (= ["Alice" "Bob"]
+             @(fluree/query db
+                            {"@context" [test-utils/default-str-context
+                                         {"ex" "http://example.org/ns/"}]
+                             "select" "?name"
+                             "where"  {"schema:name" "?name"}})))
+      "Inserted data should be retrievable."))
+
+  (testing "Inserting data into a ledger using EDN keywords"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "tx/insert-edn-keywords")
+          db     @(fluree/insert
+                   (fluree/db ledger)
+                   {:context [test-utils/default-context
+                              {:ex "http://example.org/ns/"}]
+                    :graph   [{:id          :ex/alice,
+                               :type        :ex/User,
+                               :schema/name "Alice"
+                               :schema/age  42}
+                              {:id          :ex/bob,
+                               :type        :ex/User,
+                               :schema/name "Bob"
+                               :schema/age  22}]})]
+      (is (= ["Alice" "Bob"]
+             @(fluree/query db
+                            {:context [test-utils/default-context
+                                       {:ex "http://example.org/ns/"}]
+                             :select '?name
+                             :where  {:schema/name '?name}})))
+      "Inserted data should be retrievable.")))

--- a/test/fluree/db/transact/insert_test.clj
+++ b/test/fluree/db/transact/insert_test.clj
@@ -4,7 +4,7 @@
             [fluree.db.test-utils :as test-utils]))
 
 (deftest ^:integration insert-data
-  (testing "Inserting data into a ledger using EDN"
+  (testing "Inserting data into a ledger"
     (let [conn   (test-utils/create-conn)
           ledger @(fluree/create conn "tx/insert")
           db     @(fluree/insert


### PR DESCRIPTION
This adds a basic `insert` API that works much like the current `stage` however it accepts a pure JSON-LD document.

This means a JSON-LD document doesn't need to be modified to be inserted into a Fluree db - today you must wrap a JSON-LD document in an `{"insert" <jld>}` declaration for it to work.

I'd like to see these features added to `import`, either in `fluree/db`, or perhaps more appropriately `fluree/server` in the future:
a) support other RDF formats (e.g. TTL) - there is already some work for this done in `fluree/server`
b) support very large documents - by breaking them up for the user and processing+indexing incrementally. Ideally this would be combined with work in the nameservice such that once started, a new query/txt to the ledger being processed would return an exception until it is finished. It probably also needs restart/retry logic to address power failure scenarios and ideally track some processing status to report back to user how much longer it is likely to take.