### PR TITLE
OpenTelemetry Tracing

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,5 +6,6 @@
  :config-in-call {cljs.core/pr-sequential-writer {:ignore [:private-call]}
                   fluree.db.query.exec.eval/parse-qualified-code {:ignore true}}
  :config-in-ns   {fluree.db.json-ld.api     {:ignore true}
-                  fluree.db.util.filesystem {:ignore [:locking-suspicious-lock]}}
+                  fluree.db.util.filesystem {:ignore [:locking-suspicious-lock]}
+                  fluree.db.util.trace      {:ignore true}}
  :output         {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -4,4 +4,7 @@
  :extra-indents
  {go-try [[:block 0]]
   try*   [[:block 0]]
-  catch* [[:block 1]]}}
+  catch* [[:block 1]]
+  form   [[:block 2]]
+  async-form [[:block 2]]
+  with-parent-context [[:block 2]]}}

--- a/deps.edn
+++ b/deps.edn
@@ -148,7 +148,7 @@
    :main-opts  ["-m" "eastwood.lint"
                 {:source-paths       ["src" "src-docs"]
                  :test-paths         ["test"]
-                 :exclude-linters    []
+                 :exclude-linters    [:suspicious-expression]
                  ;; Exclude IPFS namespace due to Clojure 1.12.1 compatibility issues
                  :exclude-namespaces [fluree.db.storage.ipfs
                                       fluree.db.storage.file

--- a/deps.edn
+++ b/deps.edn
@@ -148,11 +148,7 @@
    :main-opts  ["-m" "eastwood.lint"
                 {:source-paths       ["src" "src-docs"]
                  :test-paths         ["test"]
-                 ;; TODO: Un-exclude this when it stops triggering false
-                 ;;       positives on "UnsupportedOperationException empty is
-                 ;;       not supported on Flake" when using the #Flake data
-                 ;;       reader - WSM 2023-02-01
-                 :exclude-linters    [:implicit-dependencies]
+                 :exclude-linters    []
                  ;; Exclude IPFS namespace due to Clojure 1.12.1 compatibility issues
                  :exclude-namespaces [fluree.db.storage.ipfs
                                       fluree.db.storage.file

--- a/deps.edn
+++ b/deps.edn
@@ -11,9 +11,8 @@
         com.widdindustries/time-literals {:mvn/version "0.1.10"}
 
         ;; logging
-        org.clojure/tools.logging      {:mvn/version "1.3.0"}
-        ch.qos.logback/logback-classic {:mvn/version "1.5.6"}
-        org.slf4j/slf4j-api            {:mvn/version "2.0.13"}
+        org.clojure/tools.logging                {:mvn/version "1.3.0"}
+        com.github.steffan-westcott/clj-otel-api {:mvn/version "0.2.10"}
 
         ;; Vector math, BM25
         net.mikera/vectorz-clj              {:mvn/version "0.48.0"}
@@ -58,7 +57,9 @@
    :extra-deps  {org.clojure/tools.namespace       {:mvn/version "1.5.0"}
                  criterium/criterium               {:mvn/version "0.4.6"}
                  figwheel-sidecar/figwheel-sidecar {:mvn/version "0.5.20"}
-                 thheller/shadow-cljs              {:mvn/version "2.28.15"}}
+                 thheller/shadow-cljs              {:mvn/version "2.28.15"}
+                 ch.qos.logback/logback-classic    {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api               {:mvn/version "2.0.13"}}
    :jvm-opts    ["-Dlogback.configurationFile=dev-resources/logback.xml"]}
 
   :cljtest
@@ -69,20 +70,24 @@
                  babashka/fs                             {:mvn/version "0.5.20"}
                  clj-test-containers/clj-test-containers {:mvn/version "0.7.4"}
                  org.testcontainers/testcontainers       {:mvn/version "1.19.3"}
-                 org.testcontainers/localstack           {:mvn/version "1.19.3"}}
+                 org.testcontainers/localstack           {:mvn/version "1.19.3"}
+                 ch.qos.logback/logback-classic          {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api                     {:mvn/version "2.0.13"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/skip-meta [:pending :docker]}}
 
   :cljtest-sci
   {:jvm-opts    ["-Dfluree.graalvm.build=true"]
    :extra-paths ["test" "dev-resources" "test-resources"]
-   :extra-deps  {lambdaisland/kaocha                   {:mvn/version "1.91.1392"}
-                 org.clojure/test.check                {:mvn/version "1.1.1"}
-                 com.gfredericks/test.chuck            {:mvn/version "0.2.13"}
-                 babashka/fs                           {:mvn/version "0.5.20"}
+   :extra-deps  {lambdaisland/kaocha                     {:mvn/version "1.91.1392"}
+                 org.clojure/test.check                  {:mvn/version "1.1.1"}
+                 com.gfredericks/test.chuck              {:mvn/version "0.2.13"}
+                 babashka/fs                             {:mvn/version "0.5.20"}
                  clj-test-containers/clj-test-containers {:mvn/version "0.7.4"}
-                 org.testcontainers/testcontainers     {:mvn/version "1.19.3"}
-                 org.testcontainers/localstack         {:mvn/version "1.19.3"}}
+                 org.testcontainers/testcontainers       {:mvn/version "1.19.3"}
+                 org.testcontainers/localstack           {:mvn/version "1.19.3"}
+                 ch.qos.logback/logback-classic          {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api                     {:mvn/version "2.0.13"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/focus-meta [:sci]}}
 
@@ -93,7 +98,9 @@
                  babashka/fs                             {:mvn/version "0.5.20"}
                  clj-test-containers/clj-test-containers {:mvn/version "0.7.4"}
                  org.testcontainers/testcontainers       {:mvn/version "1.19.3"}
-                 org.testcontainers/localstack           {:mvn/version "1.19.3"}}
+                 org.testcontainers/localstack           {:mvn/version "1.19.3"}
+                 ch.qos.logback/logback-classic          {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api                     {:mvn/version "2.0.13"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/focus-meta [:pending]}}
 
@@ -105,12 +112,16 @@
                  babashka/fs                             {:mvn/version "0.5.20"}
                  clj-test-containers/clj-test-containers {:mvn/version "0.7.4"}
                  org.testcontainers/testcontainers       {:mvn/version "1.19.3"}
-                 org.testcontainers/localstack           {:mvn/version "1.19.3"}}
+                 org.testcontainers/localstack           {:mvn/version "1.19.3"}
+                 ch.qos.logback/logback-classic          {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api                     {:mvn/version "2.0.13"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {:kaocha.filter/focus-meta [:docker]}}
 
   :cljstest
-  {:extra-paths ["test" "dev-resources"]}
+  {:extra-paths ["test" "dev-resources"]
+   :extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api            {:mvn/version "2.0.13"}}}
 
   :js-deps
   {:extra-deps {com.timetraveltoaster/target-bundle-libs {:mvn/version "RELEASE"}}
@@ -156,5 +167,7 @@
    :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}
 
   :graalvm
-  {:extra-deps  {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}
-   :extra-paths ["graalvm"]}}}
+  {:extra-paths ["graalvm"]
+   :extra-deps  {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}
+                 ch.qos.logback/logback-classic       {:mvn/version "1.5.6"}
+                 org.slf4j/slf4j-api                  {:mvn/version "2.0.13"}}}}}

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -1,0 +1,49 @@
+# Fluree OpenTelemetry Tracing Guide
+
+## Overview
+
+Fluree can provide OpenTelemetry tracing data if a tracing collector
+is configured. Open Telemetry traces are supported in a variety of
+tools, and can provide insight into how the database is
+performing.
+
+Tracing is only available on the JVM build of Fluree.
+
+### Basic Configuration
+
+Specify the following Java system properties or environment
+vars. System properties take precedence over environment vars.
+
+| System Property             | Environment Var             | example value         |
+|-----------------------------+-----------------------------+-----------------------|
+| otel.exporter.otlp.endpoint | OTEL_EXPORTER_OTLP_ENDPOINT | http://localhost:4318 |
+| otel.exporter.otlp.protocol | OTEL_EXPORTER_OTLP_PROTOCOL | http/protobuf         |
+| otel.service.name           | OTEL_SERVICE_NAME           | my-service-name       |
+
+
+Fluree does not support Open Telemetry logging or metrics at this time, so disable them:
+| System Property       | Environment Var       | example value |
+|-----------------------+-----------------------+---------------|
+| otel.logs.exporter    | OTEL_LOGS_EXPORTER    | none          |
+| otel.metrics.exporter | OTEL_METRICS_EXPORTER | none          |
+
+### Testing
+If you would like to see the tracing in action you can use the docker
+image for the open-source tracing tool Jaeger.
+
+This will start Jaeger in a docker container, collecting traces on
+port 4318 and providing a user interface on port 16686.
+```
+docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:2.11.0
+```
+
+Then start your Fluree application with the OpenTelemetry Java agent like this:
+```
+java -jar my-service.jar -javaagent:/path/to/opentelemetry-javaagent.jar
+  \-Dotel.service.name=fluree-server
+  \-Dotel.exporter.otlp.endpoint=http://localhost:4318
+  \-Dotel.exporter.otlp.protocol=http/protobuf
+  \-Dotel.logs.exporter=none
+  \-Dotel.metrics.exporter=none
+```
+

