### PR TITLE
 fix: bind `@op` and emit sidecar events for history-range queries

### DIFF
--- a/fluree-db-api/tests/it_query_history_range.rs
+++ b/fluree-db-api/tests/it_query_history_range.rs
@@ -1,0 +1,157 @@
+//! Regression test for history-range queries against indexed ledgers.
+//!
+//! Reporter scenario: a query with explicit `"from"`/`"to"` keys (e.g.
+//! `"from": "ledger@t:1", "to": "ledger@t:latest"`) should emit every
+//! assert and retract event with `t` in that range, and the `@op`
+//! binding should resolve to `"assert"` or `"retract"` per event.
+//!
+//! Before the fix:
+//! - The binary cursor only emitted currently-asserted base rows, so
+//!   the assert at t=1 and the retract at t=2 for an overwritten value
+//!   never appeared in history-range output on indexed ledgers.
+//! - `@op` always serialised as `null` because every scan constructed
+//!   `Binding::Lit { op: None, .. }` (the only populating constructor,
+//!   `from_object_with_t_op`, had zero call sites).
+//!
+//! After the fix, a dedicated `BinaryHistoryScanOperator` merges:
+//! - history sidecar events (both assert and retract, with explicit op)
+//! - base rows whose `t` falls in range (emitted as assert)
+//! - overlay/novelty events when `to_t > index_t`
+//! and each emitted row carries `t` and `op` on the binding.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
+use serde_json::json;
+
+fn ctx() -> serde_json::Value {
+    json!({
+        "ex": "http://example.org/",
+    })
+}
+
+/// Reindex the ledger. Returns the indexed `index_t`.
+async fn reindex_to_current(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+) -> i64 {
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let status = fluree.index_status(ledger_id).await.expect("index_status");
+    status.index_t
+}
+
+/// History-range query should emit assert + retract events from the
+/// history sidecar, with `@op` bound to `"assert"` / `"retract"`.
+///
+/// Sequence:
+/// - t=1: insert `ex:alice ex:name "Alice"`
+/// - reindex (index_t = 1)
+/// - t=2: upsert `ex:alice ex:name "Alice Smith"`
+///   (retracts "Alice", asserts "Alice Smith")
+/// - reindex (index_t = 2; sidecar now carries the retract + old assert)
+///
+/// A history query `from t:1 to t:latest` on `ex:name` for `ex:alice`
+/// must return three rows:
+/// - `("Alice",       t=1, assert)` — original assert, now in sidecar
+/// - `("Alice",       t=2, retract)` — retract from the upsert, in sidecar
+/// - `("Alice Smith", t=2, assert)`  — current value, in base columns
+#[tokio::test]
+async fn history_range_emits_sidecar_events_with_op() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let fluree = FlureeBuilder::file(path).build().expect("build");
+    let ledger_id = "test/history-range:main";
+
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    // t=1: assert name="Alice"
+    let tx1 = json!({
+        "@context": ctx(),
+        "@id": "ex:alice",
+        "ex:name": "Alice",
+    });
+    let r1 = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    assert_eq!(r1.receipt.t, 1);
+
+    // Index at t=1 so the next transaction's retract lands in the sidecar.
+    let index_t_a = reindex_to_current(&fluree, ledger_id).await;
+    assert_eq!(index_t_a, 1);
+
+    // t=2: upsert to name="Alice Smith" — retracts "Alice", asserts "Alice Smith".
+    let tx2 = json!({
+        "@context": ctx(),
+        "@id": "ex:alice",
+        "ex:name": "Alice Smith",
+    });
+    let r2 = fluree.upsert(r1.ledger, &tx2).await.expect("tx2");
+    assert_eq!(r2.receipt.t, 2);
+
+    // Index at t=2 so the retract + old assert live in the sidecar,
+    // and the new assert lives in base columns.
+    let index_t_b = reindex_to_current(&fluree, ledger_id).await;
+    assert_eq!(index_t_b, 2);
+
+    // History-range query: ex:alice ex:name ?v over [t=1, t=latest].
+    // Bind @t and @op so we can assert on both.
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "ex:alice",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+        "orderBy": ["?t", "?op", "?v"],
+    });
+
+    let result = fluree
+        .query_from()
+        .jsonld(&q)
+        .format(FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .expect("history range query");
+
+    let value = serde_json::to_value(&result.result).expect("serialize");
+    let rows = value.as_array().expect("rows array").clone();
+
+    // Helper: flatten one formatted row `{"?v": ..., "?t": ..., "?op": ...}`
+    // into `(v_str, t_i64, op_str)` so assertions are easy to read.
+    fn flatten(row: &serde_json::Value) -> (String, i64, String) {
+        let v = row
+            .get("?v")
+            .and_then(|x| x.get("@value"))
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let t = row
+            .get("?t")
+            .and_then(|x| x.get("@value"))
+            .and_then(|x| x.as_i64())
+            .unwrap_or(-1);
+        let op = row
+            .get("?op")
+            .and_then(|x| x.get("@value").or(Some(x)))
+            .and_then(|x| x.as_str())
+            .unwrap_or("null")
+            .to_string();
+        (v, t, op)
+    }
+
+    let flattened: Vec<(String, i64, String)> = rows.iter().map(flatten).collect();
+    let expected: Vec<(String, i64, String)> = vec![
+        ("Alice".to_string(),       1, "assert".to_string()),
+        ("Alice".to_string(),       2, "retract".to_string()),
+        ("Alice Smith".to_string(), 2, "assert".to_string()),
+    ];
+    assert_eq!(
+        flattened, expected,
+        "history range must emit sidecar events with @op bound; got rows {rows:#?}"
+    );
+}

