### PR TITLE
fix: align JSON-LD `["optional", ...]` semantics with SPARQL `OPTIONAL`

### DIFF
--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -223,7 +223,15 @@ Match optional data that may not exist:
 }
 ```
 
-**Multiple Optionals:**
+#### Sibling vs. grouped OPTIONAL — semantics
+
+The two forms below are **not** equivalent. Each `["optional", ...]` array is a
+single OPTIONAL block in SPARQL terms — every item inside is part of the same
+conjunctive group, and a row is null-extended only when the group as a whole
+fails to match. To express two independent left joins, write two sibling
+arrays.
+
+**Sibling OPTIONALs — two independent left joins:**
 
 ```json
 {
@@ -235,7 +243,18 @@ Match optional data that may not exist:
 }
 ```
 
-**Grouped Optionals:**
+Equivalent SPARQL:
+
+```sparql
+?person ex:name ?name .
+OPTIONAL { ?person ex:email ?email }
+OPTIONAL { ?person ex:phone ?phone }
+```
+
+`?email` and `?phone` are independent — a person with only an email keeps
+`?email` bound and gets `null` for `?phone`, and vice versa.
+
+**Grouped OPTIONAL — one conjunctive left join:**
 
 ```json
 {
@@ -247,6 +266,39 @@ Match optional data that may not exist:
     ]
   ]
 }
