### PR TITLE
Dedupe identical retract/assert pairs at same t during update/upsert

### DIFF
--- a/test/fluree/db/transact/upsert_test.clj
+++ b/test/fluree/db/transact/upsert_test.clj
@@ -1,6 +1,8 @@
 (ns fluree.db.transact.upsert-test
   (:require [clojure.test :refer [deftest is testing]]
             [fluree.db.api :as fluree]
+            [fluree.db.flake :as flake]
+            [fluree.db.json-ld.iri :as iri]
             [fluree.db.query.fql.parse :as parse]
             [fluree.db.test-utils :as test-utils]))
 
@@ -135,6 +137,37 @@
                  @(fluree/query db2 {"@context" {"ex" "http://example.org/ns/"}
                                      "where"    [{"@id" "?s" "@type" "ex:User"}]
                                      "select"   {"?s" ["*"]}}))))))))
+
+(deftest ^:integration upsert-cancels-identical-pairs-in-novelty
+  (testing "Upsert cancels identical retract/assert pairs at same t in novelty"
+    (let [conn (test-utils/create-conn)
+          ledger-name "tx/upsert-cancel-pairs"
+          _  @(fluree/create conn ledger-name)
+          ctx  {"ex" "http://example.org/ns/"
+                "schema" "http://schema.org/"}
+          _  @(fluree/insert! conn ledger-name
+                              {"@context" ctx
+                               "@graph"   [{"@id"         "ex:alice"
+                                            "@type"        "ex:User"
+                                            "schema:name"  "Alice"
+                                            "ex:nums"      [1 2]}]})
+          ;; Upsert unchanged schema:name and add one new ex:nums value
+          db2  @(fluree/upsert! conn ledger-name
+                                {"@context" ctx
+                                 "@graph"   [{"@id"         "ex:alice"
+                                              "schema:name"  "Alice2"
+                                              "ex:nums"      [1 2 3]}]})
+          spot (get-in db2 [:novelty :spot])
+          s    (iri/encode-iri db2 "http://example.org/ns/alice")
+          p-name (iri/encode-iri db2 "http://schema.org/name")
+          p-nums (iri/encode-iri db2 "http://example.org/ns/nums")
+          alice-flakes (filter #(= s (flake/s %)) spot)
+          name-flakes (filter #(= p-name (flake/p %)) alice-flakes)
+          nums-flakes (filter #(= p-nums (flake/p %)) alice-flakes)]
+      (is (= 3 (count name-flakes))
+          "schema:name asserts Alice, then retracts Alice and asserts Alice2 - so three flakes total")
+      (is (= 3 (count nums-flakes))
+          "ex:nums went from [1 2] to [1 2 3] so only an assertions for total of 3 flakes"))))
 
 (deftest upsert-and-commit
   (let [conn    @(fluree/connect-memory)


### PR DESCRIPTION
We allowed update / upset to retract and then re-assert the identical flake. While I thought this should not matter except that it takes extra space unnecessarily (but performs less logic during transaction time), it turns out how we replay flakes it can matter and creates a situation where it seems data isn't there - when it actually is there in the commit correctly.

This results in flakes that look like:
[ex:alice ex:name "Bob" 1 true]
[ex:alice ex:name "Bob" 2 false]
[ex:alice ex:name "Bob" 2 true]

And this creates some unexpected problems.

### Summary
- Fixes a bug where updates/upserts that retract and then re-assert the exact same triple at the same t produced redundant flakes.
- Adds single-pass cancellation so identical retract+assert pairs at the same t are dropped from novelty.
- Keeps insert-only performance unchanged by only doing extra work when retractions occur.

### Problem
- Update/upsert pipeline produce retractions for current values and assertions for new values.
- When a value is “updated” to the same value (or passes through an update that retracts then re-asserts the same triple), both the retract and the assert were included in the resulting commit/novelty.
- This leads to unnecessary work and larger novelty/commit output, especially painful on large transactions.

### Approach
- Implement cancellation in the existing streaming accumulation step (no extra pass over all flakes):
  - While transducing the flake stream into the AVL-backed `:spot` set, we capture retractions in a local volatile.
  - In the reducer’s completion arity, if any retractions were seen, we sweep just those retractions:
    - For each retract r, compute the corresponding assertion a via `flake/flip-flake`.
    - If a is present in the set, remove both a and r (they cancel).
- This is order-independent and runs inside the single pass we already perform to build the set.

### Why this is efficient
- Insert-only transactions: unchanged. We pay zero additional lookups because we only sweep if retractions exist.
- Updates/upserts: extra work is proportional to the number of retractions R, not total flakes N.
  - Time: O(R log N) (contains?/disj on the AVL set)
  - Memory: Should not be significant as we use the same underlying Flake when tracking retractions, so I is the list and pointers only

### Complexity
- Base accumulation (unchanged): O(N log N) into the AVL set.
- Additional cancellation work (only when retractions present): O(R log N).
- Net: O(N log N + R log N), with R << N in typical workloads.

### Correctness details
- Cancellation only occurs for truly identical triples at the same t (same s, p, o, dt, m and flipped op), which matches the desired behavior.
- Non-identical changes (e.g., name “Alice” → “Alice2”, or list differences) are preserved: only new assertions and actual retractions remain.
- Works regardless of assertion/retraction arrival order from the merged channels.
