### PR TITLE
remote reindex support

### DIFF
--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -251,6 +251,36 @@ If no branch suffix is provided (e.g., `"mydb"`), the server MUST normalize to `
 
 Used by `fluree publish` (and potentially future `fluree create --remote`) to create a ledger on a remote server before pushing commits.
 
+## `/reindex` Contract
+
+- Endpoint: `POST {api_base_url}/reindex`
+- Auth: admin-protected (same middleware as `/create`, `/drop`).
+- Request body:
+  ```json
+  {
+    "ledger": "mydb:main",
+    "opts": { }
+  }
+  ```
+  `opts` is optional and reserved for future per-request overrides (e.g. indexer tuning). Servers MUST accept it and MAY ignore it — today the reference server always reindexes using its own configured indexer settings.
+- Response (200 OK):
+  ```json
+  {
+    "ledger_id": "mydb:main",
+    "index_t": 42,
+    "root_id": "fluree:index:sha256:...",
+    "stats": {
+      "flake_count": 0,
+      "leaf_count": 0,
+      "branch_count": 0,
+      "total_bytes": 0
+    }
+  }
+  ```
+- Response (4xx/5xx): standard `ApiError` envelope on failure (e.g. ledger not found).
+
+The response shape mirrors `fluree_db_api::ReindexResult` — implementers should treat that Rust struct as the source of truth and add new fields only additively. Used by `fluree reindex --remote <name>` and by the CLI's auto-routing when a local server is running.
+
 ## `/exists` Response Contract
 
 - Endpoint: `GET {api_base_url}/exists?ledger=mydb:main` (or via `fluree-ledger` header)

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -74,6 +74,7 @@ pub mod tx_builder;
 #[cfg(feature = "vector")]
 pub mod vector_worker;
 pub mod view;
+pub mod wire;
 
 // Ledger caching and management
 pub mod ledger_manager;

--- a/fluree-db-api/src/wire.rs
+++ b/fluree-db-api/src/wire.rs
@@ -1,0 +1,69 @@
+//! Wire types shared between `fluree-db-server` and `fluree-db-cli`.
+//!
+//! These structs define the JSON contract for admin HTTP endpoints. Putting
+//! them in `fluree-db-api` (a crate both server and CLI already depend on)
+//! gives both ends a single typed source and eliminates brittle
+//! `serde_json::Value::get(...)` decoding in the client.
+//!
+//! Internal library types (e.g. `ReindexResult` with `ContentId`) stay in
+//! their respective modules. Conversions from internal → wire types live
+//! here via `From` impls.
+//!
+//! Currently covers: `/reindex`. Other admin endpoints (`/create`, `/drop`,
+//! `/branch`, etc.) can be moved into this module incrementally.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::ReindexResult;
+
+/// Request body for `POST /reindex`.
+///
+/// `opts` is reserved for future per-request overrides (e.g. indexer tuning).
+/// It is accepted but ignored today — the server always reindexes using the
+/// indexer settings it is configured with.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReindexRequest {
+    /// Ledger alias (e.g. `"mydb"` or `"mydb:main"`).
+    pub ledger: String,
+    /// Reserved for future use — currently ignored by the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opts: Option<JsonValue>,
+}
+
+/// Build statistics included in `ReindexResponse`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReindexStats {
+    pub flake_count: usize,
+    pub leaf_count: usize,
+    pub branch_count: usize,
+    pub total_bytes: usize,
+}
+
+/// Response body for `POST /reindex`.
+///
+/// Mirrors the library's `ReindexResult`, with `root_id` serialized as a
+/// `String` (the `ContentId` display form) for wire compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReindexResponse {
+    pub ledger_id: String,
+    pub index_t: i64,
+    pub root_id: String,
+    pub stats: ReindexStats,
+}
+
+impl From<ReindexResult> for ReindexResponse {
+    fn from(r: ReindexResult) -> Self {
+        Self {
+            ledger_id: r.ledger_id,
+            index_t: r.index_t,
+            root_id: r.root_id.to_string(),
+            stats: ReindexStats {
+                flake_count: r.stats.flake_count,
+                leaf_count: r.stats.leaf_count,
+                branch_count: r.stats.branch_count,
+                total_bytes: r.stats.total_bytes,
+            },
+        }
+    }
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -715,6 +715,10 @@ pub enum Commands {
     Reindex {
         /// Ledger name (defaults to active ledger)
         ledger: Option<String>,
+
+        /// Execute against a remote server (by remote name, e.g., "origin")
+        #[arg(long)]
+        remote: Option<String>,
     },
 
     /// Manage the Fluree HTTP server

--- a/fluree-db-cli/src/commands/index.rs
+++ b/fluree-db-cli/src/commands/index.rs
@@ -2,6 +2,7 @@ use crate::context::{self, build_fluree, LedgerMode};
 use crate::error::{CliError, CliResult};
 use colored::Colorize;
 use fluree_db_api::server_defaults::FlureeDir;
+use fluree_db_api::wire::ReindexResponse;
 use fluree_db_api::ReindexOptions;
 
 /// Run incremental indexing for a ledger.
@@ -127,19 +128,9 @@ pub async fn run_reindex(
     Ok(())
 }
 
-fn print_reindex_result(result: &serde_json::Value) {
-    let ledger_id = result
-        .get("ledger_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("(unknown)");
-    let index_t = result
-        .get("index_t")
-        .and_then(serde_json::Value::as_i64)
-        .unwrap_or(0);
-    let root_id = result
-        .get("root_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("(unknown)");
-
-    println!("Reindexed {ledger_id} to t={index_t} (root: {root_id})");
+fn print_reindex_result(result: &ReindexResponse) {
+    println!(
+        "Reindexed {} to t={} (root: {})",
+        result.ledger_id, result.index_t, result.root_id
+    );
 }

--- a/fluree-db-cli/src/commands/index.rs
+++ b/fluree-db-cli/src/commands/index.rs
@@ -1,4 +1,4 @@
-use crate::context::{self, build_fluree};
+use crate::context::{self, build_fluree, LedgerMode};
 use crate::error::{CliError, CliResult};
 use colored::Colorize;
 use fluree_db_api::server_defaults::FlureeDir;
@@ -57,30 +57,89 @@ pub async fn run_index(ledger: Option<&str>, dirs: &FlureeDir) -> CliResult<()> 
 }
 
 /// Run a full reindex (rebuild from commit history) for a ledger.
-pub async fn run_reindex(ledger: Option<&str>, dirs: &FlureeDir) -> CliResult<()> {
-    let alias = context::resolve_ledger(ledger, dirs)?;
-    let fluree = build_fluree(dirs)?;
-    let ledger_id = context::to_ledger_id(&alias);
+///
+/// With `--remote`, routes to the named remote's `POST /reindex` endpoint.
+/// Without `--remote` but with a local server running, auto-routes to it
+/// via `server.meta.json` (pass `--direct` to bypass).
+pub async fn run_reindex(
+    ledger: Option<&str>,
+    dirs: &FlureeDir,
+    remote_flag: Option<&str>,
+    direct: bool,
+) -> CliResult<()> {
+    if let Some(remote_name) = remote_flag {
+        let alias = context::resolve_ledger(ledger, dirs)?;
+        let client = context::build_remote_client(remote_name, dirs).await?;
+        let result = client.reindex(&alias).await?;
 
-    // Verify ledger exists
-    if !fluree.ledger_exists(&ledger_id).await.unwrap_or(false) {
-        return Err(CliError::NotFound(format!("ledger '{alias}' not found")));
+        context::persist_refreshed_tokens(&client, remote_name, dirs).await;
+
+        print_reindex_result(&result);
+        return Ok(());
     }
 
-    eprintln!(
-        "  {} rebuilding index for {} from commit history...",
-        "reindex:".cyan().bold(),
-        alias
-    );
+    let mode = {
+        let mode = context::resolve_ledger_mode(ledger, dirs).await?;
+        if direct {
+            mode
+        } else {
+            context::try_server_route(mode, dirs)
+        }
+    };
 
-    let result = fluree
-        .reindex(&ledger_id, ReindexOptions::default())
-        .await?;
+    match mode {
+        LedgerMode::Tracked {
+            client,
+            remote_alias,
+            remote_name,
+            ..
+        } => {
+            let result = client.reindex(&remote_alias).await?;
 
-    println!(
-        "Reindexed {} to t={} (root: {})",
-        alias, result.index_t, result.root_id
-    );
+            context::persist_refreshed_tokens(&client, &remote_name, dirs).await;
+
+            print_reindex_result(&result);
+        }
+        LedgerMode::Local { fluree, alias } => {
+            let ledger_id = context::to_ledger_id(&alias);
+
+            if !fluree.ledger_exists(&ledger_id).await.unwrap_or(false) {
+                return Err(CliError::NotFound(format!("ledger '{alias}' not found")));
+            }
+
+            eprintln!(
+                "  {} rebuilding index for {} from commit history...",
+                "reindex:".cyan().bold(),
+                alias
+            );
+
+            let result = fluree
+                .reindex(&ledger_id, ReindexOptions::default())
+                .await?;
+
+            println!(
+                "Reindexed {} to t={} (root: {})",
+                alias, result.index_t, result.root_id
+            );
+        }
+    }
 
     Ok(())
+}
+
+fn print_reindex_result(result: &serde_json::Value) {
+    let ledger_id = result
+        .get("ledger_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(unknown)");
+    let index_t = result
+        .get("index_t")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+    let root_id = result
+        .get("root_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(unknown)");
+
+    println!("Reindexed {ledger_id} to t={index_t} (root: {root_id})");
 }

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -442,9 +442,10 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             commands::index::run_index(ledger.as_deref(), &fluree_dir).await
         }
 
-        Commands::Reindex { ledger } => {
+        Commands::Reindex { ledger, remote } => {
             let fluree_dir = config::require_fluree_dir(config_path)?;
-            commands::index::run_reindex(ledger.as_deref(), &fluree_dir).await
+            commands::index::run_reindex(ledger.as_deref(), &fluree_dir, remote.as_deref(), direct)
+                .await
         }
 
         #[cfg(feature = "server")]

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -1026,6 +1026,31 @@ impl RemoteLedgerClient {
     }
 
     // =========================================================================
+    // Reindex
+    // =========================================================================
+
+    /// Trigger a full reindex on the remote server.
+    ///
+    /// Calls `POST {base_url}/reindex` with `{"ledger": "<alias>"}`. The server
+    /// rebuilds the ledger's index from commit history using whatever indexer
+    /// settings it is configured with. Response shape mirrors
+    /// `fluree_db_api::ReindexResult` (ledger_id, index_t, root_id, stats).
+    ///
+    /// An `opts` field is reserved in the request contract for future
+    /// per-request overrides but is currently ignored by the server.
+    pub async fn reindex(&self, ledger: &str) -> Result<serde_json::Value, RemoteLedgerError> {
+        let url = self.op_url_root("reindex");
+        let body = serde_json::json!({ "ledger": ledger });
+        self.send_json(
+            reqwest::Method::POST,
+            &url,
+            "application/json",
+            Some(RequestBody::Json(&body)),
+        )
+        .await
+    }
+
+    // =========================================================================
     // List ledgers
     // =========================================================================
 

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -242,6 +242,15 @@ impl RemoteLedgerClient {
     /// safety net, not a policy knob.
     pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
 
+    /// Per-call timeout override for `POST /reindex`.
+    ///
+    /// A full commit-history rebuild on a large ledger can legitimately run
+    /// longer than the default 5-minute request timeout; if the client
+    /// abandons the connection, the server keeps rebuilding but the user
+    /// loses the result. 1 hour is a pragmatic ceiling — the server still
+    /// owns hard cutoffs.
+    pub const REINDEX_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
     /// Create a new remote ledger client with the default 5-minute timeout.
     ///
     /// `base_url` is the Fluree API base (e.g., `http://localhost:8090/fluree`
