### PR TITLE
Populate commit id field during load

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -123,7 +123,7 @@
 
 (defn connect-file
   "Forms a connection backed by local file storage.
-  
+
   Options:
     - storage-path (optional): Directory path for file storage (default: \"data\")
     - parallelism (optional): Number of parallel operations (default: 4)
@@ -133,18 +133,18 @@
       The key should be exactly 32 bytes long for optimal security.
       Example: \"my-secret-32-byte-encryption-key!\"
     - defaults (optional): Default options for ledgers created with this connection
-  
+
   Returns a core.async channel that resolves to a connection, or an exception if
   the connection cannot be established.
-  
+
   Examples:
     ;; Basic file storage
     (connect-file {:storage-path \"./my-data\"})
-    
+
     ;; File storage with encryption
     (connect-file {:storage-path \"./secure-data\"
                    :aes256-key \"my-secret-32-byte-encryption-key!\"})
-                   
+
     ;; Full configuration
     (connect-file {:storage-path \"./data\"
                    :parallelism 8
@@ -175,7 +175,7 @@
 #?(:clj
    (defn connect-s3
      "Forms a connection backed by S3 storage.
-     
+
      Options:
        - s3-bucket (required): The S3 bucket name
        - s3-endpoint (required): S3 endpoint URL
@@ -302,10 +302,10 @@
 
   Updates in-memory ledger if commit is next in sequence.
   Returns promise resolving when notification is processed."
-  [conn commit-address commit-hash]
+  [conn commit-address]
   (validate-connection conn)
   (promise-wrap
-   (connection/notify conn commit-address commit-hash)))
+   (connection/notify conn commit-address)))
 
 (defn insert
   "Stages insertion of new entities into a database.
@@ -405,7 +405,7 @@
 
 (defn ^:deprecated transact!
   "Deprecated: Use `update!` instead.
-  
+
   Updates a ledger and commits the changes in one operation."
   ([conn txn] (transact! conn txn nil))
   ([conn txn opts]
@@ -508,7 +508,7 @@
 
 (defn ^:deprecated credential-transact!
   "Deprecated: Use `credential-update!` instead.
-  
+
   Executes a transaction using a verifiable credential."
   ([conn txn] (credential-update! conn txn nil))
   ([conn txn opts] (credential-update! conn txn opts)))
@@ -557,11 +557,11 @@
 
 (defn db
   "Returns the current database value from a ledger.
-  
+
   Parameters:
     conn - Connection object
     ledger-id - Ledger alias or address
-    
+
   Returns the current database value."
   [conn ledger-id]
   (validate-connection conn)
@@ -837,7 +837,7 @@
   "Encodes an IRI to Fluree's internal compact format.
 
   Parameters:
-    db - Database value  
+    db - Database value
     iri - IRI string to encode
 
   Used for range scans, slices and advanced index operations.
@@ -900,20 +900,20 @@
 
 (defn trigger-index
   "Manually triggers indexing for a ledger and waits for completion.
-  
+
   This is useful for external indexing processes (e.g., AWS Lambda) that need
   to ensure a ledger is indexed without creating new transactions.
-  
+
   Parameters:
     conn - Database connection
     ledger-alias - The alias/name of the ledger to index
     opts - (optional) Options map:
       :branch - Branch name (defaults to main branch)
       :timeout - Max wait time in ms (default 300000 / 5 minutes)
-  
+
   Returns a promise that resolves to the indexed database object.
   Throws an exception if indexing fails or times out.
-  
+
   Example:
     ;; Trigger indexing and wait for completion
     (let [indexed-db @(trigger-index conn \"my-ledger\")]

--- a/src/fluree/db/commit/storage.cljc
+++ b/src/fluree/db/commit/storage.cljc
@@ -133,7 +133,7 @@
 
             (if (= from-t commit-t)
               (async/onto-chan! resp-ch commit-tuples*)
-              (when-let [verified-commit (<? (read-verified-commit storage prev-commit-addr))]
+              (when-let [verified-commit (<? (read-commit-jsonld storage prev-commit-addr))]
                 (recur verified-commit commit-t commit-tuples*)))))
         (catch* e
           (log/error e "Error tracing commits")

--- a/src/fluree/db/commit/storage.cljc
+++ b/src/fluree/db/commit/storage.cljc
@@ -37,7 +37,7 @@
 (defn read-verified-commit
   [storage commit-address]
   (go-try
-    (when-let [commit-data (<? (storage/read-json storage commit-address))]
+    (when-let [commit-data (<? (storage/content-read-json storage commit-address))]
       (log/trace "read-commit at:" commit-address "data:" commit-data)
       (let [addr-key-path  (if (contains? commit-data "credentialSubject")
                              ["credentialSubject" "address"]

--- a/src/fluree/db/commit/storage.cljc
+++ b/src/fluree/db/commit/storage.cljc
@@ -49,10 +49,11 @@
 
 ;; TODO: Verify hash
 (defn read-commit-jsonld
-  [storage commit-address commit-hash]
+  [storage commit-address]
   (go-try
     (when-let [[commit _proof] (<? (read-verified-commit storage commit-address))]
-      (let [commit-id (commit-data/hash->commit-id commit-hash)]
+      (let [commit-hash (storage/get-hash storage commit-address)
+            commit-id   (commit-data/hash->commit-id commit-hash)]
         (assoc commit
                const/iri-id commit-id
                const/iri-address commit-address)))))
@@ -120,8 +121,8 @@
     (go
       (try*
         (loop [[commit proof] (verify-commit latest-commit)
-               last-t        nil
-               commit-tuples (list)] ;; note 'conj' will put at beginning of list (smallest 't' first)
+               last-t         nil
+               commit-tuples  (list)] ;; note 'conj' will put at beginning of list (smallest 't' first)
           (let [prev-commit-addr (-> commit
                                      (get-first const/iri-previous)
                                      (get-first-value const/iri-address))

--- a/src/fluree/db/commit/storage.cljc
+++ b/src/fluree/db/commit/storage.cljc
@@ -46,7 +46,7 @@
                                (assoc-in addr-key-path commit-address)
                                json-ld/expand
                                verify-commit)
-            commit-hash    (storage/get-hash storage commit-address)
+            commit-hash    (<? (storage/get-hash storage commit-address))
             commit-id      (commit-data/hash->commit-id commit-hash)
             commit*        (assoc commit
                                   const/iri-id commit-id

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -93,9 +93,9 @@
     [cached? p-chan]))
 
 (defn notify
-  [{:keys [commit-catalog] :as conn} address hash]
+  [{:keys [commit-catalog] :as conn} address]
   (go-try
-    (if-let [expanded-commit (<? (commit-storage/read-commit-jsonld commit-catalog address hash))]
+    (if-let [expanded-commit (<? (commit-storage/read-commit-jsonld commit-catalog address))]
       (if-let [ledger-alias (get-first-value expanded-commit const/iri-alias)]
         (if-let [ledger-ch (ns-subscribe/cached-ledger conn ledger-alias)]
           (do (log/debug "Notification received for ledger" ledger-alias

--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -187,6 +187,10 @@
     (let [json-data (<? (storage/read-json commit-catalog addr))]
       (assoc json-data "address" addr))))
 
+(defn parse-address-hash
+  [{:keys [commit-catalog] :as _conn} addr]
+  (storage/get-hash commit-catalog addr))
+
 (defn lookup-publisher-commit
   [conn ledger-address]
   (lookup-commit* ledger-address (publishers conn)))

--- a/src/fluree/db/ledger.cljc
+++ b/src/fluree/db/ledger.cljc
@@ -47,14 +47,13 @@
   ([{:keys [state] :as ledger} branch-name db index-files-ch]
    (log/debug "Attempting to update ledger:" (:alias ledger)
               "and branch:" branch-name "with new commit to t" (:t db))
-   (let [branch-meta (get-branch-meta ledger branch-name)]
-     (when-not branch-meta
-       (throw (ex-info (str "Unable to update commit on branch: " branch-name " as it no longer exists in ledger. "
-                            "Did it just get deleted? Branches that exist are: " (keys (:branches @state)))
-                       {:status 400, :error :db/invalid-branch})))
+   (if-let [branch-meta (get-branch-meta ledger branch-name)]
      (-> branch-meta
          (branch/update-commit! db index-files-ch)
-         branch/current-db))))
+         branch/current-db)
+     (throw (ex-info (str "Unable to update commit on branch: " branch-name " as it no longer exists in ledger. "
+                          "Did it just get deleted? Branches that exist are: " (keys (:branches @state)))
+                     {:status 400, :error :db/invalid-branch})))))
 
 (defn status
   "Returns current commit metadata for specified branch (or default branch if nil)"

--- a/src/fluree/db/ledger.cljc
+++ b/src/fluree/db/ledger.cljc
@@ -87,8 +87,9 @@
                         (get-first-value const/iri-fluree-t))
           db        (current-db ledger branch)
           current-t (:t db)]
-      (log/debug "notify of new commit for ledger:" (:alias ledger) "at t value:" commit-t
-                 "where current cached db t value is:" current-t)
+      (log/debug "notify of new commit for ledger:" (:alias ledger)
+                 "at t value:" commit-t "where current cached db t value is:"
+                 current-t)
       ;; note, index updates will have same t value as current one, so still need to check if t = current-t
       (cond
         (= commit-t (flake/next-t current-t))

--- a/src/fluree/db/nameservice/sub.cljc
+++ b/src/fluree/db/nameservice/sub.cljc
@@ -50,9 +50,9 @@
   (update current-state :subscriptions dissoc ledger-alias))
 
 (defn notify
-  [{:keys [commit-catalog] :as conn} address hash]
+  [{:keys [commit-catalog] :as conn} address]
   (go-try
-    (if-let [expanded-commit (<? (commit-storage/read-commit-jsonld commit-catalog address hash))]
+    (if-let [expanded-commit (<? (commit-storage/read-commit-jsonld commit-catalog address))]
       (if-let [ledger-alias (get-first-value expanded-commit const/iri-alias)]
         (if-let [ledger-ch (cached-ledger conn ledger-alias)]
           (do (log/debug "Notification received for ledger" ledger-alias

--- a/src/fluree/db/nameservice/sub.cljc
+++ b/src/fluree/db/nameservice/sub.cljc
@@ -91,8 +91,8 @@
             (log/info "Subscribed ledger:" ledger-alias "received subscription message:" msg)
             (let [action (get msg "action")]
               (if (= "new-commit" action)
-                (let [{:keys [address hash]} (get msg "data")]
-                  (notify conn address hash))
+                (let [{:keys [address]} (get msg "data")]
+                  (notify conn address))
                 (log/info "New subscrition message with action: " action "received, ignored.")))
             (recur)))
         :subscribed))))

--- a/src/fluree/db/remote_system.cljc
+++ b/src/fluree/db/remote_system.cljc
@@ -65,6 +65,22 @@
                      {:resource resource-key}
                      {:keywordize-keys keywordize-keys?})))
 
+(defn remote-read-bytes
+  [system-state resource-key]
+  (log/debug "Remote read json initiated for: " resource-key)
+  (let [server-host (pick-server system-state)]
+    (xhttp/post (str server-host "/fluree/remote/resource")
+                {:resource resource-key}
+                {:keywordize-keys false})))
+
+(defn remote-get-hash
+  [system-state address]
+  (log/debug "Remote get hash initiated for: " address)
+  (let [server-host (pick-server system-state)]
+    (xhttp/post (str server-host "/fluree/remote/hash")
+                {:address address}
+                {:keywordize-keys false})))
+
 (defn not-found-error?
   [e]
   (-> e ex-data :status (= 404)))
@@ -128,6 +144,12 @@
   storage/JsonArchive
   (-read-json [_ address keywordize?]
     (remote-read-json system-state address keywordize?))
+
+  storage/ContentArchive
+  (-content-read-bytes [_ address]
+    (remote-read-bytes system-state address))
+  (get-hash [_ address]
+    (remote-get-hash system-state address))
 
   storage/Identifiable
   (identifiers [_]

--- a/src/fluree/db/remote_system.cljc
+++ b/src/fluree/db/remote_system.cljc
@@ -77,9 +77,9 @@
   [system-state address]
   (log/debug "Remote get hash initiated for: " address)
   (let [server-host (pick-server system-state)]
-    (xhttp/post (str server-host "/fluree/remote/hash")
-                {:address address}
-                {:keywordize-keys false})))
+    (xhttp/post-json (str server-host "/fluree/remote/hash")
+                     {:address address}
+                     {:keywordize-keys false})))
 
 (defn not-found-error?
   [e]
@@ -147,9 +147,13 @@
 
   storage/ContentArchive
   (-content-read-bytes [_ address]
-    (remote-read-bytes system-state address))
+    (go-try
+      (let [read-result (<? (remote-read-json system-state address false))]
+        (json/stringify read-result))))
   (get-hash [_ address]
-    (remote-get-hash system-state address))
+    (go-try
+      (let [hash-result (<? (remote-get-hash system-state address))]
+        (json/stringify hash-result))))
 
   storage/Identifiable
   (identifiers [_]

--- a/src/fluree/db/remote_system.cljc
+++ b/src/fluree/db/remote_system.cljc
@@ -57,7 +57,7 @@
                       :error  :db/websocket-error})))))))
 
 (defn remote-read-json
-  "Returns a core async channel with value of remote resource."
+  "Returns a core async channel with value of remote resources."
   [system-state resource-key keywordize-keys?]
   (log/debug "Remote read json initiated for: " resource-key)
   (let [server-host (pick-server system-state)]

--- a/src/fluree/db/remote_system.cljc
+++ b/src/fluree/db/remote_system.cljc
@@ -56,13 +56,13 @@
                      {:status 400
                       :error  :db/websocket-error})))))))
 
-(defn remote-read
+(defn remote-read-json
   "Returns a core async channel with value of remote resource."
-  [system-state commit-key keywordize-keys?]
-  (log/debug "Remote read initiated for: " commit-key)
+  [system-state resource-key keywordize-keys?]
+  (log/debug "Remote read json initiated for: " resource-key)
   (let [server-host (pick-server system-state)]
     (xhttp/post-json (str server-host "/fluree/remote/resource")
-                     {:resource commit-key}
+                     {:resource resource-key}
                      {:keywordize-keys keywordize-keys?})))
 
 (defn not-found-error?
@@ -127,7 +127,7 @@
 (defrecord RemoteSystem [system-state address-identifiers msg-in pub msg-out]
   storage/JsonArchive
   (-read-json [_ address keywordize?]
-    (remote-read system-state address keywordize?))
+    (remote-read-json system-state address keywordize?))
 
   storage/Identifiable
   (identifiers [_]

--- a/src/fluree/db/storage.cljc
+++ b/src/fluree/db/storage.cljc
@@ -51,6 +51,12 @@
   (let [i (str/last-index-of address ":")]
     [(subs address 0 i) (subs address (inc i))]))
 
+(defn strip-extension
+  [filename]
+  (if-let [idx (str/last-index-of filename ".")]
+    (subs filename 0 idx)
+    filename))
+
 (defn valid-identifier?
   [x]
   (and (str/includes? x "/")
@@ -103,7 +109,9 @@
 (defprotocol ContentAddressedStore
   (-content-write-bytes [store k v]
     "Writes pre-serialized data `v` to store associated with key `k` and the
-    hashed value of `v`. Returns value's address."))
+    hashed value of `v`. Returns value's address.")
+  (get-hash [store address]
+    "Returns the hash of the data associated with `address` within `store`"))
 
 (defprotocol ByteStore
   "ByteStore is used by consensus to replicate files across servers"

--- a/src/fluree/db/storage.cljc
+++ b/src/fluree/db/storage.cljc
@@ -228,6 +228,11 @@
     (let [store (get-content-store clg ::default)]
       (-content-write-bytes store k v)))
 
+  (get-hash [clg address]
+    (if-let [store (locate-address clg address)]
+      (get-hash store address)
+      (async-location-error address)))
+
   EraseableStore
   (delete [clg address]
     (if-let [store (locate-address clg address)]

--- a/src/fluree/db/storage.cljc
+++ b/src/fluree/db/storage.cljc
@@ -28,6 +28,12 @@
     path
     (str "//" path)))
 
+(defn unsanitize-path
+  [path]
+  (if (str/starts-with? path "//")
+    (subs path 2)
+    path))
+
 (defn build-address
   ([location path]
    (let [path* (sanitize-path path)]

--- a/src/fluree/db/storage/file.cljc
+++ b/src/fluree/db/storage/file.cljc
@@ -3,7 +3,7 @@
             #?@(:cljs [[fluree.db.platform :as platform]
                        ["fs" :as node-fs]
                        ["path" :as node-path]])
-            [clojure.core.async :as async]
+            [clojure.core.async :as async :refer [go]]
             [clojure.string :as str]
             [fluree.crypto :as crypto]
             [fluree.crypto.aes :as aes]
@@ -108,7 +108,13 @@
       (fs/read-file path encryption-key)))
 
   (get-hash [_ address]
-    (-> address storage/split-address last (str/split #"/") last storage/strip-extension))
+    (go
+      (-> address
+          storage/split-address
+          last
+          (str/split #"/")
+          last
+          storage/strip-extension)))
 
   storage/ByteStore
   (write-bytes [_ path bytes]

--- a/src/fluree/db/storage/file.cljc
+++ b/src/fluree/db/storage/file.cljc
@@ -102,6 +102,11 @@
          :hash    hash
          :size    original-size})))
 
+  storage/ContentArchive
+  (-content-read-bytes [_ address]
+    (let [path (storage-path root address)]
+      (fs/read-file path encryption-key)))
+
   (get-hash [_ address]
     (-> address storage/split-address last (str/split #"/") last storage/strip-extension))
 

--- a/src/fluree/db/storage/file.cljc
+++ b/src/fluree/db/storage/file.cljc
@@ -102,6 +102,9 @@
          :hash    hash
          :size    original-size})))
 
+  (get-hash [_ address]
+    (-> address storage/split-address last (str/split #"/") last storage/strip-extension))
+
   storage/ByteStore
   (write-bytes [_ path bytes]
     (let [final-bytes (if encryption-key

--- a/src/fluree/db/storage/ipfs.cljc
+++ b/src/fluree/db/storage/ipfs.cljc
@@ -51,7 +51,10 @@
         {:path    hash
          :hash    hash
          :address (ipfs-address identifier hash)
-         :size    size}))))
+         :size    size})))
+
+  (get-hash [_ address]
+    (-> address storage/split-address last)))
 
 (defn open
   ([endpoint]

--- a/src/fluree/db/storage/ipfs.cljc
+++ b/src/fluree/db/storage/ipfs.cljc
@@ -1,6 +1,6 @@
 (ns fluree.db.storage.ipfs
-  (:require [clojure.string :as str]
-            [clojure.core.async :refer [go]]
+  (:require [clojure.core.async :refer [go]]
+            [clojure.string :as str]
             [fluree.db.method.ipfs.xhttp :as ipfs]
             [fluree.db.storage :as storage]
             [fluree.db.util.async :refer [<? go-try]]

--- a/src/fluree/db/storage/ipfs.cljc
+++ b/src/fluree/db/storage/ipfs.cljc
@@ -53,6 +53,17 @@
          :address (ipfs-address identifier hash)
          :size    size})))
 
+  storage/ContentArchive
+  (-content-read-bytes [_ address]
+    (go-try
+      (let [{:keys [ns method local]} (storage/parse-address address)
+            path                      (build-ipfs-path method local)]
+        (when-not (and (= "fluree" ns)
+                       (#{"ipfs" "ipns"} method))
+          (throw (ex-info (str "Invalid file type or method: " address)
+                          {:status 500 :error :db/invalid-address})))
+        (<? (ipfs/cat endpoint path false)))))
+
   (get-hash [_ address]
     (-> address storage/split-address last)))
 

--- a/src/fluree/db/storage/ipfs.cljc
+++ b/src/fluree/db/storage/ipfs.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.storage.ipfs
   (:require [clojure.string :as str]
+            [clojure.core.async :refer [go]]
             [fluree.db.method.ipfs.xhttp :as ipfs]
             [fluree.db.storage :as storage]
             [fluree.db.util.async :refer [<? go-try]]
@@ -65,7 +66,7 @@
         (<? (ipfs/cat endpoint path false)))))
 
   (get-hash [_ address]
-    (-> address storage/split-address last)))
+    (go (-> address storage/split-address last))))
 
 (defn open
   ([endpoint]

--- a/src/fluree/db/storage/localstorage.cljs
+++ b/src/fluree/db/storage/localstorage.cljs
@@ -47,6 +47,12 @@
          :hash    hash
          :size    (count hashable)})))
 
+  storage/ContentArchive
+  (-content-read-bytes [_ address]
+    (go
+      (let [path (storage/get-local-path address)]
+        (.getItem js/localStorage path))))
+
   (get-hash [_ address]
     (-> address storage/split-address last)))
 

--- a/src/fluree/db/storage/localstorage.cljs
+++ b/src/fluree/db/storage/localstorage.cljs
@@ -54,7 +54,7 @@
         (.getItem js/localStorage path))))
 
   (get-hash [_ address]
-    (-> address storage/split-address last)))
+    (go (-> address storage/split-address last))))
 
 (defn open
   ([]

--- a/src/fluree/db/storage/localstorage.cljs
+++ b/src/fluree/db/storage/localstorage.cljs
@@ -35,17 +35,20 @@
         (.removeItem js/localStorage path))))
 
   storage/ContentAddressedStore
