### PR TITLE
fix: preserve projection shape in JSON-LD query output

### DIFF
--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -634,7 +634,7 @@ mod tests {
             novelty: None,
             context,
             orig_context: None,
-            output: crate::QueryOutput::Select(var_ids),
+            output: crate::QueryOutput::select(var_ids),
             batches: vec![batch],
             binary_graph: None,
             graph_select: None,

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -16,7 +16,6 @@ use super::{FormatError, Result};
 use crate::QueryResult;
 use fluree_db_core::FlakeValue;
 use fluree_db_query::binding::Binding;
-use fluree_db_query::parse::ProjectionShape;
 use fluree_vocab::rdf;
 use serde_json::{json, Map, Value as JsonValue};
 
@@ -58,9 +57,7 @@ pub fn format(
     // JSON-LD `select: "?x"` (bare-string form), which is the user's opt-in
     // to scalar output. SPARQL and JSON-LD array-form select use `Tuple`
     // and skip this step — their rows stay tabular.
-    if result.output.projection_shape() == Some(ProjectionShape::Scalar)
-        && result.output.select_vars_or_empty().len() == 1
-    {
+    if result.output.should_flatten_scalar() {
         rows = rows
             .into_iter()
             .map(|row| match row {

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -2,6 +2,12 @@
 //!
 //! Simple JSON format with compact IRIs. Rows are arrays aligned to SELECT order:
 //! `[["ex:alice", "Alice", 30], ...]`
+//!
+//! Row shaping is driven by `ProjectionShape`:
+//! - `Tuple` (default; SPARQL and JSON-LD array-form select): every row stays
+//!   as an array, preserving tabular semantics.
+//! - `Scalar` (JSON-LD bare-string `select: "?x"` only): 1-var rows flatten
+//!   to bare values — opt-in scalar output.
 
 use super::config::FormatterConfig;
 use super::datatype::is_inferable_datatype;
@@ -10,6 +16,7 @@ use super::{FormatError, Result};
 use crate::QueryResult;
 use fluree_db_core::FlakeValue;
 use fluree_db_query::binding::Binding;
+use fluree_db_query::parse::ProjectionShape;
 use fluree_vocab::rdf;
 use serde_json::{json, Map, Value as JsonValue};
 
@@ -47,8 +54,13 @@ pub fn format(
         }
     }
 
-    // For a 1-column SELECT, return a flat array of values (not `[ [v1], [v2] ]`).
-    if !result.output.is_wildcard() && result.output.select_vars_or_empty().len() == 1 {
+    // Scalar shaping: flatten 1-var rows to bare values. Fires only for
+    // JSON-LD `select: "?x"` (bare-string form), which is the user's opt-in
+    // to scalar output. SPARQL and JSON-LD array-form select use `Tuple`
+    // and skip this step — their rows stay tabular.
+    if result.output.projection_shape() == Some(ProjectionShape::Scalar)
+        && result.output.select_vars_or_empty().len() == 1
+    {
         rows = rows
             .into_iter()
             .map(|row| match row {
@@ -266,7 +278,10 @@ pub(crate) fn format_binding_with_result(
 
 // NOTE: encoded binding materialization is centralized in `format::materialize`.
 
-/// Format row as array.
+/// Format a single row as a `JsonValue::Array` of length `select.len()`.
+///
+/// Always returns array-shaped output regardless of arity. Scalar flattening is
+/// applied once at the top-level `format()` when `ProjectionShape::Scalar` is set.
 fn format_row_array(
     result: &QueryResult,
     batch: &fluree_db_query::Batch,
@@ -274,16 +289,6 @@ fn format_row_array(
     select: &[fluree_db_query::VarId],
     compactor: &IriCompactor,
 ) -> Result<JsonValue> {
-    // If only one variable is selected, return a flat array of values.
-    // (not an array of 1-element rows).
-    if select.len() == 1 {
-        let var_id = select[0];
-        return match batch.get(row_idx, var_id) {
-            Some(binding) => format_binding_with_result(result, binding, compactor),
-            None => Ok(JsonValue::Null),
-        };
-    }
-
     let values: Result<Vec<_>> = select
         .iter()
         .map(|&var_id| match batch.get(row_idx, var_id) {

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -391,7 +391,7 @@ mod tests {
             novelty: None,
             context: fluree_graph_json_ld::ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![]),
+            output: QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
             graph_select: None,

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -462,7 +462,7 @@ mod tests {
             novelty: None,
             context: crate::ParsedContext::default(),
             orig_context: None,
-            output: crate::QueryOutput::Select(vec![]),
+            output: crate::QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
             graph_select: None,

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -355,7 +355,7 @@ mod tests {
             novelty: None,
             context: fluree_graph_json_ld::ParsedContext::default(),
             orig_context: None,
-            output: fluree_db_query::parse::QueryOutput::Select(vec![]),
+            output: fluree_db_query::parse::QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
             graph_select: None,
@@ -380,7 +380,7 @@ mod tests {
         let mut result = make_test_result();
 
         let s_var = result.vars.get_or_insert("?s");
-        result.output = fluree_db_query::parse::QueryOutput::Select(vec![s_var]);
+        result.output = fluree_db_query::parse::QueryOutput::select(vec![s_var]);
 
         let schema = std::sync::Arc::from(vec![s_var].into_boxed_slice());
         let sid = Sid::new(100, "alice");

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -337,7 +337,7 @@ mod tests {
             novelty: None,
             context: crate::ParsedContext::default(),
             orig_context: None,
-            output: crate::QueryOutput::Select(vec![]),
+            output: crate::QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
             graph_select: None,

--- a/fluree-db-api/src/shacl_tests.rs
+++ b/fluree-db-api/src/shacl_tests.rs
@@ -69,7 +69,7 @@ async fn shacl_cardinality_constraints() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "ex:john", "schema:name": "?name"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -151,7 +151,7 @@ async fn shacl_datatype_constraints() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "ex:john", "schema:name": "?name"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -312,7 +312,7 @@ async fn shacl_pattern_constraints() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?greeting"],
+        "select": "?greeting",
         "where": {"@id": "ex:alice", "ex:greeting": "?greeting"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -376,7 +376,7 @@ async fn shacl_has_value_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?role"],
+        "select": "?role",
         "where": {"@id": "ex:alice", "schema:role": "?role"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -440,7 +440,7 @@ async fn shacl_node_kind_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?home"],
+        "select": "?home",
         "where": {"@id": "ex:alice", "schema:homepage": "?home"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -515,7 +515,7 @@ async fn shacl_closed_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "ex:alice", "schema:name": "?name"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -626,7 +626,7 @@ async fn shacl_pattern_with_flags() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?text"],
+        "select": "?text",
         "where": {"@id": "ex:msg1", "ex:text": "?text"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -695,7 +695,7 @@ async fn shacl_in_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?status"],
+        "select": "?status",
         "where": {"@id": "ex:task1", "ex:status": "?status"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -762,7 +762,7 @@ async fn shacl_equals_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?date"],
+        "select": "?date",
         "where": {"@id": "ex:event1", "ex:startDate": "?date"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -1653,7 +1653,7 @@ async fn shacl_not_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?status"],
+        "select": "?status",
         "where": {"@id": "ex:alice", "ex:status": "?status"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -1737,7 +1737,7 @@ async fn shacl_and_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "ex:alice", "schema:name": "?name"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -1820,7 +1820,7 @@ async fn shacl_or_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?email"],
+        "select": "?email",
         "where": {"@id": "ex:alice", "schema:email": "?email"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);
@@ -1903,7 +1903,7 @@ async fn shacl_xone_constraint() {
         .ledger;
     let query = json!({
         "@context": context.clone(),
-        "select": ["?id"],
+        "select": "?id",
         "where": {"@id": "ex:acct1", "ex:personalId": "?id"}
     });
     let db = crate::GraphDb::from_ledger_state(&ledger_ok);

--- a/fluree-db-api/tests/it_config_graph.rs
+++ b/fluree-db-api/tests/it_config_graph.rs
@@ -293,7 +293,7 @@ async fn reasoning_defaults_apply() {
     let query = json!({
         "@context": {"ex": "http://example.org/"},
         "from": ledger_id,
-        "select": ["?v"],
+        "select": "?v",
         "where": {"@id": "ex:alice", "ex:name": "?v"}
     });
 
@@ -312,7 +312,7 @@ async fn reasoning_defaults_apply() {
     let query_none = json!({
         "@context": {"ex": "http://example.org/"},
         "from": ledger_id,
-        "select": ["?v"],
+        "select": "?v",
         "where": {"@id": "ex:alice", "ex:name": "?v"},
         "reasoning": "none"
     });

--- a/fluree-db-api/tests/it_credential.rs
+++ b/fluree-db-api/tests/it_credential.rs
@@ -11,10 +11,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use ed25519_dalek::{Signer, SigningKey};
 use fluree_db_api::{credential, FlureeBuilder};
 use serde_json::{json, Value as JsonValue};
-use support::{
-    assert_index_defaults, genesis_ledger, normalize_rows, normalize_rows_array, MemoryFluree,
-    MemoryLedger,
-};
+use support::{assert_index_defaults, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 fn decode_hex_32(s: &str) -> [u8; 32] {
     assert_eq!(s.len(), 64, "expected 32-byte hex");
@@ -284,8 +281,8 @@ ORDER BY ?name
         .expect("credential_query_sparql root");
     let jsonld_root = result_root.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
-        normalize_rows_array(&jsonld_root),
-        normalize_rows_array(&json!([["Daniel"]]))
+        normalize_rows(&jsonld_root),
+        normalize_rows(&json!([["Daniel"]]))
     );
 
     // Pleb cannot see root.

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -85,7 +85,7 @@ async fn datalog_grandparent_rule() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?parent"],
+        "select": "?parent",
         "where": {"@id": "ex:alice", "ex:parent": "?parent"}
     });
     let data_rows = support::query_jsonld(&fluree, &ledger, &data_check)
@@ -105,7 +105,7 @@ async fn datalog_grandparent_rule() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?grandparent"],
+        "select": "?grandparent",
         "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
         "reasoning": "datalog"
     });
@@ -173,7 +173,7 @@ async fn datalog_sibling_rule() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?sibling"],
+        "select": "?sibling",
         "where": {"@id": "ex:alice", "ex:sibling": "?sibling"},
         "reasoning": "datalog"
     });
@@ -215,7 +215,7 @@ async fn datalog_no_rules_returns_empty() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?grandparent"],
+        "select": "?grandparent",
         "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
         "reasoning": "datalog"
     });
@@ -289,7 +289,7 @@ async fn datalog_combined_with_owl2rl() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?fof"],
+        "select": "?fof",
         "where": {"@id": "ex:alice", "ex:friendOfFriend": "?fof"},
         "reasoning": ["owl2rl", "datalog"]
     });
@@ -369,7 +369,7 @@ async fn datalog_recursive_ancestor_rule() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?ancestor"],
+        "select": "?ancestor",
         "where": {"@id": "ex:alice", "ex:ancestor": "?ancestor"},
         "reasoning": "datalog"
     });
@@ -557,7 +557,7 @@ async fn datalog_chains_off_owl_entailments() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?interest"],
+        "select": "?interest",
         "where": {"@id": "ex:alice", "ex:learnsAbout": "?interest"},
         "reasoning": ["owl2rl", "datalog"]
     });
@@ -631,7 +631,7 @@ async fn datalog_filter_expression() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?person"],
+        "select": "?person",
         "where": {"@id": "?person", "ex:status": "senior"},
         "reasoning": "datalog"
     });
@@ -713,7 +713,7 @@ async fn datalog_filter_less_than() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?item"],
+        "select": "?item",
         "where": {"@id": "?item", "ex:affordable": true},
         "reasoning": "datalog"
     });
@@ -769,7 +769,7 @@ async fn datalog_query_time_rules() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?grandparent"],
+        "select": "?grandparent",
         "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
         "reasoning": "datalog",
         "rules": [{
@@ -816,7 +816,7 @@ async fn datalog_query_time_rules_with_id() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?grandparent"],
+        "select": "?grandparent",
         "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
         "reasoning": "datalog",
         "rules": [{
@@ -865,7 +865,7 @@ async fn datalog_query_time_rules_multiple() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?aunt"],
+        "select": "?aunt",
         "where": {"@id": "ex:brian", "ex:aunt": "?aunt"},
         "reasoning": "datalog",
         "rules": [
@@ -921,7 +921,7 @@ async fn datalog_query_time_rules_with_filter() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?person"],
+        "select": "?person",
         "where": {"@id": "?person", "ex:status": "senior"},
         "reasoning": "datalog",
         "rules": [{
@@ -1002,7 +1002,7 @@ async fn datalog_query_time_rules_merged_with_db_rules() {
         "@context": {
             "ex": "http://example.org/"
         },
-        "select": ["?aunt"],
+        "select": "?aunt",
         "where": {"@id": "ex:brian", "ex:aunt": "?aunt"},
         "reasoning": "datalog",
         "rules": [{

--- a/fluree-db-api/tests/it_enforce_unique_upsert_indexed.rs
+++ b/fluree-db-api/tests/it_enforce_unique_upsert_indexed.rs
@@ -364,7 +364,7 @@ async fn upsert_enforce_unique_urn_iris_after_indexing() {
                 .unwrap()
                 .to_jsonld(&fluree.ledger(ledger_id).await.unwrap().snapshot)
                 .unwrap();
-            assert_eq!(count, json!([1]), "entity should appear exactly once");
+            assert_eq!(count, json!([[1]]), "entity should appear exactly once");
         })
         .await;
 }

--- a/fluree-db-api/tests/it_fast_group_count.rs
+++ b/fluree-db-api/tests/it_fast_group_count.rs
@@ -153,7 +153,7 @@ async fn object_count_fallback_basic() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(as (count ?s) ?count)"],
+        "select": "(as (count ?s) ?count)",
         "where": [{ "@id": "?s", "schema:age": 30 }]
     });
 
@@ -174,7 +174,7 @@ async fn object_count_single_match() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(as (count ?s) ?count)"],
+        "select": "(as (count ?s) ?count)",
         "where": [{ "@id": "?s", "schema:age": 40 }]
     });
 
@@ -195,7 +195,7 @@ async fn object_count_zero_matches() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(as (count ?s) ?count)"],
+        "select": "(as (count ?s) ?count)",
         "where": [{ "@id": "?s", "schema:age": 999 }]
     });
 
@@ -272,7 +272,7 @@ async fn object_count_with_allow_all_policy() {
             }],
             "default-allow": true
         },
-        "select": ["(as (count ?s) ?count)"],
+        "select": "(as (count ?s) ?count)",
         "where": [{ "@id": "?s", "schema:age": 30 }]
     });
 
@@ -451,7 +451,7 @@ async fn object_count_at_earlier_t() {
     let ctx = context_ex_schema();
     let query = json!({
         "@context": ctx,
-        "select": ["(as (count ?s) ?count)"],
+        "select": "(as (count ?s) ?count)",
         "where": [{ "@id": "?s", "schema:age": 30 }]
     });
 

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -433,7 +433,7 @@ async fn e2e_r2rml_query_iceberg_table() {
 
     let mut parsed = ParsedQuery::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::Select(vec![airline_var, name_var, country_var]);
+    parsed.output = QueryOutput::select(vec![airline_var, name_var, country_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1083,7 +1083,7 @@ async fn engine_e2e_graph_pattern_r2rml_scan() {
     // Build ParsedQuery with this pattern
     let mut parsed = ParsedQuery::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::Select(vec![subject_var, name_var]);
+    parsed.output = QueryOutput::select(vec![subject_var, name_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1201,7 +1201,7 @@ async fn engine_e2e_provider_method_calls() {
 
     let mut parsed = ParsedQuery::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::Select(vec![subject_var]);
+    parsed.output = QueryOutput::select(vec![subject_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1836,7 +1836,7 @@ async fn engine_e2e_ref_object_map_join_execution() {
 
     let mut parsed = ParsedQuery::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::Select(vec![route_var, airline_var]);
+    parsed.output = QueryOutput::select(vec![route_var, airline_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();

--- a/fluree-db-api/tests/it_host_plus_n_e2e.rs
+++ b/fluree-db-api/tests/it_host_plus_n_e2e.rs
@@ -193,7 +193,7 @@ async fn host_plus_n_insert_index_reload_query() {
                 .unwrap();
             assert_eq!(
                 items,
-                json!(["Beta", "Delta"]),
+                json!([["Beta"], ["Delta"]]),
                 "deep namespace query should return both items"
             );
 
@@ -218,10 +218,10 @@ async fn host_plus_n_insert_index_reload_query() {
                 .unwrap();
             assert_eq!(
                 widget_count,
-                json!([2]),
+                json!([[2]]),
                 "should find 2 widgets after reload"
             );
-            assert_eq!(item_count, json!([2]), "should find 2 items after reload");
+            assert_eq!(item_count, json!([[2]]), "should find 2 items after reload");
         })
         .await;
 }

--- a/fluree-db-api/tests/it_import_v3.rs
+++ b/fluree-db-api/tests/it_import_v3.rs
@@ -403,7 +403,7 @@ ex:bob a ex:User ;
                 "ex": "http://example.org/ns/",
                 "schema": "http://schema.org/"
             },
-            "select": ["?name"],
+            "select": "?name",
             "where": { "schema:name": "?name" }
         }),
     )

--- a/fluree-db-api/tests/it_indexing_workflow.rs
+++ b/fluree-db-api/tests/it_indexing_workflow.rs
@@ -261,7 +261,7 @@ async fn indexing_coalesces_multiple_commits_and_latest_root_is_queryable() {
 
             let query = json!({
                 "@context": { "ex":"http://example.org/" },
-                "select": ["?name"],
+                "select": "?name",
                 "where": { "@id": "?s", "@type": "ex:Person", "ex:name": "?name" }
             });
 

--- a/fluree-db-api/tests/it_named_graph_isolation.rs
+++ b/fluree-db-api/tests/it_named_graph_isolation.rs
@@ -432,7 +432,7 @@ async fn pre_index_upsert_isolates_named_graphs() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": &alpha_alias,
-                "select": ["?score"],
+                "select": "?score",
                 "where": {"@id": "ex:alice", "schema:score": "?score"}
             });
 
@@ -454,7 +454,7 @@ async fn pre_index_upsert_isolates_named_graphs() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": &beta_alias,
-                "select": ["?score"],
+                "select": "?score",
                 "where": {"@id": "ex:alice", "schema:score": "?score"}
             });
 
@@ -478,7 +478,7 @@ async fn pre_index_upsert_isolates_named_graphs() {
                     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 },
                 "from": &alpha_alias,
-                "select": ["?type"],
+                "select": "?type",
                 "where": {"@id": "ex:alice", "rdf:type": "?type"}
             });
 
@@ -646,7 +646,7 @@ async fn push_roundtrip_named_graph_retractions() {
                     "schema": "http://schema.org/"
                 },
                 "from": &hr_alias,
-                "select": ["?name"],
+                "select": "?name",
                 "where": {
                     "@id": "?s",
                     "rdf:type": {"@id": "ex:Employee"},
@@ -679,7 +679,7 @@ async fn push_roundtrip_named_graph_retractions() {
                     "schema": "http://schema.org/"
                 },
                 "from": &payroll_alias,
-                "select": ["?salary"],
+                "select": "?salary",
                 "where": {
                     "@id": "ex:alice",
                     "schema:salary": "?salary"

--- a/fluree-db-api/tests/it_named_graphs.rs
+++ b/fluree-db-api/tests/it_named_graphs.rs
@@ -71,7 +71,7 @@ async fn test_trig_named_graph_basic() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": ledger_id,
-                "select": ["?name"],
+                "select": "?name",
                 "where": {"@id": "ex:alice", "schema:name": "?name"}
             });
 
@@ -90,7 +90,7 @@ async fn test_trig_named_graph_basic() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": &named_graph_alias,
-                "select": ["?desc"],
+                "select": "?desc",
                 "where": {"@id": "ex:event1", "schema:description": "?desc"}
             });
 
@@ -202,7 +202,7 @@ async fn test_trig_multiple_named_graphs() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": &products_alias,
-                "select": ["?name"],
+                "select": "?name",
                 "where": {"@id": "ex:prod1", "schema:name": "?name"}
             });
 
@@ -324,7 +324,7 @@ async fn test_update_default_graph_and_template_graph_sugar() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": &named_graph_alias,
-                "select": ["?desc"],
+                "select": "?desc",
                 "where": { "@id": "ex:event1", "schema:description": "?desc" }
             });
 
@@ -342,7 +342,7 @@ async fn test_update_default_graph_and_template_graph_sugar() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": ledger_id,
-                "select": ["?desc"],
+                "select": "?desc",
                 "where": { "@id": "ex:event1", "schema:description": "?desc" }
             });
 
@@ -404,7 +404,7 @@ async fn test_update_from_scopes_where_default_graph() {
             let query = json!({
                 "@context": { "ex": "http://example.org/", "schema": "http://schema.org/" },
                 "from": &named_g2,
-                "select": ["?d"],
+                "select": "?d",
                 "where": { "@id": "ex:s", "schema:copyFromG1": "?d" }
             });
             let results = fluree.query_connection(&query).await.expect("query g2 copy");
@@ -468,7 +468,7 @@ async fn test_update_from_multiple_default_graphs_merge_where() {
             let query = json!({
                 "@context": { "ex": "http://example.org/" },
                 "from": &named_g1,
-                "select": ["?m"],
+                "select": "?m",
                 "where": { "@id": "ex:a", "ex:marker": "?m" }
             });
             let results = fluree
@@ -523,7 +523,7 @@ async fn test_update_from_named_alias_usable_in_templates() {
             let query = json!({
                 "@context": { "ex": "http://example.org/", "schema": "http://schema.org/" },
                 "from": &named_g2,
-                "select": ["?d"],
+                "select": "?d",
                 "where": { "@id": "ex:s", "schema:description": "?d" }
             });
             let results = fluree.query_connection(&query).await.expect("query g2");
@@ -587,7 +587,7 @@ async fn test_default_graph_isolation() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": ledger_id,
-                "select": ["?val"],
+                "select": "?val",
                 "where": {"@id": "ex:secret", "schema:value": "?val"}
             });
 
@@ -607,7 +607,7 @@ async fn test_default_graph_isolation() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": &private_alias,
-                "select": ["?val"],
+                "select": "?val",
                 "where": {"@id": "ex:secret", "schema:value": "?val"}
             });
 
@@ -676,7 +676,7 @@ async fn test_txn_meta_and_named_graph_coexist() {
             let query = json!({
                 "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
                 "from": ledger_id,
-                "select": ["?name"],
+                "select": "?name",
                 "where": {"@id": "ex:alice", "schema:name": "?name"}
             });
 
@@ -694,7 +694,7 @@ async fn test_txn_meta_and_named_graph_coexist() {
             let query = json!({
                 "@context": {"ex": "http://example.org/"},
                 "from": &meta_alias,
-                "select": ["?batch"],
+                "select": "?batch",
                 "where": {"@id": "?commit", "ex:batchId": "?batch"}
             });
 
@@ -712,7 +712,7 @@ async fn test_txn_meta_and_named_graph_coexist() {
             let query = json!({
                 "@context": {"ex": "http://example.org/"},
                 "from": &audit_alias,
-                "select": ["?action"],
+                "select": "?action",
                 "where": {"@id": "ex:log1", "ex:action": "?action"}
             });
 
@@ -1127,7 +1127,7 @@ async fn test_named_graph_retraction() {
             let query = json!({
                 "@context": {"ex": "http://example.org/"},
                 "from": &users_alias,
-                "select": ["?user"],
+                "select": "?user",
                 "where": {"@id": "?user", "ex:active": true},
                 "orderBy": "?user"
             });
@@ -1170,7 +1170,7 @@ async fn test_named_graph_retraction() {
                     "t": 1,
                     "graph": "http://example.org/graphs/users"
                 },
-                "select": ["?user"],
+                "select": "?user",
                 "where": {"@id": "?user", "ex:active": true}
             });
 

--- a/fluree-db-api/tests/it_ns_sync_conflict.rs
+++ b/fluree-db-api/tests/it_ns_sync_conflict.rs
@@ -165,5 +165,5 @@ async fn reload_after_index_preserves_namespace_consistency() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert_eq!(result, json!(["Alpha"]));
+    assert_eq!(result, json!([["Alpha"]]));
 }

--- a/fluree-db-api/tests/it_policy_named_graphs.rs
+++ b/fluree-db-api/tests/it_policy_named_graphs.rs
@@ -82,7 +82,7 @@ async fn policy_applies_to_named_graph_queries() {
             let q_private_ssn_no_policy = json!({
                 "@context": {"ex": "http://example.org/ns/", "schema":"http://schema.org/"},
                 "from": {"@id": ledger_id, "graph": "http://example.org/graphs/private"},
-                "select": ["?ssn"],
+                "select": "?ssn",
                 "where": {"@id":"ex:alice", "schema:ssn":"?ssn"}
             });
             let out_private = fluree
@@ -95,7 +95,7 @@ async fn policy_applies_to_named_graph_queries() {
             let q_public_name_no_policy = json!({
                 "@context": {"ex": "http://example.org/ns/", "schema":"http://schema.org/"},
                 "from": {"@id": ledger_id, "graph": "http://example.org/graphs/public"},
-                "select": ["?name"],
+                "select": "?name",
                 "where": {"@id":"ex:alice", "schema:name":"?name"}
             });
             let out_public = fluree
@@ -130,7 +130,7 @@ async fn policy_applies_to_named_graph_queries() {
                 "@context": {"ex": "http://example.org/ns/", "schema":"http://schema.org/", "f":"https://ns.flur.ee/db#"},
                 "from": format!("{ledger_id}#http://example.org/graphs/public"),
                 "opts": {"policy": policy.clone(), "default-allow": true},
-                "select": ["?name"],
+                "select": "?name",
                 "where": {"@id":"ex:alice", "schema:name":"?name"}
             });
 
@@ -146,7 +146,7 @@ async fn policy_applies_to_named_graph_queries() {
                 "@context": {"ex": "http://example.org/ns/", "schema":"http://schema.org/", "f":"https://ns.flur.ee/db#"},
                 "from": {"@id": ledger_id, "graph": "http://example.org/graphs/public"},
                 "opts": {"policy": policy.clone(), "default-allow": true},
-                "select": ["?name"],
+                "select": "?name",
                 "where": {"@id":"ex:alice", "schema:name":"?name"}
             });
 

--- a/fluree-db-api/tests/it_policy_query_connection.rs
+++ b/fluree-db-api/tests/it_policy_query_connection.rs
@@ -104,7 +104,7 @@ async fn policy_inline_denies_restricted_property_in_graph_crawl() {
             "policy": query["opts"]["policy"].clone(),
             "default-allow": true
         },
-        "select": ["?name"],
+        "select": "?name",
         "where": { "@id": "?s", "@type": "ex:User", "schema:name": "?name" }
     });
     let sanity_result = fluree
@@ -173,7 +173,7 @@ async fn policy_per_source_override_takes_precedence_over_global() {
         "opts": {
             "default-allow": false
         },
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?s",
             "@type": "ex:User",

--- a/fluree-db-api/tests/it_policy_time_travel.rs
+++ b/fluree-db-api/tests/it_policy_time_travel.rs
@@ -45,7 +45,7 @@ async fn policy_applies_to_time_travel_queries() {
     let q_ssn_t1 = json!({
         "@context": {"ex":"http://example.org/ns/","schema":"http://schema.org/"},
         "from": {"@id": ledger_id, "t": 1},
-        "select": ["?ssn"],
+        "select": "?ssn",
         "where": {"@id":"ex:alice", "schema:ssn":"?ssn"}
     });
     let out = fluree
@@ -93,7 +93,7 @@ async fn policy_applies_to_time_travel_queries() {
         "@context": {"ex":"http://example.org/ns/","schema":"http://schema.org/","f":"https://ns.flur.ee/db#"},
         "from": {"@id": ledger_id, "t": 1},
         "opts": {"policy": policy.clone(), "default-allow": true},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id":"ex:alice", "schema:name":"?name"}
     });
     let out = fluree

--- a/fluree-db-api/tests/it_policy_tx.rs
+++ b/fluree-db-api/tests/it_policy_tx.rs
@@ -155,7 +155,7 @@ async fn modify_policy_allows_own_property() {
     // Verify the update happened
     let (tx_result, _tally) = result.unwrap();
     let query = json!({
-        "select": ["?email"],
+        "select": "?email",
         "where": {
             "@id": "http://example.org/ns/john",
             "http://schema.org/email": "?email"

--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -183,7 +183,7 @@ async fn aggregates_implicit_grouping_count_all() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(count ?name)"],
+        "select": "(count ?name)",
         "where": { "schema:name": "?name" }
     });
 
@@ -204,7 +204,7 @@ async fn aggregates_min_implicit_grouping() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(min ?nums)"],
+        "select": "(min ?nums)",
         "where": { "ex:favNums": "?nums" }
     });
 
@@ -226,7 +226,7 @@ async fn aggregates_max_date_implicit_grouping() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(max ?birthDate)"],
+        "select": "(max ?birthDate)",
         "where": { "schema:birthDate": "?birthDate" }
     });
 
@@ -291,7 +291,7 @@ async fn aggregates_count_all_favnums_implicit_grouping() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["(count ?favNums)"],
+        "select": "(count ?favNums)",
         "where": [{"@id": "?s", "ex:favNums": "?favNums"}]
     });
 

