### PR TITLE
Move blocking HTTP operations to thread pool

### DIFF
--- a/src/fluree/db/commit/storage.cljc
+++ b/src/fluree/db/commit/storage.cljc
@@ -101,16 +101,19 @@
   "Loads commit from disk and merges nameservice metadata (address, index)"
   [storage commit-address index-address]
   (go-try
+    (log/debug "commit.storage/load-commit-with-metadata start" {:address commit-address :index-address index-address})
     (when-let [commit-data (<? (storage/read-json storage commit-address))]
       (let [addr-key-path (if (contains? commit-data "credentialSubject")
                             ["credentialSubject" "address"]
                             ["address"])
             index-key-path (if (contains? commit-data "credentialSubject")
                              ["credentialSubject" "index" "address"]
-                             ["index" "address"])]
-        (-> commit-data
-            (assoc-in addr-key-path commit-address)
-            (cond-> index-address (assoc-in index-key-path index-address)))))))
+                             ["index" "address"])
+            result (-> commit-data
+                       (assoc-in addr-key-path commit-address)
+                       (cond-> index-address (assoc-in index-key-path index-address)))]
+        (log/debug "commit.storage/load-commit-with-metadata done" {:address commit-address})
+        result))))
 
 (defn trace-commits
   "Returns a list of two-tuples each containing [commit proof] as applicable.

--- a/src/fluree/db/nameservice/storage.cljc
+++ b/src/fluree/db/nameservice/storage.cljc
@@ -50,7 +50,10 @@
           ns-metadata    (ns-record ledger-alias branch commit-address t-value index-address)
           record-bytes   (json/stringify-UTF8 ns-metadata)
           filename       (local-filename ledger-alias branch)]
-      (storage/write-bytes store filename record-bytes)))
+      (log/debug "nameservice.storage/publish start" {:ledger ledger-alias :branch branch :filename filename})
+      (let [res (storage/write-bytes store filename record-bytes)]
+        (log/debug "nameservice.storage/publish enqueued" {:ledger ledger-alias :branch branch :filename filename})
+        res)))
 
   (retract [_ ledger-alias]
     (let [filename (local-filename ledger-alias)

--- a/src/fluree/db/transact.cljc
+++ b/src/fluree/db/transact.cljc
@@ -227,6 +227,7 @@
   ([{ledger-alias :alias, :as ledger}
     {:keys [branch t stats commit] :as staged-db}
     opts]
+   (log/debug "commit!: write-transaction start" {:ledger ledger-alias})
    (go-try
      (let [{:keys [commit-catalog]} ledger
 
@@ -240,7 +241,12 @@
            {:keys [txn-id author annotation]}
            (<? (write-transaction! ledger staged-txn))
 
+           _ (log/debug "commit!: write-jsonld(db) start" {:ledger ledger-alias})
+
            data-write-result (<? (commit-storage/write-jsonld commit-catalog ledger-alias db-jsonld))
+
+           _ (log/debug "commit!: write-jsonld(db) done" {:ledger ledger-alias :db-address (:address data-write-result)})
+
            db-address        (:address data-write-result) ; may not have address (e.g. IPFS) until after writing file
            dbid              (commit-data/hash->db-id (:hash data-write-result))
            keypair           {:did did, :private private}
@@ -259,15 +265,24 @@
                                                       :flakes     (:flakes stats)
                                                       :size       (:size stats)})
 
+           _ (log/debug "commit!: write-commit start" {:ledger ledger-alias})
+
            {:keys [commit-map commit-jsonld write-result]}
            (<? (write-commit commit-catalog ledger-alias keypair new-commit))
 
+           _ (log/debug "commit!: write-commit done" {:ledger ledger-alias :commit-address (:address write-result)})
+
            db  (formalize-commit staged-db commit-map)
+
+           _ (log/debug "commit!: ledger/update-commit! start" {:ledger ledger-alias :t t})
+
            db* (ledger/update-commit! ledger branch db index-files-ch)]
 
-       (log/debug "Committing t" t "at" time)
+       (log/debug "commit!: ledger/update-commit! done, publish-commit start" {:ledger ledger-alias :t t :at time})
 
        (<? (publish-commit ledger commit-jsonld))
+
+       (log/debug "commit!: publish-commit done" {:ledger ledger-alias})
 
        (if (track/track-txn? opts)
          (let [indexing-disabled? (-> ledger

--- a/src/fluree/db/util/xhttp.cljc
+++ b/src/fluree/db/util/xhttp.cljc
@@ -97,7 +97,7 @@
                         json? (assoc "Content-Type" "application/json")
                         token (assoc "Authorization" (str "Bearer " token)))]
     #?(:clj
-       (async/go
+       (async/thread
          (try
            (let [builder (-> (HttpRequest/newBuilder)
                              (.uri (URI/create url))
@@ -184,7 +184,7 @@
                         headers (merge headers)
                         token   (assoc "Authorization" (str "Bearer " token)))]
     #?(:clj
-       (async/go
+       (async/thread
          (try
            (let [builder (-> (HttpRequest/newBuilder)
                              (.uri (URI/create url))
@@ -258,7 +258,7 @@
          :or {request-timeout 5000}} opts
         response-chan (async/chan)]
     #?(:clj
-       (async/go
+       (async/thread
          (try
            (let [builder (-> (HttpRequest/newBuilder)
                              (.uri (URI/create url))
@@ -306,7 +306,7 @@
          :or {request-timeout 5000}} opts
         response-chan (async/chan)]
     #?(:clj
-       (async/go
+       (async/thread
          (try
            (let [builder (-> (HttpRequest/newBuilder)
                              (.uri (URI/create url))


### PR DESCRIPTION
## Summary
- Replace async/go with async/thread in xhttp.cljc for blocking HTTP operations
- Add debug logging in critical I/O paths for S3 operations
- Prevents blocking I/O from monopolizing limited go thread pool

## Changes
- HTTP operations (post/get/put/delete) now use async/thread instead of async/go
- Added logging in storage, nameservice, and transact operations
- Should improve resource utilization in Lambda/serverless environments