### PR TITLE
log with mdc context and propagate locals for mdc and otel in go blocks

### DIFF
--- a/src/fluree/db/util/async.cljc
+++ b/src/fluree/db/util/async.cljc
@@ -1,9 +1,12 @@
 (ns fluree.db.util.async
   (:require
+   #?(:clj [clojure.core.async.impl.dispatch :as dispatch])
    [clojure.core.async :as async]
    [clojure.core.async.impl.protocols :as async-protocols]
    [fluree.db.util.core :as util #?(:clj :refer :cljs :refer-macros) [try* catch*]])
-  #?(:cljs (:require-macros [fluree.db.util.async :refer [<? go-try]])))
+  #?(:cljs (:require-macros [fluree.db.util.async :refer [<? go-try]]))
+  #?(:clj (:import [java.util.concurrent Executor]
+                   [org.slf4j MDC])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -105,3 +108,57 @@
   "Returns true if core async channel."
   [x]
   (satisfies? async-protocols/Channel x))
+
+;;  "OpenTelemetry uses ThreadLocal storage to propagate trace state.
+;;   This typically requires wrapping your tasks or executors so that this state
+;;   is propagated to threads when desired.
+;;   See https://github.com/open-telemetry/opentelemetry-java/blob/main/context/src/main/java/io/opentelemetry/context/Context.java
+;;   core.async does not expose the thread pool direclty so we need to monkey patch it.
+
+;;   core.async will propagate clojure var bindings, so alternatively it might be possible
+;;   to implement a ContextStorageProvider that stores state in a var instead of thread locals.
+;;   I spent a bit of time trying to figure this out but it seems quite a bit more involved than
+;;   patching core.aysnc"
+#?(:clj
+   (do
+     (defn wrap-mdc ^Runnable [^Runnable r]
+       (let [context (MDC/getCopyOfContextMap)]
+         (reify Runnable
+           (run [_]
+             (let [current (MDC/getCopyOfContextMap)]
+               (try
+                 (MDC/setContextMap context)
+                 (.run r)
+                 (finally
+                   (MDC/setContextMap current))))))))
+
+     (defonce original-run dispatch/run)
+
+     ;; if OpenTelemetry is on classpath than propagate otel context otherwise no-op
+     (def wrap-otel
+       (try
+         (let [context-class (Class/forName "io.opentelemetry.context.Context")
+               current-method (.getMethod context-class "current" (into-array Class []))
+               wrap-method (.getMethod context-class "wrap" (into-array Class [Runnable]))]
+           (fn wrap-otel ^Runnable [^Runnable r]
+             (let [current-context (.invoke current-method nil (into-array Object []))]
+               (.invoke wrap-method current-context (into-array Object [r])))))
+         (catch ClassNotFoundException _
+           (fn wrap-otel ^Runnable [^Runnable r] r))))
+
+     (defn wrapped-runable ^Runnable [^Runnable r] (wrap-otel (wrap-mdc r)))
+     (defn patched-run
+       "Runs Runnable r with OpenTelemetry context propagation."
+       [^Runnable r]
+       (original-run (wrapped-runable r)))
+
+     (alter-var-root #'dispatch/run (constantly patched-run))
+
+     (defonce ^Executor original-thread-macro-executor @#'async/thread-macro-executor)
+
+     (defn context-wrapping-executor ^Executor [^Executor wrapped-executor]
+       (reify Executor
+         (execute [_ runnable]
+           (.execute wrapped-executor (wrapped-runable runnable)))))
+
+     (alter-var-root #'async/thread-macro-executor (constantly (context-wrapping-executor original-thread-macro-executor)))))

--- a/src/fluree/db/util/log.cljc
+++ b/src/fluree/db/util/log.cljc
@@ -124,3 +124,28 @@
      them."
      [msg c]
      `(debug-async->vals ~c ~msg)))
+
+#?(:clj
+   (defn with-mdc* [context f]
+     (let [original (org.slf4j.MDC/getCopyOfContextMap)]
+       (try
+         (doseq [[k v] context]
+           (org.slf4j.MDC/put (name k) (str v)))
+         (f)
+         (finally
+           (org.slf4j.MDC/clear)
+           (when original
+             (doseq [[k v] original]
+               (org.slf4j.MDC/put k v)))))))
+
+   :cljs
+   (defn with-mdc* [_context f]
+     (f)))
+
+#?(:clj
+   (defmacro with-mdc [context & body]
+     `(with-mdc* ~context (fn [] ~@body)))
+
+   :cljs
+   (defmacro with-mdc [_context & body]
+     `(do ~@body)))


### PR DESCRIPTION
Update core async to support mdc and otel context propagation