### PR TITLE
Return all @type values in select graph crawls; flatten rdf:type and skip policy checks

### DIFF
--- a/src/fluree/db/flake/format.cljc
+++ b/src/fluree/db/flake/format.cljc
@@ -35,21 +35,9 @@
         end-flake   (query-range/resolve-match-flake end-test s2 p2 o2 t2 op2 m2)]
     [start-flake end-flake]))
 
-(defn rdf-type?
-  [pid]
-  (= const/$rdf:type pid))
-
 (defn list-element?
   [flake]
   (-> flake flake/m (contains? :i)))
-
-(defn type-value
-  [db cache compact-fn type-flakes]
-  (->> type-flakes
-       (into [] (comp (map flake/o)
-                      (map (partial cache-sid->iri db cache compact-fn))
-                      (map :as)))
-       util/unwrap-singleton))
 
 (defn format-reference
   [db spec sid]
@@ -78,14 +66,12 @@
                         (when wildcard?
                           (cache-sid->iri db cache compact-fn pid)))]
       (let [p-iri (:as spec)
-            v     (if (rdf-type? pid)
-                    (type-value db cache compact-fn p-flakes)
-                    (let [p-flakes* (if (list-element? ff)
-                                      (sort-by (comp :i flake/m) p-flakes)
-                                      p-flakes)]
-                      (->> p-flakes*
-                           (mapv (partial format-object db spec))
-                           (util/unwrap-singleton p-iri context))))]
+            v     (let [p-flakes* (if (list-element? ff)
+                                    (sort-by (comp :i flake/m) p-flakes)
+                                    p-flakes)]
+                    (->> p-flakes*
+                         (mapv (partial format-object db spec))
+                         (util/unwrap-singleton p-iri context)))]
         [p-iri v]))))
 
 (defn format-subject-xf

--- a/test/fluree/db/query/misc_queries_test.clj
+++ b/test/fluree/db/query/misc_queries_test.clj
@@ -59,6 +59,22 @@
              @(fluree/query db {"@context" []
                                 :select    {"http://example.org/ns/dan" ["*"]}}))
           "empty context vector"))
+
+    (testing "@type returns all values in select graph crawl"
+      (let [conn2         (test-utils/create-conn)
+            ledger2       "query-multitype"
+            _             @(fluree/create conn2 ledger2)
+            db2           @(fluree/update @(fluree/db conn2 ledger2)
+                                          {"@context" [test-utils/default-context
+                                                       {:ex "http://example.org/ns/"}]
+                                           "insert"   [{:id   :ex/item
+                                                        :type [:ex/Foo :ex/Bar]}]})
+            db2           @(fluree/commit! conn2 db2)
+            res           @(fluree/query db2 {:context [test-utils/default-context
+                                                        {:ex "http://example.org/ns/"}]
+                                              :select  {:ex/item ["*"]}})]
+        (is (= [{:id :ex/item, :type [:ex/Bar :ex/Foo]}]
+               res))))
     (testing "history query"
       (is (= [{:f/t       1
                :f/assert  [{:id :ex/dan :ex/x 1}]

--- a/test/fluree/db/transact/insert_test.clj
+++ b/test/fluree/db/transact/insert_test.clj
@@ -86,5 +86,5 @@
                   "insert"   [{"@id"   "ex:bad"
                                "@type" [{"@value" "not-a-iri"
                                          "@type"  "xsd:string"}]}]}
-          res    (ex-data @(fluree/update db0 txn))]  
+          res    (ex-data @(fluree/update db0 txn))]
       (is (= 400 (:status res)) "Status should indicate a bad request"))))

--- a/test/fluree/db/transact/insert_test.clj
+++ b/test/fluree/db/transact/insert_test.clj
@@ -75,3 +75,16 @@
                                :select '?name
                                :where  {:schema/name '?name}})))
         (is (= 2 (:t db)))))))
+
+(deftest ^:integration insert-invalid-type-literal
+  (testing "Inserting a node with @type as a literal (non-IRI) should error"
+    (let [conn   (test-utils/create-conn)
+          db0    @(fluree/create conn "tx/invalid-type-literal")
+          txn    {"@context" [test-utils/default-str-context
+                              {"ex"  "http://example.org/ns/"
+                               "xsd" "http://www.w3.org/2001/XMLSchema#"}]
+                  "insert"   [{"@id"   "ex:bad"
+                               "@type" [{"@value" "not-a-iri"
+                                         "@type"  "xsd:string"}]}]}
+          res    (ex-data @(fluree/update db0 txn))]  
+      (is (= 400 (:status res)) "Status should indicate a bad request"))))


### PR DESCRIPTION
### Summary
- Fixes select graph crawl to return multiple @type values instead of collapsing to one.
- Treats rdf:type as normal references during accumulation; at final formatting:
  - Flattens references under @type to compact IRI strings (unwrap when single).
  - Skips policy checks for @type references to preserve class visibility semantics.

### Changes
- `src/fluree/db/flake/format.cljc`: Emit rdf:type via the standard reference path (no special-casing here).
- `src/fluree/db/query/exec/select/subject.cljc`: For `@type`, bypass resolve-reference (policy) and flatten refs to compact IRIs; accumulate multiple values and unwrap when single.
- Tests:
  - `test/fluree/db/query/misc_queries_test.clj`: Added a case ensuring graph crawl returns all @type values. This test failed before this fix.
  - `test/fluree/db/transact/insert_test.clj`: Added `insert-invalid-type-literal` to assert a 400 when @type is provided as a literal, not an IRI.

### Notes
- This keeps rdf:type output shape as `@type: ["ex:Foo", "ex:Bar"]`, while other refs remain objects (`{"@id": ...}`).
- Policy enforcement for @type is intentionally skipped at final formatting; other properties continue to enforce policy as before.