### PR TITLE
feat: Ontology imports via `f:schemaSource` + `owl:imports`

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -74,6 +74,7 @@
   - [ContentId and ContentStore](design/content-id-and-contentstore.md)
   - [Index format](design/index-format.md)
   - [Namespace allocation and fallback modes](design/namespace-allocation.md)
+  - [Ontology imports (`f:schemaSource` + `owl:imports`)](design/ontology-imports.md)
   - [Storage traits](design/storage-traits.md)
 
 - [HTTP API (fluree-db-server)](api/README.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -32,6 +32,10 @@ Binary columnar index format: branch/leaf/leaflet hierarchy, dictionary artifact
 
 How Fluree assigns `ns_code` values for IRIs (prefix trie matching, fallback split modes), including bulk-import preflight mitigation and how the “host-only” fallback persists for future transactions.
 
+### [Ontology imports (`f:schemaSource` + `owl:imports`)](ontology-imports.md)
+
+How the reasoner consumes schema from a named `f:schemaSource` graph and transitively resolves `owl:imports`: resolution order, the `SchemaBundleOverlay` projection, schema-triple whitelist, and caching.
+
 ### [Storage Traits](storage-traits.md)
 
 Storage trait architecture: `StorageRead`, `StorageWrite`, `ContentAddressedWrite`, `Storage`, and `NameService` trait design with guidance for implementing new backends.

--- a/docs/design/ontology-imports.md
+++ b/docs/design/ontology-imports.md
@@ -1,0 +1,244 @@
+# Ontology imports (`f:schemaSource` + `owl:imports`)
+
+Reasoning in Fluree needs to see a ledger's **ontology** — class and
+property hierarchies, OWL axioms — even when those triples don't live in
+the same graph as the instance data being queried. This document describes
+how that binding is configured, resolved, and plumbed into the reasoning
+pipeline.
+
+Topics:
+
+- Config-layer contract (`f:schemaSource`, `f:followOwlImports`,
+  `f:ontologyImportMap`).
+- Resolution algorithm for the `owl:imports` closure.
+- `SchemaBundleOverlay` — how the resolved closure is presented to the
+  reasoner without changing reasoner internals.
+- Caching, error semantics, and the schema-triple whitelist.
+
+Related docs:
+
+- [Query execution and overlay merge](query-execution.md)
+- [Reasoning and inference](../concepts/reasoning.md)
+
+## Configuration
+
+Reasoning config is declared in the ledger's config graph (`g_id=2`), on the
+`f:LedgerConfig` resource's `f:reasoningDefaults`. Three fields drive
+ontology resolution:
+
+```turtle
+@prefix f:    <https://ns.flur.ee/db#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+
+GRAPH <urn:fluree:myapp:main#config> {
+  <urn:myapp:config> a f:LedgerConfig ;
+    f:reasoningDefaults <urn:myapp:config:reasoning> .
+
+  <urn:myapp:config:reasoning>
+    f:reasoningModes ( "rdfs" "owl2-rl" ) ;
+    f:schemaSource <urn:myapp:config:schema-ref> ;
+    f:followOwlImports true ;
+    f:ontologyImportMap <urn:myapp:config:bfo-binding> .
+
+  <urn:myapp:config:schema-ref> a f:GraphRef ;
+    f:graphSource <urn:myapp:config:schema-source> .
+  <urn:myapp:config:schema-source>
+    f:graphSelector <http://example.org/ontology/core> .
+
+  <urn:myapp:config:bfo-binding>
+    f:ontologyIri <http://purl.obolibrary.org/obo/bfo.owl> ;
+    f:graphRef   <urn:myapp:config:bfo-ref> .
+  <urn:myapp:config:bfo-ref> a f:GraphRef ;
+    f:graphSource <urn:myapp:config:bfo-source> .
+  <urn:myapp:config:bfo-source>
+    f:graphSelector <http://example.org/ontology/local/bfo> .
+}
+```
+
+Field reference:
+
+| Field                    | Type                            | Meaning |
+|--------------------------|---------------------------------|---------|
+| `f:schemaSource`         | `f:GraphRef`                    | Starting graph for schema extraction. When absent, reasoning uses the default graph directly. |
+| `f:followOwlImports`     | `xsd:boolean`                   | When `true`, resolve the transitive closure of `owl:imports` triples starting from `f:schemaSource`. When absent or `false`, the bundle contains only the starting graph. |
+| `f:ontologyImportMap`    | list of `OntologyImportBinding` | Mapping table from external ontology IRIs to local graphs. Consulted when an `owl:imports` IRI doesn't match a named graph in the current ledger. |
+
+An `OntologyImportBinding` has two fields:
+
+- `f:ontologyIri` — the IRI that appears in `owl:imports` statements.
+- `f:graphRef` — a nested `f:GraphRef` identifying the local graph.
+
+The `GraphRef` shape supported for `f:schemaSource` and
+`f:ontologyImportMap.graphRef` is the same-ledger shape:
+`f:graphSelector` naming a local named graph, `f:defaultGraph`, or a
+registered graph IRI. References are resolved at the query's effective
+`to_t` — every named graph in a Fluree ledger shares the ledger's
+monotonic `t`, so the entire closure is consistent at a single point in
+time without per-import bookkeeping.
+
+## Resolution algorithm
+
+For each `owl:imports <X>` triple discovered while walking the closure, the
+resolver (`fluree_db_api::ontology_imports::resolve_schema_bundle`) applies
+this order:
+
+1. **Named-graph match** — if `<X>` is registered as a graph IRI in the
+   current ledger's [`GraphRegistry`], resolve to that `GraphId`.
+2. **Mapping-table fallback** — if `<X>` appears in `f:ontologyImportMap`,
+   resolve via the bound `GraphSourceRef`.
+3. **Strict error** — otherwise, fail the query with
+   `ApiError::OntologyImport`. There is no silent skip.
+
+The walk is BFS, deduplicated by resolved `GraphId`, and cycle-safe by
+construction (we only push unseen IDs onto the queue). The result is a
+`ResolvedSchemaBundle { ledger_id, to_t, sources: Vec<GraphId> }`.
+
+### System graphs are off-limits
+
+Imports resolving to `CONFIG_GRAPH_ID` (g_id=2) or `TXN_META_GRAPH_ID`
+(g_id=1) are rejected — those graphs are structurally reserved and would
+leak framework triples into reasoning. The guard sits in the single
+`resolve_local_graph_source` chokepoint, so **every** resolution path
+(direct graph-IRI match, `f:ontologyImportMap` entry, `f:schemaSource`
+selector) is covered.
+
+### `owl:imports` discovery is subject-wildcarded
+
+Every `?s owl:imports ?o` triple in a schema graph is treated as
+authoritative, regardless of whether `?s` is typed `owl:Ontology`. This is
+broader than strict OWL 2 (which restricts `owl:imports` to the ontology
+header) and matches real-world OWL inputs that rely on file-level
+provenance. The resolution layer's strictness still applies: a stray
+`owl:imports` triple that doesn't map to a local graph fails the query
+rather than silently expanding the closure.
+
+### Reasoning-disabled queries don't trigger resolution
+
+Queries that opt out of reasoning (`"reasoning": "none"`) skip bundle
+resolution entirely — a broken ontology import in the ledger's config
+shouldn't produce errors for a non-reasoning workload. The short-circuit
+lives in `attach_schema_bundle` (both the single-view and dataset paths).
+
+## Projecting the bundle into reasoning
+
+RDFS and OWL extraction code reads schema triples out of the default graph
+(`g_id=0`). The resolver feeds that code via a
+[`SchemaBundleOverlay`](../../fluree-db-query/src/schema_bundle.rs) that
+**projects** whitelisted triples from every bundle source onto `g_id=0`,
+so the reasoner sees the full closure without being aware of it.
+
+The projection happens in two phases:
+
+1. **Materialize.** `build_schema_bundle_flakes` runs targeted reads against
+   every source graph — one PSOT scan per schema predicate and one OPST
+   scan per schema class — and collects the matching flakes into per-index
+   sorted arrays (SPOT / PSOT / POST / OPST). Reads go through the normal
+   `range_with_overlay` path, so both committed index data and novelty are
+   visible.
+2. **Overlay.** `SchemaBundleOverlay::new(base_overlay, flakes)` wraps the
+   query's base overlay. For `g_id != 0` it delegates straight to the
+   base. For `g_id == 0` it emits a linear merge of base flakes and
+   bundle flakes in index order.
+
+The reasoner sees: base default-graph flakes ∪ projected schema flakes,
+presented as a single ordered stream at `g_id=0`. Reasoner code is
+unmodified.
+
+### Schema-triple whitelist
+
+Only the following predicates are eligible for projection:
+
+- **RDFS:** `rdfs:subClassOf`, `rdfs:subPropertyOf`, `rdfs:domain`, `rdfs:range`
+- **OWL:** `owl:inverseOf`, `owl:equivalentClass`, `owl:equivalentProperty`,
+  `owl:sameAs`, `owl:imports`
+
+And `rdf:type` triples are projected **only when the object is** one of:
+`owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`,
+`owl:SymmetricProperty`, `owl:TransitiveProperty`, `owl:FunctionalProperty`,
+`owl:InverseFunctionalProperty`, `owl:Ontology`, `rdf:Property`.
+
+Anything else in an import graph — in particular, instance data —
+**does not surface** in the reasoner's view. See
+`fluree_db_core::{is_schema_predicate, is_schema_class}` for the canonical
+checks and
+`fluree-db-api/tests/it_reasoning_imports.rs::instance_data_in_schema_graph_does_not_leak`
+for the regression test.
+
+## Caching
+
+`global_schema_bundle_cache()` is a process-wide `moka::sync::Cache` keyed
+by:
+
+- `ledger_id: Arc<str>`
+- `to_t: i64`
+- `starting_g_id: GraphId` (the resolved `f:schemaSource`)
+- `follow_imports: bool`
+
+Because config lives in the same ledger (g_id=2) and any config change
+advances `t`, the `to_t` dimension is sufficient to express "config
+version" — there is no separate config_epoch key, and no explicit
+invalidation logic. Stale entries age out via LRU.
+
+The cache stores the **resolution result** (`Vec<GraphId>`); the projected
+flake arrays are rebuilt per query. Materialization is cheap relative to
+reasoning itself, and keeping the cached value small lets many entries
+coexist for many ledgers without memory pressure.
+
+## Error semantics
+
+`ApiError::OntologyImport` is raised when the configured closure is
+invalid. Every message identifies the offending resource and suggests
+remediation. Queries fail rather than silently returning reduced results,
+so broken ontology references surface early. Sources of this error:
+
+- An `owl:imports <X>` that doesn't match a local named graph and has no
+  `f:ontologyImportMap` entry.
+- A resolution that would land on a reserved system graph (config or
+  txn-meta), whether via direct graph-IRI match, mapping table, or
+  `f:schemaSource` selector.
+- A `GraphRef` that targets a different ledger, uses `f:atT`, or carries a
+  `f:trustPolicy` / `f:rollbackGuard`. The bundle is resolved at the
+  query's single `to_t`, same-ledger scope only, and accepting these
+  fields silently would create a gap between declared intent and actual
+  behavior.
+
+## Wiring at query time
+
+`Fluree::query(&db, ...)` (and the dataset-query counterpart) call
+`build_executable_for_view` → `attach_schema_bundle` on every query. The
+attach step:
+
+1. Reads `db.resolved_config().reasoning`. If there is no `f:schemaSource`,
+   returns immediately — the legacy default-graph path applies unchanged.
+2. Calls `resolve_schema_bundle` for the closure, consulting the cache.
+3. Materializes `SchemaBundleFlakes` via `build_schema_bundle_flakes`.
+4. Sets `executable.options.schema_bundle` so `prepare_execution` wraps
+   `db.overlay` in a `SchemaBundleOverlay` for the reasoning_prep block.
+
+Downstream, `schema_hierarchy_with_overlay`, `reason_owl2rl`, and
+`Ontology::from_db_with_overlay` all receive the same wrapped overlay and
+see the full closure on `g_id=0` reads.
+
+## Testing
+
+The acceptance suite lives in
+`fluree-db-api/tests/it_reasoning_imports.rs` and covers:
+
+- Same-ledger auto resolution of a named schema source.
+- Transitive `A → B` with a subclass edge in `B`.
+- Mapping table fallback for external IRIs.
+- Unresolved imports surface as `ApiError::OntologyImport`.
+- Cycle `A → B → A` terminates and still yields the correct closure.
+- Mapping entries that would target a reserved system graph are rejected.
+- `"reasoning": "none"` queries skip resolution entirely (no spurious
+  errors from unrelated config).
+- `f:atT` on a `GraphRef` is rejected with a clear message.
+- Instance data in the schema graph does **not** leak into query results.
+- **End-to-end OWL2-RL rule firing through a transitive import:**
+  `owl:TransitiveProperty`, `owl:inverseOf`, and `rdfs:domain` axioms
+  declared in an imported graph produce the expected entailments against
+  instance data in the default graph.
+
+Module-level unit tests cover the cache keys, empty-bundle passthrough,
+and non-default-graph delegation.

--- a/fluree-db-api/src/config_resolver.rs
+++ b/fluree-db-api/src/config_resolver.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 
 use fluree_db_core::ledger_config::{
     DatalogDefaults, FullTextDefaults, FullTextProperty, GraphConfig, GraphSourceRef, LedgerConfig,
-    OverrideControl, PolicyDefaults, ReasoningDefaults, ResolvedConfig, RollbackGuard,
-    ShaclDefaults, TransactDefaults, TrustMode, TrustPolicy, ValidationMode,
+    OntologyImportBinding, OverrideControl, PolicyDefaults, ReasoningDefaults, ResolvedConfig,
+    RollbackGuard, ShaclDefaults, TransactDefaults, TrustMode, TrustPolicy, ValidationMode,
 };
 use fluree_db_core::{GraphDbRef, LedgerSnapshot, OverlayProvider, Sid, CONFIG_GRAPH_ID};
 use fluree_db_query::{
@@ -524,9 +524,21 @@ impl MergeableGroup for ReasoningDefaults {
     }
 
     fn merge_over(&self, base: &Self) -> Self {
+        // `ontology_import_map`: per-graph additions extend ledger-wide bindings.
+        // Per-graph entries come first so they win on duplicate ontology IRIs.
+        let mut import_map = self.ontology_import_map.clone();
+        let existing: std::collections::HashSet<String> =
+            import_map.iter().map(|b| b.ontology_iri.clone()).collect();
+        for b in &base.ontology_import_map {
+            if !existing.contains(&b.ontology_iri) {
+                import_map.push(b.clone());
+            }
+        }
         ReasoningDefaults {
             modes: self.modes.clone().or(base.modes.clone()),
             schema_source: self.schema_source.clone().or(base.schema_source.clone()),
+            follow_owl_imports: self.follow_owl_imports.or(base.follow_owl_imports),
+            ontology_import_map: import_map,
             override_control: base.override_control.effective_min(&self.override_control),
         }
     }
@@ -938,13 +950,95 @@ async fn read_reasoning_defaults(
         config_iris::SCHEMA_SOURCE,
     )
     .await?;
+    let follow_owl_imports = read_bool_field(
+        snapshot,
+        overlay,
+        to_t,
+        &group_sid,
+        config_iris::FOLLOW_OWL_IMPORTS,
+    )
+    .await?;
+    let ontology_import_map = read_ontology_import_map(snapshot, overlay, to_t, &group_sid).await?;
     let override_control = read_override_control(snapshot, overlay, to_t, &group_sid).await?;
 
     Ok(Some(ReasoningDefaults {
         modes,
         schema_source,
+        follow_owl_imports,
+        ontology_import_map,
         override_control,
     }))
+}
+
+/// Read an `f:ontologyImportMap` as a list of [`OntologyImportBinding`].
+///
+/// Each binding subject has:
+/// - `f:ontologyIri` — the external import IRI (IRI ref)
+/// - `f:graphRef` — nested `f:GraphRef` resolved via [`read_single_graph_ref_from_sid`]
+///
+/// Bindings missing either field are skipped with a debug log rather than
+/// failing the whole config read — strict error semantics live at the
+/// resolution layer in `fluree-db-api::ontology_imports`.
+async fn read_ontology_import_map(
+    snapshot: &LedgerSnapshot,
+    overlay: &dyn OverlayProvider,
+    to_t: i64,
+    parent_sid: &Sid,
+) -> Result<Vec<OntologyImportBinding>> {
+    let pred_sid = match try_encode(snapshot, config_iris::ONTOLOGY_IMPORT_MAP) {
+        Some(sid) => sid,
+        None => return Ok(Vec::new()),
+    };
+
+    let bindings = query_config_predicate(snapshot, overlay, to_t, parent_sid, &pred_sid).await?;
+
+    let mut result = Vec::new();
+    for binding in bindings {
+        let Some(entry_sid) = binding.as_sid() else {
+            continue;
+        };
+        let Some(ontology_iri) = read_iri_field(
+            snapshot,
+            overlay,
+            to_t,
+            entry_sid,
+            config_iris::ONTOLOGY_IRI,
+        )
+        .await?
+        else {
+            tracing::debug!("f:ontologyImportMap entry missing f:ontologyIri — skipping");
+            continue;
+        };
+        let Some(graph_ref_sid) = read_ref_field(
+            snapshot,
+            overlay,
+            to_t,
+            entry_sid,
+            config_iris::GRAPH_REF_PROP,
+        )
+        .await?
+        else {
+            tracing::debug!(
+                ontology_iri = %ontology_iri,
+                "f:ontologyImportMap entry missing f:graphRef — skipping"
+            );
+            continue;
+        };
+        let Some(graph_ref) =
+            read_single_graph_ref_from_sid(snapshot, overlay, to_t, &graph_ref_sid).await?
+        else {
+            tracing::debug!(
+                ontology_iri = %ontology_iri,
+                "f:ontologyImportMap entry's f:graphRef could not be resolved — skipping"
+            );
+            continue;
+        };
+        result.push(OntologyImportBinding {
+            ontology_iri,
+            graph_ref,
+        });
+    }
+    Ok(result)
 }
 
 /// Read datalog defaults from a parent subject.

--- a/fluree-db-api/src/error.rs
+++ b/fluree-db-api/src/error.rs
@@ -187,6 +187,16 @@ pub enum ApiError {
     #[error("Invalid configuration: {0}")]
     Config(String),
 
+    /// Unresolved `owl:imports` in the reasoning schema closure.
+    ///
+    /// Produced when a graph reachable from `f:schemaSource` declares
+    /// `owl:imports <iri>` that cannot be resolved — the IRI is neither a
+    /// named graph in the current ledger nor listed in
+    /// `f:ontologyImportMap`. Import chains are strict: unresolved imports
+    /// fail the query rather than being silently ignored.
+    #[error("Unresolved owl:imports: {0}")]
+    OntologyImport(String),
+
     /// Result formatting errors
     #[error("Format error: {0}")]
     Format(#[from] FormatError),

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -59,6 +59,7 @@ pub mod ledger_info;
 mod merge;
 pub mod nameservice_query;
 pub(crate) mod ns_helpers;
+pub mod ontology_imports;
 mod overlay;
 pub mod pack;
 pub mod policy_builder;

--- a/fluree-db-api/src/ontology_imports.rs
+++ b/fluree-db-api/src/ontology_imports.rs
@@ -422,6 +422,116 @@ pub fn global_schema_bundle_cache() -> &'static SchemaBundleCache {
     CACHE.get_or_init(SchemaBundleCache::default)
 }
 
+// ============================================================================
+// Flakes cache
+// ============================================================================
+
+/// Cache key for [`SchemaBundleFlakesCache`].
+///
+/// Derived directly from a [`ResolvedSchemaBundle`]: same `(ledger_id, to_t)`
+/// lifetime as the bundle cache, plus the resolved source graph list so two
+/// bundles resolving to the same sources share materialized flakes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SchemaBundleFlakesCacheKey {
+    pub ledger_id: Arc<str>,
+    pub to_t: i64,
+    pub sources: Vec<GraphId>,
+}
+
+/// Process-global LRU cache of materialized schema-bundle flakes.
+///
+/// `build_schema_bundle_flakes` does ~18 overlay range reads per source graph
+/// (schema predicates + schema classes); with `f:schemaSource` configured
+/// every query would repeat that work for the same `(ledger_id, to_t,
+/// sources)` triple. Since the inputs are immutable at a given `t` and any
+/// config change advances `t`, a plain LRU cache is sufficient — no
+/// invalidation.
+pub struct SchemaBundleFlakesCache {
+    inner: moka::sync::Cache<
+        SchemaBundleFlakesCacheKey,
+        Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>,
+    >,
+}
+
+impl SchemaBundleFlakesCache {
+    /// Capacity parallels `SchemaBundleCache`: one flakes entry per bundle
+    /// entry in steady state.
+    const DEFAULT_CAPACITY: u64 = 1024;
+
+    pub fn with_capacity(capacity: u64) -> Self {
+        Self {
+            inner: moka::sync::Cache::new(capacity),
+        }
+    }
+
+    pub fn get(
+        &self,
+        key: &SchemaBundleFlakesCacheKey,
+    ) -> Option<Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>> {
+        self.inner.get(key)
+    }
+
+    pub fn insert(
+        &self,
+        key: SchemaBundleFlakesCacheKey,
+        flakes: Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>,
+    ) {
+        self.inner.insert(key, flakes);
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.inner.invalidate_all();
+        self.inner.run_pending_tasks();
+    }
+}
+
+impl Default for SchemaBundleFlakesCache {
+    fn default() -> Self {
+        Self::with_capacity(Self::DEFAULT_CAPACITY)
+    }
+}
+
+/// Process-global schema-bundle flakes cache.
+pub fn global_schema_bundle_flakes_cache() -> &'static SchemaBundleFlakesCache {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<SchemaBundleFlakesCache> = OnceLock::new();
+    CACHE.get_or_init(SchemaBundleFlakesCache::default)
+}
+
+/// Fetch-or-build materialized schema-bundle flakes for a resolved bundle.
+///
+/// On a cache hit, returns the shared `Arc<SchemaBundleFlakes>` without any
+/// overlay reads. On a miss, calls
+/// [`fluree_db_query::schema_bundle::build_schema_bundle_flakes`] and stores
+/// the result.
+pub async fn get_or_build_schema_bundle_flakes(
+    snapshot: &LedgerSnapshot,
+    overlay: &dyn OverlayProvider,
+    bundle: &ResolvedSchemaBundle,
+) -> Result<Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>> {
+    let key = SchemaBundleFlakesCacheKey {
+        ledger_id: bundle.ledger_id.clone(),
+        to_t: bundle.to_t,
+        sources: bundle.sources.clone(),
+    };
+    if let Some(cached) = global_schema_bundle_flakes_cache().get(&key) {
+        return Ok(cached);
+    }
+
+    let flakes = fluree_db_query::schema_bundle::build_schema_bundle_flakes(
+        snapshot,
+        overlay,
+        bundle.to_t,
+        &bundle.sources,
+    )
+    .await
+    .map_err(|e| ApiError::OntologyImport(format!("failed to materialize schema bundle: {e}")))?;
+    let flakes = Arc::new(flakes);
+    global_schema_bundle_flakes_cache().insert(key, flakes.clone());
+    Ok(flakes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fluree-db-api/src/ontology_imports.rs
+++ b/fluree-db-api/src/ontology_imports.rs
@@ -1,0 +1,527 @@
+//! Resolve the schema-bundle closure driven by `f:schemaSource` and `owl:imports`.
+//!
+//! # What this does
+//!
+//! Given a resolved [`ReasoningDefaults`], walk from the configured
+//! `f:schemaSource` through the transitive closure of `owl:imports` triples
+//! and produce a deduped list of local graph IDs that together constitute
+//! the schema for reasoning. The result is a [`ResolvedSchemaBundle`] that
+//! the query runner feeds into a `SchemaBundleOverlay` so the existing
+//! RDFS/OWL-RL/OWL-QL extraction code can operate unchanged.
+//!
+//! # Resolution order for each `owl:imports` IRI
+//!
+//! 1. **Named graph IRI match** — the import IRI is registered as a graph in
+//!    the current ledger's [`GraphRegistry`]. Resolve to that `GraphId`.
+//! 2. **Explicit mapping** — the import IRI appears in
+//!    `f:ontologyImportMap`; resolve via the bound [`GraphSourceRef`].
+//! 3. **Error** — strict: unresolved imports fail the query. There is no
+//!    silent skip.
+//!
+//! Imports resolve to graphs within the same ledger. A `GraphSourceRef`
+//! that names a different ledger is rejected with a clear error; same
+//! treatment for `f:atT`, `f:trustPolicy`, and `f:rollbackGuard`, which are
+//! parsed by the config layer but not honored by bundle resolution.
+//!
+//! # `at_t` / temporal semantics
+//!
+//! Every named graph in a Fluree ledger advances together at the ledger's
+//! monotonic `t`, so the entire closure is resolved at the query's
+//! effective `to_t` — one number, one consistent view, no per-import
+//! bookkeeping.
+//!
+//! # Caching
+//!
+//! The bundle is cached keyed by `(ledger_id, to_t, starting_g_id,
+//! follow_imports)` via a process-global [`SchemaBundleCache`]. Because
+//! ledger config lives in the config graph (g_id=2) of the same ledger,
+//! any config change advances `t` and naturally invalidates older cache
+//! entries; no explicit invalidation is needed.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+
+use fluree_db_core::graph_registry::{CONFIG_GRAPH_ID, DEFAULT_GRAPH_ID, TXN_META_GRAPH_ID};
+use fluree_db_core::ledger_config::{GraphSourceRef, ReasoningDefaults};
+use fluree_db_core::{GraphDbRef, GraphId, LedgerSnapshot, OverlayProvider};
+use fluree_db_query::{execute_pattern_with_overlay_at, Ref, Term, TriplePattern, VarRegistry};
+use fluree_vocab::config_iris;
+
+use crate::error::{ApiError, Result};
+
+/// The resolved schema-graph closure for a query.
+///
+/// Produced by [`resolve_schema_bundle`] from a [`ReasoningDefaults`] that
+/// configures `f:schemaSource` (and optionally follows `owl:imports`).
+///
+/// All `sources` belong to the same ledger (`ledger_id`) at the same logical
+/// point-in-time (`to_t`) — guaranteed by the same-ledger resolution rule.
+#[derive(Debug, Clone)]
+pub struct ResolvedSchemaBundle {
+    /// Ledger the bundle was resolved against.
+    pub ledger_id: Arc<str>,
+    /// Logical `t` at which the closure was walked.
+    pub to_t: i64,
+    /// Deduplicated graph IDs in BFS discovery order; the starting graph
+    /// (from `f:schemaSource`) is always first.
+    pub sources: Vec<GraphId>,
+}
+
+/// Resolve the schema bundle for a query.
+///
+/// Returns `Ok(None)` when no bundle is needed — typically because
+/// `reasoning.schema_source` is not configured, in which case the caller
+/// should keep the existing default-graph behavior.
+///
+/// When `schema_source` is configured, always returns `Ok(Some(_))`; the
+/// returned bundle always includes the starting graph. Imports are only
+/// walked when `follow_owl_imports` is `true` (or, when unset, the caller
+/// opts in at its own discretion).
+///
+/// Errors with [`ApiError::OntologyImport`] on:
+/// - an unresolved `owl:imports` IRI,
+/// - an `f:schemaSource` whose `graph_selector` cannot be resolved locally,
+/// - a `GraphSourceRef` that targets a different ledger, sets `f:atT`, or
+///   carries a `f:trustPolicy` / `f:rollbackGuard` — see
+///   [`resolve_local_graph_source`] for the full list of enforced invariants.
+pub async fn resolve_schema_bundle(
+    snapshot: &LedgerSnapshot,
+    overlay: &dyn OverlayProvider,
+    to_t: i64,
+    reasoning: &ReasoningDefaults,
+) -> Result<Option<Arc<ResolvedSchemaBundle>>> {
+    let Some(schema_source) = reasoning.schema_source.as_ref() else {
+        return Ok(None);
+    };
+
+    let starting_g_id = resolve_local_graph_source(snapshot, schema_source)?;
+
+    let follow_imports = reasoning.follow_owl_imports.unwrap_or(false);
+
+    // Cache lookup — keyed on (ledger_id, to_t, starting_g_id). Different
+    // `follow_owl_imports` / import-map settings change `t` (because config
+    // is transactional) so they don't need separate key dimensions.
+    let cache_key = SchemaBundleCacheKey {
+        ledger_id: Arc::from(snapshot.ledger_id.as_str()),
+        to_t,
+        starting_g_id,
+        follow_imports,
+    };
+    if let Some(cached) = global_schema_bundle_cache().get(&cache_key) {
+        return Ok(Some(cached));
+    }
+
+    // BFS walk the import closure.
+    let mut sources: Vec<GraphId> = vec![starting_g_id];
+    let mut seen: HashSet<GraphId> = HashSet::from([starting_g_id]);
+
+    if follow_imports {
+        let mut queue: VecDeque<GraphId> = VecDeque::from([starting_g_id]);
+        while let Some(g_id) = queue.pop_front() {
+            for import_iri in scan_owl_imports_in_graph(snapshot, overlay, to_t, g_id).await? {
+                let resolved = resolve_import_iri(snapshot, reasoning, &import_iri)?;
+                if seen.insert(resolved) {
+                    sources.push(resolved);
+                    queue.push_back(resolved);
+                }
+                // If `seen` already contained it, BFS naturally handles the cycle.
+            }
+        }
+    }
+
+    let bundle = Arc::new(ResolvedSchemaBundle {
+        ledger_id: Arc::from(snapshot.ledger_id.as_str()),
+        to_t,
+        sources,
+    });
+    global_schema_bundle_cache().insert(cache_key, bundle.clone());
+
+    Ok(Some(bundle))
+}
+
+/// Resolve a `GraphSourceRef` to a local `GraphId` in the current ledger.
+///
+/// Central chokepoint for the three invariants applied to every
+/// `f:schemaSource` or `f:ontologyImportMap` entry:
+///
+/// - **Same-ledger resolution.** Refs targeting a different ledger are
+///   rejected with a clear error.
+/// - **No reserved system graphs.** Resolving to `g_id=1` (txn-meta) or
+///   `g_id=2` (config) is always an error — those graphs hold framework
+///   triples that must not be mixed into the reasoning view.
+/// - **No unsupported `GraphSourceRef` fields.** `at_t`, `trust_policy`,
+///   and `rollback_guard` are accepted by the config parser but not
+///   honored by bundle resolution; setting any of them is rejected so
+///   misconfigurations surface immediately rather than running with a
+///   silent behavior gap.
+fn resolve_local_graph_source(
+    snapshot: &LedgerSnapshot,
+    source: &GraphSourceRef,
+) -> Result<GraphId> {
+    if let Some(ledger) = source.ledger.as_deref() {
+        if ledger != snapshot.ledger_id {
+            return Err(ApiError::OntologyImport(format!(
+                "schema/import sources must resolve within the current \
+                 ledger (ref targets ledger '{ledger}', current ledger is \
+                 '{}'). Move the schema into the current ledger.",
+                snapshot.ledger_id
+            )));
+        }
+    }
+
+    // Unsupported `GraphSourceRef` fields: reject rather than silently
+    // ignore. Accepting these would make the user think they'd pinned a
+    // specific `at_t` or constrained trust, while in reality the bundle
+    // is resolved at the query's `to_t` with no trust checks.
+    if source.at_t.is_some() {
+        return Err(ApiError::OntologyImport(
+            "`f:atT` on an `f:schemaSource` / `f:ontologyImportMap` graph \
+             ref is not honored — the schema closure resolves at the query's \
+             `to_t`. Remove the pin."
+                .to_string(),
+        ));
+    }
+    if source.trust_policy.is_some() {
+        return Err(ApiError::OntologyImport(
+            "`f:trustPolicy` on an `f:schemaSource` / `f:ontologyImportMap` \
+             graph ref is not honored — same-ledger resolution requires no \
+             separate trust verification. Remove the trust policy."
+                .to_string(),
+        ));
+    }
+    if source.rollback_guard.is_some() {
+        return Err(ApiError::OntologyImport(
+            "`f:rollbackGuard` on an `f:schemaSource` / `f:ontologyImportMap` \
+             graph ref is not honored — rollback semantics apply to \
+             cross-ledger refs, which aren't used by bundle resolution. \
+             Remove the guard."
+                .to_string(),
+        ));
+    }
+
+    let g_id = match source.graph_selector.as_deref() {
+        None => DEFAULT_GRAPH_ID,
+        Some(sel) if sel == config_iris::DEFAULT_GRAPH => DEFAULT_GRAPH_ID,
+        Some(sel) if sel == config_iris::TXN_META_GRAPH => TXN_META_GRAPH_ID,
+        Some(sel) => snapshot
+            .graph_registry
+            .graph_id_for_iri(sel)
+            .ok_or_else(|| {
+                ApiError::OntologyImport(format!(
+                    "f:schemaSource / f:graphRef points to graph '{sel}' \
+                     which is not a named graph in ledger '{}'. \
+                     Add a mapping via f:ontologyImportMap or change the \
+                     selector to match a local graph.",
+                    snapshot.ledger_id
+                ))
+            })?,
+    };
+
+    // Reject resolution to a reserved system graph, regardless of how we
+    // arrived here (direct `f:graphSelector <f:txnMetaGraph>`, mapped
+    // import, or a user graph IRI that happens to be registered at g_id=1/2).
+    reject_if_system_graph(g_id)?;
+    Ok(g_id)
+}
+
+/// Gate any resolved `GraphId` against the reserved-system-graph list.
+///
+/// Called at the single chokepoint (`resolve_local_graph_source`) so the
+/// check can't be bypassed by a new resolution path in the future.
+fn reject_if_system_graph(g_id: GraphId) -> Result<()> {
+    if g_id == CONFIG_GRAPH_ID || g_id == TXN_META_GRAPH_ID {
+        return Err(ApiError::OntologyImport(format!(
+            "schema/import resolution landed on a reserved system graph \
+             (g_id={g_id}); refusing to use it as a schema source."
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve an `owl:imports <X>` IRI to a local `GraphId`.
+///
+/// Resolution order:
+/// 1. `X` is a named graph IRI in the current ledger.
+/// 2. `X` has an entry in `f:ontologyImportMap` whose `graph_ref` resolves
+///    locally.
+/// 3. Otherwise, strict error.
+///
+/// The reserved-system-graph guard lives in [`resolve_local_graph_source`],
+/// so both resolution paths (direct registry lookup and mapping-table
+/// fallback) are covered by the single check.
+fn resolve_import_iri(
+    snapshot: &LedgerSnapshot,
+    reasoning: &ReasoningDefaults,
+    import_iri: &str,
+) -> Result<GraphId> {
+    if let Some(g_id) = snapshot.graph_registry.graph_id_for_iri(import_iri) {
+        reject_if_system_graph(g_id)?;
+        return Ok(g_id);
+    }
+
+    if let Some(binding) = reasoning
+        .ontology_import_map
+        .iter()
+        .find(|b| b.ontology_iri == import_iri)
+    {
+        return resolve_local_graph_source(snapshot, &binding.graph_ref);
+    }
+
+    Err(ApiError::OntologyImport(format!(
+        "owl:imports <{import_iri}> could not be resolved: not a named \
+         graph in ledger '{}' and not present in f:ontologyImportMap. \
+         Add a mapping entry or change the import IRI to match a local graph.",
+        snapshot.ledger_id
+    )))
+}
+
+/// Find every object IRI of `owl:imports` within a single graph at `to_t`.
+///
+/// # Subject is wildcarded (deliberate, broader than OWL header semantics)
+///
+/// Every `?s owl:imports ?o` triple in the graph is treated as
+/// authoritative, **regardless of whether `?s` carries an
+/// `rdf:type owl:Ontology` assertion**. Strict OWL 2 would restrict
+/// `owl:imports` to the ontology-header triple, but:
+///
+/// - Many real-world OWL files omit the `owl:Ontology` type assertion and
+///   rely on file-level provenance instead; matching only typed ontologies
+///   would silently break those inputs.
+/// - The resolution layer is already strict: every resolved import lands
+///   on a specific local graph, so a stray/garbage `owl:imports` triple
+///   fails the query rather than silently expanding the closure.
+///
+/// The tradeoff: a stray `owl:imports` triple sneaked into a schema graph
+/// will turn into a hard `ApiError::OntologyImport`. That's the intended
+/// failure mode — users see the broken reference immediately instead of
+/// inheriting it as silent schema.
+async fn scan_owl_imports_in_graph(
+    snapshot: &LedgerSnapshot,
+    overlay: &dyn OverlayProvider,
+    to_t: i64,
+    g_id: GraphId,
+) -> Result<Vec<String>> {
+    let Some(imports_pred_sid) = snapshot.encode_iri(fluree_vocab::owl::IMPORTS) else {
+        // The namespace/name has never been seen in this ledger — no imports possible.
+        return Ok(Vec::new());
+    };
+
+    let mut vars = VarRegistry::new();
+    let subj_var = vars.get_or_insert("?s");
+    let obj_var = vars.get_or_insert("?o");
+
+    let pattern = TriplePattern::new(
+        Ref::Var(subj_var),
+        Ref::Sid(imports_pred_sid),
+        Term::Var(obj_var),
+    );
+
+    let db = GraphDbRef::new(snapshot, g_id, overlay, to_t).eager();
+    let batches = execute_pattern_with_overlay_at(db, &vars, pattern, None)
+        .await
+        .map_err(|e| {
+            ApiError::OntologyImport(format!("failed to scan owl:imports in graph {g_id}: {e}"))
+        })?;
+
+    let mut iris = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for batch in &batches {
+        for row in 0..batch.len() {
+            let Some(binding) = batch.get(row, obj_var) else {
+                continue;
+            };
+            let Some(sid) = binding.as_sid() else {
+                continue;
+            };
+            let Some(iri) = snapshot.decode_sid(sid) else {
+                continue;
+            };
+            if seen.insert(iri.clone()) {
+                iris.push(iri);
+            }
+        }
+    }
+    Ok(iris)
+}
+
+// ============================================================================
+// Cache
+// ============================================================================
+
+/// Cache key for [`SchemaBundleCache`].
+///
+/// `to_t` naturally captures config changes (the config graph lives in the
+/// same ledger, so any config edit advances `t`). No separate "config
+/// version" dimension is needed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SchemaBundleCacheKey {
+    /// Ledger the bundle was resolved against.
+    pub ledger_id: Arc<str>,
+    /// Query "as-of" `t`.
+    pub to_t: i64,
+    /// The `f:schemaSource` starting `GraphId`. Per-graph overrides can
+    /// point different queries at different schema sources in the same
+    /// ledger, so we key separately.
+    pub starting_g_id: GraphId,
+    /// Whether the closure was walked via `owl:imports`; a closure with
+    /// `follow_imports=false` is just `[starting_g_id]` and must not be
+    /// reused at a query that requests the full closure.
+    pub follow_imports: bool,
+}
+
+/// Process-global LRU cache of resolved schema bundles.
+///
+/// Backed by `moka::sync::Cache`. Entries have no TTL — eviction is purely
+/// by LRU capacity; stale entries age out naturally as new (ledger, t)
+/// combinations dominate.
+pub struct SchemaBundleCache {
+    inner: moka::sync::Cache<SchemaBundleCacheKey, Arc<ResolvedSchemaBundle>>,
+}
+
+impl SchemaBundleCache {
+    /// Capacity chosen to cover hundreds of active ledgers at a handful of
+    /// recent `t` values each, which is well below the reasoning cache
+    /// budget and comfortable for a small-payload key/value pair.
+    const DEFAULT_CAPACITY: u64 = 1024;
+
+    /// Create a new cache with the given entry capacity.
+    pub fn with_capacity(capacity: u64) -> Self {
+        Self {
+            inner: moka::sync::Cache::new(capacity),
+        }
+    }
+
+    /// Fetch a bundle, if cached.
+    pub fn get(&self, key: &SchemaBundleCacheKey) -> Option<Arc<ResolvedSchemaBundle>> {
+        self.inner.get(key)
+    }
+
+    /// Insert a bundle.
+    pub fn insert(&self, key: SchemaBundleCacheKey, bundle: Arc<ResolvedSchemaBundle>) {
+        self.inner.insert(key, bundle);
+    }
+
+    /// Clear the cache. Intended for tests only.
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.inner.invalidate_all();
+        self.inner.run_pending_tasks();
+    }
+}
+
+impl Default for SchemaBundleCache {
+    fn default() -> Self {
+        Self::with_capacity(Self::DEFAULT_CAPACITY)
+    }
+}
+
+/// Process-global schema bundle cache.
+pub fn global_schema_bundle_cache() -> &'static SchemaBundleCache {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<SchemaBundleCache> = OnceLock::new();
+    CACHE.get_or_init(SchemaBundleCache::default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::ledger_config::{OntologyImportBinding, OverrideControl};
+
+    fn make_reasoning(
+        schema_source: Option<GraphSourceRef>,
+        follow: Option<bool>,
+        map: Vec<OntologyImportBinding>,
+    ) -> ReasoningDefaults {
+        ReasoningDefaults {
+            modes: None,
+            schema_source,
+            follow_owl_imports: follow,
+            ontology_import_map: map,
+            override_control: OverrideControl::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_schema_source_returns_none() {
+        let snapshot = LedgerSnapshot::genesis("test:a");
+        let reasoning = make_reasoning(None, None, Vec::new());
+        let bundle = resolve_schema_bundle(&snapshot, &fluree_db_core::NoOverlay, 0, &reasoning)
+            .await
+            .unwrap();
+        assert!(bundle.is_none());
+    }
+
+    #[tokio::test]
+    async fn cross_ledger_rejected() {
+        let snapshot = LedgerSnapshot::genesis("test:a");
+        let reasoning = make_reasoning(
+            Some(GraphSourceRef {
+                ledger: Some("other:main".into()),
+                graph_selector: None,
+                at_t: None,
+                trust_policy: None,
+                rollback_guard: None,
+            }),
+            None,
+            Vec::new(),
+        );
+        let err = resolve_schema_bundle(&snapshot, &fluree_db_core::NoOverlay, 0, &reasoning)
+            .await
+            .unwrap_err();
+        match err {
+            ApiError::OntologyImport(msg) => {
+                assert!(
+                    msg.contains("current ledger") && msg.contains("other:main"),
+                    "unexpected message: {msg}"
+                );
+            }
+            e => panic!("expected OntologyImport, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn default_graph_schema_source_resolves_to_zero() {
+        let snapshot = LedgerSnapshot::genesis("test:a");
+        let reasoning = make_reasoning(
+            Some(GraphSourceRef {
+                ledger: None,
+                graph_selector: None,
+                at_t: None,
+                trust_policy: None,
+                rollback_guard: None,
+            }),
+            None,
+            Vec::new(),
+        );
+        let bundle = resolve_schema_bundle(&snapshot, &fluree_db_core::NoOverlay, 0, &reasoning)
+            .await
+            .unwrap()
+            .expect("bundle");
+        assert_eq!(bundle.sources, vec![DEFAULT_GRAPH_ID]);
+    }
+
+    #[tokio::test]
+    async fn unknown_graph_selector_errors() {
+        let snapshot = LedgerSnapshot::genesis("test:a");
+        let reasoning = make_reasoning(
+            Some(GraphSourceRef {
+                ledger: None,
+                graph_selector: Some("urn:does:not:exist".into()),
+                at_t: None,
+                trust_policy: None,
+                rollback_guard: None,
+            }),
+            None,
+            Vec::new(),
+        );
+        let err = resolve_schema_bundle(&snapshot, &fluree_db_core::NoOverlay, 0, &reasoning)
+            .await
+            .unwrap_err();
+        match err {
+            ApiError::OntologyImport(msg) => {
+                assert!(msg.contains("not a named graph"), "unexpected: {msg}");
+            }
+            e => panic!("expected OntologyImport, got {e:?}"),
+        }
+    }
+}

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -527,17 +527,13 @@ impl Fluree {
         else {
             return Ok(());
         };
-        let flakes = fluree_db_query::schema_bundle::build_schema_bundle_flakes(
+        let flakes = crate::ontology_imports::get_or_build_schema_bundle_flakes(
             db_ref.snapshot,
             db_ref.overlay,
-            db_ref.t,
-            &bundle.sources,
+            &bundle,
         )
-        .await
-        .map_err(|e| {
-            ApiError::OntologyImport(format!("failed to materialize schema bundle: {e}"))
-        })?;
-        executable.options.schema_bundle = Some(std::sync::Arc::new(flakes));
+        .await?;
+        executable.options.schema_bundle = Some(flakes);
         Ok(())
     }
 

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -100,7 +100,7 @@ impl Fluree {
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
 
         // 2. Build executable with optional reasoning override from primary view
-        let executable = self.build_executable_for_dataset(dataset, &parsed)?;
+        let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
 
         // 3. Get tracker for fuel limits
         let tracker = match &input {
@@ -192,7 +192,7 @@ impl Fluree {
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
 
         // 2. Build executable with optional reasoning override from primary view
-        let executable = self.build_executable_for_dataset(dataset, &parsed)?;
+        let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
 
         // 3. Get tracker for fuel limits
         let tracker = match &input {
@@ -286,6 +286,7 @@ impl Fluree {
         // Build executable
         let executable = self
             .build_executable_for_dataset(dataset, &parsed)
+            .await
             .map_err(|e| {
                 crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
             })?;
@@ -399,6 +400,7 @@ impl Fluree {
 
         let executable = self
             .build_executable_for_dataset(dataset, &parsed)
+            .await
             .map_err(|e| {
                 crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
             })?;
@@ -465,8 +467,10 @@ impl Fluree {
 
     /// Build an ExecutableQuery for dataset queries.
     ///
-    /// Applies reasoning from the primary view if set.
-    fn build_executable_for_dataset(
+    /// Applies reasoning from the primary view if set. When reasoning config
+    /// on the primary view declares `f:schemaSource`, resolves the schema
+    /// bundle closure and attaches it to `executable.options.schema_bundle`.
+    async fn build_executable_for_dataset(
         &self,
         dataset: &DataSetDb,
         parsed: &fluree_db_query::parse::ParsedQuery,
@@ -485,9 +489,56 @@ impl Fluree {
                     executable.options.reasoning = effective.clone();
                 }
             }
+
+            // Resolve schema bundle against the primary view's ledger
+            // (same-ledger only). Mirrors the single-view path in
+            // `view/query.rs::attach_schema_bundle`; see that method for the
+            // reasoning-disabled short-circuit rationale.
+            Self::attach_dataset_schema_bundle(primary, &mut executable).await?;
         }
 
         Ok(executable)
+    }
+
+    async fn attach_dataset_schema_bundle(
+        primary: &crate::view::GraphDb,
+        executable: &mut ExecutableQuery,
+    ) -> Result<()> {
+        if executable.options.reasoning.is_disabled() {
+            return Ok(());
+        }
+        let Some(resolved) = primary.resolved_config() else {
+            return Ok(());
+        };
+        let Some(reasoning) = resolved.reasoning.as_ref() else {
+            return Ok(());
+        };
+        if reasoning.schema_source.is_none() {
+            return Ok(());
+        }
+        let db_ref = primary.as_graph_db_ref();
+        let Some(bundle) = crate::ontology_imports::resolve_schema_bundle(
+            db_ref.snapshot,
+            db_ref.overlay,
+            db_ref.t,
+            reasoning,
+        )
+        .await?
+        else {
+            return Ok(());
+        };
+        let flakes = fluree_db_query::schema_bundle::build_schema_bundle_flakes(
+            db_ref.snapshot,
+            db_ref.overlay,
+            db_ref.t,
+            &bundle.sources,
+        )
+        .await
+        .map_err(|e| {
+            ApiError::OntologyImport(format!("failed to materialize schema bundle: {e}"))
+        })?;
+        executable.options.schema_bundle = Some(std::sync::Arc::new(flakes));
+        Ok(())
     }
 
     /// Execute against dataset (multi-ledger).

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -561,18 +561,14 @@ impl Fluree {
             return Ok(());
         };
 
-        let flakes = fluree_db_query::schema_bundle::build_schema_bundle_flakes(
+        let flakes = crate::ontology_imports::get_or_build_schema_bundle_flakes(
             db_ref.snapshot,
             db_ref.overlay,
-            db_ref.t,
-            &bundle.sources,
+            &bundle,
         )
-        .await
-        .map_err(|e| {
-            ApiError::OntologyImport(format!("failed to materialize schema bundle: {e}"))
-        })?;
+        .await?;
 
-        executable.options.schema_bundle = Some(std::sync::Arc::new(flakes));
+        executable.options.schema_bundle = Some(flakes);
         Ok(())
     }
 

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -94,7 +94,7 @@ impl Fluree {
 
         // 2. Build executable with optional reasoning override
         let plan_start = std::time::Instant::now();
-        let executable = self.build_executable_for_view(db, &parsed)?;
+        let executable = self.build_executable_for_view(db, &parsed).await?;
         let plan_ms = plan_start.elapsed().as_secs_f64() * 1000.0;
 
         // 3. Get tracker for fuel limits only (no tracking overhead for non-tracked calls)
@@ -158,7 +158,7 @@ impl Fluree {
         maybe_wrap_for_graph_source(db, &mut parsed);
 
         // 2. Build executable with optional reasoning override
-        let executable = self.build_executable_for_view(db, &parsed)?;
+        let executable = self.build_executable_for_view(db, &parsed).await?;
 
         // 3. Tracker (fuel limits only)
         let tracker = match &input {
@@ -269,9 +269,12 @@ impl Fluree {
         maybe_wrap_for_graph_source(db, &mut parsed);
 
         // Build executable with reasoning
-        let executable = self.build_executable_for_view(db, &parsed).map_err(|e| {
-            crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
-        })?;
+        let executable = self
+            .build_executable_for_view(db, &parsed)
+            .await
+            .map_err(|e| {
+                crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
+            })?;
 
         // Execute with tracking
         let batches = self
@@ -376,9 +379,12 @@ impl Fluree {
         // Auto-wrap for graph source context
         maybe_wrap_for_graph_source(db, &mut parsed);
 
-        let executable = self.build_executable_for_view(db, &parsed).map_err(|e| {
-            crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
-        })?;
+        let executable = self
+            .build_executable_for_view(db, &parsed)
+            .await
+            .map_err(|e| {
+                crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
+            })?;
 
         let batches = self
             .execute_view_tracked_with_r2rml(
@@ -470,8 +476,11 @@ impl Fluree {
     ///
     /// Also enforces config-graph datalog restrictions: if config disables
     /// datalog and the query can't override, the datalog flag and/or
-    /// query-time rules are stripped.
-    fn build_executable_for_view(
+    /// query-time rules are stripped. When reasoning config declares an
+    /// `f:schemaSource` (with optional `owl:imports` closure), the resolved
+    /// schema bundle is attached to `options.schema_bundle` so the runner
+    /// can layer it as a `SchemaBundleOverlay` at prep time.
+    async fn build_executable_for_view(
         &self,
         db: &GraphDb,
         parsed: &fluree_db_query::parse::ParsedQuery,
@@ -502,7 +511,69 @@ impl Fluree {
             }
         }
 
+        // Resolve `f:schemaSource` + `owl:imports` closure, if configured.
+        self.attach_schema_bundle(db, &mut executable).await?;
+
         Ok(executable)
+    }
+
+    /// Resolve the schema bundle from the ledger's reasoning config and attach
+    /// the projected schema flakes to `executable.options.schema_bundle`.
+    ///
+    /// Short-circuits in three cases (no bundle is built, no error is
+    /// raised):
+    /// - The view has no resolved config.
+    /// - Reasoning defaults have no `f:schemaSource`.
+    /// - The effective query reasoning is **explicitly disabled**
+    ///   (`"reasoning": "none"`). Users who opt out of reasoning must not
+    ///   be exposed to errors from an otherwise-unrelated broken ontology
+    ///   import; the bundle is a reasoning-only concern.
+    ///
+    /// Errors with [`ApiError::OntologyImport`] only when reasoning is
+    /// actually engaged and an import can't be resolved locally.
+    async fn attach_schema_bundle(
+        &self,
+        db: &GraphDb,
+        executable: &mut ExecutableQuery,
+    ) -> Result<()> {
+        if executable.options.reasoning.is_disabled() {
+            return Ok(());
+        }
+        let Some(resolved) = db.resolved_config() else {
+            return Ok(());
+        };
+        let Some(reasoning) = resolved.reasoning.as_ref() else {
+            return Ok(());
+        };
+        if reasoning.schema_source.is_none() {
+            return Ok(());
+        }
+
+        let db_ref = db.as_graph_db_ref();
+        let Some(bundle) = crate::ontology_imports::resolve_schema_bundle(
+            db_ref.snapshot,
+            db_ref.overlay,
+            db_ref.t,
+            reasoning,
+        )
+        .await?
+        else {
+            return Ok(());
+        };
+
+        let flakes = fluree_db_query::schema_bundle::build_schema_bundle_flakes(
+            db_ref.snapshot,
+            db_ref.overlay,
+            db_ref.t,
+            &bundle.sources,
+        )
+        .await
+        .map_err(|e| {
+            ApiError::OntologyImport(format!("failed to materialize schema bundle: {e}"))
+        })?;
+
+        executable.options.schema_bundle = Some(std::sync::Arc::new(flakes));
+        Ok(())
     }
 
     /// Execute against a GraphDb with policy awareness.

--- a/fluree-db-api/tests/it_reasoning_imports.rs
+++ b/fluree-db-api/tests/it_reasoning_imports.rs
@@ -1,0 +1,952 @@
+//! Integration tests for `f:schemaSource` + `owl:imports` closure support.
+//!
+//! Covers the v1 behavior of `fluree_db_api::ontology_imports` composed with
+//! `fluree_db_query::schema_bundle::SchemaBundleOverlay`:
+//!
+//! - `f:schemaSource` pointing at a local named graph is honored.
+//! - `owl:imports` is resolved transitively from same-ledger graphs.
+//! - `f:ontologyImportMap` provides a mapping fallback.
+//! - Unresolved imports fail the query (strict semantics).
+//! - Cycles in the import graph don't loop forever.
+//! - The schema-projection whitelist keeps instance data from leaking.
+
+mod support;
+
+use fluree_db_api::{ApiError, FlureeBuilder};
+use serde_json::json;
+use support::genesis_ledger;
+
+fn config_graph_iri(ledger_id: &str) -> String {
+    format!("urn:fluree:{ledger_id}#config")
+}
+
+/// Stage a TriG document and return the resulting ledger.
+async fn apply_trig(
+    fluree: &fluree_db_api::Fluree,
+    ledger: fluree_db_api::LedgerState,
+    trig: &str,
+) -> fluree_db_api::LedgerState {
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(trig)
+        .execute()
+        .await
+        .expect("trig stage should succeed")
+        .ledger
+}
+
+// ============================================================================
+// 1. Same-ledger auto resolution of a named-graph schema source
+// ============================================================================
+
+/// When `f:schemaSource` points at a named graph (not the default graph) and
+/// reasoning is enabled, `rdfs:subClassOf` assertions in that named graph are
+/// visible to the RDFS hierarchy expansion.
+#[tokio::test]
+async fn schema_source_in_named_graph_expands_subclass_queries() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-basic:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Put instance data (ex:alice typed as ex:Employee) in the DEFAULT graph.
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r"
+        @prefix ex: <http://example.org/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        ex:alice rdf:type ex:Employee .
+        ",
+    )
+    .await;
+
+    // Put `ex:Employee rdfs:subClassOf ex:Person` in a NAMED graph.
+    // Also write config pointing `f:schemaSource` at that graph.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/core> {{
+            ex:Employee rdfs:subClassOf ex:Person .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/core> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    // Query for all ex:Person — should include ex:alice via subclass reasoning.
+    let q = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+    assert!(
+        normalized.contains(&json!("ex:alice")),
+        "ex:alice should appear as a Person via rdfs:subClassOf in the schema-source graph; got {normalized:?}"
+    );
+}
+
+// ============================================================================
+// 2. Transitive owl:imports: A -> B
+// ============================================================================
+
+/// `schemaSource -> A`, `A owl:imports B`, followOwlImports=true.
+/// A subclass edge that lives in B must be visible to reasoning on the default
+/// graph (instance data stays in the default graph).
+#[tokio::test]
+async fn transitive_owl_imports_are_followed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-transitive:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Instance data in the default graph.
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r"
+        @prefix ex: <http://example.org/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        ex:alice rdf:type ex:Manager .
+        ",
+    )
+    .await;
+
+    // A imports B; B holds the subclass edges.
+    //   A:  ex:Manager rdfs:subClassOf ex:Employee (+ owl:imports <B>)
+    //   B:  ex:Employee rdfs:subClassOf ex:Person
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/A> {{
+            <http://example.org/ontology/A> rdf:type owl:Ontology ;
+                                            owl:imports <http://example.org/ontology/B> .
+            ex:Manager rdfs:subClassOf ex:Employee .
+        }}
+
+        GRAPH <http://example.org/ontology/B> {{
+            ex:Employee rdfs:subClassOf ex:Person .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> ;
+                                   f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/A> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    // With the transitive closure, Manager ⊑ Employee ⊑ Person, so alice is a Person.
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+    assert!(
+        normalized.contains(&json!("ex:alice")),
+        "alice should be a Person via Manager ⊑ Employee ⊑ Person; got {normalized:?}"
+    );
+}
+
+// ============================================================================
+// 3. Mapped external import via f:ontologyImportMap
+// ============================================================================
+
+/// Import IRI doesn't match any local graph, but `f:ontologyImportMap` binds
+/// it to a local graph — the closure is resolved via the mapping.
+#[tokio::test]
+async fn ontology_import_map_resolves_external_iri() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-mapped:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r"
+        @prefix ex: <http://example.org/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        ex:alice rdf:type ex:Staff .
+        ",
+    )
+    .await;
+
+    // Main ontology graph imports <http://upstream.example/bfo> which does
+    // NOT exist as a local named graph; the config provides a mapping to
+    // <http://example.org/local/bfo>.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/main> {{
+            <http://example.org/ontology/main>
+                rdf:type owl:Ontology ;
+                owl:imports <http://upstream.example/bfo> .
+        }}
+
+        GRAPH <http://example.org/local/bfo> {{
+            ex:Staff rdfs:subClassOf ex:Person .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning>
+                f:schemaSource <urn:config:schema-ref> ;
+                f:followOwlImports true ;
+                f:ontologyImportMap <urn:config:bfo-binding> .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/main> .
+            <urn:config:bfo-binding>
+                f:ontologyIri <http://upstream.example/bfo> ;
+                f:graphRef <urn:config:bfo-ref> .
+            <urn:config:bfo-ref> rdf:type f:GraphRef ;
+                                 f:graphSource <urn:config:bfo-source> .
+            <urn:config:bfo-source> f:graphSelector <http://example.org/local/bfo> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+    assert!(
+        normalized.contains(&json!("ex:alice")),
+        "mapped external import should expose ex:Staff ⊑ ex:Person; got {normalized:?}"
+    );
+}
+
+// ============================================================================
+// 4. Unresolved owl:imports -> strict error
+// ============================================================================
+
+#[tokio::test]
+async fn unresolved_owl_import_errors() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-unresolved:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <http://example.org/ontology/main> {{
+            <http://example.org/ontology/main>
+                rdf:type owl:Ontology ;
+                owl:imports <http://unknown.example/missing> .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> ;
+                                   f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/main> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let err = fluree
+        .query(&view, &q)
+        .await
+        .expect_err("unresolved import must fail the query");
+    match err {
+        ApiError::OntologyImport(msg) => {
+            assert!(msg.contains("missing"), "error should name the IRI: {msg}");
+        }
+        other => panic!("expected OntologyImport, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// 5. Cycles terminate
+// ============================================================================
+
+#[tokio::test]
+async fn owl_imports_cycle_terminates() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-cycle:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r"
+        @prefix ex: <http://example.org/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        ex:alice rdf:type ex:Employee .
+        ",
+    )
+    .await;
+
+    // A imports B; B imports A (cycle). Subclass edge lives in B.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/A> {{
+            <http://example.org/ontology/A>
+                rdf:type owl:Ontology ;
+                owl:imports <http://example.org/ontology/B> .
+        }}
+
+        GRAPH <http://example.org/ontology/B> {{
+            <http://example.org/ontology/B>
+                rdf:type owl:Ontology ;
+                owl:imports <http://example.org/ontology/A> .
+            ex:Employee rdfs:subClassOf ex:Person .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> ;
+                                   f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/A> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+    // Must complete — no infinite loop.
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+    assert!(
+        normalized.contains(&json!("ex:alice")),
+        "cycle should not prevent closure; got {normalized:?}"
+    );
+}
+
+// ============================================================================
+// 6. Whitelist enforcement: instance data in a schema-source graph doesn't leak
+// ============================================================================
+
+/// The bundle overlay projects only schema-whitelisted predicates to `g_id=0`.
+/// Instance triples that happen to live in the schema graph must not appear
+/// as default-graph results.
+#[tokio::test]
+async fn instance_data_in_schema_graph_does_not_leak() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-whitelist:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Put ex:real in the default graph; put ex:leaked in the schema graph
+    // (as instance data, not a schema axiom).
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r#"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        ex:real rdf:type ex:Person .
+        ex:real ex:name "Real Person" .
+
+        GRAPH <http://example.org/ontology/core> {{
+            # A legitimate schema axiom — should be projected.
+            ex:Employee rdfs:subClassOf ex:Person .
+            # Instance data that lives in the schema graph —
+            # MUST NOT surface in default-graph queries.
+            ex:leaked rdf:type ex:Person .
+            ex:leaked ex:name "Leaked Instance" .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/core> .
+        }}
+        "#
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+    assert!(
+        normalized.contains(&json!("ex:real")),
+        "ex:real from the default graph should match; got {normalized:?}"
+    );
+    assert!(
+        !normalized.contains(&json!("ex:leaked")),
+        "ex:leaked lives in the schema graph and must NOT appear in default-graph results; got {normalized:?}"
+    );
+}
+
+// ============================================================================
+// 7. System-graph guard covers the `f:ontologyImportMap` path
+// ============================================================================
+
+/// A mapping entry that points `owl:imports <...>` at the ledger's txn-meta
+/// graph must be rejected. Otherwise the mapping path would bypass the
+/// system-graph guard that covers the direct graph-IRI resolution.
+#[tokio::test]
+async fn mapping_table_cannot_target_system_graph() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-system-map:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Main ontology imports an external IRI that the mapping table then
+    // aims at the txn-meta system graph (via `f:txnMetaGraph` sentinel).
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <http://example.org/ontology/main> {{
+            <http://example.org/ontology/main>
+                rdf:type owl:Ontology ;
+                owl:imports <http://upstream.example/evil> .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning>
+                f:schemaSource <urn:config:schema-ref> ;
+                f:followOwlImports true ;
+                f:ontologyImportMap <urn:config:evil-binding> .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/main> .
+            <urn:config:evil-binding>
+                f:ontologyIri <http://upstream.example/evil> ;
+                f:graphRef <urn:config:evil-ref> .
+            <urn:config:evil-ref> rdf:type f:GraphRef ;
+                                  f:graphSource <urn:config:evil-source> .
+            <urn:config:evil-source> f:graphSelector f:txnMetaGraph .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Thing"},
+        "reasoning": "rdfs"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let err = fluree
+        .query(&view, &q)
+        .await
+        .expect_err("mapping to a system graph must be rejected");
+    match err {
+        ApiError::OntologyImport(msg) => {
+            assert!(
+                msg.contains("reserved system graph"),
+                "error should identify the reserved-graph rule: {msg}"
+            );
+        }
+        other => panic!("expected OntologyImport, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// 8. reasoning=none skips bundle resolution (no regression on broken imports)
+// ============================================================================
+
+/// A query with `"reasoning": "none"` must not fail because of an unresolved
+/// `owl:imports` in the ledger's reasoning config. The bundle is a
+/// reasoning-only concern; non-reasoning queries short-circuit before
+/// touching it.
+#[tokio::test]
+async fn reasoning_none_skips_bundle_resolution() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-disabled:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Seed one fact in the default graph.
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:name "Alice" .
+        "#,
+    )
+    .await;
+
+    // Configure a broken `owl:imports` chain. With reasoning ON, this would
+    // error (covered by `unresolved_owl_import_errors`).
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <http://example.org/ontology/main> {{
+            <http://example.org/ontology/main>
+                rdf:type owl:Ontology ;
+                owl:imports <http://unknown.example/missing> .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> ;
+                                   f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/main> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    // Explicit reasoning=none — query must succeed and return ex:alice,
+    // even though the config-graph import is broken.
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "ex:name": "Alice"},
+        "reasoning": "none"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .expect("reasoning=none must short-circuit past the broken import")
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+    assert!(
+        normalized.contains(&json!("ex:alice")),
+        "query with reasoning=none should return normal results; got {normalized:?}"
+    );
+}
+
+// ============================================================================
+// 9. Deferred `GraphSourceRef` fields are rejected, not silently ignored
+// ============================================================================
+
+/// A schema source that pins `f:atT` is rejected: v1 resolves the entire
+/// closure at the query's `to_t`, so honoring a per-source `at_t` would
+/// require bookkeeping that isn't there yet.
+#[tokio::test]
+async fn schema_source_at_t_rejected() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-at-t:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/core> {{
+            ex:Employee rdfs:subClassOf ex:Person .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning> f:schemaSource <urn:config:schema-ref> .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source>
+                f:graphSelector <http://example.org/ontology/core> ;
+                f:atT 1 .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Person"},
+        "reasoning": "rdfs"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let err = fluree
+        .query(&view, &q)
+        .await
+        .expect_err("at_t on schema source must be rejected in v1");
+    match err {
+        ApiError::OntologyImport(msg) => {
+            assert!(
+                msg.contains("atT") || msg.contains("at_t"),
+                "error should name the unsupported field: {msg}"
+            );
+        }
+        other => panic!("expected OntologyImport, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// 10. End-to-end: OWL2-RL rules declared in a transitive import actually fire
+// ============================================================================
+//
+// These tests are the real proof of the feature. The earlier tests verify that
+// a schema-predicate flake (rdfs:subClassOf) can traverse the projection path
+// and influence hierarchy lookups. These go further:
+//
+//   1. The axiom lives in an imported graph B (reached via `A owl:imports B`).
+//   2. Instance data lives in the default graph.
+//   3. Reasoning is OWL2-RL, which requires the reasoner to scan for the
+//      ontology axiom, materialize derived facts against instance data, and
+//      make them visible to the query.
+//
+// If the projection layer only carried RDFS edges to `schema_hierarchy_with_overlay`
+// but failed to expose OWL axioms (`rdf:type owl:TransitiveProperty`,
+// `owl:inverseOf`, `rdfs:domain`) to `reason_owl2rl`, these would return
+// empty bindings.
+
+/// Case A: `owl:TransitiveProperty` declared in an imported graph B.
+/// Instance chain `alice → bob → carol` in the default graph.
+/// Query `alice hasAncestor ?x` with OWL2-RL must include `carol`.
+#[tokio::test]
+async fn owl2rl_transitive_property_axiom_from_transitive_import() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-owl2rl-trans:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Instance data in the default graph; ancestry chain of three.
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:hasAncestor ex:bob .
+        ex:bob   ex:hasAncestor ex:carol .
+        ",
+    )
+    .await;
+
+    // A imports B; B declares the transitive-property axiom.
+    //   A: (no axioms, pure imports hub)
+    //   B: ex:hasAncestor rdf:type owl:TransitiveProperty
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/A> {{
+            <http://example.org/ontology/A>
+                rdf:type owl:Ontology ;
+                owl:imports <http://example.org/ontology/B> .
+        }}
+
+        GRAPH <http://example.org/ontology/B> {{
+            ex:hasAncestor rdf:type owl:TransitiveProperty .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning>
+                f:schemaSource <urn:config:schema-ref> ;
+                f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/A> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?x",
+        "where": {"@id": "ex:alice", "ex:hasAncestor": "?x"},
+        "reasoning": "owl2rl"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+
+    // Base fact: alice hasAncestor bob.
+    assert!(
+        normalized.contains(&json!("ex:bob")),
+        "alice hasAncestor bob (base); got {normalized:?}"
+    );
+    // Entailment: alice hasAncestor carol via transitive closure — ONLY
+    // visible if the TransitiveProperty axiom from graph B reached the
+    // reasoner at g_id=0.
+    assert!(
+        normalized.contains(&json!("ex:carol")),
+        "alice hasAncestor carol should be entailed by owl:TransitiveProperty \
+         declared in imported graph B; got {normalized:?}"
+    );
+}
+
+/// Case B: `owl:inverseOf` declared in an imported graph B, query asks for
+/// the inverse direction. Without the projection, the reasoner wouldn't see
+/// the inverse axiom and the inverse query would return empty.
+#[tokio::test]
+async fn owl2rl_inverse_of_axiom_from_transitive_import() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-owl2rl-inverse:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Instance data: alice is bob's parent.
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:parentOf ex:bob .
+        ",
+    )
+    .await;
+
+    // A imports B; B declares parentOf owl:inverseOf childOf.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/A> {{
+            <http://example.org/ontology/A>
+                rdf:type owl:Ontology ;
+                owl:imports <http://example.org/ontology/B> .
+        }}
+
+        GRAPH <http://example.org/ontology/B> {{
+            ex:parentOf owl:inverseOf ex:childOf .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning>
+                f:schemaSource <urn:config:schema-ref> ;
+                f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/A> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    // Query the INVERSE direction: who is alice a child of?
+    //   No `childOf` triple in the data.
+    //   Expect `ex:alice` via owl:inverseOf(parentOf, childOf) applied to
+    //   `alice parentOf bob`  →  `bob childOf alice`.
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?child",
+        "where": {"@id": "?child", "ex:childOf": {"@id": "ex:alice"}},
+        "reasoning": "owl2rl"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+
+    assert!(
+        normalized.contains(&json!("ex:bob")),
+        "owl:inverseOf in the imported graph should entail `bob childOf alice`; \
+         got {normalized:?}"
+    );
+}
+
+/// Case C: `rdfs:domain` declared in an imported graph produces a class
+/// typing for instance data in the default graph. Uses auto-RDFS rather
+/// than an explicit mode to also verify that hierarchy availability
+/// detection sees the imported schema.
+#[tokio::test]
+async fn owl2rl_domain_axiom_from_transitive_import_types_instance() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reasoning-imports-owl2rl-domain:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Instance data: alice has a name, no explicit rdf:type.
+    let ledger = apply_trig(
+        &fluree,
+        ledger,
+        r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:employeeName "Alice" .
+        "#,
+    )
+    .await;
+
+    // A imports B; B declares ex:employeeName rdfs:domain ex:Employee.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex:   <http://example.org/> .
+
+        GRAPH <http://example.org/ontology/A> {{
+            <http://example.org/ontology/A>
+                rdf:type owl:Ontology ;
+                owl:imports <http://example.org/ontology/B> .
+        }}
+
+        GRAPH <http://example.org/ontology/B> {{
+            ex:employeeName rdfs:domain ex:Employee .
+        }}
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig ;
+                              f:reasoningDefaults <urn:config:reasoning> .
+            <urn:config:reasoning>
+                f:schemaSource <urn:config:schema-ref> ;
+                f:followOwlImports true .
+            <urn:config:schema-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:schema-source> .
+            <urn:config:schema-source> f:graphSelector <http://example.org/ontology/A> .
+        }}
+        "
+    );
+    let _ = apply_trig(&fluree, ledger, &trig).await;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Employee"},
+        "reasoning": "owl2rl"
+    });
+    let view = fluree.db(ledger_id).await.unwrap();
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&view.snapshot)
+        .unwrap();
+    let normalized = support::normalize_rows(&rows);
+
+    assert!(
+        normalized.contains(&json!("ex:alice")),
+        "rdfs:domain from imported graph B should type alice as Employee; \
+         got {normalized:?}"
+    );
+}

