### PR TITLE
test: stabilize drop-test by increasing max-old-indexes to 1000

### DIFF
--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -1040,7 +1040,7 @@
                                                      "secondaryPublishers" {"@type" "Publisher"
                                                                             "storage" {"@id" "secondaryStorage"}}}]})
              alias    "destined-for-drop"
-             _        @(fluree/create conn alias {:reindex-min-bytes 100 :max-old-indexes 3})
+             _        @(fluree/create conn alias {:reindex-min-bytes 100 :max-old-indexes 1000})
              db0      (-> @(fluree/db conn alias)
                           ;; wrap with a policy so we are storing txns
                           (fluree/wrap-policy {"@context" {"ex" "http://example.org/ns/" "f" "https://ns.flur.ee/ledger#"}


### PR DESCRIPTION
Fix intermittent drop-test failure caused by background index garbage collection pruning older index roots/segments during pre-drop file count assertions. Increase max-old-indexes for this test to prevent GC from running during the assertions, making the test consistent across runs.