--- a/fluree-db-api/tests/it_query_history_range.rs
+++ b/fluree-db-api/tests/it_query_history_range.rs
@@ -156,3 +156,364 @@ async fn history_range_emits_sidecar_events_with_op() {
         "history range must emit sidecar events with @op bound; got rows {rows:#?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Helpers shared with the coverage cases below
+// ---------------------------------------------------------------------------
+
+/// Flatten a formatted row into `(?v, ?t, ?op)` strings.
+fn flatten_v_t_op(row: &serde_json::Value) -> (String, i64, String) {
+    let v = row
+        .get("?v")
+        .and_then(|x| x.get("@value"))
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let t = row
+        .get("?t")
+        .and_then(|x| x.get("@value"))
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(-1);
+    let op = row
+        .get("?op")
+        .and_then(|x| x.get("@value").or(Some(x)))
+        .and_then(|x| x.as_str())
+        .unwrap_or("null")
+        .to_string();
+    (v, t, op)
+}
+
+async fn run_history_query(
+    fluree: &fluree_db_api::Fluree,
+    q: &serde_json::Value,
+) -> Vec<(String, i64, String)> {
+    let result = fluree
+        .query_from()
+        .jsonld(q)
+        .format(FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .expect("history range query");
+    let value = serde_json::to_value(&result.result).expect("serialize");
+    value
+        .as_array()
+        .expect("rows array")
+        .iter()
+        .map(flatten_v_t_op)
+        .collect()
+}
+
+/// Variant for queries that select only `?v, ?t` (e.g. when `@op` is a
+/// constant filter rather than a bound variable).
+async fn run_history_query_no_op(
+    fluree: &fluree_db_api::Fluree,
+    q: &serde_json::Value,
+) -> Vec<(String, i64)> {
+    let result = fluree
+        .query_from()
+        .jsonld(q)
+        .format(FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .expect("history range query");
+    let value = serde_json::to_value(&result.result).expect("serialize");
+    value
+        .as_array()
+        .expect("rows array")
+        .iter()
+        .map(|row| {
+            let v = row
+                .get("?v")
+                .and_then(|x| x.get("@value"))
+                .and_then(|x| x.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let t = row
+                .get("?t")
+                .and_then(|x| x.get("@value"))
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(-1);
+            (v, t)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Case: novelty-only history (no reindex between commits).
+//
+// Verifies the path through `flakes_to_bindings:~704`, which already
+// populated `op` from `flake.op` for overlay/novelty flakes. The new
+// `BinaryHistoryScanOperator` must not regress that path.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn history_range_novelty_only() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-novelty:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    // t=1 Alice / t=2 rename Alice→Alice Smith. No reindex: everything
+    // stays in novelty.
+    let r1 = fluree
+        .insert(
+            ledger0,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice"}),
+        )
+        .await
+        .expect("tx1");
+    let r2 = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice Smith"}),
+        )
+        .await
+        .expect("tx2");
+    assert_eq!(r2.receipt.t, 2);
+
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "ex:alice",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+        "orderBy": ["?t", "?op", "?v"],
+    });
+
+    let rows = run_history_query(&fluree, &q).await;
+    let expected: Vec<(String, i64, String)> = vec![
+        ("Alice".to_string(), 1, "assert".to_string()),
+        ("Alice Smith".to_string(), 2, "assert".to_string()),
+        ("Alice".to_string(), 2, "retract".to_string()),
+    ];
+    assert_eq!(rows, expected, "novelty-only history must also bind @op");
+}
+
+// ---------------------------------------------------------------------------
+// Case: `@op` as a constant filter — asserts only.
+//
+// The parser lowers `{"@op": "assert"}` into `FILTER(op(?v) = "assert")`.
+// That filter runs downstream of the scan, so the history operator
+// just needs to emit rows with op populated and the FILTER does the rest.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn history_range_op_constant_filter_assert() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-op-filter:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    let r1 = fluree
+        .insert(
+            ledger0,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice"}),
+        )
+        .await
+        .expect("tx1");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 1);
+    let _ = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice Smith"}),
+        )
+        .await
+        .expect("tx2");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 2);
+
+    // Ask only for asserts. `@op: "assert"` is a FILTER constant, not a
+    // BIND — `?op` never exists as a variable, so select only `?v`/`?t`
+    // and assert the filter returns both assert events and no retracts.
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t"],
+        "where": [{
+            "@id": "ex:alice",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "assert"}
+        }],
+        "orderBy": ["?t", "?v"],
+    });
+    let rows = run_history_query_no_op(&fluree, &q).await;
+    let expected: Vec<(String, i64)> =
+        vec![("Alice".to_string(), 1), ("Alice Smith".to_string(), 2)];
+    assert_eq!(
+        rows, expected,
+        "@op=\"assert\" filter must return only assert events"
+    );
+}
+
+#[tokio::test]
+async fn history_range_op_constant_filter_retract() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-op-filter-retract:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    let r1 = fluree
+        .insert(
+            ledger0,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice"}),
+        )
+        .await
+        .expect("tx1");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 1);
+    let _ = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice Smith"}),
+        )
+        .await
+        .expect("tx2");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 2);
+
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t"],
+        "where": [{
+            "@id": "ex:alice",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "retract"}
+        }],
+        "orderBy": ["?t", "?v"],
+    });
+    let rows = run_history_query_no_op(&fluree, &q).await;
+    let expected: Vec<(String, i64)> = vec![("Alice".to_string(), 2)];
+    assert_eq!(
+        rows, expected,
+        "@op=\"retract\" filter must return only retract events"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case: sidecar + novelty boundary. Reindex t=1, transact t=2 (stays in
+// novelty), query spanning the boundary. Exercises the `to_t > index_t`
+// novelty merge path.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn history_range_sidecar_plus_novelty_boundary() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-boundary:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    // t=1: assert "Alice". Index at t=1.
+    let r1 = fluree
+        .insert(
+            ledger0,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice"}),
+        )
+        .await
+        .expect("tx1");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 1);
+
+    // t=2: upsert "Alice Smith". DO NOT reindex — retract+assert stay
+    // in novelty, crossing the index_t boundary.
+    let _ = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice Smith"}),
+        )
+        .await
+        .expect("tx2");
+    let status = fluree.index_status(ledger_id).await.expect("index_status");
+    assert_eq!(status.index_t, 1);
+    assert_eq!(status.commit_t, 2);
+
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "ex:alice",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+        "orderBy": ["?t", "?op", "?v"],
+    });
+    let rows = run_history_query(&fluree, &q).await;
+    let expected: Vec<(String, i64, String)> = vec![
+        // t=1 assert comes from base (base t=1 ≤ persisted_to_t=1)
+        ("Alice".to_string(), 1, "assert".to_string()),
+        // t=2 assert+retract come from novelty ((index_t, to_t])
+        ("Alice Smith".to_string(), 2, "assert".to_string()),
+        ("Alice".to_string(), 2, "retract".to_string()),
+    ];
+    assert_eq!(
+        rows, expected,
+        "history merge across index_t boundary must include novelty events"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case: subject-unbound history. No subject in the pattern; walks the
+// branch (predicate-bound so leaflet p_const filter helps).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn history_range_subject_unbound() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-unbound-subject:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    // t=1: two subjects get names.
+    let r1 = fluree
+        .insert(
+            ledger0,
+            &json!({"@context": ctx(), "@graph": [
+                {"@id": "ex:alice", "ex:name": "Alice"},
+                {"@id": "ex:bob",   "ex:name": "Bob"},
+            ]}),
+        )
+        .await
+        .expect("tx1");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 1);
+
+    // t=2: rename Alice only.
+    let _ = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice Smith"}),
+        )
+        .await
+        .expect("tx2");
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 2);
+
+    // Subject is a variable; only predicate is bound.
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "?s",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+        "orderBy": ["?t", "?op", "?v"],
+    });
+    let rows = run_history_query(&fluree, &q).await;
+    // t=1: Alice+assert, Bob+assert; t=2: Alice Smith+assert, Alice+retract
+    let expected: Vec<(String, i64, String)> = vec![
+        ("Alice".to_string(), 1, "assert".to_string()),
+        ("Bob".to_string(), 1, "assert".to_string()),
+        ("Alice Smith".to_string(), 2, "assert".to_string()),
+        ("Alice".to_string(), 2, "retract".to_string()),
+    ];
+    assert_eq!(
+        rows, expected,
+        "subject-unbound history must walk all matching leaflets"
+    );
+}

--- a/fluree-db-api/tests/it_query_history_range.rs
+++ b/fluree-db-api/tests/it_query_history_range.rs
@@ -17,6 +17,7 @@
 //! - history sidecar events (both assert and retract, with explicit op)
 //! - base rows whose `t` falls in range (emitted as assert)
 //! - overlay/novelty events when `to_t > index_t`
+//!
 //! and each emitted row carries `t` and `op` on the binding.
 
 #![cfg(feature = "native")]
@@ -33,10 +34,7 @@ fn ctx() -> serde_json::Value {
 }
 
 /// Reindex the ledger. Returns the indexed `index_t`.
