### PR TITLE
Ensure `@type` query var binding works

### DIFF
--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -180,11 +180,11 @@
 
 (defn link-lang-var
   [mch var]
-  (link-var mch :lang var))
+  (link-var mch :lang (symbol var)))
 
 (defn link-dt-var
   [mch var]
-  (link-var mch :dt var))
+  (link-var mch :dt (symbol var)))
 
 (defn link-t-var
   [mch var]
@@ -390,7 +390,10 @@
   [var db flake]
   (let [var-mch (unmatched-var var)
         dt-sid (flake/dt flake)
-        dt-iri (iri/decode-sid db dt-sid)]
+        ;; Get datatype - either explicit from flake or inferred from value
+        dt-iri (if dt-sid
+                 (iri/decode-sid db dt-sid)
+                 (datatype/infer-iri (flake/o flake)))]
     (match-iri var-mch dt-iri)))
 
 (defn match-linked-lang

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -188,7 +188,7 @@
 
 (defn link-t-var
   [mch var]
-  (link-var mch :t var))
+  (link-var mch :t (symbol var)))
 
 (defn sanitize-match
   [match]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -353,7 +353,8 @@
           filter-fn    (some-> attrs
                                (get const/iri-filter)
                                (parse-filter-function var vars context))
-          filters (cond->> [t-matcher filter-fn]
+          filters (cond->> [filter-fn]
+                    (not (v/variable? t)) (cons t-matcher)
                     (not (v/variable? dt)) (cons dt-matcher)
                     (not (v/variable? lang)) (cons lang-matcher))
           f       (apply combine-filters filters)]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -353,7 +353,10 @@
           filter-fn    (some-> attrs
                                (get const/iri-filter)
                                (parse-filter-function var vars context))
-          f            (combine-filters t-matcher dt-matcher lang-matcher filter-fn)]
+          filters (cond->> [t-matcher filter-fn]
+                    (not (v/variable? dt)) (cons dt-matcher)
+                    (not (v/variable? lang)) (cons lang-matcher))
+          f       (apply combine-filters filters)]
       (cond-> var-mch
         (v/variable? dt)   (where/link-dt-var dt)
         (v/variable? lang) (where/link-lang-var lang)

--- a/test/fluree/db/query/datatype_test.clj
+++ b/test/fluree/db/query/datatype_test.clj
@@ -220,11 +220,11 @@
                        "where"   [{"ex:name" "?name"
                                    "ex:age"  {"@value" "?age"
                                               "@type"  "?ageType"}}]}
-              results @(fluree/query db query)] 
-          (is (= [["Bart" "forever 10" "xsd:string"] 
-                  ["Homer" 36 "xsd:integer"] 
-                  ["Marge" 36 "xsd:int"]] 
-                 results)) )))))
+              results @(fluree/query db query)]
+          (is (= [["Bart" "forever 10" "xsd:string"]
+                  ["Homer" 36 "xsd:integer"]
+                  ["Marge" 36 "xsd:int"]]
+                 results)))))))
 
 (deftest ^:integration language-binding-test
   (testing "language binding with lang function"
@@ -236,7 +236,7 @@
                     "insert"
                     [{"@id"      "ex:greeting"
                       "ex:hello" {"@value" "Hello" "@language" "en"}}
-                     {"@id"      "ex:salutation"  
+                     {"@id"      "ex:salutation"
                       "ex:hello" {"@value" "Bonjour" "@language" "fr"}}]})]
       (testing "binding language to a variable with lang function"
         (let [query {"@context" {"ex" "http://example.org/ns/"}


### PR DESCRIPTION
A direct variable binding for `@type` in a where clause was not working correctly nor was `@language` bindings.

It was working when querying in EDN using a symbol as the variable, but there was an issue an no tests when string variables / JSON was used. This fixes that issue.

@aaj3f mentioned there was a ticket for this issue however I was unable to find it.
