### PR TITLE
Fix/json data type

### DIFF
--- a/src/fluree/db/json_ld/iri.cljc
+++ b/src/fluree/db/json_ld/iri.cljc
@@ -22,6 +22,9 @@
 (def ^:const type-iri "@type")
 (def ^:const json-iri "@json")
 (def ^:const rdf:type-iri "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+;; Note this JSON-iri is not a valid rdf IRI per spec.. but used internally only for now
+;; to represent @json data type. Transactions convert @json into this IRI, then select converts
+;; this IRI back into @json.
 (def ^:const rdf:JSON-iri "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON")
 
 (defn normalize

--- a/src/fluree/db/json_ld/iri.cljc
+++ b/src/fluree/db/json_ld/iri.cljc
@@ -241,15 +241,19 @@
 (def type-sid
   (iri->sid "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
 
+(def json-sid
+  (iri->sid "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON"))
+
 (defn sid->iri
   "Converts an sid back into a string iri."
   ([sid]
    (sid->iri sid default-namespace-codes))
   ([sid namespace-codes]
-   (if (= type-sid sid)
-     type-iri
-     (str (get-namespace sid namespace-codes)
-          (get-name sid)))))
+   (cond
+     (= type-sid sid) type-iri
+     (= json-sid sid) json-iri
+     :else (str (get-namespace sid namespace-codes)
+                (get-name sid)))))
 
 (defprotocol IRICodec
   (encode-iri [codec iri])

--- a/src/fluree/db/query/exec/select/fql.cljc
+++ b/src/fluree/db/query/exec/select/fql.cljc
@@ -14,10 +14,6 @@
   [match _compact]
   (where/get-value match))
 
-(defmethod display const/iri-rdf-json
-  [match _compact]
-  (-> match where/get-value (json/parse false)))
-
 (defmethod display "@json"
   [match _compact]
   (-> match where/get-value (json/parse false)))

--- a/src/fluree/db/query/exec/select/fql.cljc
+++ b/src/fluree/db/query/exec/select/fql.cljc
@@ -18,6 +18,10 @@
   [match _compact]
   (-> match where/get-value (json/parse false)))
 
+(defmethod display "@json"
+  [match _compact]
+  (-> match where/get-value (json/parse false)))
+
 (defmethod display const/iri-id
   [match compact]
   (some-> match where/get-iri compact))

--- a/src/fluree/db/query/exec/select/sparql.cljc
+++ b/src/fluree/db/query/exec/select/sparql.cljc
@@ -27,6 +27,10 @@
   [match _compact]
   {"value" (where/get-value match) "type" "literal" "datatype" const/iri-rdf-json})
 
