### PR TITLE
Fix/index novelty size NPE in indexing flow

### DIFF
--- a/src/fluree/db/flake/transact.cljc
+++ b/src/fluree/db/flake/transact.cljc
@@ -112,31 +112,29 @@
     (let [allowed-db (<? (policy.modify/allowed? tracker staged-map))]
       allowed-db)))
 
+(defn max-novelty-error
+  "Returns an ExceptionInfo for max novelty exceeded with MBs in message."
+  [db]
+  (let [novelty-bytes     (long (get-in db [:novelty :size] 0))
+        max-novelty-bytes (long (:reindex-max-bytes db))
+        round2-mb         (fn [bytes]
+                            (let [mb (/ (double bytes) 1000000.0)]
+                              (/ (double (int (+ 0.5 (* mb 100.0)))) 100.0)))
+        novelty-mb-r      (round2-mb novelty-bytes)
+        max-novelty-mb-r  (round2-mb max-novelty-bytes)
+        msg               (str "Maximum novelty exceeded ("
+                               novelty-mb-r " MB > max " max-novelty-mb-r
+                               " MB). No transactions will be processed until indexing has completed.")]
+    (ex-info msg {:status 503, :error :db/max-novelty-exceeded})))
+
 (defn stage
   [db tracker context identity author annotation raw-txn parsed-txn]
   (go-try
     (when (novelty/max-novelty? db)
-      (let [novelty-bytes        (long (get-in db [:novelty :size] 0))
-            max-novelty-bytes    (long (:reindex-max-bytes db))
-            novelty-mb           (/ (double novelty-bytes) 1000000.0)
-            max-novelty-mb       (/ (double max-novelty-bytes) 1000000.0)
-            round2               (fn [x]
-                                   (/ (double (int (+ 0.5 (* x 100.0)))) 100.0))
-            novelty-mb-r         (round2 novelty-mb)
-            max-novelty-mb-r     (round2 max-novelty-mb)
-            msg                  (str "Maximum novelty exceeded ("
-                                      novelty-mb-r " MB > max " max-novelty-mb-r
-                                      " MB). No transactions will be processed until indexing has completed.")]
-        (throw (ex-info msg
-                        {:status              503
-                         :error               :db/max-novelty-exceeded
-                         :novelty-bytes       novelty-bytes
-                         :novelty-mb          novelty-mb
-                         :max-novelty-bytes   max-novelty-bytes
-                         :max-novelty-mb      max-novelty-mb}))))
+      (throw (max-novelty-error db)))
     (when (policy.modify/deny-all? db)
       (throw (ex-info "Database policy denies all modifications."
-                      {:status 403 :error :db/policy-exception})))
+                      {:status 403, :error :db/policy-exception})))
     (let [tx-state   (->tx-state :db db
                                  :context context
                                  :txn raw-txn

--- a/src/fluree/db/transact.cljc
+++ b/src/fluree/db/transact.cljc
@@ -291,7 +291,8 @@
                                       :indexing-disabled)
                index-t (commit-data/index-t commit-map)
                novelty-size (get-in db* [:novelty :size] 0)
-               reindex-min-bytes (:reindex-min-bytes db*)
+               ;; Always read threshold from realized FlakeDB; db* may be AsyncDB
+               reindex-min-bytes (or (:reindex-min-bytes db) 1000000)
                indexing-needed? (>= novelty-size reindex-min-bytes)]
            (-> write-result
                (select-keys [:address :hash :size])


### PR DESCRIPTION
Fix race-induced NPE in commit path when checking indexing thresholds

Problem: In `commit!` we computed `indexing-needed?` using `db*` returned from `ledger/update-commit!`. Under load, `db*` can be an `AsyncDB` that doesn’t carry `:reindex-min-bytes`, causing `(>= novelty-size reindex-min-bytes)` to NPE.

Change: Read `:reindex-min-bytes` from realized FlakeDB always, with safe default fallback.

