### PR TITLE
Fix nameservice listing for ledgers with recursive directory structures

### DIFF
--- a/src/fluree/db/storage.cljc
+++ b/src/fluree/db/storage.cljc
@@ -113,9 +113,6 @@
 (defprotocol EraseableStore
   (delete [store address] "Remove value associated with `address` from the store."))
 
-(defprotocol ListableStore
-  (list-paths [store prefix] "Returns a sequence of paths that start with the given prefix."))
-
 (defprotocol RecursiveListableStore
   (list-paths-recursive [store prefix]
     "Recursively returns all file paths that start with the given prefix. Excludes directories."))

--- a/src/fluree/db/storage.cljc
+++ b/src/fluree/db/storage.cljc
@@ -116,6 +116,10 @@
 (defprotocol ListableStore
   (list-paths [store prefix] "Returns a sequence of paths that start with the given prefix."))
 
+(defprotocol RecursiveListableStore
+  (list-paths-recursive [store prefix]
+    "Recursively returns all file paths that start with the given prefix. Excludes directories."))
+
 (defn content-write-json
   [store path data]
   (go-try

--- a/src/fluree/db/storage/file.cljc
+++ b/src/fluree/db/storage/file.cljc
@@ -116,20 +116,6 @@
         (full-path path)
         (fs/read-file encryption-key)))
 
-  storage/ListableStore
-  (list-paths [_ prefix]
-    (go-try
-      (let [prefix-path (full-path root prefix)]
-        ;; Check if prefix directory exists
-        (if (<? (fs/exists? prefix-path))
-          ;; Use filesystem list-files to get all files in directory
-          (let [files (<? (fs/list-files prefix-path))
-                ;; Filter for .json files and return relative paths
-                json-files (filter #(str/ends-with? % ".json") files)]
-            (map #(str prefix "/" %) json-files))
-          ;; Directory doesn't exist, return empty sequence
-          []))))
-
   storage/RecursiveListableStore
   (list-paths-recursive [_ prefix]
     (go-try

--- a/src/fluree/db/storage/memory.cljc
+++ b/src/fluree/db/storage/memory.cljc
@@ -55,16 +55,6 @@
     (go
       (get @contents path)))
 
-  storage/ListableStore
-  (list-paths [_ prefix]
-    (go
-      ;; Filter keys in contents that start with the prefix and end with .json
-      (->> @contents
-           keys
-           (filter #(and (str/starts-with? % prefix)
-                         (str/ends-with? % ".json")))
-           vec)))
-
   storage/RecursiveListableStore
   (list-paths-recursive [_ prefix]
     ;; Memory storage already stores flat paths, so recursive is the same as regular listing

--- a/src/fluree/db/storage/memory.cljc
+++ b/src/fluree/db/storage/memory.cljc
@@ -63,6 +63,16 @@
            keys
            (filter #(and (str/starts-with? % prefix)
                          (str/ends-with? % ".json")))
+           vec)))
+
+  storage/RecursiveListableStore
+  (list-paths-recursive [_ prefix]
+    ;; Memory storage already stores flat paths, so recursive is the same as regular listing
+    (go
+      (->> @contents
+           keys
+           (filter #(and (str/starts-with? % prefix)
+                         (str/ends-with? % ".json")))
            vec))))
 
 (defn open

--- a/src/fluree/db/storage/s3.clj
+++ b/src/fluree/db/storage/s3.clj
@@ -398,7 +398,13 @@
         ;; Filter for .json files and return relative paths
         (->> all-results
              (filter #(str/ends-with? % ".json"))
-             vec)))))
+             vec))))
+
+  storage/RecursiveListableStore
+  (list-paths-recursive [this path-prefix]
+    ;; S3 list already supports recursive listing with prefix
+    ;; So we can reuse the same implementation as list-paths
+    (storage/list-paths this path-prefix)))
 
 (defn open
   "Open an S3 store using direct HTTP implementation"

--- a/src/fluree/db/storage/s3.clj
+++ b/src/fluree/db/storage/s3.clj
@@ -384,8 +384,8 @@
                          :path full-path
                          :credentials credentials})))))
 
-  storage/ListableStore
-  (list-paths [this path-prefix]
+  storage/RecursiveListableStore
+  (list-paths-recursive [this path-prefix]
     (go-try
       ;; Use existing s3-list function to list objects with the prefix
       (let [results-ch (s3-list this path-prefix)
@@ -398,13 +398,7 @@
         ;; Filter for .json files and return relative paths
         (->> all-results
              (filter #(str/ends-with? % ".json"))
-             vec))))
-
-  storage/RecursiveListableStore
-  (list-paths-recursive [this path-prefix]
-    ;; S3 list already supports recursive listing with prefix
-    ;; So we can reuse the same implementation as list-paths
-    (storage/list-paths this path-prefix)))
+             vec)))))
 
 (defn open
   "Open an S3 store using direct HTTP implementation"


### PR DESCRIPTION
## Summary
- The new nameservice implementation fails to list ledgers stored in subdirectories when ledger names contain '/' characters
- This PR adds a RecursiveListableStore protocol that enables recursive directory traversal for proper ledger discovery

## Changes
- Added `RecursiveListableStore` protocol with `list-paths-recursive` method to storage.cljc
- Implemented the protocol in all storage backends (file, S3, memory)
- Updated nameservice storage to use recursive listing instead of shallow listing
- Added tests verifying ledgers with '/' in names work correctly (e.g., "tenant1/customers")

## Future Benefits
This recursive listing capability could simplify the ledger 'drop' feature by enabling recursive deletion of all storage files for a given ledger path, eliminating the need for the current complex file tracking logic.

## Test Plan
- [x] Added test case for ledger names containing '/' characters
- [x] Verified subdirectory creation and nameservice file storage
- [x] Confirmed all existing nameservice tests pass
- [x] No linter warnings