### PR TITLE
fix blank node variable grammar

### DIFF
--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -27,7 +27,7 @@
 (defn bnode-variable?
   [x]
   (and (or (string? x) (symbol? x) (keyword? x))
-       (-> x name first (= \_))))
+       (->> x name (take 2) (= [\_ \:]))))
 
 (defn query-variable?
   [x]

--- a/test/fluree/db/query/fql_test.clj
+++ b/test/fluree/db/query/fql_test.clj
@@ -588,6 +588,29 @@
                subject)
             "returns all results")))))
 
+(deftest bnode-variables-test
+  (let [conn   (test-utils/create-conn)
+        ledger @(fluree/create conn "test/bnodes")
+        db     @(fluree/stage (fluree/db ledger)
+                              {"@context" {"ex" "http://example.org/"}
+                               "insert"
+                               [{"@id"    "ex:a",
+                                 "@type"  "ex:Thing",
+                                 "ex:foo" "_bar"}
+                                {"@id"    "ex:b",
+                                 "@type"  "ex:Thing",
+                                 "ex:foo" "_foo"}]})]
+    (testing "_ prefix is a literal value"
+      (is (= ["ex:b"]
+             @(fluree/query db {"@context" {"ex" "http://example.org/"}
+                                "where" [{"@id" "?s" "ex:foo" "_foo"}]
+                                "select" "?s"}))))
+    (testing "_: prefix matches everything"
+      (is (= ["ex:a" "ex:b"]
+             @(fluree/query db {"@context" {"ex" "http://example.org/"}
+                                "where" [{"@id" "?s" "ex:foo" "_:foo"}]
+                                "select" "?s"}))))))
+
 (deftest ^:integration select-star-no-graph-crawl-test
   (let [conn   (test-utils/create-conn)
         ledger (test-utils/load-people conn)


### PR DESCRIPTION
Our grammar for blank node variables was underspecifying the blank node prefix, checking for `_` instead of `_:`. This meant string literals that began with an underscore were being parsed as variables, which lead to unexpected query results.