-  (-content-write-bytes [_ k v]
+  (-content-write-bytes [_ _ v]
     (go
       (let [hashable (if (storage/hashable? v)
                        v
                        (pr-str v))
-            hash     (crypto/sha2-256 hashable :base32)]
-        (.setItem js/localStorage k v)
-        {:path    k
-         :address (local-storage-address identifier k)
+            hash     (crypto/sha2-256 hashable :base32)
+            address  (local-storage-address identifier hash)]
+        (.setItem js/localStorage address v)
+        {:address address
          :hash    hash
-         :size    (count hashable)}))))
+         :size    (count hashable)})))
+
+  (get-hash [_ address]
+    (-> address storage/split-address last)))
 
 (defn open
   ([]

--- a/src/fluree/db/storage/memory.cljc
+++ b/src/fluree/db/storage/memory.cljc
@@ -53,7 +53,7 @@
         (get @contents path))))
 
   (get-hash [_ address]
-    (-> address storage/split-address last))
+    (go (-> address storage/split-address last)))
 
   storage/ByteStore
   (write-bytes [_ path bytes]

--- a/src/fluree/db/storage/memory.cljc
+++ b/src/fluree/db/storage/memory.cljc
@@ -46,6 +46,9 @@
          :hash    hash
          :size    (count hashable)})))
 