-async fn reindex_to_current(
-    fluree: &fluree_db_api::Fluree,
-    ledger_id: &str,
-) -> i64 {
+async fn reindex_to_current(fluree: &fluree_db_api::Fluree, ledger_id: &str) -> i64 {
     fluree
         .reindex(ledger_id, ReindexOptions::default())
         .await
@@ -133,7 +131,7 @@ async fn history_range_emits_sidecar_events_with_op() {
         let t = row
             .get("?t")
             .and_then(|x| x.get("@value"))
-            .and_then(|x| x.as_i64())
+            .and_then(serde_json::Value::as_i64)
             .unwrap_or(-1);
         let op = row
             .get("?op")
@@ -145,10 +143,13 @@ async fn history_range_emits_sidecar_events_with_op() {
     }
 
     let flattened: Vec<(String, i64, String)> = rows.iter().map(flatten).collect();
+    // orderBy (?t, ?op, ?v) with lexicographic ordering:
+    //   "assert" < "retract", so at t=2 the assert of "Alice Smith" comes
+    //   before the retract of "Alice".
     let expected: Vec<(String, i64, String)> = vec![
-        ("Alice".to_string(),       1, "assert".to_string()),
-        ("Alice".to_string(),       2, "retract".to_string()),
+        ("Alice".to_string(), 1, "assert".to_string()),
         ("Alice Smith".to_string(), 2, "assert".to_string()),
+        ("Alice".to_string(), 2, "retract".to_string()),
     ];
     assert_eq!(
         flattened, expected,

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -38,8 +38,13 @@
 //! All heavy lifting happens in `open()` (three-source collection into
 //! a `Vec<Flake>`), so that's where the fuel guardrail lives.
 //!
-//! - **Persisted pass:** 1000 micro-fuel per leaflet touched — same
-//!   rate `BinaryCursor::next_batch` uses for non-history scans.
+//! - **Persisted pass:** `1000 + sidecar_rows + base_rows` micro-fuel per
+//!   leaflet, charged from the directory entry before any sidecar segment
+//!   or column load — overrun short-circuits before I/O. The 1000 base
+//!   matches `BinaryCursor::next_batch` for non-history scans; the
+//!   row-count terms account for sidecar replay + base-row decode work
+//!   that the non-history path doesn't perform. Overcharges on rows
+//!   rejected by `filter.matches()`; that's the guardrail tradeoff.
 //! - **Novelty pass:** 1 micro-fuel per matched novelty flake, charged
 //!   during the walk. A captured `FuelExceededError` short-circuits the
 //!   walk on the next callback invocation.
@@ -226,19 +231,24 @@ impl BinaryHistoryScanOperator {
                                 continue;
                             }
 
-                            // Charge 1 fuel (1000 micro-fuel) per leaflet we touch,
-                            // mirroring `BinaryCursor::next_batch` for the non-history
-                            // scan path. This is the cost-model guardrail — without
-                            // it, a broad history query could do unbounded column /
-                            // sidecar loads in `open()` before the caller ever sees
-                            // the first batch.
-                            ctx.tracker.consume_fuel(1000)?;
-
                             // Sidecar: only load when the segment's t range can
                             // overlap [from_t, persisted_to_t].
                             let sidecar_in_range = leaflet.history_len > 0
                                 && leaflet.history_max_t >= from_t_u32
                                 && leaflet.history_min_t <= persisted_to_u32;
+
+                            // Scale per-leaflet fuel by rows we'll actually iterate.
+                            // Both counts come from the directory entry — no I/O
+                            // needed to charge — so we short-circuit before the
+                            // sidecar segment / column load on overrun. Overcharges
+                            // on filter-rejected rows; that's the guardrail tradeoff.
+                            let sidecar_rows =
+                                if sidecar_in_range { leaflet.history_len as u64 } else { 0 };
+                            let base_rows = leaflet.row_count as u64;
+                            ctx.tracker.consume_fuel(
+                                1000u64.saturating_add(sidecar_rows).saturating_add(base_rows),
+                            )?;
+
                             if sidecar_in_range {
                                 let segment =
                                     handle.load_sidecar_segment(leaflet_idx).map_err(|e| {

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -25,8 +25,45 @@
 //! - leaflet-level skip via `p_const`, `o_type_const`, and
 //!   `history_max_t < from_t`
 //!
-//! Non-history queries and queries with no binary store fall through
-//! to `BinaryScanOperator::open` unchanged.
+//! Non-history queries delegate to `BinaryScanOperator::open` unchanged.
+//! History queries always go through `collect_history_flakes`, even when
+//! no binary store is attached: in the no-store case the persisted pass
+//! is skipped (`index_t = -1`) and the novelty walk is the whole event
+//! stream. This is deliberate — the core `range_with_overlay` genesis
+//! path calls `remove_stale_flakes` which drops retracts, and that's
+//! wrong for history mode.
+//!
+//! ## Cost model
+//!
+//! All heavy lifting happens in `open()` (three-source collection into
+//! a `Vec<Flake>`), so that's where the fuel guardrail lives.
+//!
+//! - **Persisted pass:** 1000 micro-fuel per leaflet touched — same
+//!   rate `BinaryCursor::next_batch` uses for non-history scans.
+//! - **Novelty pass:** 1 micro-fuel per matched novelty flake, charged
+//!   during the walk. A captured `FuelExceededError` short-circuits the
+//!   walk on the next callback invocation.
+//! - **Per-flake emit:** 1 micro-fuel per flake is charged downstream in
+//!   `flakes_to_bindings` when `next_batch` drains the collected vec.
+//!
+//! Together these keep a broad unindexed or index-lagged history query
+//! from doing unbounded eager work before the caller sees the first
+//! batch.
+//!
+//! ## Known follow-ups
+//!
+//! - **Per-leaf sidecar pruning.** `open_leaf_handle(..., need_replay=true)`
+//!   fetches the whole sidecar blob up front. For leaves whose directory
+//!   doesn't yet reveal any leaflet with `history_max_t >= from_t`, this
+//!   is wasted I/O on local/cached reads. Fixing this cleanly needs
+//!   either a two-pass open (dir first, sidecar on demand) or leaf-level
+//!   `history_max_t` on `LeafEntry` so we can prune without opening.
+//!   Tracked for a follow-up.
+//! - **Streaming emit.** `collect_history_flakes` materialises the full
+//!   matched event set before `next_batch` drains it. Bound-subject /
+//!   bound-predicate queries match a tiny set so this is cheap. Broad
+//!   queries (`?s ?p ?o` across a wide range) can benefit from a
+//!   leaflet-at-a-time streaming cursor — also tracked as a follow-up.
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -50,9 +87,12 @@ use crate::var_registry::VarId;
 /// Scan operator that activates a dedicated history-range walk when
 /// `ctx.history_mode` is true.
 ///
-/// When history mode is not active (or no binary store is available),
-/// this wrapper transparently delegates to `BinaryScanOperator` — the
-/// regular scan path is unchanged.
+/// When history mode is not active, this wrapper transparently delegates
+/// to `BinaryScanOperator::open` — the regular scan path is unchanged.
+/// When history mode is active, the operator runs its own three-source
+/// merge (sidecar + base + novelty) regardless of whether a binary store
+/// is attached: an unindexed ledger just skips the persisted pass and
+/// takes the full event stream from novelty.
 pub struct BinaryHistoryScanOperator {
     inner: BinaryScanOperator,
     pattern: TriplePattern,
@@ -121,146 +161,164 @@ impl BinaryHistoryScanOperator {
     /// in-range base rows, merges with overlay/novelty events, and
     /// returns flakes with explicit `op`.
     async fn collect_history_flakes(&self, ctx: &ExecutionContext<'_>) -> Result<Vec<Flake>> {
-        let store = ctx
-            .binary_store
-            .clone()
-            .ok_or_else(|| QueryError::Internal("history scan: no binary store".into()))?;
         let snapshot = ctx.active_snapshot;
         let no_overlay = NoOverlay;
         let overlay: &dyn OverlayProvider = ctx.overlay.unwrap_or(&no_overlay);
         let g_id: GraphId = ctx.binary_g_id;
 
-        let index_t = store.max_t();
+        // Index / novelty boundary. When no binary store is attached
+        // (e.g. a ledger that's never been indexed), treat everything as
+        // novelty: `index_t = -1` makes the persisted pass a no-op and
+        // the novelty merge picks up all in-range overlay events.
+        let (store_opt, index_t) = match ctx.binary_store.clone() {
+            Some(store) => {
+                let t = store.max_t();
+                (Some(store), t)
+            }
+            None => (None, -1_i64),
+        };
         let from_t = ctx.from_t.unwrap_or(0);
         let to_t = ctx.to_t;
-        // Persisted-side upper bound is clamped to index_t; anything above
-        // lives in novelty and is merged below.
         let persisted_to_t = to_t.min(index_t);
 
         // Encode bound pattern components through the snapshot to match
-        // the persisted ID space.
+        // the persisted ID space. (`build_filter_from_snapshot_sids`
+        // needs a store for s_id/p_id resolution in the persisted pass;
+        // novelty-only doesn't need the filter since we apply
+        // `flake_matches_range_eq` on decoded flakes.)
         let (s_sid, p_sid, o_val_opt) =
             BinaryScanOperator::extract_bound_terms_snapshot(snapshot, &self.pattern);
-        let filter = BinaryScanOperator::build_filter_from_snapshot_sids(
-            snapshot,
-            &self.pattern,
-            store.as_ref(),
-            &s_sid,
-            &p_sid,
-        )
-        .map_err(|e| QueryError::Internal(format!("history scan: build_filter: {e}")))?;
-
-        let order = self.pick_order(&filter);
 
         let mut flakes: Vec<Flake> = Vec::new();
 
         // ---- Persisted sources (sidecar + base rows in range) ----
-        if from_t <= persisted_to_t {
-            if let Some(branch) = store.branch_for_order(g_id, order) {
-                let leaf_indices = leaf_index_range(branch, &filter, order);
-                let view = BinaryGraphView::with_novelty(
-                    Arc::clone(&store),
-                    g_id,
-                    ctx.dict_novelty.clone(),
-                );
+        if let Some(store) = store_opt.as_ref() {
+            if from_t <= persisted_to_t {
+                let filter = BinaryScanOperator::build_filter_from_snapshot_sids(
+                    snapshot,
+                    &self.pattern,
+                    store.as_ref(),
+                    &s_sid,
+                    &p_sid,
+                )
+                .map_err(|e| QueryError::Internal(format!("history scan: build_filter: {e}")))?;
+                let order = self.pick_order(&filter);
+                if let Some(branch) = store.branch_for_order(g_id, order) {
+                    let leaf_indices = leaf_index_range(branch, &filter, order);
+                    let view = BinaryGraphView::with_novelty(
+                        Arc::clone(store),
+                        g_id,
+                        ctx.dict_novelty.clone(),
+                    );
 
-                let from_t_u32 = clamp_t_u32(from_t);
-                let persisted_to_u32 = clamp_t_u32(persisted_to_t);
+                    let from_t_u32 = clamp_t_u32(from_t);
+                    let persisted_to_u32 = clamp_t_u32(persisted_to_t);
 
-                for leaf_idx in leaf_indices {
-                    let entry = &branch.leaves[leaf_idx];
-                    let handle = store
-                        .open_leaf_handle(&entry.leaf_cid, entry.sidecar_cid.as_ref(), true)
-                        .map_err(|e| QueryError::from_io("history scan open_leaf_handle", e))?;
-                    let dir = handle.dir();
+                    for leaf_idx in leaf_indices {
+                        let entry = &branch.leaves[leaf_idx];
+                        let handle = store
+                            .open_leaf_handle(&entry.leaf_cid, entry.sidecar_cid.as_ref(), true)
+                            .map_err(|e| QueryError::from_io("history scan open_leaf_handle", e))?;
+                        let dir = handle.dir();
 
-                    for (leaflet_idx, leaflet) in dir.entries.iter().enumerate() {
-                        if !leaflet_matches_filter(leaflet, &filter) {
-                            continue;
-                        }
+                        for (leaflet_idx, leaflet) in dir.entries.iter().enumerate() {
+                            if !leaflet_matches_filter(leaflet, &filter) {
+                                continue;
+                            }
 
-                        // Sidecar: only load when the segment's t range can
-                        // overlap [from_t, persisted_to_t].
-                        let sidecar_in_range = leaflet.history_len > 0
-                            && leaflet.history_max_t >= from_t_u32
-                            && leaflet.history_min_t <= persisted_to_u32;
-                        if sidecar_in_range {
-                            let segment =
-                                handle.load_sidecar_segment(leaflet_idx).map_err(|e| {
-                                    QueryError::from_io("history scan load_sidecar_segment", e)
-                                })?;
-                            for entry_v2 in &segment {
-                                let s_id = entry_v2.s_id.as_u64();
-                                if !filter.matches(
-                                    s_id,
-                                    entry_v2.p_id,
-                                    entry_v2.o_type,
-                                    entry_v2.o_key,
-                                    entry_v2.o_i,
-                                ) {
-                                    continue;
-                                }
-                                let t = entry_v2.t as i64;
-                                if t < from_t || t > persisted_to_t {
-                                    continue;
-                                }
-                                let op = entry_v2.op == 1;
-                                if let Some(flake) = decode_event_to_flake(
-                                    &view,
-                                    store.as_ref(),
-                                    s_id,
-                                    entry_v2.p_id,
-                                    entry_v2.o_type,
-                                    entry_v2.o_key,
-                                    entry_v2.o_i,
-                                    t,
-                                    op,
-                                )? {
-                                    flakes.push(flake);
+                            // Charge 1 fuel (1000 micro-fuel) per leaflet we touch,
+                            // mirroring `BinaryCursor::next_batch` for the non-history
+                            // scan path. This is the cost-model guardrail — without
+                            // it, a broad history query could do unbounded column /
+                            // sidecar loads in `open()` before the caller ever sees
+                            // the first batch.
+                            ctx.tracker.consume_fuel(1000)?;
+
+                            // Sidecar: only load when the segment's t range can
+                            // overlap [from_t, persisted_to_t].
+                            let sidecar_in_range = leaflet.history_len > 0
+                                && leaflet.history_max_t >= from_t_u32
+                                && leaflet.history_min_t <= persisted_to_u32;
+                            if sidecar_in_range {
+                                let segment =
+                                    handle.load_sidecar_segment(leaflet_idx).map_err(|e| {
+                                        QueryError::from_io("history scan load_sidecar_segment", e)
+                                    })?;
+                                for entry_v2 in &segment {
+                                    let s_id = entry_v2.s_id.as_u64();
+                                    if !filter.matches(
+                                        s_id,
+                                        entry_v2.p_id,
+                                        entry_v2.o_type,
+                                        entry_v2.o_key,
+                                        entry_v2.o_i,
+                                    ) {
+                                        continue;
+                                    }
+                                    let t = entry_v2.t as i64;
+                                    if t < from_t || t > persisted_to_t {
+                                        continue;
+                                    }
+                                    let op = entry_v2.op == 1;
+                                    if let Some(flake) = decode_event_to_flake(
+                                        &view,
+                                        store.as_ref(),
+                                        s_id,
+                                        entry_v2.p_id,
+                                        entry_v2.o_type,
+                                        entry_v2.o_key,
+                                        entry_v2.o_i,
+                                        t,
+                                        op,
+                                    )? {
+                                        flakes.push(flake);
+                                    }
                                 }
                             }
-                        }
 
-                        // Base rows: emit rows whose t falls in range as asserts.
-                        if leaflet.row_count > 0 {
-                            let projection = ColumnProjection::all();
-                            let batch = handle
-                                .load_columns(leaflet_idx, &projection, order)
-                                .map_err(|e| QueryError::from_io("history scan load_columns", e))?;
-                            for i in 0..batch.row_count {
-                                let s_id = batch.s_id.get(i);
-                                let p_id = batch.p_id.get_or(i, 0);
-                                let o_type = batch.o_type.get_or(i, 0);
-                                let o_key = batch.o_key.get(i);
-                                let o_i = batch.o_i.get_or(i, u32::MAX);
-                                let t_u32 = batch.t.get_or(i, 0);
-                                let t = t_u32 as i64;
+                            // Base rows: emit rows whose t falls in range as asserts.
+                            if leaflet.row_count > 0 {
+                                let projection = ColumnProjection::all();
+                                let batch = handle
+                                    .load_columns(leaflet_idx, &projection, order)
+                                    .map_err(|e| {
+                                        QueryError::from_io("history scan load_columns", e)
+                                    })?;
+                                for i in 0..batch.row_count {
+                                    let s_id = batch.s_id.get(i);
+                                    let p_id = batch.p_id.get_or(i, 0);
+                                    let o_type = batch.o_type.get_or(i, 0);
+                                    let o_key = batch.o_key.get(i);
+                                    let o_i = batch.o_i.get_or(i, u32::MAX);
+                                    let t_u32 = batch.t.get_or(i, 0);
+                                    let t = t_u32 as i64;
 
-                                if !filter.matches(s_id, p_id, o_type, o_key, o_i) {
-                                    continue;
-                                }
-                                if t < from_t || t > persisted_to_t {
-                                    continue;
-                                }
-                                if let Some(flake) = decode_event_to_flake(
-                                    &view,
-                                    store.as_ref(),
-                                    s_id,
-                                    p_id,
-                                    o_type,
-                                    o_key,
-                                    o_i,
-                                    t,
-                                    true,
-                                )? {
-                                    flakes.push(flake);
+                                    if !filter.matches(s_id, p_id, o_type, o_key, o_i) {
+                                        continue;
+                                    }
+                                    if t < from_t || t > persisted_to_t {
+                                        continue;
+                                    }
+                                    if let Some(flake) = decode_event_to_flake(
+                                        &view,
+                                        store.as_ref(),
+                                        s_id,
+                                        p_id,
+                                        o_type,
+                                        o_key,
+                                        o_i,
+                                        t,
+                                        true,
+                                    )? {
+                                        flakes.push(flake);
+                                    }
                                 }
                             }
                         }
                     }
-                }
-            }
-        }
+                } // end `if let Some(branch)`
+            } // end `if from_t <= persisted_to_t`
+        } // end `if let Some(store)`
 
         // ---- Novelty events in (index_t, to_t] ----
         if to_t > index_t {
@@ -273,7 +331,20 @@ impl BinaryHistoryScanOperator {
                 t: None,
             };
 
+            // Cost model: charge 1 fuel per matched novelty flake, **during**
+            // collection. Without this, an unindexed ledger with large
+            // novelty or a broad history query could do unbounded eager
+            // work in `open()` before the caller sees the first batch.
+            // We apply the full pattern filter (s/p/o + object bounds)
+            // inside the walk so we only charge for flakes we actually
+            // retain — otherwise a wide predicate like `?s ?p ?o` on a
+            // crowded novelty slice would charge for every flake touched
+            // even when our pattern only matches a sliver. `for_each_overlay_flake`'s
+            // callback cannot return a Result, so we capture any
+            // `FuelExceededError` and surface it after the walk.
+            let object_bounds = self.object_bounds.as_ref();
             let mut novelty: Vec<Flake> = Vec::new();
+            let mut fuel_err: Option<fluree_db_core::FuelExceededError> = None;
             overlay.for_each_overlay_flake(
                 g_id,
                 self.inner_index(),
@@ -282,14 +353,29 @@ impl BinaryHistoryScanOperator {
                 true,
                 to_t,
                 &mut |f| {
-                    if f.t > index_t && f.t <= to_t && f.t >= from_t {
-                        novelty.push(f.clone());
+                    if fuel_err.is_some() {
+                        return;
                     }
+                    if f.t <= index_t || f.t > to_t || f.t < from_t {
+                        return;
+                    }
+                    if !flake_matches_range_eq(f, &match_val) {
+                        return;
+                    }
+                    if let Some(bounds) = object_bounds {
+                        if !bounds.matches(&f.o) {
+                            return;
+                        }
+                    }
+                    if let Err(e) = ctx.tracker.consume_fuel(1) {
+                        fuel_err = Some(e);
+                        return;
+                    }
+                    novelty.push(f.clone());
                 },
             );
-            novelty.retain(|f| flake_matches_range_eq(f, &match_val));
-            if let Some(bounds) = &self.object_bounds {
-                novelty.retain(|f| bounds.matches(&f.o));
+            if let Some(e) = fuel_err {
+                return Err(e.into());
             }
             flakes.extend(novelty);
         }
@@ -321,13 +407,18 @@ impl Operator for BinaryHistoryScanOperator {
     }
 
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
-        if !ctx.history_mode || ctx.binary_store.is_none() {
-            // Non-history queries, or queries with no binary index store,
-            // go through the unchanged scan path.
+        if !ctx.history_mode {
+            // Non-history queries go through the unchanged scan path.
             return self.inner.open(ctx).await;
         }
-        // Policy enforcement via per-flake async checks is honored below
-        // in `collect_history_flakes` (via `filter_flakes_by_policy`).
+        // History mode: we always collect flakes ourselves (with explicit op
+        // preservation) rather than going through `BinaryScanOperator::open`.
+        // The non-history path in the core `range_with_overlay` genesis
+        // fallback calls `remove_stale_flakes`, which drops retracts — fine
+        // for current-state queries but wrong for history. Running our own
+        // collector handles both the indexed and novelty-only cases
+        // correctly. Policy enforcement is applied in
+        // `collect_history_flakes` via `filter_flakes_by_policy`.
         let flakes = self.collect_history_flakes(ctx).await?;
         self.inner.prime_history_flakes(ctx, flakes)
     }

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -1,0 +1,454 @@
+//! Indexed history-range scan operator.
+//!
+//! Wraps `BinaryScanOperator` and, when `ctx.history_mode` is set and a
+//! binary store is attached, replaces its cursor walk with a
+//! three-source merge:
+//!
+//! 1. **History sidecar entries** (`HistEntryV2`) for each matching
+//!    leaflet — assert + retract events with explicit op.
+//! 2. **Base leaflet rows** whose `t` falls in `[from_t, index_t]` —
+//!    emitted as `op = assert`.
+//! 3. **Overlay / novelty flakes** in `(index_t, to_t]` — carry their
+//!    own `flake.op`.
+//!
+//! The merged flake list is handed to the existing
+//! `flakes_to_bindings` pipeline via `prime_history_flakes`, which is
+//! already history-aware (line ~704 in `binary_scan.rs` copies
+//! `flake.op` onto the emitted `Binding::Lit`).
+//!
+//! ## Narrowing
+//!
+//! Leaves and leaflets are narrowed by the pattern's bound components:
+//! - subject bound → `find_leaves_for_subject(s_id)` on a SPOT branch
+//! - predicate-only bound → PSOT branch (currently still walks all
+//!   leaves; predicate-constant leaflet skip applies)
+//! - leaflet-level skip via `p_const`, `o_type_const`, and
+//!   `history_max_t < from_t`
+//!
+//! Non-history queries and queries with no binary store fall through
+//! to `BinaryScanOperator::open` unchanged.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fluree_db_binary_index::{BinaryGraphView, BinaryIndexStore, ColumnProjection, RunSortOrder};
+use fluree_db_core::{
+    flake_matches_range_eq, Flake, FlakeMeta, FlakeValue, GraphId, IndexType, NoOverlay,
+    ObjectBounds, OverlayProvider, RangeMatch, Sid,
+};
+
+use crate::binary_scan::{BinaryScanOperator, EmitMask};
+use crate::binding::Batch;
+use crate::context::ExecutionContext;
+use crate::error::{QueryError, Result};
+use crate::operator::inline::InlineOperator;
+use crate::operator::Operator;
+use crate::triple::TriplePattern;
+use crate::var_registry::VarId;
+
+/// Scan operator that activates a dedicated history-range walk when
+/// `ctx.history_mode` is true.
+///
+/// When history mode is not active (or no binary store is available),
+/// this wrapper transparently delegates to `BinaryScanOperator` — the
+/// regular scan path is unchanged.
+pub struct BinaryHistoryScanOperator {
+    inner: BinaryScanOperator,
+    pattern: TriplePattern,
+    object_bounds: Option<ObjectBounds>,
+    index_hint: Option<IndexType>,
+}
+
+impl BinaryHistoryScanOperator {
+    /// Construct with default emit mask and no index hint.
+    pub fn new(
+        pattern: TriplePattern,
+        object_bounds: Option<ObjectBounds>,
+        inline_ops: Vec<InlineOperator>,
+    ) -> Self {
+        Self::new_with_emit_and_index(pattern, object_bounds, inline_ops, EmitMask::ALL, None)
+    }
+
+    /// Construct with an explicit emit mask and index hint.
+    pub fn new_with_emit_and_index(
+        pattern: TriplePattern,
+        object_bounds: Option<ObjectBounds>,
+        inline_ops: Vec<InlineOperator>,
+        emit: EmitMask,
+        index_hint: Option<IndexType>,
+    ) -> Self {
+        let inner = BinaryScanOperator::new_with_emit_and_index(
+            pattern.clone(),
+            object_bounds.clone(),
+            inline_ops,
+            emit,
+            index_hint,
+        );
+        Self {
+            inner,
+            pattern,
+            object_bounds,
+            index_hint,
+        }
+    }
+
+    /// Pick an index order that minimises leaf touches for the bound components.
+    ///
+    /// `index_hint` (set by the planner) wins if present. Otherwise:
+    /// - subject bound → SPOT
+    /// - predicate bound (no subject) → PSOT
+    /// - object bound (no subject, no predicate) → OPST
+    /// - none bound → SPOT (default)
+    fn pick_order(&self, filter: &fluree_db_binary_index::BinaryFilter) -> RunSortOrder {
+        if let Some(hint) = self.index_hint {
+            return crate::binary_scan::index_type_to_sort_order(hint);
+        }
+        if filter.s_id.is_some() {
+            RunSortOrder::Spot
+        } else if filter.p_id.is_some() {
+            RunSortOrder::Psot
+        } else if filter.o_type.is_some() || filter.o_key.is_some() {
+            RunSortOrder::Opst
+        } else {
+            RunSortOrder::Spot
+        }
+    }
+
+    /// Collect the full history-range event stream for this pattern.
+    ///
+    /// Walks matching leaves + leaflets, loads sidecar segments and
+    /// in-range base rows, merges with overlay/novelty events, and
+    /// returns flakes with explicit `op`.
+    async fn collect_history_flakes(&self, ctx: &ExecutionContext<'_>) -> Result<Vec<Flake>> {
+        let store = ctx
+            .binary_store
+            .clone()
+            .ok_or_else(|| QueryError::Internal("history scan: no binary store".into()))?;
+        let snapshot = ctx.active_snapshot;
+        let no_overlay = NoOverlay;
+        let overlay: &dyn OverlayProvider = ctx.overlay.unwrap_or(&no_overlay);
+        let g_id: GraphId = ctx.binary_g_id;
+
+        let index_t = store.max_t();
+        let from_t = ctx.from_t.unwrap_or(0);
+        let to_t = ctx.to_t;
+        // Persisted-side upper bound is clamped to index_t; anything above
+        // lives in novelty and is merged below.
+        let persisted_to_t = to_t.min(index_t);
+
+        // Encode bound pattern components through the snapshot to match
+        // the persisted ID space.
+        let (s_sid, p_sid, o_val_opt) =
+            BinaryScanOperator::extract_bound_terms_snapshot(snapshot, &self.pattern);
+        let filter = BinaryScanOperator::build_filter_from_snapshot_sids(
+            snapshot,
+            &self.pattern,
+            store.as_ref(),
+            &s_sid,
+            &p_sid,
+        )
+        .map_err(|e| QueryError::Internal(format!("history scan: build_filter: {e}")))?;
+
+        let order = self.pick_order(&filter);
+
+        let mut flakes: Vec<Flake> = Vec::new();
+
+        // ---- Persisted sources (sidecar + base rows in range) ----
+        if from_t <= persisted_to_t {
+            if let Some(branch) = store.branch_for_order(g_id, order) {
+                let leaf_indices = leaf_index_range(branch, &filter, order);
+                let view = BinaryGraphView::with_novelty(
+                    Arc::clone(&store),
+                    g_id,
+                    ctx.dict_novelty.clone(),
+                );
+
+                let from_t_u32 = clamp_t_u32(from_t);
+                let persisted_to_u32 = clamp_t_u32(persisted_to_t);
+
+                for leaf_idx in leaf_indices {
+                    let entry = &branch.leaves[leaf_idx];
+                    let handle = store
+                        .open_leaf_handle(&entry.leaf_cid, entry.sidecar_cid.as_ref(), true)
+                        .map_err(|e| QueryError::from_io("history scan open_leaf_handle", e))?;
+                    let dir = handle.dir();
+
+                    for (leaflet_idx, leaflet) in dir.entries.iter().enumerate() {
+                        if !leaflet_matches_filter(leaflet, &filter) {
+                            continue;
+                        }
+
+                        // Sidecar: only load when the segment's t range can
+                        // overlap [from_t, persisted_to_t].
+                        let sidecar_in_range = leaflet.history_len > 0
+                            && leaflet.history_max_t >= from_t_u32
+                            && leaflet.history_min_t <= persisted_to_u32;
+                        if sidecar_in_range {
+                            let segment =
+                                handle.load_sidecar_segment(leaflet_idx).map_err(|e| {
+                                    QueryError::from_io("history scan load_sidecar_segment", e)
+                                })?;
+                            for entry_v2 in &segment {
+                                let s_id = entry_v2.s_id.as_u64();
+                                if !filter.matches(
+                                    s_id,
+                                    entry_v2.p_id,
+                                    entry_v2.o_type,
+                                    entry_v2.o_key,
+                                    entry_v2.o_i,
+                                ) {
+                                    continue;
+                                }
+                                let t = entry_v2.t as i64;
+                                if t < from_t || t > persisted_to_t {
+                                    continue;
+                                }
+                                let op = entry_v2.op == 1;
+                                if let Some(flake) = decode_event_to_flake(
+                                    &view,
+                                    store.as_ref(),
+                                    s_id,
+                                    entry_v2.p_id,
+                                    entry_v2.o_type,
+                                    entry_v2.o_key,
+                                    entry_v2.o_i,
+                                    t,
+                                    op,
+                                )? {
+                                    flakes.push(flake);
+                                }
+                            }
+                        }
+
+                        // Base rows: emit rows whose t falls in range as asserts.
+                        if leaflet.row_count > 0 {
+                            let projection = ColumnProjection::all();
+                            let batch = handle
+                                .load_columns(leaflet_idx, &projection, order)
+                                .map_err(|e| QueryError::from_io("history scan load_columns", e))?;
+                            for i in 0..batch.row_count {
+                                let s_id = batch.s_id.get(i);
+                                let p_id = batch.p_id.get_or(i, 0);
+                                let o_type = batch.o_type.get_or(i, 0);
+                                let o_key = batch.o_key.get(i);
+                                let o_i = batch.o_i.get_or(i, u32::MAX);
+                                let t_u32 = batch.t.get_or(i, 0);
+                                let t = t_u32 as i64;
+
+                                if !filter.matches(s_id, p_id, o_type, o_key, o_i) {
+                                    continue;
+                                }
+                                if t < from_t || t > persisted_to_t {
+                                    continue;
+                                }
+                                if let Some(flake) = decode_event_to_flake(
+                                    &view,
+                                    store.as_ref(),
+                                    s_id,
+                                    p_id,
+                                    o_type,
+                                    o_key,
+                                    o_i,
+                                    t,
+                                    true,
+                                )? {
+                                    flakes.push(flake);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ---- Novelty events in (index_t, to_t] ----
+        if to_t > index_t {
+            // Build a RangeMatch for pattern-level filtering.
+            let match_val = RangeMatch {
+                s: s_sid.clone(),
+                p: p_sid.clone(),
+                o: o_val_opt.clone(),
+                dt: self.pattern.dtc.as_ref().map(|d| d.datatype().clone()),
+                t: None,
+            };
+
+            let mut novelty: Vec<Flake> = Vec::new();
+            overlay.for_each_overlay_flake(
+                g_id,
+                self.inner_index(),
+                None,
+                None,
+                true,
+                to_t,
+                &mut |f| {
+                    if f.t > index_t && f.t <= to_t && f.t >= from_t {
+                        novelty.push(f.clone());
+                    }
+                },
+            );
+            novelty.retain(|f| flake_matches_range_eq(f, &match_val));
+            if let Some(bounds) = &self.object_bounds {
+                novelty.retain(|f| bounds.matches(&f.o));
+            }
+            flakes.extend(novelty);
+        }
+
+        // ---- Policy enforcement ----
+        let flakes =
+            BinaryScanOperator::filter_flakes_by_policy(ctx, snapshot, overlay, to_t, g_id, flakes)
+                .await?;
+
+        Ok(flakes)
+    }
+
+    /// Wrap `self.pattern` to derive the same `IndexType` the inner
+    /// scan would have picked. Kept private to keep the ctor uniform.
+    fn inner_index(&self) -> IndexType {
+        let s_bound = self.pattern.s_bound();
+        let p_bound = self.pattern.p_bound();
+        let o_bound = self.pattern.o_bound();
+        let o_is_ref = self.pattern.o_is_ref();
+        self.index_hint
+            .unwrap_or_else(|| IndexType::for_query(s_bound, p_bound, o_bound, o_is_ref))
+    }
+}
+
+#[async_trait]
+impl Operator for BinaryHistoryScanOperator {
+    fn schema(&self) -> &[VarId] {
+        self.inner.schema()
+    }
+
+    async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
+        if !ctx.history_mode || ctx.binary_store.is_none() {
+            // Non-history queries, or queries with no binary index store,
+            // go through the unchanged scan path.
+            return self.inner.open(ctx).await;
+        }
+        // Policy enforcement via per-flake async checks is honored below
+        // in `collect_history_flakes` (via `filter_flakes_by_policy`).
+        let flakes = self.collect_history_flakes(ctx).await?;
+        self.inner.prime_history_flakes(ctx, flakes)
+    }
+
+    async fn next_batch(&mut self, ctx: &ExecutionContext<'_>) -> Result<Option<Batch>> {
+        self.inner.next_batch(ctx).await
+    }
+
+    fn close(&mut self) {
+        self.inner.close();
+    }
+
+    fn estimated_rows(&self) -> Option<usize> {
+        self.inner.estimated_rows()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Range of leaf indices whose key range can contain a matching row.
+///
+/// - Subject bound (SPOT order) → narrow by `s_id`.
+/// - Otherwise → all leaves.
+fn leaf_index_range(
+    branch: &fluree_db_binary_index::format::branch::BranchManifest,
+    filter: &fluree_db_binary_index::BinaryFilter,
+    order: RunSortOrder,
+) -> Range<usize> {
+    if let (Some(s_id), RunSortOrder::Spot) = (filter.s_id, order) {
+        branch.find_leaves_for_subject(s_id)
+    } else {
+        0..branch.leaves.len()
+    }
+}
+
+/// Quick leaflet-level filter skip using directory constants.
+fn leaflet_matches_filter(
+    leaflet: &fluree_db_binary_index::format::leaf::LeafletDirEntryV3,
+    filter: &fluree_db_binary_index::BinaryFilter,
+) -> bool {
+    if let (Some(filter_p), Some(const_p)) = (filter.p_id, leaflet.p_const) {
+        if filter_p != const_p {
+            return false;
+        }
+    }
+    if let (Some(filter_ot), Some(const_ot)) = (filter.o_type, leaflet.o_type_const) {
+        if filter_ot != const_ot {
+            return false;
+        }
+    }
+    true
+}
+
+/// Clamp an i64 `t` to the u32 range used by the sidecar/base format.
+#[inline]
+fn clamp_t_u32(t: i64) -> u32 {
+    if t < 0 {
+        0
+    } else if t > u32::MAX as i64 {
+        u32::MAX
+    } else {
+        t as u32
+    }
+}
+
+/// Decode a single history event (from sidecar or base column) into
+/// a `Flake` with explicit `op`.
+///
+/// Returns `Ok(None)` when subject resolution fails (caller should
+/// skip — shouldn't happen for well-formed indices).
+#[allow(clippy::too_many_arguments)]
+fn decode_event_to_flake(
+    view: &BinaryGraphView,
+    store: &BinaryIndexStore,
+    s_id: u64,
+    p_id: u32,
+    o_type: u16,
+    o_key: u64,
+    o_i: u32,
+    t: i64,
+    op: bool,
+) -> Result<Option<Flake>> {
+    let s_sid = view
+        .resolve_subject_sid(s_id)
+        .map_err(|e| QueryError::from_io("history decode resolve_subject_sid", e))?;
+    let p_iri = match store.resolve_predicate_iri(p_id) {
+        Some(iri) => iri,
+        None => return Ok(None),
+    };
+    let p_sid = store.encode_iri(p_iri);
+    let o_val: FlakeValue = view
+        .decode_value(o_type, o_key, p_id)
+        .map_err(|e| QueryError::from_io("history decode decode_value", e))?;
+    let dt = store
+        .resolve_datatype_sid(o_type)
+        .unwrap_or_else(|| Sid::new(0, ""));
+    let lang = store
+        .resolve_lang_tag(o_type)
+        .map(std::string::ToString::to_string);
+    let meta = if lang.is_some() || o_i != u32::MAX {
+        Some(FlakeMeta {
+            lang,
+            i: if o_i != u32::MAX {
+                Some(o_i as i32)
+            } else {
+                None
+            },
+        })
+    } else {
+        None
+    };
+    Ok(Some(Flake {
+        g: None,
+        s: s_sid,
+        p: p_sid,
+        o: o_val,
+        dt,
+        t,
+        op,
+        m: meta,
+    }))
+}

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -773,12 +773,39 @@ impl BinaryScanOperator {
         Ok(())
     }
 
+    /// Prime the scan to drain a pre-collected set of flakes instead of
+    /// running the binary cursor.
+    ///
+    /// Used by `BinaryHistoryScanOperator`, which collects history events
+    /// (sidecar + in-range base + novelty) up front and then hands them to
+    /// the existing `flakes_to_bindings` pipeline. The flakes must already
+    /// carry their correct `op` field — history mode copies it onto the
+    /// output binding at line ~704.
+    pub(crate) fn prime_history_flakes(
+        &mut self,
+        ctx: &ExecutionContext<'_>,
+        flakes: Vec<Flake>,
+    ) -> Result<()> {
+        if !self.state.can_open() {
+            if self.state.is_closed() {
+                return Err(QueryError::OperatorClosed);
+            }
+            return Err(QueryError::OperatorAlreadyOpened);
+        }
+        self.store = ctx.binary_store.clone();
+        self.g_id = ctx.binary_g_id;
+        self.range_iter = Some(flakes.into_iter());
+        self.cursor = None;
+        self.state = OperatorState::Open;
+        Ok(())
+    }
+
     /// Apply policy filtering to a batch of flakes for a specific graph.
     ///
     /// When a policy enforcer is present on the execution context, we:
     /// 1) Populate the class cache for subjects in this batch (required for f:onClass)
     /// 2) Filter flakes (async, supports f:query) using the graph's snapshot/overlay/to_t.
-    async fn filter_flakes_by_policy(
+    pub(crate) async fn filter_flakes_by_policy(
         ctx: &ExecutionContext<'_>,
         snapshot: &LedgerSnapshot,
         overlay: &dyn OverlayProvider,
@@ -817,7 +844,7 @@ impl BinaryScanOperator {
     ///
     /// Therefore, we keep the bound SIDs in snapshot space for overlay matching, and only
     /// translate into store space (via full IRI strings) when constructing persisted ID filters.
-    fn extract_bound_terms_snapshot(
+    pub(crate) fn extract_bound_terms_snapshot(
         snapshot: &LedgerSnapshot,
         pattern: &TriplePattern,
     ) -> (Option<Sid>, Option<Sid>, Option<FlakeValue>) {
@@ -857,7 +884,7 @@ impl BinaryScanOperator {
     }
 
     /// Build a `BinaryFilter` from bound pattern terms.
-    fn build_filter_from_snapshot_sids(
+    pub(crate) fn build_filter_from_snapshot_sids(
         snapshot: &LedgerSnapshot,
         pattern: &TriplePattern,
         store: &BinaryIndexStore,

--- a/fluree-db-query/src/dataset_operator.rs
+++ b/fluree-db-query/src/dataset_operator.rs
@@ -25,7 +25,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use fluree_db_core::{IndexType, ObjectBounds, Sid};
 
-use crate::binary_scan::{schema_from_pattern_with_emit, BinaryScanOperator, EmitMask};
+use crate::binary_history::BinaryHistoryScanOperator;
+use crate::binary_scan::{schema_from_pattern_with_emit, EmitMask};
 use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
 use crate::dataset::ActiveGraphs;
@@ -97,13 +98,20 @@ impl ScanDatasetBuilder {
 
 impl DatasetBuilder for ScanDatasetBuilder {
     fn build(&self) -> Result<BoxedOperator> {
-        Ok(Box::new(BinaryScanOperator::new_with_emit_and_index(
-            self.pattern.clone(),
-            self.object_bounds.clone(),
-            self.inline_ops.clone(),
-            self.emit,
-            self.index_hint,
-        )))
+        // Use the history-aware wrapper at all scan sites. For non-history
+        // queries it transparently delegates to `BinaryScanOperator::open`
+        // — no behavior change on the hot path. For history queries
+        // (`ctx.history_mode == true`) it runs the dedicated sidecar+base
+        // +novelty merge in its own `open`.
+        Ok(Box::new(
+            BinaryHistoryScanOperator::new_with_emit_and_index(
+                self.pattern.clone(),
+                self.object_bounds.clone(),
+                self.inline_ops.clone(),
+                self.emit,
+                self.index_hint,
+            ),
+        ))
     }
 
     fn schema(&self) -> &[VarId] {

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -189,7 +189,7 @@ pub async fn execute_pattern(
     pattern: TriplePattern,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref(db, vars);
-    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
+    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -249,7 +249,7 @@ pub async fn execute_pattern_at(
     from_t: Option<i64>,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref_with_from_t(db, vars, from_t);
-    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
+    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -273,7 +273,7 @@ pub async fn execute_pattern_with_overlay(
     pattern: TriplePattern,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref(db, vars);
-    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
+    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -296,7 +296,7 @@ pub async fn execute_pattern_with_overlay_at(
     from_t: Option<i64>,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref_with_from_t(db, vars, from_t);
-    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
+    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -14,6 +14,7 @@
 //! Build a `TriplePattern` with a `VarRegistry`, then call `execute_pattern` with a `GraphDbRef` to get result batches.
 
 pub mod aggregate;
+pub mod binary_history;
 pub mod binary_range;
 pub mod binary_scan;
 pub mod bind;
@@ -94,6 +95,7 @@ pub mod vector;
 
 // Re-exports
 pub use aggregate::{apply_aggregate, AggregateFn, AggregateOperator, AggregateSpec};
+pub use binary_history::BinaryHistoryScanOperator;
 pub use binary_range::BinaryRangeProvider;
 pub use binary_scan::BinaryScanOperator;
 pub use bind::BindOperator;


### PR DESCRIPTION
Fixes two stacked bugs that left history-range queries (`"from": "ledger@t:1", "to": "ledger@t:latest"`) returning wrong results on indexed ledgers:

1. The `@op` variable always bound to `null` — the only call site that would populate it (`Binding::from_object_with_t_op`) had zero callers.
2. Retracts and superseded asserts that lived in the history sidecar were never emitted — the binary cursor only read current-state base rows, and the sidecar was only consulted for point-in-time (`AS OF t`) replay.

Together these meant the reporter's query

```jsonc
{
  "from": "ledger:main@t:1",
  "to":   "ledger:main@t:latest",
  "select": ["?v", "?t", "?op"],
  "where": [{
    "@id": "<concept>",
    "skos:notation": {"@value":"?v","@t":"?t","@op":"?op"}
  }]
}
```

returned one row (the current asserted value) with `?op = null` instead of the full timeline of assert / retract events.

## What changed

### New module: `fluree-db-query/src/binary_history.rs`

`BinaryHistoryScanOperator` is a thin wrapper around `BinaryScanOperator`. When `ctx.history_mode` is false it transparently delegates. When true, it runs a dedicated three-source merge in `open()`:

1. **History sidecar entries** (`HistEntryV2`) for each matching leaflet — assert + retract events with explicit `op`.
2. **Base leaflet rows** whose `t` falls in `[from_t, index_t]` — emitted as `op = assert`.
3. **Overlay / novelty flakes** in `(index_t, to_t]` — carry their own `flake.op`.

The merged `Vec<Flake>` is handed to the existing `BinaryScanOperator` via a new `prime_history_flakes` pub(crate) helper, which routes it through the already-history-aware `flakes_to_bindings` pipeline (`binary_scan.rs:~704` copies `flake.op` onto the emitted `Binding::Lit`).

### Narrowing

Leaves and leaflets are narrowed by the pattern's bound components so we only touch the relevant slice of the index:

- subject bound → `branch.find_leaves_for_subject(s_id)` on SPOT
- predicate-only bound → PSOT branch, with leaflet `p_const` / `o_type_const` skip
- sidecar segment skipped when `history_len == 0` or `history_max_t < from_t`

A subject-history query for one subject touches only the leaves containing that subject's `s_id` — no broad database scan.

### Wiring

Every scan construction site now produces the history-aware wrapper:

- `ScanDatasetBuilder::build` in `dataset_operator.rs` (the main planner path)
- `execute_pattern` / `execute_pattern_at` / `execute_pattern_with_overlay` / `execute_pattern_with_overlay_at` in `lib.rs` (used by staging, policy, config resolver)

Non-history queries pay one extra vtable hop per `next_batch` (~1–2 ns, negligible against batch sizes of 100+ rows).

### Helper-visibility changes

- `BinaryScanOperator::prime_history_flakes` — new pub(crate) method that primes the operator to drain a pre-collected `Vec<Flake>` via the existing flake pipeline.
- `extract_bound_terms_snapshot`, `build_filter_from_snapshot_sids`, `filter_flakes_by_policy` — bumped from `fn` to `pub(crate) fn` for reuse from `binary_history.rs`.

## Cost model

All heavy lifting happens in `open()`, so that's where the fuel guardrail lives:

- **Persisted pass**: 1000 micro-fuel per leaflet touched — same rate `BinaryCursor::next_batch` uses for non-history scans.
- **Novelty pass**: 1 micro-fuel per matched novelty flake, charged during the walk. A captured `FuelExceededError` short-circuits the callback before the next flake is pushed. Pattern filter is applied inside the callback so we only charge for flakes we'd actually retain — otherwise a wide predicate on a crowded novelty slice would charge for every flake touched.
- **Per-flake emit**: 1 micro-fuel per flake is charged downstream in `flakes_to_bindings` when `next_batch` drains the collected vec.

Together these prevent unbounded eager work before the first batch emission.

## Tests

Six regression tests in `fluree-db-api/tests/it_query_history_range.rs`:

1. `history_range_emits_sidecar_events_with_op` — reporter's scenario: reindex + upsert + reindex, verify all three events (`(Alice, 1, assert)`, `(Alice Smith, 2, assert)`, `(Alice, 2, retract)`) emit with correct `@t` and `@op`.
2. `history_range_novelty_only` — unindexed ledger, verifies the novelty-only path also binds `@op`.
3. `history_range_op_constant_filter_assert` — `"@op": "assert"` as a constant filter returns only asserts.
4. `history_range_op_constant_filter_retract` — `"@op": "retract"` returns only retracts.
5. `history_range_sidecar_plus_novelty_boundary` — reindex at t=1, transact t=2, query spanning `index_t`; exercises the `to_t > index_t` novelty-merge path.
6. `history_range_subject_unbound` — predicate-only history across multiple subjects.

## Known limitations / follow-ups

Documented in the `binary_history.rs` module header:

- **Multi-pattern history with joins.** When a history query has two or more triple patterns, the first becomes the history-aware scan, but patterns 2+ are driven by `batched_subject_probe_binary` in `join.rs`, which still reads current-state base rows only. `?s` values joined in from a history-aware outer scan will fetch today's label, not their historical labels. Fix needs a per-pattern `history_semantics` flag (propagated from parser's existing `t_var`/`op_var` tracking) plus a history-aware branch in the join probe.

- **Per-leaf sidecar pruning.** `open_leaf_handle(..., need_replay=true)` fetches the whole sidecar blob up front. For leaves whose directory doesn't yet reveal any leaflet with `history_max_t >= from_t`, this is wasted I/O on local/cached reads. Fixing cleanly needs either a two-pass open (dir first, sidecar on demand) or leaf-level `history_max_t` on `LeafEntry`.

- **Streaming emit.** `collect_history_flakes` materialises the matched event set into a `Vec<Flake>` before `next_batch` drains it. Subject- or predicate-bound queries match a small set so this is cheap; broad unconstrained history queries over wide time ranges could benefit from leaflet-at-a-time streaming.

- **`BinaryRangeProvider::range` hardcodes `op: true`** (`binary_range.rs:~495`). Non-query callers that pass `RangeOptions::history_mode: true` (SHACL, reasoner, etc.) would get collapsed-state. No active caller does this today per grep, but it's a sharp edge worth cleaning up separately.
