### PR TITLE
handle whitespace in order-by expressions

### DIFF
--- a/resources/sparql.bnf
+++ b/resources/sparql.bnf
@@ -139,7 +139,7 @@ UnaryExpression ::= '!' PrimaryExpression
 | '-' PrimaryExpression
 | PrimaryExpression
 <PrimaryExpression>	  ::=  	BrackettedExpression | BuiltInCall | iriOrFunction | RDFLiteral | NumericLiteral | BooleanLiteral | Var
-BrackettedExpression	  ::=  	<'('> WS Expression WS <')'>
+BrackettedExpression	  ::=  	<'('> WS Expression WS <')'> WS
 
 <BuiltInCall> ::= Aggregate
 | ExistsFunc

--- a/test/fluree/db/query/sparql_test.cljc
+++ b/test/fluree/db/query/sparql_test.cljc
@@ -843,6 +843,19 @@
                    ORDER BY desc(?favNums)"
             {:keys [orderBy]} (sparql/->fql query)]
         (is (= [["desc" "?favNums"]]
+               orderBy))))
+    (testing "multiple vars"
+      (let [query "SELECT ?favNums
+                   WHERE {?person person:favNums ?favNums. ?person ex:name ?name .}
+                   ORDER BY desc(?favNums) ?name"
+            {:keys [orderBy]} (sparql/->fql query)]
+        (is (= [["desc" "?favNums"] "?name"]
+               orderBy)))
+      (let [query "SELECT ?favNums
+                   WHERE {?person person:favNums ?favNums. ?person ex:name ?name .}
+                   ORDER BY ?favNums ?name"
+            {:keys [orderBy]} (sparql/->fql query)]
+        (is (= ["?favNums" "?name"]
                orderBy)))))
   (testing "PRETTY-PRINT"
     (let [query "SELECT ?person


### PR DESCRIPTION
Update the SPARQL grammar to account for whitespace between multiple order-by expressions.