### PR TITLE
Feature/upsert

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -226,6 +226,23 @@
    (promise-wrap
     (transact-api/insert db json-ld opts))))
 
+(defn upsert
+  "Performs an upsert operation, which will insert the data if it does not exist,
+   or update the existing data if it does. This is useful for ensuring that a
+   specific document is present in the database with the desired values.
+
+   The 'opts' key is a map with the following key options:
+    - `:context` - (optional) and externally provided context that will be used
+                   for document expansion, the @context in the json-ld will be 
+                   ignored if present.
+
+   The data is expected to be in JSON-LD format, and will be expanded before
+   being inserted into the database."
+  ([db json-ld] (upsert db json-ld nil))
+  ([db json-ld opts]
+   (promise-wrap
+    (transact-api/upsert db json-ld opts))))
+
 (defn update
   "Performs an update and queues change if valid (does not commit).
    Multiple updates can be staged together and will be merged into a single
@@ -233,7 +250,7 @@
   ([db json-ld] (update db json-ld nil))
   ([db json-ld opts]
    (promise-wrap
-    (transact-api/stage db json-ld opts))))
+    (transact-api/update db json-ld opts))))
 
 ;; TODO - deprecate `stage` in favor of `update` eventually
 (defn stage

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -1,4 +1,5 @@
 (ns fluree.db.api.transact
+  (:refer-clojure :exclude [update])
   (:require [fluree.db.connection :as connection]
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.query.fql.parse :as parse]
@@ -14,12 +15,23 @@
     txn))
 
 (defn insert
-  [db txn override-opts]
+  [db rdf override-opts]
   (go-try
-    (let [parsed-triples (parse/jld->parsed-triples txn nil (:context override-opts))]
-      (<? (connection/stage-triples db {:insert parsed-triples})))))
+    (let [parsed-triples (parse/jld->parsed-triples rdf nil (:context override-opts))
+          parsed-txn {:insert parsed-triples}]
+      (<? (connection/stage-triples db parsed-txn)))))
 
-(defn stage
+(defn upsert
+  "Takes an insertion RDF document and returns a map with :where and :delete keys.
+   
+   The :where key contains the triples to match existing data, while the :delete
+   key contains the triples to delete before inserting new data."
+  [db rdf override-opts]
+  (go-try
+    (let [parsed-txn (parse/parse-upsert-txn rdf override-opts)]
+      (<? (connection/stage-triples db parsed-txn)))))
+
+(defn update
   [db txn override-opts]
   (go-try
     (let [parsed-txn (-> txn
@@ -63,15 +75,15 @@
            (-> txn
                (format-txn override-opts)
                (parse/parse-ledger-txn override-opts)
-               (update :opts dissoc :context :did :identity)) ; Using an
-                                                              ; identity option
-                                                              ; with an empty
-                                                              ; ledger will
-                                                              ; always fail
-                                                              ; policy checks
-                                                              ; because there
-                                                              ; are no policies
-                                                              ; to check.
+               (clojure.core/update :opts dissoc :context :did :identity)) ; Using an
+                                                                           ; identity option
+                                                                           ; with an empty
+                                                                           ; ledger will
+                                                                           ; always fail
+                                                                           ; policy checks
+                                                                           ; because there
+                                                                           ; are no policies
+                                                                           ; to check.
            ledger-opts (-> parsed-txn :opts syntax/coerce-ledger-opts)
            ledger      (<? (connection/create-ledger conn ledger-id ledger-opts))]
        (<? (connection/transact-ledger! conn ledger parsed-txn))))))

--- a/src/fluree/db/json_ld/api.cljc
+++ b/src/fluree/db/json_ld/api.cljc
@@ -217,7 +217,7 @@
   ([db json-ld] (stage db json-ld nil))
   ([db json-ld opts]
    (log/warn "DEPRECATED function `stage` superseded by `fluree.db.api/stage`")
-   (let [result-ch (transact-api/stage db json-ld opts)]
+   (let [result-ch (transact-api/update db json-ld opts)]
      (promise-wrap result-ch))))
 
 (defn ^{:deprecated    "3.0"

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -823,6 +823,14 @@
         (when-not (::invalidated solution*)
           solution*)))))
 
