### PR TITLE
Turtle (TTL) insert + upsert supprt

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,21 +1,15 @@
-{:deps {org.clojure/clojure                 {:mvn/version "1.11.3"}
-        org.clojure/clojurescript           {:mvn/version "1.11.132"}
-        org.clojure/core.async              {:mvn/version "1.6.681"}
-        org.clojure/core.cache              {:mvn/version "1.1.234"}
-        org.clojars.mmb90/cljs-cache        {:mvn/version "0.1.4"}
-        org.clojure/data.avl                {:mvn/version "0.2.0"}
-        org.clojure/data.xml                {:mvn/version "0.2.0-alpha9"}
-        environ/environ                     {:mvn/version "1.2.0"}
-        byte-streams/byte-streams           {:mvn/version "0.2.4"}
-        cheshire/cheshire                   {:mvn/version "5.13.0"}
-        instaparse/instaparse               {:mvn/version "1.5.0"}
-        metosin/malli                       {:mvn/version "0.17.0"}
-        nano-id/nano-id                     {:mvn/version "1.1.0"}
-        integrant/integrant                 {:mvn/version "0.10.0"}
-        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-        com.widdindustries/time-literals    {:mvn/version "0.1.10"}
-        com.fluree/json-ld                  {:git/url "https://github.com/fluree/json-ld.git"
-                                             :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
+{:deps {org.clojure/clojure              {:mvn/version "1.11.3"}
+        org.clojure/clojurescript        {:mvn/version "1.11.132"}
+        org.clojure/core.async           {:mvn/version "1.6.681"}
+        org.clojure/core.cache           {:mvn/version "1.1.234"}
+        org.clojars.mmb90/cljs-cache     {:mvn/version "0.1.4"}
+        org.clojure/data.avl             {:mvn/version "0.2.0"}
+        environ/environ                  {:mvn/version "1.2.0"}
+        byte-streams/byte-streams        {:mvn/version "0.2.4"}
+        metosin/malli                    {:mvn/version "0.17.0"}
+        nano-id/nano-id                  {:mvn/version "1.1.0"}
+        integrant/integrant              {:mvn/version "0.10.0"}
+        com.widdindustries/time-literals {:mvn/version "0.1.10"}
 
         ;; logging
         org.clojure/tools.logging      {:mvn/version "1.3.0"}
@@ -30,15 +24,18 @@
         http-kit/http-kit {:mvn/version "2.8.0"}
         hato/hato         {:mvn/version "1.0.0"}
 
-        ;; benchmarking
-        criterium/criterium {:mvn/version "0.4.6"}
-
-        ;; serialization / compression
-        com.fluree/alphabase {:mvn/version "3.3.0"}
+        ;; parsing / serialization
+        com.fluree/json-ld                  {:git/url "https://github.com/fluree/json-ld.git"
+                                             :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
+        com.fluree/alphabase                {:mvn/version "3.3.0"}
+        cheshire/cheshire                   {:mvn/version "5.13.0"}
+        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
+        org.clojure/data.xml                {:mvn/version "0.2.0-alpha9"}
+        instaparse/instaparse               {:mvn/version "1.5.0"}
+        org.clojars.quoll/raphael           {:mvn/version "0.3.12"} ;; turtle (TTL) parsing
 
         ;; cryptography
         com.fluree/crypto {:mvn/version "3.0.0"}
-
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 
         ;; storage

--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -219,13 +219,15 @@
    Multiple inserts and updates can be staged together and will be merged into a single
    transaction when committed.
 
+   Supports JSON-LD (default) and Turtle (TTL) formats.
+
    The 'opts' key is a map with the following key options:
     - `:context` - (optional) and externally provided context that will be used
-                   for document expansition, the @context in the json-ld will be
-                   ignored if present.
-
-   The data is expected to be in JSON-LD format, and will be expanded before
-   being inserted into the database."
+                   for JSON-LD document expansition, the @context in the json-ld
+                   will be ignored if present.
+    - `:format`  - (optional) the format of the data, currently json-ld is assumed
+                  unless `:format` is set to `:turtle`. If `:turtle` is set,
+                  the `:context` option will be ignored if provided."
   ([db json-ld] (insert db json-ld nil))
   ([db json-ld opts]
    (promise-wrap
@@ -236,10 +238,15 @@
    or update the existing data if it does. This is useful for ensuring that a
    specific document is present in the database with the desired values.
 
+   Supports JSON-LD and Turtle (TTL) formats.
+
    The 'opts' key is a map with the following key options:
     - `:context` - (optional) and externally provided context that will be used
                    for document expansion, the @context in the json-ld will be 
                    ignored if present.
+   - `:format`  - (optional) the format of the data, currently json-ld is assumed
+                  unless `:format` is set to `:turtle`. If `:turtle` is set,
+                  the `:context` option will be ignored if provided.
 
    The data is expected to be in JSON-LD format, and will be expanded before
    being inserted into the database."

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -117,7 +117,7 @@
     ::issuer            [:maybe string?]
     ::role              :any
     ::identity          :any
-    ::format            [:enum :sparql :fql]
+    ::format            [:enum :sparql :fql :turtle]
     ::meta              [:orn
                          [:all :boolean]
                          [:specific [:map-of :keyword :boolean]]]

--- a/src/fluree/db/query/turtle/parse.cljc
+++ b/src/fluree/db/query/turtle/parse.cljc
@@ -1,0 +1,53 @@
+(ns fluree.db.query.turtle.parse
+  (:require [fluree.db.constants :as const]
+            [fluree.db.json-ld.iri :as iri]
+            [fluree.db.query.exec.where :as exec.where]
+            [quoll.raphael.core :as raphael]))
+
+(set! *warn-on-reflection* true)
+
+(defrecord Generator [namespaces]
+  raphael/NodeGenerator
+  (new-node [this]
+    [this (exec.where/match-iri (iri/new-blank-node-id))])
+  (new-node [this label]
+    [this (exec.where/match-iri (str "_:" label))])
+  (add-base [this iri]
+    (update this :namespaces assoc :base (str iri)))
+  (add-prefix [this prefix iri]
+    (update this :namespaces assoc prefix (str iri)))
+  (iri-for [_ prefix]
+    (get namespaces prefix))
+  (get-namespaces [_]
+    (dissoc namespaces :base))
+  (get-base [_]
+    (:base namespaces))
+  (new-qname [_ prefix local]
+    (exec.where/match-iri (str (get namespaces prefix) local)))
+  (new-iri [_ iri]
+    iri)
+  (new-literal [_ s]
+    (-> exec.where/unmatched
+        (exec.where/match-value s)))
+  (new-literal [_ s t]
+    (let [datatype (-> t ::exec.where/iri)]
+      (-> exec.where/unmatched
+          (exec.where/match-value s datatype))))
+  (new-lang-string [_ s lang]
+    (-> exec.where/unmatched
+        (exec.where/match-lang s lang)))
+  (rdf-type [_]
+    (exec.where/match-iri const/iri-rdf-type))
+  (rdf-first [_]
+    (exec.where/match-iri const/iri-rdf-first))
+  (rdf-rest [_]
+    (exec.where/match-iri const/iri-rdf-rest))
+  (rdf-nil [_]
+    (exec.where/match-iri const/iri-rdf-nil)))
+
+(defn parse
+  [ttl]
+  (let [gen (->Generator {})]
+    (-> ttl
+        (raphael/parse gen)
+        :triples)))


### PR DESCRIPTION
This adds Turtle file format (.ttl) support for `insert` and `upsert` APIs that were recently introduced.

I originally built this support into a fluree/server PR for a new `import` API here: https://github.com/fluree/server/pull/88 - but that PR never got merged. I'll close that PR, and the fluree/server work to support this will need to be done over to now leverage this capability directly in fluree/db.

This PR (as did the original fluree/server PR) leverages the great library from @quoll to assist with the Turtle parsing.

