### PR TITLE
Revert "Optimize subject joins"

### DIFF
--- a/dev/commit_explore.clj
+++ b/dev/commit_explore.clj
@@ -12,11 +12,18 @@
        (filter #(.isFile %))
        (map #(.getName %))))
 
+(defn parse-file
+  [source-dir file-name]
+  (-> source-dir
+      (io/file file-name)
+      slurp
+      (json/parse false)))
+
 (defn parsed-files
   "Lazily returns every file in a directory as a parsed json object"
   [source-dir]
   (let [files (list-files source-dir)]
-    (map #(json/parse (slurp (io/file source-dir %)) false) files)))
+    (map (partial parse-file source-dir) files)))
 
 (defn data-file?
   "Truthy if the parsed file is a data file (@type = f:DB)"

--- a/src/fluree/db/async_db.cljc
+++ b/src/fluree/db/async_db.cljc
@@ -78,19 +78,6 @@
             (>! error-ch e))))
       match-ch))
 
-  (-match-properties [_ tracker solution triples error-ch]
-    (let [match-ch (async/chan)]
-      (go
-        (try*
-          (let [db (<? db-chan)]
-            (-> db
-                (where/-match-properties tracker solution triples error-ch)
-                (async/pipe match-ch)))
-          (catch* e
-            (log/error e "Error loading database")
-            (>! error-ch e))))
-      match-ch))
-
   (-activate-alias [_ alias']
     (go-try
       (let [db (<? db-chan)]

--- a/src/fluree/db/branch.cljc
+++ b/src/fluree/db/branch.cljc
@@ -228,8 +228,10 @@
   (let [updated-db (-> state
                        (swap! update-commit (policy/root-db new-db))
                        :current-db)]
-    (when (indexing-enabled? branch-map)
-      (enqueue-index! index-queue updated-db index-files-ch))
+    (if (indexing-enabled? branch-map)
+      (do (log/debug "Enqueueing new commit reindex for branch:" branch-map)
+          (enqueue-index! index-queue updated-db index-files-ch))
+      (log/debug "Indexing disabled for branch:" branch-map))
     branch-map))
 
 (defn current-db

--- a/src/fluree/db/dataset.cljc
+++ b/src/fluree/db/dataset.cljc
@@ -79,13 +79,6 @@
         (where/-match-class active-graph tracker solution triple error-ch))
       empty-channel))
 
-  (-match-properties [ds tracker solution triples error-ch]
-    (if-let [active-graph (get-active-graph ds)]
-      (if (sequential? active-graph)
-        (where/match-triples ds tracker solution triples error-ch)
-        (where/-match-properties active-graph tracker solution triples error-ch))
-      empty-channel))
-
   (-activate-alias [ds alias]
     (go-try
       (activate ds alias)))

--- a/src/fluree/db/flake.cljc
+++ b/src/fluree/db/flake.cljc
@@ -356,15 +356,6 @@
    (cmp-op (op f1) (op f2))
    (cmp-meta (m f1) (m f2))))
 
-(defn cmp-flakes-psot [f1 f2]
-  (combine-cmp
-   (cmp-pred (p f1) (p f2))
-   (cmp-subj (s f1) (s f2))
-   (cmp-obj (o f1) (dt f1) (o f2) (dt f2))
-   (cmp-tx (t f1) (t f2))
-   (cmp-op (op f1) (op f2))
-   (cmp-meta (m f1) (m f2))))
-
 (defn cmp-flakes-post [f1 f2]
   (combine-cmp
    (cmp-pred (p f1) (p f2))

--- a/src/fluree/db/flake/commit_data.cljc
+++ b/src/fluree/db/flake/commit_data.cljc
@@ -177,9 +177,9 @@
       issuer (assoc :issuer {:id (get-id issuer)}))))
 
 (defn update-index-roots
-  [commit-map {:keys [spot psot post opst tspo]}]
+  [commit-map {:keys [spot post opst tspo]}]
   (if (contains? commit-map :index)
-    (update commit-map :index assoc :spot spot, :psot psot, :post post, :opst opst, :tspo tspo)
+    (update commit-map :index assoc :spot spot, :post post, :opst opst, :tspo tspo)
     commit-map))
 
 (defn json-ld->map
@@ -362,8 +362,6 @@
            ;; launch futures for parallellism on JVM
            flake-size  #?(:clj  (future (calc-flake-size add rem))
                           :cljs (calc-flake-size add rem))
