### PR TITLE
Update AWS S3 libraries for Java 11+ compatibility

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,9 +36,9 @@
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 
         ;; storage
-        com.cognitect.aws/api       {:mvn/version "0.8.692"}
-        com.cognitect.aws/endpoints {:mvn/version "1.1.12.718"}
-        com.cognitect.aws/s3        {:mvn/version "868.2.1580.0"}}
+        com.cognitect.aws/api       {:mvn/version "0.8.741"}
+        com.cognitect.aws/endpoints {:mvn/version "871.2.32.2"}
+        com.cognitect.aws/s3        {:mvn/version "871.2.32.2"}}
 
  :paths ["src" "resources" "target/classes"]
 


### PR DESCRIPTION
Updates AWS Cognitect libraries to newer versions that maintain Java 11+ compatibility.