### PR TITLE
refactor: streamline ledger alias handling and ensure branch inclusion

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -13,6 +13,7 @@
             [fluree.db.storage :as storage]
             [fluree.db.util :as util :refer [get-first get-first-value try* catch*]]
             [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.util.ledger :as util.ledger]
             [fluree.db.util.log :as log :include-macros true]
             [fluree.json-ld :as json-ld])
   #?(:clj (:import (java.io Writer))))
@@ -66,14 +67,6 @@
         state (atom blank-state)]
     (->Connection id state parallelism commit-catalog index-catalog primary-publisher
                   secondary-publishers remote-systems serializer cache defaults)))
-
-(defn normalize-ledger-alias
-  "Ensures ledger alias includes branch. 
-  If no : symbol present, appends :main as default branch."
-  [ledger-alias]
-  (if (clojure.string/includes? ledger-alias ":")
-    ledger-alias
-    (str ledger-alias ":" const/default-branch-name)))
 
 (defn register-ledger
   "Creates a promise-chan and saves it in a cache of ledgers being held
@@ -173,7 +166,7 @@
   ledger alias"
   [{:keys [primary-publisher] :as _conn} ledger-alias]
   (->> ledger-alias
-       normalize-ledger-alias
+       util.ledger/ensure-ledger-branch
        (nameservice/publishing-address primary-publisher)))
 
 (defn lookup-commit*
@@ -280,7 +273,7 @@
   [{:keys [commit-catalog index-catalog primary-publisher secondary-publishers] :as conn} ledger-alias opts]
   (go-try
     (let [;; Normalize ledger-alias to include branch
-          normalized-alias (normalize-ledger-alias ledger-alias)]
+          normalized-alias (util.ledger/ensure-ledger-branch ledger-alias)]
       (if (<? (ledger-exists? conn normalized-alias))
         (throw-ledger-exists normalized-alias)
         (let [[cached? ledger-chan] (register-ledger conn normalized-alias)]
@@ -356,7 +349,7 @@
   [conn alias]
   (go-try
     (let [;; Normalize ledger-alias to include branch
-          normalized-alias (normalize-ledger-alias alias)
+          normalized-alias (util.ledger/ensure-ledger-branch alias)
           [cached? ledger-chan] (register-ledger conn normalized-alias)]
       (if cached?
         (<? ledger-chan)
@@ -450,7 +443,7 @@
       (let [alias (if (fluree-address? alias)
                     (nameservice/address-path alias)
                     ;; Normalize alias to include branch if not present
-                    (normalize-ledger-alias alias))]
+                    (util.ledger/ensure-ledger-branch alias))]
         (loop [[publisher & r] (publishers conn)]
           (when publisher
             (let [ledger-addr   (<? (nameservice/publishing-address publisher alias))

--- a/src/fluree/db/ledger.cljc
+++ b/src/fluree/db/ledger.cljc
@@ -135,15 +135,15 @@
   context."
   [alias ledger-address commit-catalog index-catalog primary-publisher secondary-publishers
    indexing-opts did latest-commit]
-  (let [[_ branch] (util.ledger/ledger-parts alias)
-        branch (or branch const/default-branch-name)
+  (let [alias* (util.ledger/ensure-ledger-branch alias)
+        branch (util.ledger/ledger-branch alias*)
         publishers (cons primary-publisher secondary-publishers)
         branches {branch (branch/state-map alias branch commit-catalog index-catalog
                                            publishers latest-commit indexing-opts)}]
     (map->Ledger {:id                   (random-uuid)
                   :did                  did
                   :state                (atom (initial-state branches branch))
-                  :alias                alias  ;; Full alias including branch
+                  :alias                alias*  ;; Full alias including branch
                   :address              ledger-address
                   :commit-catalog       commit-catalog
                   :index-catalog        index-catalog

--- a/src/fluree/db/nameservice.cljc
+++ b/src/fluree/db/nameservice.cljc
@@ -1,8 +1,6 @@
 (ns fluree.db.nameservice
   (:refer-clojure :exclude [alias])
   (:require [clojure.core.async :as async :refer [go]]
-            [clojure.string :as str]
-            [fluree.db.storage :as storage]
             [fluree.db.util :refer [try* catch*]]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.log :as log]))
@@ -56,41 +54,3 @@
   (go-try
     (let [addr (<? (publishing-address nsv ledger-alias))]
       (boolean (<? (lookup nsv addr))))))
-
-(defn address-path
-  [address]
-  (storage/get-local-path address))
-
-(defn extract-branch
-  "Splits a given namespace address into its nameservice and branch parts.
-  Returns two-tuple of [nameservice branch].
-  If no branch is found, returns nil as branch value and original ns-address as the nameservice."
-  [ns-address]
-  (if (str/ends-with? ns-address ")")
-    (let [[_ ns branch] (re-matches #"(.*)\((.*)\)" ns-address)]
-      [ns branch])
-    [ns-address nil]))
-
-(defn absolute-address?
-  [address location]
-  (str/starts-with? address location))
-
-(defn resolve-address
-  "Resolves a provided namespace address, which might be relative or absolute,
-   into three parts returned as a map:
-  - :alias - ledger alias
-  - :branch - branch (or nil if default)
-  - :address - absolute namespace address (including branch if provided)
-  If 'branch' parameter is provided will always use it as the branch regardless
-  of if a branch is specificed in the ns-address."
-  [location ns-address branch]
-  (let [[ns-address* extracted-branch] (extract-branch ns-address)
-        branch* (or branch extracted-branch)
-        [ns-address** alias] (if (absolute-address? ns-address location)
-                               [ns-address* (storage/get-local-path ns-address*)]
-                               [(storage/build-address location ns-address*) ns-address*])]
-    {:alias   alias
-     :branch  branch*
-     :address (if branch*
-                (str ns-address** "(" branch* ")")
-                ns-address*)}))

--- a/src/fluree/db/query/api.cljc
+++ b/src/fluree/db/query/api.cljc
@@ -162,7 +162,7 @@
   (let [{:keys [ledger branch t]} (ledger-util/parse-ledger-alias alias)
         base-alias (if branch
                      (str ledger ":" branch)
-                     ledger)]
+                     (ledger-util/ensure-ledger-branch ledger))]
     [base-alias t]))
 
 (def ledger-specific-opts #{:policy-class :policy :policy-values})

--- a/src/fluree/db/util/ledger.cljc
+++ b/src/fluree/db/util/ledger.cljc
@@ -1,21 +1,8 @@
 (ns fluree.db.util.ledger
   "Utility functions for working with ledger names and branches."
   (:require [clojure.string :as str]
+            [fluree.db.constants :as const]
             [fluree.db.util :as util]))
-
-(defn ledger-base-name
-  "Extracts the base ledger name from a ledger alias that may include a branch.
-   e.g., 'my-ledger:main' -> 'my-ledger'"
-  [ledger-alias]
-  (first (str/split ledger-alias #":" 2)))
-
-(defn ledger-branch
-  "Extracts the branch name from a ledger alias.
-   Returns the branch name or nil if no branch is specified.
-   e.g., 'my-ledger:main' -> 'main'
-         'my-ledger' -> nil"
-  [ledger-alias]
-  (second (str/split ledger-alias #":" 2)))
 
 (defn ledger-parts
   "Splits a ledger alias into [ledger-name branch-name].
@@ -24,6 +11,30 @@
   [ledger-alias]
   (let [parts (str/split ledger-alias #":" 2)]
     [(first parts) (second parts)]))
+
+(defn ledger-base-name
+  "Extracts the base ledger name from a ledger alias that may include a branch.
+   e.g., 'my-ledger:main' -> 'my-ledger'"
+  [ledger-alias]
+  (first (ledger-parts ledger-alias)))
+
+(defn ledger-branch
+  "Extracts the branch name from a ledger alias.
+   Returns the branch name or nil if no branch is specified.
+   e.g., 'my-ledger:main' -> 'main'
+         'my-ledger' -> nil"
+  [ledger-alias]
+  (second (ledger-parts ledger-alias)))
+
+(defn ensure-ledger-branch
+  "Ensures a ledger alias includes a branch.
+   If no : symbol present, appends :main as default branch.
+   e.g., 'my-ledger' -> 'my-ledger:main'
+         'my-ledger:branch' -> 'my-ledger:branch'"
+  [ledger-alias]
+  (if (ledger-branch ledger-alias)
+    ledger-alias
+    (str ledger-alias ":" const/default-branch-name)))
 
 (defn validate-ledger-name
   "Validates a ledger name for creation. Throws if invalid.


### PR DESCRIPTION
## Summary
- Consolidated ledger name and branch handling into `fluree.db.util.ledger` namespace
- Moved `normalize-ledger-alias` → `ensure-ledger-branch` for better naming consistency
- Fixed branch handling in `query/api` to ensure consistent branch inclusion