### PR TITLE
fix handling of GRAPH patterns in INSERT DATA operations

### DIFF
--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -868,8 +868,7 @@
 (defmethod parse-term :QuadsNotTriples
   ;; QuadsNotTriples ::= <'GRAPH'> WS VarOrIri <'{'> WS TriplesTemplate? <'}'> WS
   [[_ graph-iri & triples]]
-  ;; This is how we would translate it if we supported it in FQL
-  [(into [:graph (parse-term graph-iri)] (mapv parse-term triples))])
+  [(conj [:graph (parse-term graph-iri)] (vec (mapcat parse-term triples)))])
 
 (defmethod parse-term :Quads
   ;; <Quads> ::= TriplesTemplate? ( QuadsNotTriples '.'? TriplesTemplate? )*


### PR DESCRIPTION
We were losing all but the first triple produced from an INSERT DATA operation when they were nested under a GRAPH clause, this ensures that all the triples are preserved.