+```
+
+Equivalent SPARQL:
+
+```sparql
+?person ex:name ?name .
+OPTIONAL { ?person ex:email ?email . ?person ex:phone ?phone }
+```
+
+`?email` and `?phone` are bound together — a person who has an email but no
+phone is null-extended on **both** variables, because the inner conjunctive
+group did not match as a whole.
+
+#### Filters and binds inside OPTIONAL
+
+`filter` and `bind` constrain or compute from existing bindings, so they need
+something to anchor to inside the OPTIONAL block. Any binding-producing
+pattern qualifies as an anchor — a node-map, `values`, an earlier `bind`, a
+nested `optional`, or a sub-`query`. A `filter` or `bind` as the very first
+item in an OPTIONAL array is rejected.
+
+```json
+["optional",
+  { "@id": "?person", "ex:age": "?age" },
+  ["filter", "(> ?age 18)"]
+]
+```
+
+```json
+["optional",
+  ["values", ["?x", [1, 2, 3]]],
+  ["filter", "(> ?x 0)"]
+]
 ```
 
 ### Union Patterns

--- a/fluree-db-api/tests/it_query_jsonld.rs
+++ b/fluree-db-api/tests/it_query_jsonld.rs
@@ -577,10 +577,12 @@ async fn jsonld_optional_two_separate() {
 }
 
 #[tokio::test]
-async fn jsonld_optional_two_in_same_vector() {
-    // Mirrors "query with two optionals in the same vector"
+async fn jsonld_optional_conjunctive_inner() {
+    // SPARQL semantics: ["optional", {a}, {b}] is one OPTIONAL with conjunctive inner —
+    // both a and b must match together, or both go null. Equivalent to
+    // SPARQL OPTIONAL { ?s :favColor ?favColor . ?s :email ?email }.
     let fluree = FlureeBuilder::memory().build_memory();
-    let ledger_id = "query/optional-two-same-vector:main";
+    let ledger_id = "query/optional-conjunctive:main";
 
     let ledger0 = genesis_ledger(&fluree, ledger_id);
     let ctx = context_ex_schema();
@@ -615,12 +617,14 @@ async fn jsonld_optional_two_in_same_vector() {
         .expect("query");
     let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
 
+    // Only Alice has BOTH favColor and email — the conjunctive inner matches.
+    // Brian has neither, Cam has only email — both null-extend on both vars.
     assert_eq!(
         normalize_rows(&json_rows),
         normalize_rows(&json!([
             ["Alice", "Green", "alice@flur.ee"],
             ["Brian", null, null],
-            ["Cam", null, "cam@flur.ee"]
+            ["Cam", null, null]
         ]))
     );
 }
@@ -849,11 +853,78 @@ async fn jsonld_optional_with_filter() {
 }
 
 #[tokio::test]
-async fn jsonld_optional_with_multiple_triples() {
-    // OPTIONAL with multiple node patterns (separate objects) - each is a separate optional
-    // Fluree semantics: ["optional", {node1}, {node2}] means two separate left joins
+async fn jsonld_optional_with_filter_multivalue_skosxl() {
+    // Regression for the SKOS-XL "language picker" bug:
+    // ?child has N candidate prefLabels. OPTIONAL { triple-chain . FILTER(lang=en) }
+    // must emit ONLY the matching label, not also a spurious null-extended row for
+    // each non-matching candidate (SPARQL 1.1 §8.1: LeftJoin null-extends only when
+    // NO inner solution is compatible).
     let fluree = FlureeBuilder::memory().build_memory();
-    let ledger_id = "query/optional-multi-triple:main";
+    let ledger_id = "query/optional-filter-multivalue:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    let ctx = json!({
+        "skos":   "http://www.w3.org/2004/02/skos/core#",
+        "skosxl": "http://www.w3.org/2008/05/skos-xl#",
+        "ex":     "https://example.com/"
+    });
+
+    let insert = json!({
+        "@context": ctx,
+        "@graph": [
+            { "@id": "ex:c1",   "@type": "skos:Concept" },
+            { "@id": "ex:L-en", "@type": "skosxl:Label",
+              "skosxl:literalForm": { "@value": "Spreadsheet Work",   "@language": "en" } },
+            { "@id": "ex:L-fr", "@type": "skosxl:Label",
+              "skosxl:literalForm": { "@value": "Travail sur tableur","@language": "fr" } },
+            { "@id": "ex:L-zh", "@type": "skosxl:Label",
+              "skosxl:literalForm": { "@value": "电子表格工作",         "@language": "zh" } },
+            { "@id": "ex:c1", "skosxl:prefLabel": [
+                { "@id": "ex:L-en" }, { "@id": "ex:L-fr" }, { "@id": "ex:L-zh" }
+            ]}
+        ]
+    });
+
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert")
+        .ledger;
+
+    let query = json!({
+        "@context": ctx,
+        "selectDistinct": ["?child", "?xlLang"],
+        "where": [
+            { "@id": "?child", "@type": "skos:Concept" },
+            ["optional",
+                { "@id": "?child", "skosxl:prefLabel": { "@id": "?xlLn" } },
+                { "@id": "?xlLn",  "skosxl:literalForm": "?xlLang" },
+                ["filter", "(= (lang ?xlLang) \"en\")"]
+            ]
+        ]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+
+    // Expected: exactly one row (the en label). NO spurious null-extended row,
+    // even though fr and zh candidates fail the filter.
+    assert_eq!(
+        normalize_rows(&json_rows),
+        normalize_rows(&json!([
+            ["ex:c1", { "@value": "Spreadsheet Work", "@language": "en" }]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn jsonld_two_independent_optionals() {
+    // Two sibling ["optional", ...] arrays = two independent left joins (SPARQL: two
+    // separate OPTIONAL { } blocks). Each OPTIONAL can independently null-extend.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "query/optional-two-independent:main";
     let ledger0 = genesis_ledger(&fluree, ledger_id);
     let ctx = context_ex_schema();
 
@@ -872,17 +943,13 @@ async fn jsonld_optional_with_multiple_triples() {
         .expect("insert")
         .ledger;
 
-    // Query: select users, optionally get age, optionally get city (separate optionals)
-    // Two node-map objects = two separate optional joins
     let query = json!({
         "@context": ctx,
         "select": ["?name", "?age", "?city"],
         "where": [
             {"@id": "?s", "@type": "ex:User", "schema:name": "?name"},
-            ["optional",
-                {"@id": "?s", "ex:age": "?age"},
-                {"@id": "?s", "ex:city": "?city"}
-            ]
+            ["optional", {"@id": "?s", "ex:age": "?age"}],
+            ["optional", {"@id": "?s", "ex:city": "?city"}]
         ],
         "orderBy": "?name"
     });
@@ -892,7 +959,6 @@ async fn jsonld_optional_with_multiple_triples() {
         .expect("query");
     let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
 
-    // Each optional is independent: Alice has both, Brian has only age, Cam has only city
     assert_eq!(
         json_rows,
         json!([

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1497,11 +1497,8 @@ pub fn build_where_operators_seeded_with_needed(
             }
 
             Pattern::Optional(_inner_patterns) => {
-                // OPTIONAL with conjunctive semantics: all inner patterns must match together.
-                //
-                // The parser now creates separate Optional patterns for each node-map in
-                // `["optional", {node1}, {node2}]`, so by the time we get here, each Optional
-                // contains patterns from a SINGLE node-map (conjunctive group).
+                // OPTIONAL with conjunctive semantics: all inner patterns must match together
+                // (SPARQL 1.1 §8.1 LeftJoin).
                 //
                 // Two paths:
                 // 1. Fast path: single triple pattern uses PatternOptionalBuilder (direct scan)

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -2826,6 +2826,86 @@ mod tests {
     }
 
     #[test]
+    fn test_optional_values_then_filter() {
+        // VALUES is a binding-producing pattern, so a following FILTER inside the
+        // same OPTIONAL block has an anchor and must be accepted.
+        // SPARQL: OPTIONAL { VALUES (?x) { (1) (2) (3) } FILTER(?x > 0) }
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?s", "?x"],
+            "where": [
+                { "@id": "?s", "ex:name": "?name" },
+                ["optional",
+                    ["values", ["?x", [1, 2, 3]]],
+                    ["filter", "(> ?x 0)"]
+                ]
+            ]
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let optional = find_optional(&ast.patterns).expect("Should have optional");
+        assert_eq!(optional.len(), 2);
+        assert!(matches!(optional[0], UnresolvedPattern::Values { .. }));
+        assert!(matches!(optional[1], UnresolvedPattern::Filter(_)));
+    }
+
+    #[test]
+    fn test_optional_bind_anchor_for_filter() {
+        // BIND inside OPTIONAL produces a binding for ?doubled, anchoring the
+        // following FILTER. The leading node-map provides the BIND anchor.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?s", "?x", "?doubled"],
+            "where": [
+                ["optional",
+                    { "@id": "?s", "ex:x": "?x" },
+                    ["bind", "?doubled", ["*", "?x", 2]],
+                    ["filter", "(> ?doubled 0)"]
+                ]
+            ]
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let optional = find_optional(&ast.patterns).expect("Should have optional");
+        // 1 triple from node-map + 1 bind + 1 filter
+        assert_eq!(optional.len(), 3);
+    }
+
+    #[test]
+    fn test_optional_filter_first_rejected() {
+        // FILTER as the very first item in an OPTIONAL has nothing to constrain
+        // and must be rejected.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?s"],
+            "where": [
+                { "@id": "?s", "ex:name": "?name" },
+                ["optional", ["filter", "(> ?name 0)"]]
+            ]
+        });
+
+        let result = parse_query_ast(&json, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_optional_bind_first_rejected() {
+        // BIND as the very first item in an OPTIONAL has nothing to bind from
+        // and must be rejected (matches the pre-existing contract).
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?s", "?x"],
+            "where": [
+                { "@id": "?s", "ex:name": "?name" },
+                ["optional", ["bind", "?x", ["+", 1, 1]]]
+            ]
+        });
+
+        let result = parse_query_ast(&json, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_nested_optional_structure_preserved() {
         // Nested OPTIONAL should create nested Optional(...) wrapper, not flatten
         let json = json!({

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -2712,7 +2712,9 @@ mod tests {
 
         let optional = find_optional(&ast.patterns).expect("Should have optional");
         assert_eq!(optional.len(), 2);
-        assert!(optional.iter().all(super::ast::UnresolvedPattern::is_triple));
+        assert!(optional
+            .iter()
+            .all(super::ast::UnresolvedPattern::is_triple));
     }
 
     #[test]

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -2691,7 +2691,8 @@ mod tests {
 
     #[test]
     fn test_optional_multiple_patterns() {
-        // Optional with multiple patterns inside
+        // SPARQL semantics: ["optional", {a}, {b}] is one conjunctive OPTIONAL,
+        // equivalent to OPTIONAL { a . b }.
         let json = json!({
             "@context": { "ex": "http://example.org/" },
             "select": ["?s", "?name", "?email", "?phone"],
@@ -2707,13 +2708,11 @@ mod tests {
         let (ast, _) = parse_query_ast(&json, None).unwrap();
 
         assert_eq!(count_triples(&ast.patterns), 1);
-        // Fluree semantics: each node-map object becomes its own OPTIONAL clause.
-        assert_eq!(count_optionals(&ast.patterns), 2);
+        assert_eq!(count_optionals(&ast.patterns), 1);
 
         let optional = find_optional(&ast.patterns).expect("Should have optional");
-        // Each OPTIONAL should contain 1 triple pattern
-        assert_eq!(optional.len(), 1);
-        assert!(optional[0].is_triple());
+        assert_eq!(optional.len(), 2);
+        assert!(optional.iter().all(super::ast::UnresolvedPattern::is_triple));
     }
 
     #[test]

--- a/fluree-db-query/src/parse/where_clause.rs
+++ b/fluree-db-query/src/parse/where_clause.rs
@@ -452,16 +452,20 @@ pub fn parse_subquery_patterns(
     Ok(patterns)
 }
 
-/// Parse OPTIONAL patterns with Fluree's grouping semantics
+/// Parse OPTIONAL patterns with SPARQL-canonical grouping semantics
 ///
-/// Fluree semantics: each node-map OBJECT is a SEPARATE optional.
-/// - `["optional", {nodeA}, {nodeB}]` means two separate left joins
-/// - `["optional", {nodeWithMultipleProps}]` is a single conjunctive optional
-/// - `["optional", {node}, ["filter", ...]]` keeps filter with preceding node (conjunctive)
+/// The entire `["optional", ...]` array is a single OPTIONAL block — equivalent
+/// to one SPARQL `OPTIONAL { ... }`. All items inside become a conjunctive group
+/// (a single `LeftJoin` in the algebra).
 ///
-/// Array elements (filters, nested optionals, values, etc.) are accumulated
-/// with the preceding node-map patterns to form conjunctive groups.
-/// Array elements must follow a node-map; ["optional", ["filter", ...], {...}] is invalid.
+/// - `["optional", {a}, {b}]` ≡ `OPTIONAL { a . b }` (one left join, conjunctive inner)
+/// - `["optional", {a}, ["filter", ...]]` ≡ `OPTIONAL { a FILTER(...) }`
+/// - To get two independent left joins, use two sibling arrays:
+///   `["optional", {a}], ["optional", {b}]`.
+///
+/// Filters and binds require a preceding node-map in the group, since they
+/// constrain or compute from existing bindings. Other array forms (nested
+/// optional, values, query, etc.) are self-contained.
 fn parse_optional_patterns(
     items: &[JsonValue],
     ctx: &JsonLdParseCtx,
@@ -476,25 +480,14 @@ fn parse_optional_patterns(
         ));
     }
 
-    // Accumulate patterns for the current optional group
-    let mut current_group: Vec<UnresolvedPattern> = Vec::new();
-    // Track whether we've seen a node-map in the current group
+    let mut group: Vec<UnresolvedPattern> = Vec::new();
     let mut has_node_map_anchor = false;
 
     for item in items {
         match item {
             JsonValue::Object(map) => {
-                // Fluree semantics: each node-map OBJECT is its own OPTIONAL clause.
-                // When we see a new node-map object and we already have accumulated patterns,
-                // flush the current group as one OPTIONAL and start a new one.
-                if !current_group.is_empty() {
-                    query.add_optional(std::mem::take(&mut current_group));
-                }
-
-                // Node-map object adds patterns to the new/current optional group.
                 has_node_map_anchor = true;
 
-                // Parse node-map and add its patterns to the current group
                 let mut temp_query = UnresolvedQuery::new(ctx.context.clone());
                 node_map::parse_node_map(
                     map,
@@ -504,15 +497,10 @@ fn parse_optional_patterns(
                     nested_counter,
                     object_var_parsing,
                 )?;
-                current_group.extend(temp_query.patterns);
+                group.extend(temp_query.patterns);
             }
             JsonValue::Array(inner_arr) => {
-                // Array elements are added to the current group.
-                // Some elements (filter, bind) require a node-map anchor since they
-                // constrain/compute from existing patterns. Others (query, optional,
-                // union, values, exists, etc.) are self-contained and can stand alone.
-                if !has_node_map_anchor && current_group.is_empty() {
-                    // Check if this is a constraint that needs an anchor
+                if !has_node_map_anchor {
                     let keyword = inner_arr.first().and_then(|v| v.as_str());
                     if matches!(keyword, Some("filter" | "bind")) {
                         return Err(ParseError::InvalidWhere(
@@ -522,7 +510,6 @@ fn parse_optional_patterns(
                     }
                 }
 
-                // Add to the current group
                 let mut temp_query = UnresolvedQuery::new(ctx.context.clone());
                 parse_where_array_element(
                     inner_arr,
@@ -532,7 +519,7 @@ fn parse_optional_patterns(
                     nested_counter,
                     object_var_parsing,
                 )?;
-                current_group.extend(temp_query.patterns);
+                group.extend(temp_query.patterns);
             }
             _ => {
                 return Err(ParseError::InvalidWhere(
@@ -542,9 +529,8 @@ fn parse_optional_patterns(
         }
     }
 
-    // Flush any remaining patterns as the final optional group
-    if !current_group.is_empty() {
-        query.add_optional(current_group);
+    if !group.is_empty() {
+        query.add_optional(group);
     }
     Ok(())
 }

--- a/fluree-db-query/src/parse/where_clause.rs
+++ b/fluree-db-query/src/parse/where_clause.rs
@@ -463,9 +463,11 @@ pub fn parse_subquery_patterns(
 /// - To get two independent left joins, use two sibling arrays:
 ///   `["optional", {a}], ["optional", {b}]`.
 ///
-/// Filters and binds require a preceding node-map in the group, since they
-/// constrain or compute from existing bindings. Other array forms (nested
-/// optional, values, query, etc.) are self-contained.
+/// Filters and binds require a preceding pattern in the group, since they
+/// constrain or compute from existing bindings. Any anchor — node-map,
+/// `values`, `bind`, nested `optional`, sub-`query`, etc. — qualifies; only a
+/// filter/bind as the very first item in the array is rejected. Other array
+/// forms are self-contained and may appear in any position.
 fn parse_optional_patterns(
     items: &[JsonValue],
     ctx: &JsonLdParseCtx,
@@ -500,11 +502,12 @@ fn parse_optional_patterns(
                 group.extend(temp_query.patterns);
             }
             JsonValue::Array(inner_arr) => {
-                if !has_node_map_anchor {
+                if !has_node_map_anchor && group.is_empty() {
                     let keyword = inner_arr.first().and_then(|v| v.as_str());
                     if matches!(keyword, Some("filter" | "bind")) {
                         return Err(ParseError::InvalidWhere(
-                            "filter and bind in optional must follow a node-map pattern"
+                            "filter and bind in optional must follow a binding-producing \
+                             pattern"
                                 .to_string(),
                         ));
                     }


### PR DESCRIPTION

Fixes a SPARQL-conformance bug where `OPTIONAL { ... FILTER(...) }` over a multi-valued predicate emitted a spurious null-extended row in addition to the matching row.

The root cause was JSON-LD-specific: the WHERE-clause parser treated each node-map object inside an `["optional", {a}, {b}, ...]` array as a separate `OPTIONAL` clause (`OPTIONAL { a } OPTIONAL { b }`). Per SPARQL 1.1 §8.1, an `OPTIONAL` block is a single conjunctive group graph pattern, so the array should lower to one `LeftJoin` over a conjunctive inner pattern.

## What was happening

The reported repro:

```jsonc
["optional",
  { "@id": "?child", "skosxl:prefLabel": { "@id": "?xlLn" } },
  { "@id": "?xlLn",  "skosxl:literalForm": "?xlLang" },
  ["filter", "(= (lang ?xlLang) \"en\")"]
]
```

…parsed to **two** sibling `Optional`s, producing `LeftJoin(LeftJoin(outer, P1), P2_with_filter)`. For a concept with three multi-language labels, the outer LeftJoin produced three candidate `?xlLn` bindings; for two of them the filter inside the second OPTIONAL rejected every inner row, so the operator emitted a null-extended row per non-match. After `SELECT DISTINCT` this surfaced as `[concept, "Spreadsheet Work"@en]` plus a spurious `[concept, null]`.

The OPTIONAL execution operator (`fluree-db-query/src/optional.rs`) was already correct — it tracks `matched` per required row and only null-extends when no inner row was compatible. The bug was purely upstream, in how the parser grouped the OPTIONAL block.

## Fix

`fluree-db-query/src/parse/where_clause.rs::parse_optional_patterns` now accumulates **all** items in the `["optional", ...]` array into one conjunctive group (one `Pattern::Optional`). To express two independent left joins, write two sibling arrays:

```jsonc
// Before (split into two OPTIONALs implicitly):
["optional", {a}, {b}]
// Now equivalent to SPARQL: OPTIONAL { a . b }  (one LeftJoin, conjunctive inner)