--- a/fluree-db-api/tests/it_query_connection.rs
+++ b/fluree-db-api/tests/it_query_connection.rs
@@ -9,8 +9,8 @@ mod support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use support::{
-    assert_index_defaults, context_ex_schema, genesis_ledger, normalize_rows, normalize_rows_array,
-    MemoryFluree, MemoryLedger,
+    assert_index_defaults, context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree,
+    MemoryLedger,
 };
 
 fn ctx_schema() -> serde_json::Value {
@@ -239,8 +239,8 @@ async fn query_connection_from_combined_datasets_direct_select_vars() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["Gone with the Wind", "0-582-41805-4", "Margaret Mitchell"],
             [
                 "The Hitchhiker's Guide to the Galaxy",
@@ -284,8 +284,8 @@ async fn query_connection_from_named_with_graph_patterns() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["Gone with the Wind", "0-582-41805-4", "Margaret Mitchell"],
             [
                 "The Hitchhiker's Guide to the Galaxy",
@@ -305,7 +305,7 @@ async fn query_connection_single_ledger_from_top_level() {
     let query = json!({
         "@context": context_ex_schema(),
         "from": "people:main",
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -338,7 +338,7 @@ async fn query_connection_multiple_default_graphs_union() {
     let query = json!({
         "@context": context_ex_schema(),
         "from": ["people1:main", "people2:main"],
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -370,7 +370,7 @@ async fn query_connection_uses_opts_ledger_fallback() {
     let query = json!({
         "@context": context_ex_schema(),
         "opts": { "ledger": "people:main" },
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -470,9 +470,10 @@ WHERE {
     let ledger = fluree.ledger("people:main").await.expect("ledger load");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
+    // SPARQL queries always return array-of-arrays, even for single-var selects.
     assert_eq!(
-        normalize_flat_results(&jsonld),
-        normalize_flat_results(&json!(["Alice", "Bob"]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 }
 
@@ -485,7 +486,7 @@ async fn query_connection_jsonld_tracked_single_ledger() {
     let query = json!({
         "@context": context_ex_schema(),
         "from": "people:main",
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",

--- a/fluree-db-api/tests/it_query_dataset.rs
+++ b/fluree-db-api/tests/it_query_dataset.rs
@@ -14,8 +14,8 @@ use fluree_db_api::{DataSetDb, DatasetSpec, FlureeBuilder, GraphDb, GraphSource,
 use fluree_db_core::load_commit_by_id;
 use serde_json::json;
 use support::{
-    assert_index_defaults, genesis_ledger, normalize_flat_results, normalize_rows_array,
-    MemoryFluree, MemoryLedger,
+    assert_index_defaults, genesis_ledger, normalize_flat_results, normalize_rows, MemoryFluree,
+    MemoryLedger,
 };
 
 // =============================================================================
@@ -219,7 +219,7 @@ async fn dataset_single_default_graph_basic_query() {
             "ex": "http://example.org/ns/",
             "schema": "http://schema.org/"
         },
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -276,7 +276,7 @@ async fn dataset_multiple_default_graphs_union() {
             "ex": "http://example.org/ns/",
             "schema": "http://schema.org/"
         },
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -344,8 +344,8 @@ async fn dataset_composed_across_connections_selecting_variables() {
         .expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["Gone with the Wind", "0-582-41805-4", "Margaret Mitchell"],
             [
                 "The Hitchhiker's Guide to the Galaxy",
@@ -394,8 +394,8 @@ async fn dataset_composed_across_connections_selecting_subgraph_depth_3() {
         .expect("to_jsonld_async");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([{
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([{
             "@id": "https://www.wikidata.org/wiki/Q2875",
             "@type": "Movie",
             "name": "Gone with the Wind",
@@ -491,7 +491,7 @@ async fn dataset_named_graph_basic() {
             "ex": "http://example.org/ns/",
             "schema": "http://schema.org/"
         },
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?s",
             "@type": "ex:Person",
@@ -533,7 +533,7 @@ async fn dataset_from_json_single_string() {
             "schema": "http://schema.org/"
         },
         "from": "test:main",
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -580,7 +580,7 @@ async fn dataset_from_json_array() {
             "schema": "http://schema.org/"
         },
         "from": ["p1:main", "p2:main"],
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?person",
             "@type": "ex:Person",
@@ -628,7 +628,7 @@ async fn dataset_from_json_named() {
         },
         "from": "default:main",
         "fromNamed": ["graph1:main"],
-        "select": ["?name"],
+        "select": "?name",
         "where": {
             "@id": "?s",
             "@type": "ex:Person",
@@ -768,8 +768,8 @@ async fn dataset_cross_graph_join_in_union() {
 
     // Should find Alice works at Acme (join across union)
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([["Alice", "Acme Corp"]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Alice", "Acme Corp"]]))
     );
 }
 
@@ -838,8 +838,8 @@ async fn sparql_graph_pattern_concrete_iri() {
 
     // Should return names from the named graph (people:main)
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([["Alice"], ["Bob"]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 }
 
@@ -887,8 +887,8 @@ async fn sparql_graph_pattern_variable_iteration() {
     // People graph: Alice, Bob
     // Orgs graph: Acme Corp, Globex Inc
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["orgs:main", "Acme Corp"],
             ["orgs:main", "Globex Inc"],
             ["people:main", "Alice"],
@@ -978,8 +978,8 @@ async fn sparql_graph_pattern_default_vs_named() {
 
     // Default graph should only have people
     assert_eq!(
-        normalize_flat_results(&jsonld_default),
-        normalize_flat_results(&json!(["Alice", "Bob"]))
+        normalize_rows(&jsonld_default),
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 
     // Query named graph via GRAPH pattern - should get orgs
@@ -1004,8 +1004,8 @@ async fn sparql_graph_pattern_default_vs_named() {
 
     // Named graph should only have orgs
     assert_eq!(
-        normalize_flat_results(&jsonld_named),
-        normalize_flat_results(&json!(["Acme Corp", "Globex Inc"]))
+        normalize_rows(&jsonld_named),
+        normalize_rows(&json!([["Acme Corp"], ["Globex Inc"]]))
     );
 }
 
@@ -1040,7 +1040,7 @@ async fn fql_graph_pattern_basic() {
     // Query using JSON-LD ["graph", "name", {...}] syntax
     let query = json!({
         "@context": {"schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": [
             ["graph", "people:main", {"@id": "?person", "schema:name": "?name"}]
         ]
@@ -1084,7 +1084,7 @@ async fn fql_graph_pattern_with_alias() {
     // Query using JSON-LD ["graph", <alias>, {...}] syntax with the alias "folks"
     let query = json!({
         "@context": {"schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": [
             ["graph", "folks", {"@id": "?person", "schema:name": "?name"}]
         ]
@@ -1138,7 +1138,7 @@ async fn dataset_time_travel_at_t() {
 
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1189,7 +1189,7 @@ async fn dataset_time_travel_at_time_iso() {
 
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1261,7 +1261,7 @@ async fn dataset_time_travel_mixed_graphs() {
 
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1300,7 +1300,7 @@ async fn dataset_time_travel_alias_syntax_at_t() {
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
         "from": "people:main@t:1",
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1355,7 +1355,7 @@ async fn dataset_time_travel_at_commit() {
 
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1402,7 +1402,7 @@ async fn dataset_time_travel_at_commit_short_prefix() {
 
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1444,7 +1444,7 @@ async fn dataset_time_travel_alias_syntax_commit() {
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
         "from": alias_with_commit,
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "schema:name": "?name"}
     });
 
@@ -1552,8 +1552,8 @@ async fn sparql_single_db_graph_matching_alias() {
 
     // Should return results because alias matches
     assert_eq!(
-        normalize_flat_results(&jsonld),
-        normalize_flat_results(&json!(["Alice", "Bob"]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 }
 
@@ -1614,7 +1614,7 @@ async fn sparql_single_db_graph_variable_unbound() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     // Should return results with ?g bound to "people:main"
-    let normalized = normalize_rows_array(&jsonld);
+    let normalized = normalize_rows(&jsonld);
     assert_eq!(normalized.len(), 2);
 
     // Check that ?g is bound to the alias (first element of each row)
@@ -1657,7 +1657,7 @@ async fn sparql_single_db_graph_variable_bound_matching() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     // Should return results because bound value matches alias
-    let normalized = normalize_rows_array(&jsonld);
+    let normalized = normalize_rows(&jsonld);
     assert_eq!(normalized.len(), 2);
 }
 
@@ -1763,7 +1763,7 @@ async fn dataset_multi_ledger_time_travel_execution() {
     let query = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
         "from": ["ledger1:main@t:1", "ledger2:main@t:2"],
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?person", "@type": "ex:Person", "schema:name": "?name"}
     });
 
@@ -1832,8 +1832,8 @@ async fn sparql_from_time_travel_suffixes() {
 
     // Expect ledger1@t=1 (Alice) + ledger2@t=2 (Carol, Dave)
     assert_eq!(
-        normalize_flat_results(&jsonld),
-        normalize_flat_results(&json!(["Alice", "Carol", "Dave"]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Alice"], ["Carol"], ["Dave"]]))
     );
 }
 
@@ -1876,10 +1876,7 @@ async fn single_ledger_dataset_string_functions() {
     let jsonld = result
         .to_jsonld(primary.snapshot.as_ref())
         .expect("to_jsonld");
-    assert_eq!(
-        normalize_flat_results(&jsonld),
-        normalize_flat_results(&json!(["Alice"]))
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["Alice"]])));
 
     // STRLEN — should return actual lengths (not empty/unbound)
     let strlen = r#"
@@ -1898,8 +1895,8 @@ async fn single_ledger_dataset_string_functions() {
         .to_jsonld(primary.snapshot.as_ref())
         .expect("to_jsonld");
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        vec![vec![json!("Bob"), json!(3)]]
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Bob", 3]]))
     );
 
     // LCASE — should return lowercased string (not empty)
@@ -1918,10 +1915,7 @@ async fn single_ledger_dataset_string_functions() {
     let jsonld = result
         .to_jsonld(primary.snapshot.as_ref())
         .expect("to_jsonld");
-    assert_eq!(
-        normalize_flat_results(&jsonld),
-        normalize_flat_results(&json!(["alice"]))
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["alice"]])));
 }
 
 // =============================================================================
@@ -2018,7 +2012,7 @@ async fn dataset_staged_transaction_with_novel_namespace() {
         .expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([["Alice", "Acme Corp"]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Alice", "Acme Corp"]]))
     );
 }

--- a/fluree-db-api/tests/it_query_datatype.rs
+++ b/fluree-db-api/tests/it_query_datatype.rs
@@ -107,7 +107,7 @@ async fn datatype_query_explicit_typed_value_object_matches() {
 
     let q = json!({
         "@context": ctx,
-        "select": ["?name"],
+        "select": "?name",
         // Rust normalizes xsd:int to xsd:integer.
         "where": {"ex:name":"?name","ex:age":{"@value":36,"@type":"xsd:integer"}}
     });
@@ -189,7 +189,7 @@ async fn custom_datatype_equality_matches_indexed_and_novelty_rows_after_reindex
 
     let q = json!({
         "@context": ctx,
-        "select": ["?s"],
+        "select": "?s",
         "where": {
             "@id": "?s",
             "ex:label": {"@value": "Abcdefg", "@type": "ex:mystring"}

--- a/fluree-db-api/tests/it_query_geo.rs
+++ b/fluree-db-api/tests/it_query_geo.rs
@@ -133,7 +133,7 @@ async fn geof_distance_in_filter_finds_nearby_cities() {
     // Paris coordinates for reference point - using s-expression filter
     let query = json!({
         "@context": ctx,
-        "select": ["?name"],
+        "select": "?name",
         "where": [
             {"@id": "?city", "@type": "ex:City", "ex:name": "?name", "ex:location": "?loc"},
             // Filter: distance from Paris < 500km (500000 meters)
@@ -184,7 +184,7 @@ async fn geof_distance_in_bind_calculates_distances() {
     // Get distance from Paris to London using bind with s-expression
     let query = json!({
         "@context": ctx,
-        "select": ["?distance"],
+        "select": "?distance",
         "where": [
             {"@id": "ex:paris", "ex:location": "?paris_loc"},
             {"@id": "ex:london", "ex:location": "?london_loc"},
@@ -226,7 +226,7 @@ async fn geof_distance_with_literal_wkt_points() {
     // Query using literal WKT points in BIND
     let query = json!({
         "@context": geo_context(),
-        "select": ["?distance"],
+        "select": "?distance",
         "where": [
             {"@id": "ex:placeholder", "ex:name": "?name"},
             // Paris to London using literal WKT strings
@@ -340,8 +340,9 @@ async fn geof_distance_via_sparql() {
 
     let rows = result.as_array().expect("result should be array");
     assert_eq!(rows.len(), 1, "Should have exactly one result");
-    // For single-variable select, the value is directly in rows[0] (not rows[0][0])
-    let distance = rows[0].as_f64().expect("distance should be number");
+    // SPARQL queries always return array-of-arrays, even for single-var selects.
+    let row = rows[0].as_array().expect("row should be array");
+    let distance = row[0].as_f64().expect("distance should be number");
 
     // Paris to London is approximately 343.5 km (343500 meters)
     assert!(

--- a/fluree-db-api/tests/it_query_jsonld.rs
+++ b/fluree-db-api/tests/it_query_jsonld.rs
@@ -1791,7 +1791,7 @@ async fn jsonld_bind_arithmetic_in_select() {
     // JSON-LD equivalent of: SELECT ?z WHERE { ?s ex:p ?o . BIND(?o+10 AS ?z) }
     let query = json!({
         "@context": ctx,
-        "select": ["?z"],
+        "select": "?z",
         "where": [
             {"@id": "?s", "ex:p": "?o"},
             ["bind", "?z", ["expr", ["+", "?o", 10]]]
@@ -1883,7 +1883,7 @@ async fn jsonld_bind_with_filter() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["?z"],
+        "select": "?z",
         "where": [
             {"@id": "?s", "ex:p": "?o"},
             ["bind", "?z", ["expr", ["+", "?o", 10]]],
@@ -1932,7 +1932,7 @@ async fn jsonld_bind_in_union() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["?z"],
+        "select": "?z",
         "where": [
             ["union",
                 [

--- a/fluree-db-api/tests/it_query_misc.rs
+++ b/fluree-db-api/tests/it_query_misc.rs
@@ -38,7 +38,7 @@ async fn simple_where_select_limit_without_context_returns_full_iri() {
     let ledger = seed_three_people(&fluree, "misc/simple-where-select:main").await;
 
     let query = json!({
-        "select": ["?s"],
+        "select": "?s",
         // Rust does not treat {"@id":"?s"} alone as a binding pattern; include a predicate.
         "where":  {"@id": "?s", "http://example.org/ns/name": "?name"},
         "orderBy": "?s",
@@ -62,7 +62,7 @@ async fn simple_where_select_limit_with_context_returns_compacted_iri() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["?s"],
+        "select": "?s",
         // Rust does not treat {"@id":"?s"} alone as a binding pattern; include a predicate.
         "where":  {"@id": "?s", "ex:name": "?name"},
         "orderBy": "?s",
@@ -97,7 +97,7 @@ async fn class_queries_type_and_all_types() {
 
     let q1 = json!({
         "@context": ctx,
-        "select": ["?class"],
+        "select": "?class",
         "where": {"@id":"ex:jane","@type":"?class"}
     });
     let r1 = support::query_jsonld(&fluree, &ledger, &q1)
@@ -150,7 +150,7 @@ async fn result_formatting_graph_crawl_variants() {
     // Sanity: the data is queryable via WHERE.
     let sanity = json!({
         "@context": {"ex":"http://example.org/ns/"},
-        "select": ["?v"],
+        "select": "?v",
         "where": {"@id":"ex:dan","ex:x":"?v"}
     });
     let sanity_rows = support::query_jsonld(&fluree, &ledger, &sanity)

--- a/fluree-db-api/tests/it_query_negation.rs
+++ b/fluree-db-api/tests/it_query_negation.rs
@@ -89,7 +89,7 @@ async fn exists_when_pattern_present_returns_subjects() {
 
     let q = json!({
         "@context": ctx,
-        "select": ["?person"],
+        "select": "?person",
         "where": [
             {"@id":"?person","@type":"ex:Person"},
             ["exists", {"@id":"?person","ex:givenName":"?name"}]
@@ -135,7 +135,7 @@ async fn not_exists_filters_subjects_without_nickname() {
 
     let q = json!({
         "@context": ctx,
-        "select": ["?person"],
+        "select": "?person",
         "where": [
             {"@id":"?person","ex:givenName":"?gname"},
             ["not-exists", {"@id":"?person","ex:nickname":"?name"}]
@@ -232,7 +232,7 @@ async fn minus_removes_bound_solutions() {
 
     let q = json!({
         "@context": ctx,
-        "select": ["?s"],
+        "select": "?s",
         "distinct": true,
         "where": [
             {"@id":"?s","?p":"?o"},

--- a/fluree-db-api/tests/it_query_owl2ql.rs
+++ b/fluree-db-api/tests/it_query_owl2ql.rs
@@ -37,7 +37,7 @@ async fn owl2ql_equivalent_property_expands_across_properties() {
     // Query p2 should see p1 value when owl2ql enabled
     let q = json!({
         "@context": {"ex":"http://example.org/"},
-        "select": ["?v"],
+        "select": "?v",
         "where": {"@id":"ex:s","ex:p2":"?v"},
         "reasoning": "owl2ql"
     });
@@ -72,7 +72,7 @@ async fn owl_ql_alias_string_is_accepted() {
 
     let q = json!({
         "@context": {"ex":"http://example.org/"},
-        "select": ["?v"],
+        "select": "?v",
         "where": {"@id":"ex:s","ex:p2":"?v"},
         "reasoning": "owl-ql"
     });

--- a/fluree-db-api/tests/it_query_owl2rl.rs
+++ b/fluree-db-api/tests/it_query_owl2rl.rs
@@ -56,7 +56,7 @@ async fn owl2rl_same_as_symmetry() {
             "ex": "http://example.org/",
             "owl": "http://www.w3.org/2002/07/owl#"
         },
-        "select": ["?same"],
+        "select": "?same",
         "where": {"@id": "ex:carol-lynn", "owl:sameAs": "?same"},
         "reasoning": "owl2rl"
     });
@@ -100,7 +100,7 @@ async fn owl2rl_same_as_transitivity() {
             "ex": "http://example.org/",
             "owl": "http://www.w3.org/2002/07/owl#"
         },
-        "select": ["?same"],
+        "select": "?same",
         "where": {"@id": "ex:carol1", "owl:sameAs": "?same"},
         "reasoning": "owl2rl"
     });
@@ -154,7 +154,7 @@ async fn owl2rl_symmetric_property() {
     // Query: who does person-b live with?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?x"],
+        "select": "?x",
         "where": {"@id": "ex:person-b", "ex:livesWith": "?x"},
         "reasoning": "owl2rl"
     });
@@ -194,7 +194,7 @@ async fn owl2rl_transitive_property() {
     // Query: who does person-a live with?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?people"],
+        "select": "?people",
         "where": {"@id": "ex:person-a", "ex:livesWith": "?people"},
         "reasoning": "owl2rl"
     });
@@ -234,7 +234,7 @@ async fn owl2rl_inverse_of() {
     // Query: who is mom's child?
     let q1 = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?x"],
+        "select": "?x",
         "where": {"@id": "ex:mom", "ex:child": "?x"},
         "reasoning": "owl2rl"
     });
@@ -248,7 +248,7 @@ async fn owl2rl_inverse_of() {
     // Query: who is bob's parent?
     let q2 = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?x"],
+        "select": "?x",
         "where": {"@id": "ex:bob", "ex:parents": "?x"},
         "reasoning": "owl2rl"
     });
@@ -283,7 +283,7 @@ async fn owl2rl_domain_rule() {
     // Query: what type is brian?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?t"],
+        "select": "?t",
         "where": {"@id": "ex:brian", "@type": "?t"},
         "reasoning": "owl2rl"
     });
@@ -328,7 +328,7 @@ async fn owl2rl_range_rule() {
     // Query: what type is carol?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?t"],
+        "select": "?t",
         "where": {"@id": "ex:carol", "@type": "?t"},
         "reasoning": "owl2rl"
     });
@@ -383,7 +383,7 @@ async fn owl2rl_functional_property() {
             "ex": "http://example.org/",
             "owl": "http://www.w3.org/2002/07/owl#"
         },
-        "select": ["?same"],
+        "select": "?same",
         "where": {"@id": "ex:carol", "owl:sameAs": "?same"},
         "reasoning": "owl2rl"
     });
@@ -427,7 +427,7 @@ async fn owl2rl_inverse_functional_property() {
             "ex": "http://example.org/",
             "owl": "http://www.w3.org/2002/07/owl#"
         },
-        "select": ["?same"],
+        "select": "?same",
         "where": {"@id": "ex:brian1", "owl:sameAs": "?same"},
         "reasoning": "owl2rl"
     });
@@ -468,7 +468,7 @@ async fn owl2rl_sub_property_of() {
     // Query: who are bob's parents?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?p"],
+        "select": "?p",
         "where": {"@id": "ex:bob", "ex:parents": "?p"},
         "reasoning": "owl2rl"
     });
@@ -513,7 +513,7 @@ async fn owl2rl_property_chain_axiom() {
     // Query: who are person-a's grandparents?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?gp"],
+        "select": "?gp",
         "where": {"@id": "ex:person-a", "ex:grandparent": "?gp"},
         "reasoning": "owl2rl"
     });
@@ -562,7 +562,7 @@ async fn owl2rl_has_key() {
             "ex": "http://example.org/",
             "owl": "http://www.w3.org/2002/07/owl#"
         },
-        "select": ["?same"],
+        "select": "?same",
         "where": {"@id": "ex:brian", "owl:sameAs": "?same"},
         "reasoning": "owl2rl"
     });
@@ -613,7 +613,7 @@ async fn owl2rl_subclass_of() {
     // Query: who is type Human?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:Human"},
         "reasoning": "owl2rl"
     });
@@ -653,7 +653,7 @@ async fn owl2rl_equivalent_class() {
     // Query: who is type Person?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:Person"},
         "reasoning": "owl2rl"
     });
@@ -707,7 +707,7 @@ async fn owl2rl_has_value_forward() {
     // Query: what is mass1's unit?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?unit"],
+        "select": "?unit",
         "where": {"@id": "ex:mass1", "ex:hasUnit": "?unit"},
         "reasoning": "owl2rl"
     });
@@ -759,7 +759,7 @@ async fn owl2rl_has_value_backward() {
     // Query: who is type KilogramMagnitude?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:KilogramMagnitude"},
         "reasoning": "owl2rl"
     });
@@ -815,7 +815,7 @@ async fn owl2rl_some_values_from() {
     // Query: who is type Wine?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:Wine"},
         "reasoning": "owl2rl"
     });
@@ -870,7 +870,7 @@ async fn owl2rl_all_values_from() {
     // Query: what type is thing1?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?t"],
+        "select": "?t",
         "where": {"@id": "ex:thing1", "@type": "?t"},
         "reasoning": "owl2rl"
     });
@@ -924,7 +924,7 @@ async fn owl2rl_max_cardinality() {
             "ex": "http://example.org/",
             "owl": "http://www.w3.org/2002/07/owl#"
         },
-        "select": ["?same"],
+        "select": "?same",
         "where": {"@id": "ex:carol", "owl:sameAs": "?same"},
         "reasoning": "owl2rl"
     });
@@ -978,7 +978,7 @@ async fn owl2rl_intersection_of() {
     // Query: who is type Mother?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:Mother"},
         "reasoning": "owl2rl"
     });
@@ -1039,7 +1039,7 @@ async fn owl2rl_union_of() {
     // Query: who is type Parent?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:Parent"},
         "reasoning": "owl2rl"
     });
@@ -1093,7 +1093,7 @@ async fn owl2rl_one_of() {
     // Query: who is type RedOrGreen?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:RedOrGreen"},
         "reasoning": "owl2rl"
     });

--- a/fluree-db-api/tests/it_query_owl2rl_edge_cases.rs
+++ b/fluree-db-api/tests/it_query_owl2rl_edge_cases.rs
@@ -70,7 +70,7 @@ async fn owl2rl_allvaluesfrom_with_inverse_property() {
     // Query: what types does y have?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?type"],
+        "select": "?type",
         "where": {"@id": "ex:y", "@type": "?type"},
         "reasoning": "owl2rl"
     });
@@ -90,7 +90,7 @@ async fn owl2rl_allvaluesfrom_with_inverse_property() {
     // Also check z
     let q2 = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?type"],
+        "select": "?type",
         "where": {"@id": "ex:z", "@type": "?type"},
         "reasoning": "owl2rl"
     });
@@ -168,7 +168,7 @@ async fn owl2rl_multi_same_property_restrictions() {
     // Query: who is DrugProduct?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:DrugProduct"},
         "reasoning": "owl2rl"
     });
@@ -242,7 +242,7 @@ async fn owl2rl_union_3_plus_branches() {
     // Query: who is MultiTarget?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:MultiTarget"},
         "reasoning": "owl2rl"
     });
@@ -325,7 +325,7 @@ async fn owl2rl_nested_unions() {
     // Query: who is NestedTarget?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:NestedTarget"},
         "reasoning": "owl2rl"
     });
@@ -409,7 +409,7 @@ async fn owl2rl_union_with_intersection() {
     // Query: who is UnionIntersection?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:UnionIntersection"},
         "reasoning": "owl2rl"
     });
@@ -478,7 +478,7 @@ async fn owl2rl_inverse_in_deeper_chain() {
     // Query for alice's grandparent via chain
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?gp"],
+        "select": "?gp",
         "where": {"@id": "ex:alice", "ex:hasGrandparent": "?gp"},
         "reasoning": "owl2rl"
     });
@@ -498,7 +498,7 @@ async fn owl2rl_inverse_in_deeper_chain() {
     // Also test that inverse property works
     let q2 = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?child"],
+        "select": "?child",
         "where": {"@id": "ex:bob", "ex:hasChild": "?child"},
         "reasoning": "owl2rl"
     });
@@ -551,7 +551,7 @@ async fn owl2rl_double_inverse_normalization() {
     // Query via double inverse (should be same as original)
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?t"],
+        "select": "?t",
         "where": {"@id": "ex:source", "ex:doubleInverseProp": "?t"},
         "reasoning": "owl2rl"
     });
@@ -571,7 +571,7 @@ async fn owl2rl_double_inverse_normalization() {
     // Also verify single inverse works in opposite direction
     let q2 = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "ex:target", "ex:inverseProp": "?s"},
         "reasoning": "owl2rl"
     });
@@ -651,7 +651,7 @@ async fn owl2rl_partial_conditions_no_inference() {
     // Query: who is ConjunctiveClass?
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id": "?s", "@type": "ex:ConjunctiveClass"},
         "reasoning": "owl2rl"
     });
@@ -722,7 +722,7 @@ async fn owl2rl_hasvalue_class_to_property_entailment() {
     // Query: what unit does mass1 have? (should be inferred)
     let q = json!({
         "@context": {"ex": "http://example.org/"},
-        "select": ["?unit"],
+        "select": "?unit",
         "where": {"@id": "ex:mass1", "ex:hasUnit": "?unit"},
         "reasoning": "owl2rl"
     });

--- a/fluree-db-api/tests/it_query_property.rs
+++ b/fluree-db-api/tests/it_query_property.rs
@@ -63,7 +63,7 @@ async fn subjects_as_predicates_variable_predicate_scan() {
     let ctx = json!({"id":"@id","ex":"http://example.com/"});
     let q = json!({
         "@context": ctx,
-        "select": ["?p"],
+        "select": "?p",
         "where": {"@id":"ex:subject-as-predicate","?p":"?o"}
     });
 
@@ -159,7 +159,7 @@ async fn equivalent_properties_equivalent_symmetric_transitive_and_graph_crawl()
     // Querying for the property defined to be equivalent returns all values.
     let q1 = json!({
         "@context": {"vocab2":"http://vocab2.example.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"vocab2:firstName":"?name"},
         "reasoning": "owl2ql"
     });
@@ -176,7 +176,7 @@ async fn equivalent_properties_equivalent_symmetric_transitive_and_graph_crawl()
     // Querying for the symmetric property.
     let q2 = json!({
         "@context": {"vocab1":"http://vocab1.example.org/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"vocab1:givenName":"?name"},
         "reasoning": "owl2ql"
     });
@@ -193,7 +193,7 @@ async fn equivalent_properties_equivalent_symmetric_transitive_and_graph_crawl()
     // Querying for the transitive properties.
     let q3 = json!({
         "@context": {"vocab3":"http://vocab3.example.fr/"},
-        "select": ["?name"],
+        "select": "?name",
         "where": {"vocab3:prenom":"?name"},
         "reasoning": "owl2ql"
     });
@@ -299,7 +299,7 @@ async fn rdfs_subpropertyof_expansion() {
     // Querying one-level up in subproperty hierarchy.
     let q1 = json!({
         "@context": {"ex":"http://example.org/ns/"},
-        "select": ["?parent"],
+        "select": "?parent",
         "where": {"@id":"ex:bob","ex:biologicalParent":"?parent"}
         // relies on default auto-RDFS (hierarchy exists)
     });
@@ -317,7 +317,7 @@ async fn rdfs_subpropertyof_expansion() {
     // Use owl2ql to ensure equivalentProperty contributes to expansion.
     let q2 = json!({
         "@context": {"ex":"http://example.org/ns/"},
-        "select": ["?parent"],
+        "select": "?parent",
         "where": {"@id":"ex:bob","ex:parent":"?parent"},
         "reasoning": "owl2ql"
     });
@@ -340,7 +340,7 @@ async fn rdfs_subpropertyof_expansion() {
     // Sanity: explicit "none" disables auto-RDFS (so parent expansion disappears).
     let q3 = json!({
         "@context": {"ex":"http://example.org/ns/"},
-        "select": ["?parent"],
+        "select": "?parent",
         "where": {"@id":"ex:bob","ex:parent":"?parent"},
         "reasoning": "none"
     });

--- a/fluree-db-api/tests/it_query_property_path.rs
+++ b/fluree-db-api/tests/it_query_property_path.rs
@@ -81,7 +81,7 @@ async fn property_path_one_or_more_no_vars_matches_transitively() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert_eq!(sanity_rows, json!(["ex:f"]));
+    assert_eq!(sanity_rows, json!([["ex:f"]]));
 
     // Property path traversal from ex:a should reach ex:f.
     let sanity_path = json!({
@@ -97,7 +97,7 @@ async fn property_path_one_or_more_no_vars_matches_transitively() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert!(normalize_rows(&sanity_path_rows).contains(&json!("ex:f")));
+    assert!(normalize_rows(&sanity_path_rows).contains(&json!(["ex:f"])));
 
     // Use VALUES to seed a single solution row and treat the (non-)transitive pattern
     // as a filter, so we can assert reachability without relying on graph crawl output.
@@ -128,7 +128,7 @@ async fn property_path_one_or_more_no_vars_matches_transitively() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert_eq!(r_plus, json!([1]));
+    assert_eq!(r_plus, json!([[1]]));
 }
 
 #[tokio::test]
@@ -146,7 +146,7 @@ async fn property_path_one_or_more_object_var_with_and_without_cycle() {
         .unwrap()
         .to_jsonld(&ledger1.snapshot)
         .unwrap();
-    assert_eq!(non, json!(["ex:b"]));
+    assert_eq!(non, json!([["ex:b"]]));
 
     // Use @path with string form
     let q_plus = json!({
@@ -164,7 +164,7 @@ async fn property_path_one_or_more_object_var_with_and_without_cycle() {
         .unwrap();
     assert_eq!(
         normalize_rows(&plus),
-        normalize_rows(&json!(["ex:b", "ex:c", "ex:d", "ex:e"]))
+        normalize_rows(&json!([["ex:b"], ["ex:c"], ["ex:d"], ["ex:e"]]))
     );
 
     // Add cycle: e knows a. One-or-more from a should now include a as reachable.
@@ -186,7 +186,7 @@ async fn property_path_one_or_more_object_var_with_and_without_cycle() {
         .unwrap();
     assert_eq!(
         normalize_rows(&plus2),
-        normalize_rows(&json!(["ex:a", "ex:b", "ex:c", "ex:d", "ex:e"]))
+        normalize_rows(&json!([["ex:a"], ["ex:b"], ["ex:c"], ["ex:d"], ["ex:e"]]))
     );
 }
 
@@ -205,7 +205,7 @@ async fn property_path_one_or_more_subject_var_with_and_without_cycle() {
         .unwrap()
         .to_jsonld(&ledger1.snapshot)
         .unwrap();
-    assert_eq!(non, json!(["ex:d"]));
+    assert_eq!(non, json!([["ex:d"]]));
 
     let q_plus = json!({
         "@context": {
@@ -222,7 +222,7 @@ async fn property_path_one_or_more_subject_var_with_and_without_cycle() {
         .unwrap();
     assert_eq!(
         normalize_rows(&plus),
-        normalize_rows(&json!(["ex:d", "ex:b", "ex:a"]))
+        normalize_rows(&json!([["ex:d"], ["ex:b"], ["ex:a"]]))
     );
 
     // Add cycle: e knows a. Now e is also in the reverse transitive set.
@@ -236,7 +236,7 @@ async fn property_path_one_or_more_subject_var_with_and_without_cycle() {
         .unwrap();
     assert_eq!(
         normalize_rows(&plus2),
-        normalize_rows(&json!(["ex:d", "ex:b", "ex:a", "ex:e"]))
+        normalize_rows(&json!([["ex:d"], ["ex:b"], ["ex:a"], ["ex:e"]]))
     );
 }
 
@@ -336,7 +336,7 @@ async fn property_path_zero_or_more_object_var_and_subject_object_vars() {
         .unwrap();
     assert_eq!(
         normalize_rows(&star),
-        normalize_rows(&json!(["ex:a", "ex:b", "ex:c", "ex:d", "ex:e"]))
+        normalize_rows(&json!([["ex:a"], ["ex:b"], ["ex:c"], ["ex:d"], ["ex:e"]]))
     );
 
     // Subject+object vars, disjoint graphs
@@ -407,7 +407,7 @@ async fn property_path_array_form() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:b", "ex:c", "ex:d", "ex:e"]))
+        normalize_rows(&json!([["ex:b"], ["ex:c"], ["ex:d"], ["ex:e"]]))
     );
 }
 
@@ -478,7 +478,7 @@ async fn property_path_inverse_object_var() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert_eq!(normalize_rows(&result), normalize_rows(&json!(["ex:a"])));
+    assert_eq!(normalize_rows(&result), normalize_rows(&json!([["ex:a"]])));
 }
 
 #[tokio::test]
@@ -500,7 +500,7 @@ async fn property_path_inverse_subject_var() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert_eq!(normalize_rows(&result), normalize_rows(&json!(["ex:b"])));
+    assert_eq!(normalize_rows(&result), normalize_rows(&json!([["ex:b"]])));
 }
 
 // -- Alternative (|) tests --
@@ -534,7 +534,7 @@ async fn property_path_alternative_object_var() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:b", "ex:x"]))
+        normalize_rows(&json!([["ex:b"], ["ex:x"]]))
     );
 }
 
@@ -559,7 +559,7 @@ async fn property_path_alternative_with_inverse() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:a", "ex:c", "ex:d"]))
+        normalize_rows(&json!([["ex:a"], ["ex:c"], ["ex:d"]]))
     );
 }
 
@@ -592,7 +592,7 @@ async fn property_path_alternative_array_form() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:b", "ex:x"]))
+        normalize_rows(&json!([["ex:b"], ["ex:x"]]))
     );
 }
 
@@ -627,7 +627,7 @@ async fn property_path_alternative_duplicate_semantics() {
     // Bag semantics: ex:b appears once per matching branch
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:b", "ex:b"]))
+        normalize_rows(&json!([["ex:b"], ["ex:b"]]))
     );
 }
 
@@ -679,7 +679,7 @@ async fn property_path_sequence_two_step_string_form() {
         .to_jsonld(&ledger.snapshot)
         .unwrap();
     // alice's friend is bob, bob's name is "Bob"
-    assert_eq!(normalize_rows(&result), normalize_rows(&json!(["Bob"])));
+    assert_eq!(normalize_rows(&result), normalize_rows(&json!([["Bob"]])));
 }
 
 #[tokio::test]
@@ -701,7 +701,7 @@ async fn property_path_sequence_two_step_array_form() {
         .unwrap()
         .to_jsonld(&ledger.snapshot)
         .unwrap();
-    assert_eq!(normalize_rows(&result), normalize_rows(&json!(["Bob"])));
+    assert_eq!(normalize_rows(&result), normalize_rows(&json!([["Bob"]])));
 }
 
 #[tokio::test]
@@ -728,7 +728,7 @@ async fn property_path_sequence_three_step() {
     // alice -> friend bob -> friend carol -> address addr1 -> city "Springfield"
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Springfield"]))
+        normalize_rows(&json!([["Springfield"]]))
     );
 }
 
@@ -753,7 +753,7 @@ async fn property_path_sequence_with_inverse_step() {
         .to_jsonld(&ledger.snapshot)
         .unwrap();
     // alice <--parent-- bob, bob's name is "Bob"
-    assert_eq!(normalize_rows(&result), normalize_rows(&json!(["Bob"])));
+    assert_eq!(normalize_rows(&result), normalize_rows(&json!([["Bob"]])));
 }
 
 #[tokio::test]
@@ -810,7 +810,7 @@ async fn property_path_sequence_transitive_step_allowed() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Bob", "Carol"]))
+        normalize_rows(&json!([["Bob"], ["Carol"]]))
     );
 }
 
@@ -861,7 +861,7 @@ async fn property_path_alternative_of_sequences() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Bob", "Carol"]))
+        normalize_rows(&json!([["Bob"], ["Carol"]]))
     );
 }
 
@@ -893,7 +893,7 @@ async fn property_path_alternative_mixed_simple_and_sequence() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Alice", "Bob"]))
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 }
 
@@ -963,7 +963,7 @@ async fn property_path_alternative_of_sequences_duplicate_semantics() {
     // Bag semantics: "Bob" appears once per matching branch
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Bob", "Bob"]))
+        normalize_rows(&json!([["Bob"], ["Bob"]]))
     );
 }
 
@@ -992,7 +992,7 @@ async fn property_path_inverse_one_or_more() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:a", "ex:b"]))
+        normalize_rows(&json!([["ex:a"], ["ex:b"]]))
     );
 }
 
@@ -1018,7 +1018,7 @@ async fn property_path_inverse_zero_or_more() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:a", "ex:b"]))
+        normalize_rows(&json!([["ex:a"], ["ex:b"]]))
     );
 }
 
@@ -1068,7 +1068,7 @@ async fn property_path_sequence_with_alternative_step() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Bob", "Bobby"]))
+        normalize_rows(&json!([["Bob"], ["Bobby"]]))
     );
 }
 
@@ -1093,7 +1093,7 @@ async fn property_path_sequence_with_alternative_step_array_form() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["Bob", "Bobby"]))
+        normalize_rows(&json!([["Bob"], ["Bobby"]]))
     );
 }
 
@@ -1157,7 +1157,7 @@ async fn property_path_inverse_of_sequence() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:alice"])),
+        normalize_rows(&json!([["ex:alice"]])),
     );
 }
 
@@ -1185,7 +1185,7 @@ async fn property_path_inverse_of_alternative() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:alice"])),
+        normalize_rows(&json!([["ex:alice"]])),
     );
 }
 
@@ -1213,6 +1213,6 @@ async fn property_path_inverse_of_three_step_sequence() {
         .unwrap();
     assert_eq!(
         normalize_rows(&result),
-        normalize_rows(&json!(["ex:alice"])),
+        normalize_rows(&json!([["ex:alice"]])),
     );
 }

--- a/fluree-db-api/tests/it_query_reverse.rs
+++ b/fluree-db-api/tests/it_query_reverse.rs
@@ -107,7 +107,7 @@ async fn reverse_predicate_in_where_finds_kid() {
             "parent":{"@reverse":"ex:child"}
         },
         "where": {"@id":"?s","parent":"?x"},
-        "select": ["?s"],
+        "select": "?s",
         "distinct": true
     });
 
@@ -131,7 +131,7 @@ async fn reverse_at_type_in_where_finds_classes() {
             "isTypeObject":{"@reverse":"@type"}
         },
         "where": {"@id":"?class","isTypeObject":"?x"},
-        "select": ["?class"],
+        "select": "?class",
         "distinct": true
     });
 
@@ -155,7 +155,7 @@ async fn forward_at_type_in_where_finds_classes() {
     let q = json!({
         "@context": {"ex":"http://example.org/ns/"},
         "where": {"@id":"?x","@type":"?class"},
-        "select": ["?class"],
+        "select": "?class",
         "distinct": true
     });
 
@@ -262,7 +262,7 @@ async fn reverse_predicate_in_where_selects_parents() {
 
     let q = json!({
         "@context": ctx,
-        "select": ["?parent"],
+        "select": "?parent",
         "distinct": true,
         "where": {"@id":"ex:kid","parent":"?parent"}
     });
@@ -286,13 +286,13 @@ async fn type_reverse_and_forward_agree_on_classes() {
 
     let q_reverse = json!({
         "@context": {"ex":"http://example.org/ns/","isTypeObject":{"@reverse":"@type"}},
-        "select": ["?class"],
+        "select": "?class",
         "distinct": true,
         "where": {"@id":"?class","isTypeObject":"?x"}
     });
     let q_forward = json!({
         "@context": {"ex":"http://example.org/ns/"},
-        "select": ["?class"],
+        "select": "?class",
         "distinct": true,
         "where": {"@id":"?x","@type":"?class"}
     });

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -8,8 +8,8 @@ use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
 use std::sync::Arc;
 use support::{
-    assert_index_defaults, genesis_ledger, normalize_rows, normalize_rows_array,
-    normalize_sparql_bindings, MemoryFluree, MemoryLedger,
+    assert_index_defaults, genesis_ledger, normalize_rows, normalize_sparql_bindings, MemoryFluree,
+    MemoryLedger,
 };
 
 fn normalize_object_rows(value: &JsonValue) -> Vec<String> {
@@ -408,8 +408,8 @@ async fn sparql_filter_query_outputs_jsonld_and_sparql_json() {
 
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([["bbob", 23], ["jdoe", 42], ["jdoe", 99]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["bbob", 23], ["jdoe", 42], ["jdoe", 99]]))
     );
 
     let sparql_json = result
@@ -455,8 +455,7 @@ async fn sparql_count_star_counts_solutions() {
         .await
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    // Single-variable queries return flat array
-    assert_eq!(jsonld, json!([4]));
+    assert_eq!(jsonld, json!([[4]]));
 }
 
 #[tokio::test]
@@ -490,8 +489,8 @@ async fn sparql_count_distinct_with_group_by_and_order_by() {
     // fbueller has no favNums so won't appear
     // ORDER BY DESC means jbob first, then jdoe, then bbob
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([["jbob", 7], ["jdoe", 4], ["bbob", 1]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jbob", 7], ["jdoe", 4], ["bbob", 1]]))
     );
 }
 
@@ -529,8 +528,7 @@ async fn sparql_delete_data_removes_specified_triples() {
         .await
         .unwrap();
     let jsonld = result.to_jsonld(&ledger2.snapshot).expect("to_jsonld");
-    // Single-variable queries return flat array
-    assert_eq!(jsonld, json!([42, 99]));
+    assert_eq!(jsonld, json!([[42], [99]]));
 }
 
 #[tokio::test]
@@ -596,7 +594,7 @@ async fn sparql_lang_filter_limits_language_tagged_literals() {
         .await
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(jsonld, json!([{"@value": "Heyyyy", "@language": "en"}]));
+    assert_eq!(jsonld, json!([[{"@value": "Heyyyy", "@language": "en"}]]));
 }
 
 #[tokio::test]
@@ -621,7 +619,7 @@ async fn sparql_union_combines_unioned_patterns() {
         .await
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(jsonld, json!(["Alice", "Bob"]));
+    assert_eq!(jsonld, json!([["Alice"], ["Bob"]]));
 }
 
 #[tokio::test]
@@ -662,10 +660,7 @@ async fn sparql_optional_includes_unbound_values_as_null() {
         ["ex:jdoe", 99]
     ]);
 
-    assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&expected)
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&expected));
 }
 
 #[tokio::test]
@@ -700,10 +695,7 @@ async fn sparql_optional_multi_pattern_requires_conjunctive_match() {
         ["ex:jdoe", null, null]
     ]);
 
-    assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&expected)
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&expected));
 }
 
 #[tokio::test]
@@ -736,10 +728,7 @@ async fn sparql_group_by_with_optional_preserves_grouped_lists() {
         ["ex:jdoe", [3, 7, 42, 99]]
     ]);
 
-    assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&expected)
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&expected));
 }
 
 #[tokio::test]
@@ -772,10 +761,7 @@ async fn sparql_omitted_subjects_match_expanded_subject_bindings() {
         ["ex:jdoe", "Jane Doe", 99]
     ]);
 
-    assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&expected)
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&expected));
 }
 
 #[tokio::test]
@@ -797,16 +783,13 @@ async fn sparql_scalar_sha512_function_binds_values() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     let expected = json!([
-        "f162b1f2b3a824f459164fe40ffc24a019993058061ca1bf90eca98a4652f98ccaa5f17496be3da45ce30a1f79f45d82d8b8b532c264d4455babc1359aaa461d",
-        "eca2f5ab92fddbf2b1c51a60f5269086ce2415cb37964a05ae8a0b999625a8a50df876e97d34735ebae3fa3abb088fca005a596312fdf3326c4e73338f4c8c90",
-        "696ba1c7597f0d80287b8f0917317a904fa23a8c25564331a0576a482342d3807c61eff8e50bf5cf09859cfdeb92d448490073f34fb4ea4be43663d2359b51a9",
-        "fee256e1850ef33410630557356ea3efd56856e9045e59350dbceb6b5794041d50991093c07ad871e1124e6961f2198c178057cf391435051ac24eb8952bc401"
+        ["f162b1f2b3a824f459164fe40ffc24a019993058061ca1bf90eca98a4652f98ccaa5f17496be3da45ce30a1f79f45d82d8b8b532c264d4455babc1359aaa461d"],
+        ["eca2f5ab92fddbf2b1c51a60f5269086ce2415cb37964a05ae8a0b999625a8a50df876e97d34735ebae3fa3abb088fca005a596312fdf3326c4e73338f4c8c90"],
+        ["696ba1c7597f0d80287b8f0917317a904fa23a8c25564331a0576a482342d3807c61eff8e50bf5cf09859cfdeb92d448490073f34fb4ea4be43663d2359b51a9"],
+        ["fee256e1850ef33410630557356ea3efd56856e9045e59350dbceb6b5794041d50991093c07ad871e1124e6961f2198c178057cf391435051ac24eb8952bc401"]
     ]);
 
-    assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&expected)
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&expected));
 }
 
 #[tokio::test]
@@ -830,6 +813,8 @@ async fn sparql_aggregate_avg_over_values() {
     let avg = jsonld
         .as_array()
         .and_then(|arr| arr.first())
+        .and_then(|row| row.as_array())
+        .and_then(|row| row.first())
         .and_then(serde_json::Value::as_f64)
         .expect("avg result");
     assert!((avg - 17.666_666_666_666_67).abs() < 1e-12);
@@ -859,6 +844,7 @@ async fn sparql_group_by_having_filters_groups() {
         .as_array()
         .expect("avg rows array")
         .iter()
+        .flat_map(|row| row.as_array().expect("row array").iter())
         .filter_map(serde_json::Value::as_f64)
         .collect();
     values.sort_by(|a, b| a.partial_cmp(b).unwrap());
@@ -914,7 +900,7 @@ async fn sparql_having_aggregate_without_select_alias() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(jsonld, json!(["ex:jbob"]));
+    assert_eq!(jsonld, json!([["ex:jbob"]]));
 }
 
 #[tokio::test]
@@ -935,7 +921,7 @@ async fn sparql_multiple_select_expressions_with_aggregate_alias() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    let rows = normalize_rows_array(&jsonld);
+    let rows = normalize_rows(&jsonld);
     assert_eq!(rows.len(), 1);
     let avg = rows[0][0].as_f64().expect("avg");
     let ceil = rows[0][1].as_f64().expect("ceil");
@@ -963,8 +949,8 @@ async fn sparql_group_concat_aggregate_per_group() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([["0, 3, 5, 6, 7, 8, 9"], ["3, 7, 42, 99"], ["23"]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["0, 3, 5, 6, 7, 8, 9"], ["3, 7, 42, 99"], ["23"]]))
     );
 }
 
@@ -990,8 +976,8 @@ async fn sparql_concat_function_formats_strings() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["bbob-Billy Bob"],
             ["dankeshön-Ferris Bueller"],
             ["jbob-Jenny Bob"],
@@ -1023,7 +1009,7 @@ async fn sparql_mix_of_grouped_values_and_aggregates() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    let mut rows: Vec<(String, String, Vec<i64>, f64, i64)> = normalize_rows_array(&jsonld)
+    let mut rows: Vec<(String, String, Vec<i64>, f64, i64)> = normalize_rows(&jsonld)
         .into_iter()
         .map(|row| {
             let fav_nums = row[0]
@@ -1095,8 +1081,8 @@ async fn sparql_count_aggregate_per_group() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([[7], [4], [1]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([[7], [4], [1]]))
     );
 }
 
@@ -1120,8 +1106,8 @@ async fn sparql_count_star_per_group() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([[7], [4], [1]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([[7], [4], [1]]))
     );
 }
 
@@ -1144,7 +1130,7 @@ async fn sparql_sample_aggregate_returns_one_value() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    let rows = normalize_rows_array(&jsonld);
+    let rows = normalize_rows(&jsonld);
     assert_eq!(rows.len(), 3);
     for row in rows {
         assert!(row[0].as_i64().is_some());
@@ -1171,8 +1157,8 @@ async fn sparql_sum_aggregate_per_group() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([[38], [151], [23]]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([[38], [151], [23]]))
     );
 }
 
@@ -1194,10 +1180,7 @@ async fn sparql_sum_boolean_comparison_counts_true_rows() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([[3]]))
-    );
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[3]])));
 }
 
 #[tokio::test]
@@ -1219,7 +1202,7 @@ async fn sparql_order_by_ascending_sorts_results() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(jsonld, json!(["bbob", "dankeshön", "jbob", "jdoe"]));
+    assert_eq!(jsonld, json!([["bbob"], ["dankeshön"], ["jbob"], ["jdoe"]]));
 }
 
 #[tokio::test]
@@ -1241,7 +1224,7 @@ async fn sparql_order_by_descending_sorts_results() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(jsonld, json!(["jdoe", "jbob", "dankeshön", "bbob"]));
+    assert_eq!(jsonld, json!([["jdoe"], ["jbob"], ["dankeshön"], ["bbob"]]));
 }
 
 #[tokio::test]
