### PR TITLE
Handle authorization checks on reversed properties in subgraph selector

### DIFF
--- a/test/fluree/db/query/reverse_query_test.clj
+++ b/test/fluree/db/query/reverse_query_test.clj
@@ -104,3 +104,41 @@
              (set @(fluree/query db1 {"@context"       {"ex" "http://example.org/ns/"}
                                       "where"          {"@id" "?x" "@type" "?class"}
                                       "selectDistinct" "?class"})))))))
+
+(deftest ^:integration reverse-subject-crawl-with-policy
+  (let [conn   @(fluree/connect-memory)
+        ledger @(fluree/create conn "reverse")
+        db0    (fluree/db ledger)
+
+        db1 @(fluree/update db0 {"@context" {"ex" "http://example.org/ns/"}
+                                 "insert"   [{"@id"      "ex:dad"
+                                              "@type"    "ex:Person"
+                                              "ex:name"  "Dad"
+                                              "ex:child" {"@id" "ex:kid"}}
+                                             {"@id"      "ex:mom"
+                                              "@type"    "ex:Person"
+                                              "ex:name"  "Mom"
+                                              "ex:child" {"@id" "ex:kid"}}
+                                             {"@id"     "ex:kid"
+                                              "@type"   "ex:Person"
+                                              "ex:name" "Kiddo"}
+                                             {"@id"        "ex:school"
+                                              "@type"      "ex:Organization"
+                                              "ex:student" "ex:kid"}]})
+        db2 @(fluree/wrap-policy db1 {"@context" {"ex" "http://example.org/ns/"
+                                                  "f" "https://ns.flur.ee/ledger#"}
+                                      "@type" "ex:PolicyGroup/1"
+                                      "f:action" {"@id" "f:view"}
+                                      "f:query" {"@type" "@json" "@value" {}}})]
+    (is (= [{"parent"
+             [{"@type" "ex:Person",
+               "ex:child" {"@id" "ex:kid"},
+               "ex:name" "Dad",
+               "@id" "ex:dad"}
+              {"@type" "ex:Person",
+               "ex:child" {"@id" "ex:kid"},
+               "ex:name" "Mom",
+               "@id" "ex:mom"}]}]
+           @(fluree/query db2 {"@context" {"ex" "http://example.org/ns/"
+                                           "parent" {"@reverse" "ex:child"}}
+                               "select" {"ex:kid" [{"parent" ["*"]}]}})))))


### PR DESCRIPTION
When do formatting a SubgraphSelector with a reversed property, we were using a flake-xf that changed the result from a flake to a sid, which cannot be handled by the authorize-flakes transducer.

This PR moves the subject extraction out of the flake-xf and only applies it afterward as part of the formatting.

Fixes https://github.com/fluree/core/issues/161