-           psot        #?(:clj  (future (flake/revise (get-in db [:novelty :psot]) add rem))
-                          :cljs (flake/revise (get-in db [:novelty :psot]) add rem))
            post        #?(:clj  (future (flake/revise (get-in db [:novelty :post]) add rem))
                           :cljs (flake/revise (get-in db [:novelty :post]) add rem))
            opst        #?(:clj  (future (flake/revise (get-in db [:novelty :opst]) (ref-flakes add) (ref-flakes rem)))
@@ -371,8 +369,6 @@
        (-> db
            (update-in [:novelty :spot] flake/revise add rem)
            (update-in [:novelty :tspo] flake/revise add rem)
-           (assoc-in [:novelty :psot] #?(:clj  @psot
-                                         :cljs psot))
            (assoc-in [:novelty :post] #?(:clj  @post
                                          :cljs post))
            (assoc-in [:novelty :opst] #?(:clj  @opst
@@ -397,7 +393,7 @@
   data as its own entity."
   [db]
   (let [tt-id   (random-uuid)
-        indexes [:spot :psot :post :opst :tspo]]
+        indexes [:spot :post :opst :tspo]]
     (-> (reduce
          (fn [db* idx]
            (let [{:keys [children] :as node} (get db* idx)

--- a/src/fluree/db/flake/flake_db.cljc
+++ b/src/fluree/db/flake/flake_db.cljc
@@ -313,9 +313,6 @@
   (-match-triple [db tracker solution triple-mch error-ch]
     (match/match-triple db tracker solution triple-mch error-ch))
 
-  (-match-properties [db tracker solution triple-mchs error-ch]
-    (match/match-properties db tracker solution triple-mchs error-ch))
-
   (-match-class [db tracker solution class-mch error-ch]
     (match/match-class db tracker solution class-mch error-ch))
 

--- a/src/fluree/db/flake/flake_db.cljc
+++ b/src/fluree/db/flake/flake_db.cljc
@@ -351,8 +351,10 @@
   indexer/Indexable
   (index [db changes-ch]
     (if (novelty/min-novelty? db)
-      (novelty/refresh db changes-ch max-old-indexes)
-      (go db)))
+      (do (log/debug "minimum reindex novelty exceeded for:" (:alias db) ". starting reindex")
+          (novelty/refresh db changes-ch max-old-indexes))
+      (do (log/debug "minimum reindex novelty size not met for:" (:alias db) ". skipping reindex")
+          (go db))))
 
   TimeTravel
   (datetime->t [db datetime]

--- a/src/fluree/db/flake/history.cljc
+++ b/src/fluree/db/flake/history.cljc
@@ -115,7 +115,6 @@
           idx     (index/for-components s p o nil)
           pattern (case idx
                     :spot [s p o]
-                    :psot [p s o]
                     :post [p o s]
                     :opst [o p s])]
       [pattern idx])))

--- a/src/fluree/db/flake/index.cljc
+++ b/src/fluree/db/flake/index.cljc
@@ -10,16 +10,15 @@
             [fluree.db.util.log :as log :include-macros true]))
 
 (def comparators
-  "Map of default index comparators for the five index types"
+  "Map of default index comparators for the four index types"
   (array-map ;; when using futures, can base other calcs on :spot (e.g. size), so ensure comes first
    :spot flake/cmp-flakes-spot
-   :psot flake/cmp-flakes-psot
    :post flake/cmp-flakes-post
    :opst flake/cmp-flakes-opst
    :tspo flake/cmp-flakes-block))
 
 (def types
-  "The five possible index orderings based on the subject, predicate, object,
+  "The four possible index orderings based on the subject, predicate, object,
   and transaction flake attributes"
   (-> comparators keys vec))
 