--- a/fluree-db-core/src/ledger_config.rs
+++ b/fluree-db-core/src/ledger_config.rs
@@ -100,8 +100,30 @@ pub struct ReasoningDefaults {
     pub modes: Option<Vec<String>>,
     /// `f:schemaSource` — reference to graph containing schema hierarchy.
     pub schema_source: Option<GraphSourceRef>,
+    /// `f:followOwlImports` — when `true`, resolve `owl:imports` transitively
+    /// from `schema_source` and include each imported graph in the schema
+    /// bundle used by reasoning. `None` or `Some(false)` both mean "don't
+    /// follow imports" — the bundle consists of only the starting graph.
+    /// Opt in explicitly with `true` when you want the closure.
+    pub follow_owl_imports: Option<bool>,
+    /// `f:ontologyImportMap` — explicit mapping from external `owl:imports`
+    /// IRIs to local `GraphSourceRef`s. Consulted when an import IRI does not
+    /// match a named graph in the current ledger.
+    pub ontology_import_map: Vec<OntologyImportBinding>,
     /// Override control for this setting group.
     pub override_control: OverrideControl,
+}
+
+/// One entry in `f:ontologyImportMap`.
+///
+/// Binds an external ontology IRI (as it appears in `owl:imports`) to the
+/// local graph that provides that ontology's triples.
+#[derive(Debug, Clone)]
+pub struct OntologyImportBinding {
+    /// `f:ontologyIri` — the IRI that appears in `owl:imports` statements.
+    pub ontology_iri: String,
+    /// `f:graphRef` — where to find that ontology's triples locally.
+    pub graph_ref: GraphSourceRef,
 }
 
 /// Datalog rules defaults from the config graph (`f:datalogDefaults`).

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -118,10 +118,13 @@ pub use ledger_id::{
     ParsedLedgerId, DEFAULT_BRANCH,
 };
 pub use namespaces::{
-    default_namespace_codes, is_owl_equivalent_class, is_owl_equivalent_property,
-    is_owl_inverse_of, is_owl_same_as, is_owl_symmetric_property, is_owl_transitive_property,
-    is_rdf_first, is_rdf_nil, is_rdf_rest, is_rdf_type, is_rdfs_domain, is_rdfs_range,
-    is_rdfs_subclass_of, is_rdfs_subproperty_of,
+    default_namespace_codes, is_owl_class_class, is_owl_datatype_property_class,
+    is_owl_equivalent_class, is_owl_equivalent_property, is_owl_functional_property,
+    is_owl_imports, is_owl_inverse_functional_property, is_owl_inverse_of,
+    is_owl_object_property_class, is_owl_ontology_class, is_owl_same_as, is_owl_symmetric_property,
+    is_owl_transitive_property, is_rdf_first, is_rdf_nil, is_rdf_property_class, is_rdf_rest,
+    is_rdf_type, is_rdfs_domain, is_rdfs_range, is_rdfs_subclass_of, is_rdfs_subproperty_of,
+    is_schema_class, is_schema_predicate,
 };
 pub use ns_encoding::{
     builtin_prefix_trie, canonical_split, NamespaceCodes, NsAllocError, NsLookup, NsSplitMode,

--- a/fluree-db-core/src/namespaces.rs
+++ b/fluree-db-core/src/namespaces.rs
@@ -104,6 +104,89 @@ pub fn is_owl_transitive_property(sid: &Sid) -> bool {
     sid.namespace_code == OWL && sid.name.as_ref() == OWL_TRANSITIVEPROPERTY
 }
 
+/// Check if a SID is owl:FunctionalProperty
+#[inline]
+pub fn is_owl_functional_property(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_FUNCTIONALPROPERTY
+}
+
+/// Check if a SID is owl:InverseFunctionalProperty
+#[inline]
+pub fn is_owl_inverse_functional_property(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_INVERSEFUNCTIONALPROPERTY
+}
+
+/// Check if a SID is owl:imports
+#[inline]
+pub fn is_owl_imports(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_IMPORTS
+}
+
+/// Check if a SID is owl:Ontology (the class)
+#[inline]
+pub fn is_owl_ontology_class(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_ONTOLOGY
+}
+
+/// Check if a SID is owl:Class
+#[inline]
+pub fn is_owl_class_class(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_CLASS
+}
+
+/// Check if a SID is owl:ObjectProperty
+#[inline]
+pub fn is_owl_object_property_class(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_OBJECTPROPERTY
+}
+
+/// Check if a SID is owl:DatatypeProperty
+#[inline]
+pub fn is_owl_datatype_property_class(sid: &Sid) -> bool {
+    sid.namespace_code == OWL && sid.name.as_ref() == OWL_DATATYPEPROPERTY
+}
+
+/// Check if a SID is rdf:Property
+#[inline]
+pub fn is_rdf_property_class(sid: &Sid) -> bool {
+    sid.namespace_code == RDF && sid.name.as_ref() == RDF_PROPERTY
+}
+
+/// Check whether `pred` is a schema-describing predicate that may be projected
+/// from an imported ontology graph into the schema bundle overlay.
+///
+/// The set is deliberately narrow: entailment-relevant RDFS/OWL predicates only.
+/// Instance-data predicates are excluded so that importing an ontology graph
+/// cannot leak its non-schema triples into query results.
+#[inline]
+pub fn is_schema_predicate(pred: &Sid) -> bool {
+    is_rdfs_subclass_of(pred)
+        || is_rdfs_subproperty_of(pred)
+        || is_rdfs_domain(pred)
+        || is_rdfs_range(pred)
+        || is_owl_inverse_of(pred)
+        || is_owl_equivalent_class(pred)
+        || is_owl_equivalent_property(pred)
+        || is_owl_same_as(pred)
+        || is_owl_imports(pred)
+}
+
+/// Check whether `cls` is a schema-describing class — when an `rdf:type <cls>`
+/// triple appears in an imported graph it should be projected into the schema
+/// bundle. Other `rdf:type` triples (instance typing) are dropped.
+#[inline]
+pub fn is_schema_class(cls: &Sid) -> bool {
+    is_owl_ontology_class(cls)
+        || is_owl_class_class(cls)
+        || is_owl_object_property_class(cls)
+        || is_owl_datatype_property_class(cls)
+        || is_owl_symmetric_property(cls)
+        || is_owl_transitive_property(cls)
+        || is_owl_functional_property(cls)
+        || is_owl_inverse_functional_property(cls)
+        || is_rdf_property_class(cls)
+}
+
 /// Baseline namespace codes (code -> prefix) matching Fluree's reserved codepoints.
 pub fn default_namespace_codes() -> HashMap<u16, String> {
     let mut map = HashMap::new();

--- a/fluree-db-query/src/execute/runner.rs
+++ b/fluree-db-query/src/execute/runner.rs
@@ -14,6 +14,7 @@ use crate::options::QueryOptions;
 use crate::parse::ParsedQuery;
 use crate::reasoning::ReasoningOverlay;
 use crate::rewrite_owl_ql::Ontology;
+use crate::schema_bundle::SchemaBundleOverlay;
 use crate::stats_cache::cached_stats_view_for_db;
 use crate::triple::{Ref, Term, TriplePattern};
 use crate::var_registry::VarRegistry;
@@ -175,9 +176,23 @@ pub async fn prepare_execution_with_binary_store(
 
         // ---- reasoning_prep: schema hierarchy, reasoning modes, derived facts, ontology ----
         let reasoning_span = tracing::debug_span!("reasoning_prep");
+        // If the upstream API layer pre-resolved an `f:schemaSource` + `owl:imports`
+        // closure into `query.options.schema_bundle`, project it as an overlay now.
+        // This makes schema-whitelisted flakes from every source graph visible at
+        // `g_id=0`, which is what RDFS/OWL extraction code scans.
+        let schema_overlay_binding: Option<SchemaBundleOverlay<'_>> = query
+            .options
+            .schema_bundle
+            .as_ref()
+            .filter(|b| !b.is_empty())
+            .map(|bundle| SchemaBundleOverlay::new(db.overlay, bundle.clone()));
+        let effective_overlay: &dyn fluree_db_core::OverlayProvider = schema_overlay_binding
+            .as_ref()
+            .map(|o| o as &dyn fluree_db_core::OverlayProvider)
+            .unwrap_or(db.overlay);
         let (hierarchy, reasoning, derived_overlay, ontology) = async {
             // Step 1: Compute schema hierarchy from overlay
-            let hierarchy = schema_hierarchy_with_overlay(db.snapshot, db.overlay, db.t);
+            let hierarchy = schema_hierarchy_with_overlay(db.snapshot, effective_overlay, db.t);
 
             // Step 2: Determine effective reasoning modes
             let reasoning =
@@ -194,19 +209,26 @@ pub async fn prepare_execution_with_binary_store(
             }
 
             // Step 3: Compute derived facts from OWL2-RL and/or datalog rules
+            //
+            // Note: `compute_derived_facts` reads the query graph (`db.g_id`)
+            // for instance data but uses `effective_overlay` so that OWL2-RL
+            // axioms (e.g. `?p a owl:TransitiveProperty`) from the import
+            // closure are visible when scanning g_id=0, and base-overlay
+            // novelty remains visible for other graphs.
             let derived_overlay =
-                compute_derived_facts(db.snapshot, db.g_id, db.overlay, db.t, &reasoning).await;
+                compute_derived_facts(db.snapshot, db.g_id, effective_overlay, db.t, &reasoning)
+                    .await;
 
             // Step 4: Build ontology for OWL2-QL mode (if enabled)
             let reasoning_overlay_for_ontology: Option<ReasoningOverlay<'_>> = derived_overlay
                 .as_ref()
-                .map(|derived| ReasoningOverlay::new(db.overlay, derived.clone()));
+                .map(|derived| ReasoningOverlay::new(effective_overlay, derived.clone()));
 
             let effective_overlay_for_ontology: &dyn fluree_db_core::OverlayProvider =
                 reasoning_overlay_for_ontology
                     .as_ref()
                     .map(|o| o as &dyn fluree_db_core::OverlayProvider)
-                    .unwrap_or(db.overlay);
+                    .unwrap_or(effective_overlay);
 
             let ontology = if reasoning.owl2ql {
                 tracing::debug!("building OWL2-QL ontology");

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -77,6 +77,7 @@ pub mod remote_service;
 pub mod rewrite;
 pub mod rewrite_owl_ql;
 pub mod s2_search;
+pub mod schema_bundle;
 pub mod seed;
 pub(crate) mod semijoin;
 pub mod service;

--- a/fluree-db-query/src/options.rs
+++ b/fluree-db-query/src/options.rs
@@ -3,9 +3,12 @@
 //! This module contains QueryOptions, shared by both parse and execute modules.
 //! It lives in a neutral location to avoid circular dependencies.
 
+use std::sync::Arc;
+
 use crate::aggregate::AggregateSpec;
 use crate::ir::Expression;
 use crate::rewrite::ReasoningModes;
+use crate::schema_bundle::SchemaBundleFlakes;
 use crate::sort::SortSpec;
 use crate::var_registry::VarId;
 
@@ -40,6 +43,16 @@ pub struct QueryOptions {
     /// Use `reasoning.effective_with_hierarchy(has_hierarchy)` at execution
     /// time to compute the actual modes to apply.
     pub reasoning: ReasoningModes,
+    /// Pre-resolved schema bundle flakes projected to `g_id=0`.
+    ///
+    /// Populated upstream (in `fluree-db-api`) from the ledger's
+    /// `f:schemaSource` and transitive `owl:imports` closure. When set, the
+    /// runner layers a [`SchemaBundleOverlay`](crate::schema_bundle::SchemaBundleOverlay)
+    /// over the query's base overlay for reasoning prep so that hierarchy
+    /// extraction and OWL axiom discovery see the full import closure.
+    ///
+    /// When `None`, reasoning reads schema from `db.g_id` directly.
+    pub schema_bundle: Option<Arc<SchemaBundleFlakes>>,
 }
 
 impl QueryOptions {
@@ -105,6 +118,15 @@ impl QueryOptions {
     /// ```
     pub fn with_reasoning(mut self, modes: ReasoningModes) -> Self {
         self.reasoning = modes;
+        self
+    }
+
+    /// Attach a pre-resolved schema bundle for reasoning.
+    ///
+    /// Populated upstream once per (ledger, `to_t`, schema-source) — see
+    /// `fluree_db_api::ontology_imports::resolve_schema_bundle`.
+    pub fn with_schema_bundle(mut self, bundle: Arc<SchemaBundleFlakes>) -> Self {
+        self.schema_bundle = Some(bundle);
         self
     }
 

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -1785,6 +1785,7 @@ fn lower_options(opts: &UnresolvedOptions, vars: &mut VarRegistry) -> Result<Que
             .transpose()?,
         post_binds: Vec::new(),
         reasoning,
+        schema_bundle: None,
     })
 }
 

--- a/fluree-db-query/src/schema_bundle.rs
+++ b/fluree-db-query/src/schema_bundle.rs
@@ -1,0 +1,407 @@
+//! Schema-bundle overlay that projects whitelisted ontology flakes into `g_id=0`.
+//!
+//! # Purpose
+//!
+//! When reasoning is configured with an `f:schemaSource` (plus, optionally, a
+//! transitive `owl:imports` closure), RDFS/OWL extraction needs to see
+//! schema triples regardless of which graph they physically live in.
+//!
+//! The existing reasoning extraction code only scans the default graph
+//! (`g_id=0`). Rather than teach every reasoner to scan multiple graphs,
+//! this module materializes the **relevant** triples from each source graph
+//! up-front and exposes them via an `OverlayProvider` that answers queries
+//! against `g_id=0`. The reasoner then runs unchanged.
+//!
+//! # What gets projected
+//!
+//! Only triples matching a narrow schema/ontology whitelist are projected.
+//! Instance data from an imported graph never leaks into the reasoning view:
+//!
+//! - `rdfs:subClassOf`, `rdfs:subPropertyOf`, `rdfs:domain`, `rdfs:range`
+//! - `owl:inverseOf`, `owl:equivalentClass`, `owl:equivalentProperty`,
+//!   `owl:sameAs`, `owl:imports`
+//! - `rdf:type` **when the object is** one of
+//!   `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`,
+//!   `owl:SymmetricProperty`, `owl:TransitiveProperty`,
+//!   `owl:FunctionalProperty`, `owl:InverseFunctionalProperty`,
+//!   `owl:Ontology`, `rdf:Property`.
+//!
+//! See `fluree_db_core::{is_schema_predicate, is_schema_class}` for the
+//! canonical whitelist used at projection time.
+//!
+//! # Composition
+//!
+//! [`SchemaBundleOverlay`] wraps a base overlay (the query's novelty). For
+//! `g_id != 0` it delegates straight to the base. For `g_id == 0` it emits
+//! the merge of base flakes and the projected schema flakes in index order.
+//!
+//! The overlay is trivially cheap: the source flakes have already been read
+//! and sorted by [`build_schema_bundle_flakes`]; serving them is just a slice
+//! walk.
+
+use std::sync::Arc;
+
+use fluree_db_core::comparator::IndexType;
+use fluree_db_core::flake::Flake;
+use fluree_db_core::ids::GraphId;
+use fluree_db_core::overlay::OverlayProvider;
+use fluree_db_core::range::range_with_overlay;
+use fluree_db_core::value::FlakeValue;
+use fluree_db_core::{
+    is_rdf_type, is_schema_class, is_schema_predicate, LedgerSnapshot, RangeMatch, RangeOptions,
+    RangeTest,
+};
+
+use crate::error::Result;
+
+/// Pre-sorted schema flakes projected from a set of source graphs to `g_id=0`.
+///
+/// Produced by [`build_schema_bundle_flakes`] once per query (or once per
+/// cached bundle) and wrapped by [`SchemaBundleOverlay`] at overlay time.
+#[derive(Debug, Clone)]
+pub struct SchemaBundleFlakes {
+    spot: Arc<[Flake]>,
+    psot: Arc<[Flake]>,
+    post: Arc<[Flake]>,
+    opst: Arc<[Flake]>,
+    /// Stable identifier for cache composition with other overlays.
+    epoch: u64,
+}
+
+impl SchemaBundleFlakes {
+    /// Empty bundle — the overlay will pass through to its base.
+    pub fn empty() -> Self {
+        Self {
+            spot: Arc::from([]),
+            psot: Arc::from([]),
+            post: Arc::from([]),
+            opst: Arc::from([]),
+            epoch: 0,
+        }
+    }
+
+    /// Total number of projected flakes (same across all index orderings).
+    pub fn len(&self) -> usize {
+        self.spot.len()
+    }
+
+    /// Whether the bundle projected zero flakes.
+    pub fn is_empty(&self) -> bool {
+        self.spot.is_empty()
+    }
+
+    /// Epoch value used for `OverlayProvider::epoch` composition.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    fn flakes(&self, index: IndexType) -> &[Flake] {
+        match index {
+            IndexType::Spot => &self.spot,
+            IndexType::Psot => &self.psot,
+            IndexType::Post => &self.post,
+            IndexType::Opst => &self.opst,
+        }
+    }
+
+    fn upper_bound(&self, index: IndexType, target: &Flake) -> usize {
+        let flakes = self.flakes(index);
+        let cmp = index.comparator();
+        flakes.partition_point(|f| cmp(f, target).is_le())
+    }
+}
+
+/// Read whitelisted schema flakes from each source graph at `to_t`.
+///
+/// For each `g_id` in `sources`, runs targeted reads (one per schema
+/// predicate, one per schema class) against the base overlay. Flakes from
+/// `g_id == 0` are intentionally skipped — they are already visible to the
+/// reasoner via the default-graph path and should not be double-counted.
+///
+/// Results are aggregated, deduplicated by `(s, p, o, t, op)`, and sorted
+/// into the four index orderings expected by `OverlayProvider`.
+pub async fn build_schema_bundle_flakes<O>(
+    snapshot: &LedgerSnapshot,
+    base_overlay: &O,
+    to_t: i64,
+    sources: &[GraphId],
+) -> Result<SchemaBundleFlakes>
+where
+    O: OverlayProvider + ?Sized,
+{
+    use fluree_vocab::owl;
+    use fluree_vocab::rdf;
+    use fluree_vocab::rdfs;
+
+    // Predicates whose flakes are projected wholesale.
+    let schema_predicate_iris: &[&str] = &[
+        rdfs::SUB_CLASS_OF,
+        rdfs::SUB_PROPERTY_OF,
+        rdfs::DOMAIN,
+        rdfs::RANGE,
+        owl::INVERSE_OF,
+        owl::EQUIVALENT_CLASS,
+        owl::EQUIVALENT_PROPERTY,
+        owl::SAME_AS,
+        owl::IMPORTS,
+    ];
+    // Classes whose `rdf:type` triples are projected (i.e. subject is
+    // declared as an instance of the class).
+    let schema_class_iris: &[&str] = &[
+        owl::CLASS,
+        owl::OBJECT_PROPERTY,
+        owl::DATATYPE_PROPERTY,
+        owl::SYMMETRIC_PROPERTY,
+        owl::TRANSITIVE_PROPERTY,
+        owl::FUNCTIONAL_PROPERTY,
+        owl::INVERSE_FUNCTIONAL_PROPERTY,
+        owl::ONTOLOGY,
+        rdf::PROPERTY,
+    ];
+
+    // Pre-encode whitelist Sids; missing entries (namespace/name never seen in
+    // this ledger) simply contribute nothing.
+    let schema_predicates: Vec<_> = schema_predicate_iris
+        .iter()
+        .filter_map(|iri| snapshot.encode_iri(iri))
+        .collect();
+    let schema_classes: Vec<_> = schema_class_iris
+        .iter()
+        .filter_map(|iri| snapshot.encode_iri(iri))
+        .collect();
+    let rdf_type_sid = snapshot.encode_iri(rdf::TYPE);
+
+    let opts = RangeOptions::default().with_to_t(to_t);
+
+    let mut collected: Vec<Flake> = Vec::new();
+
+    for &g_id in sources {
+        if g_id == 0 {
+            // The query already sees g_id=0 via its own overlay; skip.
+            continue;
+        }
+
+        // Per-predicate PSOT scans for hierarchy/OWL axioms.
+        for p in &schema_predicates {
+            let flakes = range_with_overlay(
+                snapshot,
+                g_id,
+                base_overlay,
+                IndexType::Psot,
+                RangeTest::Eq,
+                RangeMatch::predicate(p.clone()),
+                opts.clone(),
+            )
+            .await?;
+            for f in flakes {
+                if is_schema_predicate(&f.p) {
+                    collected.push(f);
+                }
+            }
+        }
+
+        // Per-class OPST scans for `?s rdf:type <class>` axioms.
+        if let Some(rdf_type) = rdf_type_sid.clone() {
+            for cls in &schema_classes {
+                let flakes = range_with_overlay(
+                    snapshot,
+                    g_id,
+                    base_overlay,
+                    IndexType::Opst,
+                    RangeTest::Eq,
+                    RangeMatch {
+                        p: Some(rdf_type.clone()),
+                        o: Some(FlakeValue::Ref(cls.clone())),
+                        ..Default::default()
+                    },
+                    opts.clone(),
+                )
+                .await?;
+                for f in flakes {
+                    // Defense in depth: confirm the filter matched our
+                    // whitelist before projecting.
+                    if !is_rdf_type(&f.p) {
+                        continue;
+                    }
+                    let FlakeValue::Ref(obj) = &f.o else { continue };
+                    if is_schema_class(obj) {
+                        collected.push(f);
+                    }
+                }
+            }
+        }
+    }
+
+    if collected.is_empty() {
+        return Ok(SchemaBundleFlakes::empty());
+    }
+
+    // Deduplicate — the same axiom triple can appear across multiple source
+    // graphs when an ontology is re-imported transitively. `Flake` isn't
+    // hashable, so dedupe via sort+dedup over a normalizing comparator.
+    collected.sort_by(|a, b| {
+        a.s.cmp(&b.s)
+            .then_with(|| a.p.cmp(&b.p))
+            .then_with(|| a.o.cmp(&b.o))
+            .then_with(|| a.t.cmp(&b.t))
+            .then_with(|| a.op.cmp(&b.op))
+    });
+    collected.dedup_by(|a, b| a.s == b.s && a.p == b.p && a.o == b.o && a.t == b.t && a.op == b.op);
+
+    let mut spot = collected.clone();
+    let mut psot = collected.clone();
+    let mut post = collected.clone();
+    let mut opst = collected;
+
+    let spot_cmp = IndexType::Spot.comparator();
+    let psot_cmp = IndexType::Psot.comparator();
+    let post_cmp = IndexType::Post.comparator();
+    let opst_cmp = IndexType::Opst.comparator();
+
+    spot.sort_by(spot_cmp);
+    psot.sort_by(psot_cmp);
+    post.sort_by(post_cmp);
+    opst.sort_by(opst_cmp);
+
+    // Epoch combines (source graph ids, flake count) so the overlay's
+    // composed epoch is stable for caching but changes when the bundle
+    // materially differs.
+    let mut epoch: u64 = spot.len() as u64;
+    for &g in sources {
+        epoch = epoch.wrapping_mul(31).wrapping_add(u64::from(g));
+    }
+
+    Ok(SchemaBundleFlakes {
+        spot: spot.into(),
+        psot: psot.into(),
+        post: post.into(),
+        opst: opst.into(),
+        epoch,
+    })
+}
+
+/// Overlay that exposes [`SchemaBundleFlakes`] at `g_id=0`, composed with a base overlay.
+///
+/// For `g_id != 0`, delegates to the base overlay unchanged — imports never
+/// surface on other graphs' overlay reads.
+pub struct SchemaBundleOverlay<'a> {
+    base: &'a dyn OverlayProvider,
+    bundle: Arc<SchemaBundleFlakes>,
+    epoch: u64,
+}
+
+impl<'a> SchemaBundleOverlay<'a> {
+    /// Compose a base overlay with a projected schema bundle.
+    pub fn new(base: &'a dyn OverlayProvider, bundle: Arc<SchemaBundleFlakes>) -> Self {
+        let epoch = base
+            .epoch()
+            .wrapping_mul(1_000_003)
+            .wrapping_add(bundle.epoch());
+        Self {
+            base,
+            bundle,
+            epoch,
+        }
+    }
+}
+
+impl OverlayProvider for SchemaBundleOverlay<'_> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.base.as_any()
+    }
+
+    fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    fn for_each_overlay_flake(
+        &self,
+        g_id: GraphId,
+        index: IndexType,
+        first: Option<&Flake>,
+        rhs: Option<&Flake>,
+        leftmost: bool,
+        to_t: i64,
+        callback: &mut dyn FnMut(&Flake),
+    ) {
+        if g_id != 0 || self.bundle.is_empty() {
+            self.base
+                .for_each_overlay_flake(g_id, index, first, rhs, leftmost, to_t, callback);
+            return;
+        }
+
+        // Collect base flakes and bundle flakes separately (both are already
+        // in index order), then linear-merge.
+        let mut base_flakes: Vec<Flake> = Vec::new();
+        self.base
+            .for_each_overlay_flake(g_id, index, first, rhs, leftmost, to_t, &mut |f| {
+                base_flakes.push(f.clone());
+            });
+
+        // Slice the bundle to the requested sub-range in index order.
+        let flakes = self.bundle.flakes(index);
+        let start = if leftmost {
+            0
+        } else if let Some(first_flake) = first {
+            self.bundle.upper_bound(index, first_flake)
+        } else {
+            0
+        };
+        let end = if let Some(rhs_flake) = rhs {
+            self.bundle.upper_bound(index, rhs_flake)
+        } else {
+            flakes.len()
+        };
+        let mut bundle_iter = flakes[start..end].iter().filter(|f| f.t <= to_t).peekable();
+        let mut base_iter = base_flakes.iter().peekable();
+
+        loop {
+            match (base_iter.peek(), bundle_iter.peek()) {
+                (Some(b), Some(s)) => {
+                    if index.compare(b, s).is_le() {
+                        callback(base_iter.next().unwrap());
+                    } else {
+                        callback(bundle_iter.next().unwrap());
+                    }
+                }
+                (Some(_), None) => callback(base_iter.next().unwrap()),
+                (None, Some(_)) => callback(bundle_iter.next().unwrap()),
+                (None, None) => break,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::NoOverlay;
+
+    #[test]
+    fn empty_bundle_delegates_to_base() {
+        let bundle = Arc::new(SchemaBundleFlakes::empty());
+        let base = NoOverlay;
+        let overlay = SchemaBundleOverlay::new(&base, bundle);
+
+        let mut count = 0;
+        overlay.for_each_overlay_flake(0, IndexType::Psot, None, None, true, i64::MAX, &mut |_| {
+            count += 1;
+        });
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn non_default_graph_passes_through_to_base() {
+        // Even when the bundle has projected flakes, a non-zero g_id query
+        // must not see them — only g_id=0 receives the projection.
+        let bundle = Arc::new(SchemaBundleFlakes::empty());
+        let base = NoOverlay;
+        let overlay = SchemaBundleOverlay::new(&base, bundle);
+
+        let mut count = 0;
+        overlay.for_each_overlay_flake(5, IndexType::Psot, None, None, true, i64::MAX, &mut |_| {
+            count += 1;
+        });
+        assert_eq!(count, 0);
+    }
+}

--- a/fluree-vocab/src/lib.rs
+++ b/fluree-vocab/src/lib.rs
@@ -74,6 +74,9 @@ pub mod rdf {
 
     /// rdf:nil IRI (RDF list terminator)
     pub const NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+
+    /// rdf:Property IRI (the class of RDF properties)
+    pub const PROPERTY: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
 }
 
 /// RDFS vocabulary constants
@@ -699,6 +702,21 @@ pub mod owl {
 
     /// owl:oneOf IRI
     pub const ONE_OF: &str = "http://www.w3.org/2002/07/owl#oneOf";
+
+    /// owl:Ontology IRI
+    pub const ONTOLOGY: &str = "http://www.w3.org/2002/07/owl#Ontology";
+
+    /// owl:imports IRI
+    pub const IMPORTS: &str = "http://www.w3.org/2002/07/owl#imports";
+
+    /// owl:Class IRI
+    pub const CLASS: &str = "http://www.w3.org/2002/07/owl#Class";
+
+    /// owl:ObjectProperty IRI
+    pub const OBJECT_PROPERTY: &str = "http://www.w3.org/2002/07/owl#ObjectProperty";
+
+    /// owl:DatatypeProperty IRI
+    pub const DATATYPE_PROPERTY: &str = "http://www.w3.org/2002/07/owl#DatatypeProperty";
 }
 
 /// OWL local names (for SID construction)
@@ -765,6 +783,21 @@ pub mod owl_names {
 
     /// owl:oneOf local name
     pub const ONE_OF: &str = "oneOf";
+
+    /// owl:Ontology local name
+    pub const ONTOLOGY: &str = "Ontology";
+
+    /// owl:imports local name
+    pub const IMPORTS: &str = "imports";
+
+    /// owl:Class local name
+    pub const CLASS: &str = "Class";
+
+    /// owl:ObjectProperty local name
+    pub const OBJECT_PROPERTY: &str = "ObjectProperty";
+
+    /// owl:DatatypeProperty local name
+    pub const DATATYPE_PROPERTY: &str = "DatatypeProperty";
 }
 
 /// JSON-LD keyword local names (for SID construction)
@@ -1473,6 +1506,30 @@ pub mod predicates {
 
     /// owl:TransitiveProperty local name (class, not predicate)
     pub const OWL_TRANSITIVEPROPERTY: &str = "TransitiveProperty";
+
+    /// owl:FunctionalProperty local name (class, not predicate)
+    pub const OWL_FUNCTIONALPROPERTY: &str = "FunctionalProperty";
+
+    /// owl:InverseFunctionalProperty local name (class, not predicate)
+    pub const OWL_INVERSEFUNCTIONALPROPERTY: &str = "InverseFunctionalProperty";
+
+    /// owl:imports local name
+    pub const OWL_IMPORTS: &str = "imports";
+
+    /// owl:Ontology local name (class)
+    pub const OWL_ONTOLOGY: &str = "Ontology";
+
+    /// owl:Class local name (class)
+    pub const OWL_CLASS: &str = "Class";
+
+    /// owl:ObjectProperty local name (class)
+    pub const OWL_OBJECTPROPERTY: &str = "ObjectProperty";
+
+    /// owl:DatatypeProperty local name (class)
+    pub const OWL_DATATYPEPROPERTY: &str = "DatatypeProperty";
+
+    /// rdf:Property local name (class)
+    pub const RDF_PROPERTY: &str = "Property";
 }
 
 /// Fluree DB namespace predicate local names (for SID construction)
@@ -1777,6 +1834,18 @@ pub mod config_iris {
 
     /// `f:schemaSource` — GraphRef pointing to schema hierarchy graph
     pub const SCHEMA_SOURCE: &str = "https://ns.flur.ee/db#schemaSource";
+
+    /// `f:followOwlImports` — boolean, follow owl:imports closure from schemaSource
+    pub const FOLLOW_OWL_IMPORTS: &str = "https://ns.flur.ee/db#followOwlImports";
+
+    /// `f:ontologyImportMap` — list of OntologyImportBinding
+    pub const ONTOLOGY_IMPORT_MAP: &str = "https://ns.flur.ee/db#ontologyImportMap";
+
+    /// `f:ontologyIri` — the external ontology IRI being mapped
+    pub const ONTOLOGY_IRI: &str = "https://ns.flur.ee/db#ontologyIri";
+
+    /// `f:graphRef` — nested GraphRef inside an OntologyImportBinding
+    pub const GRAPH_REF_PROP: &str = "https://ns.flur.ee/db#graphRef";
 
     // ---- Datalog fields ----
 


### PR DESCRIPTION
\
- Reasoning now sees class/property axioms that live outside the query's graph. Configure `f:schemaSource` on `f:reasoningDefaults` to point at an ontology graph, optionally set `f:followOwlImports true` to transitively resolve `owl:imports` across same-ledger graphs, and optionally provide an `f:ontologyImportMap` to bind external ontology IRIs to local graphs.
- Existing RDFS / OWL2-RL / OWL2-QL extraction code is unchanged. A new `SchemaBundleOverlay` projects whitelisted schema triples from every source graph onto `g_id=0`, so reasoners that scan the default graph pick them up automatically.
- End-to-end tests prove OWL2-RL rule firing (TransitiveProperty, inverseOf, rdfs:domain) when the axiom is declared in a transitively imported ontology.

## Problem

`f:schemaSource` was declared in the ledger-config schema but effectively ignored — `ReasoningDefaults.schema_source` was parsed into the type and never consulted. Reasoning always read schema from the query's graph (usually the default graph), so there was no way to:

- Keep instance data in one graph and the ontology in another.
- Share an ontology across multiple data graphs in a ledger.
- Use OWL's native `owl:imports` to compose ontologies.

The `reasoning_prep` / OWL2-RL code paths hardcoded `g_id=0` or `db.g_id`, so simply extending the config wiring wasn't enough — schema triples from other graphs had to be made visible to code that only looks at one graph.

## Fix

Three pieces, composed:

### 1. Resolver (`fluree-db-api/src/ontology_imports.rs`)

Given `ReasoningDefaults`, walk from `f:schemaSource` through the transitive `owl:imports` closure and return a `ResolvedSchemaBundle { ledger_id, to_t, sources: Vec<GraphId> }`.

Each `owl:imports <X>` triple is resolved in this order:

1. `<X>` is a named graph IRI in the current ledger → use that `GraphId`.
2. `<X>` has an entry in `f:ontologyImportMap` → resolve via the bound `GraphSourceRef`.
3. Otherwise, hard error with `ApiError::OntologyImport`. No silent skip.

Walk is BFS with dedup-by-resolved-`GraphId`, so cycles terminate naturally.

All resolutions flow through a single `resolve_local_graph_source` chokepoint that enforces:

- **Same-ledger.** Cross-ledger `GraphSourceRef` targets are rejected.
- **No reserved system graphs.** Resolving to `g_id=1` (txn-meta) or `g_id=2` (config) is always an error, regardless of resolution path (direct match, mapping table, or selector).
- **No unhonored `GraphSourceRef` fields.** `f:atT`, `f:trustPolicy`, `f:rollbackGuard` are rejected with clear errors rather than silently ignored — the bundle resolves at the query's single `to_t` with no trust verification.

Resolutions are cached in a process-global `SchemaBundleCache` (moka) keyed by `(ledger_id, to_t, starting_g_id, follow_imports)`. Because any config change in the ledger advances `t`, old entries naturally invalidate via LRU; no explicit invalidation needed.

### 2. Overlay (`fluree-db-query/src/schema_bundle.rs`)

`SchemaBundleOverlay` is an `OverlayProvider` wrapper that exposes whitelisted schema flakes from the bundle's source graphs **as if they lived in `g_id=0`**. This lets existing reasoning code run unchanged:

- For `g_id != 0`, delegates straight to the base overlay.
- For `g_id == 0`, linear-merges base flakes with bundle flakes in index order.

Flakes are materialized up-front via `build_schema_bundle_flakes`:

- One PSOT scan per schema predicate (`rdfs:subClassOf`, `rdfs:subPropertyOf`, `rdfs:domain`, `rdfs:range`, `owl:inverseOf`, `owl:equivalentClass`, `owl:equivalentProperty`, `owl:sameAs`, `owl:imports`).
- One OPST scan per schema class (`rdf:type ?` where the class is `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`, `owl:SymmetricProperty`, `owl:TransitiveProperty`, `owl:FunctionalProperty`, `owl:InverseFunctionalProperty`, `owl:Ontology`, `rdf:Property`).

Results are sorted into the four index orderings and stored as `Arc<[Flake]>`.

### 3. Wiring (`fluree-db-api/src/view/{query,dataset_query}.rs`)

`build_executable_for_view` → `attach_schema_bundle` runs per query:

1. Short-circuits when `"reasoning": "none"` — a query that opted out of reasoning must not fail because of an unrelated broken import in the ledger's config.
2. Short-circuits when there's no `f:schemaSource` — legacy default-graph reasoning applies unchanged.
3. Otherwise calls `resolve_schema_bundle` (cached), then `build_schema_bundle_flakes`, then sets `executable.options.schema_bundle`.

`prepare_execution` in `fluree-db-query` detects `schema_bundle` on the options and wraps `db.overlay` in a `SchemaBundleOverlay` for the reasoning-prep block. Hierarchy extraction, OWL2-RL materialization, and OWL2-QL ontology loading all see the full closure.

## Schema-triple whitelist

Only entailment-relevant predicates are projected from import graphs:

- **RDFS:** `subClassOf`, `subPropertyOf`, `domain`, `range`
- **OWL:** `inverseOf`, `equivalentClass`, `equivalentProperty`, `sameAs`, `imports`
- **`rdf:type`** only when the object is one of: `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`, `owl:SymmetricProperty`, `owl:TransitiveProperty`, `owl:FunctionalProperty`, `owl:InverseFunctionalProperty`, `owl:Ontology`, `rdf:Property`.

Anything else in an import graph — in particular, instance data — does not surface in the reasoner's view. Covered by the `instance_data_in_schema_graph_does_not_leak` regression test.

## Example config

```turtle
@prefix f:    <https://ns.flur.ee/db#> .
@prefix owl:  <http://www.w3.org/2002/07/owl#> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

GRAPH <urn:fluree:myapp:main#config> {
  <urn:myapp:config> a f:LedgerConfig ;
    f:reasoningDefaults <urn:myapp:config:reasoning> .

  <urn:myapp:config:reasoning>
    f:reasoningModes ( "rdfs" "owl2-rl" ) ;
    f:schemaSource <urn:myapp:config:schema-ref> ;
    f:followOwlImports true ;
    f:ontologyImportMap <urn:myapp:config:bfo-binding> .

  <urn:myapp:config:schema-ref> a f:GraphRef ;
    f:graphSource [ f:graphSelector <http://example.org/ontology/core> ] .

  <urn:myapp:config:bfo-binding>
    f:ontologyIri <http://purl.obolibrary.org/obo/bfo.owl> ;
    f:graphRef [ a f:GraphRef ;
                 f:graphSource [ f:graphSelector <http://example.org/ontology/local/bfo> ] ] .
}
```

## Tests

`fluree-db-api/tests/it_reasoning_imports.rs` covers:

- Same-ledger auto resolution of a named schema source.
- Transitive `A → B` with a subclass edge in `B`.
- Mapping table fallback for external IRIs.
- Unresolved imports surface as `ApiError::OntologyImport`.
- Cycle `A → B → A` terminates and still yields the correct closure.
- Mapping entries that would target a reserved system graph are rejected.
- `"reasoning": "none"` queries skip resolution entirely (no spurious errors from unrelated config).
- `f:atT` on a `GraphRef` is rejected with a clear message.
- Instance data in the schema graph does **not** leak into query results.
- **End-to-end OWL2-RL rule firing through a transitive import:**
  - `owl:TransitiveProperty` in imported graph B → transitive closure computed correctly.
  - `owl:inverseOf` in imported graph B → inverse query returns entailed bindings (base data has zero direct matches).
  - `rdfs:domain` in imported graph B → instance typed with the target class even though the data has no `rdf:type` triple.

Module-level unit tests cover cache keys, empty-bundle passthrough, and non-default-graph delegation.

## Files

**Core**
- `fluree-db-core/src/ledger_config.rs` — `ReasoningDefaults` gets `follow_owl_imports`, `ontology_import_map: Vec<OntologyImportBinding>`.
- `fluree-db-core/src/namespaces.rs` — `is_schema_predicate`, `is_schema_class`, `is_owl_imports` helpers (+ re-exports in `lib.rs`).

**Vocab**
- `fluree-vocab/src/lib.rs` — `owl::{IMPORTS, ONTOLOGY, CLASS, OBJECT_PROPERTY, DATATYPE_PROPERTY}`, `rdf::PROPERTY`, predicate local names, `config_iris::{FOLLOW_OWL_IMPORTS, ONTOLOGY_IMPORT_MAP, ONTOLOGY_IRI, GRAPH_REF_PROP}`.

**API**
- `fluree-db-api/src/ontology_imports.rs` (new) — resolver, closure walk, cache.
- `fluree-db-api/src/config_resolver.rs` — parses the two new reasoning fields, new `read_ontology_import_map`.
- `fluree-db-api/src/error.rs` — `ApiError::OntologyImport` variant.
- `fluree-db-api/src/view/{query,dataset_query}.rs` — `build_executable_for_view` is async; calls `attach_schema_bundle`.

**Query**
- `fluree-db-query/src/schema_bundle.rs` (new) — `SchemaBundleFlakes`, `SchemaBundleOverlay`, `build_schema_bundle_flakes`.
- `fluree-db-query/src/options.rs` — `QueryOptions::schema_bundle` field + `with_schema_bundle`.
- `fluree-db-query/src/execute/runner.rs` — wraps base overlay with `SchemaBundleOverlay` when a bundle is attached.

**Tests & Docs**
- `fluree-db-api/tests/it_reasoning_imports.rs` (new) — 12 integration tests.
- `docs/design/ontology-imports.md` (new), linked from `docs/SUMMARY.md`, `docs/design/README.md`, `CLAUDE.md`.
