### PR TITLE
Fix/remote ledger not found

### DIFF
--- a/src/fluree/db/connection.cljc
+++ b/src/fluree/db/connection.cljc
@@ -98,8 +98,8 @@
   nil)
 
 (defn all-publications
-  [{:keys [remote-systems] :as _conn}]
-  remote-systems)
+  [conn]
+  (:remote-systems conn))
 
 (defn subscribe-all
   [publications ledger-alias]
@@ -307,10 +307,6 @@
   [{:keys [primary-publisher] :as _conn}]
   primary-publisher)
 
-(defn publications
-  [conn]
-  (:remote-systems conn))
-
 (defn all-nameservices
   [{:keys [remote-systems] :as conn}]
   (concat (publishers conn) remote-systems))
@@ -413,7 +409,7 @@
 (defn known-addresses
   [conn ledger-alias]
   (go-try
-    (loop [[nsv & r] (publications conn)
+    (loop [[nsv & r] (all-publications conn)
            addrs     []]
       (if nsv
         (recur r (into addrs (<? (nameservice/known-addresses nsv ledger-alias))))

--- a/src/fluree/db/query/api.cljc
+++ b/src/fluree/db/query/api.cljc
@@ -229,16 +229,13 @@
            (throw (ex-info "Virtual graphs are not supported in ClojureScript"
                            {:status 400 :error :db/unsupported})))
         ;; Regular ledger
-        (if ns-record
-          (let [ledger (<? (connection/load-ledger-alias conn normalized-alias))
-                db     (ledger/current-db ledger)
-                t*     (or explicit-t t)
-                query* (-> sanitized-query
-                           (assoc :t t*)
-                           (ledger-opts-override db))]
-            (<? (restrict-db db tracker query* conn)))
-          (throw (ex-info (str "Load for " normalized-alias " failed due to failed address lookup.")
-                          {:status 404 :error :db/unkown-ledger})))))))
+        (let [ledger (<? (connection/load-ledger-alias conn normalized-alias))
+              db     (ledger/current-db ledger)
+              t*     (or explicit-t t)
+              query* (-> sanitized-query
+                         (assoc :t t*)
+                         (ledger-opts-override db))]
+          (<? (restrict-db db tracker query* conn)))))))
 
 (defn load-aliases
   [conn tracker aliases sanitized-query]


### PR DESCRIPTION
This fixes a problem introduced on `main` where we only check the primary publisher for a ledger alias before returning a 404 Not Found error. However this is handled correctly by the `connection/ledger-ledger-alias` function, so this PR restores the old, correct behavior.