@@ -1266,8 +1249,8 @@ async fn sparql_values_filters_bindings() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!(["bbob", "jdoe"]))
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["bbob"], ["jdoe"]]))
     );
 }
 
@@ -1412,8 +1395,8 @@ async fn sparql_base_iri_compacts_relative_ids() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["1", "For Whom the Bell Tolls"],
             ["2", "The Hitchhiker's Guide to the Galaxy"]
         ]))
@@ -1440,8 +1423,8 @@ async fn sparql_prefix_declarations_compact_ids() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["book:1", "For Whom the Bell Tolls"],
             ["book:2", "The Hitchhiker's Guide to the Galaxy"]
         ]))
@@ -1507,8 +1490,8 @@ async fn sparql_concat_with_langtag_argument() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&json!([
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
             ["Billy Bob's handle is bbob"],
             ["Ferris Bueller's handle is dankeshön"],
             ["Jenny Bob's handle is jbob"],
@@ -1531,7 +1514,7 @@ async fn sparql_property_path_inverse_object_var() {
         .await
         .expect("inverse path query should succeed");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!(["ex:a"])));
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["ex:a"]])));
 }
 
 #[tokio::test]
@@ -1548,7 +1531,7 @@ async fn sparql_property_path_inverse_subject_var() {
         .await
         .expect("inverse path subject var query should succeed");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!(["ex:b"])));
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["ex:b"]])));
 }
 
 #[tokio::test]