@@ -452,6 +461,52 @@ impl RemoteLedgerClient {
             // Retry with refreshed token
             let resp2 = self
                 .build_request(method, url, content_type, &body)
+                .send()
+                .await
+                .map_err(Self::map_network_error)?;
+
+            if resp2.status().is_success() {
+                return resp2
+                    .json()
+                    .await
+                    .map_err(|e| RemoteLedgerError::InvalidResponse(e.to_string()));
+            }
+            return Err(Self::map_error(resp2).await);
+        }
+
+        Err(Self::map_error(resp).await)
+    }
+
+    /// Execute a JSON request with a per-call timeout override.
+    ///
+    /// Used for operations (e.g. `/reindex`) whose legitimate duration can
+    /// exceed `DEFAULT_TIMEOUT`. On 401, attempts token refresh and retries once.
+    async fn send_json_with_timeout(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        content_type: &str,
+        body: Option<RequestBody<'_>>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let resp = self
+            .build_request(method.clone(), url, content_type, &body)
+            .timeout(timeout)
+            .send()
+            .await
+            .map_err(Self::map_network_error)?;
+
+        if resp.status().is_success() {
+            return resp
+                .json()
+                .await
+                .map_err(|e| RemoteLedgerError::InvalidResponse(e.to_string()));
+        }
+
+        if resp.status() == StatusCode::UNAUTHORIZED && self.try_refresh().await {
+            let resp2 = self
+                .build_request(method, url, content_type, &body)
+                .timeout(timeout)
                 .send()
                 .await
                 .map_err(Self::map_network_error)?;
@@ -1033,21 +1088,29 @@ impl RemoteLedgerClient {
     ///
     /// Calls `POST {base_url}/reindex` with `{"ledger": "<alias>"}`. The server
     /// rebuilds the ledger's index from commit history using whatever indexer
-    /// settings it is configured with. Response shape mirrors
-    /// `fluree_db_api::ReindexResult` (ledger_id, index_t, root_id, stats).
+    /// settings it is configured with. Uses `REINDEX_TIMEOUT` (1 hour) because
+    /// full rebuilds can legitimately exceed the default client timeout on
+    /// large ledgers.
     ///
     /// An `opts` field is reserved in the request contract for future
     /// per-request overrides but is currently ignored by the server.
-    pub async fn reindex(&self, ledger: &str) -> Result<serde_json::Value, RemoteLedgerError> {
+    pub async fn reindex(
+        &self,
+        ledger: &str,
+    ) -> Result<fluree_db_api::wire::ReindexResponse, RemoteLedgerError> {
         let url = self.op_url_root("reindex");
         let body = serde_json::json!({ "ledger": ledger });
-        self.send_json(
-            reqwest::Method::POST,
-            &url,
-            "application/json",
-            Some(RequestBody::Json(&body)),
-        )
-        .await
+        let raw = self
+            .send_json_with_timeout(
+                reqwest::Method::POST,
+                &url,
+                "application/json",
+                Some(RequestBody::Json(&body)),
+                Self::REINDEX_TIMEOUT,
+            )
+            .await?;
+        serde_json::from_value(raw)
+            .map_err(|e| RemoteLedgerError::InvalidResponse(format!("reindex response: {e}")))
     }
 
     // =========================================================================

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -11,6 +11,7 @@ use axum::extract::{Path, Query, Request, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use fluree_db_api::wire::{ReindexRequest, ReindexResponse};
 use fluree_db_api::{ApiError, BranchDropReport, DropMode, DropReport, DropStatus};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -339,38 +340,6 @@ async fn drop_local(state: Arc<AppState>, request: Request) -> Result<Json<DropR
 // Reindex
 // =============================================================================
 
-/// Reindex request body.
-///
-/// `opts` is reserved for future per-request overrides (e.g. indexer tuning).
-/// It is accepted but ignored today — the server always reindexes using the
-/// indexer settings it is configured with.
-#[derive(Deserialize)]
-pub struct ReindexRequest {
-    /// Ledger alias (e.g. "mydb" or "mydb:main")
-    pub ledger: String,
-    /// Reserved for future use — currently ignored.
-    #[serde(default, rename = "opts")]
-    pub _opts: Option<JsonValue>,
-}
-
-/// Build statistics for a reindex response.
-#[derive(Serialize)]
-pub struct ReindexStats {
-    pub flake_count: usize,
-    pub leaf_count: usize,
-    pub branch_count: usize,
-    pub total_bytes: usize,
-}
-
-/// Reindex response.
-#[derive(Serialize)]
-pub struct ReindexResponse {
-    pub ledger_id: String,
-    pub index_t: i64,
-    pub root_id: String,
-    pub stats: ReindexStats,
-}
-
 /// Full reindex from commit history.
 ///
 /// POST /fluree/reindex
@@ -429,17 +398,7 @@ async fn reindex_local(state: Arc<AppState>, request: Request) -> Result<Json<Re
             index_t = result.index_t,
             "ledger reindex complete"
         );
-        Ok(Json(ReindexResponse {
-            ledger_id: result.ledger_id,
-            index_t: result.index_t,
-            root_id: result.root_id.to_string(),
-            stats: ReindexStats {
-                flake_count: result.stats.flake_count,
-                leaf_count: result.stats.leaf_count,
-                branch_count: result.stats.branch_count,
-                total_bytes: result.stats.total_bytes,
-            },
-        }))
+        Ok(Json(ReindexResponse::from(result)))
     }
     .instrument(span)
     .await

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -336,6 +336,116 @@ async fn drop_local(state: Arc<AppState>, request: Request) -> Result<Json<DropR
 }
 
 // =============================================================================
+// Reindex
+// =============================================================================
+
+/// Reindex request body.
+///
+/// `opts` is reserved for future per-request overrides (e.g. indexer tuning).
+/// It is accepted but ignored today — the server always reindexes using the
+/// indexer settings it is configured with.
+#[derive(Deserialize)]
+pub struct ReindexRequest {
+    /// Ledger alias (e.g. "mydb" or "mydb:main")
+    pub ledger: String,
+    /// Reserved for future use — currently ignored.
+    #[serde(default, rename = "opts")]
+    pub _opts: Option<JsonValue>,
+}
+
+/// Build statistics for a reindex response.
+#[derive(Serialize)]
+pub struct ReindexStats {
+    pub flake_count: usize,
+    pub leaf_count: usize,
+    pub branch_count: usize,
+    pub total_bytes: usize,
+}
+
+/// Reindex response.
+#[derive(Serialize)]
+pub struct ReindexResponse {
+    pub ledger_id: String,
+    pub index_t: i64,
+    pub root_id: String,
+    pub stats: ReindexStats,
+}
+
+/// Full reindex from commit history.
+///
+/// POST /fluree/reindex
+///
+/// Rebuilds the binary index for a ledger from scratch using the server's
+/// configured indexer settings. In peer mode, forwards to the transaction
+/// server.
+pub async fn reindex(State(state): State<Arc<AppState>>, request: Request) -> Response {
+    if state.config.server_role == ServerRole::Peer {
+        return forward_write_request(&state, request).await;
+    }
+
+    reindex_local(state, request).await.into_response()
+}
+
+async fn reindex_local(state: Arc<AppState>, request: Request) -> Result<Json<ReindexResponse>> {
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+
+    let body_bytes = axum::body::to_bytes(request.into_body(), 50 * 1024 * 1024)
+        .await
+        .map_err(|e| ServerError::bad_request(format!("Failed to read body: {e}")))?;
+    let req: ReindexRequest = serde_json::from_slice(&body_bytes)
+        .map_err(|e| ServerError::bad_request(format!("Invalid JSON: {e}")))?;
+
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+
+    let span = create_request_span(
+        "ledger:reindex",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        Some(&req.ledger),
+        None,
+        None,
+    );
+    async move {
+        let span = tracing::Span::current();
+        tracing::info!(status = "start", ledger = %req.ledger, "ledger reindex requested");
+
+        let result = match state
+            .fluree
+            .reindex(&req.ledger, fluree_db_api::ReindexOptions::default())
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let server_error = ServerError::Api(e);
+                set_span_error_code(&span, "error:ReindexFailed");
+                tracing::error!(error = %server_error, "ledger reindex failed");
+                return Err(server_error);
+            }
+        };
+
+        tracing::info!(
+            status = "success",
+            index_t = result.index_t,
+            "ledger reindex complete"
+        );
+        Ok(Json(ReindexResponse {
+            ledger_id: result.ledger_id,
+            index_t: result.index_t,
+            root_id: result.root_id.to_string(),
+            stats: ReindexStats {
+                flake_count: result.stats.flake_count,
+                leaf_count: result.stats.leaf_count,
+                branch_count: result.stats.branch_count,
+                total_bytes: result.stats.total_bytes,
+            },
+        }))
+    }
+    .instrument(span)
+    .await
+}
+
+// =============================================================================
 // List ledgers + graph sources
 // =============================================================================
 

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -38,6 +38,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     let v1_admin_protected_routes = Router::new()
         .route("/create", post(ledger::create))
         .route("/drop", post(ledger::drop))