+  (get-hash [_ address]
+    (-> address storage/split-address last))
+
   storage/ByteStore
   (write-bytes [_ path bytes]
     (go

--- a/src/fluree/db/storage/memory.cljc
+++ b/src/fluree/db/storage/memory.cljc
@@ -46,6 +46,12 @@
          :hash    hash
          :size    (count hashable)})))
 
+  storage/ContentArchive
+  (-content-read-bytes [_ address]
+    (go
+      (let [path (storage/get-local-path address)]
+        (get @contents path))))
+
   (get-hash [_ address]
     (-> address storage/split-address last))
 

--- a/src/fluree/db/storage/memory.cljc
+++ b/src/fluree/db/storage/memory.cljc
@@ -53,7 +53,7 @@
         (get @contents path))))
 
   (get-hash [_ address]
-    (go (-> address storage/split-address last)))
+    (go (-> address storage/split-address last storage/unsanitize-path)))
 
   storage/ByteStore
   (write-bytes [_ path bytes]

--- a/src/fluree/db/storage/s3.clj
+++ b/src/fluree/db/storage/s3.clj
@@ -403,6 +403,14 @@
            :size    (count bytes)
            :address (s3-address identifier path)}))))
 
+  storage/ContentArchive
+  (-content-read-bytes [this address]
+    (go-try
+      (let [path (storage/get-local-path address)
+            resp (<? (read-s3-data this path))]
+        (when (not= resp ::not-found)
+          (:Body resp)))))
+
   (get-hash [_ address]
     (-> address storage/split-address last (str/split #"/") last storage/strip-extension))
 

--- a/src/fluree/db/storage/s3.clj
+++ b/src/fluree/db/storage/s3.clj
@@ -421,11 +421,11 @@
                        :retry-base-delay-ms retry-base-delay-ms
                        :retry-max-delay-ms  retry-max-delay-ms}]
         (<? (with-retries (fn [] (s3-request {:method          "DELETE"
-                                             :bucket          bucket
-                                             :region          region
-                                             :path            full-path
-                                             :credentials     credentials
-                                             :request-timeout write-timeout-ms}))
+                                              :bucket          bucket
+                                              :region          region
+                                              :path            full-path
+                                              :credentials     credentials
+                                              :request-timeout write-timeout-ms}))
               policy)))))
 
   storage/RecursiveListableStore

--- a/src/fluree/db/storage/s3.clj
+++ b/src/fluree/db/storage/s3.clj
@@ -412,7 +412,13 @@
           (:Body resp)))))
 
   (get-hash [_ address]
-    (-> address storage/split-address last (str/split #"/") last storage/strip-extension))
+    (go
+      (-> address
+          storage/split-address
+          last
+          (str/split #"/")
+          last
+          storage/strip-extension)))
 
   storage/ByteStore
   (write-bytes [this path bytes]

--- a/src/fluree/db/util/xhttp.cljc
+++ b/src/fluree/db/util/xhttp.cljc
@@ -76,7 +76,8 @@
     (ex-info message
              (cond-> {:url   url
                       :error error}
-               status (assoc :status status)))))
+               status (assoc :status status))
+             e)))
 
 #?(:clj
    (defn throw-if-timeout [error]


### PR DESCRIPTION
This patch includes fixes to allow us to populate the commit id field on load. It adds new storage protocol methods to get the hash from the address for documents saved to storage. It also changes the storage protocol for reading to be lower level and more versatile by return bytes instead of json and adds a wrapper function to turn the bytes into json when appropriate. 