+(defmethod display "@json"
+  [match _compact]
+  {"value" (where/get-value match) "type" "literal" "datatype" "@json"})
+
 (defmethod display const/iri-id
   [match _compact]
   (let [iri (where/get-iri match)]

--- a/src/fluree/db/query/exec/select/sparql.cljc
+++ b/src/fluree/db/query/exec/select/sparql.cljc
@@ -23,10 +23,6 @@
       (and v lang)                                                 (assoc "xml:lang" lang)
       (and v (not (#{const/iri-string const/iri-lang-string} dt))) (assoc "datatype" dt))))
 
-(defmethod display const/iri-rdf-json
-  [match _compact]
-  {"value" (where/get-value match) "type" "literal" "datatype" const/iri-rdf-json})
-
 (defmethod display "@json"
   [match _compact]
   {"value" (where/get-value match) "type" "literal" "datatype" "@json"})

--- a/test/fluree/db/query/construct_test.clj
+++ b/test/fluree/db/query/construct_test.clj
@@ -90,7 +90,7 @@
       (is (= {"@graph"
               [{"@id" "ex:fran",
                 "json" [{"@value" "{\"paths\":[\"dev\",\"src\"]}",
-                         "@type" "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON"}],
+                         "@type" "@json"}],
                 "name" [{"@value" "Francois", "@language" "fr"}],
                 "date" [{"@value" #time/date "2020-10-20",
                          "@type" "http://www.w3.org/2001/XMLSchema#date"}]}],

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -1,7 +1,8 @@
 (ns fluree.db.query.datatype-test
   (:require [clojure.test :refer [deftest is testing]]
             [fluree.db.api :as fluree]
-            [fluree.db.test-utils :as test-utils]))
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.util.core :refer [exception?]]))
 
 (def default-context
   {:id     "@id"
@@ -11,7 +12,7 @@
    :rdfs   "http://www.w3.org/2000/01/rdf-schema#"
    :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"})
 
-(deftest ^:integration datatype-test
+(deftest ^:integration mixed-datatypes-test
   (let [conn   (test-utils/create-conn)
         ledger @(fluree/create conn "ledger/datatype")]
     (testing "Querying predicates with mixed datatypes"
@@ -51,3 +52,101 @@
                                :select  {'?u [:*]}
                                :where   {:id '?u, :schema/name 3}}))
             "only returns the data type queried")))))
+
+(deftest ^:integration datatype-test
+  (testing "querying with datatypes"
+    (let [conn   (test-utils/create-conn)
+          ledger @(fluree/create conn "people")
+          db     @(fluree/stage
+                   (fluree/db ledger)
+                   {"@context" [test-utils/default-context
+                                {:ex    "http://example.org/ns/"
+                                 :value "@value"
+                                 :type  "@type"}]
+                    "insert"
+                    [{:id      :ex/homer
+                      :ex/name "Homer"
+                      :ex/age  36}
+                     {:id      :ex/marge
+                      :ex/name "Marge"
+                      :ex/age  {:value 36
+                                :type  :xsd/int}}
+                     {:id      :ex/bart
+                      :ex/name "Bart"
+                      :ex/age  "forever 10"}]})]
+      (testing "with literal values"
+        (testing "specifying an explicit data type"
+          (testing "compatible with the value"
+            (let [query   {:context [test-utils/default-context
+                                     {:ex    "http://example.org/ns/"
+                                      :value "@value"
+                                      :type  "@type"}]
+                           :select  '[?name]
+                           :where   '{:ex/name ?name
+                                      :ex/age  {:value 36
+                                                :type  :xsd/int}}}
+                  results @(fluree/query db query)]
+              (is (= [["Marge"]] results)
+                  "should only return the matching items with the specified type")))
+          (testing "not compatible with the value"
+            (let [query   {:context [test-utils/default-context
+                                     {:ex    "http://example.org/ns/"
+                                      :value "@value"
+                                      :type  "@type"}]
+                           :select  '[?name]
+                           :where   '{:ex/name ?name
+                                      :ex/age  {:value 36
+                                                :type  :xsd/string}}}
+                  results @(fluree/query db query)]
+              (is (exception? results)
+                  "should return an error")))))
+      (testing "bound to variables in 'bind' patterns"
+        (testing "included datatype in query results"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex "http://example.org/ns/"}]
+                         :select  '[?name ?age ?dt]
+                         :where   '[{:ex/name ?name
+                                     :ex/age  ?age}
+                                    [:bind ?dt (datatype ?age)]]}
+                results @(fluree/query db query)]
+            (is (= [["Bart" "forever 10" :xsd/string]
+                    ["Homer" 36 :xsd/integer]
+                    ["Marge" 36 :xsd/int]]
+                   results))))
+        (testing "filtered with the datatype function"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex "http://example.org/ns/"}]
+                         :select  '[?name ?age ?dt]
+                         :where   '[{:ex/name ?name
+                                     :ex/age  ?age}
+                                    [:bind ?dt (datatype ?age)]
+                                    [:filter (= (iri :xsd/integer) ?dt)]]}
+                results @(fluree/query db query)]
+            (is (= [["Homer" 36 :xsd/integer]]
+                   results)))))
+      (testing "filtered in value maps"
+        (testing "with explicit type IRIs"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex    "http://example.org/ns/"
+                                    :value "@value"
+                                    :type  "@type"}]
+                         :select  '[?name ?age]
+                         :where   '[{:ex/name ?name
+                                     :ex/age  {:value ?age
+                                               :type  :xsd/string}}]}
+                results @(fluree/query db query)]
+            (is (= [["Bart" "forever 10"]]
+                   results))))
+        (testing "with variable types"
+          (let [query   {:context [test-utils/default-context
+                                   {:ex    "http://example.org/ns/"
+                                    :value "@value"
+                                    :type  "@type"}]
+                         :select  '[?name ?age ?ageType]
+                         :where   '[{:ex/name ?name
+                                     :ex/age  {:value ?age
+                                               :type  ?ageType}}
+                                    [:bind ?ageType (iri :xsd/int)]]}
+                results @(fluree/query db query)]
+            (is (= [["Marge" 36 :xsd/int]]
+                   results))))))))

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -176,7 +176,7 @@
               results @(fluree/query db query)]
           (is (= 2 (count results))
               "should return both documents")
