### PR TITLE
default indexing on and size backpressure to 20% of RAM

### DIFF
--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -200,7 +200,8 @@ cors_enabled = true
 [server.indexing]
 enabled = true
 reindex_min_bytes = 100_000
-reindex_max_bytes = 1_000_000
+# reindex_max_bytes defaults to 20% of system RAM; uncomment to override
+# reindex_max_bytes = 536_870_912  # 512 MB
 ```
 
 For S3/DynamoDB backends, use `connection_config` instead of `storage_path`:

--- a/docs/getting-started/quickstart-server.md
+++ b/docs/getting-started/quickstart-server.md
@@ -262,7 +262,6 @@ services:
     environment:
       FLUREE_STORAGE_PATH: /data
       FLUREE_LOG_LEVEL: info
-      FLUREE_INDEXING_ENABLED: "true"
     volumes:
       - fluree-data:/data
     restart: unless-stopped

--- a/docs/indexing-and-search/background-indexing.md
+++ b/docs/indexing-and-search/background-indexing.md
@@ -137,9 +137,9 @@ Query for ex:alice's properties:
 
 ## Configuration
 
-Background indexing is enabled at the server level, and indexing is triggered based on novelty size thresholds:
+Background indexing is **on by default**. Indexing is triggered based on novelty size thresholds:
 
-- Enable/disable background indexing: `--indexing-enabled` / `FLUREE_INDEXING_ENABLED`
+- Enable/disable background indexing: `--indexing-enabled` / `FLUREE_INDEXING_ENABLED` (default `true`; disable only when a peer/indexer process owns this storage)
 - Trigger threshold (soft): `--reindex-min-bytes` / `FLUREE_REINDEX_MIN_BYTES`
 - Backpressure threshold (hard): `--reindex-max-bytes` / `FLUREE_REINDEX_MAX_BYTES`
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -42,7 +42,8 @@ log_level = "info"
 [server.indexing]
 enabled = true
 reindex_min_bytes = 100000
-reindex_max_bytes = 1000000
+# reindex_max_bytes defaults to 20% of system RAM; override only if needed:
+# reindex_max_bytes = 536870912  # 512 MB
 
 [server.auth.data]
 mode = "required"
@@ -82,16 +83,14 @@ Example `.fluree/config.jsonld`:
     "storage_path": ".fluree/storage",
     "log_level": "info",
     "indexing": {
-      "enabled": false,
-      "reindex_min_bytes": 100000,
-      "reindex_max_bytes": 1000000
+      "enabled": true,
+      "reindex_min_bytes": 100000
     }
   },
   "profiles": {
     "prod": {
       "server": {
-        "log_level": "warn",
-        "indexing": { "enabled": true }
+        "log_level": "warn"
       }
     }
   }
@@ -247,7 +246,7 @@ Example connection config (`connection.jsonld`):
 
 - `--connection-config` and `--storage-path` are mutually exclusive. If both are set, `--connection-config` takes precedence (a warning is logged).
 - Server-level settings (`--cache-max-mb`, `--indexing-enabled`, `--reindex-min-bytes`, `--reindex-max-bytes`) override any equivalent values from the connection config.
-- If `--indexing-enabled` is not explicitly set (defaults to `false`), indexing settings from the connection config are cleared. Set `--indexing-enabled` explicitly if your connection config should control indexing.
+- `--indexing-enabled` defaults to `true`. Pass `--indexing-enabled=false` only when a separate peer/indexer process owns index maintenance for the same storage.
 - AWS credentials and region are resolved via the standard AWS SDK chain (env vars, instance profile, `~/.aws/config`, etc.) — they are not part of the connection config.
 - The connection config can use `envVar` indirection for sensitive fields like S3 bucket names or encryption keys (see [ConfigurationValue](../reference/connection-config-jsonld.md#configurationvalue-env-var-indirection)).
 
@@ -313,17 +312,17 @@ Enable background indexing and configure novelty backpressure thresholds:
 
 | Flag                  | Env Var                    | Default   | Description                                     |
 | --------------------- | -------------------------- | --------- | ----------------------------------------------- |
-| `--indexing-enabled`  | `FLUREE_INDEXING_ENABLED`  | `false`   | Enable background indexing                      |
+| `--indexing-enabled`  | `FLUREE_INDEXING_ENABLED`  | `true`    | Enable background indexing (set `false` only when an external indexer process owns this storage) |
 | `--reindex-min-bytes` | `FLUREE_REINDEX_MIN_BYTES` | `100000`  | Soft threshold (triggers background indexing)   |
-| `--reindex-max-bytes` | `FLUREE_REINDEX_MAX_BYTES` | `1000000` | Hard threshold (blocks commits until reindexed) |
+| `--reindex-max-bytes` | `FLUREE_REINDEX_MAX_BYTES` | 20% of system RAM (256 MB fallback) | Hard threshold (blocks commits until reindexed) |
 
 Config file equivalent:
 
 ```toml
 [server.indexing]
 enabled = true
