### PR TITLE
Branching from historical commits

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -386,7 +386,7 @@ Each flake is a tuple: `[subject, predicate, object, datatype, operation]`. Oper
 
 ### GET /commits/*ledger
 
-Export commit blobs from a ledger using stable cursors. Pages walk backward via `previous_ref` — O(limit) per page regardless of ledger size. Used by `fluree pull` and `fluree clone`.
+Export commit blobs from a ledger using stable cursors. Pages walk backward via each commit's `parents` — O(limit) per page regardless of ledger size. Used by `fluree pull` and `fluree clone`.
 
 **Requires replication-grade permissions** (`fluree.storage.*`). The storage proxy must be enabled on the server.
 
@@ -1592,7 +1592,8 @@ POST /fluree/branch
 {
   "ledger": "mydb",
   "branch": "feature-x",
-  "source": "main"
+  "source": "main",
+  "at": "t:5"
 }
 ```
 
@@ -1601,6 +1602,7 @@ POST /fluree/branch
 | `ledger` | string | Yes | Ledger name without branch suffix (e.g., "mydb") |
 | `branch` | string | Yes | New branch name to create (e.g., "feature-x") |
 | `source` | string | No | Source branch to create from. Default: `"main"` |
+| `at` | string | No | Commit on the source branch to start from. `"t:N"` for a transaction number, or a hex digest / full CID for prefix resolution. When omitted, the branch starts at the source's current HEAD. `t:` / prefix resolution requires the source to be indexed. |
 
 **Response:**
 
@@ -1618,13 +1620,13 @@ POST /fluree/branch
 | `ledger_id` | Full ledger:branch identifier for the new branch |
 | `branch` | Branch name |
 | `source` | Source branch this was created from |
-| `t` | Transaction time of the source commit at branch point |
+| `t` | Transaction time of the commit at the branch point |
 
 **Status Codes:**
 - `201 Created` - Branch created successfully
-- `400 Bad Request` - Invalid request body
+- `400 Bad Request` - Invalid request body (including malformed `at` value)
 - `401 Unauthorized` - Bearer token required (when admin auth enabled)
-- `404 Not Found` - Source branch does not exist
+- `404 Not Found` - Source branch does not exist, or `at` commit is not reachable from source HEAD
 - `409 Conflict` - Branch already exists
 - `500 Internal Server Error` - Server error
 
@@ -1640,6 +1642,11 @@ curl -X POST http://localhost:8090/v1/fluree/branch \
 curl -X POST http://localhost:8090/v1/fluree/branch \
   -H "Content-Type: application/json" \
   -d '{"ledger": "mydb", "branch": "staging", "source": "dev"}'
+
+# Branch at a historical commit on main
+curl -X POST http://localhost:8090/v1/fluree/branch \
+  -H "Content-Type: application/json" \
+  -d '{"ledger": "mydb", "branch": "rewind", "at": "t:5"}'
 ```
 
 ### GET /fluree/branch/{ledger}

--- a/docs/cli/branch.md
+++ b/docs/cli/branch.md
@@ -26,11 +26,14 @@ fluree branch create <NAME> [OPTIONS]
 |--------|-------------|
 | `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--from <BRANCH>` | Source branch to create from (defaults to "main") |
+| `--at <COMMIT-REF>` | Commit to branch at (defaults to source branch HEAD). Accepts `t:N` for a transaction number or a hex digest / full CID. |
 | `--remote <REMOTE>` | Execute against a remote server |
 
 **Description:**
 
-Creates a new branch for a ledger. The branch starts at the same transaction time as the source branch and is fully isolated -- subsequent transactions on either branch are invisible to the other.
+Creates a new branch for a ledger. By default the branch starts at the source branch's current HEAD, and is fully isolated — subsequent transactions on either branch are invisible to the other.
+
+Pass `--at` to branch from a historical commit on the source branch instead of its HEAD. The commit must be reachable from the source HEAD; the new branch starts with no index and replays from genesis on first query. `t:N` and hex-prefix resolution require the source branch to be indexed (full CIDs work unconditionally).
 
 Branches can be nested: you can create a branch from any existing branch, not just "main".
 
@@ -45,6 +48,12 @@ fluree branch create dev --ledger mydb
 
 # Create a branch from another branch
 fluree branch create feature-x --from dev
+
+# Branch at a historical point on main (transaction number)
+fluree branch create rewind --at t:5
+
+# Branch at a historical commit by hex-digest prefix
+fluree branch create rewind --at 3dd028a7
 
 # Create a branch on a remote server
 fluree branch create staging --ledger mydb --remote origin

--- a/docs/concepts/ledgers-and-nameservice.md
+++ b/docs/concepts/ledgers-and-nameservice.md
@@ -164,7 +164,7 @@ Commit-head publishing is **CAS-based** so concurrent writers get an explicit co
 
 Create and list branches:
 
-- **`create_branch(ledger_name, new_branch, source_branch)`**: Create a new branch from the source
+- **`create_branch(ledger_name, new_branch, source_branch, at_commit)`**: Create a new branch from the source. When `at_commit` is `None`, the branch starts at the source's current HEAD; when `Some((commit_id, commit_t))`, the branch starts at the supplied historical commit instead (callers are expected to verify reachability from source HEAD before passing it in).
 - **`list_branches(ledger_name)`**: List all non-retracted branches for a ledger
 
 #### Discovery

--- a/docs/contributing/shacl-implementation.md
+++ b/docs/contributing/shacl-implementation.md
@@ -12,7 +12,7 @@ Transaction flakes
         ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │ fluree-db-transact :: stage()                                   │
-│   stages flakes into a LedgerView (novelty overlay)             │
+│   stages flakes into a StagedLedger (novelty overlay)             │
 └─────────────────────────────────────────────────────────────────┘
         │
         ▼
@@ -37,7 +37,7 @@ Transaction flakes
 | Crate | Role |
 |-------|------|
 | `fluree-db-shacl` | SHACL engine: shape compilation, cache, per-node validation, constraint evaluators. **No transaction-layer concerns.** |
-| `fluree-db-transact` | Staged-validation plumbing: `validate_view_with_shacl`, `validate_staged_nodes`. Knows about `LedgerView`, staged flakes, and graph routing. Defines the per-graph policy types. |
+| `fluree-db-transact` | Staged-validation plumbing: `validate_view_with_shacl`, `validate_staged_nodes`. Knows about `StagedLedger`, staged flakes, and graph routing. Defines the per-graph policy types. |
 | `fluree-db-api` | Config resolution, policy building, and the shared helper that every write surface (JSON-LD, Turtle, commit replay) calls through. |
 
 SHACL is feature-gated (`shacl`). See [Standards and feature flags](../reference/compatibility.md).
@@ -48,7 +48,7 @@ All SHACL-enforced write surfaces route through **`apply_shacl_policy_to_staged_
 
 ```rust
 pub(crate) async fn apply_shacl_policy_to_staged_view(
-    view: &LedgerView,
+    view: &StagedLedger,
     ctx: StagedShaclContext<'_>,
 ) -> Result<(), TransactError>
 ```
@@ -84,7 +84,7 @@ The transact layer's `validate_view_with_shacl` signature:
 
 ```rust
 pub async fn validate_view_with_shacl(
-    view: &LedgerView,
+    view: &StagedLedger,
     shacl_cache: &ShaclCache,
     graph_sids: Option<&HashMap<GraphId, Sid>>,
     tracker: Option<&Tracker>,

--- a/docs/guides/cookbook-branching.md
+++ b/docs/guides/cookbook-branching.md
@@ -179,6 +179,22 @@ Each branch has its own transaction history. Query any branch at any point in ti
 fluree query --ledger mydb:experiment --at 3 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }'
 ```
 
+### Branch at a historical point
+
+By default, `branch create` starts the new branch at the source's current HEAD. Pass `--at` to start it at an earlier commit on the source branch instead — useful for recovering to a known-good state, forking off an older release, or experimenting with what-if scenarios from a past point in time.
+
+```bash
+# Start a branch at transaction 5 on main
+fluree branch create rewind --at t:5
+
+# Or use a hex-digest prefix of the commit
+fluree branch create rewind --at 3dd028a7
+```
+
+The commit must be reachable from the source branch's HEAD (branching from an unrelated branch's commit is rejected). The new branch starts with no index and replays from genesis on first query — acceptable for small/medium histories; if replay cost matters, transact a small no-op to force an index rebuild.
+
+Full CIDs are also accepted (`--at fluree:commit:sha256:...`) and resolve without requiring the source to be indexed; `t:N` and hex prefixes require an indexed source.
+
 ## Branch lifecycle
 
 ```
@@ -196,9 +212,14 @@ After merging, the branch is still alive. You can:
 
 ```bash
 # Create a branch
-curl -X POST 'http://localhost:8090/v1/fluree/branch?ledger=mydb' \
+curl -X POST http://localhost:8090/v1/fluree/branch \
   -H "Content-Type: application/json" \
-  -d '{"name": "dev", "from": "main"}'
+  -d '{"ledger": "mydb", "branch": "dev", "source": "main"}'
+
+# Branch at a historical commit
+curl -X POST http://localhost:8090/v1/fluree/branch \
+  -H "Content-Type: application/json" \
+  -d '{"ledger": "mydb", "branch": "rewind", "at": "t:5"}'
 
 # Query a specific branch
 curl -X POST 'http://localhost:8090/v1/fluree/query?ledger=mydb:dev' \
@@ -206,9 +227,9 @@ curl -X POST 'http://localhost:8090/v1/fluree/query?ledger=mydb:dev' \
   -d 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }'
 
 # Merge
-curl -X POST 'http://localhost:8090/v1/fluree/branch/merge?ledger=mydb' \
+curl -X POST http://localhost:8090/v1/fluree/merge \
   -H "Content-Type: application/json" \
-  -d '{"source": "dev"}'
+  -d '{"ledger": "mydb", "source": "dev"}'
 ```
 
 ## Best practices