+(defmethod match-pattern :default
+  [_db _tracker _solution pattern error-ch]
+  (go
+    (>! error-ch
+        (ex-info (str "Unknown pattern type: " (pattern-type pattern))
+                 {:status 400
+                  :error  :db/invalid-query}))))
+
 (def blank-solution {})
 
 (defn values-initial-solution

--- a/test/fluree/db/transact/upsert_test.clj
+++ b/test/fluree/db/transact/upsert_test.clj
@@ -1,0 +1,93 @@
+(ns fluree.db.transact.upsert-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.api :as fluree]
+            [fluree.db.query.fql.parse :as parse]
+            [fluree.db.test-utils :as test-utils]))
+
+(def sample-insert-txn {"@context" {"ex" "http://example.org/ns/"
+                                    "schema" "http://schema.org/"}
+                        "@graph"   [{"@id"         "ex:alice",
+                                     "@type"        "ex:User",
+                                     "schema:name" "Alice"
+                                     "schema:age"  42}
+                                    {"@id"         "ex:bob",
+                                     "@type"        "ex:User",
+                                     "schema:name" "Bob"
+                                     "schema:age"  22}]})
+
+(def sample-upsert-txn {"@context" {"ex" "http://example.org/ns/"
+                                    "schema" "http://schema.org/"}
+                        "@graph"   [{"@id"         "ex:alice"
+                                     "schema:name" "Alice2"}
+                                    {"@id"         "ex:bob"
+                                     "schema:name" "Bob2"}
+                                    {"@id"         "ex:jane"
+                                     "schema:name" "Jane2"}]})
+
+(def sample-update-txn {"@context" (get sample-upsert-txn "@context")
+                        "where" [["optional" {"@id" "ex:alice"
+                                              "schema:name" "?f0"}]
+                                 ["optional" {"@id" "ex:bob"
+                                              "schema:name" "?f1"}]
+                                 ["optional" {"@id" "ex:jane"
+                                              "schema:name" "?f2"}]]
+                        "delete" [{"@id" "ex:alice"
+                                   "schema:name" "?f0"}
+                                  {"@id" "ex:bob"
+                                   "schema:name" "?f1"}
+                                  {"@id" "ex:jane"
+                                   "schema:name" "?f2"}]
+                        "insert" (get sample-upsert-txn "@graph")})
+
+(deftest upsert-parsing
+  (testing "Parsed upsert txn is identical to long-form update txn"
+    (is (= (parse/parse-upsert-txn sample-upsert-txn {})
+           (parse/parse-stage-txn sample-update-txn {})))))
+
+(deftest ^:integration upsert-data
+  (testing "Upserting data into a ledger is identitcal to long-form update txn"
+    (let [conn      (test-utils/create-conn)
+          ledger    @(fluree/create conn "tx/upsert-test")
+          db        @(fluree/insert (fluree/db ledger) sample-insert-txn)
+          db+upsert @(fluree/upsert db sample-upsert-txn)]
+
+      (is (= [{"@id"         "ex:alice",
+               "@type"       "ex:User",
+               "schema:age"  42,
+               "schema:name" "Alice2"}
+              {"@id"         "ex:bob",
+               "schema:age"  22,
+               "schema:name" "Bob2",
+               "@type"       "ex:User"}
+              {"@id"         "ex:jane",
+               "schema:name" "Jane2"}]
+             @(fluree/query db+upsert
+                            {"@context" {"ex"     "http://example.org/ns/"
+                                         "schema" "http://schema.org/"}
+                             "select"   {"?id" ["*"]}
+                             "where"    {"@id"         "?id"
+                                         "schema:name" "?name"}}))
+          "Upsert data is inconsistent"))))
+
+(deftest ^:integration upsert-no-changes
+  (testing "Upserting identical data to existing does not change ledger"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "tx/upsert2")
+
+          db     @(fluree/insert (fluree/db ledger) sample-insert-txn)
+
+          db2    @(fluree/upsert db sample-insert-txn)
+
+          db3    @(fluree/upsert db sample-insert-txn)
+
+          query  {"@context" {"ex"     "http://example.org/ns/"
+                              "schema" "http://schema.org/"}
+                  "select"   {"?id" ["*"]}
+                  "where"    {"@id"         "?id"
+                              "schema:name" "?name"}}]
+
+      (is (= (get sample-insert-txn "@graph")
+             @(fluree/query db query)
+             @(fluree/query db2 query)
+             @(fluree/query db3 query))
+          "Resulting data should be identical to original insert"))))


### PR DESCRIPTION
This adds a new top-level API of `upsert`, which takes a JSON-LD document and will update any existing subjects with the values provided in the document (replacing all existing values), and inserting any values that don't exist. `upsert` returns a staged db, just like `insert` and `update` (formerly `stage`).

Blank nodes are alway inserted (no attempt to update).
