### PR TITLE
fix translation of multi-pattern OPTIONAL sparql patterns

### DIFF
--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -553,7 +553,7 @@
 (defmethod parse-term :OptionalGraphPattern
   ;; OptionalGraphPattern ::= <'OPTIONAL'> GroupGraphPattern
   [[_ & optional]]
-  (into [:optional] (mapv parse-term optional)))
+  (into [:optional] (mapcat parse-term optional)))
 
 (defmethod parse-term :MinusGraphPattern
   [[_ & patterns]]

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -377,7 +377,7 @@
                         OPTIONAL {?person person:favNums ?num.}}"
           {:keys [where]} (sparql/->fql query)]
       (is (= [{"@id" "?person", "person:handle" "?handle"}
-              [:optional [{"@id" "?person", "person:favNums" "?num"}]]]
+              [:optional {"@id" "?person", "person:favNums" "?num"}]]
              where)))
     (testing "multi-clause"
       (let [query "SELECT ?person ?name ?handle ?favNums
@@ -387,8 +387,8 @@
             {:keys [where]} (sparql/->fql query)]
         (is (= [{"@id" "?person", "person:fullName" "?name"}
                 [:optional
-                 [{"@id" "?person", "person:handle" "?handle"}
-                  {"@id" "?person", "person:favNums" "?favNums"}]]]
+                 {"@id" "?person", "person:handle" "?handle"}
+                 {"@id" "?person", "person:favNums" "?favNums"}]]
                where))))
     (testing "OPTIONAL + FILTER"
       (let [query "SELECT ?handle ?num
@@ -398,8 +398,8 @@
             {:keys [where]} (sparql/->fql query)]
         (is (= [{"@id" "?person", "person:handle" "?handle"}
                 [:optional
-                 [{"@id" "?person", "person:favNums" "?num"}
-                  [:filter "(> ?num 10)"]]]]
+                 {"@id" "?person", "person:favNums" "?num"}
+                 [:filter "(> ?num 10)"]]]
                where)))))
   (testing "VALUES"
     (testing "pattern"
@@ -929,13 +929,11 @@
                        {
                          <http://example/book1> dc:title \"A new book\" .
                          <http://example/book2> dc:creator \"A.N.Other\" .
-
                        }
                        GRAPH <ledger/graph2>
                        {
                          <http://example/book3> dc:title \"A new book\" .
                          <http://example/book4> dc:creator \"A.N.Other\" .
-
                        }
                      }"]
         (is (= ["Multiple GRAPH declarations not supported in INSERT DATA."
@@ -1064,7 +1062,7 @@
                        "ex:jdoe a ex:Person; person:handle \"jdoe\"; person:fullName \"Jane Doe\"; person:favNums 3, 7, 42, 99."
                        "ex:bbob a ex:Person; person:handle \"bbob\"; person:fullName \"Billy Bob\"; person:favNums 23."
                        "ex:jbob a ex:Person; person:handle \"jbob\"; person:fullName \"Jenny Bob\"; person:favNums 8, 6, 7, 5, 3, 0, 9."
-                       "ex:fbueller a ex:Person; person:handle \"dankeshön\"; person:fullName \"Ferris Bueller\"."
+                       "ex:fbueller a ex:Person; person:handle \"dankeshön\"; person:fullName \"Ferris Bueller\"; person:email \"fb@example.com\"."
                        "ex:alice foaf:givenname \"Alice\"; foaf:family_name \"Hacker\"."
                        "ex:bob foaf:firstname \"Bob\"; foaf:surname \"Hacker\"."
                        "ex:carol ex:catchphrase \"Heyyyy\"@en."
@@ -1404,6 +1402,107 @@
                           {"value" "99",
                            "type" "literal",
                            "datatype" "http://www.w3.org/2001/XMLSchema#integer"}}]}}
+                      @(fluree/query db query {:format :sparql :output :sparql}))))))
+         (testing "basic query w/ multi-pattern OPTIONAL works"
+           (let [query   "PREFIX person: <http://example.org/Person#>
+                          SELECT ?person ?favNums ?email
+                          WHERE {?person person:handle ?handle.
+                                 OPTIONAL{?person person:favNums ?favNums.
+                                          ?person person:email ?email .}}"]
+             (testing "output :fql"
+               (is (= [["ex:bbob" 23 nil]
+                       ["ex:fbueller" nil "fb@example.com"]
+                       ["ex:jbob" 0 nil]
+                       ["ex:jbob" 3 nil]
+                       ["ex:jbob" 5 nil]
+                       ["ex:jbob" 6 nil]
+                       ["ex:jbob" 7 nil]
+                       ["ex:jbob" 8 nil]
+                       ["ex:jbob" 9 nil]
+                       ["ex:jdoe" 3 nil]
+                       ["ex:jdoe" 7 nil]
+                       ["ex:jdoe" 42 nil]
+                       ["ex:jdoe" 99 nil]]
+                      @(fluree/query db query {:format :sparql}))))
+             (testing "output :sparql"
+               (is (= {"head" {"vars" ["email" "favNums" "person"]},
+                       "results"
+                       {"bindings"
+                        [{"person" {"type" "uri", "value" "ex:bbob"},
+                          "favNums"
+                          {"value" "23",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:fbueller"},
+                          "favNums" {"value" "", "type" "literal"},
+                          "email" {"value" "fb@example.com", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "0",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "3",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "5",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "6",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "7",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "8",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jbob"},
+                          "favNums"
+                          {"value" "9",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jdoe"},
+                          "favNums"
+                          {"value" "3",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jdoe"},
+                          "favNums"
+                          {"value" "7",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jdoe"},
+                          "favNums"
+                          {"value" "42",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}
+                         {"person" {"type" "uri", "value" "ex:jdoe"},
+                          "favNums"
+                          {"value" "99",
+                           "type" "literal",
+                           "datatype" "http://www.w3.org/2001/XMLSchema#integer"},
+                          "email" {"value" "", "type" "literal"}}]}}
                       @(fluree/query db query {:format :sparql :output :sparql}))))))
          (testing "basic query w/ GROUP BY & OPTIONAL works"
            (let [query   "PREFIX person: <http://example.org/Person#>


### PR DESCRIPTION
We were translating multi-pattern SPARQL OPTIONAL patterns into jld-query patterns that look like this:

```[:optional [<p1> <p2>]]```

Which gets groups both patterns into a block when parsed:

```:where [... [:optional [<p1> <p2>]]]```

This produces a different result from the intended semantics of OPTIONAL. This commit changes the translation into this:

```[:optional <p1> <p2>]```

Which gets parsed to this:

```:where [... [:optional <p1>] [:optional <p2>]]```

Which provides the semantics that SPARQL expects.