@@ -1575,7 +1558,7 @@ async fn sparql_property_path_alternative_object_var() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:b", "ex:x"]))
+        normalize_rows(&json!([["ex:b"], ["ex:x"]]))
     );
 }
 
@@ -1595,7 +1578,7 @@ async fn sparql_property_path_alternative_with_inverse() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:a", "ex:c", "ex:d"]))
+        normalize_rows(&json!([["ex:a"], ["ex:c"], ["ex:d"]]))
     );
 }
 
@@ -1624,7 +1607,7 @@ async fn sparql_property_path_alternative_three_way() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:b", "ex:c", "ex:d"]))
+        normalize_rows(&json!([["ex:b"], ["ex:c"], ["ex:d"]]))
     );
 }
 
@@ -1654,7 +1637,7 @@ async fn sparql_property_path_alternative_duplicate_semantics() {
     // Bag semantics: ex:b appears once per matching branch
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:b", "ex:b"]))
+        normalize_rows(&json!([["ex:b"], ["ex:b"]]))
     );
 }
 
@@ -1694,7 +1677,7 @@ async fn sparql_property_path_sequence_two_step() {
         .await
         .expect("two-step sequence query should succeed");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!(["Bob"])));
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["Bob"]])));
 }
 
 #[tokio::test]
@@ -1711,7 +1694,7 @@ async fn sparql_property_path_sequence_three_step() {
         .await
         .expect("three-step sequence query should succeed");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!(["Carol"])));
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["Carol"]])));
 }
 
 #[tokio::test]