-reindex_min_bytes = 100000   # 100 KB
-reindex_max_bytes = 1000000  # 1 MB
+reindex_min_bytes = 100000         # 100 KB — soft trigger
+# reindex_max_bytes = 536870912    # 512 MB — defaults to 20% of system RAM if omitted
 ```
 
 ## Server Role Configuration
@@ -744,9 +743,9 @@ fluree server run \
 | `FLUREE_STORAGE_PATH`                   | File storage path                               | `.fluree/storage`                                                       |
 | `FLUREE_CONNECTION_CONFIG`              | JSON-LD connection config file path             | None                                                                    |
 | `FLUREE_CORS_ENABLED`                   | Enable CORS                                     | `true`                                                                  |
-| `FLUREE_INDEXING_ENABLED`               | Enable background indexing                      | `false`                                                                 |
+| `FLUREE_INDEXING_ENABLED`               | Enable background indexing                      | `true`                                                                  |
 | `FLUREE_REINDEX_MIN_BYTES`              | Soft reindex threshold (bytes)                  | `100000`                                                                |
-| `FLUREE_REINDEX_MAX_BYTES`              | Hard reindex threshold (bytes)                  | `1000000`                                                               |
+| `FLUREE_REINDEX_MAX_BYTES`              | Hard reindex threshold (bytes)                  | 20% of system RAM (256 MB fallback)                                      |
 | `FLUREE_CACHE_MAX_MB`                   | Global cache budget (MB)                        | `30/40/50% of RAM (tiered: <4GB / 4-8GB / ≥8GB)`                                                     |
 | `FLUREE_BODY_LIMIT`                     | Max request body bytes                          | `52428800`                                                              |
 | `FLUREE_LOG_LEVEL`                      | Log level                                       | `info`                                                                  |

--- a/fluree-db-api/src/graph_transact_builder.rs
+++ b/fluree-db-api/src/graph_transact_builder.rs
@@ -180,7 +180,10 @@ impl<'a, 'g> GraphTransactBuilder<'a, 'g> {
         let parsed = op.to_json_with_trig_meta()?;
         let txn_json = parsed.json;
         let trig_meta = parsed.trig_meta;
-        let index_config = self.core.index_config.unwrap_or_default();
+        let index_config = self
+            .core
+            .index_config
+            .unwrap_or_else(crate::server_defaults::default_index_config);
 
         // Load the current ledger state
         let ledger_state = self.graph.fluree.ledger(&self.graph.ledger_id).await?;

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1116,13 +1116,17 @@ fn build_local_storage_from_config(
 }
 
 /// Check if background indexing is enabled in the parsed connection config.
+///
+/// Defaults to `true` when not explicitly configured — indexing is core
+/// functionality and should require an explicit opt-out (e.g. a peer/transactor
+/// that delegates indexing to a separate process).
 fn is_indexing_enabled(config: &ConnectionConfig) -> bool {
     config
         .defaults
         .as_ref()
         .and_then(|d| d.indexing.as_ref())
         .and_then(|i| i.indexing_enabled)
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 /// Build IndexerConfig from connection defaults, falling back to defaults.
@@ -1218,6 +1222,23 @@ pub struct IndexingBuilderConfig {
     pub index_config: IndexConfig,
 }
 
+/// Default `IndexingBuilderConfig` for persistent storage (`file`, `s3`, `ipfs`).
+///
+/// Uses [`server_defaults::default_reindex_max_bytes`] for the hard threshold
+/// (20% of RAM), so persistent Fluree instances built programmatically get the
+/// same production-sized backpressure as the server binary. The low-level
+/// `IndexConfig::default()` value (1 MB) is deliberately kept small as a safe
+/// baseline for unit tests and direct library use.
+fn default_indexing_builder_config() -> IndexingBuilderConfig {
+    IndexingBuilderConfig {
+        indexer_config: IndexerConfig::default(),
+        index_config: IndexConfig {
+            reindex_min_bytes: server_defaults::DEFAULT_REINDEX_MIN_BYTES,
+            reindex_max_bytes: server_defaults::default_reindex_max_bytes(),
+        },
+    }
+}
+
 fn make_leaflet_cache(
     config: &fluree_db_connection::ConnectionConfig,
 ) -> std::sync::Arc<fluree_db_binary_index::LeafletCache> {
@@ -1275,6 +1296,12 @@ impl FlureeBuilder {
     /// Configure for file-based storage
     ///
     /// The path should be the root directory containing ledger data.
+    ///
+    /// Background indexing is enabled by default. Call [`without_indexing`] to
+    /// opt out — typically only appropriate when a separate process (peer or
+    /// dedicated indexer) owns index maintenance for this storage.
+    ///
+    /// [`without_indexing`]: FlureeBuilder::without_indexing
     #[cfg(feature = "native")]
     pub fn file(path: impl Into<String>) -> Self {
         let path = path.into();
@@ -1283,7 +1310,7 @@ impl FlureeBuilder {
             storage_path: Some(path),
             encryption_key: None,
             ledger_cache_config: Some(LedgerManagerConfig::default()),
-            indexing_config: None,
+            indexing_config: Some(default_indexing_builder_config()),
             novelty_thresholds: None,
             remote_connections: remote_service::RemoteConnectionRegistry::new(),
         }
@@ -1362,7 +1389,7 @@ impl FlureeBuilder {
             storage_path: None,
             encryption_key: None,
             ledger_cache_config: Some(LedgerManagerConfig::default()),
-            indexing_config: None,
+            indexing_config: Some(default_indexing_builder_config()),
             novelty_thresholds: None,
             remote_connections: remote_service::RemoteConnectionRegistry::new(),
         }
@@ -1611,14 +1638,31 @@ impl FlureeBuilder {
 
     /// Enable background indexing with default settings.
     ///
-    /// When enabled, `build()` will spawn a `BackgroundIndexerWorker` that
+    /// Persistent builders (`file`, `s3`, `ipfs`) enable indexing by default,
+    /// so this is mostly useful after [`without_indexing`] or on the `memory`
+    /// builder. `build()` will spawn a `BackgroundIndexerWorker` that
     /// automatically indexes ledgers when novelty exceeds the soft threshold.
     /// Must be called within a tokio runtime context.
+    ///
+    /// [`without_indexing`]: FlureeBuilder::without_indexing
     pub fn with_indexing(mut self) -> Self {
         self.indexing_config = Some(IndexingBuilderConfig {
             indexer_config: IndexerConfig::default(),
             index_config: IndexConfig::default(),
         });
+        self
+    }
+
+    /// Disable background indexing on this builder.
+    ///
+    /// Persistent builders (`file`, `s3`, `ipfs`) enable indexing by default;
+    /// call this to opt out. The only production reason to do so is when a
+    /// separate process (a peer or dedicated indexer) owns index maintenance
+    /// for the same storage — the transactor writes commits, the other process
+    /// produces the index roots. Running without an indexer anywhere will
+    /// accumulate novelty until the hard ceiling blocks writes.
+    pub fn without_indexing(mut self) -> Self {
+        self.indexing_config = None;
         self
     }
 
@@ -1672,11 +1716,12 @@ impl FlureeBuilder {
     /// Build a file-backed Fluree instance
     ///
     /// Returns an error if storage_path is not set.
-    /// Indexing is disabled by default; call `with_indexing()` before `build()`
-    /// to enable background indexing, or use `set_indexing_mode` after building.
     ///
-    /// When indexing is enabled via `with_indexing()`, a `BackgroundIndexerWorker`
-    /// is spawned on the tokio runtime. This must be called within a tokio context.
+    /// Indexing is enabled by default for `file`-constructed builders; call
+    /// `without_indexing()` to opt out (see that method for when that's
+    /// appropriate). When indexing is enabled, a `BackgroundIndexerWorker` is
+    /// spawned on the tokio runtime, so `build()` must be called within a
+    /// tokio context.
     #[cfg(feature = "native")]
     pub fn build(mut self) -> Result<Fluree> {
         let path = self
@@ -1845,8 +1890,12 @@ impl FlureeBuilder {
 
     /// Build a memory-backed Fluree instance
     ///
-    /// Indexing is disabled by default; use `set_indexing_mode` after building
-    /// to enable background indexing.
+    /// Background indexing is **always disabled** for this builder path
+    /// regardless of `with_indexing()` — memory storage is intended for
+    /// short-lived tests and scratch use where a background worker would
+    /// outlive the `Fluree` handle. Use `set_indexing_mode` after building
+    /// if you need it, or switch to a persistent builder (`file`, `s3`,
+    /// `ipfs`), which enable indexing by default.
     pub fn build_memory(self) -> Fluree {
         let storage = MemoryStorage::new();
         let nameservice = MemoryNameService::new();
@@ -3302,7 +3351,10 @@ mod tests {
     #[test]
     #[cfg(feature = "native")]
     fn test_fluree_builder_file() {
+        // `without_indexing()` keeps this a plain `#[test]` — the default
+        // background indexer would require a tokio runtime.
         let result = FlureeBuilder::file("/tmp/test")