-          (is (some #(= ["Document 1" "{\"age\":30,\"name\":\"John\"}" "@json"] %) results)
+          (is (some #(= ["Document 1" {"age" 30 "name" "John"} "@json"] %) results)
               "should include Document 1 with @json datatype")
           (is (some #(= ["Document 2" "plain string data" "xsd:string"] %) results)
               "should include Document 2 with string datatype")))
@@ -190,5 +190,5 @@
               results @(fluree/query db query)]
           (is (= 1 (count results))
               "should return only document with @json datatype")
-          (is (= [["Document 1" "{\"age\":30,\"name\":\"John\"}"]] results)
+          (is (= [["Document 1" {"age" 30 "name" "John"}]] results)
               "should return the correct document"))))))

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -4,7 +4,7 @@
             [fluree.db.test-utils :as test-utils]
             [fluree.db.util.core :refer [exception?]]))
 
-(def default-context
+(def context-edn
   {:id     "@id"
    :type   "@type"
    :schema "http://schema.org/"
@@ -18,15 +18,15 @@
     (testing "Querying predicates with mixed datatypes"
       (let [mixed-db @(fluree/stage (fluree/db ledger)
                                     {"insert"
-                                     [{:context     default-context
+                                     [{:context     context-edn
                                        :id          :ex/coco
                                        :type        :schema/Person
                                        :schema/name "Coco"}
-                                      {:context     default-context
+                                      {:context     context-edn
                                        :id          :ex/halie
                                        :type        :schema/Person
                                        :schema/name "Halie"}
-                                      {:context     default-context
+                                      {:context     context-edn
                                        :id          :ex/john
                                        :type        :schema/Person
                                        :schema/name 3}]})]
@@ -34,13 +34,13 @@
                  :type        :schema/Person
                  :schema/name "Halie"}]
                @(fluree/query mixed-db
-                              {:context default-context
+                              {:context context-edn
                                :select  {'?u [:*]}
                                :where   {:id '?u, :schema/name "Halie"}}))
             "only returns the data type queried")
         (is (= []
                @(fluree/query mixed-db
-                              {:context default-context
+                              {:context context-edn
                                :select  {'?u [:*]}
                                :where   {:id '?u, :schema/name "a"}}))
             "does not return results without matching subjects")
@@ -48,7 +48,7 @@
                  :type        :schema/Person
                  :schema/name 3}]
                @(fluree/query mixed-db
-                              {:context default-context
+                              {:context context-edn
                                :select  {'?u [:*]}
                                :where   {:id '?u, :schema/name 3}}))
             "only returns the data type queried")))))

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -1,8 +1,7 @@
 (ns fluree.db.query.fql-test
   (:require [clojure.test :refer [deftest is testing]]
             [fluree.db.api :as fluree]
-            [fluree.db.test-utils :as test-utils :refer [pred-match?]]
-            [fluree.db.util.core :refer [exception?]]))
+            [fluree.db.test-utils :as test-utils :refer [pred-match?]]))
 
 (deftest ^:integration grouping-test
   (testing "grouped queries"
@@ -469,103 +468,6 @@
             (is (= [["ex:bob"]] sut)
                 "returns correctly filtered results")))))))
 
-(deftest ^:integration datatype-test
-  (testing "querying with datatypes"
-    (let [conn   (test-utils/create-conn)
-          ledger @(fluree/create conn "people")
-          db     @(fluree/stage
-                   (fluree/db ledger)
-                   {"@context" [test-utils/default-context
-                                {:ex    "http://example.org/ns/"
-                                 :value "@value"
-                                 :type  "@type"}]
-                    "insert"
-                    [{:id      :ex/homer
-                      :ex/name "Homer"
-                      :ex/age  36}
-                     {:id      :ex/marge
-                      :ex/name "Marge"
-                      :ex/age  {:value 36
-                                :type  :xsd/int}}
-                     {:id      :ex/bart
-                      :ex/name "Bart"
-                      :ex/age  "forever 10"}]})]
-      (testing "with literal values"
-        (testing "specifying an explicit data type"
-          (testing "compatible with the value"
-            (let [query   {:context [test-utils/default-context
-                                     {:ex    "http://example.org/ns/"
-                                      :value "@value"
-                                      :type  "@type"}]
-                           :select  '[?name]
-                           :where   '{:ex/name ?name
-                                      :ex/age  {:value 36
-                                                :type  :xsd/int}}}
-                  results @(fluree/query db query)]
-              (is (= [["Marge"]] results)
-                  "should only return the matching items with the specified type")))
-          (testing "not compatible with the value"
-            (let [query   {:context [test-utils/default-context
-                                     {:ex    "http://example.org/ns/"
-                                      :value "@value"
-                                      :type  "@type"}]
-                           :select  '[?name]
-                           :where   '{:ex/name ?name
-                                      :ex/age  {:value 36
-                                                :type  :xsd/string}}}
-                  results @(fluree/query db query)]
-              (is (exception? results)
-                  "should return an error")))))
-      (testing "bound to variables in 'bind' patterns"
-        (testing "included datatype in query results"
-          (let [query   {:context [test-utils/default-context
-                                   {:ex "http://example.org/ns/"}]
-                         :select  '[?name ?age ?dt]
-                         :where   '[{:ex/name ?name
-                                     :ex/age  ?age}
-                                    [:bind ?dt (datatype ?age)]]}
-                results @(fluree/query db query)]
-            (is (= [["Bart" "forever 10" :xsd/string]
-                    ["Homer" 36 :xsd/integer]
-                    ["Marge" 36 :xsd/int]]
-                   results))))
-        (testing "filtered with the datatype function"
-          (let [query   {:context [test-utils/default-context
-                                   {:ex "http://example.org/ns/"}]
-                         :select  '[?name ?age ?dt]
-                         :where   '[{:ex/name ?name
-                                     :ex/age  ?age}
-                                    [:bind ?dt (datatype ?age)]
-                                    [:filter (= (iri :xsd/integer) ?dt)]]}
-                results @(fluree/query db query)]
-            (is (= [["Homer" 36 :xsd/integer]]
-                   results)))))
-      (testing "filtered in value maps"
-        (testing "with explicit type IRIs"
-          (let [query   {:context [test-utils/default-context
-                                   {:ex    "http://example.org/ns/"
-                                    :value "@value"
-                                    :type  "@type"}]
-                         :select  '[?name ?age]
-                         :where   '[{:ex/name ?name
-                                     :ex/age  {:value ?age
-                                               :type  :xsd/string}}]}
-                results @(fluree/query db query)]
-            (is (= [["Bart" "forever 10"]]
-                   results))))
-        (testing "with variable types"
-          (let [query   {:context [test-utils/default-context
-                                   {:ex    "http://example.org/ns/"
-                                    :value "@value"
-                                    :type  "@type"}]
-                         :select  '[?name ?age ?ageType]
-                         :where   '[{:ex/name ?name
-                                     :ex/age  {:value ?age
-                                               :type  ?ageType}}
-                                    [:bind ?ageType (iri :xsd/int)]]}
-                results @(fluree/query db query)]
-            (is (= [["Marge" 36 :xsd/int]]
-                   results))))))))
 
 (deftest ^:integration t-test
   (testing "querying with t values"

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -468,7 +468,6 @@
             (is (= [["ex:bob"]] sut)
                 "returns correctly filtered results")))))))
 
-
 (deftest ^:integration t-test
   (testing "querying with t values"
     (let [conn   (test-utils/create-conn)


### PR DESCRIPTION
When retrieving `@json` data types, internally we converted this to rdf:JSON iri. When querying and extracting `@type` we will return `rdf:JSON` which is not ideal... both because the user input `@json`, and second because `rdf:JSON` is not part of the ref-syntax spec at all.

This will now return `@json` in queries that try to bind datatype to a variable.