### PR TITLE
Add streaming query API with metadata tracking support

### DIFF
--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -849,6 +849,53 @@
         (throw (ex-info "No nameservice available for querying"
                         {:status 400 :error :db/no-nameservice})))))))
 
+;; Streaming Query APIs
+
+(defn query-stream
+  "Streaming version of `query`. Returns a core.async channel that emits
+  individual results as produced, rather than collecting into a vector.
+
+  See `query` for query syntax and options. Key differences:
+    - Returns core.async channel instead of promise
+    - Emits results individually (reduces memory for large result sets)
+    - Caching not supported
+    - CONSTRUCT queries emit individual graph nodes (not grouped by subject)
+    - When :meta enabled, final item is {:_fluree-meta {...}}"
+  ([ds q]
+   (query-stream ds q {}))
+  ([ds q opts]
+   (cond
+     (util/exception? ds)
+     (async/to-chan! [ds])
+
+     (:cache opts)
+     (async/to-chan! [(ex-info "Streaming queries do not support caching"
+                               {:status 400
+                                :error :db/invalid-query
+                                :message "Remove :cache option or use non-streaming query API"})])
+
+     :else
+     (query-api/query-stream ds q opts))))
+
+(defn query-connection-stream
+  "Streaming version of `query-connection`. Returns a core.async channel that
+  emits individual results as produced.
+
+  See `query-connection` for query syntax and options. Key differences:
+    - Returns core.async channel instead of promise
+    - Emits results individually (reduces memory for large result sets)
+    - Caching not supported
+    - When :meta enabled, final item is {:_fluree-meta {...}}"
+  ([conn q] (query-connection-stream conn q {}))
+  ([conn q opts]
+   (validate-connection conn)
+   (if (:cache opts)
+     (async/to-chan! [(ex-info "Streaming queries do not support caching"
+                               {:status 400
+                                :error :db/invalid-query
+                                :message "Remove :cache option or use non-streaming query API"})])
+     (query-api/query-connection-stream conn q opts))))
+
 (defn history
   "Queries the history of entities across commits.
 

--- a/src/fluree/db/query/fql.cljc
+++ b/src/fluree/db/query/fql.cljc
@@ -170,6 +170,17 @@
            (let [oq (<? (optimize/optimize ds pq))]
              (<? (exec/query ds tracker oq)))))))))
 
