### PR TITLE
Balanced index splits (byte-based multi-split), forward leaf link

### DIFF
--- a/src/fluree/db/flake/index/storage.cljc
+++ b/src/fluree/db/flake/index/storage.cljc
@@ -35,7 +35,7 @@
   "Given a child, unresolved node, extracts just the data that will go into
   storage."
   [child]
-  (select-keys child [:id :leaf :first :rhs :size :leftmost?]))
+  (select-keys child [:id :leaf :first :rhs :size :leftmost? :next-id]))
 
 (defn write-index-file
   [storage ledger-alias index-type serialized-data]

--- a/src/fluree/db/serde/json.cljc
+++ b/src/fluree/db/serde/json.cljc
@@ -82,7 +82,8 @@
 
 (defn deserialize-leaf-node
   [leaf]
-  (assoc leaf :flakes (mapv deserialize-flake (:flakes leaf))))
+  (cond-> (assoc leaf :flakes (mapv deserialize-flake (:flakes leaf)))
+    (:next-id leaf) (assoc :next-id (:next-id leaf))))
 
 #?(:clj (def ^DateTimeFormatter xsdDateTimeFormatter
           (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS[XXXXX]")))
@@ -175,7 +176,8 @@
   (-deserialize-branch [_ branch]
     (deserialize-branch-node branch))
   (-serialize-leaf [_ leaf]
-    {"flakes" (map serialize-flake (:flakes leaf))})
+    (cond-> {"flakes" (map serialize-flake (:flakes leaf))}
+      (:next-id leaf) (assoc "next-id" (:next-id leaf))))
   (-deserialize-leaf [_ leaf]
     (deserialize-leaf-node leaf))
   (-serialize-garbage [_ garbage-map]

--- a/test/fluree/db/flake/index/novelty_test.clj
+++ b/test/fluree/db/flake/index/novelty_test.clj
@@ -3,7 +3,49 @@
             [clojure.core.async :as async :refer [<!! timeout]]
             [clojure.test :refer [deftest is testing]]
             [fluree.db.api :as fluree]
-            [fluree.db.test-utils :as test-utils]))
+            [fluree.db.async-db :as async-db]
+            [fluree.db.flake :as flake]
+            [fluree.db.flake.index :as index]
+            [fluree.db.flake.index.novelty :as novelty]
+            [fluree.db.test-utils :as test-utils]
+            [fluree.db.util.async :refer [<? <?? go-try]]))
+
+(defn collect-leaf-chain
+  "Walks the index tree depth-first and collects all leaf nodes in order,
+  returning a vector of [leaf-id next-id] pairs to verify the chain."
+  [index-catalog root-node]
+  (go-try
+    (loop [stack  [root-node]
+           leaves []]
+      (if-let [node (peek stack)]
+        (let [resolved-node (<? (index/resolve index-catalog node))]
+          (if (index/leaf? resolved-node)
+            (let [leaf-info {:id      (:id resolved-node)
+                             :next-id (:next-id resolved-node)
+                             :first   (:first resolved-node)
+                             :rhs     (:rhs resolved-node)}]
+              (recur (pop stack)
+                     (conj leaves leaf-info)))
+            (let [children (->> (:children resolved-node)
+                                vals
+                                reverse
+                                vec)]
+              (recur (into (pop stack) children)
+                     leaves))))
+        leaves))))
+
+(defn verify-leaf-chain
+  "Verifies that all leaves form a proper chain via :next-id fields.
+  Each leaf's :next-id should match the next leaf's :id."
+  [leaves]
+  (loop [[leaf & rest-leaves] leaves
+         prev-leaf nil]
+    (when leaf
+      (when prev-leaf
+        (when (:next-id prev-leaf)
+          (is (= (:next-id prev-leaf) (:id leaf))
+              (str "Leaf " (:id prev-leaf) " next-id should point to " (:id leaf)))))
+      (recur rest-leaves leaf))))
 
 (deftest ^:integration index-datetimes-test
   (testing "Serialize and reread flakes with time types"
@@ -34,15 +76,12 @@
                                                "@value" "12:42:00Z"}
                          "ex:localTime"       {"@type"  "xsd:time"
                                                "@value" "12:42:00"}}]})
