### PR TITLE
change drop ledger logging to debug level

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -437,18 +437,18 @@
             (let [ledger-addr   (<? (nameservice/publishing-address publisher alias))
                   latest-commit (-> (<? (nameservice/lookup publisher ledger-addr))
                                     json-ld/expand)]
-              (log/warn "Dropping ledger" ledger-addr)
+              (log/debug "Dropping ledger" ledger-addr)
               (drop-index-artifacts conn latest-commit)
               (drop-commit-artifacts conn latest-commit)
               (<? (nameservice/retract publisher alias))
               (recur r))))
-        (log/warn "Dropped ledger" alias)
+        (log/debug "Dropped ledger" alias)
         :dropped)
       (catch* e (log/debug e "Failed to complete ledger deletion")))))
 
 (defn resolve-txn
   "Reads a transaction from the commit catalog by address.
-   
+
    Used by fluree/server in consensus/events."
   [{:keys [commit-catalog] :as _conn} address]
   (storage/read-json commit-catalog address))


### PR DESCRIPTION
`warn` isn't an appropriate level for routine events, changing to `debug`.