### PR TITLE
fix xhttp response handling

### DIFF
--- a/src/fluree/db/util/xhttp.cljc
+++ b/src/fluree/db/util/xhttp.cljc
@@ -102,7 +102,8 @@
                               url
                               (or error (ex-info "error response"
                                                  response)))))
-                          (let [data (try (cond-> (slurp body)
+                          (let [data (try (cond-> body
+                                            (bytes? body) slurp
                                             json? (json/parse keywordize-keys))
                                           (catch Exception e
                                             ;; don't throw, as `data` will get exception and put on response-chan


### PR DESCRIPTION
You can't slurp a string, and body is sometimes a string depending on how the request is created. This change was needed in order to get tests passing in server.