--- a/src/fluree/db/api.cljc
+++ b/src/fluree/db/api.cljc
@@ -857,7 +857,9 @@
   ([conn q] (query-connection conn q {}))
   ([conn q opts]
    (validate-connection conn)
-   (promise-wrap (query-api/query-connection conn q opts))))
+   (promise-wrap
+    (trace/async-form ::query-connection {}
+      (query-api/query-connection conn q opts)))))
 
 (defn credential-query-connection
   "Executes a query via connection using a verifiable credential.

--- a/src/fluree/db/api/transact.cljc
+++ b/src/fluree/db/api/transact.cljc
@@ -11,6 +11,7 @@
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.context :as ctx-util]
             [fluree.db.util.ledger :as util.ledger]
+            [fluree.db.util.trace :as trace]
             [fluree.json-ld :as json-ld]))
 
 (defn prep-opts
@@ -50,19 +51,20 @@
 
 (defn transact!
   [conn ledger-id parsed-txn]
-  (go-try
-    (if ledger-id
-      (let [ledger (async/<! (connection/load-ledger conn ledger-id))]
-        (if (util/exception? ledger)
-          (if (not-found? ledger)
-            (throw (ex-info (str "Ledger " ledger-id " does not exist")
-                            {:status 409 :error :db/ledger-not-exists}
-                            ledger))
-            (throw ledger))
-          (<? (ledger/transact! ledger parsed-txn))))
-      (throw (ex-info "Missing ledger specification."
-                      {:ledger-id ledger-id
-                       :status 400})))))
+  (trace/async-form ::transact! {:ledger-alias ledger-id}
+    (go-try
+      (if ledger-id
+        (let [ledger (async/<! (connection/load-ledger conn ledger-id))]
+          (if (util/exception? ledger)
+            (if (not-found? ledger)
+              (throw (ex-info (str "Ledger " ledger-id " does not exist")
+                              {:status 409 :error :db/ledger-not-exists}
+                              ledger))
+              (throw ledger))
+            (<? (ledger/transact! ledger parsed-txn))))
+        (throw (ex-info "Missing ledger specification."
+                        {:ledger-id ledger-id
+                         :status 400}))))))
 
 (defn insert!
   [conn ledger-id txn override-opts]

--- a/src/fluree/db/flake/index/novelty.cljc
+++ b/src/fluree/db/flake/index/novelty.cljc
@@ -602,7 +602,7 @@
 
 (defn refresh
   [{:keys [novelty t alias] :as db} changes-ch max-old-indexes]
-  (trace/async-form ::refresh {}
+  (trace/async-form ::refresh {:ledger-alias alias :t t}
     (go-try
       (if (dirty? db)
         (let [start-time-ms (util/current-time-millis)

--- a/src/fluree/db/flake/index/novelty.cljc
+++ b/src/fluree/db/flake/index/novelty.cljc
@@ -12,7 +12,8 @@
             [fluree.db.util :as util :refer [try* catch*]]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.ledger :as util.ledger]
-            [fluree.db.util.log :as log :include-macros true]))
+            [fluree.db.util.log :as log :include-macros true]
+            [fluree.db.util.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -601,72 +602,73 @@
 
 (defn refresh
   [{:keys [novelty t alias] :as db} changes-ch max-old-indexes]
-  (go-try
-    (if (dirty? db)
-      (let [start-time-ms (util/current-time-millis)
-            novelty-size  (:size novelty)
-            init-stats    {:ledger-alias alias
-                           :t            t
-                           :novelty-size novelty-size
-                           :start-time   (util/current-time-iso)}
-            error-ch   (async/chan)
-            refresh-ch (refresh-all db changes-ch error-ch)]
-        (log/info "Refreshing Index:" init-stats)
-        (async/alt!
-          error-ch
-          ([e]
-           (throw e))
+  (trace/async-form ::refresh {}
+    (go-try
+      (if (dirty? db)
+        (let [start-time-ms (util/current-time-millis)
+              novelty-size  (:size novelty)
+              init-stats    {:ledger-alias alias
+                             :t            t
+                             :novelty-size novelty-size
+                             :start-time   (util/current-time-iso)}
+              error-ch   (async/chan)
+              refresh-ch (refresh-all db changes-ch error-ch)]
+          (log/info "Refreshing Index:" init-stats)
+          (async/alt!
+            error-ch
+            ([e]
+             (throw e))
 
-          refresh-ch
-          ([{:keys [garbage properties old-sketch-paths classes], refreshed-db :db, :as _status}]
-           (let [;; Add computed fields to properties for O(1) optimizer lookups
-                 properties-with-computed (add-computed-fields properties)
+            refresh-ch
+            ([{:keys [garbage properties old-sketch-paths classes], refreshed-db :db, :as _status}]
+             (let [ ;; Add computed fields to properties for O(1) optimizer lookups
+                   properties-with-computed (add-computed-fields properties)
 
-                 {:keys [index-catalog alias] :as refreshed-db*}
-                 (-> refreshed-db
-                     (assoc-in [:stats :indexed] t)
-                     (assoc-in [:stats :properties] properties-with-computed)
-                     (assoc-in [:stats :classes] classes))
+                   {:keys [index-catalog alias] :as refreshed-db*}
+                   (-> refreshed-db
+                       (assoc-in [:stats :indexed] t)
+                       (assoc-in [:stats :properties] properties-with-computed)
+                       (assoc-in [:stats :classes] classes))
 
-                 garbage-with-sketches (into garbage (or old-sketch-paths #{}))
+                   garbage-with-sketches (into garbage (or old-sketch-paths #{}))
 
-                ;; TODO - ideally issue garbage/root writes to RAFT together
-                ;;        as a tx, currently requires waiting for both
-                ;;        through raft sync
-                 garbage-res   (when (seq garbage-with-sketches)
-                                 (let [write-res (<? (index-storage/write-garbage index-catalog alias t garbage-with-sketches))]
-                                   (<! (notify-new-index-file write-res :garbage t changes-ch))
-                                   write-res))
+                   ;; TODO - ideally issue garbage/root writes to RAFT together
+                   ;;        as a tx, currently requires waiting for both
+                   ;;        through raft sync
+                   garbage-res   (when (seq garbage-with-sketches)
+                                   (let [write-res (<? (index-storage/write-garbage index-catalog alias t garbage-with-sketches))]
+                                     (<! (notify-new-index-file write-res :garbage t changes-ch))
+                                     write-res))
 
-                 ;; No need to update db with sketches pointer - using fixed filenames
-                 refreshed-db**  refreshed-db*
+                   ;; No need to update db with sketches pointer - using fixed filenames
+                   refreshed-db**  refreshed-db*
 
-                 db-root-res   (<? (index-storage/write-db-root index-catalog refreshed-db** (:address garbage-res)))
-                 _             (<! (notify-new-index-file db-root-res :root t changes-ch))
+                   db-root-res   (<? (index-storage/write-db-root index-catalog refreshed-db** (:address garbage-res)))
+                   _             (<! (notify-new-index-file db-root-res :root t changes-ch))
 
-                 index-address (:address db-root-res)
-                 index-id      (str "fluree:index:sha256:" (:hash db-root-res))
+                   index-address (:address db-root-res)
+                   index-id      (str "fluree:index:sha256:" (:hash db-root-res))
 
-                 prev-idx-v    (get-in refreshed-db* [:commit :index :v])
-                 index-version (if (get-in refreshed-db* [:commit :index :data :t])
-                                 (or prev-idx-v 1)
-                                 2)
+                   prev-idx-v    (get-in refreshed-db* [:commit :index :v])
+                   index-version (if (get-in refreshed-db* [:commit :index :data :t])
+                                   (or prev-idx-v 1)
+                                   2)
 
-                 commit-index  (commit-data/new-index (-> refreshed-db* :commit :data)
-                                                      index-id
-                                                      index-address
-                                                      index-version
-                                                      (index/select-roots refreshed-db*))
-                 indexed-db    (dbproto/-index-update refreshed-db* commit-index)
-                 duration      (- (util/current-time-millis) start-time-ms)
-                 end-stats     (assoc init-stats
-                                      :end-time (util/current-time-iso)
-                                      :duration duration
-                                      :address (:address db-root-res)
-                                      :garbage (:address garbage-res))]
-             (log/info "Index refresh complete:" end-stats)
-            ;; kick off automatic garbage collection in the background
-             (garbage/clean-garbage indexed-db max-old-indexes)
+                   commit-index  (commit-data/new-index (-> refreshed-db* :commit :data)
+                                                        index-id
+                                                        index-address
+                                                        index-version
+                                                        (index/select-roots refreshed-db*))
+                   indexed-db    (dbproto/-index-update refreshed-db* commit-index)
+                   duration      (- (util/current-time-millis) start-time-ms)
+                   end-stats     (assoc init-stats
+                                        :end-time (util/current-time-iso)
+                                        :duration duration
+                                        :address (:address db-root-res)
+                                        :garbage (:address garbage-res))]
+               (log/info "Index refresh complete:" end-stats)
+               ;; kick off automatic garbage collection in the background
+               (garbage/clean-garbage indexed-db max-old-indexes)
 
-             indexed-db))))
-      db)))
+               indexed-db))))
+        db))))

--- a/src/fluree/db/ledger.cljc
+++ b/src/fluree/db/ledger.cljc
@@ -22,6 +22,7 @@
             [fluree.db.util.context :as context]
             [fluree.db.util.ledger :as util.ledger]
             [fluree.db.util.log :as log]
+            [fluree.db.util.trace :as trace]
             [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -602,15 +603,16 @@
 ;; TODO - however this is really a concern of "commit", not staging and I don't think the db should be handling any of it
 (defn write-transaction!
   [ledger ledger-name staged]
-  (go-try
-    (let [{:keys [txn author annotation]} staged
-          {:keys [commit-catalog]} ledger]
-      (if txn
-        (let [{txn-id :address} (<? (save-txn! commit-catalog ledger-name txn))]
-          {:txn-id     txn-id
-           :author     author
-           :annotation annotation})
-        staged))))
+  (trace/async-form ::write-transaction! {}
+    (go-try
+      (let [{:keys [txn author annotation]} staged
+            {:keys [commit-catalog]} ledger]
+        (if txn
+          (let [{txn-id :address} (<? (save-txn! commit-catalog ledger-name txn))]
+            {:txn-id     txn-id
+             :author     author
+             :annotation annotation})
+          staged)))))
 
 (defn update-commit-address
   "Once a commit address is known, which might be after the commit is written
@@ -627,46 +629,53 @@
     [(assoc commit-map :id commit-id)
      (assoc commit-jsonld "id" commit-id)]))
 
-(defn write-commit
-  [commit-storage alias {:keys [did private]} commit]
-  (go-try
-    (let [commit-jsonld (commit-data/->json-ld commit)
-          ;; For credential/generate, we need a DID map with public key
-          did-map (when (and did private)
-                    (if (map? did)
-                      did
-                      (did/private->did-map private)))
-          signed-commit (if did-map
-                          (<? (credential/generate commit-jsonld private did-map))
-                          commit-jsonld)
-          commit-res    (<? (commit-storage/write-jsonld commit-storage alias signed-commit))
+(defn write-commit-data
+  [commit-catalog ledger-name db-jsonld]
+  (trace/async-form ::write-commit-data {}
+    (commit-storage/write-jsonld commit-catalog ledger-name db-jsonld)))
 
-          [commit* commit-jsonld*]
-          (-> [commit commit-jsonld]
-              (update-commit-id (:hash commit-res))
-              (update-commit-address (:address commit-res)))]
-      {:commit-map    commit*
-       :commit-jsonld commit-jsonld*
-       :write-result  commit-res})))
+(defn write-commit-wrapper
+  [commit-storage alias {:keys [did private]} commit]
+  (trace/async-form ::write-commit-wrapper {}
+    (go-try
+      (let [commit-jsonld (commit-data/->json-ld commit)
+            ;; For credential/generate, we need a DID map with public key
+            did-map (when (and did private)
+                      (if (map? did)
+                        did
+                        (did/private->did-map private)))
+            signed-commit (if did-map
+                            (<? (credential/generate commit-jsonld private did-map))
+                            commit-jsonld)
+            commit-res    (<? (commit-storage/write-jsonld commit-storage alias signed-commit))
+
+            [commit* commit-jsonld*]
+            (-> [commit commit-jsonld]
+                (update-commit-id (:hash commit-res))
+                (update-commit-address (:address commit-res)))]
+        {:commit-map    commit*
+         :commit-jsonld commit-jsonld*
+         :write-result  commit-res}))))
 
 (defn publish-commit
   "Publishes commit to all nameservices registered with the ledger.
    Uses atomic publish-commit to update only commit fields, avoiding
    overwriting index data that may have been updated by a separate indexer."
   [{:keys [primary-publisher secondary-publishers] :as _ledger} commit-jsonld]
-  (go-try
-    (let [ledger-alias   (get commit-jsonld "alias")
-          commit-address (get commit-jsonld "address")
-          commit-t       (get-in commit-jsonld ["data" "t"])
-          _              (log/debug "publish-commit using atomic update"
-                                    {:alias ledger-alias :commit-t commit-t})
-          result         (<? (nameservice/publish-commit primary-publisher
-                                                         ledger-alias
-                                                         commit-address
-                                                         commit-t))]
-      (when-let [secondaries (seq secondary-publishers)]
-        (nameservice/publish-commit-to-all ledger-alias commit-address commit-t secondaries))
-      result)))
+  (trace/async-form ::publish-commit {}
+    (go-try
+      (let [ledger-alias   (get commit-jsonld "alias")
+            commit-address (get commit-jsonld "address")
+            commit-t       (get-in commit-jsonld ["data" "t"])
+            _              (log/debug "publish-commit using atomic update"
+                                      {:alias ledger-alias :commit-t commit-t})
+            result         (<? (nameservice/publish-commit primary-publisher
+                                                           ledger-alias
+                                                           commit-address
+                                                           commit-t))]
+        (when-let [secondaries (seq secondary-publishers)]
+          (nameservice/publish-commit-to-all ledger-alias commit-address commit-t secondaries))
+        result))))
 
 (defn formalize-commit
   [{prev-commit :commit :as staged-db} new-commit]
@@ -692,93 +701,95 @@
     {:keys [branch t stats commit] :as staged-db}
     opts]
    (log/debug "commit!: write-transaction start" {:ledger ledger-alias})
-   (go-try
-     (let [{:keys [commit-catalog]} ledger
-           ledger-name (util.ledger/ledger-base-name ledger-alias)
+   (trace/async-form ::commit! {}
+     (go-try
+       (let [{:keys [commit-catalog]} ledger
+             ledger-name (util.ledger/ledger-base-name ledger-alias)
 
-           {:keys [tag time message did private commit-data-opts index-files-ch]
-            :or   {time (util/current-time-iso)}}
-           (parse-commit-opts ledger opts)
+             {:keys [tag time message did private commit-data-opts index-files-ch]
+              :or   {time (util/current-time-iso)}}
+             (parse-commit-opts ledger opts)
 
-           {:keys [db-jsonld staged-txn]}
-           (commit-data/db->jsonld staged-db commit-data-opts)
+             {:keys [db-jsonld staged-txn]}
+             (commit-data/db->jsonld staged-db commit-data-opts)
 
-           {:keys [txn-id author annotation]}
-           (<? (write-transaction! ledger ledger-name staged-txn))
+             {:keys [txn-id author annotation]}
+             (<? (write-transaction! ledger ledger-name staged-txn))
 
-           _ (log/debug "commit!: write-jsonld(db) start" {:ledger ledger-alias})
+             _ (log/debug "commit!: write-commit-data start" {:ledger ledger-alias})
 
-           data-write-result (<? (commit-storage/write-jsonld commit-catalog ledger-name db-jsonld))
+             data-write-result (<? (write-commit-data commit-catalog ledger-name db-jsonld))
 
-           _ (log/debug "commit!: write-jsonld(db) done" {:ledger ledger-alias :db-address (:address data-write-result)})
-           db-address        (:address data-write-result) ; may not have address (e.g. IPFS) until after writing file
-           dbid              (commit-data/hash->db-id (:hash data-write-result))
-           keypair           {:did did, :private private}
+             _ (log/debug "commit!: write-commit-data done" {:ledger ledger-alias :db-address (:address data-write-result)})
+             db-address        (:address data-write-result) ; may not have address (e.g. IPFS) until after writing file
+             dbid              (commit-data/hash->db-id (:hash data-write-result))
+             keypair           {:did did, :private private}
 
-           new-commit (commit-data/new-db-commit-map {:old-commit commit
-                                                      :issuer     did
-                                                      :message    message
-                                                      :tag        tag
-                                                      :dbid       dbid
-                                                      :t          t
-                                                      :time       time
-                                                      :db-address db-address
-                                                      :author     author
-                                                      :annotation annotation
-                                                      :txn-id     txn-id
-                                                      :flakes     (:flakes stats)
-                                                      :size       (:size stats)})
+             new-commit (commit-data/new-db-commit-map {:old-commit commit
+                                                        :issuer     did
+                                                        :message    message
+                                                        :tag        tag
+                                                        :dbid       dbid
+                                                        :t          t
+                                                        :time       time
+                                                        :db-address db-address
+                                                        :author     author
+                                                        :annotation annotation
+                                                        :txn-id     txn-id
+                                                        :flakes     (:flakes stats)
+                                                        :size       (:size stats)})
 
-           _ (log/debug "commit!: write-commit start" {:ledger ledger-alias})
+             _ (log/debug "commit!: write-commit-wrapper start" {:ledger ledger-alias})
 
-           {:keys [commit-map commit-jsonld write-result]}
-           (<? (write-commit commit-catalog ledger-name keypair new-commit))
+             {:keys [commit-map commit-jsonld write-result]}
+             (<? (write-commit-wrapper commit-catalog ledger-name keypair new-commit))
 
-           _ (log/debug "commit!: write-commit done" {:ledger ledger-alias :commit-address (:address write-result)})
+             _ (log/debug "commit!: write-commit-wrapper done" {:ledger ledger-alias :commit-address (:address write-result)})
 
-           db  (formalize-commit staged-db commit-map)
+             db  (formalize-commit staged-db commit-map)
 
-           _ (log/debug "commit!: ledger/update-commit! start" {:ledger ledger-alias :t t})
+             _ (log/debug "commit!: ledger/update-commit! start" {:ledger ledger-alias :t t})
 
-           db* (update-commit! ledger branch db index-files-ch)]
+             db* (update-commit! ledger branch db index-files-ch)]
 
-       (log/debug "commit!: ledger/update-commit! done, publish-commit start" {:ledger ledger-alias :t t :at time})
+         (log/debug "commit!: ledger/update-commit! done, publish-commit start" {:ledger ledger-alias :t t :at time})
 
-       (<? (publish-commit ledger commit-jsonld))
+         (<? (publish-commit ledger commit-jsonld))
 
-       (log/debug "commit!: publish-commit done" {:ledger ledger-alias})
+         (log/debug "commit!: publish-commit done" {:ledger ledger-alias})
 
-       (if (track/track-txn? opts)
-         (let [index-t (commit-data/index-t commit-map)
-               novelty-size (get-in db* [:novelty :size] 0)
-               ;; Always read threshold from realized FlakeDB; db* may be AsyncDB
-               reindex-min-bytes (or (:reindex-min-bytes db) 1000000)]
-           (-> write-result
-               (select-keys [:address :hash :size])
-               (assoc :ledger-id ledger-alias
-                      :t t
-                      :db db*
-                      :indexing-needed (indexing-needed? novelty-size reindex-min-bytes)
-                      :index-t index-t
-                      :indexing-enabled (indexing-enabled? ledger branch)
-                      :novelty-size novelty-size)))
-         db*)))))
+         (if (track/track-txn? opts)
+           (let [index-t (commit-data/index-t commit-map)
+                 novelty-size (get-in db* [:novelty :size] 0)
+                 ;; Always read threshold from realized FlakeDB; db* may be AsyncDB
+                 reindex-min-bytes (or (:reindex-min-bytes db) 1000000)]
+             (-> write-result
+                 (select-keys [:address :hash :size])
+                 (assoc :ledger-id ledger-alias
+                        :t t
+                        :db db*
+                        :indexing-needed (indexing-needed? novelty-size reindex-min-bytes)
+                        :index-t index-t
+                        :indexing-enabled (indexing-enabled? ledger branch)
+                        :novelty-size novelty-size)))
+           db*))))))
 
 (defn transact!
   [ledger parsed-txn]
-  (go-try
-    (let [{:keys [branch] :as parsed-opts,
-           :or   {branch const/default-branch-name}}
-          (:opts parsed-txn)
+  (trace/async-form ::transact! {}
+    (go-try
+      (let [{:keys [branch] :as parsed-opts,
+             :or   {branch const/default-branch-name}}
+            (:opts parsed-txn)
 
-          db       (current-db ledger branch)
-          staged   (<? (transact/stage-triples db parsed-txn))
-          ;; commit API takes a did-map and parsed context as opts
-          ;; whereas stage API takes a did IRI and unparsed context.
-          ;; Dissoc them until deciding at a later point if they can carry through.
-          cmt-opts (dissoc parsed-opts :context :identity)]
-      (if (track/track-txn? parsed-opts)
-        (let [staged-db     (:db staged)
-              commit-result (<? (commit! ledger staged-db cmt-opts))]
-          (merge staged commit-result))
-        (<? (commit! ledger staged cmt-opts))))))
+            db       (current-db ledger branch)
+            staged   (<? (transact/stage-triples db parsed-txn))
+            ;; commit API takes a did-map and parsed context as opts
+            ;; whereas stage API takes a did IRI and unparsed context.
+            ;; Dissoc them until deciding at a later point if they can carry through.
+            cmt-opts (dissoc parsed-opts :context :identity)]
+        (if (track/track-txn? parsed-opts)
+          (let [staged-db     (:db staged)
+                commit-result (<? (commit! ledger staged-db cmt-opts))]
+            (merge staged commit-result))
+          (<? (commit! ledger staged cmt-opts)))))))

--- a/src/fluree/db/query/api.cljc
+++ b/src/fluree/db/query/api.cljc
@@ -18,7 +18,8 @@
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.context :as context]
             [fluree.db.util.ledger :as ledger-util]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.db.util.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -206,36 +207,37 @@
 
 (defn load-alias
   [conn tracker alias {:keys [t] :as sanitized-query}]
-  (go-try
-    (log/debug "load-alias called with:" alias)
-    (let [[base-alias explicit-t] (extract-query-string-t alias)
-          ;; Normalize to ensure branch (e.g., "docs" -> "docs:main")
-          normalized-alias (ledger-util/ensure-ledger-branch base-alias)
-          publisher        (connection/primary-publisher conn)
-          ns-record        (<? (nameservice/lookup publisher normalized-alias))]
-      (if (virtual-graph-record? ns-record)
-        ;; Virtual graph - load via VG loader (JVM only)
-        #?(:clj
-           (let [;; For VG queries, we need a source ledger's db to initialize the VG
-                 ;; Get it from the VG's dependencies
-                 deps          (get ns-record "fidx:dependencies")
-                 source-alias  (first deps)
-                 source-ledger (<? (connection/load-ledger-alias conn source-alias))
-                 source-db     (ledger/current-db source-ledger)
-                 vg            (<? (vg-loader/load-virtual-graph-from-nameservice
-                                    source-db publisher normalized-alias))]
-             vg)
-           :cljs
-           (throw (ex-info "Virtual graphs are not supported in ClojureScript"
-                           {:status 400 :error :db/unsupported})))
-        ;; Regular ledger
-        (let [ledger (<? (connection/load-ledger-alias conn normalized-alias))
-              db     (ledger/current-db ledger)
-              t*     (or explicit-t t)
-              query* (-> sanitized-query
-                         (assoc :t t*)
-                         (ledger-opts-override db))]
-          (<? (restrict-db db tracker query* conn)))))))
+  (trace/async-form ::load-alias {}
+    (go-try
+      (log/debug "load-alias called with:" alias)
+      (let [[base-alias explicit-t] (extract-query-string-t alias)
+            ;; Normalize to ensure branch (e.g., "docs" -> "docs:main")
+            normalized-alias (ledger-util/ensure-ledger-branch base-alias)
+            publisher        (connection/primary-publisher conn)
+            ns-record        (<? (nameservice/lookup publisher normalized-alias))]
+        (if (virtual-graph-record? ns-record)
+          ;; Virtual graph - load via VG loader (JVM only)
+          #?(:clj
+             (let [ ;; For VG queries, we need a source ledger's db to initialize the VG
+                   ;; Get it from the VG's dependencies
+                   deps          (get ns-record "fidx:dependencies")
+                   source-alias  (first deps)
+                   source-ledger (<? (connection/load-ledger-alias conn source-alias))
+                   source-db     (ledger/current-db source-ledger)
+                   vg            (<? (vg-loader/load-virtual-graph-from-nameservice
+                                      source-db publisher normalized-alias))]
+               vg)
+             :cljs
+             (throw (ex-info "Virtual graphs are not supported in ClojureScript"
+                             {:status 400 :error :db/unsupported})))
+          ;; Regular ledger
+          (let [ledger (<? (connection/load-ledger-alias conn normalized-alias))
+                db     (ledger/current-db ledger)
+                t*     (or explicit-t t)
+                query* (-> sanitized-query
+                           (assoc :t t*)
+                           (ledger-opts-override db))]
+            (<? (restrict-db db tracker query* conn))))))))
 
 (defn load-aliases
   [conn tracker aliases sanitized-query]
@@ -268,15 +270,16 @@
 
 (defn load-dataset
   [conn tracker defaults named sanitized-query]
-  (go-try
-    (if (and (= (count defaults) 1)
-             (empty? named))
-      (let [alias (first defaults)]
-        ;; return an unwrapped db if the data set consists of one ledger
-        (<? (load-alias conn tracker alias sanitized-query)))
-      (let [all-aliases (->> defaults (concat named) distinct)
-            db-map      (<? (load-aliases conn tracker all-aliases sanitized-query))]
-        (dataset db-map defaults)))))
+  (trace/async-form ::load-dataset {}
+    (go-try
+      (if (and (= (count defaults) 1)
+               (empty? named))
+        (let [alias (first defaults)]
+                          ;; return an unwrapped db if the data set consists of one ledger
+          (<? (load-alias conn tracker alias sanitized-query)))
+        (let [all-aliases (->> defaults (concat named) distinct)
+              db-map      (<? (load-aliases conn tracker all-aliases sanitized-query))]
+          (dataset db-map defaults))))))
 
 (defn query-connection-fql
   [conn query override-opts]

--- a/src/fluree/db/query/exec/group.cljc
+++ b/src/fluree/db/query/exec/group.cljc
@@ -4,7 +4,8 @@
             [fluree.db.query.exec.select.fql :as select.fql]
             [fluree.db.query.exec.select.sparql :as select.sparql]
             [fluree.db.query.exec.where :as where]
-            [fluree.db.util :as util]))
+            [fluree.db.util :as util]
+            [fluree.db.util.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -102,7 +103,9 @@
   (if-let [grouping (or group-by
                         (implicit-grouping select))]
     (let [grouping-set (set grouping)]
-      (-> (async/transduce (map (partial split-solution-by grouping grouping-set))
+      (-> (async/transduce (comp
+                            (trace/xf ::group-by {})
+                            (map (partial split-solution-by grouping grouping-set)))
                            (completing group-solution
                                        (partial unwind-groups grouping))
                            {}

--- a/src/fluree/db/query/exec/having.cljc
+++ b/src/fluree/db/query/exec/having.cljc
@@ -1,13 +1,14 @@
 (ns fluree.db.query.exec.having
   (:require [clojure.core.async :as async :refer [>! go]]
             [fluree.db.util :as util :refer [try* catch*]]
-            [fluree.db.util.log :as log :include-macros true])
+            [fluree.db.util.log :as log :include-macros true]
+            [fluree.db.util.trace :as trace])
   (:refer-clojure :exclude [filter]))
 
 (defn filter
   [q error-ch solution-ch]
   (if-let [filter-fn (:having q)]
-    (let [filtered-ch (async/chan)]
+    (let [filtered-ch (async/chan 2 (trace/xf ::having {}))]
       (async/pipeline-async 2
                             filtered-ch
                             (fn [solution ch]

--- a/src/fluree/db/query/exec/order.cljc
+++ b/src/fluree/db/query/exec/order.cljc
@@ -1,6 +1,7 @@
 (ns fluree.db.query.exec.order
   (:require [clojure.core.async :as async]
-            [fluree.db.query.exec.where :as where]))
+            [fluree.db.query.exec.where :as where]
+            [fluree.db.util.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -42,7 +43,8 @@
   (if order-by
     (let [comparator (partial compare-solutions order-by)
           coll-ch    (async/into [] solution-ch)
-          ordered-ch (async/chan 2 (comp (map (partial sort comparator))
+          ordered-ch (async/chan 2 (comp (trace/xf ::order-by {})
+                                         (map (partial sort comparator))
                                          cat))]
       (async/pipe coll-ch ordered-ch))
     solution-ch))

--- a/src/fluree/db/query/exec/select.cljc
+++ b/src/fluree/db/query/exec/select.cljc
@@ -14,6 +14,7 @@
             [fluree.db.query.exec.where :as where]
             [fluree.db.util :as util :refer [catch* try*]]
             [fluree.db.util.log :as log :include-macros true]
+            [fluree.db.util.trace :as trace]
             [fluree.json-ld :as json-ld]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -169,7 +170,7 @@
                                       (log/trace "Updating solution:" sol)
                                       (update-solution sel sol))
                                     solution modifying-selectors)))
-        modify-ch               (chan 1 mods-xf)]
+        modify-ch               (chan 1 (comp (trace/xf ::modify {}) mods-xf))]
     (async/pipe solution-ch modify-ch)))
 
 (defn format-values
@@ -211,8 +212,8 @@
                                      (not-empty)
                                      (apply comp))
         format-ch           (if format-xf
-                              (chan 1 format-xf)
-                              (chan))]
+                              (chan 1 (comp (trace/xf ::format {}) format-xf))
+                              (chan 1 (trace/xf ::format {})))]
     (async/pipeline-async 3
                           format-ch
                           (fn [solution ch]

--- a/src/fluree/db/query/exec/where.cljc
+++ b/src/fluree/db/query/exec/where.cljc
@@ -666,14 +666,15 @@
   "Return a channel of all solutions from the data set `ds` that extend from the
   solutions in `solution-ch` and also match the where-clause pattern `pattern`."
   [ds tracker pattern error-ch solution-ch]
-  (let [out-ch (async/chan 2)]
-    (async/pipeline-async 2
-                          out-ch
-                          (fn [solution ch]
-                            (-> (match-pattern ds tracker solution pattern error-ch)
-                                (async/pipe ch)))
-                          solution-ch)
-    out-ch))
+  (trace/form ::pattern {:attributes {:pattern pattern}}
+    (let [out-ch (async/chan 2)]
+      (async/pipeline-async 2
+                            out-ch
+                            (fn [solution ch]
+                              (-> (match-pattern ds tracker solution pattern error-ch)
+                                  (async/pipe ch)))
+                            solution-ch)
+      out-ch)))
 
 (defn match-patterns
   [ds tracker solution patterns error-ch]

--- a/src/fluree/db/query/fql/parse.cljc
+++ b/src/fluree/db/query/fql/parse.cljc
@@ -18,6 +18,7 @@
             [fluree.db.util.context :as ctx-util]
             [fluree.db.util.log :as log :include-macros true]
             [fluree.db.util.parse :as util.parse]
+            [fluree.db.util.trace :as trace]
             [fluree.db.validation :as v]
             [fluree.json-ld :as json-ld]))
 
@@ -864,7 +865,8 @@
 (defn parse-query
   [q]
   (log/trace "parse-query" q)
-  (-> q syntax/coerce-query parse-query*))
+  (trace/form ::parse-query {}
+    (-> q syntax/coerce-query parse-query*)))
 
 (declare parse-subj-cmp)
 

--- a/src/fluree/db/query/sparql.cljc
+++ b/src/fluree/db/query/sparql.cljc
@@ -6,7 +6,8 @@
             [clojure.string :as str]
             [fluree.db.query.sparql.translator :as sparql.translator]
             [fluree.db.util.docs :as docs]
-            [fluree.db.util.log :as log]))
+            [fluree.db.util.log :as log]
+            [fluree.db.util.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -64,8 +65,9 @@
 
 (defn ->fql
   [sparql]
-  (let [parsed (parse sparql)]
-    (sparql.translator/translate parsed)))
+  (trace/form ::translate-sparql {}
+    (let [parsed (parse sparql)]
+      (sparql.translator/translate parsed))))
 
 (defn sparql-format?
   [opts]

--- a/src/fluree/db/util/trace.cljc
+++ b/src/fluree/db/util/trace.cljc
@@ -1,0 +1,55 @@
+(ns fluree.db.util.trace
+  #?(:clj
+     (:require [fluree.db.util :refer [if-cljs]]
+               [steffan-westcott.clj-otel.api.trace.chan-span :as chan-span]
+               [steffan-westcott.clj-otel.api.trace.span :as span]
+               [steffan-westcott.clj-otel.context :as otel-context])))
+
+(defn get-context
+  "Returns the current tracing context."
+  []
+  #?(:clj (otel-context/dyn)
+     :cljs nil))
+
+#?(:clj
+   (defmacro with-parent-context
+     "Start a new tracing span as a child of the supplied parent trace context."
+     [id parent-trace-ctx & body]
+     `(if-cljs
+       (do ~@body)
+       (chan-span/chan-span-binding [_context# {:parent ~parent-trace-ctx :name ~id}]
+                                    ~@body))))
+
+#?(:clj
+   (defmacro async-form
+     "Trace async body execution using the dynamically bound tracing context."
+     [id data & body]
+     `(if-cljs
+       (do ~@body)
+       (chan-span/async-bound-chan-span {:name ~id :attributes ~data}
+                                        ~@body))))
+
+#?(:clj
+   (defmacro form
+     "Trace body execution using the dynamically bound tracing context or the supplied :parent context."
+     [id opts & body]
+     `(if-cljs
+       (do ~@body)
+       (span/with-span! ~(merge {:name id} opts)
+         ~@body))))
+
+#?(:clj
+   (defmacro xf
+     "Trace the first time a transducer is executed."
+     [id data]
+     `(fn [rf#]
+        (let [logged?# (volatile! false)]
+          (fn
+            ([] (rf#))
+            ([result# x#]
+             (when-not @logged?#
+               (form ~id {:attributes ~data})
+               (vreset! logged?# true))
+             (rf# result# x#))
+            ([result#] (rf# result#)))))))
+


### PR DESCRIPTION
This PR adds a OpenTelemetry-compatible tracing facade and instruments the Fluree runtime. This allows us to correlate `db` work across services and make flamegraphs to help identify performance bottlenecks.

An example of a trace displayed in Jaeger:
<img width="1291" height="920" alt="Jaeger_create" src="https://github.com/user-attachments/assets/a3cf4d56-f575-490d-b063-582a0f8e9f7f" />

An example of a span in Jaeger:
<img width="1130" height="583" alt="Jaeger_trace-detail" src="https://github.com/user-attachments/assets/82f9b7af-714c-4723-857c-deddbc284089" />