--- a/fluree-db-api/src/block_fetch.rs
+++ b/fluree-db-api/src/block_fetch.rs
@@ -175,7 +175,7 @@ pub enum EnforcementMode {
 /// Ledger context needed for leaf decoding and policy filtering.
 ///
 /// Groups the database snapshot, time horizon, and binary index store to avoid
-/// parameter drift. Constructed from a `CachedLedgerState` at the call site.
+/// parameter drift. Constructed from a `LedgerView` at the call site.
 pub struct LedgerBlockContext<'a> {
     /// Database snapshot.
     pub snapshot: &'a LedgerSnapshot,

--- a/fluree-db-api/src/commit_ref.rs
+++ b/fluree-db-api/src/commit_ref.rs
@@ -1,0 +1,207 @@
+//! A commit reference: one of several forms a caller can use to identify a
+//! commit (exact CID, hex-digest prefix, or transaction number `t`).
+//!
+//! Each variant resolves to the canonical [`CommitId`] via the helpers in this
+//! module. The resolvers scan the commit metadata recorded in the txn-meta
+//! graph, so they require both a [`LedgerSnapshot`] and the current novelty
+//! overlay.
+
+use crate::{ApiError, Result};
+use fluree_db_core::{CommitId, ContentId, LedgerSnapshot};
+use fluree_db_novelty::Novelty;
+
+/// How a caller identifies a commit.
+///
+/// Commits have a canonical content-addressed id ([`CommitId`]), but there are
+/// several user-facing forms that resolve to the same id.
+pub enum CommitRef {
+    /// Exact CID (e.g., from API or full CID string like "bagaybqabciq...")
+    Exact(CommitId),
+    /// Hex digest prefix (e.g., "3dd028" — the SHA-256 hex prefix of the commit)
+    Prefix(String),
+    /// Transaction number (e.g., t=5)
+    T(i64),
+}
+
+/// Resolve a commit hex-digest prefix to a full [`CommitId`].
+///
+/// Uses a bounded SPOT index scan on commit subjects (same approach as
+/// `time_resolve::commit_to_t`, but returns the CID instead of `t`).
+pub(crate) async fn resolve_commit_prefix(
+    snapshot: &LedgerSnapshot,
+    overlay: &Novelty,
+    prefix: &str,
+    current_t: i64,
+) -> Result<CommitId> {
+    use fluree_db_core::{
+        range_bounded_with_overlay, Flake, IndexType, RangeOptions, Sid, TXN_META_GRAPH_ID,
+    };
+    use fluree_vocab::namespaces::FLUREE_COMMIT;
+
+    // Normalize: strip standard prefixes
+    let normalized = prefix.strip_prefix("fluree:commit:").unwrap_or(prefix);
+    let normalized = normalized.strip_prefix("sha256:").unwrap_or(normalized);
+
+    if normalized.len() < 6 {
+        return Err(ApiError::query(format!(
+            "Commit prefix must be at least 6 characters, got {}",
+            normalized.len()
+        )));
+    }
+
+    // SHA-256 in hex is 64 characters
+    if normalized.len() > 64 {
+        return Err(ApiError::query(format!(
+            "Commit prefix too long ({} chars). SHA-256 in hex is 64 characters.",
+            normalized.len()
+        )));
+    }
+
+    // Build scan range: [prefix, prefix~) where ~ sorts after all hex chars
+    let start_sid = Sid::new(FLUREE_COMMIT, normalized);
+    let end_prefix = format!("{normalized}~");
+    let end_sid = Sid::new(FLUREE_COMMIT, &end_prefix);
+
+    let start_bound = Flake::min_for_subject(start_sid);
+    let end_bound = Flake::min_for_subject(end_sid);
+
+    let opts = RangeOptions::default()
+        .with_to_t(current_t)
+        .with_flake_limit(32);
+
+    let flakes = range_bounded_with_overlay(
+        snapshot,
+        TXN_META_GRAPH_ID,
+        overlay,
+        IndexType::Spot,
+        start_bound,
+        end_bound,
+        opts,
+    )
+    .await?;
+
+    // Collect unique matching commit subjects
+    let mut seen = std::collections::HashSet::new();
+    let mut matches: Vec<String> = Vec::new();
+
+    for flake in &flakes {
+        if flake.s.namespace_code != FLUREE_COMMIT {
+            continue;
+        }
+        if !flake.s.name.starts_with(normalized) {
+            continue;
+        }
+        if seen.insert(flake.s.name.as_ref()) {
+            matches.push(flake.s.name.to_string());
+        }
+        if matches.len() > 1 {
+            break;
+        }
+    }
+
+    match matches.len() {
+        0 => Err(ApiError::NotFound(format!(
+            "No commit found with prefix: {normalized}"
+        ))),
+        1 => {
+            // Reconstruct ContentId from hex digest
+            let hex = &matches[0];
+            let digest: [u8; 32] = hex::decode(hex)
+                .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
+                .try_into()
+                .map_err(|_| ApiError::internal("Digest not 32 bytes"))?;
+            Ok(ContentId::from_sha256_digest(
+                fluree_db_core::CODEC_FLUREE_COMMIT,
+                &digest,
+            ))
+        }
+        _ => {
+            let ids: Vec<_> = matches
+                .iter()
+                .take(5)
+                .map(|h| &h[..7.min(h.len())])
+                .collect();
+            Err(ApiError::query(format!(
+                "Ambiguous commit prefix '{}': matches {:?}{}",
+                normalized,
+                ids,
+                if matches.len() > 5 { " ..." } else { "" }
+            )))
+        }
+    }
+}
+
+/// Resolve a transaction number (`t`) to a full [`CommitId`].
+///
+/// Queries the POST index for commit flakes where predicate = `fluree:db/t`
+/// and object = the target `t` value. The matching commit subject's hex digest
+/// is then converted to a [`CommitId`].
+pub(crate) async fn resolve_t_to_commit_id(
+    snapshot: &LedgerSnapshot,
+    overlay: &Novelty,
+    target_t: i64,
+    current_t: i64,
+) -> Result<CommitId> {
+    use fluree_db_core::{
+        range_with_overlay, FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest, Sid,
+        TXN_META_GRAPH_ID,
+    };
+    use fluree_vocab::namespaces::{FLUREE_COMMIT, FLUREE_DB};
+
+    if target_t < 1 {
+        return Err(ApiError::query(format!(
+            "Transaction number must be >= 1, got {target_t}"
+        )));
+    }
+    if target_t > current_t {
+        return Err(ApiError::NotFound(format!(
+            "Transaction t={target_t} not found (latest is t={current_t})"
+        )));
+    }
+
+    // POST index query: predicate = fluree:db/t, object = target_t (exact match)
+    let predicate = Sid::new(FLUREE_DB, fluree_vocab::db::T);
+    let range_match = RangeMatch::predicate_object(predicate, FlakeValue::Long(target_t));
+
+    let opts = RangeOptions::default()
+        .with_to_t(current_t)
+        .with_flake_limit(16);
+
+    let flakes = range_with_overlay(
+        snapshot,
+        TXN_META_GRAPH_ID,
+        overlay,
+        IndexType::Post,
+        RangeTest::Eq,
+        range_match,
+        opts,
+    )
+    .await?;
+
+    // Find the flake with our exact predicate and object value
+    for flake in &flakes {
+        if flake.p.namespace_code != FLUREE_DB || flake.p.name.as_ref() != fluree_vocab::db::T {
+            continue;
+        }
+        if flake.o != FlakeValue::Long(target_t) {
+            continue;
+        }
+        // The subject is in FLUREE_COMMIT namespace with hex digest as name
+        if flake.s.namespace_code != FLUREE_COMMIT {
+            continue;
+        }
+        let hex = flake.s.name.as_ref();
+        let digest: [u8; 32] = hex::decode(hex)
+            .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
+            .try_into()
+            .map_err(|_| ApiError::internal("Digest not 32 bytes"))?;
+        return Ok(ContentId::from_sha256_digest(
+            fluree_db_core::CODEC_FLUREE_COMMIT,
+            &digest,
+        ));
+    }
+
+    Err(ApiError::NotFound(format!(
+        "No commit found for t={target_t}"
+    )))
+}

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -15,7 +15,7 @@
 //! ## Export (server → client)
 //!
 //! Paginated export of commit blobs using address-cursor pagination.
-//! Pages walk backward via `previous_ref` — O(limit) per page regardless of
+//! Pages walk backward via `parents` — O(limit) per page regardless of
 //! ledger size. Used by pull and clone operations.
 
 use crate::dataset::QueryConnectionOptions;
@@ -563,7 +563,7 @@ fn decode_and_validate_commit_chain(
         // commits one parent is the prior commit and others are pre-existing.
         if let Some(prev_hash_hex) = &prev_hash {
             let ok = commit
-                .previous_refs
+                .parents
                 .iter()
                 .any(|r| r.digest_hex() == *prev_hash_hex);
             if !ok {
@@ -604,7 +604,7 @@ fn preflight_strict_next_t_and_prev(
     if let Some(expected_id) = &current.id {
         let ok = first
             .commit
-            .previous_refs
+            .parents
             .iter()
             .any(|r| r == expected_id);
         if !ok {
@@ -612,7 +612,7 @@ fn preflight_strict_next_t_and_prev(
                 "first commit previous mismatch: no parent matches expected head {expected_id:?}"
             )));
         }
-    } else if !first.commit.previous_refs.is_empty() {
+    } else if !first.commit.parents.is_empty() {
         return Err(PushError::Conflict(
             "first commit has parent refs but current head has no id".to_string(),
         ));
@@ -1015,7 +1015,7 @@ pub struct ExportCommitsResponse {
 /// Export a paginated range of commits from a ledger.
 ///
 /// Uses address-cursor pagination: each page walks backward from the cursor
-/// via `previous_ref` for up to `limit` commits. Each page is O(limit)
+/// via `parents` for up to `limit` commits. Each page is O(limit)
 /// regardless of total ledger size.
 ///
 /// Commits are returned newest → oldest. The client reverses for import.
@@ -1121,7 +1121,7 @@ impl Fluree {
             }
 
             // Enqueue all parents for traversal.
-            for parent in env.previous_refs {
+            for parent in env.parents {
                 frontier.push(parent);
             }
         }
@@ -1362,7 +1362,7 @@ impl Fluree {
         let decoded = decode_and_validate_commit_chain(base_state.ledger_id(), &request)
             .map_err(PushError::into_api_error)?;
 
-        // 4) Ancestry preflight: verify first commit's previous_ref matches local head.
+        // 4) Ancestry preflight: verify first commit's parent matches local head.
         preflight_strict_next_t_and_prev(&current_ref, &decoded)
             .map_err(PushError::into_api_error)?;
 

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -602,11 +602,7 @@ fn preflight_strict_next_t_and_prev(
 
     // Validate that at least one parent reference matches the current head CID.
     if let Some(expected_id) = &current.id {
-        let ok = first
-            .commit
-            .parents
-            .iter()
-            .any(|r| r == expected_id);
+        let ok = first.commit.parents.iter().any(|r| r == expected_id);
         if !ok {
             return Err(PushError::Conflict(format!(
                 "first commit previous mismatch: no parent matches expected head {expected_id:?}"

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -565,7 +565,7 @@ fn decode_and_validate_commit_chain(
             let ok = commit
                 .previous_refs
                 .iter()
-                .any(|r| r.id.digest_hex() == *prev_hash_hex);
+                .any(|r| r.digest_hex() == *prev_hash_hex);
             if !ok {
                 return Err(PushError::Invalid(format!(
                     "commit chain previous mismatch at commit[{idx}]: expected previous digest '{prev_hash_hex}'"
@@ -606,7 +606,7 @@ fn preflight_strict_next_t_and_prev(
             .commit
             .previous_refs
             .iter()
-            .any(|r| r.id == *expected_id);
+            .any(|r| r == expected_id);
         if !ok {
             return Err(PushError::Conflict(format!(
                 "first commit previous mismatch: no parent matches expected head {expected_id:?}"
@@ -1122,7 +1122,7 @@ impl Fluree {
 
             // Enqueue all parents for traversal.
             for parent in env.previous_refs {
-                frontier.push(parent.id);
+                frontier.push(parent);
             }
         }
 

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -667,7 +667,7 @@ async fn stage_commit_flakes(
     index_config: &IndexConfig,
     policy_ctx: &PolicyContext,
     graph_sids: &HashMap<GraphId, Sid>,
-) -> std::result::Result<fluree_db_ledger::LedgerView, PushError> {
+) -> std::result::Result<fluree_db_ledger::StagedLedger, PushError> {
     let mut options = fluree_db_transact::StageOptions::new()
         .with_index_config(index_config)
         .with_graph_sids(graph_sids);

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -19,10 +19,10 @@
 //! }
 //! ```
 
-use crate::ledger_view::CommitRef;
 use crate::dataset::QueryConnectionOptions;
 use crate::format::iri::IriCompactor;
 use crate::graph::Graph;
+use crate::ledger_view::CommitRef;
 use crate::{policy_builder, ApiError, Result};
 use fluree_db_core::commit::codec::read_commit;
 use fluree_db_core::{ContentId, ContentStore, FlakeValue, OverlayProvider, Tracker};
@@ -374,11 +374,7 @@ fn build_commit_detail(
         t: commit.t,
         time: commit.time.clone(),
         size: blob_size,
-        parents: commit
-            .parents
-            .iter()
-            .map(|r| r.to_string())
-            .collect(),
+        parents: commit.parents.iter().map(ToString::to_string).collect(),
         signer: commit.txn_signature.as_ref().map(|s| s.signer.clone()),
         asserts,
         retracts,

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -19,6 +19,7 @@
 //! }
 //! ```
 
+use crate::commit_ref::{resolve_commit_prefix, resolve_t_to_commit_id, CommitRef};
 use crate::dataset::QueryConnectionOptions;
 use crate::format::iri::IriCompactor;
 use crate::graph::Graph;
@@ -156,16 +157,6 @@ pub struct CommitDetail {
 // ============================================================================
 // Builder
 // ============================================================================
-
-/// How to identify the commit to fetch.
-enum CommitRef {
-    /// Exact CID (e.g., from API or full CID string like "bagaybqabciq...")
-    Exact(ContentId),
-    /// Hex digest prefix (e.g., "3dd028" — the SHA-256 hex prefix of the commit)
-    Prefix(String),
-    /// Transaction number (e.g., t=5)
-    T(i64),
-}
 
 /// Builder for fetching and decoding a single commit.
 ///
@@ -338,189 +329,6 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
         // 7. Build the response
         build_commit_detail(&commit, &commit_id, blob_size, &compactor)
     }
-}
-
-/// Resolve a commit hex-digest prefix to a full ContentId.
-///
-/// Uses a bounded SPOT index scan on commit subjects (same approach as
-/// `time_resolve::commit_to_t`, but returns the CID instead of `t`).
-async fn resolve_commit_prefix(
-    snapshot: &fluree_db_core::LedgerSnapshot,
-    overlay: &fluree_db_novelty::Novelty,
-    prefix: &str,
-    current_t: i64,
-) -> Result<ContentId> {
-    use fluree_db_core::{
-        range_bounded_with_overlay, Flake, IndexType, RangeOptions, Sid, TXN_META_GRAPH_ID,
-    };
-    use fluree_vocab::namespaces::FLUREE_COMMIT;
-
-    // Normalize: strip standard prefixes
-    let normalized = prefix.strip_prefix("fluree:commit:").unwrap_or(prefix);
-    let normalized = normalized.strip_prefix("sha256:").unwrap_or(normalized);
-
-    if normalized.len() < 6 {
-        return Err(ApiError::query(format!(
-            "Commit prefix must be at least 6 characters, got {}",
-            normalized.len()
-        )));
-    }
-
-    // SHA-256 in hex is 64 characters
-    if normalized.len() > 64 {
-        return Err(ApiError::query(format!(
-            "Commit prefix too long ({} chars). SHA-256 in hex is 64 characters.",
-            normalized.len()
-        )));
-    }
-
-    // Build scan range: [prefix, prefix~) where ~ sorts after all hex chars
-    let start_sid = Sid::new(FLUREE_COMMIT, normalized);
-    let end_prefix = format!("{normalized}~");
-    let end_sid = Sid::new(FLUREE_COMMIT, &end_prefix);
-
-    let start_bound = Flake::min_for_subject(start_sid);
-    let end_bound = Flake::min_for_subject(end_sid);
-
-    let opts = RangeOptions::default()
-        .with_to_t(current_t)
-        .with_flake_limit(32);
-
-    let flakes = range_bounded_with_overlay(
-        snapshot,
-        TXN_META_GRAPH_ID,
-        overlay,
-        IndexType::Spot,
-        start_bound,
-        end_bound,
-        opts,
-    )
-    .await?;
-
-    // Collect unique matching commit subjects
-    let mut seen = std::collections::HashSet::new();
-    let mut matches: Vec<String> = Vec::new();
-
-    for flake in &flakes {
-        if flake.s.namespace_code != FLUREE_COMMIT {
-            continue;
-        }
-        if !flake.s.name.starts_with(normalized) {
-            continue;
-        }
-        if seen.insert(flake.s.name.as_ref()) {
-            matches.push(flake.s.name.to_string());
-        }
-        if matches.len() > 1 {
-            break;
-        }
-    }
-
-    match matches.len() {
-        0 => Err(ApiError::NotFound(format!(
-            "No commit found with prefix: {normalized}"
-        ))),
-        1 => {
-            // Reconstruct ContentId from hex digest
-            let hex = &matches[0];
-            let digest: [u8; 32] = hex::decode(hex)
-                .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
-                .try_into()
-                .map_err(|_| ApiError::internal("Digest not 32 bytes"))?;
-            Ok(ContentId::from_sha256_digest(
-                fluree_db_core::CODEC_FLUREE_COMMIT,
-                &digest,
-            ))
-        }
-        _ => {
-            let ids: Vec<_> = matches
-                .iter()
-                .take(5)
-                .map(|h| &h[..7.min(h.len())])
-                .collect();
-            Err(ApiError::query(format!(
-                "Ambiguous commit prefix '{}': matches {:?}{}",
-                normalized,
-                ids,
-                if matches.len() > 5 { " ..." } else { "" }
-            )))
-        }
-    }
-}
-
-/// Resolve a transaction number (`t`) to a full ContentId.
-///
-/// Queries the POST index for commit flakes where predicate = `fluree:db/t`
-/// and object = the target `t` value. The matching commit subject's hex digest
-/// is then converted to a ContentId.
-async fn resolve_t_to_commit_id(
-    snapshot: &fluree_db_core::LedgerSnapshot,
-    overlay: &fluree_db_novelty::Novelty,
-    target_t: i64,
-    current_t: i64,
-) -> Result<ContentId> {
-    use fluree_db_core::{
-        range_with_overlay, FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest, Sid,
-        TXN_META_GRAPH_ID,
-    };
-    use fluree_vocab::namespaces::{FLUREE_COMMIT, FLUREE_DB};
-
-    if target_t < 1 {
-        return Err(ApiError::query(format!(
-            "Transaction number must be >= 1, got {target_t}"
-        )));
-    }
-    if target_t > current_t {
-        return Err(ApiError::NotFound(format!(
-            "Transaction t={target_t} not found (latest is t={current_t})"
-        )));
-    }
-
-    // POST index query: predicate = fluree:db/t, object = target_t (exact match)
-    let predicate = Sid::new(FLUREE_DB, fluree_vocab::db::T);
-    let range_match = RangeMatch::predicate_object(predicate, FlakeValue::Long(target_t));
-
-    let opts = RangeOptions::default()
-        .with_to_t(current_t)
-        .with_flake_limit(16);
-
-    let flakes = range_with_overlay(
-        snapshot,
-        TXN_META_GRAPH_ID,
-        overlay,
-        IndexType::Post,
-        RangeTest::Eq,
-        range_match,
-        opts,
-    )
-    .await?;
-
-    // Find the flake with our exact predicate and object value
-    for flake in &flakes {
-        if flake.p.namespace_code != FLUREE_DB || flake.p.name.as_ref() != fluree_vocab::db::T {
-            continue;
-        }
-        if flake.o != FlakeValue::Long(target_t) {
-            continue;
-        }
-        // The subject is in FLUREE_COMMIT namespace with hex digest as name
-        if flake.s.namespace_code != FLUREE_COMMIT {
-            continue;
-        }
-        let hex = flake.s.name.as_ref();
-        let digest: [u8; 32] = hex::decode(hex)
-            .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
-            .try_into()
-            .map_err(|_| ApiError::internal("Digest not 32 bytes"))?;
-        return Ok(ContentId::from_sha256_digest(
-            fluree_db_core::CODEC_FLUREE_COMMIT,
-            &digest,
-        ));
-    }
-
-    Err(ApiError::NotFound(format!(
-        "No commit found for t={target_t}"
-    )))
 }
 
 // ============================================================================

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -584,7 +584,7 @@ fn build_commit_detail(
         parents: commit
             .previous_refs
             .iter()
-            .map(|r| r.id.to_string())
+            .map(|r| r.to_string())
             .collect(),
         signer: commit.txn_signature.as_ref().map(|s| s.signer.clone()),
         asserts,

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -19,7 +19,7 @@
 //! }
 //! ```
 
-use crate::commit_ref::{resolve_commit_prefix, resolve_t_to_commit_id, CommitRef};
+use crate::ledger_view::CommitRef;
 use crate::dataset::QueryConnectionOptions;
 use crate::format::iri::IriCompactor;
 use crate::graph::Graph;
@@ -242,22 +242,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
         let namespace_codes = snapshot.snapshot.namespaces();
 
         // 2. Resolve commit reference to a full CID
-        let commit_id = match self.commit_ref {
-            CommitRef::Exact(id) => id,
-            CommitRef::Prefix(prefix) => {
-                resolve_commit_prefix(
-                    &snapshot.snapshot,
-                    snapshot.novelty.as_ref(),
-                    &prefix,
-                    snapshot.t,
-                )
-                .await?
-            }
-            CommitRef::T(t) => {
-                resolve_t_to_commit_id(&snapshot.snapshot, snapshot.novelty.as_ref(), t, snapshot.t)
-                    .await?
-            }
-        };
+        let commit_id = snapshot.resolve_commit(self.commit_ref).await?;
 
         // 3. Build IRI compactor: user-supplied context > ledger default > none
         let default_ctx;

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -582,7 +582,7 @@ fn build_commit_detail(
         time: commit.time.clone(),
         size: blob_size,
         parents: commit
-            .previous_refs
+            .parents
             .iter()
             .map(|r| r.to_string())
             .collect(),

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -2091,8 +2091,7 @@ where
     // Final commit head publish
     let commit_head_id = state
         .previous_ref
-        .as_ref()
-        .map(|r| r.id.clone())
+        .clone()
         .ok_or_else(|| ImportError::Storage("no commit head after import".to_string()))?;
 
     nameservice

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -2090,7 +2090,7 @@ where
 
     // Final commit head publish
     let commit_head_id = state
-        .previous_ref
+        .parent
         .clone()
         .ok_or_else(|| ImportError::Storage("no commit head after import".to_string()))?;
 

--- a/fluree-db-api/src/ledger/loading.rs
+++ b/fluree-db-api/src/ledger/loading.rs
@@ -297,12 +297,20 @@ impl Fluree {
 
         // If the caller specified a historical commit, resolve it and verify
         // it's reachable from source HEAD before we touch the nameservice.
+        // A ref that resolves to the source head itself is collapsed to the
+        // default (None) path so the user still gets an index copy — otherwise
+        // `--at <head-cid>` would silently produce a slower branch than
+        // omitting `--at` entirely.
         let at_commit = if let Some(commit_ref) = source_commit {
             let view = self.ledger_cached(&source_id).await?.snapshot().await;
             let resolved = view.resolve_commit(commit_ref).await?;
-            let store = self.content_store(&source_id);
-            let resolved_t = verify_ancestor(&*store, &source_head, &resolved).await?;
-            Some((resolved, resolved_t))
+            if resolved == source_head {
+                None
+            } else {
+                let store = self.content_store(&source_id);
+                let resolved_t = verify_ancestor(&*store, &source_head, &resolved).await?;
+                Some((resolved, resolved_t))
+            }
         } else {
             None
         };

--- a/fluree-db-api/src/ledger/loading.rs
+++ b/fluree-db-api/src/ledger/loading.rs
@@ -384,6 +384,14 @@ impl Fluree {
 ///
 /// Used by `create_branch` when a caller specifies a historical commit — we
 /// only allow branching from commits on the source branch's ancestry.
+///
+/// "Ancestry" here is the full commit DAG, not the linear first-parent chain:
+/// `collect_dag_cids` walks every parent edge (including merge parents), so
+/// any commit reachable from `source_head` via any sequence of parent edges
+/// is a valid branch point. This is what enables branching at a commit that
+/// originally lived on a side branch that was later merged into the source
+/// — once merged in, those commits are part of the source's ancestry too.
+///
 /// Loads only the target commit's envelope (not its flakes) since we just
 /// need `t` for the ancestry walk's stop condition.
 async fn verify_ancestor<C: ContentStore + ?Sized>(
@@ -401,7 +409,8 @@ async fn verify_ancestor<C: ContentStore + ?Sized>(
         return Ok(target_envelope.t);
     }
 
-    // Walk backward from source_head, stopping once we pass below target's t.
+    // Walk backward from source_head over the full DAG (all parent edges,
+    // including merge parents), stopping once we pass below target's t.
     let stop_at = (target_envelope.t - 1).max(0);
     let dag = collect_dag_cids(store, source_head, stop_at).await?;
 

--- a/fluree-db-api/src/ledger/loading.rs
+++ b/fluree-db-api/src/ledger/loading.rs
@@ -5,7 +5,7 @@ use crate::{ApiError, Fluree, HistoricalLedgerView, LedgerState, Result, TypeEra
 use fluree_db_binary_index::BinaryIndexStore;
 use fluree_db_core::ContentStore;
 use fluree_db_core::DictNovelty;
-use fluree_db_core::{collect_dag_cids, load_commit_by_id, CommitId};
+use fluree_db_core::{collect_dag_cids, load_commit_envelope_by_id, CommitId};
 use fluree_db_nameservice::{NameServiceError, NsRecord};
 
 impl Fluree {
@@ -301,8 +301,8 @@ impl Fluree {
             let view = self.ledger_cached(&source_id).await?.snapshot().await;
             let resolved = view.resolve_commit(commit_ref).await?;
             let store = self.content_store(&source_id);
-            let commit = verify_ancestor_and_load(&*store, &source_head, &resolved).await?;
-            Some((resolved, commit.t))
+            let resolved_t = verify_ancestor(&*store, &source_head, &resolved).await?;
+            Some((resolved, resolved_t))
         } else {
             None
         };
@@ -470,29 +470,32 @@ impl Fluree {
     }
 }
 
-/// Load `target` and verify it's reachable by walking parents from `source_head`.
+/// Verify `target` is reachable by walking parents from `source_head`, and
+/// return its `t` value.
 ///
 /// Used by `create_branch` when a caller specifies a historical commit — we
 /// only allow branching from commits on the source branch's ancestry.
-async fn verify_ancestor_and_load<C: ContentStore + ?Sized>(
+/// Loads only the target commit's envelope (not its flakes) since we just
+/// need `t` for the ancestry walk's stop condition.
+async fn verify_ancestor<C: ContentStore + ?Sized>(
     store: &C,
     source_head: &CommitId,
     target: &CommitId,
-) -> Result<fluree_db_core::Commit> {
-    let target_commit = load_commit_by_id(store, target).await.map_err(|_| {
+) -> Result<i64> {
+    let target_envelope = load_commit_envelope_by_id(store, target).await.map_err(|_| {
         ApiError::NotFound(format!("commit {target} not found in source namespace"))
     })?;
 
     if source_head == target {
-        return Ok(target_commit);
+        return Ok(target_envelope.t);
     }
 
     // Walk backward from source_head, stopping once we pass below target's t.
-    let stop_at = (target_commit.t - 1).max(0);
+    let stop_at = (target_envelope.t - 1).max(0);
     let dag = collect_dag_cids(store, source_head, stop_at).await?;
 
     if dag.iter().any(|(_, cid)| cid == target) {
-        Ok(target_commit)
+        Ok(target_envelope.t)
     } else {
         Err(ApiError::NotFound(format!(
             "commit {target} is not an ancestor of source head {source_head}"

--- a/fluree-db-api/src/ledger/loading.rs
+++ b/fluree-db-api/src/ledger/loading.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
+use crate::ledger_view::CommitRef;
 use crate::{ApiError, Fluree, HistoricalLedgerView, LedgerState, Result, TypeErasedStore};
 use fluree_db_binary_index::BinaryIndexStore;
 use fluree_db_core::ContentStore;
 use fluree_db_core::DictNovelty;
+use fluree_db_core::{collect_dag_cids, load_commit_by_id, CommitId};
 use fluree_db_nameservice::{NameServiceError, NsRecord};
 
 impl Fluree {
@@ -239,23 +241,33 @@ impl Fluree {
     /// Create a new branch for a ledger.
     ///
     /// Looks up the source branch to capture its current commit state, then
-    /// creates a new [`NsRecord`] for `ledger_name:new_branch` with the commit
-    /// head copied from the source. If the source has an index, the index
-    /// files are copied into the new branch's storage namespace so the branch
-    /// owns its own copy (safe from GC on the source).
+    /// creates a new [`NsRecord`] for `ledger_name:new_branch`.
     ///
-    /// Commits are **not** copied — the branch's [`BranchedContentStore`]
+    /// When `source_commit` is `None`, the new branch starts at the source's
+    /// current HEAD and inherits its index (copied into the new branch's
+    /// storage namespace so it's safe from GC on the source). This is the
+    /// default behavior.
+    ///
+    /// When `source_commit` is `Some(ref)`, the ref is resolved to a canonical
+    /// [`CommitId`] against the source branch, verified to be reachable from
+    /// the source HEAD, and becomes the new branch's head. The index is not
+    /// copied — the index at the source HEAD is typically too fresh for a
+    /// historical branch point, so the new branch replays from genesis.
+    ///
+    /// Commits themselves are **not** copied — the branch's content store
     /// reads historical commits from the source namespace via fallback.
     ///
     /// # Errors
     ///
     /// - [`ApiError::LedgerExists`] if the branch already exists
-    /// - [`ApiError::NotFound`] if the source branch does not exist
+    /// - [`ApiError::NotFound`] if the source branch does not exist, or if
+    ///   `source_commit` resolves to a commit not reachable from source HEAD
     pub async fn create_branch(
         &self,
         ledger_name: &str,
         new_branch: &str,
         source_branch: Option<&str>,
+        source_commit: Option<CommitRef>,
     ) -> Result<NsRecord> {
         use fluree_db_core::ledger_id::{format_ledger_id, validate_branch_name};
         use tracing::info;
@@ -279,36 +291,51 @@ impl Fluree {
             .ok_or_else(|| ApiError::NotFound(source_id.clone()))?;
 
         // Verify the source branch has a commit head before creating.
-        if source_record.commit_head_id.is_none() {
-            return Err(ApiError::internal(format!(
-                "Source branch {source_id} has no commit head"
-            )));
-        }
+        let source_head = source_record.commit_head_id.clone().ok_or_else(|| {
+            ApiError::internal(format!("Source branch {source_id} has no commit head"))
+        })?;
+
+        // If the caller specified a historical commit, resolve it and verify
+        // it's reachable from source HEAD before we touch the nameservice.
+        let at_commit = if let Some(commit_ref) = source_commit {
+            let view = self.ledger_cached(&source_id).await?.snapshot().await;
+            let resolved = view.resolve_commit(commit_ref).await?;
+            let store = self.content_store(&source_id);
+            let commit = verify_ancestor_and_load(&*store, &source_head, &resolved).await?;
+            Some((resolved, commit.t))
+        } else {
+            None
+        };
+
+        let is_historical = at_commit.is_some();
 
         self.nameservice()
-            .create_branch(ledger_name, new_branch, source)
+            .create_branch(ledger_name, new_branch, source, at_commit)
             .await
             .map_err(|e| match e {
                 NameServiceError::LedgerAlreadyExists(a) => ApiError::ledger_exists(a),
                 other => other.into(),
             })?;
 
-        // Copy the source's index files into the new branch's namespace.
-        // This gives the branch its own copy, safe from GC on the source.
-        if let Some(ref index_cid) = source_record.index_head_id {
-            if let Err(e) = self
-                .copy_index_to_branch(&source_id, &new_id, index_cid)
-                .await
-            {
-                tracing::warn!(
-                    %e, source = %source_id, branch = %new_id,
-                    "failed to copy index to branch; branch will replay from genesis"
-                );
-            } else {
-                // Register the copied index in the new branch's nameservice record
-                self.publisher()?
-                    .publish_index(&new_id, source_record.index_t, index_cid)
-                    .await?;
+        // Historical branches replay from genesis — skip the index copy.
+        // The source's current index reflects HEAD, which is too fresh.
+        if !is_historical {
+            if let Some(ref index_cid) = source_record.index_head_id {
+                // Copy the source's index files into the new branch's
+                // namespace so it owns its own copy, safe from GC on source.
+                if let Err(e) = self
+                    .copy_index_to_branch(&source_id, &new_id, index_cid)
+                    .await
+                {
+                    tracing::warn!(
+                        %e, source = %source_id, branch = %new_id,
+                        "failed to copy index to branch; branch will replay from genesis"
+                    );
+                } else {
+                    self.publisher()?
+                        .publish_index(&new_id, source_record.index_t, index_cid)
+                        .await?;
+                }
             }
         }
 
@@ -440,5 +467,35 @@ impl Fluree {
     /// List all non-retracted branches for a ledger.
     pub async fn list_branches(&self, ledger_name: &str) -> Result<Vec<NsRecord>> {
         Ok(self.nameservice().list_branches(ledger_name).await?)
+    }
+}
+
+/// Load `target` and verify it's reachable by walking parents from `source_head`.
+///
+/// Used by `create_branch` when a caller specifies a historical commit — we
+/// only allow branching from commits on the source branch's ancestry.
+async fn verify_ancestor_and_load<C: ContentStore + ?Sized>(
+    store: &C,
+    source_head: &CommitId,
+    target: &CommitId,
+) -> Result<fluree_db_core::Commit> {
+    let target_commit = load_commit_by_id(store, target).await.map_err(|_| {
+        ApiError::NotFound(format!("commit {target} not found in source namespace"))
+    })?;
+
+    if source_head == target {
+        return Ok(target_commit);
+    }
+
+    // Walk backward from source_head, stopping once we pass below target's t.
+    let stop_at = (target_commit.t - 1).max(0);
+    let dag = collect_dag_cids(store, source_head, stop_at).await?;
+
+    if dag.iter().any(|(_, cid)| cid == target) {
+        Ok(target_commit)
+    } else {
+        Err(ApiError::NotFound(format!(
+            "commit {target} is not an ancestor of source head {source_head}"
+        )))
     }
 }

--- a/fluree-db-api/src/ledger/loading.rs
+++ b/fluree-db-api/src/ledger/loading.rs
@@ -490,9 +490,11 @@ async fn verify_ancestor<C: ContentStore + ?Sized>(
     source_head: &CommitId,
     target: &CommitId,
 ) -> Result<i64> {
-    let target_envelope = load_commit_envelope_by_id(store, target).await.map_err(|_| {
-        ApiError::NotFound(format!("commit {target} not found in source namespace"))
-    })?;
+    let target_envelope = load_commit_envelope_by_id(store, target)
+        .await
+        .map_err(|_| {
+            ApiError::NotFound(format!("commit {target} not found in source namespace"))
+        })?;
 
     if source_head == target {
         return Ok(target_envelope.t);

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -562,7 +562,7 @@ async fn build_commit_jsonld<S: Storage + Clone>(
             .map(|r| {
                 json!({
                     "type": ["Commit"],
-                    "id": r.id.to_string(),
+                    "id": r.to_string(),
                 })
             })
             .collect();

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -555,9 +555,9 @@ async fn build_commit_jsonld<S: Storage + Clone>(
         obj["time"] = json!(time);
     }
 
-    if !commit.previous_refs.is_empty() {
+    if !commit.parents.is_empty() {
         let parents: Vec<_> = commit
-            .previous_refs
+            .parents
             .iter()
             .map(|r| {
                 json!({

--- a/fluree-db-api/src/ledger_manager.rs
+++ b/fluree-db-api/src/ledger_manager.rs
@@ -33,10 +33,10 @@ use fluree_db_core::trace_commits_by_id;
 use fluree_db_core::{ledger_id::normalize_ledger_id, ContentId, ContentStore, StorageBackend};
 use fluree_db_ledger::{LedgerState, TypeErasedStore};
 use fluree_db_nameservice::NsRecord;
-use fluree_db_novelty::Novelty;
 use tokio::sync::{oneshot, Mutex, RwLock};
 
 use crate::error::{ApiError, Result};
+use crate::ledger_view::LedgerView;
 
 // ============================================================================
 // Monotonic Clock for Eviction
@@ -55,104 +55,6 @@ static PROCESS_START: OnceLock<Instant> = OnceLock::new();
 fn monotonic_secs() -> u64 {
     let start = PROCESS_START.get_or_init(Instant::now);
     start.elapsed().as_secs()
-}
-
-// ============================================================================
-// CachedLedgerState - Read-only view (no lock held)
-// ============================================================================
-
-/// Read-only snapshot of ledger state - does NOT hold any lock
-///
-/// Safe to pass around and use for queries without blocking other operations.
-/// This is a cheap clone of the underlying state (LedgerSnapshot clone is cheap via Arc fields).
-pub struct CachedLedgerState {
-    /// The indexed database snapshot (cheap clone - Arc fields)
-    pub snapshot: LedgerSnapshot,
-    /// In-memory overlay of uncommitted transactions
-    pub novelty: Arc<Novelty>,
-    /// Dictionary novelty layer (subjects and strings since last index build)
-    pub dict_novelty: Arc<fluree_db_core::DictNovelty>,
-    /// Ledger-scoped runtime IDs for predicates and datatypes.
-    pub runtime_small_dicts: Arc<fluree_db_core::RuntimeSmallDicts>,
-    /// Current transaction t value
-    pub t: i64,
-    /// Content identifier of the head commit (identity)
-    pub head_commit_id: Option<fluree_db_core::ContentId>,
-    /// Content identifier of the current index root (identity)
-    pub head_index_id: Option<fluree_db_core::ContentId>,
-    /// Nameservice record (if loaded via nameservice)
-    pub ns_record: Option<NsRecord>,
-    /// Binary columnar index store (v2 only).
-    ///
-    /// Present when `snapshot.range_provider` is also set — the two are always
-    /// set/cleared together (see coherence `debug_assert` in `snapshot()`).
-    pub binary_store: Option<Arc<BinaryIndexStore>>,
-    /// Default JSON-LD @context for this ledger.
-    pub default_context: Option<serde_json::Value>,
-}
-
-impl CachedLedgerState {
-    /// Create a snapshot from ledger state
-    ///
-    /// Note: `binary_store` is set to `None` here — callers that have a
-    /// binary store must set it after construction (see `LedgerHandle::snapshot()`).
-    fn from_state(state: &LedgerState) -> Self {
-        Self {
-            snapshot: state.snapshot.clone(), // Cheap: Arc fields
-            novelty: Arc::clone(&state.novelty),
-            dict_novelty: Arc::clone(&state.dict_novelty),
-            runtime_small_dicts: Arc::clone(&state.runtime_small_dicts),
-            t: state.t(),
-            head_commit_id: state.head_commit_id.clone(),
-            head_index_id: state.head_index_id.clone(),
-            ns_record: state.ns_record.clone(),
-            binary_store: None,
-            default_context: state.default_context.clone(),
-        }
-    }
-
-    /// Get the ledger name (without branch suffix)
-    ///
-    /// Returns the base ledger name (e.g., "mydb"), NOT the canonical form (e.g., "mydb:main").
-    /// For the canonical ledger_id, use `ledger_id()` instead.
-    ///
-    /// Note: This matches `NsRecord.name` semantics where "name" is the base name.
-    pub fn name(&self) -> Option<&str> {
-        self.ns_record.as_ref().map(|r| r.name.as_str())
-    }
-
-    /// Get the canonical ledger ID (with branch suffix)
-    ///
-    /// Returns the canonical form (e.g., "mydb:main") suitable for cache keys.
-    /// This is the primary identifier for ledger lookups.
-    pub fn ledger_id(&self) -> Option<&str> {
-        self.ns_record.as_ref().map(|r| r.ledger_id.as_str())
-    }
-
-    /// Get index_t from the underlying LedgerSnapshot
-    pub fn index_t(&self) -> i64 {
-        self.snapshot.t
-    }
-
-    /// Convert snapshot to LedgerState for backward compatibility
-    ///
-    /// This creates a LedgerState with the same data as the snapshot.
-    /// Use this when you need to pass the state to APIs that expect LedgerState.
-    pub fn to_ledger_state(self) -> LedgerState {
-        let dict_novelty = self.dict_novelty;
-        LedgerState {
-            snapshot: self.snapshot,
-            novelty: self.novelty,
-            dict_novelty,
-            runtime_small_dicts: self.runtime_small_dicts,
-            head_commit_id: self.head_commit_id,
-            head_index_id: self.head_index_id,
-            ns_record: self.ns_record,
-            binary_store: self.binary_store.map(|store| TypeErasedStore(store)),
-            default_context: self.default_context,
-            spatial_indexes: None,
-        }
-    }
 }
 
 // ============================================================================
@@ -257,11 +159,11 @@ impl LedgerHandle {
     ///
     /// IMPORTANT: Queries must NOT execute while holding the internal lock.
     /// The snapshot is a cheap clone; the lock is released immediately after.
-    pub async fn snapshot(&self) -> CachedLedgerState {
+    pub async fn snapshot(&self) -> LedgerView {
         self.touch();
         let state = self.inner.state.lock().await;
         let binary_store = self.inner.binary_store.lock().await.clone();
-        let mut snap = CachedLedgerState::from_state(&state);
+        let mut snap = LedgerView::from_state(&state);
         snap.binary_store = binary_store;
         debug_assert!(
             snap.snapshot.range_provider.is_some() == snap.binary_store.is_some(),

--- a/fluree-db-api/src/ledger_view.rs
+++ b/fluree-db-api/src/ledger_view.rs
@@ -35,6 +35,29 @@ pub enum CommitRef {
     T(i64),
 }
 
+impl CommitRef {
+    /// Parse a user-supplied commit reference string.
+    ///
+    /// - `"t:N"` → [`CommitRef::T`] with transaction number `N`
+    /// - anything else → [`CommitRef::Prefix`] (full CIDs and hex-digest
+    ///   prefixes are both handled by the prefix resolver)
+    ///
+    /// [`CommitRef::Exact`] is not produced by this parser — callers holding
+    /// a concrete [`CommitId`] should construct it directly.
+    pub fn parse(s: &str) -> Result<Self> {
+        if let Some(t_str) = s.strip_prefix("t:") {
+            let t: i64 = t_str
+                .parse()
+                .map_err(|_| ApiError::query(format!("invalid t value in commit ref '{s}'")))?;
+            Ok(CommitRef::T(t))
+        } else if s.is_empty() {
+            Err(ApiError::query("empty commit reference"))
+        } else {
+            Ok(CommitRef::Prefix(s.to_string()))
+        }
+    }
+}
+
 /// Read-only view of a ledger at a point in time.
 ///
 /// Holds no locks. Safe to clone, pass to subtasks, or keep across `.await`

--- a/fluree-db-api/src/ledger_view.rs
+++ b/fluree-db-api/src/ledger_view.rs
@@ -363,10 +363,7 @@ async fn resolve_t_to_commit_id(
             ))
         }
         _ => {
-            let ids: Vec<_> = matches
-                .iter()
-                .map(|h| &h[..7.min(h.len())])
-                .collect();
+            let ids: Vec<_> = matches.iter().map(|h| &h[..7.min(h.len())]).collect();
             Err(ApiError::query(format!(
                 "Ambiguous t={target_t}: multiple commits match {ids:?} (likely a rebased history). Disambiguate by passing the full commit CID."
             )))

--- a/fluree-db-api/src/ledger_view.rs
+++ b/fluree-db-api/src/ledger_view.rs
@@ -27,7 +27,11 @@ use crate::error::{ApiError, Result};
 /// Commits have a canonical content-addressed id ([`CommitId`]), but there are
 /// several user-facing forms that resolve to the same id.
 pub enum CommitRef {
-    /// Exact CID (e.g., from API or full CID string like "bagaybqabciq...")
+    /// Fully resolved CID — no lookup needed.
+    ///
+    /// Produced by [`CommitRef::parse`] when the input is a valid multibase
+    /// CID string (e.g., `"bafybei..."`), or constructed directly by callers
+    /// that already hold a [`CommitId`].
     Exact(CommitId),
     /// Hex digest prefix (e.g., "3dd028" — the SHA-256 hex prefix of the commit)
     Prefix(String),
@@ -39,11 +43,10 @@ impl CommitRef {
     /// Parse a user-supplied commit reference string.
     ///
     /// - `"t:N"` → [`CommitRef::T`] with transaction number `N`
-    /// - anything else → [`CommitRef::Prefix`] (full CIDs and hex-digest
-    ///   prefixes are both handled by the prefix resolver)
-    ///
-    /// [`CommitRef::Exact`] is not produced by this parser — callers holding
-    /// a concrete [`CommitId`] should construct it directly.
+    /// - a valid multibase CID (e.g., `"bafybei..."`) → [`CommitRef::Exact`]
+    /// - anything else → [`CommitRef::Prefix`] (hex digest prefixes, and the
+    ///   `fluree:commit:` / `sha256:` prefixed hex forms, are all handled by
+    ///   the prefix resolver)
     pub fn parse(s: &str) -> Result<Self> {
         if let Some(t_str) = s.strip_prefix("t:") {
             let t: i64 = t_str
@@ -52,6 +55,8 @@ impl CommitRef {
             Ok(CommitRef::T(t))
         } else if s.is_empty() {
             Err(ApiError::query("empty commit reference"))
+        } else if let Ok(cid) = s.parse::<ContentId>() {
+            Ok(CommitRef::Exact(cid))
         } else {
             Ok(CommitRef::Prefix(s.to_string()))
         }
@@ -343,4 +348,24 @@ async fn resolve_t_to_commit_id(
     Err(ApiError::NotFound(format!(
         "No commit found for t={target_t}"
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::ContentKind;
+
+    /// `parse` must accept the multibase CID string produced by
+    /// `ContentId::Display` and return [`CommitRef::Exact`]. If it falls
+    /// through to `Prefix` instead, the prefix resolver (which scans by hex
+    /// digest) silently fails to match a base32-multibase string.
+    #[test]
+    fn parse_full_multibase_cid_produces_exact() {
+        let cid = ContentId::new(ContentKind::Commit, b"regression-probe");
+        let parsed = CommitRef::parse(&cid.to_string()).expect("parse should succeed");
+        assert!(
+            matches!(&parsed, CommitRef::Exact(c) if c == &cid),
+            "expected Exact({cid}), got a different variant"
+        );
+    }
 }

--- a/fluree-db-api/src/ledger_view.rs
+++ b/fluree-db-api/src/ledger_view.rs
@@ -1,14 +1,26 @@
-//! A commit reference: one of several forms a caller can use to identify a
-//! commit (exact CID, hex-digest prefix, or transaction number `t`).
+//! Read-only, lock-free view of a ledger at a point in time.
 //!
-//! Each variant resolves to the canonical [`CommitId`] via the helpers in this
-//! module. The resolvers scan the commit metadata recorded in the txn-meta
-//! graph, so they require both a [`LedgerSnapshot`] and the current novelty
-//! overlay.
+//! A [`LedgerView`] bundles the indexed snapshot, novelty overlay, dictionary
+//! state, and head metadata needed to query or resolve against a ledger without
+//! taking the write lock. It's produced by [`LedgerHandle::snapshot`] and is
+//! safe to hold across `.await` points or pass to subtasks.
+//!
+//! This module also defines [`CommitRef`] — the user-facing forms for
+//! identifying a commit — and owns the resolvers that turn one into a
+//! canonical [`CommitId`] via [`LedgerView::resolve_commit`].
+//!
+//! [`LedgerHandle::snapshot`]: crate::LedgerHandle::snapshot
 
-use crate::{ApiError, Result};
-use fluree_db_core::{CommitId, ContentId, LedgerSnapshot};
+use std::sync::Arc;
+
+use fluree_db_binary_index::BinaryIndexStore;
+use fluree_db_core::db::LedgerSnapshot;
+use fluree_db_core::{CommitId, ContentId};
+use fluree_db_ledger::{LedgerState, TypeErasedStore};
+use fluree_db_nameservice::NsRecord;
 use fluree_db_novelty::Novelty;
+
+use crate::error::{ApiError, Result};
 
 /// How a caller identifies a commit.
 ///
@@ -23,11 +35,119 @@ pub enum CommitRef {
     T(i64),
 }
 
+/// Read-only view of a ledger at a point in time.
+///
+/// Holds no locks. Safe to clone, pass to subtasks, or keep across `.await`
+/// points. Underlying state is Arc-shared, so cloning is cheap.
+pub struct LedgerView {
+    /// The indexed database snapshot (cheap clone - Arc fields)
+    pub snapshot: LedgerSnapshot,
+    /// In-memory overlay of uncommitted transactions
+    pub novelty: Arc<Novelty>,
+    /// Dictionary novelty layer (subjects and strings since last index build)
+    pub dict_novelty: Arc<fluree_db_core::DictNovelty>,
+    /// Ledger-scoped runtime IDs for predicates and datatypes.
+    pub runtime_small_dicts: Arc<fluree_db_core::RuntimeSmallDicts>,
+    /// Current transaction t value
+    pub t: i64,
+    /// Content identifier of the head commit (identity)
+    pub head_commit_id: Option<ContentId>,
+    /// Content identifier of the current index root (identity)
+    pub head_index_id: Option<ContentId>,
+    /// Nameservice record (if loaded via nameservice)
+    pub ns_record: Option<NsRecord>,
+    /// Binary columnar index store (v2 only).
+    ///
+    /// Present when `snapshot.range_provider` is also set — the two are always
+    /// set/cleared together (see coherence `debug_assert` in `snapshot()`).
+    pub binary_store: Option<Arc<BinaryIndexStore>>,
+    /// Default JSON-LD @context for this ledger.
+    pub default_context: Option<serde_json::Value>,
+}
+
+impl LedgerView {
+    /// Build a view from ledger state.
+    ///
+    /// Note: `binary_store` is set to `None` here — callers that have a
+    /// binary store must set it after construction (see `LedgerHandle::snapshot()`).
+    pub(crate) fn from_state(state: &LedgerState) -> Self {
+        Self {
+            snapshot: state.snapshot.clone(),
+            novelty: Arc::clone(&state.novelty),
+            dict_novelty: Arc::clone(&state.dict_novelty),
+            runtime_small_dicts: Arc::clone(&state.runtime_small_dicts),
+            t: state.t(),
+            head_commit_id: state.head_commit_id.clone(),
+            head_index_id: state.head_index_id.clone(),
+            ns_record: state.ns_record.clone(),
+            binary_store: None,
+            default_context: state.default_context.clone(),
+        }
+    }
+
+    /// Get the ledger name (without branch suffix)
+    ///
+    /// Returns the base ledger name (e.g., "mydb"), NOT the canonical form (e.g., "mydb:main").
+    /// For the canonical ledger_id, use `ledger_id()` instead.
+    ///
+    /// Note: This matches `NsRecord.name` semantics where "name" is the base name.
+    pub fn name(&self) -> Option<&str> {
+        self.ns_record.as_ref().map(|r| r.name.as_str())
+    }
+
+    /// Get the canonical ledger ID (with branch suffix)
+    ///
+    /// Returns the canonical form (e.g., "mydb:main") suitable for cache keys.
+    /// This is the primary identifier for ledger lookups.
+    pub fn ledger_id(&self) -> Option<&str> {
+        self.ns_record.as_ref().map(|r| r.ledger_id.as_str())
+    }
+
+    /// Get index_t from the underlying LedgerSnapshot
+    pub fn index_t(&self) -> i64 {
+        self.snapshot.t
+    }
+
+    /// Resolve a [`CommitRef`] to a canonical [`CommitId`] against this
+    /// view's indexes and novelty overlay.
+    pub async fn resolve_commit(&self, commit_ref: CommitRef) -> Result<CommitId> {
+        match commit_ref {
+            CommitRef::Exact(id) => Ok(id),
+            CommitRef::Prefix(prefix) => {
+                resolve_commit_prefix(&self.snapshot, &self.novelty, &prefix, self.t).await
+            }
+            CommitRef::T(t) => {
+                resolve_t_to_commit_id(&self.snapshot, &self.novelty, t, self.t).await
+            }
+        }
+    }
+
+    /// Convert the view to a [`LedgerState`] for backward compatibility.
+    ///
+    /// This creates a `LedgerState` with the same data as the view. Use this
+    /// when you need to pass the state to APIs that expect `LedgerState`.
+    pub fn to_ledger_state(self) -> LedgerState {
+        let dict_novelty = self.dict_novelty;
+        LedgerState {
+            snapshot: self.snapshot,
+            novelty: self.novelty,
+            dict_novelty,
+            runtime_small_dicts: self.runtime_small_dicts,
+            head_commit_id: self.head_commit_id,
+            head_index_id: self.head_index_id,
+            ns_record: self.ns_record,
+            binary_store: self.binary_store.map(|store| TypeErasedStore(store)),
+            default_context: self.default_context,
+            spatial_indexes: None,
+        }
+    }
+}
+
 /// Resolve a commit hex-digest prefix to a full [`CommitId`].
 ///
 /// Uses a bounded SPOT index scan on commit subjects (same approach as
 /// `time_resolve::commit_to_t`, but returns the CID instead of `t`).
-pub(crate) async fn resolve_commit_prefix(
+async fn resolve_commit_prefix(
     snapshot: &LedgerSnapshot,
     overlay: &Novelty,
     prefix: &str,
@@ -104,7 +224,6 @@ pub(crate) async fn resolve_commit_prefix(
             "No commit found with prefix: {normalized}"
         ))),
         1 => {
-            // Reconstruct ContentId from hex digest
             let hex = &matches[0];
             let digest: [u8; 32] = hex::decode(hex)
                 .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
@@ -136,7 +255,7 @@ pub(crate) async fn resolve_commit_prefix(
 /// Queries the POST index for commit flakes where predicate = `fluree:db/t`
 /// and object = the target `t` value. The matching commit subject's hex digest
 /// is then converted to a [`CommitId`].
-pub(crate) async fn resolve_t_to_commit_id(
+async fn resolve_t_to_commit_id(
     snapshot: &LedgerSnapshot,
     overlay: &Novelty,
     target_t: i64,
@@ -159,7 +278,6 @@ pub(crate) async fn resolve_t_to_commit_id(
         )));
     }
 
-    // POST index query: predicate = fluree:db/t, object = target_t (exact match)
     let predicate = Sid::new(FLUREE_DB, fluree_vocab::db::T);
     let range_match = RangeMatch::predicate_object(predicate, FlakeValue::Long(target_t));
 
@@ -178,7 +296,6 @@ pub(crate) async fn resolve_t_to_commit_id(
     )
     .await?;
 
-    // Find the flake with our exact predicate and object value
     for flake in &flakes {
         if flake.p.namespace_code != FLUREE_DB || flake.p.name.as_ref() != fluree_vocab::db::T {
             continue;
@@ -186,7 +303,6 @@ pub(crate) async fn resolve_t_to_commit_id(
         if flake.o != FlakeValue::Long(target_t) {
             continue;
         }
-        // The subject is in FLUREE_COMMIT namespace with hex digest as name
         if flake.s.namespace_code != FLUREE_COMMIT {
             continue;
         }

--- a/fluree-db-api/src/ledger_view.rs
+++ b/fluree-db-api/src/ledger_view.rs
@@ -324,6 +324,12 @@ async fn resolve_t_to_commit_id(
     )
     .await?;
 
+    // A rebased ledger can have multiple commits at the same `t` (old chain
+    // + new chain both leave flakes in the POST index). Collect unique
+    // matching subjects so we can detect and surface the ambiguity rather
+    // than silently returning the first one.
+    let mut seen = std::collections::HashSet::new();
+    let mut matches: Vec<String> = Vec::new();
     for flake in &flakes {
         if flake.p.namespace_code != FLUREE_DB || flake.p.name.as_ref() != fluree_vocab::db::T {
             continue;
@@ -334,20 +340,38 @@ async fn resolve_t_to_commit_id(
         if flake.s.namespace_code != FLUREE_COMMIT {
             continue;
         }
-        let hex = flake.s.name.as_ref();
-        let digest: [u8; 32] = hex::decode(hex)
-            .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
-            .try_into()
-            .map_err(|_| ApiError::internal("Digest not 32 bytes"))?;
-        return Ok(ContentId::from_sha256_digest(
-            fluree_db_core::CODEC_FLUREE_COMMIT,
-            &digest,
-        ));
+        if seen.insert(flake.s.name.as_ref()) {
+            matches.push(flake.s.name.to_string());
+        }
+        if matches.len() > 1 {
+            break;
+        }
     }
 
-    Err(ApiError::NotFound(format!(
-        "No commit found for t={target_t}"
-    )))
+    match matches.len() {
+        0 => Err(ApiError::NotFound(format!(
+            "No commit found for t={target_t}"
+        ))),
+        1 => {
+            let digest: [u8; 32] = hex::decode(&matches[0])
+                .map_err(|e| ApiError::internal(format!("Invalid hex digest: {e}")))?
+                .try_into()
+                .map_err(|_| ApiError::internal("Digest not 32 bytes"))?;
+            Ok(ContentId::from_sha256_digest(
+                fluree_db_core::CODEC_FLUREE_COMMIT,
+                &digest,
+            ))
+        }
+        _ => {
+            let ids: Vec<_> = matches
+                .iter()
+                .map(|h| &h[..7.min(h.len())])
+                .collect();
+            Err(ApiError::query(format!(
+                "Ambiguous t={target_t}: multiple commits match {ids:?} (likely a rebased history). Disambiguate by passing the full commit CID."
+            )))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -351,9 +351,10 @@ impl fluree_db_nameservice::NameService for NameServiceMode {
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(fluree_db_core::ContentId, i64)>,
     ) -> std::result::Result<(), fluree_db_nameservice::NameServiceError> {
         self.reader()
-            .create_branch(ledger_name, new_branch, source_branch)
+            .create_branch(ledger_name, new_branch, source_branch, at_commit)
             .await
     }
 

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -36,6 +36,7 @@
 pub mod admin;
 pub mod block_fetch;
 pub mod bm25_worker;
+pub mod commit_ref;
 pub mod commit_transfer;
 pub mod config_resolver;
 #[cfg(feature = "credential")]

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -36,7 +36,6 @@
 pub mod admin;
 pub mod block_fetch;
 pub mod bm25_worker;
-pub mod commit_ref;
 pub mod commit_transfer;
 pub mod config_resolver;
 #[cfg(feature = "credential")]
@@ -78,6 +77,7 @@ pub mod view;
 
 // Ledger caching and management
 pub mod ledger_manager;
+pub mod ledger_view;
 
 // Search service integration (embedded adapter, remote client)
 pub mod search;
@@ -125,10 +125,11 @@ pub use import::{
 };
 pub use ledger_info::LedgerInfoBuilder;
 pub use ledger_manager::{
-    CachedLedgerState, FreshnessCheck, FreshnessSource, LedgerHandle, LedgerManager,
-    LedgerManagerConfig, LedgerWriteGuard, NotifyResult, NsNotify, RefreshOpts, RefreshResult,
-    RemoteWatermark, UpdatePlan,
+    FreshnessCheck, FreshnessSource, LedgerHandle, LedgerManager, LedgerManagerConfig,
+    LedgerWriteGuard, NotifyResult, NsNotify, RefreshOpts, RefreshResult, RemoteWatermark,
+    UpdatePlan,
 };
+pub use ledger_view::{CommitRef, LedgerView};
 pub use merge::MergeReport;
 pub use pack::{
     compute_missing_index_artifacts, full_ledger_pack_request, validate_pack_request, PackChunk,
@@ -194,7 +195,7 @@ pub use fluree_db_core::{
     Storage, StorageMethod, StorageRead, StorageWrite,
 };
 pub use fluree_db_ledger::{
-    HistoricalLedgerView, IndexConfig, LedgerState, LedgerView, TypeErasedStore,
+    HistoricalLedgerView, IndexConfig, LedgerState, StagedLedger, TypeErasedStore,
 };
 pub use fluree_db_nameservice::{
     ConfigCasResult, ConfigPayload, ConfigPublisher, ConfigValue, GraphSourceLookup,

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -11,7 +11,7 @@ use fluree_db_core::content_kind::ContentKind;
 use fluree_db_core::ledger_id::format_ledger_id;
 use fluree_db_core::{collect_dag_cids, load_commit_by_id, CommonAncestor};
 use fluree_db_core::{ConflictKey, ContentId, ContentStore, Flake};
-use fluree_db_ledger::{LedgerState, LedgerView};
+use fluree_db_ledger::{LedgerState, StagedLedger};
 use fluree_db_nameservice::{NsRecord, NsRecordSnapshot};
 use fluree_db_novelty::compute_delta_keys;
 use fluree_db_transact::{CommitOpts, NamespaceRegistry};
@@ -343,7 +343,7 @@ impl crate::Fluree {
             ApiError::internal(format!("Failed to build reverse graph during merge: {e}"))
         })?;
 
-        let view = LedgerView::stage(target_state, resolved_flakes, &reverse_graph)
+        let view = StagedLedger::new(target_state, resolved_flakes, &reverse_graph)
             .map_err(|e| ApiError::internal(format!("Failed to stage flakes during merge: {e}")))?;
 
         // Create merge commit with the source head as an additional parent,

--- a/fluree-db-api/src/pack.rs
+++ b/fluree-db-api/src/pack.rs
@@ -112,7 +112,7 @@ pub async fn compute_missing_commits<C: ContentStore>(
 
             chain.push(current_id);
 
-            for parent in env.previous_refs {
+            for parent in env.parents {
                 frontier.push(parent);
             }
         }

--- a/fluree-db-api/src/pack.rs
+++ b/fluree-db-api/src/pack.rs
@@ -113,7 +113,7 @@ pub async fn compute_missing_commits<C: ContentStore>(
             chain.push(current_id);
 
             for parent in env.previous_refs {
-                frontier.push(parent.id);
+                frontier.push(parent);
             }
         }
 

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -11,7 +11,7 @@ use fluree_db_core::{
     RangeTest,
 };
 use fluree_db_core::{trace_commits_by_id, Commit};
-use fluree_db_ledger::{LedgerState, LedgerView};
+use fluree_db_ledger::{LedgerState, StagedLedger};
 use fluree_db_nameservice::NsRecordSnapshot;
 use fluree_db_novelty::compute_delta_keys;
 use fluree_db_transact::{CommitOpts, NamespaceRegistry};
@@ -403,7 +403,7 @@ impl crate::Fluree {
             ApiError::internal(format!("Failed to build reverse graph during rebase: {e}"))
         })?;
 
-        let view = LedgerView::stage(state, flakes, &reverse_graph).map_err(|e| {
+        let view = StagedLedger::new(state, flakes, &reverse_graph).map_err(|e| {
             ApiError::internal(format!("Failed to stage flakes during rebase: {e}"))
         })?;
 

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -16,7 +16,7 @@ use fluree_db_core::{
     RangeOptions, RangeTest, Sid,
 };
 use fluree_db_indexer::IndexerHandle;
-use fluree_db_ledger::{IndexConfig, LedgerState, LedgerView};
+use fluree_db_ledger::{IndexConfig, LedgerState, StagedLedger};
 use fluree_db_novelty::TxnMetaEntry;
 #[cfg(feature = "shacl")]
 use fluree_db_shacl::ShaclEngine;
@@ -231,7 +231,7 @@ fn build_per_graph_shacl_policy(
     }
 }
 
-/// Context for applying SHACL policy to an already-staged [`LedgerView`].
+/// Context for applying SHACL policy to an already-staged [`StagedLedger`].
 ///
 /// All fields are optional: callers without full transaction context (Turtle
 /// insert, commit replay) pass `None` and get sensible default behavior:
@@ -318,7 +318,7 @@ fn resolve_shapes_source_g_ids(
     }
 }
 
-/// Apply SHACL policy to an already-staged [`LedgerView`].
+/// Apply SHACL policy to an already-staged [`StagedLedger`].
 ///
 /// This is the single canonical post-stage SHACL entry point shared by every
 /// write surface (JSON-LD txn staging, Turtle insert, commit replay). It:
@@ -336,7 +336,7 @@ fn resolve_shapes_source_g_ids(
 /// is API-layer policy, not a staging primitive.
 #[cfg(feature = "shacl")]
 pub(crate) async fn apply_shacl_policy_to_staged_view(
-    view: &LedgerView,
+    view: &StagedLedger,
     ctx: StagedShaclContext<'_>,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
     let base = view.base();
@@ -475,7 +475,7 @@ async fn stage_with_config_shacl(
     txn: Txn,
     ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
-) -> std::result::Result<(LedgerView, NamespaceRegistry), fluree_db_transact::TransactError> {
+) -> std::result::Result<(StagedLedger, NamespaceRegistry), fluree_db_transact::TransactError> {
     // Capture graph_delta + tracker before stage_txn consumes the options/txn.
     // graph_delta is used both for per-graph config lookup and for rebuilding
     // graph_sids after staging (IRIs are already interned in ns_registry, so
@@ -513,7 +513,7 @@ async fn stage_with_config_shacl(
 /// staged flakes against `f:enforceUnique` annotations. Zero-cost when
 /// no `f:transactDefaults` / `f:uniqueEnabled` is configured.
 async fn enforce_unique_after_staging(
-    view: &LedgerView,
+    view: &StagedLedger,
     graph_delta: &FxHashMap<u16, String>,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
     let config = load_transaction_config(view.base()).await;
@@ -532,7 +532,7 @@ async fn enforce_unique_after_staging(
 ///
 /// Returns an empty map when no uniqueness constraints are configured (fast path).
 async fn resolve_per_graph_unique_sids(
-    view: &LedgerView,
+    view: &StagedLedger,
     config: &LedgerConfig,
     graph_delta: &FxHashMap<u16, String>,
 ) -> std::result::Result<HashMap<GraphId, FxHashSet<Sid>>, fluree_db_transact::TransactError> {
@@ -646,7 +646,7 @@ fn resolve_constraint_source_g_ids(
 /// Queries the POST index at the pre-transaction state for all subjects
 /// where `?prop f:enforceUnique true`. Returns the set of property SIDs.
 async fn read_enforce_unique_from_graph(
-    view: &LedgerView,
+    view: &StagedLedger,
     source_g_id: GraphId,
 ) -> std::result::Result<Vec<Sid>, fluree_db_transact::TransactError> {
     let snapshot = view.db();
@@ -692,7 +692,7 @@ async fn read_enforce_unique_from_graph(
 ///
 /// Returns `Ok(())` if no violations, or a `UniqueConstraintViolation` error.
 async fn enforce_unique_constraints(
-    view: &LedgerView,
+    view: &StagedLedger,
     per_graph_unique: &HashMap<GraphId, FxHashSet<Sid>>,
     graph_delta: &FxHashMap<u16, String>,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
@@ -893,7 +893,7 @@ pub struct TransactResultRef {
 
 /// Result of staging a transaction
 pub struct StageResult {
-    pub view: LedgerView,
+    pub view: StagedLedger,
     pub ns_registry: NamespaceRegistry,
     /// User-provided transaction metadata (extracted from envelope-form JSON-LD)
     pub txn_meta: Vec<TxnMetaEntry>,
@@ -1382,7 +1382,7 @@ impl crate::Fluree {
     /// Commit a staged transaction (persists commit record + publishes nameservice head).
     pub async fn commit_staged(
         &self,
-        view: LedgerView,
+        view: StagedLedger,
         ns_registry: NamespaceRegistry,
         index_config: &IndexConfig,
         commit_opts: CommitOpts,

--- a/fluree-db-api/src/tx_builder.rs
+++ b/fluree-db-api/src/tx_builder.rs
@@ -23,7 +23,7 @@ use crate::{
     Tracker, TrackingOptions,
 };
 use fluree_db_core::{ContentId, ContentKind};
-use fluree_db_ledger::{IndexConfig, LedgerState, LedgerView};
+use fluree_db_ledger::{IndexConfig, LedgerState, StagedLedger};
 use fluree_db_transact::{
     parse_trig_phase1, CommitOpts, NamedGraphBlock, NamespaceRegistry, RawTrigMeta, Txn, TxnOpts,
     TxnType,
@@ -203,7 +203,7 @@ impl<'a> TransactCore<'a> {
 /// ```
 pub struct Staged {
     /// The queryable staged view (base + overlay with staged flakes).
-    pub view: LedgerView,
+    pub view: StagedLedger,
     /// Namespace registry needed for commit.
     pub ns_registry: NamespaceRegistry,
     /// Named graph IRI mappings introduced by this transaction (g_id → IRI).

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -278,6 +278,77 @@ async fn create_branch_at_historical_commit() {
     assert_eq!(branch.t(), 2);
 }
 
+/// Branch at a historical commit via `CommitRef::T`.
+///
+/// Resolution scans the txn-meta graph for a commit with matching `t`.
+/// The scan includes the novelty overlay, so freshly committed transactions
+/// are visible without running the indexer.
+#[tokio::test]
+async fn create_branch_at_t() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let ctx = json!({"ex": "http://example.org/ns/"});
+
+    let r1 = fluree
+        .insert(ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}))
+        .await
+        .unwrap();
+    let r2 = fluree
+        .insert(r1.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}))
+        .await
+        .unwrap();
+    let t2_commit_id = r2.receipt.commit_id.clone();
+    let _r3 = fluree
+        .insert(r2.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}))
+        .await
+        .unwrap();
+
+    let record = fluree
+        .create_branch("mydb", "historical", None, Some(CommitRef::T(2)))
+        .await
+        .unwrap();
+
+    assert_eq!(record.commit_head_id.as_ref(), Some(&t2_commit_id));
+    assert_eq!(record.commit_t, 2);
+}
+
+/// Branch at a historical commit via `CommitRef::Prefix` using a hex digest.
+///
+/// Like `T`, the prefix resolver scans novelty and tolerates unindexed sources.
+#[tokio::test]
+async fn create_branch_at_prefix() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let ctx = json!({"ex": "http://example.org/ns/"});
+
+    let r1 = fluree
+        .insert(ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}))
+        .await
+        .unwrap();
+    let r2 = fluree
+        .insert(r1.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}))
+        .await
+        .unwrap();
+    let t2_commit_id = r2.receipt.commit_id.clone();
+    let _r3 = fluree
+        .insert(r2.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}))
+        .await
+        .unwrap();
+
+    // An 8-hex-char prefix is plenty to uniquely identify the commit in a
+    // tiny test ledger; the resolver requires >= 6 chars.
+    let prefix = t2_commit_id.digest_hex()[..8].to_string();
+    let record = fluree
+        .create_branch("mydb", "historical", None, Some(CommitRef::Prefix(prefix)))
+        .await
+        .unwrap();
+
+    assert_eq!(record.commit_head_id.as_ref(), Some(&t2_commit_id));
+    assert_eq!(record.commit_t, 2);
+}
+
 /// Branching from a commit that isn't reachable from source HEAD is rejected.
 #[tokio::test]
 async fn create_branch_at_non_ancestor_commit_fails() {

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -45,7 +45,7 @@ async fn create_and_list_branches() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create a branch
-    let record = fluree.create_branch("mydb", "dev", None).await.unwrap();
+    let record = fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     assert_eq!(record.branch, "dev");
     assert_eq!(record.ledger_id, "mydb:dev");
     assert_eq!(
@@ -73,9 +73,9 @@ async fn create_branch_duplicate_fails() {
     });
     fluree.insert(ledger, &txn).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     let err = fluree
-        .create_branch("mydb", "dev", None)
+        .create_branch("mydb", "dev", None, None)
         .await
         .expect_err("duplicate branch creation should fail");
     assert!(
@@ -97,16 +97,16 @@ async fn create_branch_invalid_name() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Empty name
-    assert!(fluree.create_branch("mydb", "", None).await.is_err());
+    assert!(fluree.create_branch("mydb", "", None, None).await.is_err());
 
     // Contains colon
-    assert!(fluree.create_branch("mydb", "foo:bar", None).await.is_err());
+    assert!(fluree.create_branch("mydb", "foo:bar", None, None).await.is_err());
 
     // Contains @
-    assert!(fluree.create_branch("mydb", "foo@bar", None).await.is_err());
+    assert!(fluree.create_branch("mydb", "foo@bar", None, None).await.is_err());
 
     // Path traversal
-    assert!(fluree.create_branch("mydb", "..", None).await.is_err());
+    assert!(fluree.create_branch("mydb", "..", None, None).await.is_err());
 }
 
 /// Creating a branch from a non-existent source returns not-found.
@@ -116,7 +116,7 @@ async fn create_branch_missing_source() {
     fluree.create_ledger("mydb").await.unwrap();
 
     let err = fluree
-        .create_branch("mydb", "dev", Some("nonexistent"))
+        .create_branch("mydb", "dev", Some("nonexistent"), None)
         .await
         .expect_err("missing source branch should fail");
     assert!(
@@ -145,7 +145,7 @@ async fn branch_data_isolation() {
     let main_after_base = result.ledger;
 
     // 2. Create branch "dev" from main
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // 3. Transact data only on main
     let main_data = json!({
@@ -206,7 +206,7 @@ async fn branch_t_advances_independently() {
     assert_eq!(result.receipt.t, 1);
 
     // Branch at t=1
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Transact twice on dev
     let dev = fluree.ledger("mydb:dev").await.unwrap();
@@ -246,7 +246,7 @@ async fn drop_branch_leaf() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create and then drop a leaf branch
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     let report = fluree.drop_branch("mydb", "dev").await.unwrap();
 
     assert!(!report.deferred, "leaf branch should not be deferred");
@@ -296,7 +296,7 @@ async fn branches_count_tracks_children() {
     assert_eq!(record.branches, 0);
 
     // Create two child branches
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     let record = fluree
         .nameservice()
         .lookup("mydb:main")
@@ -305,7 +305,7 @@ async fn branches_count_tracks_children() {
         .unwrap();
     assert_eq!(record.branches, 1);
 
-    fluree.create_branch("mydb", "staging", None).await.unwrap();
+    fluree.create_branch("mydb", "staging", None, None).await.unwrap();
     let record = fluree
         .nameservice()
         .lookup("mydb:main")
@@ -349,9 +349,9 @@ async fn drop_branch_with_children_deferred() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create dev, then branch feature from dev
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     fluree
-        .create_branch("mydb", "feature", Some("dev"))
+        .create_branch("mydb", "feature", Some("dev"), None)
         .await
         .unwrap();
 
@@ -399,9 +399,9 @@ async fn transact_on_retracted_branch_fails() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create dev, then a child so dev can be retracted (not purged)
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     fluree
-        .create_branch("mydb", "feature", Some("dev"))
+        .create_branch("mydb", "feature", Some("dev"), None)
         .await
         .unwrap();
 
@@ -439,9 +439,9 @@ async fn drop_branch_cascade() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // main -> dev -> feature
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     fluree
-        .create_branch("mydb", "feature", Some("dev"))
+        .create_branch("mydb", "feature", Some("dev"), None)
         .await
         .unwrap();
 
@@ -486,7 +486,7 @@ async fn nested_branch_data_isolation() {
     let main_ledger = result.ledger;
 
     // 2. Branch dev from main
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // 3. Transact on dev
     let dev = fluree.ledger("mydb:dev").await.unwrap();
@@ -498,7 +498,7 @@ async fn nested_branch_data_isolation() {
 
     // 4. Branch feature from dev (nested branch)
     fluree
-        .create_branch("mydb", "feature", Some("dev"))
+        .create_branch("mydb", "feature", Some("dev"), None)
         .await
         .unwrap();
 

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -5,7 +5,7 @@
 
 mod support;
 
-use fluree_db_api::FlureeBuilder;
+use fluree_db_api::{CommitRef, FlureeBuilder};
 use serde_json::json;
 
 /// Extract sorted name strings from query result rows.
@@ -231,6 +231,85 @@ async fn branch_t_advances_independently() {
     // Dev is at t=3
     let dev = fluree.ledger("mydb:dev").await.unwrap();
     assert_eq!(dev.t(), 3);
+}
+
+/// Branch at a historical commit via `CommitRef::Exact`.
+///
+/// Main advances to t=3. We branch at the t=2 commit and verify the new
+/// branch starts at t=2 with no index (replay-from-genesis path).
+#[tokio::test]
+async fn create_branch_at_historical_commit() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let ctx = json!({"ex": "http://example.org/ns/"});
+
+    // t=1, t=2, t=3 on main — capture the t=2 commit id
+    let r1 = fluree
+        .insert(ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}))
+        .await
+        .unwrap();
+    let r2 = fluree
+        .insert(r1.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}))
+        .await
+        .unwrap();
+    let t2_commit_id = r2.receipt.commit_id.clone();
+    let _r3 = fluree
+        .insert(r2.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}))
+        .await
+        .unwrap();
+
+    // Branch at t=2
+    let record = fluree
+        .create_branch("mydb", "historical", None, Some(CommitRef::Exact(t2_commit_id.clone())))
+        .await
+        .unwrap();
+
+    assert_eq!(record.commit_head_id.as_ref(), Some(&t2_commit_id));
+    assert_eq!(record.commit_t, 2);
+    assert!(
+        record.index_head_id.is_none(),
+        "historical branch should skip index copy"
+    );
+    assert_eq!(record.source_branch.as_deref(), Some("main"));
+
+    // The branch loads at t=2, not at main's current head (t=3)
+    let branch = fluree.ledger("mydb:historical").await.unwrap();
+    assert_eq!(branch.t(), 2);
+}
+
+/// Branching from a commit that isn't reachable from source HEAD is rejected.
+#[tokio::test]
+async fn create_branch_at_non_ancestor_commit_fails() {
+    use fluree_db_api::ContentId;
+    use fluree_db_core::ContentKind;
+
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:seed", "ex:val": 1}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Fabricate a CID that isn't in the ledger's history
+    let bogus = ContentId::new(ContentKind::Commit, b"not-a-real-commit");
+
+    let err = fluree
+        .create_branch("mydb", "dev", None, Some(CommitRef::Exact(bogus)))
+        .await
+        .expect_err("non-ancestor commit should be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found") || msg.contains("not an ancestor"),
+        "expected not-found/not-ancestor error, got: {msg}"
+    );
 }
 
 /// Dropping a leaf branch (no children) fully deletes it.

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -45,7 +45,10 @@ async fn create_and_list_branches() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create a branch
-    let record = fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    let record = fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     assert_eq!(record.branch, "dev");
     assert_eq!(record.ledger_id, "mydb:dev");
     assert_eq!(
@@ -73,7 +76,10 @@ async fn create_branch_duplicate_fails() {
     });
     fluree.insert(ledger, &txn).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     let err = fluree
         .create_branch("mydb", "dev", None, None)
         .await
@@ -100,13 +106,22 @@ async fn create_branch_invalid_name() {
     assert!(fluree.create_branch("mydb", "", None, None).await.is_err());
 
     // Contains colon
-    assert!(fluree.create_branch("mydb", "foo:bar", None, None).await.is_err());
+    assert!(fluree
+        .create_branch("mydb", "foo:bar", None, None)
+        .await
+        .is_err());
 
     // Contains @
-    assert!(fluree.create_branch("mydb", "foo@bar", None, None).await.is_err());
+    assert!(fluree
+        .create_branch("mydb", "foo@bar", None, None)
+        .await
+        .is_err());
 
     // Path traversal
-    assert!(fluree.create_branch("mydb", "..", None, None).await.is_err());
+    assert!(fluree
+        .create_branch("mydb", "..", None, None)
+        .await
+        .is_err());
 }
 
 /// Creating a branch from a non-existent source returns not-found.
@@ -145,7 +160,10 @@ async fn branch_data_isolation() {
     let main_after_base = result.ledger;
 
     // 2. Create branch "dev" from main
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // 3. Transact data only on main
     let main_data = json!({
@@ -206,7 +224,10 @@ async fn branch_t_advances_independently() {
     assert_eq!(result.receipt.t, 1);
 
     // Branch at t=1
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Transact twice on dev
     let dev = fluree.ledger("mydb:dev").await.unwrap();
@@ -246,22 +267,36 @@ async fn create_branch_at_historical_commit() {
 
     // t=1, t=2, t=3 on main — capture the t=2 commit id
     let r1 = fluree
-        .insert(ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}))
+        .insert(
+            ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}),
+        )
         .await
         .unwrap();
     let r2 = fluree
-        .insert(r1.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}))
+        .insert(
+            r1.ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}),
+        )
         .await
         .unwrap();
     let t2_commit_id = r2.receipt.commit_id.clone();
     let _r3 = fluree
-        .insert(r2.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}))
+        .insert(
+            r2.ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}),
+        )
         .await
         .unwrap();
 
     // Branch at t=2
     let record = fluree
-        .create_branch("mydb", "historical", None, Some(CommitRef::Exact(t2_commit_id.clone())))
+        .create_branch(
+            "mydb",
+            "historical",
+            None,
+            Some(CommitRef::Exact(t2_commit_id.clone())),
+        )
         .await
         .unwrap();
 
@@ -291,16 +326,25 @@ async fn create_branch_at_t() {
     let ctx = json!({"ex": "http://example.org/ns/"});
 
     let r1 = fluree
-        .insert(ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}))
+        .insert(
+            ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}),
+        )
         .await
         .unwrap();
     let r2 = fluree
-        .insert(r1.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}))
+        .insert(
+            r1.ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}),
+        )
         .await
         .unwrap();
     let t2_commit_id = r2.receipt.commit_id.clone();
     let _r3 = fluree
-        .insert(r2.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}))
+        .insert(
+            r2.ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}),
+        )
         .await
         .unwrap();
 
@@ -324,16 +368,25 @@ async fn create_branch_at_prefix() {
     let ctx = json!({"ex": "http://example.org/ns/"});
 
     let r1 = fluree
-        .insert(ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}))
+        .insert(
+            ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:a", "ex:val": 1}]}),
+        )
         .await
         .unwrap();
     let r2 = fluree
-        .insert(r1.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}))
+        .insert(
+            r1.ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:b", "ex:val": 2}]}),
+        )
         .await
         .unwrap();
     let t2_commit_id = r2.receipt.commit_id.clone();
     let _r3 = fluree
-        .insert(r2.ledger, &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}))
+        .insert(
+            r2.ledger,
+            &json!({"@context": ctx, "@graph": [{"@id": "ex:c", "ex:val": 3}]}),
+        )
         .await
         .unwrap();
 
@@ -396,7 +449,10 @@ async fn drop_branch_leaf() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create and then drop a leaf branch
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     let report = fluree.drop_branch("mydb", "dev").await.unwrap();
 
     assert!(!report.deferred, "leaf branch should not be deferred");
@@ -446,7 +502,10 @@ async fn branches_count_tracks_children() {
     assert_eq!(record.branches, 0);
 
     // Create two child branches
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     let record = fluree
         .nameservice()
         .lookup("mydb:main")
@@ -455,7 +514,10 @@ async fn branches_count_tracks_children() {
         .unwrap();
     assert_eq!(record.branches, 1);
 
-    fluree.create_branch("mydb", "staging", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "staging", None, None)
+        .await
+        .unwrap();
     let record = fluree
         .nameservice()
         .lookup("mydb:main")
@@ -499,7 +561,10 @@ async fn drop_branch_with_children_deferred() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create dev, then branch feature from dev
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     fluree
         .create_branch("mydb", "feature", Some("dev"), None)
         .await
@@ -549,7 +614,10 @@ async fn transact_on_retracted_branch_fails() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // Create dev, then a child so dev can be retracted (not purged)
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     fluree
         .create_branch("mydb", "feature", Some("dev"), None)
         .await
@@ -589,7 +657,10 @@ async fn drop_branch_cascade() {
     fluree.insert(ledger, &txn).await.unwrap();
 
     // main -> dev -> feature
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     fluree
         .create_branch("mydb", "feature", Some("dev"), None)
         .await
@@ -636,7 +707,10 @@ async fn nested_branch_data_isolation() {
     let main_ledger = result.ledger;
 
     // 2. Branch dev from main
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // 3. Transact on dev
     let dev = fluree.ledger("mydb:dev").await.unwrap();

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -294,7 +294,10 @@ async fn merge_take_source_works_after_binary_index_reload() {
     });
     let main_ledger = fluree.insert(ledger, &base_data).await.unwrap().ledger;
     support::rebuild_and_publish_index(&fluree, "mydb:main").await;
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -65,7 +65,7 @@ async fn merge_fast_forward() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Transact on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -104,7 +104,7 @@ async fn merge_fast_forward_multiple_commits() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Several commits on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -173,7 +173,7 @@ async fn merge_self_refused() {
     });
     fluree.insert(ledger, &base_data).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     let err = fluree
         .merge_branch("mydb", "dev", Some("dev"), ConflictStrategy::default())
@@ -198,8 +198,8 @@ async fn merge_into_non_parent_allowed() {
     });
     fluree.insert(ledger, &base_data).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
-    fluree.create_branch("mydb", "feature", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree.create_branch("mydb", "feature", None, None).await.unwrap();
 
     // Merge dev into feature — both share the same base from main, so
     // this is a valid fast-forward even though feature is not dev's parent.
@@ -224,7 +224,7 @@ async fn merge_diverged_target_general_merge() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Transact on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -305,7 +305,7 @@ async fn merge_empty_source_fails() {
     // at all, which the current API doesn't easily allow.
     // Instead, test the "source has no unique commits" case — which is
     // actually valid and should still succeed (copies 0 commits).
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Merge dev → main with no unique commits on dev
     let report = fluree
@@ -334,7 +334,7 @@ async fn merge_target_head_updated() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -387,7 +387,7 @@ async fn merge_source_branch_point_updated() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -430,7 +430,7 @@ async fn merge_target_accepts_new_transactions() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -469,7 +469,7 @@ async fn merge_source_continues_after_merge() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // First round: transact on dev, merge to main
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -519,9 +519,9 @@ async fn merge_nested_branch() {
     let _main_ledger = result.ledger;
 
     // main → dev → feature
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
     fluree
-        .create_branch("mydb", "feature", Some("dev"))
+        .create_branch("mydb", "feature", Some("dev"), None)
         .await
         .unwrap();
 
@@ -562,7 +562,7 @@ async fn merge_abort_leaves_nameservice_unchanged() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Both branches modify the same subject+predicate to create a real conflict.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -634,7 +634,7 @@ async fn merge_explicit_target_matches_parent() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -65,7 +65,10 @@ async fn merge_fast_forward() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Transact on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -104,7 +107,10 @@ async fn merge_fast_forward_multiple_commits() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Several commits on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -173,7 +179,10 @@ async fn merge_self_refused() {
     });
     fluree.insert(ledger, &base_data).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let err = fluree
         .merge_branch("mydb", "dev", Some("dev"), ConflictStrategy::default())
@@ -198,8 +207,14 @@ async fn merge_into_non_parent_allowed() {
     });
     fluree.insert(ledger, &base_data).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
-    fluree.create_branch("mydb", "feature", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    fluree
+        .create_branch("mydb", "feature", None, None)
+        .await
+        .unwrap();
 
     // Merge dev into feature — both share the same base from main, so
     // this is a valid fast-forward even though feature is not dev's parent.
@@ -224,7 +239,10 @@ async fn merge_diverged_target_general_merge() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Transact on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -305,7 +323,10 @@ async fn merge_empty_source_fails() {
     // at all, which the current API doesn't easily allow.
     // Instead, test the "source has no unique commits" case — which is
     // actually valid and should still succeed (copies 0 commits).
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Merge dev → main with no unique commits on dev
     let report = fluree
@@ -334,7 +355,10 @@ async fn merge_target_head_updated() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -387,7 +411,10 @@ async fn merge_source_branch_point_updated() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -430,7 +457,10 @@ async fn merge_target_accepts_new_transactions() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -469,7 +499,10 @@ async fn merge_source_continues_after_merge() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // First round: transact on dev, merge to main
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -519,7 +552,10 @@ async fn merge_nested_branch() {
     let _main_ledger = result.ledger;
 
     // main → dev → feature
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     fluree
         .create_branch("mydb", "feature", Some("dev"), None)
         .await
@@ -562,7 +598,10 @@ async fn merge_abort_leaves_nameservice_unchanged() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Both branches modify the same subject+predicate to create a real conflict.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -634,7 +673,10 @@ async fn merge_explicit_target_matches_parent() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let _main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({

--- a/fluree-db-api/tests/it_merge_preview.rs
+++ b/fluree-db-api/tests/it_merge_preview.rs
@@ -21,7 +21,10 @@ async fn preview_fast_forward() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     let dev_data = json!({
@@ -53,7 +56,10 @@ async fn preview_fast_forward_with_conflict_details_is_empty_and_mergeable() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree
         .insert(
@@ -101,7 +107,10 @@ async fn preview_diverged_no_conflicts() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Disjoint subjects on each side.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -151,7 +160,10 @@ async fn preview_diverged_with_conflicts() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Both branches modify ex:alice / ex:name.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -199,7 +211,10 @@ async fn preview_conflict_details_include_values_and_strategy_labels() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let mut dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     dev_ledger = fluree
@@ -285,7 +300,10 @@ async fn preview_conflict_details_cover_take_branch_and_abort_labels() {
         "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree
@@ -361,7 +379,10 @@ async fn preview_conflict_details_follow_conflict_key_truncation() {
         ]
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree
@@ -426,7 +447,10 @@ async fn preview_conflict_details_preserve_key_order() {
         ]
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree
@@ -497,7 +521,10 @@ async fn preview_conflict_details_work_after_binary_index_reload() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
     support::rebuild_and_publish_index(&fluree, "mydb:main").await;
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree
@@ -560,7 +587,10 @@ async fn preview_equal_heads_is_fast_forward_with_empty_deltas() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
 
@@ -586,7 +616,10 @@ async fn preview_behind_only() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Target advances, source does not.
     fluree
@@ -623,7 +656,10 @@ async fn preview_default_target_uses_source_parent() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
     assert_eq!(preview.target, "main");
@@ -644,7 +680,10 @@ async fn preview_self_merge_rejected() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let err = fluree
         .merge_preview("mydb", "dev", Some("dev"))
@@ -671,7 +710,10 @@ async fn preview_truncation_caps_commits_list() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Five commits on dev.
     let mut dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -720,7 +762,10 @@ async fn preview_include_conflicts_false_returns_empty_conflicts() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Real conflict on ex:alice/ex:name.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -774,7 +819,10 @@ async fn preview_conflict_details_require_conflict_computation() {
         "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
     });
     fluree.insert(ledger, &base).await.unwrap();
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let err = fluree
         .merge_preview_with(
@@ -805,7 +853,10 @@ async fn preview_abort_strategy_requires_conflict_computation() {
         "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
     });
     fluree.insert(ledger, &base).await.unwrap();
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let err = fluree
         .merge_preview_with(
@@ -841,7 +892,10 @@ async fn preview_does_not_mutate_nameservice() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
     fluree
@@ -958,8 +1012,14 @@ async fn preview_between_sibling_branches() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
-    fluree.create_branch("mydb", "feature", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    fluree
+        .create_branch("mydb", "feature", None, None)
+        .await
+        .unwrap();
 
     // Advance dev (source).
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -1018,7 +1078,10 @@ async fn preview_max_commits_none_is_unbounded() {
     });
     fluree.insert(ledger, &base).await.unwrap();
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // 5 commits on dev.
     let mut dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -1086,7 +1149,10 @@ async fn preview_conflict_keys_are_sorted() {
     });
     let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Modify the same predicate on each subject from both branches.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();

--- a/fluree-db-api/tests/it_rebase.rs
+++ b/fluree-db-api/tests/it_rebase.rs
@@ -60,7 +60,10 @@ async fn rebase_fast_forward() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Advance main
     let main_data = json!({
@@ -98,7 +101,10 @@ async fn rebase_clean_replay() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Transact on dev (non-overlapping)
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -145,7 +151,10 @@ async fn rebase_abort_on_conflict() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Overlapping data on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -207,7 +216,10 @@ async fn rebase_take_source() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Dev: overlapping + unique data in one commit
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -256,7 +268,10 @@ async fn rebase_take_branch() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Dev: change Alice's name
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -307,7 +322,10 @@ async fn rebase_take_both() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Overlapping data on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -359,7 +377,10 @@ async fn rebase_skip_conflicting() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Two commits on dev: first overlaps, second doesn't
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -413,7 +434,10 @@ async fn rebase_branch_point_updated() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Advance main
     let main_data = json!({
@@ -481,7 +505,10 @@ async fn rebase_flush_novelty_mid_replay() {
     let result = fluree.insert(ledger, &base).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Make several commits on dev so replaying them exceeds the threshold.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -539,7 +566,10 @@ async fn rebase_nested_branch() {
     let main_ledger = result.ledger;
 
     // Create dev from main
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // Create feature from dev
     fluree
@@ -614,7 +644,10 @@ async fn rebase_rollback_on_mid_replay_failure() {
     let result = fluree.insert(ledger, &base).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
 
     // First commit on dev: normal data (will replay successfully)
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();

--- a/fluree-db-api/tests/it_rebase.rs
+++ b/fluree-db-api/tests/it_rebase.rs
@@ -625,7 +625,7 @@ async fn rebase_rollback_on_mid_replay_failure() {
     let result = fluree.insert(dev_ledger, &dev_data1).await.unwrap();
 
     // Second commit on dev: uses a named graph that won't exist on the
-    // source state during replay, causing LedgerView::stage to fail.
+    // source state during replay, causing StagedLedger::new to fail.
     // We insert into a named graph by specifying @graph with an @id.
     let dev_data2 = json!({
         "@context": {"ex": "http://example.org/ns/"},

--- a/fluree-db-api/tests/it_rebase.rs
+++ b/fluree-db-api/tests/it_rebase.rs
@@ -60,7 +60,7 @@ async fn rebase_fast_forward() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Advance main
     let main_data = json!({
@@ -98,7 +98,7 @@ async fn rebase_clean_replay() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Transact on dev (non-overlapping)
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -145,7 +145,7 @@ async fn rebase_abort_on_conflict() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Overlapping data on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -207,7 +207,7 @@ async fn rebase_take_source() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Dev: overlapping + unique data in one commit
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -256,7 +256,7 @@ async fn rebase_take_branch() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Dev: change Alice's name
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -307,7 +307,7 @@ async fn rebase_take_both() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Overlapping data on dev
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -359,7 +359,7 @@ async fn rebase_skip_conflicting() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Two commits on dev: first overlaps, second doesn't
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -413,7 +413,7 @@ async fn rebase_branch_point_updated() {
     let result = fluree.insert(ledger, &base_data).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Advance main
     let main_data = json!({
@@ -481,7 +481,7 @@ async fn rebase_flush_novelty_mid_replay() {
     let result = fluree.insert(ledger, &base).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Make several commits on dev so replaying them exceeds the threshold.
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
@@ -539,11 +539,11 @@ async fn rebase_nested_branch() {
     let main_ledger = result.ledger;
 
     // Create dev from main
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // Create feature from dev
     fluree
-        .create_branch("mydb", "feature", Some("dev"))
+        .create_branch("mydb", "feature", Some("dev"), None)
         .await
         .unwrap();
 
@@ -614,7 +614,7 @@ async fn rebase_rollback_on_mid_replay_failure() {
     let result = fluree.insert(ledger, &base).await.unwrap();
     let main_ledger = result.ledger;
 
-    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "dev", None, None).await.unwrap();
 
     // First commit on dev: normal data (will replay successfully)
     let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();

--- a/fluree-db-api/tests/it_tutorial_end_to_end.rs
+++ b/fluree-db-api/tests/it_tutorial_end_to_end.rs
@@ -445,7 +445,7 @@ async fn tutorial_step4_branch_and_merge() {
 
     // Create branch
     let branch_record = fluree
-        .create_branch("kb-branch", "reorganize", None)
+        .create_branch("kb-branch", "reorganize", None, None)
         .await
         .expect("create branch");
     assert_eq!(branch_record.branch, "reorganize");
@@ -683,7 +683,7 @@ async fn tutorial_step5_combined_workflow() {
 
     // Branch: create experiment
     fluree
-        .create_branch("kb-combined", "experiment", None)
+        .create_branch("kb-combined", "experiment", None, None)
         .await
         .expect("create branch");
 

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -758,6 +758,14 @@ pub enum BranchAction {
         #[arg(long)]
         from: Option<String>,
 
+        /// Commit to branch at (defaults to source branch HEAD).
+        ///
+        /// Accepts `t:N` for a transaction number, or a hex digest / full
+        /// CID for prefix resolution. The source branch must be indexed
+        /// for `t:` / prefix resolution (full CIDs work unconditionally).
+        #[arg(long)]
+        at: Option<String>,
+
         /// Execute against a remote server (by remote name, e.g., "origin")
         #[arg(long)]
         remote: Option<String>,

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -117,7 +117,7 @@ async fn run_create(
         }
         LedgerMode::Local { fluree, alias } => {
             let (ledger_name, _) = split_ledger_id(&alias)?;
-            let record = fluree.create_branch(&ledger_name, name, from).await?;
+            let record = fluree.create_branch(&ledger_name, name, from, None).await?;
 
             let source = record.source_branch.as_deref().unwrap_or("main");
             let t = record.commit_t;

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -11,12 +11,14 @@ pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliRes
             name,
             ledger,
             from,
+            at,
             remote,
         } => {
             run_create(
                 &name,
                 ledger.as_deref(),
                 from.as_deref(),
+                at.as_deref(),
                 dirs,
                 remote.as_deref(),
                 direct,
@@ -76,6 +78,7 @@ async fn run_create(
     name: &str,
     ledger: Option<&str>,
     from: Option<&str>,
+    at: Option<&str>,
     dirs: &FlureeDir,
     remote_flag: Option<&str>,
     direct: bool,
@@ -84,7 +87,7 @@ async fn run_create(
         let alias = context::resolve_ledger(ledger, dirs)?;
         let (ledger_name, _) = split_ledger_id(&alias)?;
         let client = context::build_remote_client(remote_name, dirs).await?;
-        let result = client.create_branch(&ledger_name, name, from).await?;
+        let result = client.create_branch(&ledger_name, name, from, at).await?;
 
         context::persist_refreshed_tokens(&client, remote_name, dirs).await;
 
@@ -109,7 +112,7 @@ async fn run_create(
             ..
         } => {
             let (ledger_name, _) = split_ledger_id(&remote_alias)?;
-            let result = client.create_branch(&ledger_name, name, from).await?;
+            let result = client.create_branch(&ledger_name, name, from, at).await?;
 
             context::persist_refreshed_tokens(&client, &remote_name, dirs).await;
 
@@ -117,7 +120,13 @@ async fn run_create(
         }
         LedgerMode::Local { fluree, alias } => {
             let (ledger_name, _) = split_ledger_id(&alias)?;
-            let record = fluree.create_branch(&ledger_name, name, from, None).await?;
+            let at_commit = match at {
+                Some(s) => Some(fluree_db_api::CommitRef::parse(s).map_err(CliError::from)?),
+                None => None,
+            };
+            let record = fluree
+                .create_branch(&ledger_name, name, from, at_commit)
+                .await?;
 
             let source = record.source_branch.as_deref().unwrap_or("main");
             let t = record.commit_t;

--- a/fluree-db-cli/src/commands/sync.rs
+++ b/fluree-db-cli/src/commands/sync.rs
@@ -1301,7 +1301,7 @@ pub async fn run_clone(
 
 /// Clone a ledger from an origin URI using CID-based chain walking.
 ///
-/// Downloads all commits by following the previous_ref chain from the head
+/// Downloads all commits by following the parent chain from the head
 /// commit backwards, fetching each commit + txn blob via MultiOriginFetcher.
 ///
 /// Usage: `fluree clone --origin http://localhost:8090 mydb:main`
@@ -1540,7 +1540,7 @@ pub async fn run_clone_origin(
                 bytes
             };
 
-            // Parse envelope-only (no flake decode) for previous_ref + txn CID.
+            // Parse envelope-only (no flake decode) for parent + txn CID.
             let envelope = read_commit_envelope(&commit_bytes)
                 .map_err(|e| CliError::Config(format!("clone failed (read envelope): {e}")))?;
 

--- a/fluree-db-cli/src/commands/sync.rs
+++ b/fluree-db-cli/src/commands/sync.rs
@@ -194,7 +194,7 @@ fn print_fetch_result(result: &FetchResult) {
     if !result.updated.is_empty() {
         println!("{}", "Updated:".green().bold());
         for (ledger_id, tracking) in &result.updated {
-            let t = tracking.commit_ref.as_ref().map(|r| r.t).unwrap_or(0);
+            let t = tracking.commit_head.as_ref().map(|r| r.t).unwrap_or(0);
             println!("  {ledger_id} -> t={t}");
         }
     }

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -1045,12 +1045,15 @@ impl RemoteLedgerClient {
 
     /// Create a new branch on the remote server.
     ///
-    /// Calls `POST {base_url}/branch` with a JSON body.
+    /// Calls `POST {base_url}/branch` with a JSON body. `at` optionally
+    /// specifies a historical commit to branch from (as accepted by
+    /// `CommitRef::parse`, e.g. `"t:5"` or a hex digest / full CID).
     pub async fn create_branch(
         &self,
         ledger: &str,
         branch: &str,
         source: Option<&str>,
+        at: Option<&str>,
     ) -> Result<serde_json::Value, RemoteLedgerError> {
         let url = self.op_url_root("branch");
         let mut body = serde_json::json!({
@@ -1059,6 +1062,9 @@ impl RemoteLedgerClient {
         });
         if let Some(s) = source {
             body["source"] = serde_json::Value::String(s.to_string());
+        }
+        if let Some(a) = at {
+            body["at"] = serde_json::Value::String(a.to_string());
         }
         self.send_json(
             reqwest::Method::POST,

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -304,7 +304,10 @@ impl Commit {
 // =============================================================================
 
 /// Load a single commit from a content store by CID.
-pub async fn load_commit_by_id<C: ContentStore>(store: &C, id: &ContentId) -> Result<Commit> {
+pub async fn load_commit_by_id<C: ContentStore + ?Sized>(
+    store: &C,
+    id: &ContentId,
+) -> Result<Commit> {
     let data = store
         .get(id)
         .await

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -1374,10 +1374,8 @@ mod tests {
         let branch_a = store_chain(&store, 2, 2, Some(shared[0].clone()), 100).await;
         let branch_b = store_chain(&store, 2, 1, Some(shared[0].clone()), 200).await;
 
-        let merge_commit = Commit::new(4, vec![]).with_merge_parents(vec![
-            branch_a.last().unwrap().clone(),
-            branch_b[0].clone(),
-        ]);
+        let merge_commit = Commit::new(4, vec![])
+            .with_merge_parents(vec![branch_a.last().unwrap().clone(), branch_b[0].clone()]);
         let merge_id = store_commit(&store, &merge_commit).await;
 
         let (summaries, total) = walk_commit_summaries(&store, &merge_id, 0, None)

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -16,28 +16,10 @@
 pub mod codec;
 
 use crate::error::{Error, Result};
-use crate::{ContentId, ContentStore, Flake};
+use crate::{CommitId, ContentId, ContentStore, Flake};
 use codec::format::CommitSignature;
 use futures::stream::{self, Stream};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-/// Reference to a commit (for linking previous commits)
-///
-/// In the CID-based architecture, the content identifier IS the identity.
-/// Storage location is resolved by the `ContentStore` implementation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CommitRef {
-    /// Content identifier (CIDv1). This IS the identity.
-    pub id: ContentId,
-}
-
-impl CommitRef {
-    /// Create a new commit reference from a ContentId
-    pub fn new(id: ContentId) -> Self {
-        Self { id }
-    }
-}
 
 /// Transaction signature — audit record of who submitted a transaction.
 ///
@@ -194,7 +176,7 @@ pub struct Commit {
 
     /// Parent commit references (CID-based).
     /// Empty for genesis, one element for normal commits, two+ for merge commits.
-    pub previous_refs: Vec<CommitRef>,
+    pub previous_refs: Vec<CommitId>,
 
     /// Transaction blob CID (content-addressed reference to original txn JSON).
     /// When present, the raw transaction JSON can be loaded from this CID.
@@ -276,13 +258,13 @@ impl Commit {
     ///
     /// For normal commits, call once. For merge commits, call multiple times
     /// or use [`with_merge_parents`](Self::with_merge_parents).
-    pub fn with_previous_ref(mut self, prev_ref: CommitRef) -> Self {
+    pub fn with_previous_ref(mut self, prev_ref: CommitId) -> Self {
         self.previous_refs.push(prev_ref);
         self
     }
 
     /// Set all parent commit references at once (for merge commits).
-    pub fn with_merge_parents(mut self, refs: Vec<CommitRef>) -> Self {
+    pub fn with_merge_parents(mut self, refs: Vec<CommitId>) -> Self {
         self.previous_refs = refs;
         self
     }
@@ -313,7 +295,7 @@ impl Commit {
 
     /// Iterate over all parent commit CIDs.
     pub fn parent_ids(&self) -> impl Iterator<Item = &ContentId> {
-        self.previous_refs.iter().map(|r| &r.id)
+        self.previous_refs.iter()
     }
 }
 
@@ -355,7 +337,7 @@ pub struct CommitEnvelope {
 
     /// Parent commit references (CID-based).
     /// Empty for genesis, one element for normal commits, two+ for merge commits.
-    pub previous_refs: Vec<CommitRef>,
+    pub previous_refs: Vec<CommitId>,
 
     /// Transaction blob CID (content-addressed reference to original txn JSON)
     pub txn: Option<ContentId>,
@@ -374,7 +356,7 @@ pub struct CommitEnvelope {
 impl CommitEnvelope {
     /// Iterate over all parent commit CIDs.
     pub fn parent_ids(&self) -> impl Iterator<Item = &ContentId> {
-        self.previous_refs.iter().map(|r| &r.id)
+        self.previous_refs.iter()
     }
 }
 
@@ -768,8 +750,8 @@ mod tests {
         let id2 = make_test_content_id(ContentKind::Commit, "commit-2");
 
         let commit1 = Commit::new(1, vec![]);
-        let commit2 = Commit::new(2, vec![]).with_previous_ref(CommitRef::new(id1.clone()));
-        let commit3 = Commit::new(3, vec![]).with_previous_ref(CommitRef::new(id2.clone()));
+        let commit2 = Commit::new(2, vec![]).with_previous_ref(id1.clone());
+        let commit3 = Commit::new(3, vec![]).with_previous_ref(id2.clone());
 
         assert_eq!(commit1.parent_ids().next(), None);
         assert_eq!(commit2.parent_ids().next(), Some(&id1));
@@ -785,7 +767,7 @@ mod tests {
         let prev_id = make_test_content_id(ContentKind::Commit, "commit-0");
         let envelope = CommitEnvelope {
             t: 5,
-            previous_refs: vec![CommitRef::new(prev_id.clone())],
+            previous_refs: vec![prev_id.clone()],
             txn: None,
             namespace_delta: HashMap::from([(100, "ex:".to_string())]),
             txn_meta: Vec::new(),
@@ -898,11 +880,11 @@ mod tests {
         let c1_id = store_commit(&store, &c1).await;
 
         let c2 = Commit::new(2, vec![make_test_flake(2, 3, 20, 2)])
-            .with_previous_ref(CommitRef::new(c1_id.clone()));
+            .with_previous_ref(c1_id.clone());
         let c2_id = store_commit(&store, &c2).await;
 
         let c3 = Commit::new(3, vec![make_test_flake(3, 4, 30, 3)])
-            .with_previous_ref(CommitRef::new(c2_id.clone()));
+            .with_previous_ref(c2_id.clone());
         let c3_id = store_commit(&store, &c3).await;
 
         // Trace from head (c3), stop_at_t=0 → all 3 commits
@@ -929,10 +911,10 @@ mod tests {
         let c1 = Commit::new(1, vec![]);
         let c1_id = store_commit(&store, &c1).await;
 
-        let c2 = Commit::new(2, vec![]).with_previous_ref(CommitRef::new(c1_id.clone()));
+        let c2 = Commit::new(2, vec![]).with_previous_ref(c1_id.clone());
         let c2_id = store_commit(&store, &c2).await;
 
-        let c3 = Commit::new(3, vec![]).with_previous_ref(CommitRef::new(c2_id.clone()));
+        let c3 = Commit::new(3, vec![]).with_previous_ref(c2_id.clone());
         let c3_id = store_commit(&store, &c3).await;
 
         // stop_at_t=1 → only c3 and c2 (c1 has t=1, excluded by t <= stop_at_t)
@@ -972,7 +954,7 @@ mod tests {
             let flake = make_test_flake(branch_tag, 1, t, t);
             let mut commit = Commit::new(t, vec![flake]);
             if let Some(ref p) = prev {
-                commit = commit.with_previous_ref(CommitRef::new(p.clone()));
+                commit = commit.with_previous_ref(p.clone());
             }
             let cid = store_commit(store, &commit).await;
             prev = Some(cid.clone());

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -882,12 +882,10 @@ mod tests {
         let c1 = Commit::new(1, vec![make_test_flake(1, 2, 10, 1)]);
         let c1_id = store_commit(&store, &c1).await;
 
-        let c2 = Commit::new(2, vec![make_test_flake(2, 3, 20, 2)])
-            .with_parent(c1_id.clone());
+        let c2 = Commit::new(2, vec![make_test_flake(2, 3, 20, 2)]).with_parent(c1_id.clone());
         let c2_id = store_commit(&store, &c2).await;
 
-        let c3 = Commit::new(3, vec![make_test_flake(3, 4, 30, 3)])
-            .with_parent(c2_id.clone());
+        let c3 = Commit::new(3, vec![make_test_flake(3, 4, 30, 3)]).with_parent(c2_id.clone());
         let c3_id = store_commit(&store, &c3).await;
 
         // Trace from head (c3), stop_at_t=0 → all 3 commits

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -176,7 +176,7 @@ pub struct Commit {
 
     /// Parent commit references (CID-based).
     /// Empty for genesis, one element for normal commits, two+ for merge commits.
-    pub previous_refs: Vec<CommitId>,
+    pub parents: Vec<CommitId>,
 
     /// Transaction blob CID (content-addressed reference to original txn JSON).
     /// When present, the raw transaction JSON can be loaded from this CID.
@@ -231,7 +231,7 @@ impl Commit {
             t,
             time: None,
             flakes,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::new(),
             txn_signature: None,
@@ -258,14 +258,14 @@ impl Commit {
     ///
     /// For normal commits, call once. For merge commits, call multiple times
     /// or use [`with_merge_parents`](Self::with_merge_parents).
-    pub fn with_previous_ref(mut self, prev_ref: CommitId) -> Self {
-        self.previous_refs.push(prev_ref);
+    pub fn with_parent(mut self, parent: CommitId) -> Self {
+        self.parents.push(parent);
         self
     }
 
     /// Set all parent commit references at once (for merge commits).
     pub fn with_merge_parents(mut self, refs: Vec<CommitId>) -> Self {
-        self.previous_refs = refs;
+        self.parents = refs;
         self
     }
 
@@ -295,7 +295,7 @@ impl Commit {
 
     /// Iterate over all parent commit CIDs.
     pub fn parent_ids(&self) -> impl Iterator<Item = &ContentId> {
-        self.previous_refs.iter()
+        self.parents.iter()
     }
 }
 
@@ -337,7 +337,7 @@ pub struct CommitEnvelope {
 
     /// Parent commit references (CID-based).
     /// Empty for genesis, one element for normal commits, two+ for merge commits.
-    pub previous_refs: Vec<CommitId>,
+    pub parents: Vec<CommitId>,
 
     /// Transaction blob CID (content-addressed reference to original txn JSON)
     pub txn: Option<ContentId>,
@@ -356,7 +356,7 @@ pub struct CommitEnvelope {
 impl CommitEnvelope {
     /// Iterate over all parent commit CIDs.
     pub fn parent_ids(&self) -> impl Iterator<Item = &ContentId> {
-        self.previous_refs.iter()
+        self.parents.iter()
     }
 }
 
@@ -740,7 +740,7 @@ mod tests {
 
         assert_eq!(commit.t, 1);
         assert_eq!(commit.flakes.len(), 1);
-        assert!(commit.previous_refs.is_empty());
+        assert!(commit.parents.is_empty());
         assert!(commit.id.is_none());
     }
 
@@ -750,8 +750,8 @@ mod tests {
         let id2 = make_test_content_id(ContentKind::Commit, "commit-2");
 
         let commit1 = Commit::new(1, vec![]);
-        let commit2 = Commit::new(2, vec![]).with_previous_ref(id1.clone());
-        let commit3 = Commit::new(3, vec![]).with_previous_ref(id2.clone());
+        let commit2 = Commit::new(2, vec![]).with_parent(id1.clone());
+        let commit3 = Commit::new(3, vec![]).with_parent(id2.clone());
 
         assert_eq!(commit1.parent_ids().next(), None);
         assert_eq!(commit2.parent_ids().next(), Some(&id1));
@@ -767,7 +767,7 @@ mod tests {
         let prev_id = make_test_content_id(ContentKind::Commit, "commit-0");
         let envelope = CommitEnvelope {
             t: 5,
-            previous_refs: vec![prev_id.clone()],
+            parents: vec![prev_id.clone()],
             txn: None,
             namespace_delta: HashMap::from([(100, "ex:".to_string())]),
             txn_meta: Vec::new(),
@@ -880,11 +880,11 @@ mod tests {
         let c1_id = store_commit(&store, &c1).await;
 
         let c2 = Commit::new(2, vec![make_test_flake(2, 3, 20, 2)])
-            .with_previous_ref(c1_id.clone());
+            .with_parent(c1_id.clone());
         let c2_id = store_commit(&store, &c2).await;
 
         let c3 = Commit::new(3, vec![make_test_flake(3, 4, 30, 3)])
-            .with_previous_ref(c2_id.clone());
+            .with_parent(c2_id.clone());
         let c3_id = store_commit(&store, &c3).await;
 
         // Trace from head (c3), stop_at_t=0 → all 3 commits
@@ -911,10 +911,10 @@ mod tests {
         let c1 = Commit::new(1, vec![]);
         let c1_id = store_commit(&store, &c1).await;
 
-        let c2 = Commit::new(2, vec![]).with_previous_ref(c1_id.clone());
+        let c2 = Commit::new(2, vec![]).with_parent(c1_id.clone());
         let c2_id = store_commit(&store, &c2).await;
 
-        let c3 = Commit::new(3, vec![]).with_previous_ref(c2_id.clone());
+        let c3 = Commit::new(3, vec![]).with_parent(c2_id.clone());
         let c3_id = store_commit(&store, &c3).await;
 
         // stop_at_t=1 → only c3 and c2 (c1 has t=1, excluded by t <= stop_at_t)
@@ -954,7 +954,7 @@ mod tests {
             let flake = make_test_flake(branch_tag, 1, t, t);
             let mut commit = Commit::new(t, vec![flake]);
             if let Some(ref p) = prev {
-                commit = commit.with_previous_ref(p.clone());
+                commit = commit.with_parent(p.clone());
             }
             let cid = store_commit(store, &commit).await;
             prev = Some(cid.clone());

--- a/fluree-db-core/src/commit/codec/envelope.rs
+++ b/fluree-db-core/src/commit/codec/envelope.rs
@@ -29,12 +29,8 @@ const FLAG_TIME: u8 = 0x10;
 const FLAG_TXN_SIGNATURE: u8 = 0x80;
 
 /// Mask of all flag bits the current encoder/decoder understands.
-const KNOWN_FLAGS: u8 = FLAG_TXN_META
-    | FLAG_PARENT
-    | FLAG_NAMESPACE_DELTA
-    | FLAG_TXN
-    | FLAG_TIME
-    | FLAG_TXN_SIGNATURE;
+const KNOWN_FLAGS: u8 =
+    FLAG_TXN_META | FLAG_PARENT | FLAG_NAMESPACE_DELTA | FLAG_TXN | FLAG_TIME | FLAG_TXN_SIGNATURE;
 
 /// Maximum number of named graph entries per commit.
 pub const MAX_GRAPH_DELTA_ENTRIES: usize = 256;

--- a/fluree-db-core/src/commit/codec/envelope.rs
+++ b/fluree-db-core/src/commit/codec/envelope.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 
 // --- Presence flag bits ---
 const FLAG_TXN_META: u8 = 0x01;
-const FLAG_PREVIOUS_REF: u8 = 0x02;
+const FLAG_PARENT: u8 = 0x02;
 const FLAG_NAMESPACE_DELTA: u8 = 0x04;
 const FLAG_TXN: u8 = 0x08;
 const FLAG_TIME: u8 = 0x10;
@@ -30,7 +30,7 @@ const FLAG_TXN_SIGNATURE: u8 = 0x80;
 
 /// Mask of all flag bits the current encoder/decoder understands.
 const KNOWN_FLAGS: u8 = FLAG_TXN_META
-    | FLAG_PREVIOUS_REF
+    | FLAG_PARENT
     | FLAG_NAMESPACE_DELTA
     | FLAG_TXN
     | FLAG_TIME
@@ -63,7 +63,7 @@ pub struct CodecEnvelope {
     /// Parent commit references (CID-based).
     /// Empty for genesis, one element for normal commits.
     /// V2 encoding only supports 0 or 1 parents; multi-parent requires v3.
-    pub previous_refs: Vec<CommitId>,
+    pub parents: Vec<CommitId>,
     pub namespace_delta: HashMap<u16, String>,
     /// Transaction blob CID
     pub txn: Option<ContentId>,
@@ -83,7 +83,7 @@ impl CodecEnvelope {
     pub fn from_commit(commit: &crate::Commit) -> Self {
         Self {
             t: commit.t,
-            previous_refs: commit.previous_refs.clone(),
+            parents: commit.parents.clone(),
             namespace_delta: commit.namespace_delta.clone(),
             txn: commit.txn.clone(),
             time: commit.time.clone(),
@@ -104,10 +104,10 @@ pub fn encode_envelope_fields(
     envelope: &CodecEnvelope,
     buf: &mut Vec<u8>,
 ) -> Result<(), CommitCodecError> {
-    let num_parents = envelope.previous_refs.len();
+    let num_parents = envelope.parents.len();
     if num_parents > MAX_PREVIOUS_REFS {
         return Err(CommitCodecError::EnvelopeEncode(format!(
-            "previous_refs has {num_parents} entries, max is {MAX_PREVIOUS_REFS}"
+            "parents has {num_parents} entries, max is {MAX_PREVIOUS_REFS}"
         )));
     }
 
@@ -122,8 +122,8 @@ pub fn encode_envelope_fields(
     if !envelope.txn_meta.is_empty() {
         flags |= FLAG_TXN_META;
     }
-    if !envelope.previous_refs.is_empty() {
-        flags |= FLAG_PREVIOUS_REF;
+    if !envelope.parents.is_empty() {
+        flags |= FLAG_PARENT;
     }
     if !envelope.namespace_delta.is_empty() {
         flags |= FLAG_NAMESPACE_DELTA;
@@ -143,16 +143,16 @@ pub fn encode_envelope_fields(
     if !envelope.txn_meta.is_empty() {
         encode_txn_meta(&envelope.txn_meta, buf)?;
     }
-    if !envelope.previous_refs.is_empty() {
+    if !envelope.parents.is_empty() {
         if version == 3 {
             // v3: encode count followed by each commit ref.
             encode_varint(num_parents as u64, buf);
-            for prev_ref in &envelope.previous_refs {
-                encode_commit_id(prev_ref, buf)?;
+            for parent in &envelope.parents {
+                encode_commit_id(parent, buf)?;
             }
         } else {
             // v2: single commit ref (no count prefix).
-            encode_commit_id(&envelope.previous_refs[0], buf)?;
+            encode_commit_id(&envelope.parents[0], buf)?;
         }
     }
     if !envelope.namespace_delta.is_empty() {
@@ -257,13 +257,13 @@ pub fn decode_envelope(data: &[u8]) -> Result<CodecEnvelope, CommitCodecError> {
         Vec::new()
     };
 
-    let previous_refs = if flags & FLAG_PREVIOUS_REF != 0 {
+    let parents = if flags & FLAG_PARENT != 0 {
         if v == 3 {
             // v3: varint(count) followed by count commit refs.
             let count = decode_varint(data, &mut pos)? as usize;
             if count > MAX_PREVIOUS_REFS {
                 return Err(CommitCodecError::EnvelopeDecode(format!(
-                    "previous_refs count {count} exceeds maximum {MAX_PREVIOUS_REFS}"
+                    "parents count {count} exceeds maximum {MAX_PREVIOUS_REFS}"
                 )));
             }
             let mut refs = Vec::with_capacity(count);
@@ -362,7 +362,7 @@ pub fn decode_envelope(data: &[u8]) -> Result<CodecEnvelope, CommitCodecError> {
 
     Ok(CodecEnvelope {
         t: 0,
-        previous_refs,
+        parents,
         namespace_delta,
         txn,
         time,
@@ -662,7 +662,7 @@ mod tests {
         encode_envelope(&commit, &mut buf).unwrap();
 
         let decoded = decode_envelope(&buf).unwrap();
-        assert!(decoded.previous_refs.is_empty());
+        assert!(decoded.parents.is_empty());
         assert!(decoded.namespace_delta.is_empty());
         assert!(decoded.txn.is_none());
         assert!(decoded.time.is_none());
@@ -670,16 +670,16 @@ mod tests {
     }
 
     #[test]
-    fn test_round_trip_with_previous_ref() {
+    fn test_round_trip_with_parent() {
         let prev_id = make_test_cid(ContentKind::Commit, "prev-commit");
         let mut commit = make_minimal_commit();
-        commit.previous_refs = vec![prev_id.clone()];
+        commit.parents = vec![prev_id.clone()];
 
         let mut buf = Vec::new();
         encode_envelope(&commit, &mut buf).unwrap();
 
         let decoded = decode_envelope(&buf).unwrap();
-        let decoded_prev = decoded.previous_refs.first().unwrap();
+        let decoded_prev = decoded.parents.first().unwrap();
         assert_eq!(decoded_prev, &prev_id);
     }
 
@@ -824,7 +824,7 @@ mod tests {
         let parent1 = make_test_cid(ContentKind::Commit, "parent-one");
         let parent2 = make_test_cid(ContentKind::Commit, "parent-two");
         let mut commit = make_minimal_commit();
-        commit.previous_refs = vec![parent1.clone(), parent2.clone()];
+        commit.parents = vec![parent1.clone(), parent2.clone()];
 
         let mut buf = Vec::new();
         encode_envelope(&commit, &mut buf).unwrap();
@@ -835,19 +835,19 @@ mod tests {
         assert_eq!(v, 3, "multi-parent should use v3 encoding");
 
         let decoded = decode_envelope(&buf).unwrap();
-        assert_eq!(decoded.previous_refs.len(), 2);
-        assert_eq!(decoded.previous_refs[0], parent1);
-        assert_eq!(decoded.previous_refs[1], parent2);
+        assert_eq!(decoded.parents.len(), 2);
+        assert_eq!(decoded.parents[0], parent1);
+        assert_eq!(decoded.parents[1], parent2);
     }
 
     #[test]
-    fn test_golden_bytes_previous_ref_and_txn() {
+    fn test_golden_bytes_parent_and_txn() {
         // Deterministic CIDs from fixed inputs
         let prev_id = ContentId::new(ContentKind::Commit, b"golden-prev");
         let txn_id = ContentId::new(ContentKind::Txn, b"golden-txn");
 
         let mut commit = make_minimal_commit();
-        commit.previous_refs = vec![prev_id.clone()];
+        commit.parents = vec![prev_id.clone()];
         commit.txn = Some(txn_id.clone());
 
         let mut buf = Vec::new();
@@ -857,9 +857,9 @@ mod tests {
         let mut expected = Vec::new();
         // v = zigzag(2) = 4
         encode_varint(zigzag_encode(2), &mut expected);
-        // flags = FLAG_PREVIOUS_REF | FLAG_TXN = 0x02 | 0x08 = 0x0A
+        // flags = FLAG_PARENT | FLAG_TXN = 0x02 | 0x08 = 0x0A
         expected.push(0x0A);
-        // previous_ref: varint(len) + CID binary bytes
+        // parent: varint(len) + CID binary bytes
         let prev_bytes = prev_id.to_bytes();
         encode_varint(prev_bytes.len() as u64, &mut expected);
         expected.extend_from_slice(&prev_bytes);
@@ -883,7 +883,7 @@ mod tests {
 
         // Decode the golden bytes back and verify CIDs
         let decoded = decode_envelope(&expected).unwrap();
-        assert_eq!(decoded.previous_refs.first().unwrap(), &prev_id);
+        assert_eq!(decoded.parents.first().unwrap(), &prev_id);
         assert_eq!(decoded.txn.as_ref(), Some(&txn_id));
     }
 }

--- a/fluree-db-core/src/commit/codec/envelope.rs
+++ b/fluree-db-core/src/commit/codec/envelope.rs
@@ -16,7 +16,7 @@ use super::varint::{
 };
 use crate::ns_encoding::NsSplitMode;
 use crate::ContentId;
-use crate::{CommitRef, TxnMetaEntry, TxnMetaValue, TxnSignature, MAX_TXN_META_ENTRIES};
+use crate::{CommitId, TxnMetaEntry, TxnMetaValue, TxnSignature, MAX_TXN_META_ENTRIES};
 use std::collections::HashMap;
 
 // --- Presence flag bits ---
@@ -63,7 +63,7 @@ pub struct CodecEnvelope {
     /// Parent commit references (CID-based).
     /// Empty for genesis, one element for normal commits.
     /// V2 encoding only supports 0 or 1 parents; multi-parent requires v3.
-    pub previous_refs: Vec<CommitRef>,
+    pub previous_refs: Vec<CommitId>,
     pub namespace_delta: HashMap<u16, String>,
     /// Transaction blob CID
     pub txn: Option<ContentId>,
@@ -148,11 +148,11 @@ pub fn encode_envelope_fields(
             // v3: encode count followed by each commit ref.
             encode_varint(num_parents as u64, buf);
             for prev_ref in &envelope.previous_refs {
-                encode_commit_ref(prev_ref, buf)?;
+                encode_commit_id(prev_ref, buf)?;
             }
         } else {
             // v2: single commit ref (no count prefix).
-            encode_commit_ref(&envelope.previous_refs[0], buf)?;
+            encode_commit_id(&envelope.previous_refs[0], buf)?;
         }
     }
     if !envelope.namespace_delta.is_empty() {
@@ -268,12 +268,12 @@ pub fn decode_envelope(data: &[u8]) -> Result<CodecEnvelope, CommitCodecError> {
             }
             let mut refs = Vec::with_capacity(count);
             for _ in 0..count {
-                refs.push(decode_commit_ref(data, &mut pos)?);
+                refs.push(decode_commit_id(data, &mut pos)?);
             }
             refs
         } else {
             // v2: single commit ref (no count prefix).
-            vec![decode_commit_ref(data, &mut pos)?]
+            vec![decode_commit_id(data, &mut pos)?]
         }
     } else {
         Vec::new()
@@ -422,18 +422,17 @@ fn decode_len_bytes<'a>(data: &'a [u8], pos: &mut usize) -> Result<&'a [u8], Com
 }
 
 // =============================================================================
-// CommitRef (binary CID encoding)
+// CommitId (binary CID encoding)
 // =============================================================================
 
-fn encode_commit_ref(cr: &CommitRef, buf: &mut Vec<u8>) -> Result<(), CommitCodecError> {
-    encode_len_bytes(&cr.id.to_bytes(), buf)
+fn encode_commit_id(id: &CommitId, buf: &mut Vec<u8>) -> Result<(), CommitCodecError> {
+    encode_len_bytes(&id.to_bytes(), buf)
 }
 
-fn decode_commit_ref(data: &[u8], pos: &mut usize) -> Result<CommitRef, CommitCodecError> {
+fn decode_commit_id(data: &[u8], pos: &mut usize) -> Result<CommitId, CommitCodecError> {
     let cid_bytes = decode_len_bytes(data, pos)?;
-    let content_id = ContentId::from_bytes(cid_bytes)
-        .map_err(|e| CommitCodecError::EnvelopeDecode(format!("invalid commit ref CID: {e}")))?;
-    Ok(CommitRef::new(content_id))
+    ContentId::from_bytes(cid_bytes)
+        .map_err(|e| CommitCodecError::EnvelopeDecode(format!("invalid commit id CID: {e}")))
 }
 
 // =============================================================================
@@ -674,14 +673,14 @@ mod tests {
     fn test_round_trip_with_previous_ref() {
         let prev_id = make_test_cid(ContentKind::Commit, "prev-commit");
         let mut commit = make_minimal_commit();
-        commit.previous_refs = vec![CommitRef::new(prev_id.clone())];
+        commit.previous_refs = vec![prev_id.clone()];
 
         let mut buf = Vec::new();
         encode_envelope(&commit, &mut buf).unwrap();
 
         let decoded = decode_envelope(&buf).unwrap();
         let decoded_prev = decoded.previous_refs.first().unwrap();
-        assert_eq!(decoded_prev.id, prev_id);
+        assert_eq!(decoded_prev, &prev_id);
     }
 
     #[test]
@@ -825,10 +824,7 @@ mod tests {
         let parent1 = make_test_cid(ContentKind::Commit, "parent-one");
         let parent2 = make_test_cid(ContentKind::Commit, "parent-two");
         let mut commit = make_minimal_commit();
-        commit.previous_refs = vec![
-            CommitRef::new(parent1.clone()),
-            CommitRef::new(parent2.clone()),
-        ];
+        commit.previous_refs = vec![parent1.clone(), parent2.clone()];
 
         let mut buf = Vec::new();
         encode_envelope(&commit, &mut buf).unwrap();
@@ -840,8 +836,8 @@ mod tests {
 
         let decoded = decode_envelope(&buf).unwrap();
         assert_eq!(decoded.previous_refs.len(), 2);
-        assert_eq!(decoded.previous_refs[0].id, parent1);
-        assert_eq!(decoded.previous_refs[1].id, parent2);
+        assert_eq!(decoded.previous_refs[0], parent1);
+        assert_eq!(decoded.previous_refs[1], parent2);
     }
 
     #[test]
@@ -851,7 +847,7 @@ mod tests {
         let txn_id = ContentId::new(ContentKind::Txn, b"golden-txn");
 
         let mut commit = make_minimal_commit();
-        commit.previous_refs = vec![CommitRef::new(prev_id.clone())];
+        commit.previous_refs = vec![prev_id.clone()];
         commit.txn = Some(txn_id.clone());
 
         let mut buf = Vec::new();
@@ -887,7 +883,7 @@ mod tests {
 
         // Decode the golden bytes back and verify CIDs
         let decoded = decode_envelope(&expected).unwrap();
-        assert_eq!(decoded.previous_refs.first().unwrap().id, prev_id);
+        assert_eq!(decoded.previous_refs.first().unwrap(), &prev_id);
         assert_eq!(decoded.txn.as_ref(), Some(&txn_id));
     }
 }

--- a/fluree-db-core/src/commit/codec/envelope.rs
+++ b/fluree-db-core/src/commit/codec/envelope.rs
@@ -45,7 +45,7 @@ const MAX_CID_BYTES: usize = 128;
 
 /// Maximum number of parent commit references (merge parents).
 /// 16 is generous; real merges will almost always have 2.
-const MAX_PREVIOUS_REFS: usize = 16;
+const MAX_PARENTS: usize = 16;
 
 /// Commit envelope fields — the non-flake metadata in a v2 commit blob.
 ///
@@ -101,9 +101,9 @@ pub fn encode_envelope_fields(
     buf: &mut Vec<u8>,
 ) -> Result<(), CommitCodecError> {
     let num_parents = envelope.parents.len();
-    if num_parents > MAX_PREVIOUS_REFS {
+    if num_parents > MAX_PARENTS {
         return Err(CommitCodecError::EnvelopeEncode(format!(
-            "parents has {num_parents} entries, max is {MAX_PREVIOUS_REFS}"
+            "parents has {num_parents} entries, max is {MAX_PARENTS}"
         )));
     }
 
@@ -257,9 +257,9 @@ pub fn decode_envelope(data: &[u8]) -> Result<CodecEnvelope, CommitCodecError> {
         if v == 3 {
             // v3: varint(count) followed by count commit refs.
             let count = decode_varint(data, &mut pos)? as usize;
-            if count > MAX_PREVIOUS_REFS {
+            if count > MAX_PARENTS {
                 return Err(CommitCodecError::EnvelopeDecode(format!(
-                    "parents count {count} exceeds maximum {MAX_PREVIOUS_REFS}"
+                    "parents count {count} exceeds maximum {MAX_PARENTS}"
                 )));
             }
             let mut refs = Vec::with_capacity(count);

--- a/fluree-db-core/src/commit/codec/legacy_v3.rs
+++ b/fluree-db-core/src/commit/codec/legacy_v3.rs
@@ -250,7 +250,7 @@ pub fn read_commit_v3(bytes: &[u8]) -> Result<Commit, CommitCodecError> {
         t: header.t,
         time: envelope.time,
         flakes,
-        previous_refs: envelope.previous_refs,
+        parents: envelope.parents,
         txn: envelope.txn,
         namespace_delta: envelope.namespace_delta,
         txn_signature: envelope.txn_signature,
@@ -298,7 +298,7 @@ pub fn read_commit_envelope_v3(bytes: &[u8]) -> Result<CommitEnvelope, CommitCod
 
     Ok(CommitEnvelope {
         t: header.t,
-        previous_refs: env.previous_refs,
+        parents: env.parents,
         txn: env.txn,
         namespace_delta: env.namespace_delta,
         txn_meta,
@@ -842,7 +842,7 @@ mod tests {
         // Envelope
         let envelope = CodecEnvelope {
             t,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             namespace_delta: HashMap::new(),
             txn: None,
             time: None,
@@ -986,7 +986,7 @@ mod tests {
         let blob = build_v3_test_blob(&[flake], 42);
         let envelope = crate::commit::codec::read_commit_envelope(&blob).unwrap();
         assert_eq!(envelope.t, 42);
-        assert!(envelope.previous_refs.is_empty());
+        assert!(envelope.parents.is_empty());
         assert!(envelope.txn_meta.is_empty());
     }
 

--- a/fluree-db-core/src/commit/codec/raw_reader.rs
+++ b/fluree-db-core/src/commit/codec/raw_reader.rs
@@ -593,7 +593,7 @@ mod tests {
         // Encode envelope (minimal: just v=0, no previous, no namespace_delta)
         let envelope = CodecEnvelope {
             t,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             namespace_delta: HashMap::new(),
             txn: None,
             time: None,

--- a/fluree-db-core/src/commit/codec/reader.rs
+++ b/fluree-db-core/src/commit/codec/reader.rs
@@ -161,7 +161,7 @@ pub(crate) fn read_commit_v4(bytes: &[u8]) -> Result<Commit, CommitCodecError> {
         t: header.t,
         time: envelope.time,
         flakes,
-        previous_refs: envelope.previous_refs,
+        parents: envelope.parents,
         txn: envelope.txn,
         namespace_delta: envelope.namespace_delta,
         txn_signature: envelope.txn_signature,
@@ -201,7 +201,7 @@ pub(crate) fn read_commit_envelope_v4(bytes: &[u8]) -> Result<CommitEnvelope, Co
 
     Ok(CommitEnvelope {
         t: header.t,
-        previous_refs: env.previous_refs,
+        parents: env.parents,
         txn: env.txn,
         namespace_delta: env.namespace_delta,
         txn_meta: env.txn_meta,

--- a/fluree-db-core/src/commit/codec/reader.rs
+++ b/fluree-db-core/src/commit/codec/reader.rs
@@ -3,7 +3,7 @@
 //! No NamespaceRegistry needed — Sids are reconstructed directly from
 //! (namespace_code, name) pairs stored in the binary format.
 //!
-//! The reader produces CID-based types (`ContentId`, `CommitRef`).
+//! The reader produces CID-based types (`ContentId`, `CommitId`).
 //!
 //! # Dispatch
 //!

--- a/fluree-db-core/src/graph_db_ref.rs
+++ b/fluree-db-core/src/graph_db_ref.rs
@@ -16,7 +16,7 @@
 //!
 //! - `GraphDb.as_graph_db_ref()` → `self.t`
 //! - `LedgerState.as_graph_db_ref(g_id)` → `max(novelty.t, snapshot.t)`
-//! - `LedgerView.as_graph_db_ref(g_id)` → `base.t() + 1` when staged
+//! - `StagedLedger.as_graph_db_ref(g_id)` → `base.t() + 1` when staged
 //!
 //! `from_t` is NOT part of the db value identity — history range queries
 //! pass it via `RangeOptions` or as a separate parameter.

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -80,8 +80,8 @@ pub use coerce::{coerce_json_value, coerce_value, CoercionError, CoercionResult}
 pub use commit::{
     collect_dag_cids, collect_dag_cids_with_split_mode, find_common_ancestor, load_commit_by_id,
     load_commit_envelope_by_id, trace_commit_envelopes_by_id, trace_commits_by_id, Commit,
-    CommitEnvelope, CommitRef, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature,
-    MAX_TXN_META_BYTES, MAX_TXN_META_ENTRIES,
+    CommitEnvelope, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature, MAX_TXN_META_BYTES,
+    MAX_TXN_META_ENTRIES,
 };
 pub use comparator::IndexType;
 pub use conflict_key::ConflictKey;

--- a/fluree-db-indexer/src/drop.rs
+++ b/fluree-db-indexer/src/drop.rs
@@ -282,7 +282,7 @@ mod tests {
             t,
             time: None,
             flakes: Vec::new(),
-            previous_refs: previous.cloned().into_iter().collect(),
+            parents: previous.cloned().into_iter().collect(),
             txn: txn_cid,
             namespace_delta: std::collections::HashMap::new(),
             txn_signature: None,

--- a/fluree-db-indexer/src/drop.rs
+++ b/fluree-db-indexer/src/drop.rs
@@ -206,7 +206,7 @@ mod tests {
     use fluree_db_core::content_kind::ContentKind;
     use fluree_db_core::prelude::*;
     use fluree_db_core::storage::content_store_for;
-    use fluree_db_novelty::{Commit, CommitRef};
+    use fluree_db_novelty::Commit;
     use std::collections::BTreeMap;
 
     const LEDGER: &str = "test:main";
@@ -282,10 +282,7 @@ mod tests {
             t,
             time: None,
             flakes: Vec::new(),
-            previous_refs: previous
-                .map(|id| CommitRef::new(id.clone()))
-                .into_iter()
-                .collect(),
+            previous_refs: previous.cloned().into_iter().collect(),
             txn: txn_cid,
             namespace_delta: std::collections::HashMap::new(),
             txn_signature: None,

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -1302,7 +1302,7 @@ mod tests {
     };
     use fluree_db_nameservice::memory::MemoryNameService;
     use fluree_db_nameservice::{NameService, Publisher};
-    use fluree_db_novelty::{Commit, CommitRef};
+    use fluree_db_novelty::Commit;
     use std::collections::HashMap;
 
     fn make_flake(s_code: u16, s_name: &str, p_code: u16, p_name: &str, val: i64, t: i64) -> Flake {
@@ -1542,7 +1542,7 @@ mod tests {
             t: 2,
             time: None,
             flakes: vec![make_flake(1, "ex:bob", 1, "ex:age", 25, 2)],
-            previous_refs: vec![CommitRef::new(cid1.clone())],
+            previous_refs: vec![cid1.clone()],
             txn: None,
             namespace_delta: HashMap::new(),
             txn_signature: None,

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -1333,7 +1333,7 @@ mod tests {
 
         let envelope = CodecEnvelope {
             t: commit.t,
-            previous_refs: commit.previous_refs.clone(),
+            parents: commit.parents.clone(),
             namespace_delta: commit
                 .namespace_delta
                 .iter()
@@ -1441,7 +1441,7 @@ mod tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -1475,7 +1475,7 @@ mod tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -1515,7 +1515,7 @@ mod tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -1542,7 +1542,7 @@ mod tests {
             t: 2,
             time: None,
             flakes: vec![make_flake(1, "ex:bob", 1, "ex:age", 25, 2)],
-            previous_refs: vec![cid1.clone()],
+            parents: vec![cid1.clone()],
             txn: None,
             namespace_delta: HashMap::new(),
             txn_signature: None,
@@ -1570,7 +1570,7 @@ mod tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -1606,7 +1606,7 @@ mod tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -1646,7 +1646,7 @@ mod tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -2016,7 +2016,7 @@ mod embedded_tests {
 
         let envelope = CodecEnvelope {
             t: commit.t,
-            previous_refs: commit.previous_refs.clone(),
+            parents: commit.parents.clone(),
             namespace_delta: commit
                 .namespace_delta
                 .iter()
@@ -2154,7 +2154,7 @@ mod embedded_tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,
@@ -2207,7 +2207,7 @@ mod embedded_tests {
             t: 1,
             time: None,
             flakes: vec![make_flake(1, "ex:alice", 1, "ex:age", 30, 1)],
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             txn: None,
             namespace_delta: HashMap::from([(1, "ex:".to_string())]),
             txn_signature: None,

--- a/fluree-db-indexer/src/run_index/resolve/resolver.rs
+++ b/fluree-db-indexer/src/run_index/resolve/resolver.rs
@@ -415,7 +415,7 @@ impl CommitResolver {
         // ledger:previous (ID) -- ref to parent commit(s)
         for prev_ref in &envelope.previous_refs {
             // Use CID digest hex as the subject name in FLUREE_COMMIT namespace
-            let prev_digest = prev_ref.id.digest_hex();
+            let prev_digest = prev_ref.digest_hex();
             let prev_s_id = dicts
                 .subjects
                 .get_or_insert(&prev_digest, fluree_vocab::namespaces::FLUREE_COMMIT)?;
@@ -1757,7 +1757,7 @@ impl SharedResolverState {
 
         // ledger:previous (ID) -- ref to parent commit(s) (chunk-local subject)
         for prev_ref in &envelope.previous_refs {
-            let prev_digest = prev_ref.id.digest_hex();
+            let prev_digest = prev_ref.digest_hex();
             let prev_s_id = chunk.subjects.get_or_insert(
                 fluree_vocab::namespaces::FLUREE_COMMIT,
                 prev_digest.as_bytes(),
@@ -2419,7 +2419,6 @@ mod tests {
     fn test_emit_txn_meta() {
         use fluree_db_core::commit::codec::envelope::CodecEnvelope;
         use fluree_db_core::{ContentId, ContentKind};
-        use fluree_db_novelty::CommitRef;
 
         let mut dicts = GlobalDicts::new_memory("test:main");
         let mut resolver = CommitResolver::new();
@@ -2432,10 +2431,10 @@ mod tests {
 
         let envelope = CodecEnvelope {
             t: 42,
-            previous_refs: vec![CommitRef::new(ContentId::new(
+            previous_refs: vec![ContentId::new(
                 ContentKind::Commit,
                 prev_commit_id.as_bytes(),
-            ))],
+            )],
             namespace_delta: HashMap::new(),
             txn: None,
             time: Some("2025-06-15T12:00:00Z".into()),

--- a/fluree-db-indexer/src/run_index/resolve/resolver.rs
+++ b/fluree-db-indexer/src/run_index/resolve/resolver.rs
@@ -413,9 +413,9 @@ impl CommitResolver {
         )?;
 
         // ledger:previous (ID) -- ref to parent commit(s)
-        for prev_ref in &envelope.previous_refs {
+        for parent in &envelope.parents {
             // Use CID digest hex as the subject name in FLUREE_COMMIT namespace
-            let prev_digest = prev_ref.digest_hex();
+            let prev_digest = parent.digest_hex();
             let prev_s_id = dicts
                 .subjects
                 .get_or_insert(&prev_digest, fluree_vocab::namespaces::FLUREE_COMMIT)?;
@@ -1756,8 +1756,8 @@ impl SharedResolverState {
         );
 
         // ledger:previous (ID) -- ref to parent commit(s) (chunk-local subject)
-        for prev_ref in &envelope.previous_refs {
-            let prev_digest = prev_ref.digest_hex();
+        for parent in &envelope.parents {
+            let prev_digest = parent.digest_hex();
             let prev_s_id = chunk.subjects.get_or_insert(
                 fluree_vocab::namespaces::FLUREE_COMMIT,
                 prev_digest.as_bytes(),
@@ -2104,7 +2104,7 @@ mod tests {
 
         let envelope = CodecEnvelope {
             t,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             namespace_delta: HashMap::new(),
             txn: None,
             time: None,
@@ -2431,7 +2431,7 @@ mod tests {
 
         let envelope = CodecEnvelope {
             t: 42,
-            previous_refs: vec![ContentId::new(
+            parents: vec![ContentId::new(
                 ContentKind::Commit,
                 prev_commit_id.as_bytes(),
             )],
@@ -2539,7 +2539,7 @@ mod tests {
 
         let envelope = CodecEnvelope {
             t: 1,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             namespace_delta: HashMap::new(),
             txn: None,
             time: None,
@@ -2578,7 +2578,7 @@ mod tests {
 
         let envelope = CodecEnvelope {
             t: 5,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             namespace_delta: HashMap::new(),
             txn: None,
             time: None,

--- a/fluree-db-ledger/src/lib.rs
+++ b/fluree-db-ledger/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - [`LedgerState`] - Live ledger state (mutable, has novelty)
 //! - [`HistoricalLedgerView`] - Read-only view at a specific time (for time-travel)
-//! - [`LedgerView`] - Staged transactions (uncommitted changes)
+//! - [`StagedLedger`] - Staged transactions (uncommitted changes)
 //!
 //! # Example
 //!
@@ -31,7 +31,7 @@ mod staged;
 
 pub use error::{LedgerError, Result};
 pub use historical::HistoricalLedgerView;
-pub use staged::LedgerView;
+pub use staged::StagedLedger;
 
 use fluree_db_core::{
     format_ledger_id, BranchedContentStore, ContentId, ContentStore, DictNovelty, Flake,

--- a/fluree-db-ledger/src/staged.rs
+++ b/fluree-db-ledger/src/staged.rs
@@ -1,7 +1,7 @@
 //! Staged transaction support
 //!
-//! This module provides `LedgerView` for staging transactions before commit.
-//! A LedgerView combines:
+//! This module provides `StagedLedger` for staging transactions before commit.
+//! A StagedLedger combines:
 //! - Base LedgerState (indexed LedgerSnapshot + committed novelty)
 //! - Staged flakes (not yet committed)
 //!
@@ -163,8 +163,8 @@ impl StagedOverlay {
 /// - Base LedgerState (indexed LedgerSnapshot + committed novelty)
 /// - Staged flakes (not yet committed)
 ///
-/// Queries against a LedgerView will see the staged changes.
-pub struct LedgerView {
+/// Queries against a StagedLedger will see the staged changes.
+pub struct StagedLedger {
     /// Base ledger state
     base: LedgerState,
     /// Staged changes
@@ -173,15 +173,15 @@ pub struct LedgerView {
     staged_epoch: u64,
 }
 
-impl LedgerView {
-    /// Create a new ledger view with staged flakes
+impl StagedLedger {
+    /// Build a staged ledger by layering `flakes` onto `base`.
     ///
     /// `reverse_graph` maps graph Sids to GraphIds for per-graph filtering.
     /// Pass an empty map when all flakes are default-graph only.
     ///
     /// Returns `Err` if any staged flake has a graph Sid not present in
     /// `reverse_graph` (programming error — the map must be complete).
-    pub fn stage(
+    pub fn new(
         base: LedgerState,
         flakes: Vec<Flake>,
         reverse_graph: &HashMap<Sid, GraphId>,
@@ -258,7 +258,7 @@ impl LedgerView {
     }
 }
 
-impl OverlayProvider for LedgerView {
+impl OverlayProvider for StagedLedger {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -393,7 +393,7 @@ mod tests {
 
         // Create view with interleaved staged flakes
         let staged_flakes = vec![make_flake(2, 1, 200, 2), make_flake(4, 1, 400, 2)];
-        let view = LedgerView::stage(state, staged_flakes, &HashMap::new()).unwrap();
+        let view = StagedLedger::new(state, staged_flakes, &HashMap::new()).unwrap();
 
         // Collect all flakes via overlay provider (g_id=0 for default graph)
         let mut collected = Vec::new();
@@ -420,7 +420,7 @@ mod tests {
         let state = LedgerState::new(snapshot, novelty);
 
         let view =
-            LedgerView::stage(state, vec![make_flake(2, 1, 200, 2)], &HashMap::new()).unwrap();
+            StagedLedger::new(state, vec![make_flake(2, 1, 200, 2)], &HashMap::new()).unwrap();
 
         // Staged epoch should be different from base epoch
         assert_eq!(view.epoch(), base_epoch + 1);
@@ -435,7 +435,7 @@ mod tests {
         let state = LedgerState::new(snapshot, novelty);
 
         let staged_flakes = vec![make_flake(1, 1, 100, 1)];
-        let view = LedgerView::stage(state, staged_flakes, &HashMap::new()).unwrap();
+        let view = StagedLedger::new(state, staged_flakes, &HashMap::new()).unwrap();
 
         let (base, flakes) = view.into_parts();
         assert_eq!(base.ledger_id(), "test:main");

--- a/fluree-db-nameservice-sync/src/driver.rs
+++ b/fluree-db-nameservice-sync/src/driver.rs
@@ -137,8 +137,8 @@ impl SyncDriver {
             let changed = match &existing {
                 None => true,
                 Some(tr) => {
-                    tr.commit_ref != new_commit
-                        || tr.index_ref != new_index
+                    tr.commit_head != new_commit
+                        || tr.index_head != new_index
                         || tr.retracted != record.retracted
                 }
             };
@@ -148,8 +148,8 @@ impl SyncDriver {
                     schema_version: 1,
                     remote: remote.clone(),
                     ledger_id: ledger_id.clone(),
-                    commit_ref: new_commit,
-                    index_ref: new_index,
+                    commit_head: new_commit,
+                    index_head: new_index,
                     retracted: record.retracted,
                     last_fetched: Some(now.clone()),
                 };
@@ -184,9 +184,9 @@ impl SyncDriver {
             });
         };
 
-        let remote_index = tracking.index_ref.clone();
+        let remote_index = tracking.index_head.clone();
 
-        let Some(remote_commit) = &tracking.commit_ref else {
+        let Some(remote_commit) = &tracking.commit_head else {
             return Ok(PullResult::Current {
                 ledger_id: local_alias.to_string(),
             });
@@ -368,8 +368,8 @@ impl SyncDriver {
             .tracking
             .get_tracking(&upstream.remote, &upstream.remote_alias)
             .await?;
-        let expected = tracking.as_ref().and_then(|t| t.commit_ref.as_ref());
-        let expected_index = tracking.as_ref().and_then(|t| t.index_ref.clone());
+        let expected = tracking.as_ref().and_then(|t| t.commit_head.as_ref());
+        let expected_index = tracking.as_ref().and_then(|t| t.index_head.clone());
 
         let result = client
             .push_ref(
@@ -386,7 +386,7 @@ impl SyncDriver {
                 let mut tracking_record = tracking.unwrap_or_else(|| {
                     TrackingRecord::new(upstream.remote.clone(), upstream.remote_alias.clone())
                 });
-                tracking_record.commit_ref = Some(local_commit.clone());
+                tracking_record.commit_head = Some(local_commit.clone());
                 tracking_record.last_fetched = Some(chrono_now());
 
                 // Best-effort push of index head if we have one.
@@ -401,7 +401,7 @@ impl SyncDriver {
                             )
                             .await
                         {
-                            tracking_record.index_ref = Some(local_index.clone());
+                            tracking_record.index_head = Some(local_index.clone());
                         }
                     }
                 }
@@ -546,7 +546,7 @@ mod tests {
         let result = driver.fetch_remote(&origin()).await.unwrap();
         assert_eq!(result.updated.len(), 1);
         assert_eq!(result.updated[0].0, "mydb:main");
-        assert_eq!(result.updated[0].1.commit_ref.as_ref().unwrap().t, 5);
+        assert_eq!(result.updated[0].1.commit_head.as_ref().unwrap().t, 5);
         assert!(result.unchanged.is_empty());
     }
 

--- a/fluree-db-nameservice/src/file.rs
+++ b/fluree-db-nameservice/src/file.rs
@@ -2257,7 +2257,9 @@ mod tests {
         let cid = test_cid("commit-5");
         ns.publish_commit("mydb:main", 5, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "feature-x", "main", None).await.unwrap();
+        ns.create_branch("mydb", "feature-x", "main", None)
+            .await
+            .unwrap();
 
         let record = ns.lookup("mydb:feature-x").await.unwrap().unwrap();
         assert_eq!(record.name, "mydb");
@@ -2288,7 +2290,9 @@ mod tests {
         ns.publish_commit("mydb:main", 3, &cid).await.unwrap();
 
         ns.create_branch("mydb", "dev", "main", None).await.unwrap();
-        ns.create_branch("mydb", "staging", "main", None).await.unwrap();
+        ns.create_branch("mydb", "staging", "main", None)
+            .await
+            .unwrap();
 
         // Also create a different ledger to ensure filtering works
         ns.publish_ledger_init("other:main").await.unwrap();
@@ -2335,7 +2339,9 @@ mod tests {
         let cid = test_cid("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dead", "main", None).await.unwrap();
+        ns.create_branch("mydb", "dead", "main", None)
+            .await
+            .unwrap();
         ns.retract("mydb:dead").await.unwrap();
 
         let branches = ns.list_branches("mydb").await.unwrap();
@@ -2350,7 +2356,9 @@ mod tests {
         let cid = test_cid("commit-2");
         ns.publish_commit("mydb:main", 2, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "persisted", "main", None).await.unwrap();
+        ns.create_branch("mydb", "persisted", "main", None)
+            .await
+            .unwrap();
 
         // Create a new FileNameService pointing to the same directory
         let ns2 = FileNameService::new(temp.path());

--- a/fluree-db-nameservice/src/file.rs
+++ b/fluree-db-nameservice/src/file.rs
@@ -458,17 +458,24 @@ impl NameService for FileNameService {
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
     ) -> Result<()> {
         let address = Self::ns_address(ledger_name, new_branch);
         let normalized_id = format_ledger_id(ledger_name, new_branch);
 
-        // Read the source branch to get commit head info
+        // Read the source branch to validate it exists (and to get commit info
+        // when `at_commit` is None).
         let source_record = self
             .load_record(ledger_name, source_branch)
             .await?
             .ok_or_else(|| {
                 NameServiceError::not_found(format!("source branch {ledger_name}:{source_branch}"))
             })?;
+
+        let (commit_head_id, commit_t) = match at_commit {
+            Some((id, t)) => (Some(id), t),
+            None => (source_record.commit_head_id.clone(), source_record.commit_t),
+        };
 
         let file = NsFileV2 {
             context: ns_context(),
@@ -478,12 +485,11 @@ impl NameService for FileNameService {
                 id: ledger_name.to_string(),
             },
             branch: new_branch.to_string(),
-            commit_cid: source_record
-                .commit_head_id
+            commit_cid: commit_head_id
                 .as_ref()
                 .map(std::string::ToString::to_string),
             config_cid: None,
-            t: source_record.commit_t,
+            t: commit_t,
             index: None,
             status: "ready".to_string(),
             default_context_cid: None,
@@ -2251,7 +2257,7 @@ mod tests {
         let cid = test_cid("commit-5");
         ns.publish_commit("mydb:main", 5, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "feature-x", "main").await.unwrap();
+        ns.create_branch("mydb", "feature-x", "main", None).await.unwrap();
 
         let record = ns.lookup("mydb:feature-x").await.unwrap().unwrap();
         assert_eq!(record.name, "mydb");
@@ -2268,9 +2274,9 @@ mod tests {
         let cid = test_cid("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dev", "main").await.unwrap();
+        ns.create_branch("mydb", "dev", "main", None).await.unwrap();
 
-        let result = ns.create_branch("mydb", "dev", "main").await;
+        let result = ns.create_branch("mydb", "dev", "main", None).await;
         assert!(result.is_err());
     }
 
@@ -2281,8 +2287,8 @@ mod tests {
         let cid = test_cid("commit-3");
         ns.publish_commit("mydb:main", 3, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dev", "main").await.unwrap();
-        ns.create_branch("mydb", "staging", "main").await.unwrap();
+        ns.create_branch("mydb", "dev", "main", None).await.unwrap();
+        ns.create_branch("mydb", "staging", "main", None).await.unwrap();
 
         // Also create a different ledger to ensure filtering works
         ns.publish_ledger_init("other:main").await.unwrap();
@@ -2301,10 +2307,10 @@ mod tests {
         let cid = test_cid("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "release/v1.0", "main")
+        ns.create_branch("mydb", "release/v1.0", "main", None)
             .await
             .unwrap();
-        ns.create_branch("mydb", "feature/auth", "main")
+        ns.create_branch("mydb", "feature/auth", "main", None)
             .await
             .unwrap();
 
@@ -2329,7 +2335,7 @@ mod tests {
         let cid = test_cid("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dead", "main").await.unwrap();
+        ns.create_branch("mydb", "dead", "main", None).await.unwrap();
         ns.retract("mydb:dead").await.unwrap();
 
         let branches = ns.list_branches("mydb").await.unwrap();
@@ -2344,7 +2350,7 @@ mod tests {
         let cid = test_cid("commit-2");
         ns.publish_commit("mydb:main", 2, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "persisted", "main").await.unwrap();
+        ns.create_branch("mydb", "persisted", "main", None).await.unwrap();
 
         // Create a new FileNameService pointing to the same directory
         let ns2 = FileNameService::new(temp.path());

--- a/fluree-db-nameservice/src/lib.rs
+++ b/fluree-db-nameservice/src/lib.rs
@@ -439,8 +439,13 @@ pub trait NameService:
     ///
     /// Creates a new [`NsRecord`] for `ledger_name:new_branch` with its
     /// [`source_branch`](NsRecord::source_branch) set to record the parent.
-    /// The new branch starts at the same commit head as the source, so
-    /// subsequent transactions on either branch will diverge independently.
+    ///
+    /// When `at_commit` is `None`, the new branch starts at the source
+    /// branch's current commit head. When `at_commit` is
+    /// `Some((commit_id, commit_t))`, the new branch starts at the supplied
+    /// historical commit instead — callers are responsible for verifying
+    /// that the commit is reachable from the source branch before passing
+    /// it in.
     ///
     /// Also increments the source branch's `branches` count to track
     /// the child reference for safe deletion.
@@ -453,6 +458,7 @@ pub trait NameService:
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
     ) -> Result<()>;
 
     /// Drop a branch, purging its nameservice record and decrementing

--- a/fluree-db-nameservice/src/memory.rs
+++ b/fluree-db-nameservice/src/memory.rs
@@ -126,6 +126,7 @@ impl NameService for MemoryNameService {
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
     ) -> Result<()> {
         let new_id = format_ledger_id(ledger_name, new_branch);
         let key = self.normalize_ledger_id(&new_id);
@@ -138,19 +139,23 @@ impl NameService for MemoryNameService {
             return Err(crate::NameServiceError::ledger_already_exists(&key));
         }
 
-        // Increment source branch's child count and copy commit head
+        // Increment source branch's child count and pick the starting commit
+        // head — either the caller-supplied historical commit or the source's
+        // current HEAD.
         let source = records.get_mut(&source_key).ok_or_else(|| {
             crate::NameServiceError::not_found(format!(
                 "source branch {ledger_name}:{source_branch}"
             ))
         })?;
         source.branches += 1;
-        let source_commit_head_id = source.commit_head_id.clone();
-        let source_commit_t = source.commit_t;
+        let (commit_head_id, commit_t) = match at_commit {
+            Some((id, t)) => (Some(id), t),
+            None => (source.commit_head_id.clone(), source.commit_t),
+        };
 
         let mut record = NsRecord::new(ledger_name, new_branch);
-        record.commit_head_id = source_commit_head_id;
-        record.commit_t = source_commit_t;
+        record.commit_head_id = commit_head_id;
+        record.commit_t = commit_t;
         record.source_branch = Some(source_branch.to_string());
         records.insert(key, record);
 
@@ -1508,7 +1513,7 @@ mod tests {
         let cid = test_commit_id("commit-5");
         ns.publish_commit("mydb:main", 5, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "feature-x", "main").await.unwrap();
+        ns.create_branch("mydb", "feature-x", "main", None).await.unwrap();
 
         let record = ns.lookup("mydb:feature-x").await.unwrap().unwrap();
         assert_eq!(record.name, "mydb");
@@ -1525,9 +1530,9 @@ mod tests {
         let cid = test_commit_id("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dev", "main").await.unwrap();
+        ns.create_branch("mydb", "dev", "main", None).await.unwrap();
 
-        let result = ns.create_branch("mydb", "dev", "main").await;
+        let result = ns.create_branch("mydb", "dev", "main", None).await;
         assert!(result.is_err());
     }
 
@@ -1538,8 +1543,8 @@ mod tests {
         let cid = test_commit_id("commit-3");
         ns.publish_commit("mydb:main", 3, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dev", "main").await.unwrap();
-        ns.create_branch("mydb", "staging", "main").await.unwrap();
+        ns.create_branch("mydb", "dev", "main", None).await.unwrap();
+        ns.create_branch("mydb", "staging", "main", None).await.unwrap();
 
         // Also create a different ledger to ensure filtering works
         ns.publish_ledger_init("other:main").await.unwrap();
@@ -1565,7 +1570,7 @@ mod tests {
         let cid = test_commit_id("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dead", "main").await.unwrap();
+        ns.create_branch("mydb", "dead", "main", None).await.unwrap();
         ns.retract("mydb:dead").await.unwrap();
 
         let branches = ns.list_branches("mydb").await.unwrap();

--- a/fluree-db-nameservice/src/memory.rs
+++ b/fluree-db-nameservice/src/memory.rs
@@ -1513,7 +1513,9 @@ mod tests {
         let cid = test_commit_id("commit-5");
         ns.publish_commit("mydb:main", 5, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "feature-x", "main", None).await.unwrap();
+        ns.create_branch("mydb", "feature-x", "main", None)
+            .await
+            .unwrap();
 
         let record = ns.lookup("mydb:feature-x").await.unwrap().unwrap();
         assert_eq!(record.name, "mydb");
@@ -1544,7 +1546,9 @@ mod tests {
         ns.publish_commit("mydb:main", 3, &cid).await.unwrap();
 
         ns.create_branch("mydb", "dev", "main", None).await.unwrap();
-        ns.create_branch("mydb", "staging", "main", None).await.unwrap();
+        ns.create_branch("mydb", "staging", "main", None)
+            .await
+            .unwrap();
 
         // Also create a different ledger to ensure filtering works
         ns.publish_ledger_init("other:main").await.unwrap();
@@ -1570,7 +1574,9 @@ mod tests {
         let cid = test_commit_id("commit-1");
         ns.publish_commit("mydb:main", 1, &cid).await.unwrap();
 
-        ns.create_branch("mydb", "dead", "main", None).await.unwrap();
+        ns.create_branch("mydb", "dead", "main", None)
+            .await
+            .unwrap();
         ns.retract("mydb:dead").await.unwrap();
 
         let branches = ns.list_branches("mydb").await.unwrap();

--- a/fluree-db-nameservice/src/notifying.rs
+++ b/fluree-db-nameservice/src/notifying.rs
@@ -86,9 +86,10 @@ where
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
     ) -> Result<()> {
         self.inner
-            .create_branch(ledger_name, new_branch, source_branch)
+            .create_branch(ledger_name, new_branch, source_branch, at_commit)
             .await
     }
 

--- a/fluree-db-nameservice/src/storage_ns.rs
+++ b/fluree-db-nameservice/src/storage_ns.rs
@@ -565,17 +565,24 @@ where
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
     ) -> Result<()> {
         let key = self.ns_key(ledger_name, new_branch);
         let normalized_id = format_ledger_id(ledger_name, new_branch);
 
-        // Read the source branch to get commit head info
+        // Read the source branch to validate it exists (and to get commit info
+        // when `at_commit` is None).
         let source_record = self
             .load_record(ledger_name, source_branch)
             .await?
             .ok_or_else(|| {
                 NameServiceError::not_found(format!("source branch {ledger_name}:{source_branch}"))
             })?;
+
+        let (commit_head_id, commit_t) = match at_commit {
+            Some((id, t)) => (Some(id), t),
+            None => (source_record.commit_head_id.clone(), source_record.commit_t),
+        };
 
         let file = NsFileV2 {
             context: ns_context(),
@@ -585,12 +592,11 @@ where
                 id: ledger_name.to_string(),
             },
             branch: new_branch.to_string(),
-            commit_cid: source_record
-                .commit_head_id
+            commit_cid: commit_head_id
                 .as_ref()
                 .map(std::string::ToString::to_string),
             config_cid: None,
-            t: source_record.commit_t,
+            t: commit_t,
             index: None,
             status: "ready".to_string(),
             default_context_cid: None,

--- a/fluree-db-nameservice/src/tracking.rs
+++ b/fluree-db-nameservice/src/tracking.rs
@@ -46,10 +46,10 @@ pub struct TrackingRecord {
     pub ledger_id: String,
 
     /// The remote's commit head (if known).
-    pub commit_ref: Option<RefValue>,
+    pub commit_head: Option<RefValue>,
 
     /// The remote's index head (if known).
-    pub index_ref: Option<RefValue>,
+    pub index_head: Option<RefValue>,
 
     /// Whether the ledger has been retracted on the remote.
     pub retracted: bool,
@@ -65,8 +65,8 @@ impl TrackingRecord {
             schema_version: 1,
             remote,
             ledger_id: ledger_id.into(),
-            commit_ref: None,
-            index_ref: None,
+            commit_head: None,
+            index_head: None,
             retracted: false,
             last_fetched: None,
         }
@@ -179,7 +179,7 @@ mod tests {
     async fn test_set_and_get_tracking() {
         let store = MemoryTrackingStore::new();
         let mut record = TrackingRecord::new(origin(), "mydb:main");
-        record.commit_ref = Some(RefValue { id: None, t: 5 });
+        record.commit_head = Some(RefValue { id: None, t: 5 });
         record.last_fetched = Some("2025-01-01T00:00:00Z".to_string());
 
         store.set_tracking(&record).await.unwrap();
@@ -191,7 +191,7 @@ mod tests {
             .unwrap();
         assert_eq!(fetched.ledger_id, "mydb:main");
         assert_eq!(fetched.schema_version, 1);
-        assert_eq!(fetched.commit_ref.as_ref().unwrap().t, 5);
+        assert_eq!(fetched.commit_head.as_ref().unwrap().t, 5);
         assert_eq!(
             fetched.last_fetched.as_deref(),
             Some("2025-01-01T00:00:00Z")
@@ -203,11 +203,11 @@ mod tests {
         let store = MemoryTrackingStore::new();
 
         let mut record = TrackingRecord::new(origin(), "mydb:main");
-        record.commit_ref = Some(RefValue { id: None, t: 1 });
+        record.commit_head = Some(RefValue { id: None, t: 1 });
         store.set_tracking(&record).await.unwrap();
 
         // Overwrite with newer data
-        record.commit_ref = Some(RefValue { id: None, t: 5 });
+        record.commit_head = Some(RefValue { id: None, t: 5 });
         store.set_tracking(&record).await.unwrap();
 
         let fetched = store
@@ -215,7 +215,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(fetched.commit_ref.as_ref().unwrap().t, 5);
+        assert_eq!(fetched.commit_head.as_ref().unwrap().t, 5);
     }
 
     #[tokio::test]
@@ -278,8 +278,8 @@ mod tests {
     #[test]
     fn test_tracking_record_serde_roundtrip() {
         let mut record = TrackingRecord::new(origin(), "mydb:main");
-        record.commit_ref = Some(RefValue { id: None, t: 5 });
-        record.index_ref = Some(RefValue { id: None, t: 3 });
+        record.commit_head = Some(RefValue { id: None, t: 5 });
+        record.index_head = Some(RefValue { id: None, t: 3 });
         record.retracted = false;
         record.last_fetched = Some("2025-06-15T12:00:00Z".to_string());
 
@@ -289,8 +289,8 @@ mod tests {
         assert_eq!(deserialized.schema_version, 1);
         assert_eq!(deserialized.remote, origin());
         assert_eq!(deserialized.ledger_id, "mydb:main");
-        assert_eq!(deserialized.commit_ref.as_ref().unwrap().t, 5);
-        assert_eq!(deserialized.index_ref.as_ref().unwrap().t, 3);
+        assert_eq!(deserialized.commit_head.as_ref().unwrap().t, 5);
+        assert_eq!(deserialized.index_head.as_ref().unwrap().t, 3);
         assert!(!deserialized.retracted);
     }
 

--- a/fluree-db-nameservice/src/tracking_file.rs
+++ b/fluree-db-nameservice/src/tracking_file.rs
@@ -280,7 +280,7 @@ mod tests {
         let store = FileTrackingStore::new(tmp.path());
 
         let mut record = TrackingRecord::new(origin(), "mydb:main");
-        record.commit_ref = Some(RefValue { id: None, t: 5 });
+        record.commit_head = Some(RefValue { id: None, t: 5 });
 
         store.set_tracking(&record).await.unwrap();
 
@@ -290,7 +290,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(fetched.ledger_id, "mydb:main");
-        assert_eq!(fetched.commit_ref.as_ref().unwrap().t, 5);
+        assert_eq!(fetched.commit_head.as_ref().unwrap().t, 5);
     }
 
     #[tokio::test]
@@ -389,10 +389,10 @@ mod tests {
         let store = FileTrackingStore::new(tmp.path());
 
         let mut record = TrackingRecord::new(origin(), "mydb:main");
-        record.commit_ref = Some(RefValue { id: None, t: 1 });
+        record.commit_head = Some(RefValue { id: None, t: 1 });
         store.set_tracking(&record).await.unwrap();
 
-        record.commit_ref = Some(RefValue { id: None, t: 5 });
+        record.commit_head = Some(RefValue { id: None, t: 5 });
         store.set_tracking(&record).await.unwrap();
 
         let fetched = store
@@ -400,6 +400,6 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(fetched.commit_ref.as_ref().unwrap().t, 5);
+        assert_eq!(fetched.commit_head.as_ref().unwrap().t, 5);
     }
 }

--- a/fluree-db-novelty/src/commit_flakes.rs
+++ b/fluree-db-novelty/src/commit_flakes.rs
@@ -249,7 +249,7 @@ mod tests {
 
         if with_previous {
             let prev_id = make_test_content_id(ContentKind::Commit, "prev-commit-bytes");
-            commit.previous_refs = vec![prev_id];
+            commit.parents = vec![prev_id];
         }
 
         commit

--- a/fluree-db-novelty/src/commit_flakes.rs
+++ b/fluree-db-novelty/src/commit_flakes.rs
@@ -235,7 +235,6 @@ pub fn generate_commit_flakes(commit: &Commit, ledger_id: &str, t: i64) -> Vec<F
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::CommitRef;
     use fluree_db_core::{ContentId, ContentKind};
 
     fn make_test_content_id(kind: ContentKind, label: &str) -> ContentId {
@@ -250,7 +249,7 @@ mod tests {
 
         if with_previous {
             let prev_id = make_test_content_id(ContentKind::Commit, "prev-commit-bytes");
-            commit.previous_refs = vec![CommitRef::new(prev_id)];
+            commit.previous_refs = vec![prev_id];
         }
 
         commit

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -34,8 +34,8 @@ mod stats;
 pub use commit::{
     collect_dag_cids, collect_dag_cids_with_split_mode, find_common_ancestor, load_commit_by_id,
     load_commit_envelope_by_id, trace_commit_envelopes_by_id, trace_commits_by_id, Commit,
-    CommitEnvelope, CommitRef, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature,
-    MAX_TXN_META_BYTES, MAX_TXN_META_ENTRIES,
+    CommitEnvelope, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature, MAX_TXN_META_BYTES,
+    MAX_TXN_META_ENTRIES,
 };
 pub use commit_flakes::{generate_commit_flakes, stamp_graph_on_commit_flakes};
 pub use delta::compute_delta_keys;

--- a/fluree-db-server/src/peer/proxy_nameservice.rs
+++ b/fluree-db-server/src/peer/proxy_nameservice.rs
@@ -207,6 +207,7 @@ impl NameService for ProxyNameService {
         _ledger_name: &str,
         _new_branch: &str,
         _source_branch: &str,
+        _at_commit: Option<(fluree_db_core::ContentId, i64)>,
     ) -> Result<()> {
         // Proxy peers forward branch creation to the tx server via HTTP
         Err(NameServiceError::storage(

--- a/fluree-db-server/src/peer/sync_task.rs
+++ b/fluree-db-server/src/peer/sync_task.rs
@@ -154,12 +154,12 @@ impl PeerSyncTask {
 
         // 2. Fast-forward commit head (if record has a commit)
         if record.commit_head_id.is_some() {
-            let commit_ref = RefValue {
+            let commit_head = RefValue {
                 id: record.commit_head_id.clone(),
                 t: record.commit_t,
             };
             match ns
-                .fast_forward_commit(&record.ledger_id, &commit_ref, 3)
+                .fast_forward_commit(&record.ledger_id, &commit_head, 3)
                 .await
             {
                 Ok(CasResult::Updated) => {}
@@ -191,7 +191,7 @@ impl PeerSyncTask {
                             &record.ledger_id,
                             RefKind::CommitHead,
                             actual.as_ref(),
-                            &commit_ref,
+                            &commit_head,
                         )
                         .await;
 
@@ -233,7 +233,7 @@ impl PeerSyncTask {
 
         // 3. Update index head — read current first, NOT expected=None
         if record.index_head_id.is_some() {
-            let index_ref = RefValue {
+            let index_head = RefValue {
                 id: record.index_head_id.clone(),
                 t: record.index_t,
             };
@@ -247,7 +247,7 @@ impl PeerSyncTask {
                     &record.ledger_id,
                     RefKind::IndexHead,
                     current.as_ref(),
-                    &index_ref,
+                    &index_head,
                 )
                 .await;
             match index_result {

--- a/fluree-db-server/src/routes/commits.rs
+++ b/fluree-db-server/src/routes/commits.rs
@@ -1,7 +1,7 @@
 //! Commit export endpoint: `GET /v1/fluree/commits/*ledger`.
 //!
 //! Returns paginated commit blobs using address-cursor pagination.
-//! Each page walks backward via `previous_ref` — O(limit) per page.
+//! Each page walks backward via `parents` — O(limit) per page.
 //!
 //! Requires `fluree.storage.*` permissions (replication-grade, not `ledger.read`).
 

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -880,7 +880,7 @@ async fn create_branch_local(state: Arc<AppState>, request: Request) -> Result<i
 
         let record = match state
             .fluree
-            .create_branch(&ledger, &branch, Some(&source))
+            .create_branch(&ledger, &branch, Some(&source), None)
             .await
         {
             Ok(record) => record,

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -809,6 +809,13 @@ pub struct CreateBranchRequest {
     /// Source branch to create from (defaults to "main")
     #[serde(default)]
     pub source: Option<String>,
+    /// Optional commit reference to branch at.
+    ///
+    /// Accepts `"t:N"` for a transaction number or a hex digest / full CID
+    /// for prefix resolution. When omitted, the branch starts at the source
+    /// branch's current HEAD.
+    #[serde(default)]
+    pub at: Option<String>,
 }
 
 /// Create branch response
@@ -857,6 +864,14 @@ async fn create_branch_local(state: Arc<AppState>, request: Request) -> Result<i
     let ledger = req.ledger;
     let branch = req.branch;
 
+    let at_commit = match req.at.as_deref() {
+        Some(s) => Some(
+            fluree_db_api::CommitRef::parse(s)
+                .map_err(|e| ServerError::bad_request(e.to_string()))?,
+        ),
+        None => None,
+    };
+
     let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
     let trace_id = extract_trace_id(&headers.raw);
     let span = create_request_span(
@@ -880,7 +895,7 @@ async fn create_branch_local(state: Arc<AppState>, request: Request) -> Result<i
 
         let record = match state
             .fluree
-            .create_branch(&ledger, &branch, Some(&source), None)
+            .create_branch(&ledger, &branch, Some(&source), at_commit)
             .await
         {
             Ok(record) => record,

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -108,11 +108,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // Nameservice ref endpoints (for remote sync)
         .route(
             "/nameservice/refs/:alias/commit",
-            post(nameservice_refs::push_commit_ref),
+            post(nameservice_refs::push_commit_head),
         )
         .route(
             "/nameservice/refs/:alias/index",
-            post(nameservice_refs::push_index_ref),
+            post(nameservice_refs::push_index_head),
         )
         .route(
             "/nameservice/refs/:alias/init",

--- a/fluree-db-server/src/routes/nameservice_refs.rs
+++ b/fluree-db-server/src/routes/nameservice_refs.rs
@@ -94,7 +94,7 @@ fn require_read_write_mode(state: &AppState) -> Result<(), ServerError> {
 ///
 /// Compare-and-set push for the commit head ref.
 /// Returns 200 on success, 409 on CAS conflict.
-pub async fn push_commit_ref(
+pub async fn push_commit_head(
     State(state): State<Arc<AppState>>,
     Path(alias): Path<String>,
     StorageProxyBearer(principal): StorageProxyBearer,
@@ -113,7 +113,7 @@ pub async fn push_commit_ref(
 ///
 /// Compare-and-set push for the index head ref.
 /// Returns 200 on success, 409 on CAS conflict.
-pub async fn push_index_ref(
+pub async fn push_index_head(
     State(state): State<Arc<AppState>>,
     Path(alias): Path<String>,
     StorageProxyBearer(principal): StorageProxyBearer,
@@ -128,7 +128,7 @@ pub async fn push_index_ref(
     push_ref_inner(&state, &alias, RefKind::IndexHead, body).await
 }
 
-/// Shared implementation for push_commit_ref and push_index_ref
+/// Shared implementation for push_commit_head and push_index_head
 async fn push_ref_inner(
     state: &AppState,
     alias: &str,

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -3,7 +3,7 @@ use fluree_db_api::{
     ExportCommitsRequest, ExportCommitsResponse, NamespaceRegistry, PushCommitsRequest,
 };
 use fluree_db_core::{ContentId, Flake, FlakeMeta, FlakeValue, Sid};
-use fluree_db_novelty::{Commit, CommitRef};
+use fluree_db_novelty::Commit;
 use fluree_db_server::config::{AdminAuthMode, DataAuthMode, EventsAuthMode};
 use fluree_db_server::{routes::build_router, AppState, ServerConfig, TelemetryConfig};
 use fluree_vocab::namespaces::{FLUREE_DB, XSD};
@@ -54,7 +54,7 @@ fn json_contains_string(v: &JsonValue, needle: &str) -> bool {
 fn make_commit_bytes(t: i64, previous: Option<&ContentId>, flakes: Vec<Flake>) -> Vec<u8> {
     let mut c = Commit::new(t, flakes);
     if let Some(prev_cid) = previous {
-        c = c.with_previous_ref(CommitRef::new(prev_cid.clone()));
+        c = c.with_previous_ref(prev_cid.clone());
     }
     let res = fluree_db_core::commit::codec::write_commit(&c, true, None).expect("write_commit");
     res.bytes

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -309,7 +309,9 @@ async fn create_branch_at_historical_t() {
                 .method("POST")
                 .uri("/v1/fluree/create")
                 .header("content-type", "application/json")
-                .body(Body::from(serde_json::json!({"ledger": "hist:main"}).to_string()))
+                .body(Body::from(
+                    serde_json::json!({"ledger": "hist:main"}).to_string(),
+                ))
                 .unwrap(),
         )
         .await
@@ -374,10 +376,7 @@ async fn create_branch_at_historical_t() {
         Some(2),
         "historical branch should be at t=2, got: {json}"
     );
-    assert_eq!(
-        json.get("source").and_then(|v| v.as_str()),
-        Some("main")
-    );
+    assert_eq!(json.get("source").and_then(|v| v.as_str()), Some("main"));
 
     // Bad `at` value surfaces as 400
     let bad = serde_json::json!({

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -297,6 +297,109 @@ async fn insert_then_query_finds_value() {
 }
 
 #[tokio::test]
+async fn create_branch_at_historical_t() {
+    let (_tmp, state) = test_state().await;
+    let app = build_router(state.clone());
+
+    // Create the ledger
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::json!({"ledger": "hist:main"}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // Three inserts → commits at t=1, t=2, t=3
+    for i in 1..=3 {
+        let body = serde_json::json!({
+            "@context": {"ex": "http://example.org/"},
+            "@id": format!("ex:item{i}"),
+            "ex:val": i,
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/fluree/insert")
+                    .header("content-type", "application/json")
+                    .header("fluree-ledger", "hist:main")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, json) = json_body(resp).await;
+        assert_eq!(status, StatusCode::OK, "insert {i} failed: {json}");
+        assert_eq!(
+            json.get("t").and_then(serde_json::Value::as_i64),
+            Some(i),
+            "insert {i} should have t={i}"
+        );
+    }
+
+    // Branch at t=2
+    let branch_body = serde_json::json!({
+        "ledger": "hist",
+        "branch": "historical",
+        "at": "t:2",
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/branch")
+                .header("content-type", "application/json")
+                .body(Body::from(branch_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::CREATED, "branch create failed: {json}");
+    assert_eq!(
+        json.get("ledger_id").and_then(|v| v.as_str()),
+        Some("hist:historical")
+    );
+    assert_eq!(
+        json.get("t").and_then(serde_json::Value::as_i64),
+        Some(2),
+        "historical branch should be at t=2, got: {json}"
+    );
+    assert_eq!(
+        json.get("source").and_then(|v| v.as_str()),
+        Some("main")
+    );
+
+    // Bad `at` value surfaces as 400
+    let bad = serde_json::json!({
+        "ledger": "hist",
+        "branch": "bad",
+        "at": "t:notanumber",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/branch")
+                .header("content-type", "application/json")
+                .body(Body::from(bad.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn ledger_with_slash_works_via_op_prefixed_routes() {
     let (_tmp, state) = test_state().await;
     let app = build_router(state.clone());

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -54,7 +54,7 @@ fn json_contains_string(v: &JsonValue, needle: &str) -> bool {
 fn make_commit_bytes(t: i64, previous: Option<&ContentId>, flakes: Vec<Flake>) -> Vec<u8> {
     let mut c = Commit::new(t, flakes);
     if let Some(prev_cid) = previous {
-        c = c.with_previous_ref(prev_cid.clone());
+        c = c.with_parent(prev_cid.clone());
     }
     let res = fluree_db_core::commit::codec::write_commit(&c, true, None).expect("write_commit");
     res.bytes

--- a/fluree-db-storage-aws/src/dynamodb/mod.rs
+++ b/fluree-db-storage-aws/src/dynamodb/mod.rs
@@ -532,8 +532,10 @@ impl NameService for DynamoDbNameService {
         ledger_name: &str,
         new_branch: &str,
         source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
     ) -> std::result::Result<(), NameServiceError> {
-        // Look up the source branch to get its commit head.
+        // Look up the source branch to validate it exists (and to get commit
+        // info when `at_commit` is None).
         let source_id = format_ledger_id(ledger_name, source_branch);
         let source_record = self.lookup(&source_id).await?.ok_or_else(|| {
             NameServiceError::not_found(format!(
@@ -541,10 +543,17 @@ impl NameService for DynamoDbNameService {
             ))
         })?;
 
-        let commit_id = source_record.commit_head_id.ok_or_else(|| {
-            NameServiceError::storage(format!("Source branch {source_id} has no commit head"))
-        })?;
-        let commit_t = source_record.commit_t;
+        let (commit_id, commit_t) = match at_commit {
+            Some((id, t)) => (id, t),
+            None => {
+                let id = source_record.commit_head_id.ok_or_else(|| {
+                    NameServiceError::storage(format!(
+                        "Source branch {source_id} has no commit head"
+                    ))
+                })?;
+                (id, source_record.commit_t)
+            }
+        };
 
         let pk = format_ledger_id(ledger_name, new_branch);
         let now = Self::now_epoch_ms().to_string();

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -12,7 +12,7 @@ use fluree_db_core::{ContentId, ContentKind, ContentStore, DictNovelty, Flake, T
 use fluree_db_ledger::{IndexConfig, LedgerState, LedgerView};
 use fluree_db_nameservice::{CasResult, NameService, RefKind, RefPublisher, RefValue};
 use fluree_db_novelty::{generate_commit_flakes, stamp_graph_on_commit_flakes};
-use fluree_db_novelty::{Commit, CommitRef, SigningKey, TxnMetaEntry, TxnMetaValue, TxnSignature};
+use fluree_db_novelty::{Commit, SigningKey, TxnMetaEntry, TxnMetaValue, TxnSignature};
 use fluree_db_query::BinaryRangeProvider;
 use std::sync::Arc;
 use tracing::Instrument;
@@ -501,12 +501,11 @@ where
 
             // Build previous commit reference from the head commit's ContentId.
             if let Some(cid) = head_commit_id.clone() {
-                commit_record = commit_record.with_previous_ref(CommitRef::new(cid));
+                commit_record = commit_record.with_previous_ref(cid);
             }
             // Append additional merge parent references.
             for merge_parent in &merge_parents {
-                commit_record =
-                    commit_record.with_previous_ref(CommitRef::new(merge_parent.clone()));
+                commit_record = commit_record.with_previous_ref(merge_parent.clone());
             }
 
             // 7. Content-address + write (storage-owned)

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -9,7 +9,7 @@ use crate::raw_txn_upload::PendingRawTxnUpload;
 use chrono::Utc;
 use fluree_db_binary_index::BinaryIndexStore;
 use fluree_db_core::{ContentId, ContentKind, ContentStore, DictNovelty, Flake, TXN_META_GRAPH_ID};
-use fluree_db_ledger::{IndexConfig, LedgerState, LedgerView};
+use fluree_db_ledger::{IndexConfig, LedgerState, StagedLedger};
 use fluree_db_nameservice::{CasResult, NameService, RefKind, RefPublisher, RefValue};
 use fluree_db_novelty::{generate_commit_flakes, stamp_graph_on_commit_flakes};
 use fluree_db_novelty::{Commit, SigningKey, TxnMetaEntry, TxnMetaValue, TxnSignature};
@@ -287,7 +287,7 @@ impl CommitOpts {
 ///
 /// A tuple of (CommitReceipt, new LedgerState)
 pub async fn commit<C, N>(
-    view: LedgerView,
+    view: StagedLedger,
     mut ns_registry: NamespaceRegistry,
     content_store: &C,
     nameservice: &N,

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -890,9 +890,10 @@ mod tests {
             ledger_name: &str,
             new_branch: &str,
             source_branch: &str,
+            at_commit: Option<(fluree_db_core::ContentId, i64)>,
         ) -> fluree_db_nameservice::Result<()> {
             self.inner
-                .create_branch(ledger_name, new_branch, source_branch)
+                .create_branch(ledger_name, new_branch, source_branch, at_commit)
                 .await
         }
 

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -98,7 +98,7 @@ pub struct CommitOpts {
     pub skip_sequencing: bool,
     /// Additional parent commit IDs for merge commits.
     ///
-    /// When non-empty, these are appended as extra `previous_refs` on the
+    /// When non-empty, these are appended as extra `parents` on the
     /// commit record, producing a multi-parent (merge) commit. The primary
     /// parent is still derived from `base.head_commit_id`.
     pub merge_parents: Vec<ContentId>,
@@ -501,11 +501,11 @@ where
 
             // Build previous commit reference from the head commit's ContentId.
             if let Some(cid) = head_commit_id.clone() {
-                commit_record = commit_record.with_previous_ref(cid);
+                commit_record = commit_record.with_parent(cid);
             }
             // Append additional merge parent references.
             for merge_parent in &merge_parents {
-                commit_record = commit_record.with_previous_ref(merge_parent.clone());
+                commit_record = commit_record.with_parent(merge_parent.clone());
             }
 
             // 7. Content-address + write (storage-owned)

--- a/fluree-db-transact/src/commit_v2/streaming.rs
+++ b/fluree-db-transact/src/commit_v2/streaming.rs
@@ -246,7 +246,7 @@ mod tests {
     fn make_envelope(t: i64) -> CodecEnvelope {
         CodecEnvelope {
             t,
-            previous_refs: Vec::new(),
+            parents: Vec::new(),
             namespace_delta: HashMap::new(),
             txn: None,
             time: None,
@@ -478,7 +478,7 @@ mod tests {
         let prev_cid = ContentId::new(ContentKind::Commit, b"prev-commit-bytes");
         let envelope = CodecEnvelope {
             t: 5,
-            previous_refs: vec![prev_cid.clone()],
+            parents: vec![prev_cid.clone()],
             namespace_delta: HashMap::from([(200, "ex:".to_string())]),
             txn: None,
             time: Some("2024-01-01T00:00:00Z".into()),
@@ -492,7 +492,7 @@ mod tests {
         let decoded = read_commit(&result.bytes).unwrap();
 
         assert_eq!(decoded.t, 5);
-        assert_eq!(decoded.previous_refs.first().unwrap(), &prev_cid);
+        assert_eq!(decoded.parents.first().unwrap(), &prev_cid);
         assert_eq!(decoded.namespace_delta.get(&200), Some(&"ex:".to_string()));
         assert_eq!(decoded.time.as_deref(), Some("2024-01-01T00:00:00Z"));
     }

--- a/fluree-db-transact/src/commit_v2/streaming.rs
+++ b/fluree-db-transact/src/commit_v2/streaming.rs
@@ -469,7 +469,6 @@ mod tests {
     #[test]
     fn test_streaming_envelope_fields() {
         use fluree_db_core::{ContentId, ContentKind};
-        use fluree_db_novelty::CommitRef;
 
         let mut writer = StreamingCommitWriter::new(true).unwrap();
         writer
@@ -479,7 +478,7 @@ mod tests {
         let prev_cid = ContentId::new(ContentKind::Commit, b"prev-commit-bytes");
         let envelope = CodecEnvelope {
             t: 5,
-            previous_refs: vec![CommitRef::new(prev_cid.clone())],
+            previous_refs: vec![prev_cid.clone()],
             namespace_delta: HashMap::from([(200, "ex:".to_string())]),
             txn: None,
             time: Some("2024-01-01T00:00:00Z".into()),
@@ -493,7 +492,7 @@ mod tests {
         let decoded = read_commit(&result.bytes).unwrap();
 
         assert_eq!(decoded.t, 5);
-        assert_eq!(decoded.previous_refs.first().unwrap().id, prev_cid);
+        assert_eq!(decoded.previous_refs.first().unwrap(), &prev_cid);
         assert_eq!(decoded.namespace_delta.get(&200), Some(&"ex:".to_string()));
         assert_eq!(decoded.time.as_deref(), Some("2024-01-01T00:00:00Z"));
     }

--- a/fluree-db-transact/src/commit_v2/writer.rs
+++ b/fluree-db-transact/src/commit_v2/writer.rs
@@ -263,14 +263,14 @@ mod tests {
             5,
         );
         let prev_cid = ContentId::new(ContentKind::Commit, b"prev-commit-bytes");
-        commit.previous_refs = vec![prev_cid.clone()];
+        commit.parents = vec![prev_cid.clone()];
         commit.namespace_delta = HashMap::from([(200, "ex:".to_string())]);
 
         let result = write_commit(&commit, false, None).unwrap();
         let envelope = read_commit_envelope(&result.bytes).unwrap();
 
         assert_eq!(envelope.t, 5);
-        assert_eq!(envelope.previous_refs.first().unwrap(), &prev_cid);
+        assert_eq!(envelope.parents.first().unwrap(), &prev_cid);
         assert_eq!(envelope.namespace_delta.get(&200), Some(&"ex:".to_string()));
     }
 

--- a/fluree-db-transact/src/commit_v2/writer.rs
+++ b/fluree-db-transact/src/commit_v2/writer.rs
@@ -14,7 +14,7 @@ mod tests {
     use super::*;
     use fluree_db_core::commit::codec::{read_commit, read_commit_envelope, MAGIC};
     use fluree_db_core::{ContentId, ContentKind, Flake, FlakeMeta, FlakeValue, Sid};
-    use fluree_db_novelty::{Commit, CommitRef};
+    use fluree_db_novelty::Commit;
     use std::collections::HashMap;
 
     fn make_test_commit(flakes: Vec<Flake>, t: i64) -> Commit {
@@ -263,14 +263,14 @@ mod tests {
             5,
         );
         let prev_cid = ContentId::new(ContentKind::Commit, b"prev-commit-bytes");
-        commit.previous_refs = vec![CommitRef::new(prev_cid.clone())];
+        commit.previous_refs = vec![prev_cid.clone()];
         commit.namespace_delta = HashMap::from([(200, "ex:".to_string())]);
 
         let result = write_commit(&commit, false, None).unwrap();
         let envelope = read_commit_envelope(&result.bytes).unwrap();
 
         assert_eq!(envelope.t, 5);
-        assert_eq!(envelope.previous_refs.first().unwrap().id, prev_cid);
+        assert_eq!(envelope.previous_refs.first().unwrap(), &prev_cid);
         assert_eq!(envelope.namespace_delta.get(&200), Some(&"ex:".to_string()));
     }
 

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -23,10 +23,10 @@ mod inner {
     use crate::parse::trig_meta::{parse_trig_phase1, resolve_trig_meta, RawObject, RawTerm};
     use crate::value_convert::convert_string_literal;
     use fluree_db_core::ns_encoding::NsSplitMode;
+    use fluree_db_core::CommitId;
     use fluree_db_core::{
         ContentAddressedWrite, ContentId, ContentKind, Flake, FlakeMeta, FlakeValue, Sid,
     };
-    use fluree_db_core::CommitId;
 
     /// Returns `Some(mode)` for the genesis commit (no parent), `None` otherwise.
     /// The split mode is only persisted in the genesis commit envelope.

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -26,7 +26,7 @@ mod inner {
     use fluree_db_core::{
         ContentAddressedWrite, ContentId, ContentKind, Flake, FlakeMeta, FlakeValue, Sid,
     };
-    use fluree_db_novelty::CommitRef;
+    use fluree_db_core::CommitId;
 
     /// Returns `Some(mode)` for the genesis commit (no parent), `None` otherwise.
     /// The split mode is only persisted in the genesis commit envelope.
@@ -47,7 +47,7 @@ mod inner {
         /// Current transaction number. Starts at 0; first chunk produces t=1.
         pub t: i64,
         /// Reference to the previous commit (address + id).
-        pub previous_ref: Option<CommitRef>,
+        pub previous_ref: Option<CommitId>,
         /// Namespace registry (accumulates across chunks).
         pub ns_registry: NamespaceRegistry,
         /// Cumulative flake count across all commits (for progress reporting).
@@ -228,7 +228,7 @@ mod inner {
 
         // 8. Advance state
         state.t = new_t;
-        state.previous_ref = Some(CommitRef::new(commit_cid.clone()));
+        state.previous_ref = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,
@@ -361,7 +361,7 @@ mod inner {
         );
 
         state.t = new_t;
-        state.previous_ref = Some(CommitRef::new(commit_cid.clone()));
+        state.previous_ref = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,
@@ -582,7 +582,7 @@ mod inner {
 
         // 9. Advance state
         state.t = new_t;
-        state.previous_ref = Some(CommitRef::new(commit_cid.clone()));
+        state.previous_ref = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,
@@ -1014,7 +1014,7 @@ mod inner {
         );
 
         state.t = new_t;
-        state.previous_ref = Some(CommitRef::new(commit_cid.clone()));
+        state.previous_ref = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -31,7 +31,7 @@ mod inner {
     /// Returns `Some(mode)` for the genesis commit (no parent), `None` otherwise.
     /// The split mode is only persisted in the genesis commit envelope.
     fn genesis_split_mode(state: &ImportState, mode: NsSplitMode) -> Option<NsSplitMode> {
-        if state.previous_ref.is_none() {
+        if state.parent.is_none() {
             Some(mode)
         } else {
             None
@@ -47,7 +47,7 @@ mod inner {
         /// Current transaction number. Starts at 0; first chunk produces t=1.
         pub t: i64,
         /// Reference to the previous commit (address + id).
-        pub previous_ref: Option<CommitId>,
+        pub parent: Option<CommitId>,
         /// Namespace registry (accumulates across chunks).
         pub ns_registry: NamespaceRegistry,
         /// Cumulative flake count across all commits (for progress reporting).
@@ -72,7 +72,7 @@ mod inner {
         pub fn new() -> Self {
             Self {
                 t: 0,
-                previous_ref: None,
+                parent: None,
                 ns_registry: NamespaceRegistry::new(),
                 cumulative_flakes: 0,
                 import_time: chrono::Utc::now().to_rfc3339(),
@@ -188,7 +188,7 @@ mod inner {
 
             let envelope = CodecEnvelope {
                 t: new_t,
-                previous_refs: state.previous_ref.clone().into_iter().collect(),
+                parents: state.parent.clone().into_iter().collect(),
                 namespace_delta: ns_delta,
                 txn: None,
                 time: Some(state.import_time.clone()),
@@ -228,7 +228,7 @@ mod inner {
 
         // 8. Advance state
         state.t = new_t;
-        state.previous_ref = Some(commit_cid.clone());
+        state.parent = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,
@@ -324,7 +324,7 @@ mod inner {
 
             let envelope = CodecEnvelope {
                 t: new_t,
-                previous_refs: state.previous_ref.clone().into_iter().collect(),
+                parents: state.parent.clone().into_iter().collect(),
                 namespace_delta: ns_delta,
                 txn: None,
                 time: Some(state.import_time.clone()),
@@ -361,7 +361,7 @@ mod inner {
         );
 
         state.t = new_t;
-        state.previous_ref = Some(commit_cid.clone());
+        state.parent = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,
@@ -543,7 +543,7 @@ mod inner {
 
         let envelope = CodecEnvelope {
             t: new_t,
-            previous_refs: state.previous_ref.clone().into_iter().collect(),
+            parents: state.parent.clone().into_iter().collect(),
             namespace_delta: ns_delta,
             txn: None,
             time: Some(state.import_time.clone()),
@@ -582,7 +582,7 @@ mod inner {
 
         // 9. Advance state
         state.t = new_t;
-        state.previous_ref = Some(commit_cid.clone());
+        state.parent = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,
@@ -986,7 +986,7 @@ mod inner {
 
         let envelope = CodecEnvelope {
             t: new_t,
-            previous_refs: state.previous_ref.clone().into_iter().collect(),
+            parents: state.parent.clone().into_iter().collect(),
             namespace_delta: ns_delta,
             txn: None,
             time: Some(state.import_time.clone()),
@@ -1014,7 +1014,7 @@ mod inner {
         );
 
         state.t = new_t;
-        state.previous_ref = Some(commit_cid.clone());
+        state.parent = Some(commit_cid.clone());
 
         Ok(ImportCommitResult {
             commit_id: commit_cid,

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -739,7 +739,7 @@ mod inner {
         fn make_envelope(t: i64) -> crate::commit_v2::CodecEnvelope {
             crate::commit_v2::CodecEnvelope {
                 t,
-                previous_refs: Vec::new(),
+                parents: Vec::new(),
                 namespace_delta: HashMap::new(),
                 txn: None,
                 time: None,

--- a/fluree-db-transact/src/lib.rs
+++ b/fluree-db-transact/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate provides:
 //! - Transaction parsing (JSON-LD → IR)
 //! - Flake generation from templates
-//! - Staging (creates a `LedgerView` with uncommitted changes)
+//! - Staging (creates a `StagedLedger` with uncommitted changes)
 //! - Commit (persists to storage and publishes to nameservice)
 //!
 //! ## Transaction Types

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -17,7 +17,7 @@ use crate::namespace::NamespaceRegistry;
 use fluree_db_core::OverlayProvider;
 use fluree_db_core::Tracker;
 use fluree_db_core::{Flake, FlakeValue, GraphId, Sid};
-use fluree_db_ledger::{IndexConfig, LedgerState, LedgerView};
+use fluree_db_ledger::{IndexConfig, LedgerState, StagedLedger};
 use fluree_db_policy::{
     is_schema_flake, populate_class_cache, PolicyContext, PolicyDecision, PolicyError,
 };
@@ -133,7 +133,7 @@ impl<'a> StageOptions<'a> {
 /// 3. Generates retractions from DELETE templates with those bindings
 /// 4. Generates assertions from INSERT templates with those bindings
 /// 5. Applies cancellation (matching assertion/retraction pairs cancel out)
-/// 6. Returns a LedgerView with the staged flakes
+/// 6. Returns a StagedLedger with the staged flakes
 ///
 /// # Arguments
 ///
@@ -176,7 +176,7 @@ pub async fn stage(
     mut txn: Txn,
     mut ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
-) -> Result<(LedgerView, NamespaceRegistry)> {
+) -> Result<(StagedLedger, NamespaceRegistry)> {
     let span = tracing::debug_span!("txn_stage",
         current_t = ledger.t(),
         txn_type = ?txn.txn_type,
@@ -412,7 +412,7 @@ pub async fn stage(
         );
 
         Ok((
-            LedgerView::stage(ledger, flakes, &reverse_graph)?,
+            StagedLedger::new(ledger, flakes, &reverse_graph)?,
             ns_registry,
         ))
     }
@@ -441,7 +441,7 @@ pub async fn stage_flakes(
     ledger: LedgerState,
     flakes: Vec<Flake>,
     options: StageOptions<'_>,
-) -> Result<LedgerView> {
+) -> Result<StagedLedger> {
     let span = tracing::debug_span!("stage_flakes", flake_count = flakes.len());
     async move {
         // 1. Backpressure check
@@ -498,7 +498,7 @@ pub async fn stage_flakes(
         }
 
         tracing::info!(flake_count = flakes.len(), "stage_flakes completed");
-        Ok(LedgerView::stage(ledger, flakes, &reverse_graph)?)
+        Ok(StagedLedger::new(ledger, flakes, &reverse_graph)?)
     }
     .instrument(span)
     .await
@@ -1512,7 +1512,7 @@ fn query_novelty_for_graph(
 ///
 /// # Returns
 ///
-/// Returns `(LedgerView, NamespaceRegistry)` if staging and validation succeed.
+/// Returns `(StagedLedger, NamespaceRegistry)` if staging and validation succeed.
 /// Returns `TransactError::ShaclViolation` if SHACL validation fails.
 #[cfg(feature = "shacl")]
 pub async fn stage_with_shacl(
@@ -1521,7 +1521,7 @@ pub async fn stage_with_shacl(
     ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
     shacl_cache: &ShaclCache,
-) -> Result<(LedgerView, NamespaceRegistry)> {
+) -> Result<(StagedLedger, NamespaceRegistry)> {
     // Capture graph_delta + tracker before stage() consumes the options/txn.
     let graph_delta = txn.graph_delta.clone();
     let tracker = options.tracker;
@@ -1589,7 +1589,7 @@ impl ShaclValidationOutcome {
     }
 }
 
-/// Validate a staged [`LedgerView`] against SHACL shapes.
+/// Validate a staged [`StagedLedger`] against SHACL shapes.
 ///
 /// `graph_sids` provides the `GraphId → Sid` mapping for per-graph validation.
 /// Pass `None` when the mapping is unavailable (e.g., commit-transfer path
@@ -1607,7 +1607,7 @@ impl ShaclValidationOutcome {
 /// The caller decides whether to propagate an error, log warnings, or both.
 #[cfg(feature = "shacl")]
 pub async fn validate_view_with_shacl(
-    view: &LedgerView,
+    view: &StagedLedger,
     shacl_cache: &ShaclCache,
     graph_sids: Option<&HashMap<GraphId, Sid>>,
     tracker: Option<&fluree_db_core::Tracker>,
@@ -1662,7 +1662,7 @@ pub async fn validate_view_with_shacl(
 /// the default graph (g_id=0) — matching the previous behavior.
 #[cfg(feature = "shacl")]
 async fn validate_staged_nodes(
-    view: &LedgerView,
+    view: &StagedLedger,
     engine: &ShaclEngine,
     graph_sids: Option<&HashMap<GraphId, Sid>>,
     tracker: Option<&fluree_db_core::Tracker>,


### PR DESCRIPTION
## Summary

Adds support for creating a branch at any historical commit on the source branch, not just its current HEAD. Exposed through the Rust API (`Fluree::create_branch`), the CLI (`fluree branch create --at <ref>`), and the HTTP endpoint (`POST /v1/fluree/branch` with an `at` field). Includes several supporting refactors in the commit, ledger, and nameservice layers that the feature builds on top of.

## Motivation

Today, a new branch always starts at the source branch's current HEAD. This PR lets callers branch at an earlier point — useful for recovering to a known-good state, forking off an older release, or running what-if experiments from a past transaction. The commit must still be reachable from the source branch's HEAD (branching from unrelated history is rejected).

## What's in this PR

### Feature: historical commit branching

A new `CommitRef` enum in `fluree-db-api::ledger_view` describes the three user-facing ways to identify a commit — an exact `CommitId`, a hex-digest prefix (with optional `fluree:commit:` / `sha256:` prefix stripping), or a transaction number `t`. `CommitRef::parse` produces the right variant from a user-supplied string, including multibase CID strings (e.g., `"bafybei…"`) which skip the lookup and go straight to `Exact`.

`LedgerView::resolve_commit` turns a `CommitRef` into a canonical `CommitId` against the view's indexes and novelty overlay. The `T` and `Prefix` resolvers (moved out of `graph_commit_builder.rs` since they're now shared) both detect ambiguity — if a rebased ledger has multiple commits at the same `t`, the user gets an actionable error rather than a silent wrong answer.

`Fluree::create_branch` gains a fourth parameter `source_commit: Option<CommitRef>`:
- `None` (default) → behaves exactly as before: branch starts at the source's HEAD and inherits its index (copied into the new branch's namespace).
- `Some(ref)` → the ref is resolved, verified to be an ancestor of the source HEAD via a parent-walk, and becomes the new branch's starting commit. The index is **not** copied (the source's index reflects its current HEAD, not the historical branch point); the new branch replays from genesis on first query.

A `CommitRef` that resolves to the source HEAD is collapsed to the `None` path so `--at <head-cid>` still produces an index copy rather than silently producing a slower branch than omitting `--at`.

The nameservice `create_branch` trait method gains an `at_commit: Option<(ContentId, i64)>` parameter. `None` uses the source record's head info as before; `Some((cid, t))` uses the caller-supplied pair (ancestry verification is the caller's responsibility). All implementations (`file`, `memory`, `storage_ns`, `dynamodb`, `notifying`, `proxy`) are updated.

### Refactors bundled in

**`CommitRef` struct → `CommitId` alias.** The old `CommitRef { id: ContentId }` wrapper provided no value beyond what `ContentId` already offered. It's removed; the new public `CommitRef` name is reused by the enum. Wire format is preserved — the flag bit (`0x02`) and the length-prefixed CID encoding are unchanged; only internal symbol names shift (`FLAG_PREVIOUS_REF` → `FLAG_PARENT`, `encode_commit_ref` → `encode_commit_id`). Old commits deserialize fine.

**`previous_refs` → `parents`.** On both `Commit` and `CommitEnvelope`, `Vec<CommitRef>` becomes `Vec<CommitId>`. Method renames: `with_previous_ref` → `with_parent`, `previous_refs` → `parents`. Terminology now matches standard DAG vocabulary.

**`LedgerView` / `StagedLedger` naming swap.** Two types were previously both called `LedgerView`, one in `fluree-db-ledger` (staged-transaction overlay) and a related concept (`CachedLedgerState`) in `fluree-db-api`. Post-rename:
- `fluree-db-ledger::StagedLedger` = base + staged flakes, queryable before commit.
- `fluree-db-api::LedgerView` = read-only snapshot of a ledger at a point in time (Arc-shared fields, safe to hold across `.await`, owns `resolve_commit`).

The two concepts are now clearly distinct and the common `LedgerView` name goes to the snapshot type that user code actually interacts with.

**Tracking record field renames.** `TrackingRecord.commit_ref` / `index_ref` → `commit_head` / `index_head`, matching the `head_commit_id` / `head_index_id` naming in `LedgerView`.

**HTTP handler renames.** `push_commit_ref` / `push_index_ref` → `push_commit_head` / `push_index_head` for the `/nameservice/refs/:alias/{commit,index}` endpoints.

## Public API changes

### Rust

```rust
// New
pub enum CommitRef {
    Exact(CommitId),
    Prefix(String),
    T(i64),
}

impl CommitRef {
    pub fn parse(s: &str) -> Result<Self>;
}

pub struct LedgerView { /* ... */ }
impl LedgerView {
    pub async fn resolve_commit(&self, commit_ref: CommitRef) -> Result<CommitId>;
    pub fn ledger_id(&self) -> Option<&str>;
    pub fn name(&self) -> Option<&str>;
    pub fn index_t(&self) -> i64;
    pub fn to_ledger_state(self) -> LedgerState;
}

// Changed signature — existing callers pass `None` for the new parameter
pub async fn Fluree::create_branch(
    &self,
    ledger_name: &str,
    new_branch: &str,
    source_branch: Option<&str>,
    source_commit: Option<CommitRef>,  // NEW
) -> Result<NsRecord>;

// Changed trait (NameService) — new parameter
async fn create_branch(
    &self,
    ledger_name: &str,
    new_branch: &str,
    source_branch: &str,
    at_commit: Option<(ContentId, i64)>,  // NEW
) -> Result<()>;

// Renamed
fluree_db_ledger::LedgerView → fluree_db_ledger::StagedLedger
LedgerView::stage(...) → StagedLedger::new(...)
fluree_db_api::CachedLedgerState → fluree_db_api::LedgerView
Commit::with_previous_ref(CommitRef) → Commit::with_parent(CommitId)
Commit.previous_refs: Vec<CommitRef> → Commit.parents: Vec<CommitId>
CommitEnvelope.previous_refs → CommitEnvelope.parents
TrackingRecord.commit_ref → TrackingRecord.commit_head
TrackingRecord.index_ref → TrackingRecord.index_head

// Removed (public)
pub struct CommitRef { pub id: ContentId }  // zero-value wrapper, replaced by CommitId alias
```

### HTTP

```
POST /v1/fluree/branch
{
  "ledger": "mydb",
  "branch": "feature-x",
  "source": "main",          // optional, defaults to "main"
  "at": "t:5"                // NEW: optional; accepts "t:N", hex prefix, or full CID
}
```

Status codes:
- `201 Created` — branch created.
- `400 Bad Request` — malformed `at` value (e.g., `"t:notanumber"`).
- `404 Not Found` — source branch missing, or `at` commit not reachable from source HEAD.
- `409 Conflict` — branch already exists.

### CLI

```
fluree branch create <NAME> [--from <BRANCH>] [--at <COMMIT-REF>]
```

`--at` accepts the same forms as the HTTP `at` field. Examples:

```bash
fluree branch create rewind --at t:5
fluree branch create rewind --at 3dd028a7
fluree branch create rewind --at bafybei...
```

## Design decisions worth calling out

**Historical branches replay from genesis.** The source's current index reflects its current HEAD, which is strictly newer than the historical branch point. Pointing the new branch at it would give queries the wrong answers. Copying a matching historical index snapshot isn't free (and isn't always possible — old index roots may have been GC'd), so the design ships a conservative "no index, replay from genesis" strategy. Acceptable for small/medium histories; if replay cost matters for a given workload, a no-op transaction on the new branch forces an index rebuild.

**Ancestry is verified before touching the nameservice.** `verify_ancestor` walks parents backward from the source HEAD using `collect_dag_cids` with a stop condition of `target.t - 1`, checking that the resolved commit appears in the walk. Short-circuits on `source_head == target`. Only loads the target commit's envelope (not its flakes) since we just need `t`.

**`CommitRef::T` detects ambiguity.** A rebased ledger leaves flakes from both the old and new chains in the POST index, so a naive "return the first match" resolver would silently return either commit — leading to a downstream "not an ancestor" error that doesn't point at the actual problem. The resolver now mirrors the prefix resolver's 0/1/N logic and returns an explicit ambiguous error pointing the user at using a full CID.

**Resolver is novelty-aware.** Both resolvers use `range_*_with_overlay`, so commits from transactions that haven't been indexed yet are still findable — the "commit then immediately branch at t:N" path works without forcing an indexer run.

## Test coverage

New tests:
- `fluree-db-api/tests/it_branch.rs` — four new integration tests covering each `CommitRef` variant (`Exact`, `T`, `Prefix`) at happy path, plus rejection of a non-ancestor commit.
- `fluree-db-server/tests/integration.rs` — new HTTP integration test that drives `POST /v1/fluree/branch` with `"at": "t:2"` and also asserts `400` for `"t:notanumber"`.
- `fluree-db-api/src/ledger_view.rs` — unit test `parse_full_multibase_cid_produces_exact` locking in the parse path for base32-multibase CID strings.

Existing tests in `it_branch.rs`, `it_merge.rs`, `it_rebase.rs`, and `it_tutorial_end_to_end.rs` updated to pass `None` for the new `source_commit` parameter. All 17 `it_branch` tests, the new unit test, and the server integration test pass.

## Backwards compatibility

- **Wire format** — unchanged. Commit blobs written before this branch deserialize identically; the flag bit for parents stayed at `0x02` and the CID encoding stayed the same.
- **Rust API** — `Fluree::create_branch` signature changed. Callers must add a `None` argument. The `NameService` trait gained a parameter; all in-tree impls updated. External impls of `NameService` will need the same update.
- **HTTP API** — the new `at` field is optional; existing clients are unaffected.
- **CLI** — the new `--at` flag is optional; existing invocations are unaffected.
