### PR TITLE
fix shacl property shape path segment handling

### DIFF
--- a/src/fluree/db/json_ld/shacl.cljc
+++ b/src/fluree/db/json_ld/shacl.cljc
@@ -221,11 +221,16 @@
     (if (iri/sid? segment)
       (<? (resolve-predicate-path data-db tracker focus-node segment))
       (let [{[inverse-path]   const/sh_inversePath
-             alternative-path const/sh_alternativePath}
+             alternative-path const/sh_alternativePath
+             zero-or-one-path const/sh_zeroOrOnePath
+             one+-path        const/sh_oneOrMorePath
+             zero+-path       const/sh_zeroOrMorePath}
             segment]
+        (when (or zero-or-one-path one+-path zero+-path)
+          (throw (ex-info "Unsupported property path segment." {:segment segment})))
         (cond inverse-path     (<? (resolve-inverse-path data-db tracker focus-node inverse-path))
               alternative-path (<? (resolve-alternative-path data-db tracker focus-node alternative-path))
-              :else            (throw (ex-info "Unsupported property path segment." {:segment segment})))))))
+              :else            (<? (resolve-predicate-path data-db tracker focus-node (get segment const/$id))))))))
 
 (defn resolve-value-nodes
   "Return the value nodes resolved via the path from the focus node."


### PR DESCRIPTION
When we reconstruct a shape in order to evaluate it we do so greedily, pulling in all the predicates on each subject. When we are resolving a property shape path, we were assuming that a regular property would not have any additional data associated with it, and that if the path segment's map didn't contain one of our supported path modifiers then it was invalid.

This was an erroneous assumption. Now I've added an explicit check for unsupported property paths so we can correctly handle path segments with arbitrary data.