@@ -1728,7 +1711,7 @@ async fn sparql_property_path_sequence_with_inverse() {
         .await
         .expect("sequence with inverse query should succeed");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!(["Alice"])));
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["Alice"]])));
 }
 
 #[tokio::test]
@@ -1776,7 +1759,7 @@ async fn sparql_property_path_sequence_transitive_step_allowed() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["Bob", "Carol"]))
+        normalize_rows(&json!([["Bob"], ["Carol"]]))
     );
 }
 
@@ -1800,7 +1783,7 @@ async fn sparql_property_path_inverse_one_or_more() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:a", "ex:b"]))
+        normalize_rows(&json!([["ex:a"], ["ex:b"]]))
     );
 }
 
@@ -1821,7 +1804,7 @@ async fn sparql_property_path_inverse_zero_or_more() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:a", "ex:b"]))
+        normalize_rows(&json!([["ex:a"], ["ex:b"]]))
     );
 }
 
@@ -1842,7 +1825,7 @@ async fn sparql_property_path_alternative_of_sequences() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["Bob", "Carol"]))
+        normalize_rows(&json!([["Bob"], ["Carol"]]))
     );
 }
 
@@ -1869,7 +1852,7 @@ async fn sparql_property_path_alternative_mixed_simple_and_sequence() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["Alice", "Bob"]))
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 }
 
@@ -1889,7 +1872,7 @@ async fn sparql_property_path_sequence_with_alternative_step() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["Bob", "Bobby"]))
+        normalize_rows(&json!([["Bob"], ["Bobby"]]))
     );
 }
 
@@ -1930,7 +1913,7 @@ async fn sparql_property_path_sequence_with_middle_alternative() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["Carol", "Caz"]))
+        normalize_rows(&json!([["Carol"], ["Caz"]]))
     );
 }
 
@@ -1952,7 +1935,7 @@ async fn sparql_property_path_inverse_of_sequence() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:alice"]))
+        normalize_rows(&json!([["ex:alice"]]))
     );
 }
 
@@ -1974,7 +1957,7 @@ async fn sparql_property_path_inverse_of_alternative() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         normalize_rows(&jsonld),
-        normalize_rows(&json!(["ex:alice"]))
+        normalize_rows(&json!([["ex:alice"]]))
     );
 }
 
