### PR TITLE
properly handle whitespace after composed expressions

### DIFF
--- a/resources/sparql.bnf
+++ b/resources/sparql.bnf
@@ -133,7 +133,7 @@ As ::= WS <('AS' | 'as')> WS
 <AdditiveExpression>	  ::=  	MultiplicativeExpression (WS '+' WS MultiplicativeExpression | WS '-' WS MultiplicativeExpression | ( NumericLiteralPositive | NumericLiteralNegative ) ( (WS '*' WS UnaryExpression ) | (WS '/' WS UnaryExpression ) )* )*
 
 
-MultiplicativeExpression ::= UnaryExpression ( '*' WS UnaryExpression | '/' WS UnaryExpression )*
+MultiplicativeExpression ::= UnaryExpression WS ( '*' WS UnaryExpression WS | '/' WS UnaryExpression WS )*
 UnaryExpression ::= '!' PrimaryExpression
 | '+' PrimaryExpression
 | '-' PrimaryExpression

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -89,6 +89,11 @@
                    }
                    GROUP BY ?author"]
         (is (= ["?author" "(as (groupconcat ?title \", \") ?books)"]
+               (:select (sparql/->fql query))))))
+    (testing "ROUND"
+      (let [query "SELECT (ROUND(?foo) * 100 AS ?bar)
+                   WHERE { ?s <ex:foo> ?foo . }"]
+        (is (= ["(as (* (round ?foo) 100) ?bar)"]
                (:select (sparql/->fql query))))))))
 
 (deftest parse-construct


### PR DESCRIPTION
This uses ROUND to test, but it would occur after any :UnaryExpression.