+        .route("/reindex", post(ledger::reindex))
         .route("/branch", post(ledger::create_branch))
         .route("/drop-branch", post(ledger::drop_branch))
         .route("/rebase", post(ledger::rebase))


### PR DESCRIPTION
  ## Summary                                                                         
  
  - Adds `fluree reindex --remote <name>` plus auto-routing through a locally-running
   server (same triad pattern as `fluree create` / `fluree branch`).
  - Adds `POST /reindex` to `fluree-db-server`, admin-auth-gated like `/create` and  
  `/drop`, returning `{ ledger_id, index_t, root_id, stats }`.                       
  - Documents the `/reindex` contract in `docs/cli/server-integration.md` so Solo and
   other server implementers have a fixed shape to target.                           
                                                            
  ## Motivation                                                                      
                                                            
  `fluree reindex` previously only worked against the local store — there was no CLI 
  flag, no auto-routing, and no server endpoint. That left a gap: once a ledger is
  being served by a Fluree HTTP server (or Solo), there was no CLI-compatible way to 
  trigger a full reindex remotely. This PR closes that gap end-to-end in `fluree/db`
  and defines the contract that downstream servers can implement to be compatible.

  ## What's in the request body

  ```json
  { "ledger": "mydb:main", "opts": {} }
  ```                                                                                
  
  `opts` is accepted but ignored today. It's reserved so that we can add per-request 
  indexer overrides later (e.g. leaflet tuning) without a breaking contract change.
  The server always reindexes using its own configured indexer settings for now — a  
  deliberate choice: CLI users against a remote server get the server's tuning, which
   is usually what you want.

  ## Response shape

  Mirrors `fluree_db_api::ReindexResult`. `ReindexResult` is the source of truth; new
   fields should be added additively.
                                                                                     
  ```json                                                                            
  {
    "ledger_id": "mydb:main",                                                        
    "index_t": 42,                                          
    "root_id": "fluree:index:sha256:...",
    "stats": { "flake_count": 0, "leaf_count": 0, "branch_count": 0, "total_bytes": 0
   }                                                                                 
  }                                                                                  
  ```                                                                                
                                                            
  ## Files changed

  **CLI** (`fluree-db-cli`)                                                          
  - `src/cli.rs` — `--remote <name>` on `Reindex`.
  - `src/commands/index.rs` — `run_reindex` routes via explicit `--remote` →         
  `try_server_route` auto-route → local.                                             
  - `src/lib.rs` — dispatch plumbing.                                                
  - `src/remote_client.rs` — new `RemoteClient::reindex(&alias)`.                    
                                                                                     
  **Server** (`fluree-db-server`)                                                    
  - `src/routes/mod.rs` — registered `POST /reindex` in `v1_admin_protected_routes`. 
  - `src/routes/ledger.rs` — `reindex` handler,                                      
  `ReindexRequest`/`ReindexResponse`/`ReindexStats`, peer-mode forwarding.           
                                                                                     
  **Docs**                                                                           
  - `docs/cli/server-integration.md` — added `## /reindex Contract` section.
 