### PR TITLE
Fix S3 swap-bytes ETag handling

### DIFF
--- a/src/fluree/db/storage/s3.clj
+++ b/src/fluree/db/storage/s3.clj
@@ -466,8 +466,9 @@
                              (let [read-resp     (<? (read-s3-data this path))
                                    current-bytes (when-not (= read-resp ::not-found)
                                                    (.getBytes ^String (:body read-resp)))
+                                   ;; etag header value is a vector from xhttp, extract first element
                                    etag          (when-not (= read-resp ::not-found)
-                                                   (get-in read-resp [:headers "etag"]))
+                                                   (first (get-in read-resp [:headers "etag"])))
                                    new-bytes     (f current-bytes)]
                                (when new-bytes
                                  (let [headers (if etag


### PR DESCRIPTION
## Summary
Fixes `ClassCastException` in S3 `swap-bytes` when extracting ETag from response headers.

## Problem
xhttp's `get-headers` converts all HTTP header values to vectors (to handle multi-value headers). When S3's `swap-bytes` extracted the ETag header and passed it to `sign-request`, the vector value caused a `ClassCastException` when `canonical-headers` tried to call `str/trim` on it:

```
ClassCastException: clojure.lang.PersistentVector cannot be cast to java.lang.CharSequence
at clojure.string$trim.invokeStatic(string.clj:235)
at fluree.db.storage.s3$canonical_headers$fn__59545.invoke(s3.clj:110)
```

## Solution
Extract the first element from the ETag header vector using `first` before passing it to write headers. ETags only have a single value, so this is safe.