### PR TITLE
Fix/fuel limit logging

### DIFF
--- a/src/fluree/db/query/exec.cljc
+++ b/src/fluree/db/query/exec.cljc
@@ -113,5 +113,5 @@
            prepped-q (prep-subqueries q)
            result-ch (execute ds tracker prepped-q error-ch)]
        (async/alt!
-         error-ch ([e] e)
+         error-ch ([e] (async/close! error-ch) e)
          result-ch ([result] result))))))

--- a/src/fluree/db/track/fuel.cljc
+++ b/src/fluree/db/track/fuel.cljc
@@ -23,7 +23,7 @@
       ([result next]
        (let [{:keys [limit total]} (swap! fuel update :total inc)]
          (when (and (pos? limit) (= (inc limit) total))
-           (log/error "Fuel limit of" limit "exceeded")
+           (log/info "Fuel limit of" limit "exceeded")
            (put! error-ch
                  (ex-info "Fuel limit exceeded" {:used total, :limit limit}))))
        (rf result next))

--- a/src/fluree/db/track/fuel.cljc
+++ b/src/fluree/db/track/fuel.cljc
@@ -22,8 +22,8 @@
 
       ([result next]
        (let [{:keys [limit total]} (swap! fuel update :total inc)]
-         (when (< 0 limit total)
-           (log/error "Fuel limit of" limit "exceeded:" total)
+         (when (and (pos? limit) (= (inc limit) total))
+           (log/error "Fuel limit of" limit "exceeded")
            (put! error-ch
                  (ex-info "Fuel limit exceeded" {:used total, :limit limit}))))
        (rf result next))

--- a/src/fluree/db/virtual_graph/flat_rank.cljc
+++ b/src/fluree/db/virtual_graph/flat_rank.cljc
@@ -44,7 +44,7 @@
             pid       (iri/encode-iri db property)
             score-xf  (comp (map (partial score-flake score-fn target))
                             (remove nil?))
-            flake-xf  (->> [score-xf (when tracker (track/track-fuel! tracker error-ch))]
+            flake-xf  (->> [score-xf (track/track-fuel! tracker error-ch)]
                            (remove nil?)
                            (apply comp))
             ;; For now, pulling all matching values from full index once hitting


### PR DESCRIPTION
This cleans up logging around fuel limits and removes potential channel overflows, by 1) not putting a new error on the error chan for every additional fuel spent over the limit and 2) closing the error chan after the first error.

