### PR TITLE
Fix typo in cache-max-mb property name

### DIFF
--- a/src/fluree/db/connection/vocab.cljc
+++ b/src/fluree/db/connection/vocab.cljc
@@ -89,7 +89,7 @@
   (system-iri "parallelism"))
 
 (def cache-max-mb
-  (system-iri "cachMaxMb"))
+  (system-iri "cacheMaxMb"))
 
 (def commit-storage
   (system-iri "commitStorage"))


### PR DESCRIPTION
## Summary
Fixed typo in system property name: `cachMaxMb` → `cacheMaxMb`

## Changes
- Corrected property name in connection/vocab.cljc