### PR TITLE
Fix/handle missing ledger

### DIFF
--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -49,14 +49,18 @@
 (defn transact!
   [conn ledger-id parsed-txn]
   (go-try
-    (let [ledger (async/<! (connection/load-ledger conn ledger-id))]
-      (if (util/exception? ledger)
-        (if (not-found? ledger)
-          (throw (ex-info (str "Ledger " ledger-id " does not exist")
-                          {:status 409 :error :db/ledger-not-exists}
-                          ledger))
-          (throw ledger))
-        (<? (transact/transact-ledger! ledger parsed-txn))))))
+    (if ledger-id
+      (let [ledger (async/<! (connection/load-ledger conn ledger-id))]
+        (if (util/exception? ledger)
+          (if (not-found? ledger)
+            (throw (ex-info (str "Ledger " ledger-id " does not exist")
+                            {:status 409 :error :db/ledger-not-exists}
+                            ledger))
+            (throw ledger))
+          (<? (transact/transact-ledger! ledger parsed-txn))))
+      (throw (ex-info "Missing ledger specification."
+                      {:ledger-id ledger-id
+                       :status 400})))))
 
 (defn insert!
   [conn ledger-id txn override-opts]

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -135,7 +135,10 @@
 
 (defn fluree-address?
   [x]
-  (str/starts-with? x fluree-address-prefix))
+  (if (string? x)
+    (str/starts-with? x fluree-address-prefix)
+    (throw (ex-info (str "Invalid ledger identifier: " (pr-str x))
+                    {:ledger-id x}))))
 
 (defn relative-ledger-alias?
   [ledger-alias]

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -135,10 +135,7 @@
 
 (defn fluree-address?
   [x]
-  (if (string? x)
-    (str/starts-with? x fluree-address-prefix)
-    (throw (ex-info (str "Invalid ledger identifier: " (pr-str x))
-                    {:ledger-id x}))))
+  (str/starts-with? x fluree-address-prefix))
 
 (defn relative-ledger-alias?
   [ledger-alias]

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -499,11 +499,11 @@
 
 (defn trigger-ledger-index
   "Manually triggers indexing for a ledger/branch and waits for completion.
-   
+
    Options:
    - :branch - Branch name (defaults to main branch)
    - :timeout - Max wait time in ms (default 300000 / 5 minutes)
-   
+
    Returns the indexed database object or throws an exception on failure/timeout."
   [conn ledger-alias opts]
   (go-try

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -329,6 +329,25 @@
                   @(fluree/query db q))))))))
 
 #?(:clj
+   (deftest bad-ledger-identifier-test
+     (let [conn @(fluree/connect-memory)]
+       (is (= "Missing ledger specification."
+              (ex-message @(fluree/update! conn nil {"@context" {"ex" "http://example.com/"}
+                                                     "where" [{"@id" "?s" "@type" "ex:User"}]
+                                                     "insert" [{"@id" "?s" "@type" "ex:Foo"}]}))))
+       (is (= "Missing ledger specification."
+              (ex-message @(fluree/insert! conn nil {"@context" {"ex" "http://example.com/"}
+                                                     "@graph" [{"@id" "ex:foo" "@type" "ex:Foo"}]}))))
+       (is (= "Missing ledger specification."
+              (ex-message @(fluree/upsert! conn nil {"@context" {"ex" "http://example.com/"}
+                                                     "@graph" [{"@id" "ex:foo" "@type" "ex:Foo"}]}))))
+       (is (= "Missing ledger specification in connection query"
+              (ex-message @(fluree/query-connection conn {"@context" {"ex" "http://example.com/"}
+                                                          "where" [{"@id" "?s" "@type" "ex:User"}
+                                                                   {"@id" "?s" "?p" "?o"}]
+                                                          "select" ["?s" "?p" "?o"]})))))))
+
+#?(:clj
    (deftest load-from-memory-test
      (testing "can load a memory ledger with single cardinality predicates"
        (let [conn         @(fluree/connect-memory)


### PR DESCRIPTION
If no ledger alias is provided we fail rather clumsily with a NullPointerException. This PR adds nicer error messages and prevents a server timeout when ledger ids aren't provided.