### PR TITLE
properly translate static IRIs in expression list

### DIFF
--- a/src/fluree/db/query/sparql/translator.cljc
+++ b/src/fluree/db/query/sparql/translator.cljc
@@ -259,7 +259,7 @@
   (when arglist
     (throw (ex-info "Unsupported syntax."
                     {:status 400 :error :db/invalid-query :term arglist})))
-  (parse-term iri))
+  {const/iri-id (parse-term iri)})
 
 (defmethod parse-term :UnaryExpression
   [[_ op-or-expr expr]]
@@ -527,13 +527,7 @@
   [[_ & bindings]]
   ;; bindings come in as val, var; need to be reversed to var, val.
   (into [:bind] (->> bindings
-                     (mapv (fn [term]
-                             (let [terms (into #{} (flatten term))
-                                   parsed (parse-term term)]
-                               (if (and (terms :iriOrFunction) (not= \( (first parsed)))
-                                 ;; static iri
-                                 {const/iri-id parsed}
-                                 (parse-term term)))))
+                     (mapv parse-term)
                      (partition-all 2)
                      (mapcat reverse))))
 

--- a/test/fluree/db/query/filter_query_test.clj
+++ b/test/fluree/db/query/filter_query_test.clj
@@ -132,7 +132,15 @@
                                 :where   '[{:type        :ex/User
                                             :schema/name ?name}
                                            [:bind ?nameLength "(strLen ?name)"]
-                                           [:filter "(in ?nameLength [2 3 {\"@value\" 4 :type :xsd/int}])"]]}))))
+                                           [:filter "(in ?nameLength [2 3 {\"@value\" 4 :type :xsd/int}])"]]})))
+      (is (= ["Cam" "David"]
+             @(fluree/query db {:context [test-utils/default-context
+                                          {:ex "http://example.org/ns/"}]
+                                :select  '?name
+                                :where   '[{:id          ?s
+                                            :schema/name ?name}
+                                           [:bind ?nameLength "(strLen ?name)"]
+                                           [:filter "(in ?s [{\"@id\" :ex/cam} {\"@id\" :ex/david}])"]]}))))
 
     (testing "filtering variables bound to iris"
       (let [db-dads @(fluree/update

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -332,7 +332,7 @@
                  }"
           {:keys [where]} (sparql/->fql query)]
       (is (= [{"@id" "?s", "?pred" "?o"}
-              [:filter "(not= \"schema:pred\" ?pred)"]]
+              [:filter "(not= {\"@id\" \"schema:pred\"} ?pred)"]]
              where)
           "filter string values"))
     (let [query "SELECT ?s
@@ -629,8 +629,8 @@
                 [:bind "?floor" "(floor 1.8)"]
                 [:bind "?hours" "(hours \"2024-4-1T14:45:13.815-05:00\")"]
                 [:bind "?if" "(if \"true\" \"yes\" \"no\")"]
-                [:bind "?in" "(in ?age [1 2 3 \"foo\" \"ex:bar\"])"]
-                [:bind "?notIn" "(not (in ?age [1 2 3 \"foo\" \"ex:bar\"]))"]
+                [:bind "?in" "(in ?age [1 2 3 \"foo\" {\"@id\" \"ex:bar\"}])"]
+                [:bind "?notIn" "(not (in ?age [1 2 3 \"foo\" {\"@id\" \"ex:bar\"}]))"]
                 [:bind "?iri" "(iri \"http://example.com\")"]
                 [:bind "?lang" "(lang \"Robert\"\"@en\")"]
                 [:bind "?langMatches" "(langMatches ?lang \"FR\")"]


### PR DESCRIPTION
This adds support for static IRIs in `in` functions.