@@ -2222,7 +2205,7 @@ async fn sparql_bind_iri_with_optional_propagates_binding() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         jsonld,
-        json!(["Hello"]),
+        json!([["Hello"]]),
         "control: direct IRI in OPTIONAL should find label"
     );
 
@@ -2240,7 +2223,7 @@ async fn sparql_bind_iri_with_optional_propagates_binding() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         jsonld,
-        json!(["Hello"]),
+        json!([["Hello"]]),
         "BIND+OPTIONAL should propagate IRI into OPTIONAL"
     );
 }
@@ -2617,7 +2600,7 @@ async fn sparql_substr_multibyte_characters() {
         .expect("SUBSTR query");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(jsonld, json!(["べ物"]));
+    assert_eq!(jsonld, json!([["べ物"]]));
 }
 
 #[tokio::test]
@@ -2637,7 +2620,7 @@ async fn sparql_substr_multibyte_no_length() {
         .expect("SUBSTR no-length query");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(jsonld, json!(["べ物"]));
+    assert_eq!(jsonld, json!([["べ物"]]));
 }
 
 #[tokio::test]
@@ -2717,7 +2700,7 @@ async fn sparql_tz_returns_string() {
         .expect("TZ query");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
 
-    assert_eq!(jsonld, json!(["Z"]));
+    assert_eq!(jsonld, json!([["Z"]]));
 }
 
 #[tokio::test]
@@ -2938,7 +2921,7 @@ async fn sparql_xsd_cast_double_from_integer() {
         .await
         .expect("xsd:double cast query");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(jsonld, json!([42.0]));
+    assert_eq!(jsonld, json!([[42.0]]));
 }
 
 #[tokio::test]
@@ -2958,7 +2941,7 @@ async fn sparql_xsd_cast_string_from_integer() {
         .await
         .expect("xsd:string cast query");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
-    assert_eq!(jsonld, json!(["42"]));
+    assert_eq!(jsonld, json!([["42"]]));
 }
 
 #[tokio::test]
@@ -2979,7 +2962,7 @@ async fn sparql_xsd_cast_invalid_returns_unbound() {
         .expect("invalid cast should not error");
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     // Unbound projected variables serialize as null in JSON-LD
-    assert_eq!(jsonld, json!([null]));
+    assert_eq!(jsonld, json!([[null]]));
 }
 
 // ============================================================================
@@ -3026,6 +3009,7 @@ async fn sparql_bind01_exact_w3c_unbound_predicate() {
         .as_array()
         .expect("array")
         .iter()
+        .flat_map(|row| row.as_array().expect("row array").iter())
         .filter_map(serde_json::Value::as_i64)
         .collect();
     values.sort();
@@ -3071,6 +3055,7 @@ async fn sparql_bind_expression_in_select() {
         .as_array()
         .expect("array")
         .iter()
+        .flat_map(|row| row.as_array().expect("row array").iter())
         .map(|v| v.as_i64().expect("int"))
         .collect();
     values.sort();
@@ -3252,6 +3237,7 @@ async fn sparql_bind_in_union() {
         .as_array()
         .expect("array")
         .iter()
+        .flat_map(|row| row.as_array().expect("row array").iter())
         .filter_map(serde_json::Value::as_i64)
         .collect();
     values.sort();
@@ -3294,6 +3280,7 @@ async fn sparql_bind_with_filter() {
         .as_array()
         .expect("array")
         .iter()
+        .flat_map(|row| row.as_array().expect("row array").iter())
         .filter_map(serde_json::Value::as_i64)
         .collect();
     values.sort();
@@ -3481,8 +3468,8 @@ async fn sparql_star_query_with_optional_and_filter() {
     ]);
 
     assert_eq!(
-        normalize_rows_array(&jsonld),
-        normalize_rows_array(&expected),
+        normalize_rows(&jsonld),
+        normalize_rows(&expected),
         "Star query with OPTIONAL + FILTER should return matching rows.\nGot: {jsonld:#}"
     );
 }
@@ -3512,7 +3499,7 @@ async fn sparql_service_self_reference_returns_data() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(
         jsonld,
-        json!(["bbob", "dankeshön", "jbob", "jdoe"]),
+        json!([["bbob"], ["dankeshön"], ["jbob"], ["jdoe"]]),
         "SERVICE self-reference should return all handles.\nGot: {jsonld:#}"
     );
 }

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -16,8 +16,8 @@ use fluree_db_api::{
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
 use support::{
-    assert_index_defaults, genesis_ledger_for_fluree, normalize_rows_array,
-    normalize_sparql_bindings, start_background_indexer_local, trigger_index_and_wait_outcome,
+    assert_index_defaults, genesis_ledger_for_fluree, normalize_rows, normalize_sparql_bindings,
+    start_background_indexer_local, trigger_index_and_wait_outcome,
 };
 
 type MemoryFluree = fluree_db_api::Fluree;
@@ -134,8 +134,8 @@ async fn indexed_sparql_custom_predicate_without_type_returns_results() {
                 .to_jsonld(&view.snapshot)
                 .expect("to_jsonld (with type)");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([
                     ["cust:pkg1", "anchor-value-1"],
                     ["cust:pkg2", "anchor-value-2"],
                     ["cust:pkg3", "anchor-value-3"]
@@ -158,8 +158,8 @@ async fn indexed_sparql_custom_predicate_without_type_returns_results() {
                 .to_jsonld(&view.snapshot)
                 .expect("to_jsonld (without type)");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([
                     ["cust:pkg1", "anchor-value-1"],
                     ["cust:pkg2", "anchor-value-2"],
                     ["cust:pkg3", "anchor-value-3"]
@@ -183,8 +183,8 @@ async fn indexed_sparql_custom_predicate_without_type_returns_results() {
                 .to_jsonld(&view.snapshot)
                 .expect("to_jsonld (std pred)");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([
                     ["cust:pkg1", "cust:pkg2"],
                     ["cust:pkg2", "cust:pkg3"]
                 ])),
@@ -540,8 +540,8 @@ async fn indexed_repeated_vars_in_triple_pattern_do_not_duplicate_schema() {
                 .expect("query 1 should succeed");
             let jsonld1 = r1.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld1),
-                normalize_rows_array(&json!([["ex:a"]])),
+                normalize_rows(&jsonld1),
+                normalize_rows(&json!([["ex:a"]])),
                 "expected ?x=ex:a"
             );
 
@@ -556,8 +556,8 @@ async fn indexed_repeated_vars_in_triple_pattern_do_not_duplicate_schema() {
                 .expect("query 2 should succeed");
             let jsonld2 = r2.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld2),
-                normalize_rows_array(&json!([["ex:a", "ex:b"]])),
+                normalize_rows(&jsonld2),
+                normalize_rows(&json!([["ex:a", "ex:b"]])),
                 "expected (?x,?o)=(ex:a,ex:b)"
             );
         })
@@ -630,8 +630,8 @@ async fn indexed_multicolumn_join_shared_object_var_executes() {
                 .expect("multicolumn join query should succeed");
             let jsonld = r.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([2])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[2]])),
                 "expected two matching (s,o) pairs"
             );
         })
@@ -710,8 +710,8 @@ async fn indexed_overlay_count_reflects_retract_and_reassert() {
                 .expect("count at t=1");
             let jsonld = result.to_jsonld(&view1.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([4])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[4]])),
                 "baseline count should be 4"
             );
 
@@ -738,8 +738,8 @@ async fn indexed_overlay_count_reflects_retract_and_reassert() {
                 .expect("count at t=2");
             let jsonld = result.to_jsonld(&view2.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([3])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[3]])),
                 "count should reflect novelty retraction"
             );
 
@@ -766,8 +766,8 @@ async fn indexed_overlay_count_reflects_retract_and_reassert() {
                 .expect("count at t=3");
             let jsonld = result.to_jsonld(&view3.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([4])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[4]])),
                 "count should reflect novelty re-assertion"
             );
         })
@@ -846,8 +846,8 @@ async fn indexed_overlay_group_by_count_topk_reflects_overlay() {
                 .expect("group count at t=1");
             let jsonld = result.to_jsonld(&view1.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([["CA", 3], ["WA", 2]])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["CA", 3], ["WA", 2]])),
                 "baseline group counts should be CA=3, WA=2"
             );
 
@@ -881,8 +881,8 @@ async fn indexed_overlay_group_by_count_topk_reflects_overlay() {
                 .expect("group count at t=2");
             let jsonld = result.to_jsonld(&view2.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([["CA", 5], ["WA", 1]])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["CA", 5], ["WA", 1]])),
                 "group counts should reflect overlay deltas"
             );
         })
@@ -1195,8 +1195,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("indexed CONTAINS query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Alice Adams")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Alice Adams"]]))
             );
 
             let indexed_strstarts = r#"
@@ -1213,8 +1213,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("indexed STRSTARTS query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Alice Adams")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Alice Adams"]]))
             );
 
             let indexed_regex_prefix = r#"
@@ -1231,8 +1231,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("indexed regex-prefix query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Alice Adams")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Alice Adams"]]))
             );
 
             let overlay_equality = r#"
@@ -1249,8 +1249,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("overlay equality query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Brian Platz")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Brian Platz"]]))
             );
 
             let overlay_contains = r#"
@@ -1267,8 +1267,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("overlay CONTAINS query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Brian Platz")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Brian Platz"]]))
             );
 
             let overlay_regex = r#"
@@ -1285,8 +1285,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("overlay REGEX query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Brian Platz")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Brian Platz"]]))
             );
 
             let overlay_regex_prefix = r#"
@@ -1303,8 +1303,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("overlay REGEX prefix query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Brian Platz")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Brian Platz"]]))
             );
 
             let overlay_strstarts = r#"
@@ -1321,8 +1321,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("overlay STRSTARTS query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Brian Platz")]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Brian Platz"]]))
             );
 
             let overlay_strlen = r#"
@@ -1339,8 +1339,8 @@ async fn indexed_string_functions_work_for_indexed_and_overlay_strings() {
                 .expect("overlay STRLEN query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                vec![vec![json!("Brian Platz"), json!(11)]]
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([["Brian Platz", 11]]))
             );
 
             let overlay_lcase = r#"
@@ -1431,8 +1431,8 @@ async fn indexed_count_with_lang_filter_counts_matching_lang_tag_rows() {
                 .expect("indexed LANG count query");
             let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([2])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[2]])),
                 "indexed COUNT with LANG filter should count only en-tagged literals"
             );
         })
@@ -1504,8 +1504,8 @@ async fn indexed_numeric_sum_fast_paths_work_for_identity_and_add_self() {
                 .to_jsonld(&view.snapshot)
                 .expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&baseline_json),
-                normalize_rows_array(&json!([6])),
+                normalize_rows(&baseline_json),
+                normalize_rows(&json!([[6]])),
                 "indexed SUM(?o) should add integer values directly"
             );
 
@@ -1520,8 +1520,8 @@ async fn indexed_numeric_sum_fast_paths_work_for_identity_and_add_self() {
                 .expect("indexed SUM(?o + ?o) query");
             let add_json = add_result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&add_json),
-                normalize_rows_array(&json!([12])),
+                normalize_rows(&add_json),
+                normalize_rows(&json!([[12]])),
                 "indexed SUM(?o + ?o) should double each integer value"
             );
         })
@@ -1595,8 +1595,8 @@ async fn indexed_numeric_count_fast_path_handles_threshold_filters() {
                 .expect("indexed COUNT(?s) with >= query");
             let ge_json = ge_result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&ge_json),
-                normalize_rows_array(&json!([3])),
+                normalize_rows(&ge_json),
+                normalize_rows(&json!([[3]])),
                 "indexed COUNT with ?o >= 2 should count qualifying rows"
             );
 
@@ -1614,8 +1614,8 @@ async fn indexed_numeric_count_fast_path_handles_threshold_filters() {
                 .expect("indexed COUNT(?s) with > query");
             let gt_json = gt_result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&gt_json),
-                normalize_rows_array(&json!([2])),
+                normalize_rows(&gt_json),
+                normalize_rows(&json!([[2]])),
                 "indexed COUNT with ?o > 2 should honor exclusive thresholds"
             );
         })
@@ -1686,8 +1686,8 @@ async fn indexed_numeric_avg_min_max_fast_paths_work() {
                 .expect("indexed AVG(?o) query");
             let avg_json = avg_result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&avg_json),
-                normalize_rows_array(&json!([2.5])),
+                normalize_rows(&avg_json),
+                normalize_rows(&json!([[2.5]])),
                 "indexed AVG(?o) should average numeric values directly"
             );
 
@@ -1702,8 +1702,8 @@ async fn indexed_numeric_avg_min_max_fast_paths_work() {
                 .expect("indexed MIN(?o) query");
             let min_json = min_result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&min_json),
-                normalize_rows_array(&json!([1])),
+                normalize_rows(&min_json),
+                normalize_rows(&json!([[1]])),
                 "indexed MIN(?o) should use numeric leaflet boundaries"
             );
 
@@ -1718,8 +1718,8 @@ async fn indexed_numeric_avg_min_max_fast_paths_work() {
                 .expect("indexed MAX(?o) query");
             let max_json = max_result.to_jsonld(&view.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&max_json),
-                normalize_rows_array(&json!([4])),
+                normalize_rows(&max_json),
+                normalize_rows(&json!([[4]])),
                 "indexed MAX(?o) should use numeric leaflet boundaries"
             );
         })
@@ -1791,8 +1791,8 @@ async fn indexed_strstarts_sum_counts_prefix_matches() {
                 .expect("indexed STRSTARTS SUM query");
             let jsonld = result.to_jsonld(&indexed.snapshot).expect("to_jsonld");
             assert_eq!(
-                normalize_rows_array(&jsonld),
-                normalize_rows_array(&json!([2])),
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[2]])),
                 "indexed SUM(xsd:integer(STRSTARTS(...))) should count matching rows"
             );
         })

--- a/fluree-db-api/tests/it_query_subclass.rs
+++ b/fluree-db-api/tests/it_query_subclass.rs
@@ -102,7 +102,7 @@ async fn subclass_creative_work_returns_book_and_movie_instances() {
     );
 
     let q_types = json!({
-        "select": ["?t"],
+        "select": "?t",
         "where": [{"@id":"https://www.wikidata.org/wiki/Q836821","@type":"?t"}]
     });
     let types = support::query_jsonld(&fluree, &ledger, &q_types)
@@ -116,7 +116,7 @@ async fn subclass_creative_work_returns_book_and_movie_instances() {
     );
 
     let q_movie = json!({
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id":"?s","@type":"https://schema.org/Movie"}
     });
     let movie_rows = support::query_jsonld(&fluree, &ledger, &q_movie)
