### PR TITLE
Add objectVarParsing option, parser changes, tests

### DIFF
--- a/docs/json_ld_query_syntax.md
+++ b/docs/json_ld_query_syntax.md
@@ -501,6 +501,35 @@ Query execution options.
 - `meta` - Include metadata in results
 - `policy` - Policy restrictions
 - `policy-class` - Policy class restrictions
+- `objectVarParsing` - Controls whether bare object strings that look like variables (e.g., `"?x"`) are parsed as variables in the WHERE clause.
+  - Default: `true`
+  - When `false`, scalar object values like `"?not-a-var"` are treated as string literals. Use the explicit JSON-LD form to bind a variable: `{"@variable": "?v"}`.
+  - This flag does not affect variable parsing for `@id` or predicate keys; those are always treated as variables when they begin with `?`.
+  - Explicit `{"@variable": "?..."}` is always honored regardless of this flag.
+
+### Example: Literal match vs explicit variable
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "opts": {"objectVarParsing": false},
+  "select": ["?s"],
+  "where": [
+    {"@id": "?s", "ex:prop": "?not-a-var"}
+  ]
+}
+```
+
+To bind a variable when the flag is false:
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "opts": {"objectVarParsing": false},
+  "select": ["?v"],
+  "where": [
+    {"@id": "ex:s", "ex:prop": {"@variable": "?v"}}
+  ]
+}
+```
 
 ## Complete Examples
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,0 +1,262 @@
+# Fluree Transactions Guide
+
+## Overview
+
+Fluree supports JSON-LD based transactions for adding, updating, and removing data. This guide explains how to use `insert`, `upsert`, and `update` (and their `!` variants) with clear examples and best practices. It also summarizes common transaction `opts` you can use to control behavior. A short SPARQL Update section is included; for a deeper dive into SPARQL and other Semantic Web standards, see the Semantic Web Developer Guide.
+
+## Staging vs Committing
+
+- Staging APIs return a new staged database value without committing:
+  - `insert`, `upsert`, `update`
+- Committing APIs perform the operation and persist changes in one step:
+  - `insert!`, `upsert!`, `update!`
+
+Use staging when you want to build up a set of changes and commit later. Use the bang variants for a single atomic change.
+
+## JSON-LD Transactions
+
+All operations accept JSON-LD. Keys may be provided in camelCase, kebab-case, or as keywords; they are normalized automatically.
+
+### Insert
+
+Insert adds new nodes. You provide a JSON-LD graph to add.
+
+```clojure
+@(fluree/insert db
+  {"@context" {"ex" "http://example.org/ns/"}
+   "@graph"   [{"@id" "ex:alice"
+                "@type" "ex:User"
+                "ex:name" "Alice"}]})
+```
+
+To commit immediately:
+
+```clojure
+@(fluree/insert! conn ledger-id
+  {"@context" {"ex" "http://example.org/ns/"}
+   "@graph"   [{"@id" "ex:alice" "ex:prop" "?not-a-var"}]})
+```
+
+### Upsert
+
+Upsert updates existing nodes by `@id` or inserts if they do not exist. It is equivalent to a long-form `update` with auto-generated `where`/`delete` for each `insert` triple.
+
+```clojure
+@(fluree/upsert db
+  {"@context" {"ex" "http://example.org/ns/"}
+   "@graph"   [{"@id" "ex:alice"
+                "ex:nums" [4 5 6]
+                "ex:name" "Alice2"}]})
+```
+
+`upsert!` commits atomically.
+
+### Update (long-form)
+
+`update` supports three clauses within one JSON-LD request:
+- `where` – patterns to match
+- `delete` – triples to retract (for matches)
+- `insert` – triples to add (for matches)
+
+```clojure
+@(fluree/update db
+  {"@context" {"ex" "http://example.org/ns/"}
+   "where"   [{"@id" "ex:s" "ex:prop" "?not-a-var"}]
+   "insert"  [{"@id" "ex:s" "ex:newProp" "new"}]})
+```
+
+`update!` commits atomically.
+
+#### Values
+
+Use `values` to provide a table of variable bindings.
+
+```json
+"values": [
+  ["?name", ["Alice", "Bob"]]
+]
+```
+
+## Update with variables (in depth)
+
+Updates are powerful because `where`, `delete`, and `insert` can share variables. Typical workflow:
+1) Match data with `where` and bind variables
+2) Optionally `delete` matched triples (often referencing the same variables)
+3) `insert` new triples that reuse bound variables or constants
+
+### Basic variable flow
+
+Rename a person by binding their current name and replacing it:
+
+```json
+{
+  "@context": {"schema": "http://schema.org/", "ex": "http://example.org/ns/"},
+  "where":   {"@id": "ex:bob", "schema:name": "?name"},
+  "delete":  {"@id": "ex:bob", "schema:name": "?name"},
+  "insert":  {"@id": "ex:bob", "schema:name": "Robert"}
+}
+```
+
+- `?name` is bound in `where`, used in `delete`, and replaced in `insert`.
+
+### Subject/predicate/object variables
+
+You can bind any position:
+- `@id`: `"@id": "?s"`
+- predicate: `"?p": "?o"`
+- object: `"ex:prop": "?val"` (or `{"@variable": "?val"}` when needed)
+
+Example: Move (copy) a value between properties for matched subjects:
+
+```json
+{
+  "@context": {"ex": "http://example.org/ns/"},
+  "where":  {"@id": "?s", "ex:old": "?val"},
+  "insert": {"@id": "?s", "ex:new": "?val"}
+}
+```
+
+### Multi-pattern where
+
+`where` accepts a sequence of node patterns and higher-order patterns (e.g., optional/union). Each pattern can bind more variables that are available to `delete` and `insert`.
+
+```json
+{
+  "@context": {"schema": "http://schema.org/", "ex": "http://example.org/ns/"},
+  "where": [
+    {"@id": "?s", "@type": "ex:User"},
+    {"@id": "?s", "schema:name": "?name"}
+  ],
+  "insert": {"@id": "?s", "ex:seen": true}
+}
+```
+
+### Using VALUES to bind variables
+
+`values` let you supply explicit bindings. Two common shapes are supported.
+
+Matrix form (header row + rows of values):
+
+```json
+{
+  "@context": {"schema": "http://schema.org/", "ex": "http://example.org/ns/"},
+  "values": [["?s", "?p"], ["ex:alice", "schema:age"], ["ex:bob", "schema:age"]],
+  "where":  {"@id": "?s", "?p": "?o"},
+  "delete": {"@id": "?s", "?p": "?o"},
+  "insert": {"@id": "?s", "?p": 23}
+}
+```
+
+Columnar form (per-variable lists):
+
+```json
+{
+  "@context": {"schema": "http://schema.org/", "ex": "http://example.org/ns/"},
+  "values": [["?s", ["ex:alice", "ex:bob"]], ["?p", ["schema:age", "schema:age"]]],
+  "where":  {"@id": "?s", "?p": "?o"},
+  "delete": {"@id": "?s", "?p": "?o"},
+  "insert": {"@id": "?s", "?p": 23}
+}
+```
+
+Notes:
+- All rows (or columns) must align by arity; each binding provides values for all listed variables.
+- You can also bind typed values with JSON-LD value objects (e.g., `{ "@value": "ex:foo", "@type": "@id" }`).
+
+### Explicit variables in object values
+
+When object values might look like variables, use the explicit form to ensure variable binding:
+
+```json
+{
+  "@context": {"ex": "http://example.org/ns/"},
+  "where":  {"@id": "ex:s", "ex:date": {"@variable": "?d"}},
+  "insert": {"@id": "ex:s", "ex:log": {"@variable": "?d"}}
+}
+```
+
+This works regardless of the `objectVarParsing` option.
+
+## Options (opts)
+
+Transaction calls accept an `opts` map (or JSON object) to control behavior. Below are commonly used options.
+
+### Common options
+
+- `identity` / `did`: Identity used for policy evaluation. Typically a DID string.
+- `context`: Override or supplement JSON-LD context resolution at transaction time.
+- `meta`: Attach arbitrary metadata to the transaction. Either `true` (include all) or a map/selection.
+- `message` (commit only): Commit message.
+- `tag` (commit only): Commit tag or label.
+- `author` (commit only): Author identity.
+- `private` (commit only): Marks commit as private (string identifier).
+- `policy-values`: Data made available to policy evaluation.
+- `max-fuel`: Limit on computational resources available to the operation.
+- `format`: For `insert`/`upsert`, can be `:turtle` to accept Turtle input (default is JSON-LD). For `update`, use `{:format :sparql}` to parse SPARQL Update.
+
+Example with commit metadata:
+
+```clojure
+@(fluree/update! conn ledger
+  {"@context" {"ex" "http://example.org/"}
+   "where"   {"@id" "ex:s"}
+   "insert"  {"@id" "ex:s" "ex:status" "active"}}
+  {:message "Activate subject" :tag "release-1" :author "did:example:123"})
+```
+
+Example with identity and policy values:
+
+```clojure
+@(fluree/insert! conn ledger
+  {"@context" {"ex" "http://example.org/"}
+   "@graph"   [{"@id" "ex:s" "ex:role" "user"}]}
+  {:identity "did:key:z6M..." :policy-values {:env "prod"}})
+```
+
+### Object variable parsing (advanced)
+
+Fluree supports an option to control how bare strings that look like variables are parsed in object positions.
+
+- Key: `objectVarParsing` (JSON) or `:object-var-parsing` (Clojure)
+- Behavior:
+  - When `true`: a bare string like `"?x"` is parsed as a variable in object position.
+  - When `false`: a bare string like `"?x"` is treated as a literal string.
+  - Explicit `{"@variable": "?x"}` is always honored as a variable regardless of this flag.
+  - Variable parsing for `@id` and predicate keys is unaffected (keys are always parsed as variables when they begin with `?`).
+- Defaults:
+  - Insert / Upsert: `false`
+  - Update: `true`
+
+Literal string match in WHERE when disabled:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "opts": {"objectVarParsing": false},
+  "select": ["?s"],
+  "where": [
+    {"@id": "?s", "ex:prop": "?not-a-var"}
+  ]
+}
+```
+
+## SPARQL Update (brief)
+
+Fluree supports SPARQL 1.1 Update. You can pass SPARQL strings to `update`/`update!` using `{:format :sparql}`.
+
+```clojure
+@(fluree/update db
+  "PREFIX ex: <http://example.org/>
+   INSERT DATA { ex:alice ex:status \"active\" . }"
+  {:format :sparql})
+```
+
+For a detailed, standards-focused guide (Turtle, SPARQL, SHACL, OWL), see: `docs/semantic_web_guide.md`.
+
+## Best Practices
+
+- Prefer JSON-LD transactions for Fluree-native ergonomics and consistent context handling.
+- Use `insert!`/`upsert!`/`update!` for atomic commits; use staging variants when batching multiple changes.
+- Be explicit with variables when object values can resemble variables; use `{"@variable": "?x"}` or configure `objectVarParsing` when needed.
+- Define `@context` in transactions and queries for readable IRIs.
+- When using Upsert, ensure your `@id` is present to match the intended subject.

--- a/src/fluree/db/constants.cljc
+++ b/src/fluree/db/constants.cljc
@@ -97,6 +97,7 @@
 (def ^:const iri-set "@set")
 (def ^:const iri-filter "@filter")
 (def ^:const iri-t "@t")
+(def ^:const iri-variable "@variable")
 (def ^:const iri-anyURI "http://www.w3.org/2001/XMLSchema#anyURI")
 (def ^:const iri-rdf-type "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
 (def ^:const iri-rdf-first "http://www.w3.org/1999/02/22-rdf-syntax-ns#first")

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -456,10 +456,10 @@
 (defn parse-object-map
   [s-mch p-mch o {:keys [parse-object-vars?] :as var-config} context]
   (let [o* (expand-keys o context)
-        explicit-var (get o "@variable")]
+        explicit-var (get o const/iri-variable)]
     (cond
       explicit-var
-      (let [attrs (-> o (dissoc "@variable") (expand-keys context))
+      (let [attrs (-> o (dissoc const/iri-variable) (expand-keys context))
             var   (parse-var-name explicit-var)
             o-mch (parse-variable-attributes var attrs var-config context)]
         [(flip-reverse-pattern [s-mch p-mch o-mch])])
@@ -843,7 +843,7 @@
         value  (util/get-value v-map)
         type   (util/get-types v-map)
         lang   (util/get-lang v-map)
-        explicit-var (get v-map "@variable")]
+        explicit-var (get v-map const/iri-variable)]
     (cond v-list
           (reduce (fn [triples [i list-item]]
                     (parse-obj-cmp var-config context subj-cmp pred-cmp {:i i} triples list-item))

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -28,6 +28,18 @@
   a variable. Keys and @id variable parsing are unaffected."
   true)
 
+(defn var-parsing-config
+  "If present, bound-vars is a set containing all vars that are bound earlier in query
+  execution. In the `where` clause it is just the vars from the `values` clause. In
+  `insert` and `delete` clauses it also contains vars from the `where` clause.
+
+  If `:parse-object-vars` is false then we will not attempt to parse string literals in
+  the object position as variables, only specifically tagged @variable objects will be
+  parsed as variables."
+  [bound-vars opts]
+  {:bound-vars  (set bound-vars)
+   :parse-object-vars? (get opts :object-var-parsing true)})
+
 (defn parse-var-name
   "Returns x as a symbol if x is a valid variable, or nil otherwise. A valid
   variable is a string, symbol, or keyword whose name starts with '?'."
@@ -40,8 +52,8 @@
   (some-> x parse-var-name where/unmatched-var))
 
 (defn- parse-variable-if-allowed
-  [allowed-vars x]
-  (if (->> x symbol (contains? allowed-vars))
+  [var-config x]
+  (if (contains? (:bound-vars var-config) (symbol x))
     (parse-variable x)
     (throw
      (ex-info (str "variable " x " is not bound in where nor values clause")
@@ -204,16 +216,16 @@
   filter fn.
 
   There can be multiple vars in the filter function which can utilize the
-  original query's 'vars' map, however there should be exactly one var in the
-  filter fn that isn't in that map - which should be the var that will receive
+  original query's 'values' vars, however there should be exactly one 'fresh' var in the
+  filter fn that isn't in that set - which should be the var that will receive
   flake/o."
-  [params vars]
-  (let [non-assigned-vars (set/difference params vars)]
+  [params {:keys [bound-vars] :as _var-config}]
+  (let [non-assigned-vars (set/difference params bound-vars)]
     (case (count non-assigned-vars)
       1 (first non-assigned-vars)
       0 (throw (ex-info (str "Variable filter function has no variable assigned to it, all parameters "
                              "exist in the 'values' clause. Filter function params: " params ". "
-                             "Values assigned in query: " vars ".")
+                             "Values assigned in query: " bound-vars ".")
                         {:status 400
                          :error  :db/invalid-query}))
       (throw (ex-info (str "Vars used in a filter function are not included in the 'values' clause "
@@ -259,12 +271,12 @@
 
 (defn parse-filter-function
   "Evals and returns filter function."
-  [fltr fltr-var vars ctx]
+  [fltr fltr-var var-config ctx]
   (let [code      (parse-code fltr)
         code-vars (or (not-empty (variables code))
                       (throw (ex-info (str "Filter function must contain a valid variable. Provided: " code)
                                       {:status 400 :error :db/invalid-query})))
-        var-name  (find-filtered-var code-vars vars)]
+        var-name  (find-filtered-var code-vars var-config)]
     (if (= var-name fltr-var)
       (eval/compile-filter code var-name ctx)
       (throw (ex-info (str "Variable filter must only reference the variable bound in its value map: "
@@ -315,7 +327,7 @@
       where/->iri-ref))
 
 (defmulti parse-pattern
-  (fn [pattern _vars _context]
+  (fn [pattern _var-config _context]
     (v/where-pattern-type pattern)))
 
 (defn parse-bind-map
@@ -334,18 +346,18 @@
   (and (sequential? pattern) (keyword? (first pattern))))
 
 (defn parse-where-clause
-  [clause vars context]
+  [clause var-config context]
   ;; a single higher-order where pattern is already sequential, so we need to check if it needs wrapping
   (let [clause* (if (higher-order-pattern? clause)
                   [clause]
                   (util/sequential clause))]
     (->> clause*
          (mapcat (fn [pattern]
-                   (parse-pattern pattern vars context)))
+                   (parse-pattern pattern var-config context)))
          where/->where-clause)))
 
 (defn parse-variable-attributes
-  [var attrs vars context]
+  [var attrs var-config context]
   (if (and (contains? attrs const/iri-type)
            (contains? attrs const/iri-language))
     (throw (ex-info "Language tags are not allowed when the data type is specified."
@@ -359,7 +371,7 @@
           lang-matcher (some-> lang where/lang-matcher)
           filter-fn    (some-> attrs
                                (get const/iri-filter)
-                               (parse-filter-function var vars context))
+                               (parse-filter-function var var-config context))
           filters (cond->> [filter-fn]
                     (not (v/variable? t)) (cons t-matcher)
                     (not (v/variable? dt)) (cons dt-matcher)
@@ -442,22 +454,21 @@
     pattern))
 
 (defn parse-object-map
-  [s-mch p-mch o vars context]
+  [s-mch p-mch o {:keys [parse-object-vars?] :as var-config} context]
   (let [o* (expand-keys o context)
         explicit-var (get o "@variable")]
     (cond
       explicit-var
       (let [attrs (-> o (dissoc "@variable") (expand-keys context))
             var   (parse-var-name explicit-var)
-            o-mch (parse-variable-attributes var attrs vars context)]
+            o-mch (parse-variable-attributes var attrs var-config context)]
         [(flip-reverse-pattern [s-mch p-mch o-mch])])
 
       (contains? o* const/iri-value)
       (let [v     (get o* const/iri-value)
             attrs (dissoc o* const/iri-value)
-            o-mch (if (and (parse-var-name v)
-                           *object-var-parsing*)
-                    (parse-variable-attributes (parse-var-name v) attrs vars context)
+            o-mch (if (and parse-object-vars? (parse-var-name v))
+                    (parse-variable-attributes (parse-var-name v) attrs var-config context)
                     (parse-value-attributes v attrs context))]
         [(flip-reverse-pattern [s-mch p-mch o-mch])])
 
@@ -470,21 +481,21 @@
         ;; return a thunk wrapping the recursive call to preserve stack
         ;; space by delaying execution
         #(into [(flip-reverse-pattern [s-mch p-mch o-mch])]
-               (parse-statements o-mch o-attrs vars context))))))
+               (parse-statements o-mch o-attrs var-config context))))))
 
 (defn parse-statement*
-  [s-mch p-mch o vars context]
+  [s-mch p-mch o var-config context]
   (cond
-    (and (v/query-variable? o) *object-var-parsing*)
+    (v/query-variable? o var-config)
     (let [o-mch (parse-variable o)]
       [(flip-reverse-pattern [s-mch p-mch o-mch])])
 
     (map? o)
-    (parse-object-map s-mch p-mch o vars context)
+    (parse-object-map s-mch p-mch o var-config context)
 
     (sequential? o)
     #(mapcat (fn [o*]
-               (parse-statement s-mch p-mch o* vars context))
+               (parse-statement s-mch p-mch o* var-config context))
              o)
 
     (type-pred-match? p-mch)
@@ -496,43 +507,43 @@
       [(flip-reverse-pattern [s-mch p-mch o-mch])])))
 
 (defn parse-statement
-  [s-mch p-mch o vars context]
-  (trampoline parse-statement* s-mch p-mch o vars context))
+  [s-mch p-mch o var-config context]
+  (trampoline parse-statement* s-mch p-mch o var-config context))
 
 (defn parse-statements*
-  [s-mch attrs vars context]
+  [s-mch attrs var-config context]
   #(mapcat (fn [[p o]]
              (let [p-mch (parse-predicate p context)]
-               (parse-statement s-mch p-mch o vars context)))
+               (parse-statement s-mch p-mch o var-config context)))
            attrs))
 
 (defn parse-statements
-  [s-mch attrs vars context]
-  (trampoline parse-statements* s-mch attrs vars context))
+  [s-mch attrs var-config context]
+  (trampoline parse-statements* s-mch attrs var-config context))
 
 (defn parse-id-map-pattern
-  [m vars context]
+  [m var-config context]
   (let [s-mch (-> m
                   (get const/iri-id)
                   (parse-subject context))
         attrs (dissoc m const/iri-id)]
     (if (empty? attrs)
       [(where/->pattern :id s-mch)]
-      (let [statements (parse-statements s-mch attrs vars context)]
+      (let [statements (parse-statements s-mch attrs var-config context)]
         (sort optimize/compare-triples statements)))))
 
 (defn parse-node-map
-  [m vars context]
+  [m var-config context]
   (-> m
       (with-id context)
-      (parse-id-map-pattern vars context)))
+      (parse-id-map-pattern var-config context)))
 
 (defmethod parse-pattern :node
-  [m vars context]
-  (parse-node-map m vars context))
+  [m var-config context]
+  (parse-node-map m var-config context))
 
 (defmethod parse-pattern :filter
-  [[_ & codes] _vars context]
+  [[_ & codes] _var-config context]
   (let [f (->> codes
                (map parse-code)
                (map (fn [code] (comp (fn [tv] (:value tv))
@@ -541,39 +552,39 @@
     [(where/->pattern :filter (with-meta f {:fns codes}))]))
 
 (defmethod parse-pattern :union
-  [[_ & unions] vars context]
-  (let [parsed (mapv (fn [clause] (parse-where-clause clause vars context))
+  [[_ & unions] var-config context]
+  (let [parsed (mapv (fn [clause] (parse-where-clause clause var-config context))
                      unions)]
     [(where/->pattern :union parsed)]))
 
 (defmethod parse-pattern :optional
-  [[_ & optionals] vars context]
+  [[_ & optionals] var-config context]
   (into []
-        (comp (map (fn [clause] (parse-where-clause clause vars context)))
+        (comp (map (fn [clause] (parse-where-clause clause var-config context)))
               (map (partial where/->pattern :optional)))
         optionals))
 
 (defmethod parse-pattern :bind
-  [[_ & binds] _vars context]
+  [[_ & binds] _var-config context]
   (let [parsed (parse-bind-map binds context)]
     [(where/->pattern :bind parsed)]))
 
 (defmethod parse-pattern :values
-  [[_ values] _vars context]
+  [[_ values] _var-config context]
   (let [[_vars solutions] (parse-values values context)]
     [(where/->pattern :values solutions)]))
 
 (defmethod parse-pattern :exists
-  [[_ patterns] vars context]
-  [(where/->pattern :exists (parse-where-clause patterns vars context))])
+  [[_ patterns] var-config context]
+  [(where/->pattern :exists (parse-where-clause patterns var-config context))])
 
 (defmethod parse-pattern :not-exists
-  [[_ patterns] vars context]
-  [(where/->pattern :not-exists (parse-where-clause patterns vars context))])
+  [[_ patterns] var-config context]
+  [(where/->pattern :not-exists (parse-where-clause patterns var-config context))])
 
 (defmethod parse-pattern :minus
-  [[_ patterns] vars context]
-  [(where/->pattern :minus (parse-where-clause patterns vars context))])
+  [[_ patterns] var-config context]
+  [(where/->pattern :minus (parse-where-clause patterns var-config context))])
 
 ;; TODO: This function is only necessary because ledger aliases might not be
 ;; valid IRIs but virtual graph aliases are. We should require that all ledger
@@ -587,18 +598,18 @@
         graph))))
 
 (defmethod parse-pattern :graph
-  [[_ graph where] vars context]
+  [[_ graph where] var-config context]
   (let [graph* (or (parse-variable graph)
                    (parse-graph-string graph context))
-        where* (parse-where-clause where vars context)]
+        where* (parse-where-clause where var-config context)]
     [(where/->pattern :graph [graph* where*])]))
 
 (defn parse-where
-  [where vars context]
+  [where var-config context]
   (when where
     (-> where
         syntax/coerce-where
-        (parse-where-clause vars context))))
+        (parse-where-clause var-config context))))
 
 (defn unwrap-tuple-patterns
   "Construct accepts ::v/node-map patterns, which can produce :tuple patterns, :class
@@ -618,7 +629,7 @@
   (when-let [construct (:construct q)]
     (-> construct
         syntax/coerce-where
-        (parse-where-clause nil context)
+        (parse-where-clause (var-parsing-config nil (:opts q)) context)
         unwrap-tuple-patterns
         select/construct-selector)))
 
@@ -778,41 +789,35 @@
       (get m (keyword nme))
       (get m (symbol nme))))
 
-(defn object-var-parsing
-  "Return :object-var-parsing from opts if present; otherwise nil."
-  [opts]
-  (if (contains? opts :object-var-parsing)
-    (:object-var-parsing opts)
-    true))
-
 (defn parse-query*
   ([q] (parse-query* q nil))
   ([q parent-context]
-   (binding [*object-var-parsing* (object-var-parsing (:opts q))]
-     (let [orig-context  (:context q)
-           context       (cond->> (json-ld/parse-context orig-context)
-                           parent-context (merge parent-context))
-           [vars values] (parse-values (:values q) context)
-           where         (parse-where (:where q) vars context)
-           construct     (parse-construct q context)
-           grouping      (parse-grouping q)
-           ordering      (parse-ordering q)]
-       (-> q
-           (assoc :context context
-                  :where where)
-           (cond-> (seq values) (assoc :values values)
-                   orig-context (assoc :orig-context orig-context)
-                   grouping  (assoc :group-by grouping)
-                   ordering  (assoc :order-by ordering)
-                   construct (assoc :construct construct))
-           (parse-having context)
-           (parse-select context)
-           parse-fuel)))))
+   (let [orig-context  (:context q)
+         context       (cond->> (json-ld/parse-context orig-context)
+                         parent-context (merge parent-context))
+         [vars values] (parse-values (:values q) context)
+         var-config    (var-parsing-config vars (:opts q))
+         where         (parse-where (:where q) var-config context)
+         construct     (parse-construct q context)
+         grouping      (parse-grouping q)
+         ordering      (parse-ordering q)]
+     (-> q
+         (assoc :context context
+                :where where)
+         (cond-> (seq values) (assoc :values values)
+                 orig-context (assoc :orig-context orig-context)
+                 grouping  (assoc :group-by grouping)
+                 ordering  (assoc :order-by ordering)
+                 construct (assoc :construct construct))
+         (parse-having context)
+         (parse-select context)
+         parse-fuel))))
 
 (defmethod parse-pattern :query
-  [[_ sub-query] _vars context]
+  [[_ sub-query] var-config context]
   (let [sub-query* (-> sub-query
                        syntax/coerce-subquery
+                       (update :opts merge {:object-var-parsing (:parse-object-vars? var-config)})
                        (parse-query* context))]
     [(where/->pattern :query sub-query*)]))
 
@@ -832,7 +837,7 @@
           (where/match-meta metadata)))))
 
 (defn parse-obj-cmp
-  [allowed-vars context subj-cmp pred-cmp m triples v-map]
+  [var-config context subj-cmp pred-cmp m triples v-map]
   (let [id     (util/get-id v-map)
         v-list (util/get-list v-map)
         value  (util/get-value v-map)
@@ -841,7 +846,7 @@
         explicit-var (get v-map "@variable")]
     (cond v-list
           (reduce (fn [triples [i list-item]]
-                    (parse-obj-cmp allowed-vars context subj-cmp pred-cmp {:i i} triples list-item))
+                    (parse-obj-cmp var-config context subj-cmp pred-cmp {:i i} triples list-item))
                   triples
                   (map vector (range) v-list))
 
@@ -850,7 +855,7 @@
                              (map? explicit-var) (util/get-value explicit-var)
                              (sequential? explicit-var) (-> explicit-var first util/get-value)
                              :else explicit-var)
-                var-mch    (parse-variable-if-allowed allowed-vars var-val)
+                var-mch    (parse-variable-if-allowed var-config var-val)
                 dt         (if (sequential? type) (first type) type)
                 dt-matcher (some-> dt (where/datatype-matcher context))
                 lang-mch   (some-> lang where/lang-matcher)
@@ -862,16 +867,15 @@
           (some? value)
           (let [m*      (cond-> m
                           lang (assoc :lang lang))
-                obj-cmp (if (and (v/variable? value)
-                                 *object-var-parsing*)
-                          (parse-variable-if-allowed allowed-vars value)
+                obj-cmp (if (v/variable? value var-config)
+                          (parse-variable-if-allowed var-config value)
                           (parse-object-value value type context m*))]
             (conj triples [subj-cmp pred-cmp obj-cmp]))
 
           ;; ref object
           :else
-          (let [ref-obj (if (v/variable? id)
-                          (parse-variable-if-allowed allowed-vars id)
+          (let [ref-obj (if (v/variable? id var-config)
+                          (parse-variable-if-allowed var-config id)
                           (where/match-iri
                            (if (nil? id)
                              (iri/new-blank-node-id)
@@ -883,15 +887,15 @@
                           ;; project newly created bnode-id into v-map
                           (assoc v-map const/iri-id (where/get-iri ref-cmp))
                           v-map)]
-            (conj (parse-subj-cmp allowed-vars context triples v-map*)
+            (conj (parse-subj-cmp var-config context triples v-map*)
                   [subj-cmp pred-cmp ref-cmp])))))
 
 (defn parse-pred-cmp
-  [allowed-vars context subj-cmp triples [pred values]]
+  [var-config context subj-cmp triples [pred values]]
   (cond
     (v/variable? pred)
-    (let [pred-cmp (parse-variable-if-allowed allowed-vars pred)]
-      (reduce (partial parse-obj-cmp allowed-vars context subj-cmp pred-cmp nil)
+    (let [pred-cmp (parse-variable-if-allowed var-config pred)]
+      (reduce (partial parse-obj-cmp var-config context subj-cmp pred-cmp nil)
               triples
               values))
 
@@ -904,23 +908,23 @@
     (let [values*  (map (fn [typ] {const/iri-id typ})
                         values)
           pred-cmp (where/match-iri const/iri-rdf-type)]
-      (reduce (partial parse-obj-cmp allowed-vars context subj-cmp pred-cmp nil)
+      (reduce (partial parse-obj-cmp var-config context subj-cmp pred-cmp nil)
               triples
               values*))
 
     :else
     (let [pred-cmp (where/match-iri pred)]
-      (reduce (partial parse-obj-cmp allowed-vars context subj-cmp pred-cmp nil)
+      (reduce (partial parse-obj-cmp var-config context subj-cmp pred-cmp nil)
               triples
               values))))
 
 (defn parse-subj-cmp
-  [allowed-vars context triples node]
+  [var-config context triples node]
   (let [id       (util/get-id node)
-        subj-cmp (cond (v/variable? id) (parse-variable-if-allowed allowed-vars id)
+        subj-cmp (cond (v/variable? id) (parse-variable-if-allowed var-config id)
                        (nil? id)        (where/match-iri (iri/new-blank-node-id))
                        :else            (where/match-iri id))]
-    (reduce (partial parse-pred-cmp allowed-vars context subj-cmp)
+    (reduce (partial parse-pred-cmp var-config context subj-cmp)
             triples
             (->> (dissoc node const/iri-id)
                  ;; deterministic patterns for each pred
@@ -928,9 +932,9 @@
 
 (defn parse-triples
   "Flattens and parses expanded json-ld into update triples."
-  [expanded allowed-vars context]
+  [expanded var-config context]
   (try*
-    (reduce (partial parse-subj-cmp allowed-vars context)
+    (reduce (partial parse-subj-cmp var-config context)
             [] expanded)
     (catch* e
       (throw (ex-info (str "Parsing failure due to: " (ex-message e)
@@ -952,46 +956,47 @@
    will be expanded using the context inside the txn merged with the
    provided parsed-context, if not nil.
 
-   If bound-vars is non-nil, it will replace any variables in the document
-   assuming it is a valid variable placement, otherwise it will throw."
-  [jld bound-vars parsed-context]
+   Variable parsing is constrained by the var config allows (see `var-parsing-config`)."
+  [jld var-config parsed-context]
   (-> jld
       (json-ld/expand parsed-context)
       util/get-graph
       util/sequential
-      (parse-triples bound-vars parsed-context)))
+      (parse-triples var-config parsed-context)))
 
 (defn parse-update-txn
   ([txn]
    (parse-update-txn txn {}))
   ([txn override-opts]
-   (binding [*object-var-parsing* (object-var-parsing override-opts)]
-     (let [context       (or (ctx-util/txn-context txn)
-                             (:context override-opts))
-           [vars values] (-> (get-named txn "values")
-                             (parse-values context))
-           where         (-> (get-named txn "where")
-                             (parse-where vars context))
-           bound-vars    (-> where where/clause-variables (into vars))
-           delete        (when-let [dlt (get-named txn "delete")]
-                           (jld->parsed-triples dlt bound-vars context))
-           insert        (when-let [ins (get-named txn "insert")]
-                           (jld->parsed-triples ins bound-vars context))
-           annotation    (util/get-first-value txn const/iri-annotation)
-           opts          (-> (get-named txn "opts")
-                             (parse-txn-opts override-opts context))
-           ledger-id     (get-named txn "ledger")]
-       (when (and (empty? insert) (empty? delete))
-         (throw (ex-info "Invalid transaction, insert or delete clause must contain nodes with objects."
-                         {:status 400 :error :db/invalid-transaction})))
-       (cond-> {:opts opts}
-         ledger-id    (assoc :ledger-id ledger-id)
-         context      (assoc :context context)
-         where        (assoc :where where)
-         annotation   (assoc :annotation annotation)
-         (seq values) (assoc :values values)
-         (seq delete) (assoc :delete delete)
-         (seq insert) (assoc :insert insert))))))
+   (let [context       (or (ctx-util/txn-context txn)
+                           (:context override-opts))
+         [vars values] (-> (get-named txn "values")
+                           (parse-values context))
+         var-config    (var-parsing-config vars override-opts)
+         where         (-> (get-named txn "where")
+                           (parse-where var-config context))
+         var-config*   (cond-> (update var-config :bound-vars into (where/clause-variables where))
+                         ;; don't attempt variable parsing if there are no unified vars
+                         (not (or where vars))  (assoc :parse-object-vars? false))
+         delete        (when-let [dlt (get-named txn "delete")]
+                         (jld->parsed-triples dlt var-config* context))
+         insert        (when-let [ins (get-named txn "insert")]
+                         (jld->parsed-triples ins var-config* context))
+         annotation    (util/get-first-value txn const/iri-annotation)
+         opts          (-> (get-named txn "opts")
+                           (parse-txn-opts override-opts context))
+         ledger-id     (get-named txn "ledger")]
+     (when (and (empty? insert) (empty? delete))
+       (throw (ex-info "Invalid transaction, insert or delete clause must contain nodes with objects."
+                       {:status 400 :error :db/invalid-transaction})))
+     (cond-> {:opts opts}
+       ledger-id    (assoc :ledger-id ledger-id)
+       context      (assoc :context context)
+       where        (assoc :where where)
+       annotation   (assoc :annotation annotation)
+       (seq values) (assoc :values values)
+       (seq delete) (assoc :delete delete)
+       (seq insert) (assoc :insert insert)))))
 
 (defn blank-node-subject?
   [parsed-triple]
@@ -1039,11 +1044,12 @@
         context    (when-not turtle?
                      (or (ctx-util/txn-context txn)
                          context))
-        opts       (parse-txn-opts nil opts context)
+        opts       (-> (parse-txn-opts nil opts context)
+                       (assoc :object-var-parsing false))
+        var-config (var-parsing-config nil opts)
         parsed-txn (if turtle?
                      (turtle/parse txn)
-                     (binding [*object-var-parsing* false]
-                       (jld->parsed-triples txn nil context)))
+                     (jld->parsed-triples txn var-config context))
         {:keys [where delete]} (upsert-where-del parsed-txn)]
     {:opts    opts
      :context context
@@ -1055,8 +1061,7 @@
   [txn {:keys [format context] :as opts}]
   {:insert (if (= :turtle format)
              (turtle/parse txn)
-             (binding [*object-var-parsing* false]
-               (jld->parsed-triples txn nil context)))
+             (jld->parsed-triples txn (var-parsing-config nil (assoc opts :object-var-parsing false)) context))
    :context context
    :opts opts})
 

--- a/src/fluree/db/query/fql/syntax.cljc
+++ b/src/fluree/db/query/fql/syntax.cljc
@@ -136,7 +136,8 @@
                          [:pretty-print {:optional true} ::pretty-print]
                          [:did {:optional true} ::identity]
                          [:default-allow? {:optional true} ::default-allow?]
-                         [:parse-json {:optional true} ::parse-json]]
+                         [:parse-json {:optional true} ::parse-json]
+                         [:object-var-parsing {:optional true} :boolean]]
     ::stage-opts        [:map
                          [:meta {:optional true} ::meta]
                          [:max-fuel {:optional true} ::max-fuel]
@@ -146,7 +147,8 @@
                          [:context {:optional true} ::context]
                          [:raw-txn {:optional true} :any]
                          [:author {:optional true} ::identity]
-                         [:policy-values {:optional true} :any]]
+                         [:policy-values {:optional true} :any]
+                         [:object-var-parsing {:optional true} :boolean]]
     ::commit-opts       [:map
                          [:meta {:optional true} ::meta]
                          [:identity {:optional true} ::identity]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -22,7 +22,10 @@
 (defn variable?
   [x]
   (and (or (string? x) (symbol? x) (keyword? x))
-       (-> x name first (= \?))))
+       (-> x name first (= \?))
+       (if (string? x)
+         (re-matches #"^\?\S+$" x)
+         true)))
 
 (defn bnode-variable?
   [x]

--- a/src/fluree/db/validation.cljc
+++ b/src/fluree/db/validation.cljc
@@ -20,12 +20,16 @@
     v))
 
 (defn variable?
-  [x]
-  (and (or (string? x) (symbol? x) (keyword? x))
-       (-> x name first (= \?))
-       (if (string? x)
-         (re-matches #"^\?\S+$" x)
-         true)))
+  ([x]
+   (and (or (string? x) (symbol? x) (keyword? x))
+        (-> x name first (= \?))
+        (if (string? x)
+          (re-matches #"^\?\S+$" x)
+          true)))
+  ([x {:keys [parse-object-vars?] :as _var-config}]
+   (if parse-object-vars?
+     (variable? x)
+     false)))
 
 (defn bnode-variable?
   [x]
@@ -33,9 +37,12 @@
        (->> x name (take 2) (= [\_ \:]))))
 
 (defn query-variable?
-  [x]
-  (or (variable? x)
-      (bnode-variable? x)))
+  ([x]
+   (or (variable? x)
+       (bnode-variable? x)))
+  ([x var-config]
+   (or (variable? x var-config)
+       (bnode-variable? x))))
 
 (defn property-path?
   [x]

--- a/test/fluree/db/transact/object_var_parsing_test.clj
+++ b/test/fluree/db/transact/object_var_parsing_test.clj
@@ -88,12 +88,12 @@
 
 (deftest ^:integration insert-literal-qmark-string-has-xsd-string-type
   (testing "insert! with bare '?not-a-var' stores as xsd:string and value '?not-a-var'"
-    (let [conn   (test-utils/create-conn)
-          db0 @(fluree/create conn "tx/obj-var-insert")
-          db1 @(fluree/insert! conn "tx/obj-var-insert"
-                               {"@context" {"ex" "http://example.org/ns/"}
-                                "@graph"   [{"@id" "ex:s"
-                                             "ex:prop" "?not-a-var"}]})
+    (let [conn  (test-utils/create-conn)
+          _db0 @(fluree/create conn "tx/obj-var-insert")
+          db1  @(fluree/insert! conn "tx/obj-var-insert"
+                                {"@context" {"ex" "http://example.org/ns/"}
+                                 "@graph"   [{"@id" "ex:s"
+                                              "ex:prop" "?not-a-var"}]})
           results @(fluree/query db1
                                  {"@context" {"ex" "http://example.org/ns/"
                                               "xsd" "http://www.w3.org/2001/XMLSchema#"}
@@ -107,8 +107,8 @@
 
 (deftest ^:integration upsert-literal-qmark-string-has-xsd-string-type
   (testing "upsert! with bare '?not-a-var' stores as xsd:string and value '?not-a-var'"
-    (let [conn   (test-utils/create-conn)
-          db0 @(fluree/create conn "tx/obj-var-upsert")
+    (let [conn  (test-utils/create-conn)
+          _db0 @(fluree/create conn "tx/obj-var-upsert")
           _dbi @(fluree/insert! conn "tx/obj-var-upsert"
                                 {"@context" {"ex" "http://example.org/ns/"}
                                  "@graph"   [{"@id" "ex:s"
@@ -130,12 +130,12 @@
 
 (deftest query-literal-qmark-string-with-flag-false-requires-literal-match
   (testing "With objectVarParsing false, where with bare '?not-a-var' matches literal value"
-    (let [conn   (test-utils/create-conn)
-          db0 @(fluree/create conn "tx/obj-var-query-literal")
-          db1 @(fluree/insert! conn "tx/obj-var-query-literal"
-                               {"@context" {"ex" "http://example.org/ns/"}
-                                "@graph"   [{"@id" "ex:s"
-                                             "ex:prop" "?not-a-var"}]})
+    (let [conn  (test-utils/create-conn)
+          _db0 @(fluree/create conn "tx/obj-var-query-literal")
+          db1  @(fluree/insert! conn "tx/obj-var-query-literal"
+                                {"@context" {"ex" "http://example.org/ns/"}
+                                 "@graph"   [{"@id" "ex:s"
+                                              "ex:prop" "?not-a-var"}]})
           results @(fluree/query db1
                                  {"@context" {"ex" "http://example.org/ns/"}
                                   "opts"     {"objectVarParsing" false}
@@ -148,12 +148,12 @@
 
 (deftest query-explicit-variable-in-where-still-parses-when-flag-false
   (testing "With objectVarParsing false, where with {'@variable': '?v'} binds a variable"
-    (let [conn   (test-utils/create-conn)
-          db0 @(fluree/create conn "tx/obj-var-query-var")
-          db1 @(fluree/insert! conn "tx/obj-var-query-var"
-                               {"@context" {"ex" "http://example.org/ns/"}
-                                "@graph"   [{"@id" "ex:s"
-                                             "ex:prop" "?not-a-var"}]})
+    (let [conn  (test-utils/create-conn)
+          _db0 @(fluree/create conn "tx/obj-var-query-var")
+          db1  @(fluree/insert! conn "tx/obj-var-query-var"
+                                {"@context" {"ex" "http://example.org/ns/"}
+                                 "@graph"   [{"@id" "ex:s"
+                                              "ex:prop" "?not-a-var"}]})
           results @(fluree/query db1
                                  {"@context" {"ex" "http://example.org/ns/"}
                                   "opts"     {"objectVarParsing" false}
@@ -166,7 +166,7 @@
 
 (deftest ^:integration update-literal-qmark-string-where-binds-and-updates
   (testing "update! with objectVarParsing false matches literal '?not-a-var' in where, binds subject, and adds new property"
-    (let [conn   (test-utils/create-conn)
+    (let [conn  (test-utils/create-conn)
           _db0 @(fluree/create conn "tx/obj-var-update")
           _dbi @(fluree/insert! conn "tx/obj-var-update"
                                 {"@context" {"ex" "http://example.org/ns/"}

--- a/test/fluree/db/transact/object_var_parsing_test.clj
+++ b/test/fluree/db/transact/object_var_parsing_test.clj
@@ -52,7 +52,7 @@
                            "schema:date" {"@variable" "?d"}}]
                "insert"  [{"@id" "ex:s"
                            "schema:foo" {"@variable" "?d"
-                                          "@type" "xsd:dateTime"}}]}
+                                         "@type" "xsd:dateTime"}}]}
           {:keys [insert]} (parse/parse-update-txn txn {:object-var-parsing false})
           [_ _ o] (first insert)]
       (is (= '?d (where/get-variable o))

--- a/test/fluree/db/transact/object_var_parsing_test.clj
+++ b/test/fluree/db/transact/object_var_parsing_test.clj
@@ -1,0 +1,190 @@
+(ns fluree.db.transact.object-var-parsing-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.api :as fluree]
+            [fluree.db.query.exec.where :as where]
+            [fluree.db.query.fql.parse :as parse]
+            [fluree.db.test-utils :as test-utils]))
+
+(def ctx {"ex" "http://example.org/ns/"
+          "schema" "http://schema.org/"
+          "xsd" "http://www.w3.org/2001/XMLSchema#"})
+
+(deftest insert-does-not-parse-bare-var-by-default
+  (testing "Bare object '?age' in insert remains a string literal"
+    (let [txn {"@context" ctx
+               "@graph"   [{"@id" "ex:s"
+                            "schema:text" "?age"}]}
+          {:keys [insert]} (parse/parse-insert-txn txn {:context (parse/parse-txn-opts nil nil nil)})
+          [_ _ o] (first insert)]
+      (is (nil? (where/get-variable o))
+          "Should not parse bare '?age' as a variable in insert")
+      (is (true? (where/matched-value? o))
+          "Insert object should be a matched value")
+      (is (= "?age" (where/get-value o))
+          "Literal should equal '?age'"))))
+
+(deftest update-bare-var-default-throws-when-unbound
+  (testing "Bare object '?age' in update without binding should throw by default"
+    (let [txn {"@context" ctx
+               "insert"  [{"@id" "ex:s"
+                           "schema:text" "?age"}]}]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"variable \?age is not bound"
+           (parse/parse-update-txn txn {}))))))
+
+(deftest update-with-object-var-parsing-false-treats-bare-var-as-literal
+  (testing "With objectVarParsing false, bare object '?not-a-var' in update insert is literal"
+    (let [txn {"@context" ctx
+               "insert"  [{"@id" "ex:s"
+                           "schema:text" "?not-a-var"}]}
+          {:keys [insert]} (parse/parse-update-txn txn {:object-var-parsing false})
+          [_ _ o] (first insert)]
+      (is (nil? (where/get-variable o))
+          "Should not parse '?not-a-var' as variable under flag=false")
+      (is (= "?not-a-var" (where/get-value o))
+          "Literal should equal '?not-a-var'"))))
+
+(deftest update-explicit-variable-map-parses-when-flag-false-and-bound
+  (testing "Explicit {'@variable': '?d'} parses as variable when flag=false and bound in where"
+    (let [txn {"@context" ctx
+               "where"   [{"@id" "ex:s"
+                           "schema:date" {"@variable" "?d"}}]
+               "insert"  [{"@id" "ex:s"
+                           "schema:foo" {"@variable" "?d"
+                                          "@type" "xsd:dateTime"}}]}
+          {:keys [insert]} (parse/parse-update-txn txn {:object-var-parsing false})
+          [_ _ o] (first insert)]
+      (is (= '?d (where/get-variable o))
+          "Should parse explicit @variable as the same bound var"))))
+
+(deftest update-id-var-still-parses-when-flag-false
+  (testing "@id as '?is-a-var' remains a variable, object '?not-a-var' becomes literal when objectVarParsing is false"
+    (let [txn {"@context" ctx
+               "where"   [{"@id" "?is-a-var"
+                           "schema:text" "?not-a-var"}]
+               "insert"  [{"@id" "?is-a-var"
+                           "schema:text" "?not-a-var"}]}
+          {:keys [insert]} (parse/parse-update-txn txn {:object-var-parsing false})
+          [s _ o] (first insert)]
+      (is (= '?is-a-var (where/get-variable s))
+          "Subject should be variable ?is-a-var")
+      (is (= "?not-a-var" (where/get-value o))
+          "Object should be literal string '?not-a-var'"))))
+
+(deftest update-predicate-var-still-parses-when-flag-false
+  (testing "Predicate '?is-a-var' remains a variable, object '?not-a-var' becomes literal when objectVarParsing is false"
+    (let [txn {"@context" ctx
+               "where"   [{"@id" "ex:s"
+                           "?is-a-var" "?not-a-var"}]
+               "insert"  [{"@id" "ex:s"
+                           "?is-a-var" "?not-a-var"}]}
+          {:keys [insert]} (parse/parse-update-txn txn {:object-var-parsing false})
+          [_ p o] (first insert)]
+      (is (= '?is-a-var (where/get-variable p))
+          "Predicate should be variable ?is-a-var")
+      (is (= "?not-a-var" (where/get-value o))
+          "Object should be literal string '?not-a-var'"))))
+
+(deftest ^:integration insert-literal-qmark-string-has-xsd-string-type
+  (testing "insert! with bare '?not-a-var' stores as xsd:string and value '?not-a-var'"
+    (let [conn   (test-utils/create-conn)
+          db0 @(fluree/create conn "tx/obj-var-insert")
+          db1 @(fluree/insert! conn "tx/obj-var-insert"
+                               {"@context" {"ex" "http://example.org/ns/"}
+                                "@graph"   [{"@id" "ex:s"
+                                             "ex:prop" "?not-a-var"}]})
+          results @(fluree/query db1
+                                 {"@context" {"ex" "http://example.org/ns/"
+                                              "xsd" "http://www.w3.org/2001/XMLSchema#"}
+                                  "select"   ["?val" "?dt"]
+                                  "where"    [{"@id" "ex:s"
+                                               "ex:prop" {"@value" "?val"
+                                                          "@type" "?dt"}}]})]
+      (is (= [["?not-a-var" "xsd:string"]]
+             results)
+          "Inserted bare '?not-a-var' should be value '?not-a-var' with xsd:string"))))
+
+(deftest ^:integration upsert-literal-qmark-string-has-xsd-string-type
+  (testing "upsert! with bare '?not-a-var' stores as xsd:string and value '?not-a-var'"
+    (let [conn   (test-utils/create-conn)
+          db0 @(fluree/create conn "tx/obj-var-upsert")
+          _dbi @(fluree/insert! conn "tx/obj-var-upsert"
+                                {"@context" {"ex" "http://example.org/ns/"}
+                                 "@graph"   [{"@id" "ex:s"
+                                              "ex:prop" "String val to be replaced"}]})
+          db1 @(fluree/upsert! conn "tx/obj-var-upsert"
+                               {"@context" {"ex" "http://example.org/ns/"}
+                                "@graph"   [{"@id" "ex:s"
+                                             "ex:prop" "?not-a-var"}]})
+          results @(fluree/query db1
+                                 {"@context" {"ex" "http://example.org/ns/"
+                                              "xsd" "http://www.w3.org/2001/XMLSchema#"}
+                                  "select"   ["?val" "?dt"]
+                                  "where"    [{"@id" "ex:s"
+                                               "ex:prop" {"@value" "?val"
+                                                          "@type" "?dt"}}]})]
+      (is (= [["?not-a-var" "xsd:string"]]
+             results)
+          "Upserted bare '?not-a-var' should be value '?not-a-var' with xsd:string"))))
+
+(deftest query-literal-qmark-string-with-flag-false-requires-literal-match
+  (testing "With objectVarParsing false, where with bare '?not-a-var' matches literal value"
+    (let [conn   (test-utils/create-conn)
+          db0 @(fluree/create conn "tx/obj-var-query-literal")
+          db1 @(fluree/insert! conn "tx/obj-var-query-literal"
+                               {"@context" {"ex" "http://example.org/ns/"}
+                                "@graph"   [{"@id" "ex:s"
+                                             "ex:prop" "?not-a-var"}]})
+          results @(fluree/query db1
+                                 {"@context" {"ex" "http://example.org/ns/"}
+                                  "opts"     {"objectVarParsing" false}
+                                  "select"   ["?s"]
+                                  "where"    [{"@id" "?s"
+                                               "ex:prop" "?not-a-var"}]})]
+      (is (= [["ex:s"]]
+             results)
+          "Where should treat '?not-a-var' as a literal and match the record"))))
+
+(deftest query-explicit-variable-in-where-still-parses-when-flag-false
+  (testing "With objectVarParsing false, where with {'@variable': '?v'} binds a variable"
+    (let [conn   (test-utils/create-conn)
+          db0 @(fluree/create conn "tx/obj-var-query-var")
+          db1 @(fluree/insert! conn "tx/obj-var-query-var"
+                               {"@context" {"ex" "http://example.org/ns/"}
+                                "@graph"   [{"@id" "ex:s"
+                                             "ex:prop" "?not-a-var"}]})
+          results @(fluree/query db1
+                                 {"@context" {"ex" "http://example.org/ns/"}
+                                  "opts"     {"objectVarParsing" false}
+                                  "select"   ["?v"]
+                                  "where"    [{"@id" "ex:s"
+                                               "ex:prop" {"@variable" "?v"}}]})]
+      (is (= [["?not-a-var"]]
+             results)
+          "Explicit @variable should bind and return the literal value"))))
+
+(deftest ^:integration update-literal-qmark-string-where-binds-and-updates
+  (testing "update! with objectVarParsing false matches literal '?not-a-var' in where, binds subject, and adds new property"
+    (let [conn   (test-utils/create-conn)
+          _db0 @(fluree/create conn "tx/obj-var-update")
+          _dbi @(fluree/insert! conn "tx/obj-var-update"
+                                {"@context" {"ex" "http://example.org/ns/"}
+                                 "@graph"   [{"@id" "ex:s"
+                                              "ex:prop" "?not-a-var"}]})
+          db2  @(fluree/update! conn "tx/obj-var-update"
+                                {"@context" {"ex" "http://example.org/ns/"}
+                                 "where"   [{"@id" "?s"
+                                             "ex:prop" "?not-a-var"}]
+                                 "insert"  [{"@id" "?s"
+                                             "ex:newProp" "new"}]}
+                                {:object-var-parsing false})
+          results @(fluree/query db2
+                                 {"@context" {"ex" "http://example.org/ns/"}
+                                  "select"   {"ex:s" ["*"]}
+                                  "where"    [{"@id" "ex:s"}]})]
+      (is (= [{"@id" "ex:s"
+               "ex:prop" "?not-a-var"
+               "ex:newProp" "new"}]
+             results)
+          "Subject should retain literal ex:prop and include new ex:newProp"))))

--- a/test/fluree/db/transact/upsert_test.clj
+++ b/test/fluree/db/transact/upsert_test.clj
@@ -46,7 +46,7 @@
 
 (deftest upsert-parsing
   (testing "Parsed upsert txn is identical to long-form update txn"
-    (is (= (parse/parse-upsert-txn sample-upsert-txn {})
+    (is (= (update (parse/parse-upsert-txn sample-upsert-txn {}) :opts dissoc :object-var-parsing)
            (parse/parse-update-txn sample-update-txn {})))))
 
 (deftest ^:integration upsert-data


### PR DESCRIPTION
This PR introduces a configurable objectVarParsing option for transactions and queries to control variable parsing for object values, always honors explicit {\"@variable\": \"?x\"}, and sets sensible defaults (insert/upsert=false, update=true). It includes:

- Parser updates in fql/parse.cljc and validation tweaks to variable detection
- Tests for insert/upsert/update and query behavior with the new option
- Documentation updates: json_ld_query_syntax.md (opts) and new transactions.md guide focused on JSON-LD