-            ;; Create a channel to track indexing completion
             index-ch   (async/chan 10)
             _db-commit @(fluree/commit! conn db {:index-files-ch index-ch})
-            ;; Wait for index completion (root file is written last)
             _          (loop []
                          (when-let [msg (<!! index-ch)]
                            (when-not (= :root (:file-type msg))
                              (recur))))
-            ;; Small delay to ensure file handles are released
             _          (<!! (timeout 100))
             loaded     (test-utils/retry-load conn ledger-id 100)
             q          {"@context" context
@@ -50,3 +89,302 @@
                         "where"    {"@id" "?s", "type" "ex:Bar"}}]
         (is (= @(fluree/query loaded q)
                @(fluree/query db q)))))))
+
+(deftest median-by-count-leaf-split-test
+  (testing "Leaf split using median-by-count maintains invariants"
+    (let [ledger-alias "test-ledger"
+          cmp          flake/cmp-flakes-spot
+          flakes       (reduce (fn [acc i]
+                                 (conj acc (flake/create i 1 (str "value-" i) 1 42 true nil)))
+                               (flake/sorted-set-by cmp)
+                               (range 1 101))
+          leaf         {:ledger-alias ledger-alias
+                        :comparator   cmp
+                        :id           (random-uuid)
+                        :leaf         true
+                        :first        (first flakes)
+                        :rhs          nil
+                        :flakes       flakes
+                        :size         (flake/size-bytes flakes)
+                        :t            42
+                        :leftmost?    true}]
+      (binding [novelty/*overflow-bytes* 1000]
+        (let [[right-leaf left-leaf :as result] (novelty/rebalance-leaf leaf)]
+          (is (= 2 (count result)))
+
+          (is (:leftmost? left-leaf) "Left leaf should preserve leftmost flag")
+          (is (= (:first left-leaf) (first (:flakes left-leaf)))
+              "Left leaf :first should match first flake")
+          (is (some? (:rhs left-leaf)) "Left leaf should have :rhs (split key)")
+          (is (= (:rhs left-leaf) (:first right-leaf))
+              "Left :rhs should equal right :first")
+
+          (is (false? (:leftmost? right-leaf)) "Right leaf should not be leftmost")
+          (is (= (:first right-leaf) (first (:flakes right-leaf)))
+              "Right leaf :first should match first flake")
+          (is (nil? (:rhs right-leaf)) "Right leaf should inherit parent's rhs (nil)")
+
+          (is (some? (:next-tempid left-leaf))
+              "Left leaf should have :next-tempid pointing to right")
+          (is (= (:next-tempid left-leaf) (:tempid right-leaf))
+              "Left :next-tempid should match right :tempid")
+
+          (let [all-split-flakes (into (:flakes left-leaf) (:flakes right-leaf))]
+            (is (= (count flakes) (count all-split-flakes))
+                "Total flake count should be preserved")
+            (is (= flakes all-split-flakes)
+                "All flakes should be preserved in order")))))))
+
+(deftest median-by-count-branch-split-test
+  (testing "Branch split using median-by-count maintains invariants"
+    (let [ledger-alias "test-ledger"
+          cmp          flake/cmp-flakes-spot
+          children     (mapv (fn [i]
+                               {:ledger-alias ledger-alias
+                                :comparator   cmp
+                                :id           (random-uuid)
+                                :leaf         true
+                                :first        (flake/create (* i 10) 1 "v" 1 42 true nil)
+                                :rhs          (when (< i 9)
+                                                (flake/create (* (inc i) 10) 1 "v" 1 42 true nil))
+                                :size         1000
+                                :t            42
+                                :leftmost?    (zero? i)})
+                             (range 10))
+          branch       {:ledger-alias ledger-alias
+                        :comparator   cmp
+                        :id           (random-uuid)
+                        :leaf         false
+                        :first        (:first (first children))
+                        :rhs          (:rhs (last children))
+                        :size         10000
+                        :t            42
+                        :leftmost?    true}]
+      (binding [novelty/*overflow-children* 8]
+        (let [[left-branch right-branch :as result] (novelty/rebalance-children branch 43 children)]
+          (is (= 2 (count result)))
+
+          (is (:leftmost? left-branch) "Left branch should be leftmost")
+          (is (= (:first left-branch) (:first (first children)))
+              "Left :first should match first child's :first")
+
+          (is (false? (:leftmost? right-branch)) "Right branch should not be leftmost")
+          (is (= (:rhs right-branch) (:rhs branch))
+              "Right branch should inherit parent's :rhs")
+
+          (is (= (:rhs left-branch) (:first right-branch))
+              "Left :rhs should equal right :first")
+
+          (let [left-children  (-> left-branch :children vals vec)
+                right-children (-> right-branch :children vals vec)
+                all-children   (into left-children right-children)]
+            (is (= (count children) (count all-children))
+                "Total child count should be preserved")))))))
+
+(deftest ^:integration skewed-inserts-cascade-test
+  (testing "Skewed inserts cause cascading splits to maintain uniform height"
+    (with-temp-dir [storage-path {}]
+      (let [storage-opts {:storage-path (str storage-path)
+                          :defaults
+                          {:indexing {:reindex-min-bytes 100
+                                      :reindex-max-bytes 10000000}}}
+            conn         @(fluree/connect-file storage-opts)
+            ledger-id    "test/cascade"
+            context      {"ex" "http://example.org/ns/"}
+            db0          @(fluree/create conn ledger-id)
+            items        (mapv (fn [i]
+                                 {"@id"      (str "ex:item" i)
+                                  "@type"    "ex:Item"
+                                  "ex:name"  (str "Item " i)
+                                  "ex:index" i})
+                               (range 1 200))
+            db           @(fluree/update db0
+                                         {"@context" context
+                                          "insert"   items})
+            index-ch     (async/chan 10)
+            _db-commit   @(fluree/commit! conn db {:index-files-ch index-ch})
+            _            (loop []
+                           (when-let [msg (<!! index-ch)]
+                             (when-not (= :root (:file-type msg))
+                               (recur))))
+            _            (<!! (timeout 100))
+            conn-fresh   @(fluree/connect-file storage-opts)
+            loaded       @(fluree/load conn-fresh ledger-id)]
+        (is (nil? (:novelty loaded))
+            "Loaded db should have no novelty, proving it was loaded from index")
+
+        (is (= 199
+               (count @(fluree/query loaded
+                                     {"@context" context
+                                      "select"   "?item"
+                                      "where"    {"@id" "?item", "@type" "ex:Item"}})))
+            "All items should be queryable after cascading splits")
+
+        (is (= [{"@id"      "ex:item42"
+                 "@type"    "ex:Item"
+                 "ex:name"  "Item 42"
+                 "ex:index" 42}]
+               @(fluree/query loaded
+                              {"@context" context
+                               "select"   {"?s" ["*"]}
+                               "where"    {"@id" "?s", "ex:index" 42}}))
+            "Range scans should work correctly after splits")))))
+
+(deftest ^:integration next-id-persistence-test
+  (testing "next-id field is persisted to storage and read back correctly"
+    (with-temp-dir [storage-path {}]
+      (let [storage-opts {:storage-path (str storage-path)
+                          :defaults
+                          {:indexing {:reindex-min-bytes 100
+                                      :reindex-max-bytes 10000000}}}
+            conn         @(fluree/connect-file storage-opts)
+            ledger-id    "test/nextid"
+            context      {"ex" "http://example.org/ns/"}
+            db0          @(fluree/create conn ledger-id)
+            items        (mapv (fn [i]
+                                 {"@id"      (str "ex:item" i)
+                                  "@type"    "ex:Item"
+                                  "ex:name"  (str "Item " i)
+                                  "ex:index" i})
+                               (range 1 150))
+            db           @(fluree/update db0
+                                         {"@context" context
+                                          "insert"   items})
+            index-ch     (async/chan 10)
+            _db-commit   @(fluree/commit! conn db {:index-files-ch index-ch})
+            _            (loop []
+                           (when-let [msg (<!! index-ch)]
+                             (when-not (= :root (:file-type msg))
+                               (recur))))
+            _            (<!! (timeout 100))
+            conn-fresh   @(fluree/connect-file storage-opts)
+            loaded       @(fluree/load conn-fresh ledger-id)]
+        (is (nil? (:novelty loaded))
+            "Loaded db should have no novelty, proving it was loaded from index")
+
+        (is (= 149
+               (count @(fluree/query loaded
+                                     {"@context" context
+                                      "select"   "?item"
+                                      "where"    {"@id" "?item", "@type" "ex:Item"}})))
+            "All items should be queryable after split with next-id")
+
+        (is (= 10
+               (count @(fluree/query loaded
+                                     {"@context" context
+                                      "select"   "?item"
+                                      "where"    {"@id" "?item", "@type" "ex:Item"}
+                                      "limit"    10})))
+            "Limited range queries should work correctly with next-id")))))
+
+(deftest ^:integration next-id-chain-verification-test
+  (testing "Verify next-id chain is correct after first and second reindex"
+    (with-temp-dir [storage-path {}]
+      (binding [novelty/*overflow-bytes* 1000
+                novelty/*overflow-children* 8]
+        (let [storage-opts  {:storage-path (str storage-path)
+                             :defaults
+                             {:indexing {:reindex-min-bytes 100
+                                         :reindex-max-bytes 10000000}}}
+              conn          @(fluree/connect-file storage-opts)
+              ledger-id     "test/chain"
+              context       {"ex" "http://example.org/ns/"}
+              db0           @(fluree/create conn ledger-id)
+              items         (mapv (fn [i]
+                                    {"@id"      (str "ex:item" i)
+                                     "@type"    "ex:Item"
+                                     "ex:name"  (str "Item " i)
+                                     "ex:value" i})
+                                  (range 1 150))
+              db1           @(fluree/update db0
+                                            {"@context" context
+                                             "insert"   items})
+              index-ch1     (async/chan 10)
+              _             @(fluree/commit! conn db1 {:index-files-ch index-ch1})
+              _             (loop []
+                              (when-let [msg (<!! index-ch1)]
+                                (when-not (= :root (:file-type msg))
+                                  (recur))))
+              _             (<!! (timeout 100))
+              conn-fresh1   @(fluree/connect-file storage-opts)
+              loaded1-async @(fluree/load conn-fresh1 ledger-id)
+              loaded1       (<?? (async-db/deref-async loaded1-async))
+              leaves1       (<?? (collect-leaf-chain (:index-catalog loaded1)
+                                                     (:spot loaded1)))]
+
+          (is (> (count leaves1) 1)
+              "Should have multiple leaves after split")
+          (verify-leaf-chain leaves1)
+
+          (let [more-items   (mapv (fn [i]
+                                     {"@id"      (str "ex:item" i)
+                                      "@type"    "ex:Item"
+                                      "ex:name"  (str "Item " i)
+                                      "ex:value" i})
+                                   (range 150 200))
+                db2          @(fluree/update loaded1
+                                             {"@context" context
+                                              "insert"   more-items})
+                index-ch2    (async/chan 10)
+                _            @(fluree/commit! conn-fresh1 db2 {:index-files-ch index-ch2})
+                _            (loop []
+                               (when-let [msg (<!! index-ch2)]
+                                 (when-not (= :root (:file-type msg))
+                                   (recur))))
+                _            (<!! (timeout 100))
+                conn-fresh2  @(fluree/connect-file storage-opts)
+                loaded2-async @(fluree/load conn-fresh2 ledger-id)
+                loaded2      (<?? (async-db/deref-async loaded2-async))
+                leaves2      (<?? (collect-leaf-chain (:index-catalog loaded2)
+                                                      (:spot loaded2)))]
+
+            (is (>= (count leaves2) (count leaves1))
+                "Second index should have at least as many leaves as first")
+            (verify-leaf-chain leaves2)
+
+            (is (= 199
+                   (count @(fluree/query loaded2
+                                         {"@context" context
+                                          "select"   "?item"
+                                          "where"    {"@id" "?item", "@type" "ex:Item"}})))
+                "All items should be queryable after second reindex")))))))
+
+(deftest ^:integration backward-compatibility-test
+  (testing "New split logic is backward compatible with old indexes"
+    (with-temp-dir [storage-path {}]
+      (let [storage-opts {:storage-path (str storage-path)
+                          :defaults
+                          {:indexing {:reindex-min-bytes 100
+                                      :reindex-max-bytes 10000000}}}
+            conn         @(fluree/connect-file storage-opts)
+            ledger-id    "test/compat"
+            context      {"ex" "http://example.org/ns/"}
+            db0          @(fluree/create conn ledger-id)
+            db1          @(fluree/update db0
+                                         {"@context" context
+                                          "insert"   [{"@id"     "ex:alice"
+                                                       "@type"   "ex:Person"
+                                                       "ex:name" "Alice"}]})
+            index-ch     (async/chan 10)
+            _db-commit   @(fluree/commit! conn db1 {:index-files-ch index-ch})
+            _            (loop []
+                           (when-let [msg (<!! index-ch)]
+                             (when-not (= :root (:file-type msg))
+                               (recur))))
+            _            (<!! (timeout 100))
+            conn-fresh   @(fluree/connect-file storage-opts)
+            loaded       @(fluree/load conn-fresh ledger-id)
+            db2          @(fluree/update loaded
+                                         {"@context" context
+                                          "insert"   [{"@id"     "ex:bob"
+                                                       "@type"   "ex:Person"
+                                                       "ex:name" "Bob"}]})]
+        (is (nil? (:novelty loaded))
+            "Loaded db should have no novelty, proving it was loaded from index")
+
+        (is (= 2
+               (count @(fluree/query db2
+                                     {"@context" context
+                                      "select"   "?person"
+                                      "where"    {"@id" "?person", "@type" "ex:Person"}})))
+            "Mixed old and new index nodes should work together")))))


### PR DESCRIPTION
The way we indexed, the persistent index tree could become unbalanced (varying heights). In larger ledgers with specific insert patterns that can affect performance adversely.

This fix keeps the index tree at constant height. I also added a :next-id to the leaf which will allow range scans in the future (once support is implemented) to skip directly to the next node which can also improve performance but TBD on how much. 

### Summary
- Leaf rebalancing now performs byte-based multi-splits: a single oversized leaf can split into N leaves, targeting ≈ half the overflow threshold per leaf.
- Branch rebalancing uses median-by-count splits to maintain even fanout.
- Forward leaf link `:next-id` added (optional) and resolved at write-time in a single pass.
- Traversal remains index-only; novelty overlay stays post-traversal and authorized.
- Tests added for split invariants, cascading behavior, and backward compatibility.

### Motivation
Heavy inserts localized to one key range could repeatedly split the same path, increasing depth on the “hot” side. Prior leaf splitting didn’t always produce balanced results when a single leaf was significantly over target. We also lacked a forward link to optimize sequential scans across leaves. This change ensures:
- Branches remain balanced with median child splits.
- Range scans can optionally hop via `:next-id`.

### Key Changes
- Leaf splits (byte-based, N-way)
  - New split planner computes target number of leaves from total bytes and a per-leaf byte budget (≈ overflow/2).
  - Single pass partitions flakes into multiple leaves; sets `:rhs` on each left sibling to the next sibling’s first flake; final sibling inherits original `:rhs`.
  - Emits leaves in reverse order (right-to-left) so right siblings are written first; this enables resolving each left sibling’s `:next-id` to its right sibling’s final id without extra writes.
- Branch splits (median-by-count)
  - When a branch overflows, children are split at the median child; reconstruct fence keys (`:first`, `:rhs`), and ensure only the first sibling is `:leftmost?`.
- Cascading and global height
  - Parent branches are updated on child splits; if parent overflows, split and promote; root overflow creates a new root. Height increases only at the root, keeping leaf depth uniform globally.
- Forward leaf link
  - Optional `:next-id` added to leaf node schema (backward compatible).
  - On split, left sibling sets `:next-tempid` to the right sibling’s temp id. Before persistence, `:next-tempid` is resolved to the right sibling’s final id using the existing updated-ids mapping. No second write required.

### Behavior and Invariants
- Leaf multi-split maintains order, preserves all flakes, sets correct fence keys: for each adjacent pair, `left.rhs = right.first`.
- Only the first sibling retains `:leftmost?`; others are false.
- `:next-id` is forward-only and optional; readers fall back to traversal if absent.
- Traversal/auth unchanged: novelty overlay is post-traversal and runs through authorization and paging (as previously fixed).

### Backward Compatibility
- On-disk format unchanged except an optional `:next-id` on leaves. Old nodes remain valid; readers ignore missing `:next-id`.
- No full reindex required; subtrees converge to balanced shape as they are updated.