// To get the old "two independent OPTIONALs" behavior, write:
["optional", {a}],
["optional", {b}]
// Equivalent to SPARQL: OPTIONAL { a } OPTIONAL { b }
```

This matches SPARQL semantics exactly and incidentally fixes the secondary "cartesian-join" issue mentioned in the bug report (a fallback OPTIONAL adjacent to one with a filter was also being split into multiple LeftJoins).

## Behavior changes

| Form                                | Before                                  | After                                           |
|-------------------------------------|-----------------------------------------|-------------------------------------------------|
| `["optional", {a}]`                 | one OPTIONAL                            | one OPTIONAL (unchanged)                        |
| `["optional", {a}, ["filter",...]]` | one OPTIONAL with filter (unchanged)    | one OPTIONAL with filter (unchanged)            |
| `["optional", {a}, {b}]`            | **two** independent OPTIONALs (Fluree)  | **one** OPTIONAL with conjunctive inner (SPARQL)|
| `["optional", {a}], ["optional", {b}]` | two independent OPTIONALs            | two independent OPTIONALs (unchanged)           |

Tests updated:

- `fluree-db-query::parse::tests::test_optional_multiple_patterns` — now asserts one OPTIONAL with two triples.
- `it_query_jsonld::jsonld_optional_two_in_same_vector` → renamed to `jsonld_optional_conjunctive_inner`; expected output updated to reflect conjunctive semantics (subjects missing either var get null on both, not just the missing one).
- `it_query_jsonld::jsonld_optional_with_multiple_triples` → renamed to `jsonld_two_independent_optionals`; rewritten with two sibling arrays so the original "independent left joins" intent still has coverage under SPARQL semantics.

New regression test:

- `it_query_jsonld::jsonld_optional_with_filter_multivalue_skosxl` — direct port of the bug-report repro.