+(defn query-stream
+  "Parses query and delegates to exec/query-stream. Returns channel emitting
+   individual results. Caching not supported for streaming."
+  ([ds query-map]
+   (query-stream ds nil query-map))
+  ([ds tracker query-map]
+   (go-try
+     (let [pq (parse/parse-query query-map)
+           oq (<? (optimize/optimize ds pq))]
+       (exec/query-stream ds tracker oq)))))
+
 (defn explain
   "Returns query execution plan without executing the query.
   Returns core async channel with query plan or exception."

--- a/test/fluree/db/query/stream_test.clj
+++ b/test/fluree/db/query/stream_test.clj
@@ -1,0 +1,281 @@
+(ns fluree.db.query.stream-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer [deftest is testing]]
+            [fluree.db.api :as fluree]
+            [fluree.db.query.api :as query-api]
+            [fluree.db.test-utils :as test-utils]))
+
+(deftest basic-streaming-query-test
+  (testing "Basic streaming query returns individual results"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/stream"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"     "ex:alice"
+                                    "@type"   "ex:Person"
+                                    "ex:name" "Alice"
+                                    "ex:age"  30}
+                                   {"@id"     "ex:bob"
+                                    "@type"   "ex:Person"
+                                    "ex:name" "Bob"
+                                    "ex:age"  25}
+                                   {"@id"     "ex:charlie"
+                                    "@type"   "ex:Person"
+                                    "ex:name" "Charlie"
+                                    "ex:age"  35}]})
+          query     {"@context" {"ex" "http://example.org/"}
+                     "select"   ["?name" "?age"]
+                     "where"    [{"@id"     "?person"
+                                  "@type"   "ex:Person"
+                                  "ex:name" "?name"
+                                  "ex:age"  "?age"}]}
+          result-ch (query-api/query-stream db1 query {})
+          results   (async/<!! (async/into [] result-ch))]
+
+      (is (= 3 (count results)) "Should return 3 individual results")
+      (is (every? vector? results) "Each result should be a vector")
+      (is (every? #(= 2 (count %)) results) "Each result should have 2 elements")
+      (is (= ["Alice" "Bob" "Charlie"]
+             (mapv first results))
+          "Should return names in insertion order"))))
+
+(deftest streaming-with-limit-test
+  (testing "Streaming query with LIMIT"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/stream-limit"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"     "ex:person1"
+                                    "ex:name" "Person 1"}
+                                   {"@id"     "ex:person2"
+                                    "ex:name" "Person 2"}
+                                   {"@id"     "ex:person3"
+                                    "ex:name" "Person 3"}
+                                   {"@id"     "ex:person4"
+                                    "ex:name" "Person 4"}
+                                   {"@id"     "ex:person5"
+                                    "ex:name" "Person 5"}]})
+          query     {"@context" {"ex" "http://example.org/"}
+                     "select"   ["?name"]
+                     "where"    [{"@id"     "?person"
+                                  "ex:name" "?name"}]
+                     "limit"    2}
+          result-ch (query-api/query-stream db1 query {})
+          results   (async/<!! (async/into [] result-ch))]
+
+      (is (= 2 (count results)) "Should return only 2 results due to LIMIT"))))
+
+(deftest streaming-select-one-test
+  (testing "Streaming SELECT ONE query"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/stream-one"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"     "ex:alice"
+                                    "ex:name" "Alice"}
+                                   {"@id"     "ex:bob"
+                                    "ex:name" "Bob"}]})
+          query     {"@context"  {"ex" "http://example.org/"}
+                     "selectOne" ["?name"]
+                     "where"     [{"@id"     "?person"
+                                   "ex:name" "?name"}]}
+          result-ch (query-api/query-stream db1 query {})
+          results   (async/<!! (async/into [] result-ch))]
+
+      (is (= 1 (count results)) "SELECT ONE should return only one result")
+      (is (vector? (first results)) "Result should be a vector"))))
+
+(deftest streaming-with-meta-tracking-test
+  (testing "Streaming query with :meta tracking emits final metadata"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/stream-meta"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"     "ex:alice"
+                                    "ex:name" "Alice"}
+                                   {"@id"     "ex:bob"
+                                    "ex:name" "Bob"}]})
+          query     {"@context" {"ex" "http://example.org/"}
+                     "select"   ["?name"]
+                     "where"    [{"@id"     "?person"
+                                  "ex:name" "?name"}]}
+          result-ch (query-api/query-stream db1 query {:meta true})
+          results   (async/<!! (async/into [] result-ch))]
+
+      (is (= 3 (count results)) "Should return 2 results + 1 metadata map")
+      (is (vector? (first results)) "First result should be a vector")
+      (is (vector? (second results)) "Second result should be a vector")
+
+      (let [meta-map (last results)]
+        (is (map? meta-map) "Last result should be a map")
+        (is (contains? meta-map :_fluree-meta) "Should contain :_fluree-meta key")
+        (is (= 200 (get-in meta-map [:_fluree-meta :status])) "Metadata should have status 200")
+        (is (contains? (get meta-map :_fluree-meta) :time) "Metadata should include :time")
+        (is (contains? (get meta-map :_fluree-meta) :fuel) "Metadata should include :fuel")))))
+
+(deftest streaming-connection-query-test
+  (testing "Streaming query via connection"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "stream/conn"
+          db0       @(fluree/create conn ledger-id)
+          _         @(fluree/commit! conn
+                                     @(fluree/update
+                                       db0
+                                       {"@context" {"ex" "http://example.org/"}
+                                        "insert"   [{"@id"     "ex:alice"
+                                                     "ex:name" "Alice"}
+                                                    {"@id"     "ex:bob"
+                                                     "ex:name" "Bob"}]}))
+          query     {"@context" {"ex" "http://example.org/"}
+                     "from"     ledger-id
+                     "select"   ["?name"]
+                     "where"    [{"@id"     "?person"
+                                  "ex:name" "?name"}]}
+          result-ch (query-api/query-connection-stream conn query {})
+          results   (async/<!! (async/into [] result-ch))]
+
+      (is (= 2 (count results)) "Should return 2 results")
+      (is (every? vector? results) "Each result should be a vector")
+      (is (= ["Alice" "Bob"]
+             (mapv first results))
+          "Should return both names in order"))))
+
+(deftest streaming-connection-with-meta-test
+  (testing "Streaming connection query with :meta tracking"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "stream/conn-meta"
+          db0       @(fluree/create conn ledger-id)
+          _         @(fluree/commit! conn
+                                     @(fluree/update
+                                       db0
+                                       {"@context" {"ex" "http://example.org/"}
+                                        "insert"   [{"@id"     "ex:alice"
+                                                     "ex:name" "Alice"}
+                                                    {"@id"     "ex:bob"
+                                                     "ex:name" "Bob"}]}))
+          query     {"@context" {"ex" "http://example.org/"}
+                     "from"     ledger-id
+                     "select"   ["?name"]
+                     "where"    [{"@id"     "?person"
+                                  "ex:name" "?name"}]}
+          result-ch (query-api/query-connection-stream conn query {:meta true})
+          results   (async/<!! (async/into [] result-ch))]
+
+      (is (= 3 (count results)) "Should return 2 results + 1 metadata map")
+      (is (every? vector? (take 2 results)) "First two results should be vectors")
+
+      (let [meta-map (last results)]
+        (is (map? meta-map) "Last result should be a map")
+        (is (contains? meta-map :_fluree-meta) "Should contain :_fluree-meta key")
+        (is (= 200 (get-in meta-map [:_fluree-meta :status])) "Metadata should have status 200")))))
+
+(deftest streaming-sparql-query-test
+  (testing "Streaming SPARQL query returns individual results"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/sparql-stream"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"     "ex:alice"
+                                    "ex:name" "Alice"
+                                    "ex:age"  30}
+                                   {"@id"     "ex:bob"
+                                    "ex:name" "Bob"
+                                    "ex:age"  25}]})
+          sparql-query "SELECT ?name ?age WHERE { ?person <http://example.org/name> ?name . ?person <http://example.org/age> ?age }"
+          result-ch    (query-api/query-stream db1 sparql-query {:format :sparql})
+          results      (async/<!! (async/into [] result-ch))]
+
+      (is (= 2 (count results)) "Should return 2 individual results")
+      (is (every? vector? results) "Each result should be a vector"))))
+
+(deftest streaming-sparql-with-meta-test
+  (testing "Streaming SPARQL query with :meta tracking"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/sparql-stream-meta"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"     "ex:alice"
+                                    "ex:name" "Alice"}
+                                   {"@id"     "ex:bob"
+                                    "ex:name" "Bob"}]})
+          sparql-query "SELECT ?name WHERE { ?person <http://example.org/name> ?name }"
+          result-ch    (query-api/query-stream db1 sparql-query {:format :sparql :meta true})
+          results      (async/<!! (async/into [] result-ch))]
+
+      (is (= 3 (count results)) "Should return 2 results + 1 metadata map")
+      (is (every? vector? (take 2 results)) "First two results should be vectors")
+
+      (let [meta-map (last results)]
+        (is (map? meta-map) "Last result should be a map")
+        (is (contains? meta-map :_fluree-meta) "Should contain :_fluree-meta key")
+        (is (= 200 (get-in meta-map [:_fluree-meta :status])) "Metadata should have status 200")))))
+
+(deftest streaming-construct-query-test
+  (testing "Streaming CONSTRUCT query returns individual graph nodes"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/construct-stream"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"       "ex:alice"
+                                    "ex:name"   "Alice"
+                                    "ex:hobby"  ["reading" "hiking"]}
+                                   {"@id"      "ex:bob"
+                                    "ex:name"  "Bob"
+                                    "ex:hobby" ["swimming"]}]})
+          query     {"@context" {"ex" "http://example.org/"}
+                     "where"    [{"@id"      "?person"
+                                  "ex:name"  "?name"}
+                                 {"@id"      "?person"
+                                  "ex:hobby" "?hobby"}]
+                     "construct" [{"@id"    "?person"
+                                   "label"  "?name"}
+                                  {"@id"    "?person"
+                                   "hobby"  "?hobby"}]}
+          result-ch (query-api/query-stream db1 query {})
+          results   (async/<!! (async/into [] result-ch))]
+
+      ;; Alice has 2 hobbies + Bob has 1 hobby = 3 WHERE solutions
+      ;; Each solution produces 2 CONSTRUCT templates = 6 graph nodes total
+      (is (>= (count results) 3) "Should return at least 3 individual graph nodes")
+      (is (every? map? results) "Each result should be a map")
+      (is (every? #(contains? % "@id") results) "Each result should have @id")
+      (is (not-any? #(contains? % "@graph") results) "Results should NOT be wrapped in @graph")
+      (is (>= (count results) 3) "Should stream multiple individual graph nodes"))))
+
+(deftest streaming-sparql-construct-test
+  (testing "Streaming SPARQL CONSTRUCT query returns individual graph nodes"
+    (let [conn      (test-utils/create-conn)
+          ledger-id "query/sparql-construct-stream"
+          db0       @(fluree/create conn ledger-id)
+          db1       @(fluree/update
+                      db0
+                      {"@context" {"ex" "http://example.org/"}
+                       "insert"   [{"@id"       "ex:alice"
+                                    "ex:name"   "Alice"
+                                    "ex:hobby"  ["reading" "hiking"]}
+                                   {"@id"      "ex:bob"
+                                    "ex:name"  "Bob"
+                                    "ex:hobby" ["swimming"]}]})
+          sparql-query "CONSTRUCT { ?person <http://example.org/label> ?name . ?person <http://example.org/hobby> ?hobby }
+                        WHERE { ?person <http://example.org/name> ?name . ?person <http://example.org/hobby> ?hobby }"
+          result-ch    (query-api/query-stream db1 sparql-query {:format :sparql})
+          results      (async/<!! (async/into [] result-ch))]
+
+      (is (>= (count results) 3) "Should return at least 3 individual graph nodes")
+      (is (every? map? results) "Each result should be a map")
+      (is (every? #(contains? % "@id") results) "Each result should have @id")
+      (is (not-any? #(contains? % "@graph") results) "Results should NOT be wrapped in @graph"))))


### PR DESCRIPTION
## Summary
Adds streaming query API that emits individual results as they are produced, rather than collecting all results into a vector. Supports all query types (SELECT, SELECT ONE, CONSTRUCT) and formats (FQL, SPARQL).

## Key Features
- **Memory efficient streaming**: Results emitted individually for large result sets
- **Metadata tracking**: Optional `:meta` tracking emits final metadata map after results
- **CONSTRUCT streaming**: Emits ungrouped graph nodes without @graph wrapper
- **Full query support**: ORDER BY, GROUP BY, and aggregates (collect before emitting)
- **Cache validation**: Early validation rejects :cache option for streaming queries

## API Functions
- `fluree.db.api/query-stream` - Stream query against database
- `fluree.db.api/query-connection-stream` - Stream query via connection

## Metadata Format
When `:meta true` is enabled, final result is:
```clojure
{:_fluree-meta {:fuel 123, :time "5ms", :policy {...}, :status 200}}
```

## Test Coverage
10 tests, 39 assertions covering:
- Basic streaming (SELECT, LIMIT, SELECT ONE)
- Metadata tracking (FQL and SPARQL)
- Connection-based queries
- CONSTRUCT queries (FQL and SPARQL)

## Implementation Notes
- Cache validation moved to public API layer
- Internal functions simplified (validation upstream)
- CONSTRUCT uses `cat` transducer for streaming ungrouped nodes
- Metadata calculated from tracker counters without forcing realization