### PR TITLE
Refactor/async db indexing opts

### DIFF
--- a/src/fluree/db/async_db.cljc
+++ b/src/fluree/db/async_db.cljc
@@ -19,7 +19,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(declare ->async-db deliver!)
+(declare deliver!)
 
 (defrecord AsyncDB [alias branch commit t db-chan
                     reindex-min-bytes
@@ -275,11 +275,17 @@
   (:db-chan async-db))
 
 (defn ->async-db
-  "Creates an async-db.
-  This is to be used in conjunction with `deliver!` that will deliver the
-  loaded db to the async-db."
-  [ledger-alias branch commit-map t]
-  (->AsyncDB ledger-alias branch commit-map t (async/promise-chan) nil nil nil))
+  "Creates an async-db from a flake-db when updating the index. The async db will receive
+  the flake db with the updated index reference on the :db-chan promise-chan."
+  [{:keys [alias branch commit t reindex-min-bytes reindex-max-bytes max-old-indexes] :as _flake-db}]
+  (map->AsyncDB {:alias             alias
+                 :branch            branch
+                 :commit            commit
+                 :t                 t
+                 :db-chan           (async/promise-chan)
+                 :reindex-min-bytes reindex-min-bytes
+                 :reindex-max-bytes reindex-max-bytes
+                 :max-old-indexes   max-old-indexes}))
 
 (defn load
   ([ledger-alias branch commit-catalog index-catalog commit-jsonld indexing-opts]

--- a/src/fluree/db/branch.cljc
+++ b/src/fluree/db/branch.cljc
@@ -60,7 +60,7 @@
   (if (async-db/db? current-db)
     (dbproto/-index-update current-db index-map)
     (let [updated-commit (assoc commit :index index-map)
-          updated-db     (async-db/->async-db alias branch updated-commit t)]
+          updated-db     (async-db/->async-db (assoc current-db :commit updated-commit))]
       (go ;; update index in the background, return updated db immediately
         (->> (dbproto/-index-update current-db index-map)
              (async-db/deliver! updated-db)))

--- a/src/fluree/db/transact.cljc
+++ b/src/fluree/db/transact.cljc
@@ -291,8 +291,7 @@
                                       :indexing-disabled)
                index-t (commit-data/index-t commit-map)
                novelty-size (get-in db* [:novelty :size] 0)
-               ;; Always read threshold from realized FlakeDB; db* may be AsyncDB
-               reindex-min-bytes (or (:reindex-min-bytes db) 1000000)
+               reindex-min-bytes (:reindex-min-bytes db*)
                indexing-needed? (>= novelty-size reindex-min-bytes)]
            (-> write-result
                (select-keys [:address :hash :size])


### PR DESCRIPTION
This is a refactor that ensures that the static data that doesn't change over the lifetime of a DB record (the indexing opts) is always present, regardless of whether we have an `AsyncDB` or `FlakeDB`. 

A FlakeDB carries the indexing thresholds around under the keys `:reindex-min-bytes`, `:reindex-max-bytes`, and `:max-old-indexes`. These were not carried over to an `AsyncDB`, which caused a bug when we started reporting indexing data for txn tracking - we would compare the novelty size to `:reindex-min-bytes` to determine the result for the `:indexing-needed` key, but you can't compare a number with `nil`. This was fixed by just falling back to the default `:reindex-min-bytes` setting (1000000), but that was inaccurate. This PR refactors our `AsyncDB` initialization so that we always have that data, and any other static data.