@@ -344,7 +344,7 @@ async fn subclass_nested_stages() {
 
     let q = json!({
         "@context": {"ex":"http://example.org/"},
-        "select": ["?s"],
+        "select": "?s",
         "where": {"@id":"?s","@type":"ex:Human"}
     });
     let rows = support::query_jsonld(&fluree, &db3, &q)

--- a/fluree-db-api/tests/it_query_subquery.rs
+++ b/fluree-db-api/tests/it_query_subquery.rs
@@ -430,7 +430,7 @@ async fn subquery_with_values_filters_results() {
 
     let q = json!({
         "@context": ctx,
-        "select": ["?person"],
+        "select": "?person",
         "where": [
             ["query", {
                 "@context": ctx,

--- a/fluree-db-api/tests/it_query_time_travel.rs
+++ b/fluree-db-api/tests/it_query_time_travel.rs
@@ -10,9 +10,7 @@ mod support;
 use chrono::{DateTime, Duration, FixedOffset, SecondsFormat, TimeZone, Utc};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{
-    assert_index_defaults, genesis_ledger, normalize_rows_array, MemoryFluree, MemoryLedger,
-};
+use support::{assert_index_defaults, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use tokio::time::sleep;
 
 fn ctx_test() -> JsonValue {
@@ -86,7 +84,7 @@ async fn query_names_at(
     fluree: &MemoryFluree,
     db_for_formatting: fluree_db_core::GraphDbRef<'_>,
     from_spec: &str,
-) -> Vec<Vec<JsonValue>> {
+) -> Vec<JsonValue> {
     let q = json!({
         "@context": ctx_test(),
         "from": [from_spec],
@@ -101,18 +99,9 @@ async fn query_names_at(
         .await
         .expect("to_jsonld_async");
 
-    // JSON-LD formatter returns single-column results as a flat array.
-    // Normalize to array-of-rows for easy comparison with expectations.
-    let names: Vec<Vec<JsonValue>> = jsonld
-        .as_array()
-        .expect("result array")
-        .iter()
-        .map(|v| vec![v.clone()])
-        .collect();
-
-    normalize_rows_array(&JsonValue::Array(
-        names.iter().map(|r| JsonValue::Array(r.clone())).collect(),
-    ))
+    // JSON-LD formatter returns array-of-arrays for array-form select
+    // (e.g. `select: ["?name"]` → `[["Alice"]]`).
+    normalize_rows(&jsonld)
 }
 
 #[tokio::test]
@@ -132,7 +121,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@t:1")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
     assert_eq!(
         query_names_at(
@@ -141,7 +130,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@t:2")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"], ["Bob"]]))
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
     assert_eq!(
         query_names_at(
@@ -150,7 +139,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@t:3")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"], ["Bob"], ["Carol"]]))
+        normalize_rows(&json!([["Alice"], ["Bob"], ["Carol"]]))
     );
 
     // @iso: (use commit timestamp for t=1; should resolve to exactly t=1)
@@ -161,7 +150,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@iso:{iso_t1}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
 
     // Also ensure @iso: at "now" returns head state.
@@ -173,7 +162,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@iso:{iso_now}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"], ["Bob"], ["Carol"]]))
+        normalize_rows(&json!([["Alice"], ["Bob"], ["Carol"]]))
     );
 
     // @commit: — uses hex SHA-256 digest from the ContentId
@@ -188,7 +177,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@commit:{sha_7}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
     assert_eq!(
         query_names_at(
@@ -197,7 +186,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@commit:{sha_52}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
     assert_eq!(
         query_names_at(
@@ -206,7 +195,7 @@ async fn time_travel_query_connection_at_t_iso_and_sha() {
             &format!("{ledger_id}@commit:{sha_6}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
 }
 
@@ -238,7 +227,7 @@ async fn time_travel_invalid_format_errors() {
             &format!("{ledger_id}@t:1")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
 }
 
@@ -321,7 +310,7 @@ async fn time_travel_iso_too_early_errors() {
             &format!("{ledger_id}@t:1")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
 }
 
@@ -372,7 +361,7 @@ async fn time_travel_iso_between_commits_resolves_to_previous_commit() {
             &format!("{ledger_id}@iso:{mid_12}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"]]))
+        normalize_rows(&json!([["Alice"]]))
     );
     // Mid between t2 and t3 should resolve to t2
     assert_eq!(
@@ -382,7 +371,7 @@ async fn time_travel_iso_between_commits_resolves_to_previous_commit() {
             &format!("{ledger_id}@iso:{mid_23}")
         )
         .await,
-        normalize_rows_array(&json!([["Alice"], ["Bob"]]))
+        normalize_rows(&json!([["Alice"], ["Bob"]]))
     );
 }
 
@@ -441,7 +430,7 @@ async fn time_travel_branch_interaction_main_at_t() {
         .await
         .expect("to_jsonld_async");
 
-    let rows = normalize_rows_array(&jsonld);
+    let rows = normalize_rows(&jsonld);
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][1], json!("main-value"));
 }

--- a/fluree-db-api/tests/it_query_values.rs
+++ b/fluree-db-api/tests/it_query_values.rs
@@ -78,7 +78,7 @@ async fn values_top_level_no_where_single_var() {
 
     let query = json!({
         "@context": context_ex_schema(),
-        "select": ["?foo"],
+        "select": "?foo",
         "values": ["?foo", ["foo1","foo2","foo3"]]
     });
 
@@ -145,7 +145,7 @@ async fn values_equivalent_iri_forms_var_in_id_map() {
     let q1 = json!({
         "@context": ctx,
         "where": [{"@id":"?s","ex:friend":{"@id":"ex:alice"}}],
-        "select": ["?s"]
+        "select": "?s"
     });
 
     // variable via VALUES
@@ -153,7 +153,7 @@ async fn values_equivalent_iri_forms_var_in_id_map() {
         "@context": ctx,
         "values": ["?friend", [{"@value":"ex:alice","@type":"@id"}]],
         "where": [{"@id":"?s","ex:friend":"?friend"}],
-        "select": ["?s"]
+        "select": "?s"
     });
 
     // variable inside id-map
@@ -161,7 +161,7 @@ async fn values_equivalent_iri_forms_var_in_id_map() {
         "@context": ctx,
         "values": ["?friend", [{"@value":"ex:alice","@type":"@id"}]],
         "where": [{"@id":"?s","ex:friend":{"@id":"?friend"}}],
-        "select": ["?s"]
+        "select": "?s"
     });
 
     let r1 = support::query_jsonld(&fluree, &ledger, &q1)
@@ -292,7 +292,7 @@ async fn values_match_meta_language_tag() {
 
     let query = json!({
         "@context": ctx,
-        "select": ["?s"],
+        "select": "?s",
         "where": [
             {"@id":"?s","ex:greeting":"?greet"},
             ["values", ["?greet", [{"@value":"Здраво","@language":"sb"}]]]
@@ -369,7 +369,7 @@ async fn values_federated_query_connection_from_two_ledgers() {
     let query = json!({
         "@context": ctx,
         "from": ["values-test:main", "other-ledger:main"],
-        "select": ["?name"],
+        "select": "?name",
         "where": [
             {"@id":"?s","schema:name":"?name"},
             ["values", ["?s", [

--- a/fluree-db-api/tests/it_select_star_novelty_retract.rs
+++ b/fluree-db-api/tests/it_select_star_novelty_retract.rs
@@ -145,10 +145,10 @@ async fn graph_crawl_applies_novelty_retractions() {
         rows.len(),
         rows
     );
-    // Single-column SELECT flattens to scalar in JSON-LD format.
+    // SPARQL always returns array-of-arrays (one array per binding row).
     assert_eq!(
         rows[0],
-        json!("updated description"),
+        json!(["updated description"]),
         "SPARQL should return only the updated description"
     );
 
@@ -249,7 +249,7 @@ async fn graph_crawl_applies_novelty_retractions_for_indexed_base_rows() {
     );
     assert_eq!(
         rows[0],
-        json!("updated description"),
+        json!(["updated description"]),
         "SPARQL should return only the updated description"
     );
 
@@ -340,7 +340,7 @@ async fn graph_crawl_applies_novelty_retractions_for_list_indexed_values() {
     let rows = sparql_json.as_array().expect("sparql rows");
     assert_eq!(
         rows,
-        &vec![json!("desc c")],
+        &vec![json!(["desc c"])],
         "SPARQL should return only the updated single description"
     );
 

--- a/fluree-db-api/tests/it_time_travel_indexing.rs
+++ b/fluree-db-api/tests/it_time_travel_indexing.rs
@@ -87,7 +87,7 @@ async fn query_names_at(fluree: &MemoryFluree, from_spec: &str) -> Vec<String> {
     let query = json!({
         "@context": {"ex": "http://example.org/"},
         "from": from_spec,
-        "select": ["?name"],
+        "select": "?name",
         "where": {"@id": "?s", "@type": "ex:Person", "ex:name": "?name"},
         "orderBy": "?name"
     });
@@ -477,7 +477,7 @@ async fn time_travel_updates_across_index_novelty_boundary() {
             let query_t1 = json!({
                 "@context": {"ex": "http://example.org/"},
                 "from": format!("{ledger_id}@t:1"),
-                "select": ["?age"],
+                "select": "?age",
                 "where": {"@id": "ex:alice", "ex:age": "?age"}
             });
             let result = fluree.query_connection(&query_t1).await.expect("query t=1");
@@ -497,7 +497,7 @@ async fn time_travel_updates_across_index_novelty_boundary() {
             let query_t2 = json!({
                 "@context": {"ex": "http://example.org/"},
                 "from": format!("{ledger_id}@t:2"),
-                "select": ["?age"],
+                "select": "?age",
                 "where": {"@id": "ex:alice", "ex:age": "?age"}
             });
             let result = fluree.query_connection(&query_t2).await.expect("query t=2");
@@ -516,7 +516,7 @@ async fn time_travel_updates_across_index_novelty_boundary() {
             let query_current = json!({
                 "@context": {"ex": "http://example.org/"},
                 "from": ledger_id,
-                "select": ["?age"],
+                "select": "?age",
                 "where": {"@id": "ex:alice", "ex:age": "?age"}
             });
             let result = fluree
@@ -733,7 +733,7 @@ async fn query_person_age(fluree: &MemoryFluree, from_spec: &str, person_id: &st
     let query = json!({
         "@context": {"ex": "http://example.org/"},
         "from": from_spec,
-        "select": ["?age"],
+        "select": "?age",
         "where": {"@id": person_id, "ex:age": "?age"}
     });
 

--- a/fluree-db-api/tests/it_transact.rs
+++ b/fluree-db-api/tests/it_transact.rs
@@ -760,7 +760,7 @@ async fn insert_data_then_query_names() {
 
     let query = json!({
         "@context": ctx_ex_schema(),
-        "select": ["?name"],
+        "select": "?name",
         "where": {"schema:name": "?name"}
     });
 

--- a/fluree-db-api/tests/it_transact_list_retract.rs
+++ b/fluree-db-api/tests/it_transact_list_retract.rs
@@ -68,7 +68,13 @@ async fn count_items(fluree: &fluree_db_api::Fluree, ledger: &fluree_db_api::Led
     if arr.is_empty() {
         return 0;
     }
-    arr[0].as_u64().map(|v| v as usize).unwrap_or(0)
+    // SPARQL always returns array-of-arrays (one inner array per binding row).
+    arr[0]
+        .as_array()
+        .and_then(|row| row.first())
+        .and_then(serde_json::Value::as_u64)
+        .map(|v| v as usize)
+        .unwrap_or(0)
 }
 
 /// Three distinct `@list` entries, wildcard DELETE WHERE.

--- a/fluree-db-api/tests/it_transact_object_var.rs
+++ b/fluree-db-api/tests/it_transact_object_var.rs
@@ -35,7 +35,7 @@ async fn insert_does_not_parse_bare_var_by_default() {
 
     let query = json!({
         "@context": ctx(),
-        "select": ["?val"],
+        "select": "?val",
         "where": [{"@id": "ex:s", "schema:text": "?val"}]
     });
     let result = support::query_jsonld(&fluree, &ledger1, &query)
@@ -75,7 +75,7 @@ async fn object_var_parsing_update_opt() {
 
     let query = json!({
         "@context": ctx(),
-        "select": ["?val"],
+        "select": "?val",
         "where": [{"@id": "ex:s", "schema:text": "?val"}]
     });
     let jsonld = support::query_jsonld(&fluree, &ledger1, &query)
@@ -136,7 +136,7 @@ async fn update_with_object_var_parsing_false_treats_bare_var_as_literal() {
 
     let query = json!({
         "@context": ctx(),
-        "select": ["?val"],
+        "select": "?val",
         "where": [{"@id": "ex:s", "schema:text": "?val"}]
     });
     let jsonld = support::query_jsonld(&fluree, &ledger1, &query)
@@ -183,7 +183,7 @@ async fn update_explicit_variable_map_parses_when_flag_false_and_bound() {
 
     let query = json!({
         "@context": ctx(),
-        "select": ["?val"],
+        "select": "?val",
         "where": [{
             "@id": "ex:s",
             "schema:foo": {"@value": "?val"}
@@ -278,7 +278,7 @@ async fn update_predicate_var_still_parses_when_flag_false() {
 
     let query = json!({
         "@context": ctx(),
-        "select": ["?p"],
+        "select": "?p",
         "where": [{"@id":"ex:s","?p":"?o"}]
     });
     let jsonld = support::query_jsonld(&fluree, &ledger2, &query)
@@ -396,7 +396,7 @@ async fn query_literal_qmark_string_with_flag_false_requires_literal_match() {
     let query = json!({
         "@context": {"ex": "http://example.org/ns/"},
         "opts": {"objectVarParsing": false},
-        "select": ["?s"],
+        "select": "?s",
         "where": [{"@id": "?s", "ex:prop": "?not-a-var"}]
     });
 
@@ -424,7 +424,7 @@ async fn query_explicit_variable_in_where_still_parses_when_flag_false() {
     let query = json!({
         "@context": {"ex": "http://example.org/ns/"},
         "opts": {"objectVarParsing": false},
-        "select": ["?v"],
+        "select": "?v",
         "where": [{"@id": "ex:s", "ex:prop": {"@variable": "?v"}}]
     });
 

--- a/fluree-db-api/tests/it_transact_update.rs
+++ b/fluree-db-api/tests/it_transact_update.rs
@@ -56,7 +56,7 @@ async fn seed_users(ledger_id: &str) -> (fluree_db_api::Fluree, LedgerState) {
 async fn query_names(fluree: &fluree_db_api::Fluree, ledger: &LedgerState) -> Vec<String> {
     let q = json!({
         "@context": ctx_ex_schema(),
-        "select": ["?name"],
+        "select": "?name",
         "where": {"schema:name": "?name"}
     });
     let result = support::query_jsonld(fluree, ledger, &q)
@@ -2082,7 +2082,7 @@ async fn update_wildcard_delete_duplicate_facts_across_index_and_novelty() {
                 &txn2.ledger,
                 &json!({
                     "@context": ctx_ex_schema(),
-                    "select": ["?name"],
+                    "select": "?name",
                     "where": { "@id": "ex:space1", "schema:name": "?name" }
                 }),
             )

--- a/fluree-db-api/tests/it_transact_upsert.rs
+++ b/fluree-db-api/tests/it_transact_upsert.rs
@@ -699,7 +699,7 @@ async fn novelty_dedup_prevents_duplicate_assertions() {
     // Novelty dedup: only 3 distinct values should exist, not 6
     let query = json!({
         "@context": ctx,
-        "select": ["?status"],
+        "select": "?status",
         "where": { "@id": "ex:task1", "ex:status": "?status" }
     });
     let result = support::query_jsonld(&fluree, &ledger, &query)

--- a/fluree-db-api/tests/it_tutorial_end_to_end.rs
+++ b/fluree-db-api/tests/it_tutorial_end_to_end.rs
@@ -369,7 +369,7 @@ async fn tutorial_step3_update_and_time_travel() {
     // Query current state: should see updated content
     let query = json!({
         "@context": ctx(),
-        "select": ["?content"],
+        "select": "?content",
         "where": [{"@id": "ex:doc1", "ex:content": "?content"}]
     });
 
@@ -387,7 +387,7 @@ async fn tutorial_step3_update_and_time_travel() {
     let time_travel_query = json!({
         "@context": ctx(),
         "from": ["kb-timetravel:main@t:1"],
-        "select": ["?content"],
+        "select": "?content",
         "where": [{"@id": "ex:doc1", "ex:content": "?content"}]
     });
 
@@ -526,7 +526,7 @@ async fn tutorial_step4_branch_and_merge() {
     let branch_ledger = fluree.ledger("kb-branch:reorganize").await.unwrap();
     let vis_query = json!({
         "@context": ctx(),
-        "select": ["?vis"],
+        "select": "?vis",
         "where": [{"@id": "ex:doc3", "ex:visibility": "?vis"}]
     });
     let result = support::query_jsonld(&fluree, &branch_ledger, &vis_query)
@@ -662,7 +662,7 @@ async fn tutorial_step5_combined_workflow() {
     let tt_query = json!({
         "@context": ctx(),
         "from": ["kb-combined:main@t:1"],
-        "select": ["?content"],
+        "select": "?content",
         "where": [{"@id": "ex:doc1", "ex:content": "?content"}]
     });
     let result = fluree
@@ -791,7 +791,7 @@ async fn tutorial_turtle_insert() {
             "schema": "http://schema.org/",
             "ex": "http://example.org/"
         },
-        "select": ["?name"],
+        "select": "?name",
         "where": [{"@id": "ex:alice", "schema:name": "?name"}]
     });
     let result = support::query_jsonld(&fluree, &ledger, &query)

--- a/fluree-db-api/tests/it_upsert_duplicate_ids_repro.rs
+++ b/fluree-db-api/tests/it_upsert_duplicate_ids_repro.rs
@@ -218,9 +218,9 @@ async fn repro_upsert_repeated_ids_create_duplicate_subject_ids() {
                 .to_jsonld(&ledger2_loaded.snapshot)
                 .unwrap();
 
-            assert_eq!(const_count, json!([1]));
-            assert_eq!(var_count, json!([1]));
-            assert_eq!(type_count, json!([1]));
+            assert_eq!(const_count, json!([[1]]));
+            assert_eq!(var_count, json!([[1]]));
+            assert_eq!(type_count, json!([[1]]));
             assert_eq!(join_counts, json!([[1, 1]]));
             assert_eq!(graph_counts, json!([[ledger_id, 1]]));
 

--- a/fluree-db-api/tests/support/mod.rs
+++ b/fluree-db-api/tests/support/mod.rs
@@ -272,31 +272,6 @@ pub fn normalize_rows(v: &JsonValue) -> Vec<JsonValue> {
     rows
 }
 
-/// Normalize JSON-LD row results as nested arrays for unordered comparison.
-///
-/// Similar to `normalize_rows` but preserves the inner array structure.
-pub fn normalize_rows_array(v: &JsonValue) -> Vec<Vec<JsonValue>> {
-    let mut rows: Vec<Vec<JsonValue>> = v
-        .as_array()
-        .expect("rows should be an array")
-        .iter()
-        .map(|row| {
-            // JSON-LD formatter flattens single-column selects to a flat array of values.
-            // Preserve a consistent nested-array shape for callers by wrapping scalars.
-            match row.as_array() {
-                Some(arr) => arr.to_vec(),
-                None => vec![row.clone()],
-            }
-        })
-        .collect();
-    rows.sort_by(|a, b| {
-        serde_json::to_string(a)
-            .unwrap()
-            .cmp(&serde_json::to_string(b).unwrap())
-    });
-    rows
-}
-
 /// Normalize SPARQL JSON bindings for unordered comparison.
 ///
 /// Extracts `results.bindings` from a SPARQL JSON response and sorts

--- a/fluree-db-query/src/count_plan.rs
+++ b/fluree-db-query/src/count_plan.rs
@@ -969,7 +969,7 @@ mod tests {
         let query = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![out_var]),
+            output: QueryOutput::select(vec![out_var]),
             patterns,
             options: options.clone(),
             graph_select: None,

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -381,7 +381,7 @@ mod tests {
         let query = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![VarId(99)]), // Variable not in pattern
+            output: QueryOutput::select(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             graph_select: None,
@@ -400,7 +400,7 @@ mod tests {
         let query = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![VarId(0)]),
+            output: QueryOutput::select(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             graph_select: None,

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -132,8 +132,8 @@ mod tests {
         select_mode: SelectMode,
     ) -> ParsedQuery {
         let output = match select_mode {
-            SelectMode::Many => QueryOutput::Select(select),
-            SelectMode::One => QueryOutput::SelectOne(select),
+            SelectMode::Many => QueryOutput::select(select),
+            SelectMode::One => QueryOutput::select_one(select),
             SelectMode::Wildcard => QueryOutput::Wildcard,
             SelectMode::Construct => QueryOutput::Construct(ConstructTemplate::new(Vec::new())),
             SelectMode::Boolean => QueryOutput::Boolean,

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -3041,7 +3041,7 @@ mod tests {
         let output = if select.is_empty() {
             QueryOutput::Wildcard
         } else {
-            QueryOutput::Select(select)
+            QueryOutput::select(select)
         };
         ParsedQuery {
             context: ParsedContext::default(),
@@ -3091,7 +3091,7 @@ mod tests {
         let query = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![s, label]),
+            output: QueryOutput::select(vec![s, label]),
             patterns,
             options: QueryOptions::default(),
             graph_select: None,
@@ -3118,7 +3118,7 @@ mod tests {
         let query = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![VarId(99)]), // Variable not in pattern
+            output: QueryOutput::select(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             graph_select: None,
@@ -3137,7 +3137,7 @@ mod tests {
         let query = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![VarId(0)]),
+            output: QueryOutput::select(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             graph_select: None,
@@ -3176,7 +3176,7 @@ mod tests {
         let counted_first = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![out]),
+            output: QueryOutput::select(vec![out]),
             patterns: vec![
                 Pattern::Triple(TriplePattern::new(
                     Ref::Var(s),
@@ -3196,7 +3196,7 @@ mod tests {
         let reversed = ParsedQuery {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Select(vec![out]),
+            output: QueryOutput::select(vec![out]),
             patterns: vec![
                 Pattern::Triple(TriplePattern::new(
                     Ref::Var(s),

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -1004,6 +1004,13 @@ pub struct UnresolvedQuery {
     /// For graph crawl queries, this still contains the root variable(s)
     /// needed for execution. The graph_select field controls formatting.
     pub select: Vec<Arc<str>>,
+    /// User-declared projection shape from the input syntax.
+    ///
+    /// `Scalar` for bare-string select (`select: "?x"`), `Tuple` otherwise
+    /// (array form, or SPARQL, which has no scalar form). Propagated into
+    /// `QueryOutput::Select` / `SelectOne` so formatters can decide rendering
+    /// without inferring from `vars.len()`.
+    pub select_shape: crate::parse::lower::ProjectionShape,
     /// Ordered patterns in where clause (triples, filters, optionals, etc.)
     pub patterns: Vec<UnresolvedPattern>,
     /// Query options (limit, offset, order by, group by, etc.)
@@ -1024,6 +1031,7 @@ impl UnresolvedQuery {
             context,
             orig_context: None,
             select: Vec::new(),
+            select_shape: crate::parse::lower::ProjectionShape::default(),
             patterns: Vec::new(),
             options: UnresolvedOptions::default(),
             construct_template: None,

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -32,6 +32,29 @@ use fluree_graph_json_ld::ParsedContext;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+/// Projection shape — how each row should be rendered by row-array formatters.
+///
+/// - `Tuple` (default): every row is an array regardless of arity. This is
+///   the spec-correct shape for SPARQL (solution sequences are tabular) and
+///   for JSON-LD `select: ["?x"]` / `["?x","?y"]` (the user's array wrapper
+///   is preserved end-to-end).
+/// - `Scalar`: 1-var rows flatten to the bare value. JSON-LD sets this only
+///   when the user writes `select: "?x"` (bare string) — an explicit opt-in
+///   to scalar shape. Multi-var `Scalar` is unreachable from the parser.
+///
+/// Formatters that emit row arrays (jsonld, delimited, etc.) consult this to
+/// decide scalar-vs-tuple rendering. Object-based formatters (typed, agent_json)
+/// ignore it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProjectionShape {
+    /// Every row is an array, regardless of arity. Default; used by SPARQL
+    /// and JSON-LD array-form select.
+    #[default]
+    Tuple,
+    /// 1-var rows flatten to scalars. JSON-LD bare-string `select: "?x"`.
+    Scalar,
+}
+
 /// Select mode determines result shape
 ///
 /// This is derived from the parsed query (select vs selectOne vs construct) and controls
@@ -98,10 +121,16 @@ impl ConstructTemplate {
 /// template, or `Many` with an empty variable list) are unrepresentable.
 #[derive(Debug, Clone)]
 pub enum QueryOutput {
-    /// Normal SELECT with explicit variable list.
-    Select(Vec<VarId>),
+    /// Normal SELECT with explicit variable list and projection shape.
+    Select {
+        vars: Vec<VarId>,
+        shape: ProjectionShape,
+    },
     /// selectOne — same as Select but formatters return first row or null.
-    SelectOne(Vec<VarId>),
+    SelectOne {
+        vars: Vec<VarId>,
+        shape: ProjectionShape,
+    },
     /// SELECT * — all bound variables from WHERE.
     Wildcard,
     /// CONSTRUCT — template patterns instantiated with bindings.
@@ -111,10 +140,29 @@ pub enum QueryOutput {
 }
 
 impl QueryOutput {
+    /// Construct a `Select` with the default (`Tuple`) shape.
+    ///
+    /// Used by SPARQL lowering and internal fixtures. JSON-LD bare-string
+    /// `select: "?x"` builds the struct variant directly with `shape: Scalar`.
+    pub fn select(vars: Vec<VarId>) -> Self {
+        Self::Select {
+            vars,
+            shape: ProjectionShape::Tuple,
+        }
+    }
+
+    /// Construct a `SelectOne` with the default (`Tuple`) shape.
+    pub fn select_one(vars: Vec<VarId>) -> Self {
+        Self::SelectOne {
+            vars,
+            shape: ProjectionShape::Tuple,
+        }
+    }
+
     /// Get select vars for Select/SelectOne, `None` otherwise.
     pub fn select_vars(&self) -> Option<&[VarId]> {
         match self {
-            QueryOutput::Select(vars) | QueryOutput::SelectOne(vars) => Some(vars),
+            QueryOutput::Select { vars, .. } | QueryOutput::SelectOne { vars, .. } => Some(vars),
             _ => None,
         }
     }
@@ -122,6 +170,16 @@ impl QueryOutput {
     /// Get select vars, or an empty slice for non-select outputs.
     pub fn select_vars_or_empty(&self) -> &[VarId] {
         self.select_vars().unwrap_or(&[])
+    }
+
+    /// Get the projection shape for Select/SelectOne, `None` otherwise.
+    pub fn projection_shape(&self) -> Option<ProjectionShape> {
+        match self {
+            QueryOutput::Select { shape, .. } | QueryOutput::SelectOne { shape, .. } => {
+                Some(*shape)
+            }
+            _ => None,
+        }
     }
 
     /// Get the construct template for Construct, `None` otherwise.
@@ -134,7 +192,7 @@ impl QueryOutput {
 
     /// Returns `true` for `SelectOne` output.
     pub fn is_select_one(&self) -> bool {
-        matches!(self, Self::SelectOne(_))
+        matches!(self, Self::SelectOne { .. })
     }
 
     /// Returns `true` for `Wildcard` output.
@@ -162,8 +220,12 @@ impl QueryOutput {
     pub fn variables(&self) -> Option<HashSet<VarId>> {
         match self {
             QueryOutput::Wildcard | QueryOutput::Boolean => None,
-            QueryOutput::Select(vars) | QueryOutput::SelectOne(vars) if vars.is_empty() => None,
-            QueryOutput::Select(vars) | QueryOutput::SelectOne(vars) => {
+            QueryOutput::Select { vars, .. } | QueryOutput::SelectOne { vars, .. }
+                if vars.is_empty() =>
+            {
+                None
+            }
+            QueryOutput::Select { vars, .. } | QueryOutput::SelectOne { vars, .. } => {
                 Some(vars.iter().copied().collect())
             }
             QueryOutput::Construct(t) if t.patterns.is_empty() => None,
@@ -305,9 +367,16 @@ pub(crate) fn lower_query<E: IriEncoder>(
     let options = lower_options(&ast.options, vars)?;
 
     // Build QueryOutput from mode + lowered components
+    let shape = ast.select_shape;
     let output = match select_mode {
-        SelectMode::Many => QueryOutput::Select(select_vars),
-        SelectMode::One => QueryOutput::SelectOne(select_vars),
+        SelectMode::Many => QueryOutput::Select {
+            vars: select_vars,
+            shape,
+        },
+        SelectMode::One => QueryOutput::SelectOne {
+            vars: select_vars,
+            shape,
+        },
         SelectMode::Wildcard => QueryOutput::Wildcard,
         SelectMode::Construct => {
             let template = match ast.construct_template {
@@ -1849,7 +1918,7 @@ mod tests {
         assert_eq!(query.output.select_vars().unwrap().len(), 2);
         assert_eq!(query.patterns.len(), 1);
         assert_eq!(vars.len(), 2);
-        assert!(matches!(query.output, QueryOutput::Select(_)));
+        assert!(matches!(query.output, QueryOutput::Select { .. }));
     }
 
     #[test]

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -182,6 +182,21 @@ impl QueryOutput {
         }
     }
 
+    /// Returns `true` iff rows should be flattened from `[v]` to `v` at format
+    /// time. True only when the user opted into scalar output via JSON-LD
+    /// `select: "?x"` (bare-string form) AND there is exactly one projected
+    /// variable. Wildcard, Construct, Boolean, and `Tuple`-shaped Select all
+    /// return `false`, so tabular output (SPARQL + JSON-LD array-form select)
+    /// is preserved.
+    pub fn should_flatten_scalar(&self) -> bool {
+        match self {
+            QueryOutput::Select { vars, shape } | QueryOutput::SelectOne { vars, shape } => {
+                *shape == ProjectionShape::Scalar && vars.len() == 1
+            }
+            _ => false,
+        }
+    }
+
     /// Get the construct template for Construct, `None` otherwise.
     pub fn construct_template(&self) -> Option<&ConstructTemplate> {
         match self {

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -45,7 +45,7 @@ pub use error::{ParseError, Result};
 pub(crate) use lower::{lower_query, SelectMode};
 pub use lower::{
     lower_unresolved_pattern, lower_unresolved_patterns, ConstructTemplate, GraphSelectSpec,
-    NestedSelectSpec, ParsedQuery, QueryOutput, Root, SelectionSpec,
+    NestedSelectSpec, ParsedQuery, ProjectionShape, QueryOutput, Root, SelectionSpec,
 };
 pub use policy::{JsonLdParseCtx, JsonLdParsePolicy};
 pub use where_clause::parse_where_with_counters;
@@ -265,6 +265,14 @@ fn parse_query_ast_internal(
             })
             .collect();
     }
+    // selectOne is semantically "first solution" — enforce LIMIT 1 at the query
+    // level so execution can stop after one row, rather than materializing the
+    // full sequence and discarding the rest at format time. Overrides any
+    // user-provided limit because selectOne intent is unambiguous.
+    if select_mode == SelectMode::One {
+        query.options.limit = Some(1);
+    }
+
     if implied_distinct {
         query.options.distinct = true;
         // select-distinct without explicit order defaults to sorting
@@ -548,6 +556,9 @@ fn parse_select(
     match select {
         // Case 2, 3, 5: Array form - could be simple vars, mixed, or with aggregates
         JsonValue::Array(arr) => {
+            // Record shape: array form always yields tuple rows, regardless of
+            // how many items are inside (`["?x"]` → `[[v1],[v2]]`, not `[v1,v2]`).
+            query.select_shape = ProjectionShape::Tuple;
             for item in arr {
                 match item {
                     JsonValue::String(s) => {
@@ -572,8 +583,9 @@ fn parse_select(
             query.graph_select = Some(spec);
         }
 
-        // Case 1: Single string form: "?x"
+        // Case 1: Single string form: "?x" — bare variable, scalar shape.
         JsonValue::String(s) => {
+            query.select_shape = ProjectionShape::Scalar;
             parse_select_string(s, query)?;
         }
 

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -36,7 +36,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> ParsedQuery {
     let output = if select.is_empty() {
         QueryOutput::Wildcard
     } else {
-        QueryOutput::Select(select)
+        QueryOutput::select(select)
     };
     ParsedQuery {
         context: ParsedContext::default(),

--- a/fluree-db-query/tests/values_bind_union_tests.rs
+++ b/fluree-db-query/tests/values_bind_union_tests.rs
@@ -36,7 +36,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> ParsedQuery {
     let output = if select.is_empty() {
         QueryOutput::Wildcard
     } else {
-        QueryOutput::Select(select)
+        QueryOutput::select(select)
     };
     ParsedQuery {
         context: ParsedContext::default(),

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -232,9 +232,14 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
 
                 // SELECT * should behave like "wildcard select" for JSON-LD-style outputs.
                 // This lets formatters emit object rows keyed by variable name.
+                //
+                // SPARQL solution sequences are tabular by spec — every
+                // `SELECT ?x` is a sequence of single-column rows, not a list
+                // of bare values. Projection shape is `Tuple` (the default of
+                // the `select`/`select_one` helpers).
                 let output = match &select_query.select.variables {
                     SelectVariables::Star => QueryOutput::Wildcard,
-                    _ => QueryOutput::Select(select),
+                    _ => QueryOutput::select(select),
                 };
 
                 Ok(ParsedQuery {


### PR DESCRIPTION
- Output formatter no longer flattens 1-var SELECT results via a `vars.len() == 1` heuristic. Shape is now driven by user-declared projection intent captured at parse time.
- SPARQL results are now spec-correct tabular (`[[v1],[v2]]`), not the previous flat `[v1,v2]`.
- JSON-LD `select: ["?x"]` (array form) now round-trips to array-of-arrays, preserving the user's wrapper; `select: "?x"` (bare string) remains scalar-flat.
- `selectOne` now enforces `LIMIT 1` at parse time (not just format-time break), matching the ASK path.

## Problem

The JSON-LD output formatter at `fluree-db-api/src/format/jsonld.rs:50-59` collapsed 1-variable SELECT results to a flat array whenever `vars.len() == 1`, regardless of input syntax:

```
selectDistinct: "?type"          → ["x", "y"]   (flat)
selectDistinct: ["?type"]        → ["x", "y"]   (flat — wrong; array wrapper discarded)
selectDistinct: ["?s", "?type"]  → [["a","b"],…] (tuple — correct)
```

## Fix

**`ProjectionShape { Tuple, Scalar }`** (new enum in `fluree-db-query/src/parse/lower.rs`) captures the user's declared intent at parse time:

- `Tuple` (default): every row stays an array. Used by SPARQL and JSON-LD array-form select.
- `Scalar`: 1-var rows flatten to bare values. JSON-LD bare-string select only — an explicit opt-in.

`QueryOutput::Select` / `SelectOne` became struct variants carrying `{ vars, shape }`. The formatter's flatten is now gated on `shape == Scalar && vars.len() == 1` instead of `vars.len() == 1` alone. Flattening happens once at the top level; `format_row_array` always emits a `JsonValue::Array` internally.

## Behavior contract

| Input                         | Output (1 var)   | Output (≥2 vars)  |
|-------------------------------|------------------|-------------------|
| `select: "?x"`        | `[v1, v2]`       | n/a               |
| `select: ["?x"]`      | `[[v1],[v2]]`    | `[[a,b],[c,d]]`   |
| `selectOne: "?x"`     | `v1` (LIMIT 1)   | n/a               |
| `selectOne: ["?x"]`   | `[v1]` (LIMIT 1) | `[a,b]` (LIMIT 1) |

`selectOne` now injects `options.limit = Some(1)` at parse time, so execution stops after one row instead of materializing the full sequence and discarding the rest at format time.

## Test fallout & migration

256 test assertions updated across ~35 integration test files plus one unit-test module (`shacl_tests`). Two migration patterns were used:

1. **Bare-string migration** (JSON-LD tests that just wanted values): `"select": ["?x"]` → `"select": "?x"`. Preserves the existing flat assertion; lowest-churn fix. Used by the majority of JSON-LD tests.
2. **Assertion update** (SPARQL tests and multi-var tests): `json!([v1,v2])` → `json!([[v1],[v2]])`. Required for SPARQL — the syntax has no scalar form.

Also removed `normalize_rows_array` helper from `tests/support/mod.rs`. It accepted both flat and tuple shapes (wrapping scalars into 1-element arrays), which meant a regression back to flattening would have silently passed tuple-expecting tests. All 179 call sites migrated to `normalize_rows` (pure sort, shape-preserving). Remaining helpers (`normalize_rows`, `normalize_flat_results`, `normalize_sparql_bindings`) are pure sort / envelope-extraction — not shape-shifters.
