### PR TITLE
Fix/config val parsing

### DIFF
--- a/src/fluree/db/connection/system.cljc
+++ b/src/fluree/db/connection/system.cljc
@@ -151,7 +151,7 @@
   (let [env-var     (get-first-value config-value-node conn-vocab/env-var)
         java-prop   (get-first-value config-value-node conn-vocab/java-prop)
         default-val (get-first-value config-value-node conn-vocab/default-val)]
-    {:value (get-priority-value env-var java-prop default-val)}))
+    {const/iri-value (get-priority-value env-var java-prop default-val)}))
 
 (defmethod ig/init-key :fluree.db/cache
   [_ max-mb]

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -69,7 +69,7 @@
    (deftest load-from-file-test
      (testing "can load a file ledger with single cardinality predicates"
        (with-temp-dir [storage-path {}]
-         (let [conn         @(fluree/connect-file {:storage-path (str storage-path)})
+         (let [conn         @(fluree/connect-file {:storage-path {"defaultVal" (str storage-path)}})
                ledger-alias "load-from-file-test-single-card"
                db0          @(fluree/create conn ledger-alias)
                db           @(fluree/update


### PR DESCRIPTION
When we updated the json-ld library to output actual json-ld, we missed one place where we had hardcoded the `:value` key. This commit changes it to "https://github.com/value" so that all the json-ld utility functions we have can access the value.

This was never encountered because we weren't exercising the `:fluree.db/config-value` initialization path in our tests. I've added a `defaultVal` map as a config value to reproduce the issue and ensure the fix.