### PR TITLE
Improve ledger cache management with idle timeout

### DIFF
--- a/src/fluree/db/connection/config.cljc
+++ b/src/fluree/db/connection/config.cljc
@@ -341,11 +341,19 @@
 (defn parse-defaults
   [config]
   (when-let [defaults (get-first config conn-vocab/defaults)]
-    (let [identity      (parse-identity defaults)
-          index-options (parse-index-options defaults)]
+    (let [identity                 (parse-identity defaults)
+          index-options            (parse-index-options defaults)
+          ;; Get idle minutes as a number (may be float like 0.1)
+          idle-minutes-raw         (get-first-value defaults conn-vocab/ledger-cache-idle-minutes)
+          idle-minutes             (when idle-minutes-raw
+                                     (if (string? idle-minutes-raw)
+                                       #?(:clj (Double/parseDouble idle-minutes-raw)
+                                          :cljs (js/parseFloat idle-minutes-raw))
+                                       (double idle-minutes-raw)))]
       (cond-> nil
         identity      (assoc :identity identity)
-        index-options (assoc :indexing index-options)))))
+        index-options (assoc :indexing index-options)
+        idle-minutes  (assoc :ledger-cache-idle-minutes idle-minutes)))))
 
 (defn parse-connection-map
   [{:keys [cache commit-catalog index-catalog serializer] :as config}]

--- a/src/fluree/db/connection/vocab.cljc
+++ b/src/fluree/db/connection/vocab.cljc
@@ -136,6 +136,9 @@
 (def indexing-enabled
   (system-iri "indexingEnabled"))
 
+(def ledger-cache-idle-minutes
+  (system-iri "ledgerCacheIdleMinutes"))
+
 (def connection
   (system-iri "connection"))
 

--- a/src/fluree/db/nameservice.cljc
+++ b/src/fluree/db/nameservice.cljc
@@ -27,7 +27,37 @@
     This may be a full address/IRI (e.g., fluree:ipns://...) or a resolvable
     identifier such as a ledger alias (e.g., ledger:branch), depending on the
     nameservice implementation. The returned value will be used with this same
-    nameservice's lookup function. If publishing should be private, return nil."))
+    nameservice's lookup function. If publishing should be private, return nil.")
+  (index-start [publisher ledger-alias target-t machine-id]
+    "Marks the start of an indexing process for the specified target-t.
+
+    Parameters:
+      publisher - The nameservice publisher
+      ledger-alias - The ledger being indexed
+      target-t - The 't' value being indexed
+      machine-id - Machine identifier (hostname:pid) performing the indexing
+
+    Returns a channel that will contain:
+    - {:status :started} on success
+    - {:status :already-indexing, :started <iso>, :machine-id <id>, :last-heartbeat <iso>}
+      if indexing already in progress and not stale (heartbeat within 5 min)")
+  (index-heartbeat [publisher ledger-alias]
+    "Updates the last-heartbeat timestamp for an in-progress indexing operation.
+
+    Should be called periodically (every ~60 seconds) during indexing to indicate
+    the process is still active. If heartbeat stops for > 5 minutes, the indexing
+    is considered stale and another process can take over.
+
+    Returns a channel that will contain:
+    - {:status :updated} on success
+    - {:status :not-indexing} if no indexing in progress")
+  (index-finish [publisher ledger-alias]
+    "Marks the completion of an indexing process.
+
+    Clears the indexing metadata from the nameservice record.
+
+    Returns a channel that will contain:
+    - {:status :completed}"))
 
 (defprotocol Publication
   (subscribe [publication ledger-alias]

--- a/src/fluree/db/nameservice/ipns.cljc
+++ b/src/fluree/db/nameservice/ipns.cljc
@@ -1,5 +1,6 @@
 (ns fluree.db.nameservice.ipns
-  (:require [clojure.string :as str]
+  (:require [clojure.core.async :refer [go]]
+            [clojure.string :as str]
             [fluree.db.method.ipfs :as ipfs]
             [fluree.db.method.ipfs.directory :as ipfs-dir]
             [fluree.db.method.ipfs.keys :as ipfs-keys]
@@ -62,6 +63,15 @@
     (ipfs/write ipfs-endpoint "null"))
   (publishing-address [_ ledger-alias]
     (ipns-address ipfs-endpoint ipns-key ledger-alias))
+  (index-start [_ _ledger-alias _target-t _machine-id]
+    (log/debug "IPNS does not support fine-grained indexing status")
+    (go {:status :not-supported}))
+  (index-heartbeat [_ _ledger-alias]
+    (log/debug "IPNS does not support fine-grained indexing status")
+    (go {:status :not-supported}))
+  (index-finish [_ _ledger-alias]
+    (log/debug "IPNS does not support fine-grained indexing status")
+    (go {:status :not-supported}))
 
   nameservice/iNameService
   (lookup [_ ledger-alias]

--- a/test/fluree/db/connection/disconnect_test.clj
+++ b/test/fluree/db/connection/disconnect_test.clj
@@ -1,0 +1,84 @@
+(ns fluree.db.connection.disconnect-test
+  "Tests for connection disconnect, ledger release, and idle cleanup functionality"
+  (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.api :as fluree]))
+
+(deftest disconnect-prevents-new-operations-test
+  (testing "Connection rejects operations after disconnect begins"
+    (let [conn @(fluree/connect-memory)
+          _    @(fluree/create conn "test1")
+          _    @(fluree/db conn "test1")]
+
+      (fluree/disconnect conn)
+
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Connection is disconnecting"
+           @(fluree/create conn "test2"))
+          "Creating new ledger should fail after disconnect")
+
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Connection is disconnecting"
+           @(fluree/db conn "test1"))
+          "Getting db should fail after disconnect"))))
+
+(deftest disconnect-releases-multiple-ledgers-test
+  (testing "Disconnect releases all cached ledgers in parallel"
+    (let [conn @(fluree/connect-memory)
+          _    @(fluree/create conn "ledger1")
+          _    @(fluree/create conn "ledger2")
+          _    @(fluree/create conn "ledger3")
+
+          ;; Load all ledgers into cache
+          _    @(fluree/db conn "ledger1")
+          _    @(fluree/db conn "ledger2")
+          _    @(fluree/db conn "ledger3")
+
+          ;; Verify all are cached
+          state-before @(:state conn)
+          cached-count (count (:ledger state-before))]
+
+      (is (= 3 cached-count) "All three ledgers should be cached")
+
+      @(fluree/disconnect conn)
+
+      (let [state-after @(:state conn)
+            remaining   (count (:ledger state-after))]
+        (is (= 0 remaining) "All ledgers should be released after disconnect")))))
+
+(deftest idle-cleanup-enabled-test
+  (testing "Idle cleanup loop is created when configured"
+    (let [conn-with-idle @(fluree/connect-memory
+                           {:defaults {:ledger-cache-idle-minutes 15}})
+          conn-without-idle @(fluree/connect-memory {})]
+
+      ;; Connection with idle timeout should have cleanup channel
+      (is (some? (:idle-cleanup-ch conn-with-idle))
+          "Idle cleanup channel should be created when timeout configured")
+
+      ;; Connection without idle timeout should not have cleanup channel
+      (is (nil? (:idle-cleanup-ch conn-without-idle))
+          "Idle cleanup channel should not be created when timeout not configured")
+
+      @(fluree/disconnect conn-with-idle)
+      @(fluree/disconnect conn-without-idle))))
+
+(deftest release-ledger-idempotent-test
+  (testing "Releasing the same ledger multiple times is safe (race condition protection)"
+    (let [conn @(fluree/connect-memory)
+          _    @(fluree/create conn "test1")
+          _    @(fluree/db conn "test1")]
+
+      ;; Release the ledger once
+      @(fluree/release-ledger conn "test1")
+
+      ;; Release again - should not throw
+      (is (= :released @(fluree/release-ledger conn "test1"))
+          "Second release should succeed")
+
+      ;; And again for good measure
+      (is (= :released @(fluree/release-ledger conn "test1"))
+          "Third release should also succeed")
+
+      @(fluree/disconnect conn))))


### PR DESCRIPTION
## Changes

  ### Ledger Release
  - Added `fluree.db.api/release-ledger` - Removes ledger from connection cache and cleans up resources (index queues, nameservice subscriptions)
  - Release is idempotent and thread-safe (safe to call multiple times on same ledger)

  ### Idle Timeout
  - Added `:ledger-cache-idle-minutes` config option (default: disabled)
  - Background loop checks for idle ledgers every minute and releases them
  - Respects active indexing operations - resets idle timer if indexing is in progress
  - Tracks last-accessed timestamp per ledger in connection state

  ### Disconnect Improvements
  - Added `:disconnecting?` flag to prevent new operations during disconnect
  - Changed to release all cached ledgers in parallel using `async/merge`
  - Logs warnings for release errors but continues with disconnect
  - Stops idle cleanup loop before releasing ledgers

  ### Implementation Details
  - `connection.cljc`: Added `start-idle-cleanup-loop`, `touch-ledger-access`, `close-ledger-resources`, `release-ledger`
  - `api.cljc`: Updated `disconnect` for parallel release, added `release-ledger` wrapper, updated `validate-connection`
  - `nameservice/storage.cljc`: Helper functions for indexing status tracking

  ## Test Coverage

  Added `test/fluree/db/connection/disconnect_test.clj` with 4 tests (8 assertions):
  - Disconnect prevents new operations after starting
  - Disconnect releases multiple ledgers in parallel
  - Idle cleanup loop is created when configured
  - Release ledger is idempotent (race condition safety)