+            .without_indexing()
             .parallelism(8)
             .cache_max_mb(1000)
             .build();

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1167,11 +1167,11 @@ fn derive_index_config(config: &ConnectionConfig) -> IndexConfig {
         reindex_min_bytes: indexing
             .and_then(|i| i.reindex_min_bytes)
             .map(|v| v as usize)
-            .unwrap_or(IndexConfig::default().reindex_min_bytes),
+            .unwrap_or(server_defaults::DEFAULT_REINDEX_MIN_BYTES),
         reindex_max_bytes: indexing
             .and_then(|i| i.reindex_max_bytes)
             .map(|v| v as usize)
-            .unwrap_or(IndexConfig::default().reindex_max_bytes),
+            .unwrap_or_else(server_defaults::default_reindex_max_bytes),
     }
 }
 
@@ -1224,18 +1224,15 @@ pub struct IndexingBuilderConfig {
 
 /// Default `IndexingBuilderConfig` for persistent storage (`file`, `s3`, `ipfs`).
 ///
-/// Uses [`server_defaults::default_reindex_max_bytes`] for the hard threshold
-/// (20% of RAM), so persistent Fluree instances built programmatically get the
-/// same production-sized backpressure as the server binary. The low-level
-/// `IndexConfig::default()` value (1 MB) is deliberately kept small as a safe
-/// baseline for unit tests and direct library use.
+/// Uses [`server_defaults::default_index_config`] for the novelty thresholds
+/// (RAM-tiered hard threshold), so persistent Fluree instances built
+/// programmatically get the same production-sized backpressure as the server
+/// binary. `IndexConfig` itself has no `Default` impl — configuration policy
+/// lives here in the API layer, not in the lower-level `fluree-db-ledger` crate.
 fn default_indexing_builder_config() -> IndexingBuilderConfig {
     IndexingBuilderConfig {
         indexer_config: IndexerConfig::default(),
-        index_config: IndexConfig {
-            reindex_min_bytes: server_defaults::DEFAULT_REINDEX_MIN_BYTES,
-            reindex_max_bytes: server_defaults::default_reindex_max_bytes(),
-        },
+        index_config: server_defaults::default_index_config(),
     }
 }
 
@@ -1646,10 +1643,7 @@ impl FlureeBuilder {
     ///
     /// [`without_indexing`]: FlureeBuilder::without_indexing
     pub fn with_indexing(mut self) -> Self {
-        self.indexing_config = Some(IndexingBuilderConfig {
-            indexer_config: IndexerConfig::default(),
-            index_config: IndexConfig::default(),
-        });
+        self.indexing_config = Some(default_indexing_builder_config());
         self
     }
 
@@ -2168,7 +2162,7 @@ impl FlureeBuilder {
         self.indexing_config
             .as_ref()
             .map(|c| c.index_config.clone())
-            .unwrap_or_default()
+            .unwrap_or_else(server_defaults::default_index_config)
     }
 
     /// Spawn the background indexer worker if configured.
@@ -2550,7 +2544,7 @@ impl Fluree {
             nameservice_mode: nameservice,
             leaflet_cache,
             indexing_mode: tx::IndexingMode::Disabled,
-            index_config: IndexConfig::default(),
+            index_config: server_defaults::default_index_config(),
             r2rml_cache: std::sync::Arc::new(graph_source::R2rmlCache::with_defaults()),
             event_bus: Arc::new(fluree_db_nameservice::LedgerEventBus::new(1024)),
             ledger_manager: None,
@@ -2572,7 +2566,7 @@ impl Fluree {
             nameservice_mode: nameservice,
             leaflet_cache,
             indexing_mode,
-            index_config: IndexConfig::default(),
+            index_config: server_defaults::default_index_config(),
             r2rml_cache: std::sync::Arc::new(graph_source::R2rmlCache::with_defaults()),
             event_bus: Arc::new(fluree_db_nameservice::LedgerEventBus::new(1024)),
             ledger_manager: None,
@@ -3384,14 +3378,9 @@ mod tests {
     fn test_default_index_config_returns_defaults_without_thresholds() {
         let fluree = FlureeBuilder::memory().build_memory();
         let cfg = fluree.default_index_config();
-        assert_eq!(
-            cfg.reindex_min_bytes,
-            IndexConfig::default().reindex_min_bytes
-        );
-        assert_eq!(
-            cfg.reindex_max_bytes,
-            IndexConfig::default().reindex_max_bytes
-        );
+        let expected = server_defaults::default_index_config();
+        assert_eq!(cfg.reindex_min_bytes, expected.reindex_min_bytes);
+        assert_eq!(cfg.reindex_max_bytes, expected.reindex_max_bytes);
     }
 
     #[test]
@@ -3435,14 +3424,9 @@ mod tests {
     fn test_derive_index_config_falls_back_to_defaults() {
         let config = ConnectionConfig::default();
         let idx = derive_index_config(&config);
-        assert_eq!(
-            idx.reindex_min_bytes,
-            IndexConfig::default().reindex_min_bytes
-        );
-        assert_eq!(
-            idx.reindex_max_bytes,
-            IndexConfig::default().reindex_max_bytes
-        );
+        let expected = server_defaults::default_index_config();
+        assert_eq!(idx.reindex_min_bytes, expected.reindex_min_bytes);
+        assert_eq!(idx.reindex_max_bytes, expected.reindex_max_bytes);
     }
 
     // ========================================================================

--- a/fluree-db-api/src/nameservice_query.rs
+++ b/fluree-db-api/src/nameservice_query.rs
@@ -25,7 +25,6 @@
 
 use crate::ledger_info::{gs_record_to_jsonld, ns_record_to_jsonld};
 use crate::{ApiError, FlureeBuilder, GraphDb, Result};
-use fluree_db_ledger::IndexConfig;
 use fluree_db_nameservice::NameService;
 use fluree_db_transact::{CommitOpts, TxnOpts, TxnType};
 use serde_json::{json, Value as JsonValue};
@@ -89,7 +88,7 @@ where
 
     // 7. Insert all records as JSON-LD transaction
     let txn_json = json!({ "@graph": all_records });
-    let index_config = IndexConfig::default();
+    let index_config = crate::server_defaults::default_index_config();
 
     let result = temp_fluree
         .transact(

--- a/fluree-db-api/src/query/nameservice_builder.rs
+++ b/fluree-db-api/src/query/nameservice_builder.rs
@@ -37,7 +37,6 @@ use crate::ledger_info::{gs_record_to_jsonld, ns_record_to_jsonld};
 use crate::query::builder::QueryCore;
 use crate::view::QueryInput;
 use crate::{ApiError, Fluree, GraphDb, Result};
-use fluree_db_ledger::IndexConfig;
 use fluree_db_transact::{CommitOpts, TxnOpts, TxnType};
 use serde_json::json;
 
@@ -264,7 +263,7 @@ impl<'a> NameserviceQueryBuilder<'a> {
 
         // 7. Insert all records as JSON-LD transaction
         let txn_json = json!({ "@graph": all_records });
-        let index_config = IndexConfig::default();
+        let index_config = crate::server_defaults::default_index_config();
 
         let result = temp_fluree
             .transact(

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -17,9 +17,45 @@ pub const DEFAULT_BODY_LIMIT: usize = 52_428_800; // 50 MB
 
 // ── Indexing ────────────────────────────────────────────────────────
 
-pub const DEFAULT_INDEXING_ENABLED: bool = false;
+pub const DEFAULT_INDEXING_ENABLED: bool = true;
 pub const DEFAULT_REINDEX_MIN_BYTES: usize = 100_000;
-pub const DEFAULT_REINDEX_MAX_BYTES: usize = 1_000_000;
+
+/// Fallback hard-threshold when RAM detection is unavailable (WASM, sandbox).
+///
+/// Production defaults use [`default_reindex_max_bytes`], which returns 20%
+/// of detected system RAM. This constant is only used when that detection
+/// fails or on platforms without `sysinfo`.
+pub const DEFAULT_REINDEX_MAX_BYTES_FALLBACK: usize = 256 * 1024 * 1024; // 256 MB
+
+/// Default hard-threshold for novelty backpressure (bytes).
+///
+/// Returns 20% of system RAM on native platforms, with a 256 MB fallback
+/// when detection is unavailable. Novelty is held in memory between index
+/// builds; once it exceeds this threshold, commits block until indexing
+/// catches up. 20% of RAM leaves plenty of headroom for the query cache,
+/// incoming requests, and the indexer itself.
+#[cfg(feature = "native")]
+pub fn default_reindex_max_bytes() -> usize {
+    use sysinfo::{MemoryRefreshKind, System};
+
+    let mut sys = System::new();
+    sys.refresh_memory_specifics(MemoryRefreshKind::everything());
+
+    let total_memory_bytes = sys.total_memory() as usize;
+    if total_memory_bytes == 0 {
+        return DEFAULT_REINDEX_MAX_BYTES_FALLBACK;
+    }
+
+    // 20% of RAM, floored at 64 MB so very small hosts still have a
+    // workable buffer between soft and hard thresholds.
+    (total_memory_bytes / 5).max(64 * 1024 * 1024)
+}
+
+/// Default hard-threshold (WASM/non-native fallback).
+#[cfg(not(feature = "native"))]
+pub fn default_reindex_max_bytes() -> usize {
+    DEFAULT_REINDEX_MAX_BYTES_FALLBACK
+}
 
 // ── Auth ────────────────────────────────────────────────────────────
 
@@ -262,9 +298,9 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
 # cache_max_mb = 4096                    # global cache budget (MB); default: tiered fraction of RAM (30% <4GB, 40% 4-8GB, 50% ≥8GB)
 
 # [server.indexing]
-# enabled = {indexing_enabled}
+# enabled = {indexing_enabled}                    # disable only when a separate peer/indexer owns indexing for this storage
 # reindex_min_bytes = {reindex_min_bytes}         # {reindex_min_kb} KB — triggers background reindexing
-# reindex_max_bytes = {reindex_max_bytes}        # {reindex_max_kb} KB — blocks commits until reindexed
+# reindex_max_bytes = {reindex_max_bytes}      # {reindex_max_mb} MB (default: 20% of system RAM) — blocks commits until reindexed
 
 # [server.auth.events]
 # mode = "{auth_mode}"                      # none, optional, required
@@ -320,10 +356,17 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
 
 # [profiles.prod.server]
 # log_level = "warn"
-# [profiles.prod.server.indexing]
-# enabled = true
 # [profiles.prod.server.auth.data]
 # mode = "required"
+
+# Example: a transaction-only peer that delegates index maintenance to a
+# separate indexer process. Only disable indexing when something else
+# is producing index roots for this storage.
+# [profiles.peer.server.indexing]
+# enabled = false
+# [profiles.peer.server.peer]
+# role = "transaction"
+# tx_server_url = "http://indexer.internal:8090"
 "#,
         listen_addr = DEFAULT_LISTEN_ADDR,
         storage_comment = storage_comment,
@@ -333,8 +376,8 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
         indexing_enabled = DEFAULT_INDEXING_ENABLED,
         reindex_min_bytes = DEFAULT_REINDEX_MIN_BYTES,
         reindex_min_kb = DEFAULT_REINDEX_MIN_BYTES / 1000,
-        reindex_max_bytes = DEFAULT_REINDEX_MAX_BYTES,
-        reindex_max_kb = DEFAULT_REINDEX_MAX_BYTES / 1000,
+        reindex_max_bytes = default_reindex_max_bytes(),
+        reindex_max_mb = default_reindex_max_bytes() / (1024 * 1024),
         auth_mode = DEFAULT_AUTH_MODE,
         jwks_cache_ttl = DEFAULT_JWKS_CACHE_TTL,
         mcp_enabled = DEFAULT_MCP_ENABLED,
@@ -370,7 +413,7 @@ pub fn generate_jsonld_config_template(storage_path_override: Option<&str>) -> S
             "indexing": {
                 "enabled": DEFAULT_INDEXING_ENABLED,
                 "reindex_min_bytes": DEFAULT_REINDEX_MIN_BYTES,
-                "reindex_max_bytes": DEFAULT_REINDEX_MAX_BYTES
+                "reindex_max_bytes": default_reindex_max_bytes()
             },
             "auth": {
                 "events": { "mode": DEFAULT_AUTH_MODE },

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -57,6 +57,18 @@ pub fn default_reindex_max_bytes() -> usize {
     DEFAULT_REINDEX_MAX_BYTES_FALLBACK
 }
 
+/// Canonical default `IndexConfig` for API-layer callers.
+///
+/// Combines [`DEFAULT_REINDEX_MIN_BYTES`] with [`default_reindex_max_bytes`]
+/// so the server, CLI, programmatic `FlureeBuilder`, and any transient
+/// internal callers all resolve the same value.
+pub fn default_index_config() -> fluree_db_ledger::IndexConfig {
+    fluree_db_ledger::IndexConfig {
+        reindex_min_bytes: DEFAULT_REINDEX_MIN_BYTES,
+        reindex_max_bytes: default_reindex_max_bytes(),
+    }
+}
+
 // ── Auth ────────────────────────────────────────────────────────────
 
 pub const DEFAULT_AUTH_MODE: &str = "none";

--- a/fluree-db-api/src/tx_builder.rs
+++ b/fluree-db-api/src/tx_builder.rs
@@ -349,7 +349,11 @@ impl<'a> OwnedTransactBuilder<'a> {
     pub async fn execute(self) -> Result<TransactResult> {
         self.core.validate().map_err(ApiError::Builder)?;
 
-        let index_config = self.core.index_config.unwrap_or_default();
+        let index_config = self
+            .core
+            .index_config
+            .clone()
+            .unwrap_or_else(crate::server_defaults::default_index_config);
 
         // Pre-built Txn IR path (e.g., SPARQL UPDATE lowered to Txn)
         if let Some(txn) = self.core.pre_built_txn {
@@ -506,7 +510,11 @@ impl<'a> OwnedTransactBuilder<'a> {
     pub async fn stage(self) -> Result<Staged> {
         self.core.validate().map_err(ApiError::Builder)?;
 
-        let index_config = self.core.index_config.unwrap_or_default();
+        let index_config = self
+            .core
+            .index_config
+            .clone()
+            .unwrap_or_else(crate::server_defaults::default_index_config);
 
         // Pre-built Txn IR path
         if let Some(txn) = self.core.pre_built_txn {
@@ -745,7 +753,10 @@ pub(crate) async fn commit_with_handle(
 ) -> Result<TransactResultRef> {
     core.validate().map_err(ApiError::Builder)?;
 
-    let index_config = core.index_config.unwrap_or_default();
+    let index_config = core
+        .index_config
+        .clone()
+        .unwrap_or_else(crate::server_defaults::default_index_config);
     let store_raw_txn = core.txn_opts.store_raw_txn.unwrap_or(false);
 
     // Create tracker from builder-level tracking options when present.

--- a/fluree-db-api/tests/it_drop_ledger.rs
+++ b/fluree-db-api/tests/it_drop_ledger.rs
@@ -249,7 +249,7 @@ async fn drop_ledger_cancels_pending_indexing() {
 
             let index_cfg = IndexConfig {
                 reindex_min_bytes: 0,
-                ..Default::default()
+                reindex_max_bytes: 1_000_000_000,
             };
 
             // Make commits to create indexing work

--- a/fluree-db-api/tests/it_import_v3.rs
+++ b/fluree-db-api/tests/it_import_v3.rs
@@ -625,7 +625,10 @@ ex:bob schema:name "Bob" ;
             &delete_data,
             fluree_db_api::TxnOpts::default(),
             fluree_db_api::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .expect("retract should succeed");

--- a/fluree-db-api/tests/it_named_graph_isolation.rs
+++ b/fluree-db-api/tests/it_named_graph_isolation.rs
@@ -619,7 +619,10 @@ async fn push_roundtrip_named_graph_retractions() {
                     &tgt_handle,
                     push_req,
                     &QueryConnectionOptions::default(),
-                    &IndexConfig::default(),
+                    &IndexConfig {
+                        reindex_min_bytes: 100_000,
+                        reindex_max_bytes: 1_000_000_000,
+                    },
                 )
                 .await
                 .expect("push should succeed with named-graph retractions");

--- a/fluree-db-api/tests/it_policy_tracking.rs
+++ b/fluree-db-api/tests/it_policy_tracking.rs
@@ -92,7 +92,10 @@ async fn transact_policy_denied_includes_policy_and_fuel_tracking() {
             ledger,
             input,
             CommitOpts::default(),
-            &IndexConfig::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
     {

--- a/fluree-db-api/tests/it_policy_tx.rs
+++ b/fluree-db-api/tests/it_policy_tx.rs
@@ -142,7 +142,10 @@ async fn modify_policy_allows_own_property() {
             ledger,
             input,
             CommitOpts::default(),
-            &IndexConfig::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await;
 
@@ -260,7 +263,10 @@ async fn modify_policy_denies_other_property() {
             ledger,
             input,
             CommitOpts::default(),
-            &IndexConfig::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await;
 
@@ -343,7 +349,10 @@ async fn view_only_policy_blocks_modify() {
             ledger,
             input,
             CommitOpts::default(),
-            &IndexConfig::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await;
 
@@ -440,7 +449,10 @@ async fn modify_query_always_false_denies() {
             ledger,
             input,
             CommitOpts::default(),
-            &IndexConfig::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await;
 

--- a/fluree-db-api/tests/it_raw_txn_parallel_upload.rs
+++ b/fluree-db-api/tests/it_raw_txn_parallel_upload.rs
@@ -8,7 +8,7 @@
 
 mod support;
 
-use fluree_db_api::{CommitOpts, FlureeBuilder, LedgerState, Novelty};
+use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig, LedgerState, Novelty};
 use fluree_db_core::{commit::codec::read_commit, ContentKind, LedgerSnapshot};
 use fluree_db_transact::{ir::TxnType, TxnOpts as IrTxnOpts};
 use serde_json::{json, Value as JsonValue};
@@ -36,7 +36,10 @@ async fn store_raw_txn_roundtrip_via_parallel_upload() {
     });
 
     let txn_opts = IrTxnOpts::default().store_raw_txn(true);
-    let index_config = fluree_db_api::IndexConfig::default();
+    let index_config = IndexConfig {
+        reindex_min_bytes: 100_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
 
     // If the spawned upload had failed, commit() would have aborted here and
     // this call would return Err.

--- a/fluree-db-api/tests/it_transact.rs
+++ b/fluree-db-api/tests/it_transact.rs
@@ -698,7 +698,10 @@ async fn transact_with_explicit_commit() {
         .commit_staged(
             stage.view,
             stage.ns_registry,
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
             fluree_db_transact::CommitOpts::default(),
         )
         .await

--- a/fluree-db-api/tests/it_transact_object_var.rs
+++ b/fluree-db-api/tests/it_transact_object_var.rs
@@ -67,7 +67,10 @@ async fn object_var_parsing_update_opt() {
                 ..Default::default()
             },
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()
@@ -94,7 +97,10 @@ async fn object_var_parsing_update_opt() {
                 ..Default::default()
             },
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()
@@ -128,7 +134,10 @@ async fn update_with_object_var_parsing_false_treats_bare_var_as_literal() {
                 ..Default::default()
             },
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()
@@ -175,7 +184,10 @@ async fn update_explicit_variable_map_parses_when_flag_false_and_bound() {
                 ..Default::default()
             },
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()
@@ -222,7 +234,10 @@ async fn update_id_var_still_parses_when_flag_false() {
                 ..Default::default()
             },
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()
@@ -270,7 +285,10 @@ async fn update_predicate_var_still_parses_when_flag_false() {
                 ..Default::default()
             },
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()
@@ -464,7 +482,10 @@ async fn update_literal_qmark_string_where_binds_and_updates() {
             &update,
             txn_opts,
             fluree_db_transact::CommitOpts::default(),
-            &fluree_db_ledger::IndexConfig::default(),
+            &fluree_db_ledger::IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap()

--- a/fluree-db-api/tests/it_transact_update.rs
+++ b/fluree-db-api/tests/it_transact_update.rs
@@ -246,7 +246,10 @@ async fn update_where_bound_typed_string_delete_and_insert_use_same_datatype_sid
             &update_txn,
             txn_opts,
             Default::default(),
-            &Default::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .unwrap();
@@ -1888,7 +1891,10 @@ async fn update_values_wildcard_delete_index_plus_novelty() {
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/transact-update:wildcard-delete-indexed";
-    let index_cfg = IndexConfig::default();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 100_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
     let ledger0 = LedgerSnapshot::genesis(ledger_id);
     let ledger0 = LedgerState::new(ledger0, Novelty::new(0));
 
@@ -2016,7 +2022,10 @@ async fn update_wildcard_delete_duplicate_facts_across_index_and_novelty() {
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/transact-update:wildcard-delete-dup-index-novelty";
-    let index_cfg = IndexConfig::default();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 100_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
     let ledger0 = LedgerSnapshot::genesis(ledger_id);
     let ledger0 = LedgerState::new(ledger0, Novelty::new(0));
 
@@ -2143,7 +2152,10 @@ async fn update_values_wildcard_delete_after_updates_and_indexing() {
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/transact-update:wildcard-delete-updates-indexed";
-    let index_cfg = IndexConfig::default();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 100_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
     let ledger0 = LedgerSnapshot::genesis(ledger_id);
     let ledger0 = LedgerState::new(ledger0, Novelty::new(0));
 

--- a/fluree-db-api/tests/it_txn_meta.rs
+++ b/fluree-db-api/tests/it_txn_meta.rs
@@ -9,7 +9,7 @@
 
 mod support;
 
-use fluree_db_api::{FlureeBuilder, LedgerManagerConfig};
+use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerManagerConfig};
 use serde_json::json;
 use std::sync::Arc;
 use support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
@@ -1630,7 +1630,10 @@ async fn test_commit_opts_identity_and_user_claims_in_txn_meta() {
             &data,
             TxnOpts::default(),
             commit_opts,
-            &fluree_db_api::IndexConfig::default(),
+            &IndexConfig {
+                reindex_min_bytes: 100_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
         )
         .await
         .expect("insert with identity + body f:message + body f:author");

--- a/fluree-db-api/tests/support/mod.rs
+++ b/fluree-db-api/tests/support/mod.rs
@@ -12,7 +12,7 @@
 
 pub mod span_capture;
 
-use fluree_db_api::{IndexConfig, LedgerState, Novelty};
+use fluree_db_api::{LedgerState, Novelty};
 use fluree_db_core::LedgerSnapshot;
 use serde_json::{json, Value as JsonValue};
 use std::sync::Arc;
@@ -241,15 +241,18 @@ pub fn start_background_indexer_local(
 // Index config assertions
 // =============================================================================
 
-/// Assert that IndexConfig defaults match expected defaults.
+/// Sanity-check that the soft reindex threshold constant is stable.
 ///
-/// Reindex threshold defaults:
-/// - min: 100_000
-/// - max: 1_000_000
+/// `IndexConfig` no longer has a `Default` impl — configuration policy lives
+/// at the API layer — so this helper only pins the soft-threshold constant
+/// used by production defaults. It's called from many tests as a cheap
+/// guard against accidental constant drift; kept for backward compatibility
+/// with those call sites.
 pub fn assert_index_defaults() {
-    let cfg = IndexConfig::default();
-    assert_eq!(cfg.reindex_min_bytes, 100_000);
-    assert_eq!(cfg.reindex_max_bytes, 1_000_000);
+    assert_eq!(
+        fluree_db_api::server_defaults::DEFAULT_REINDEX_MIN_BYTES,
+        100_000
+    );
 }
 
 // =============================================================================

--- a/fluree-db-cli/src/commands/server.rs
+++ b/fluree-db-cli/src/commands/server.rs
@@ -1029,7 +1029,13 @@ fn print_resolved_config(config: &ServerConfig, dirs: &FlureeDir) {
     eprintln!("  indexing:     {}", config.indexing_enabled);
     if config.indexing_enabled {
         eprintln!("    min_bytes:  {}", config.reindex_min_bytes);
-        eprintln!("    max_bytes:  {}", config.reindex_max_bytes);
+        eprintln!(
+            "    max_bytes:  {}",
+            config
+                .reindex_max_bytes
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "(default: 20% of RAM)".into())
+        );
     }
     eprintln!(
         "  cache_max_mb: {}",

--- a/fluree-db-cli/src/context.rs
+++ b/fluree-db-cli/src/context.rs
@@ -317,8 +317,10 @@ pub fn build_fluree(dirs: &FlureeDir) -> CliResult<Fluree> {
         .unwrap_or(default_config.reindex_min_bytes);
     let max_bytes = thresholds
         .reindex_max_bytes
-        .unwrap_or(default_config.reindex_max_bytes);
-    builder = builder.with_novelty_thresholds(min_bytes, max_bytes);
+        .unwrap_or_else(fluree_db_api::server_defaults::default_reindex_max_bytes);
+    builder = builder
+        .without_indexing()
+        .with_novelty_thresholds(min_bytes, max_bytes);
 
     builder
         .build()

--- a/fluree-db-cli/src/context.rs
+++ b/fluree-db-cli/src/context.rs
@@ -3,7 +3,7 @@ use crate::error::{CliError, CliResult};
 use crate::remote_client::{RefreshConfig, RemoteLedgerClient};
 use colored::Colorize;
 use fluree_db_api::server_defaults::FlureeDir;
-use fluree_db_api::{Fluree, FlureeBuilder, IndexConfig};
+use fluree_db_api::{Fluree, FlureeBuilder};
 use fluree_db_nameservice::RemoteName;
 use fluree_db_nameservice_sync::{
     RemoteAuth, RemoteAuthType, RemoteConfig, RemoteEndpoint, SyncConfigStore,
@@ -311,10 +311,9 @@ pub fn build_fluree(dirs: &FlureeDir) -> CliResult<Fluree> {
     // the CLI is a short-lived process — a background indexer would be
     // killed before it could finish.
     let thresholds = config::read_indexing_thresholds(dirs.config_dir());
-    let default_config = IndexConfig::default();
     let min_bytes = thresholds
         .reindex_min_bytes
-        .unwrap_or(default_config.reindex_min_bytes);
+        .unwrap_or(fluree_db_api::server_defaults::DEFAULT_REINDEX_MIN_BYTES);
     let max_bytes = thresholds
         .reindex_max_bytes
         .unwrap_or_else(fluree_db_api::server_defaults::default_reindex_max_bytes);

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -2104,7 +2104,10 @@ mod embedded_tests {
         let ledger = LedgerState::new(db, novelty);
 
         let ns = MemoryNameService::new();
-        let index_config = IndexConfig::default(); // High threshold
+        let index_config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        }; // High threshold
         let indexer_config = IndexerConfig::small();
 
         let (returned_ledger, result) =

--- a/fluree-db-ledger/src/lib.rs
+++ b/fluree-db-ledger/src/lib.rs
@@ -58,25 +58,18 @@ impl std::fmt::Debug for TypeErasedStore {
     }
 }
 
-/// Configuration for novelty backpressure
+/// Configuration for novelty backpressure.
+///
+/// No `Default` impl — configuration policy (RAM-tiered sizing, env/flag
+/// resolution) lives at the API layer (`fluree-db-api::server_defaults`).
+/// Callers must construct this explicitly so a missing upstream wiring
+/// fails at compile time rather than silently using a hidden default.
 #[derive(Clone, Debug)]
 pub struct IndexConfig {
-    /// Soft threshold - trigger background indexing (default 100KB)
+    /// Soft threshold — triggers background indexing.
     pub reindex_min_bytes: usize,
-    /// Hard threshold - block new commits until indexed (default 1MB)
+    /// Hard threshold — blocks new commits until indexed.
     pub reindex_max_bytes: usize,
-}
-
-impl Default for IndexConfig {
-    fn default() -> Self {
-        Self {
-            // Compatibility defaults:
-            // - reindex-min-bytes: 100000  (100 kb, decimal)
-            // - reindex-max-bytes: 1000000 (1 mb, decimal)
-            reindex_min_bytes: 100_000,
-            reindex_max_bytes: 1_000_000,
-        }
-    }
 }
 
 /// Ledger state combining indexed LedgerSnapshot with novelty overlay

--- a/fluree-db-server/src/config.rs
+++ b/fluree-db-server/src/config.rs
@@ -415,8 +415,10 @@ pub struct ServerConfig {
     pub reindex_min_bytes: usize,
 
     /// Novelty size (bytes) that blocks new commits until reindexing completes (hard threshold)
-    #[arg(long, env = "FLUREE_REINDEX_MAX_BYTES", default_value_t = server_defaults::DEFAULT_REINDEX_MAX_BYTES)]
-    pub reindex_max_bytes: usize,
+    ///
+    /// Default: 20% of system RAM (256 MB fallback). Set explicitly to override.
+    #[arg(long, env = "FLUREE_REINDEX_MAX_BYTES")]
+    pub reindex_max_bytes: Option<usize>,
 
     /// Global cache budget in MB (default: tiered fraction of system RAM — 30% if <4GB, 40% if 4-8GB, 50% if ≥8GB)
     ///
@@ -649,7 +651,7 @@ impl Default for ServerConfig {
             cors_enabled: server_defaults::DEFAULT_CORS_ENABLED,
             indexing_enabled: server_defaults::DEFAULT_INDEXING_ENABLED,
             reindex_min_bytes: server_defaults::DEFAULT_REINDEX_MIN_BYTES,
-            reindex_max_bytes: server_defaults::DEFAULT_REINDEX_MAX_BYTES,
+            reindex_max_bytes: None,
             cache_max_mb: None,
             body_limit: server_defaults::DEFAULT_BODY_LIMIT,
             log_level: server_defaults::DEFAULT_LOG_LEVEL.to_string(),

--- a/fluree-db-server/src/config_file.rs
+++ b/fluree-db-server/src/config_file.rs
@@ -493,7 +493,7 @@ pub fn apply_to_server_config(
         }
         if is_default("reindex_max_bytes") {
             if let Some(v) = idx.reindex_max_bytes {
-                config.reindex_max_bytes = v;
+                config.reindex_max_bytes = Some(v);
             }
         }
     }

--- a/fluree-db-server/src/routes/push.rs
+++ b/fluree-db-server/src/routes/push.rs
@@ -87,8 +87,11 @@ async fn push_ledger_local(
         opts.policy_class = Some(headers.policy_class.clone());
     }
 
-    // Index config: server-level override if present, else default.
-    let index_config_owned = state.index_config.clone().unwrap_or_default();
+    // Index config: server-level override if present, else canonical default.
+    let index_config_owned = state
+        .index_config
+        .clone()
+        .unwrap_or_else(fluree_db_api::server_defaults::default_index_config);
     let index_config = &index_config_owned;
 
     // Parse JSON body.

--- a/fluree-db-server/src/state.rs
+++ b/fluree-db-server/src/state.rs
@@ -165,7 +165,9 @@ impl AppState {
         // so that novelty backpressure thresholds are respected for external indexers).
         let index_config = Some(IndexConfig {
             reindex_min_bytes: config.reindex_min_bytes,
-            reindex_max_bytes: config.reindex_max_bytes,
+            reindex_max_bytes: config
+                .reindex_max_bytes
+                .unwrap_or_else(fluree_db_api::server_defaults::default_reindex_max_bytes),
         });
 
         Ok(Self {
@@ -226,11 +228,20 @@ impl AppState {
             builder = builder.cache_max_mb(max_mb);
         }
         if config.indexing_enabled {
+            let max_bytes = config
+                .reindex_max_bytes
+                .unwrap_or_else(fluree_db_api::server_defaults::default_reindex_max_bytes);
+            builder = builder.with_indexing_thresholds(config.reindex_min_bytes, max_bytes);
+        } else {
+            // Peer / external-indexer mode: skip spawning a background indexer,
+            // but still set novelty thresholds so backpressure works.
+            let max_bytes = config
+                .reindex_max_bytes
+                .unwrap_or_else(fluree_db_api::server_defaults::default_reindex_max_bytes);
             builder = builder
-                .with_indexing_thresholds(config.reindex_min_bytes, config.reindex_max_bytes);
+                .without_indexing()
+                .with_novelty_thresholds(config.reindex_min_bytes, max_bytes);
         }
-        // When indexing is disabled (default), we don't call with_indexing_thresholds,
-        // so the builder stays in no-indexing mode regardless of connection config defaults.
 
         let fluree = Arc::new(builder.build_client().await?);
 

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -1023,7 +1023,10 @@ mod tests {
             .unwrap();
 
         // Commit
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
         let (receipt, new_state) = commit(
             view,
@@ -1061,7 +1064,10 @@ mod tests {
             .unwrap();
 
         // Commit should fail
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
         let result = commit(
             view,
@@ -1084,7 +1090,10 @@ mod tests {
         let ledger = LedgerState::new(db, novelty);
 
         let nameservice = MemoryNameService::new();
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
 
         // First commit
@@ -1213,7 +1222,10 @@ mod tests {
             .await
             .unwrap();
 
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
         let result = commit(
             view,

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -2031,7 +2031,10 @@ mod tests {
         let ledger = LedgerState::new(db, novelty);
 
         let nameservice = MemoryNameService::new();
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
 
         // First: insert ex:alice with name="Alice"
@@ -2128,7 +2131,10 @@ mod tests {
         let ledger = LedgerState::new(db, novelty);
 
         let nameservice = MemoryNameService::new();
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
 
         // Commit 1: Insert schema:alice with schema:name="Alice"
@@ -2232,7 +2238,10 @@ mod tests {
         let ledger = LedgerState::new(db, novelty);
 
         let nameservice = MemoryNameService::new();
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
 
         // Commit 1: Insert schema:alice with name="Alice" and age=30
@@ -2449,7 +2458,10 @@ mod tests {
         let ledger = LedgerState::new(db, novelty);
 
         let nameservice = MemoryNameService::new();
-        let config = IndexConfig::default();
+        let config = IndexConfig {
+            reindex_min_bytes: 100_000,
+            reindex_max_bytes: 1_000_000_000,
+        };
         let cs = content_store_for(storage.clone(), "test:main");
 
         // Insert data: alice has age 30, bob has age 25


### PR DESCRIPTION
The out-of-the-box Docker experience in v4.0.1 was biased toward "tiny ephemeral test ledger" rather than "production database":

- **Indexing was disabled by default.** `fluree init` (now run automatically by the v4.0.1 Docker entrypoint) generated a config with `[server.indexing]` commented out, falling through to `DEFAULT_INDEXING_ENABLED = false`.
- **Hard novelty ceiling was 1 MB.** `DEFAULT_REINDEX_MAX_BYTES = 1_000_000` — a test-sized value.

This PR flips both defaults and wires the programmatic `FlureeBuilder` API consistently with the server/CLI paths.

## What changed

### Indexing on by default

- `DEFAULT_INDEXING_ENABLED: true` (const in `fluree-db-api::server_defaults`). Used by the server clap `default_value_t`, the `fluree init` TOML + JSON-LD templates, and the Docker entrypoint.
- `is_indexing_enabled()` (JSON-LD config path) now defaults to `true`, resolving the prior mismatch with `defaults_indexing_enabled()` which was already `true`.
- `FlureeBuilder::file()`, `::s3()`, `::ipfs()` now default `indexing_config` to `Some(default_indexing_builder_config())`. The programmatic API path now matches the server path — indexing is the default for any persistent builder.
- New `FlureeBuilder::without_indexing()` opt-out method. The only legitimate production reason to disable indexing is a peer / external-indexer setup where a separate process owns index maintenance; the method's doc comment says so explicitly.
- `build_memory()` is left as hardcoded `IndexingMode::Disabled` — it's a sync test helper that would need a tokio runtime to spawn the background worker.
- Template profile example in `fluree init` flipped from "enable indexing for prod" to "disable indexing for a dedicated-indexer peer setup".

### `reindex_max_bytes` → 20% of RAM, single source of truth at the API layer

Configuration policy (RAM detection, tiered sizing, env/flag resolution) belongs at the API layer, not in leaf crates. A leaf crate that hands out a hidden default invites bugs where upstream forgets to wire something and the system silently runs on the leaf's value.

- **`fluree-db-ledger::IndexConfig` no longer impls `Default`.** Callers must construct it explicitly. Missing upstream wiring now fails to compile rather than running on a stale hardcoded value. Doc comment on the struct says so.
- **`fluree-db-api::server_defaults::default_index_config()`** (new) is the canonical default for any API-layer caller. It composes `DEFAULT_REINDEX_MIN_BYTES` (100 KB) with `default_reindex_max_bytes()`.
- **`fluree-db-api::server_defaults::default_reindex_max_bytes()`** (new) returns 20% of detected system RAM, floored at 64 MB, with a 256 MB fallback when `sysinfo` is unavailable. Mirrors the existing `CacheConfig::default` RAM-tiered pattern.
- All production sites that previously called `IndexConfig::default()` or `Option<IndexConfig>::unwrap_or_default()` now route through `default_index_config()`: `FlureeBuilder::file()`/`::s3()`, `derive_indexing()`, the JSON-LD `derive_index_config()` fallback, the server's commit-push handler, the transient in-memory Fluree used by `nameservice_query`, etc.
- Server's `reindex_max_bytes: usize` field → `Option<usize>` (same shape as `cache_max_mb`). Resolves lazily via `default_reindex_max_bytes()` when unset, so CLI args, env vars, config file, and built-in defaults all flow through one place.
- Tests use explicit `IndexConfig { reindex_min_bytes: …, reindex_max_bytes: … }` literals — no more hidden defaults in test fixtures.
- `reindex_min_bytes` constant unchanged at 100 KB — indexing is fast, jobs queue and drain under load.

### Peer / external-indexer backpressure

- When `indexing_enabled = false` on the server, the startup path now calls `.without_indexing().with_novelty_thresholds(...)` rather than leaving the builder with no thresholds. Without this, a peer transactor whose external indexer falls behind would accumulate novelty indefinitely and eventually OOM.

### Effective defaults on typical Docker hosts

| Host RAM | `reindex_max_bytes` |
|---:|---:|
| 2 GB | 400 MB |
| 4 GB | 800 MB |
| 8 GB | 1.6 GB |
| 16 GB | 3.2 GB |
| 32 GB | 6.4 GB |

### Docs

- `docs/operations/configuration.md` — flag table, env-var table, TOML example, and JSON-LD example updated. `20% of system RAM (256 MB fallback)` replaces the old `1000000` default in reference tables.
- `docs/indexing-and-search/background-indexing.md` — "enabled at the server level" → "on by default".
- `docs/cli/server.md`, `docs/getting-started/quickstart-server.md` — reference examples updated; the redundant `FLUREE_INDEXING_ENABLED: "true"` line removed from the docker-compose snippet (keeping it would misleadingly imply users need to set it).

## What this does NOT change

- `FlureeBuilder::build_memory()` stays as hardcoded `IndexingMode::Disabled` (test helper; flipping would require tokio for every call-site and break many tests).
- Integration tests that construct `ServerConfig { indexing_enabled: false, .. }` explicitly are unchanged — they're explicit opt-outs, which still works.