--- a/src/fluree/db/flake/index/storage.cljc
+++ b/src/fluree/db/flake/index/storage.cljc
@@ -89,7 +89,7 @@
 (defn write-db-root
   [{:keys [storage serializer] :as index-catalog} db garbage-addr]
   (go-try
-    (let [{:keys [alias schema t stats spot psot post opst tspo vg commit namespace-codes
+    (let [{:keys [alias schema t stats spot post opst tspo vg commit namespace-codes
                   reindex-min-bytes reindex-max-bytes max-old-indexes]}
           db
 
@@ -102,7 +102,6 @@
                                  :schema          (vocab/serialize-schema schema)
                                  :stats           (select-keys stats [:flakes :size])
                                  :spot            (child-data spot)
-                                 :psot            (child-data psot)
                                  :post            (child-data post)
                                  :opst            (child-data opst)
                                  :tspo            (child-data tspo)

--- a/src/fluree/db/flake/match.cljc
+++ b/src/fluree/db/flake/match.cljc
@@ -7,8 +7,7 @@
             [fluree.db.query.exec.where :as where]
             [fluree.db.query.range :as query-range]
             [fluree.db.util :as util :refer [vswap!]]
-            [fluree.db.util.async :refer [<? go-try inner-join-by
-                                          repartition-each-by]]))
+            [fluree.db.util.async :refer [<? go-try]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -174,12 +173,12 @@
 
 (defn match-triple
   [db tracker solution tuple error-ch]
-  (let [out-ch   (async/chan 2)
-        db-alias (:alias db)
-        triple   (where/assign-matched-values tuple solution)]
-    (if-some [[s p o] (where/compute-sids db triple)]
+  (let [out-ch     (async/chan 2)
+        db-alias   (:alias db)
+        triple     (where/assign-matched-values tuple solution)]
+    (if-let [[s p o] (where/compute-sids db triple)]
       (let [pid (where/get-sid p db)]
-        (if-some [props (and pid (where/get-child-properties db pid))]
+        (if-let [props (and pid (where/get-child-properties db pid))]
           (let [prop-ch (-> props (conj pid) async/to-chan!)]
             (async/pipeline-async 2
                                   out-ch
@@ -200,50 +199,6 @@
                 (async/pipe out-ch)))))
       (async/close! out-ch))
     out-ch))
-
-(defn match-property-flakes
-  [solution triple db property-flakes]
-  (map (fn [flake]
-         (where/match-flake solution triple db flake))
-       property-flakes))
-
-(defn match-subject-property
-  [initial-solutions triple-map db property-flakes]
-  (let [pid        (->> property-flakes first flake/p)
-        triple     (-> triple-map (get pid) first)]
-    (mapcat (fn [solution]
-              (match-property-flakes solution triple db property-flakes))
-            initial-solutions)))
-
-(defn match-join
-  [solution triples db join]
-  (let [triple-map (group-by (fn [[_ p-mch _]]
-                               (where/get-sid p-mch db))
-                             triples)]
-    (loop [[s-chunk & r] join
-           new-solutions [solution]]
-      (if s-chunk
-        (let [new-solutions* (match-subject-property new-solutions triple-map db s-chunk)]
-          (recur r new-solutions*))
-        new-solutions))))
-
-(defn match-properties
-  [db tracker solution triples error-ch]
-  (let [triples* (->> triples
-                      (map (fn [triple]
-                             (where/assign-matched-values triple solution)))
-                      (map (partial where/compute-sids db)))]
-    (if (every? some? triples*)
-      (let [property-ranges (->> triples*
-                                 (map (fn [triple]
-                                        (where/resolve-flake-range db tracker error-ch triple :psot)))
-                                 (repartition-each-by flake/s))
-            extract-sid     (comp flake/s first)
-            join-xf         (mapcat (fn [join]
-                                      (match-join solution triples* db join)))]
-        (inner-join-by flake/cmp-sid extract-sid 2 join-xf property-ranges))
-      (doto (async/chan)
-        (async/close!)))))
 
 (defn with-distinct-subjects
   "Return a transducer that filters a stream of flakes by removing any flakes with

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -304,7 +304,6 @@
   (-match-id [s tracker solution s-match error-ch])
   (-match-triple [s tracker solution triple error-ch])
   (-match-class [s tracker solution triple error-ch])
-  (-match-properties [s tracker solution triples error-ch])
   (-activate-alias [s alias])
   (-aliases [s])
   (-finalize [s tracker error-ch solution-ch]))
@@ -593,11 +592,6 @@
   [ds tracker solution pattern error-ch]
   (let [triple (pattern-data pattern)]
     (-match-class ds tracker solution triple error-ch)))
-
-(defmethod match-pattern :property-join
-  [ds tracker solution pattern error-ch]
-  (let [triples (pattern-data pattern)]
-    (-match-properties ds tracker solution triples error-ch)))
 
 (defn filter-exception
   "Reformats raw filter exception to try to provide more useful feedback."

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -529,13 +529,6 @@
   [attrs]
   (every? v/query-variable? (vals attrs)))
 
-(defn simple-property-join?
-  [id attrs]
-  (and (>= (count attrs) 2)
-       (v/query-variable? id)
-       (specified-properties? attrs)
-       (variable-objects? attrs)))
-
 (defn parse-id-map-pattern
   [m var-config context]
   (let [id    (get m const/iri-id)
@@ -544,9 +537,7 @@
     (if (empty? attrs)
       [(where/->pattern :id s-mch)]
       (let [statements (parse-statements s-mch attrs var-config context)]
-        (if (simple-property-join? id attrs)
-          [(where/->pattern :property-join statements)]
-          (sort optimize/compare-triples statements))))))
+        (sort optimize/compare-triples statements)))))
 
 (defn parse-node-map
   [m var-config context]

--- a/src/fluree/db/query/range.cljc
+++ b/src/fluree/db/query/range.cljc
@@ -29,7 +29,6 @@
   (let [[p1 p2 p3 p4 op m] match]
     (case idx
       :spot [p1 (coerce-predicate db p2) p3 p4 op m]
-      :psot [p2 (coerce-predicate db p1) p3 p4 op m]
       :post [p3 (coerce-predicate db p1) p2 p4 op m]
       :opst [p3 (coerce-predicate db p2) p1 p4 op m]
       :tspo [p2 (coerce-predicate db p3) p4 p1 op m])))

--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -163,7 +163,7 @@
                 (:stats :config :garbage :prev-index)
                 (util/stringify-keys v)
 
-                (:spot :psot :post :opst :tspo)
+                (:spot :post :opst :tspo)
                 (stringify-child v)
 
                 v)))

--- a/src/fluree/db/virtual_graph/bm25/index.clj
+++ b/src/fluree/db/virtual_graph/bm25/index.clj
@@ -260,9 +260,6 @@
   (-match-class [_ _tracker _solution _s-mch _error-ch]
     empty-channel)
 
-  (-match-properties [this tracker solution triples error-ch]
-    (where/match-triples this tracker solution triples error-ch))
-
   ;; activate-alias should not be called on an index VG, return empty chan
   (-activate-alias [_ _]
     (let [ch (async/chan)]

--- a/src/fluree/db/virtual_graph/flat_rank.cljc
+++ b/src/fluree/db/virtual_graph/flat_rank.cljc
@@ -74,9 +74,6 @@
   (-match-class [_ _tracker _solution _s-mch _error-ch]
     empty-channel)
 
-  (-match-properties [_ tracker solution triples error-ch]
-    (where/match-triples db tracker solution triples error-ch))
-
   (-activate-alias [_ alias']
     (where/-activate-alias db alias'))
 
@@ -101,9 +98,6 @@
   (-match-class [_ _tracker _solution _s-mch _error-ch]
     empty-channel)
 
-  (-match-properties [_ tracker solution triples error-ch]
-    (where/match-triples db tracker solution triples error-ch))
-
   (-activate-alias [_ alias']
     (where/-activate-alias db alias'))
 
@@ -127,9 +121,6 @@
 
   (-match-class [_ _tracker _solution _s-mch _error-ch]
     empty-channel)
-
-  (-match-properties [_ tracker solution triples error-ch]
-    (where/match-triples db tracker solution triples error-ch))
 
   (-activate-alias [_ alias']
     (where/-activate-alias db alias'))

--- a/test/fluree/db_test.cljc
+++ b/test/fluree/db_test.cljc
@@ -1097,7 +1097,7 @@
            ;; initial create call generates an initial commit, each commit has two files
            (is (= (* 2 (inc tx-count))
                   (count (async/<!! (fs/list-files (str primary-path "/" alias "/commit"))))))
-           (is (= ["garbage" "opst" "post" "psot" "root" "spot" "tspo"]
+           (is (= ["garbage" "opst" "post" "root" "spot" "tspo"]
                   (sort (async/<!! (fs/list-files (str primary-path "/" alias "/index"))))))
            ;; one new index root per tx
            (is (= tx-count
@@ -1129,7 +1129,7 @@
                   (async/<!! (fs/list-files (str secondary-path "/ns@v2/destined-for-drop")))))
            (is (= ["commit" "index" "txn"]
                   (sort (async/<!! (fs/list-files (str primary-path "/" alias))))))
-           (is (= ["garbage" "opst" "post" "psot" "root" "spot" "tspo"]
+           (is (= ["garbage" "opst" "post" "root" "spot" "tspo"]
                   (sort (async/<!! (fs/list-files (str primary-path "/" alias "/index"))))))
            (is (zero? (count (async/<!! (fs/list-files (str primary-path "/" alias "/txn"))))))
            (is (zero? (count (async/<!! (fs/list-files (str primary-path "/" alias "/commit"))))))


### PR DESCRIPTION
This patch reverts #1080 because the optimizations there required a `psot` index which would have been onerous to build for large existing ledgers. There are also some other proposals or changing our indexing and serialization approach which may make those optimization unnecessary, and, at the very least, would also require migrations, so it would be better to do those all at once.