### PR TITLE
Uninitialized config nodes

### DIFF
--- a/src/fluree/db/connection/config.cljc
+++ b/src/fluree/db/connection/config.cljc
@@ -26,6 +26,16 @@
   [node]
   (type? node conn-vocab/connection-type))
 
+(defn connection-config?
+  [node]
+  (or (type? node conn-vocab/config-type)
+      (and (not (contains? node :type))
+           (or (contains? node conn-vocab/primary-publisher)
+               (contains? node conn-vocab/secondary-publishers)
+               (contains? node conn-vocab/commit-storage)
+               (contains? node conn-vocab/index-storage)
+               (contains? node conn-vocab/parallelism)))))
+
 (defn system?
   [node]
   (type? node conn-vocab/system-type))
@@ -127,12 +137,16 @@
           (get-first-value k)
           get-boolean))
 
+(derive :fluree.db/connection :fluree.db/abstract-connection)
+(derive :fluree.db/connection-config :fluree.db/abstract-connection)
+
 (defn derive-node-id
   [node]
   (let [id (get-id node)]
     (cond
       (config-value? node)        (derive id :fluree.db/config-value)
       (connection? node)          (derive id :fluree.db/connection)
+      (connection-config? node)   (derive id :fluree.db/connection-config)
       (system? node)              (derive id :fluree.db/remote-system)
       (memory-storage? node)      (derive id :fluree.db.storage/memory)
       (file-storage? node)        (derive id :fluree.db.storage/file)

--- a/src/fluree/db/connection/config.cljc
+++ b/src/fluree/db/connection/config.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.connection.config
   (:require [clojure.string :as str]
+            [fluree.crypto :as crypto]
             [fluree.db.connection.vocab :as conn-vocab]
             [fluree.db.json-ld.iri :as iri]
             [fluree.db.util :as util :refer [get-id get-first get-first-value
@@ -306,3 +307,50 @@
                (map derive-fn)
                (map (juxt get-id identity)))
          (standardize cfg))))
+
+(defn parse-identity
+  [defaults]
+  (when-let [identity (get-first defaults conn-vocab/identity)]
+    (let [public-key  (get-first-string identity conn-vocab/public-key)
+          private-key (get-first-string identity conn-vocab/private-key)
+          ;; Derive public key from private key if public key is missing
+          public-key* (if (and (nil? public-key) private-key)
+                        (crypto/public-key-from-private private-key)
+                        public-key)
+          result {:id      (get-id identity)
+                  :public  public-key*
+                  :private private-key}]
+      result)))
+
+(defn parse-index-options
+  [defaults]
+  (when-let [index-options (get-first defaults conn-vocab/index-options)]
+    {:reindex-min-bytes (get-first-long index-options conn-vocab/reindex-min-bytes)
+     :reindex-max-bytes (get-first-long index-options conn-vocab/reindex-max-bytes)
+     :max-old-indexes   (get-first-integer index-options conn-vocab/max-old-indexes)}))
+
+(defn parse-defaults
+  [config]
+  (when-let [defaults (get-first config conn-vocab/defaults)]
+    (let [identity      (parse-identity defaults)
+          index-options (parse-index-options defaults)]
+      (cond-> nil
+        identity      (assoc :identity identity)
+        index-options (assoc :indexing index-options)))))
+
+(defn parse-connection-map
+  [{:keys [cache commit-catalog index-catalog serializer] :as config}]
+  (let [parallelism          (get-first-integer config conn-vocab/parallelism)
+        primary-publisher    (get-first config conn-vocab/primary-publisher)
+        secondary-publishers (get config conn-vocab/secondary-publishers)
+        remote-systems       (get config conn-vocab/remote-systems)
+        defaults             (parse-defaults config)]
+    {:parallelism          parallelism
+     :cache                cache
+     :commit-catalog       commit-catalog
+     :index-catalog        index-catalog
+     :primary-publisher    primary-publisher
+     :secondary-publishers secondary-publishers
+     :remote-systems       remote-systems
+     :serializer           serializer
+     :defaults             defaults}))

--- a/src/fluree/db/connection/system.cljc
+++ b/src/fluree/db/connection/system.cljc
@@ -75,7 +75,7 @@
                (assoc m id (convert-node-references node)))
              {} cfg))
 
-(defmethod ig/expand-key :fluree.db/connection
+(defmethod ig/expand-key :fluree.db/abstract-connection
   [k config]
   (let [cache-max-mb   (config/get-first-integer config conn-vocab/cache-max-mb)
         commit-storage (get config conn-vocab/commit-storage)

--- a/src/fluree/db/connection/vocab.cljc
+++ b/src/fluree/db/connection/vocab.cljc
@@ -16,6 +16,9 @@
 (def connection-type
   (system-iri "Connection"))
 
+(def config-type
+  (system-iri "Configuration"))
+
 (def storage-type
   (system-iri "Storage"))
 

--- a/src/fluree/db/connection/vocab.cljc
+++ b/src/fluree/db/connection/vocab.cljc
@@ -10,14 +10,14 @@
   [s]
   (str system-ns s))
 
+(def config-type
+  (system-iri "Configuration"))
+
 (def config-val-type
   (system-iri "ConfigurationValue"))
 
 (def connection-type
   (system-iri "Connection"))
-
-(def config-type
-  (system-iri "Configuration"))
 
 (def storage-type
   (system-iri "Storage"))
@@ -117,3 +117,6 @@
 
 (def connection
   (system-iri "connection"))
+
+(def connection-config
+  (system-iri "connectionConfig"))


### PR DESCRIPTION
This patch adds a `Configuration` type for config nodes. These types are not meant to be initialized at startup but instead stored by another component to be initialized dynamically later. 

Along with the `Configuration` type is the `connectionConfig` property which is meant to refer to a stored connection configuration that components with that configuration property can use to dynamically create Fluree database connections after startup. 