### PR TITLE
Positive configuration setting for indexing

### DIFF
--- a/src/fluree/db/connection/config.cljc
+++ b/src/fluree/db/connection/config.cljc
@@ -336,7 +336,7 @@
     {:reindex-min-bytes (get-first-long index-options conn-vocab/reindex-min-bytes)
      :reindex-max-bytes (get-first-long index-options conn-vocab/reindex-max-bytes)
      :max-old-indexes   (get-first-integer index-options conn-vocab/max-old-indexes)
-     :indexing-disabled (get-first-boolean index-options conn-vocab/indexing-disabled)}))
+     :indexing-enabled  (not (false? (get-first-boolean index-options conn-vocab/indexing-enabled)))}))
 
 (defn parse-defaults
   [config]

--- a/src/fluree/db/connection/vocab.cljc
+++ b/src/fluree/db/connection/vocab.cljc
@@ -133,8 +133,8 @@
 (def max-old-indexes
   (system-iri "maxOldIndexes"))
 
-(def indexing-disabled
-  (system-iri "indexingDisabled"))
+(def indexing-enabled
+  (system-iri "indexingEnabled"))
 
 (def connection
   (system-iri "connection"))

--- a/src/fluree/db/ledger.cljc
+++ b/src/fluree/db/ledger.cljc
@@ -22,6 +22,10 @@
       ;; default branch
       (get branches branch))))
 
+(defn indexing-enabled?
+  [ledger branch]
+  (-> ledger (get-branch-meta branch) branch/indexing-enabled?))
+
 (defn available-branches
   [{:keys [state] :as _ledger}]
   (-> @state :branches keys))

--- a/src/fluree/db/transact.cljc
+++ b/src/fluree/db/transact.cljc
@@ -218,6 +218,10 @@
                :max-namespace-code max-ns-code)
         (commit-data/add-commit-flakes))))
 
+(defn indexing-needed?
+  [novelty-size min-size]
+  (>= novelty-size min-size))
+
 (defn commit!
   "Finds all uncommitted transactions and wraps them in a Commit document as the subject
   of a VerifiableCredential. Persists according to the :ledger :conn :method and
@@ -285,23 +289,18 @@
        (log/debug "commit!: publish-commit done" {:ledger ledger-alias})
 
        (if (track/track-txn? opts)
-         (let [indexing-disabled? (-> ledger
-                                      (ledger/get-branch-meta branch)
-                                      :indexing-opts
-                                      :indexing-disabled)
-               index-t (commit-data/index-t commit-map)
+         (let [index-t (commit-data/index-t commit-map)
                novelty-size (get-in db* [:novelty :size] 0)
                ;; Always read threshold from realized FlakeDB; db* may be AsyncDB
-               reindex-min-bytes (or (:reindex-min-bytes db) 1000000)
-               indexing-needed? (>= novelty-size reindex-min-bytes)]
+               reindex-min-bytes (or (:reindex-min-bytes db) 1000000)]
            (-> write-result
                (select-keys [:address :hash :size])
                (assoc :ledger-id ledger-alias
                       :t t
                       :db db*
-                      :indexing-needed indexing-needed?
+                      :indexing-needed (indexing-needed? novelty-size reindex-min-bytes)
                       :index-t index-t
-                      :indexing-disabled indexing-disabled?
+                      :indexing-enabled (ledger/indexing-enabled? ledger branch)
                       :novelty-size novelty-size)))
          db*)))))
 

--- a/test/fluree/db/indexing_test.clj
+++ b/test/fluree/db/indexing_test.clj
@@ -7,8 +7,8 @@
 
 (deftest ^:integration manual-indexing-test
   (testing "Manual indexing API and transaction metadata"
-    (let [;; Create connection with auto-indexing disabled  
-          conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-disabled true}}})
+    (let [;; Create connection with auto-indexing disabled
+          conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-enabled false}}})
           _       @(fluree/create conn "test-indexing")
           db0     @(fluree/db conn "test-indexing")
 
@@ -37,7 +37,7 @@
 
       (testing "Transaction metadata includes indexing information"
         ;; Specific value checks
-        (is (true? (:indexing-disabled result)) "Response should indicate indexing is disabled")
+        (is (false? (:indexing-enabled result)) "Response should indicate indexing is disabled")
         (is (false? (:indexing-needed result)) "Should not need indexing with small data")
         (is (number? (:novelty-size result)) "Should have novelty size as a number")
         (is (< (:novelty-size result) 100000) "Novelty size should be below default threshold")))))
@@ -45,7 +45,7 @@
 (deftest ^:integration manual-indexing-blocking-test
   (testing "Manual indexing with blocking returns indexed database"
     (let [;; Create connection with auto-indexing disabled
-          conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-disabled true
+          conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-enabled false
                                                                  :reindex-min-bytes 1000}}})
           _       @(fluree/create conn "test-blocking-index")]
 
@@ -96,7 +96,7 @@
 
 (deftest ^:integration automatic-indexing-disabled-test
   (testing "When indexing is disabled, automatic indexing does not occur"
-    (let [conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-disabled true
+    (let [conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-enabled false
                                                                  :reindex-min-bytes 100}}})
           _       @(fluree/create conn "test-no-auto-index")]
 
@@ -123,7 +123,7 @@
 
 (deftest ^:integration manual-indexing-updates-branch-state-test
   (testing "Manual indexing updates branch state and subsequent queries use index"
-    (let [conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-disabled true
+    (let [conn    @(fluree/connect-memory {:defaults {:indexing {:indexing-enabled false
                                                                  :reindex-min-bytes 100}}})
           _       @(fluree/create conn "test-branch-update")]
 
@@ -163,7 +163,7 @@
   (testing "Manual indexing with file storage and loading from disk"
     (with-temp-dir [storage-path {}]
       (let [conn    @(fluree/connect-file {:storage-path (str storage-path)
-                                           :defaults {:indexing {:indexing-disabled true
+                                           :defaults {:indexing {:indexing-enabled false
                                                                  :reindex-min-bytes 100}}})
             _       @(fluree/create conn "test-file-indexing")]
 
@@ -202,7 +202,7 @@
         (testing "Loading from disk with new connection"
           ;; Create a new connection to ensure we're not using cached data
           (let [conn2   @(fluree/connect-file {:storage-path (str storage-path)
-                                               :defaults {:indexing {:indexing-disabled true}}})
+                                               :defaults {:indexing {:indexing-enabled false}}})
                 _       @(fluree/load conn2 "test-file-indexing")
                 db      @(fluree/db conn2 "test-file-indexing")
                 query   {"@context" {"ex" "http://example.org/"}

--- a/test/fluree/db/transact/transact_test.clj
+++ b/test/fluree/db/transact/transact_test.clj
@@ -361,7 +361,7 @@
                               :quux/corge "grault"}]}
             committed  @(fluree/update! conn txn {:meta true})]
         (is (= #{:address :db :fuel :hash :ledger-id :size :status :t :time :policy
-                 :index-t :indexing-disabled :indexing-needed :novelty-size}
+                 :index-t :indexing-enabled :indexing-needed :novelty-size}
                (set (keys committed))))))
 
     (testing "Throws on invalid txn"


### PR DESCRIPTION
This patch changes the indexing options configuration to use `indexingEnabled` instead of the inverted `indexingDisabled`. I think this makes for a friendlier api because it requires less boolean inversions to reason about whether or not indexing will run.