### PR TITLE
feat: read-only branch merge preview (`merge_preview` / `branch diff`)

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1910,6 +1910,85 @@ curl -X POST http://localhost:8090/v1/fluree/merge \
   -d '{"ledger": "mydb", "source": "dev", "target": "main"}'
 ```
 
+### GET /fluree/merge-preview/{ledger}
+
+Read-only preview of merging a source branch into a target branch. Returns the rich diff — ahead/behind commit summaries, conflict keys, and fast-forward eligibility — without mutating any nameservice or content store state.
+
+Bearer token required when `data_auth.mode = required`; reads are gated on `bearer.can_read(ledger)`.
+
+**URL:**
+```
+GET /fluree/merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}
+```
+
+**Path / Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ledger` (path) | string | Yes | Ledger name (e.g., "mydb") |
+| `source` | string | Yes | Source branch to merge from (e.g., "feature-x") |
+| `target` | string | No | Target branch (defaults to the source's parent branch) |
+| `max_commits` | number | No | Cap on per-side commit summaries returned (default 500). Server clamps to a hard maximum of 5,000 — values above are silently lowered. Bounds response size, **not** divergence-walk cost (the unbounded `count` is still computed). |
+| `max_conflict_keys` | number | No | Cap on conflict keys returned (default 200). Server clamps to a hard maximum of 5,000. Bounds response size, **not** the conflict-delta walks. |
+| `include_conflicts` | bool | No | When false, skips the conflict computation (default true). Use this to make the preview cheap on diverged branches. |
+
+**Response body (200 OK):**
+
+```json
+{
+  "source": "feature-x",
+  "target": "main",
+  "ancestor": { "commit_id": "bafy...", "t": 5 },
+  "ahead": {
+    "count": 3,
+    "commits": [
+      { "t": 8, "commit_id": "bafy...", "time": "2026-04-25T12:00:00Z",
+        "asserts": 2, "retracts": 0, "flake_count": 2, "message": null }
+    ],
+    "truncated": false
+  },
+  "behind": { "count": 1, "commits": [...], "truncated": false },
+  "fast_forward": false,
+  "conflicts": {
+    "count": 0,
+    "keys": [],
+    "truncated": false
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source` | string | Source branch name |
+| `target` | string | Target branch name (resolved from default when not supplied) |
+| `ancestor` | object \| null | Common ancestor `{commit_id, t}`. `null` when both heads are absent |
+| `ahead` | object | Commits on source not on target (`count`, `commits`, `truncated`) |
+| `behind` | object | Commits on target not on source |
+| `fast_forward` | bool | True when target HEAD == ancestor (or both heads absent) |
+| `conflicts` | object | Overlapping `(s, p, g)` keys touched on both sides since the ancestor. Empty when `fast_forward` or `include_conflicts=false` |
+
+Per-commit summaries (`ahead.commits[]` / `behind.commits[]`) are newest-first and include assert/retract counts plus an optional `message` extracted from `txn_meta` when an `f:message` string entry is present.
+
+**Status codes:**
+
+- `200 OK` — Preview computed successfully
+- `400 Bad Request` — Source has no branch point (e.g., main) or `source == target`
+- `401 Unauthorized` — Bearer token required
+- `404 Not Found` — Ledger or branch does not exist (or bearer cannot read it)
+
+**Examples:**
+
+```bash
+# Default target (source's parent), defaults for caps and conflict computation
+curl "http://localhost:8090/v1/fluree/merge-preview/mydb?source=feature-x"
+
+# Counts only — skip the conflict walks for a faster response
+curl "http://localhost:8090/v1/fluree/merge-preview/mydb?source=dev&target=main&include_conflicts=false"
+
+# Cap commit lists at 50 per side
+curl "http://localhost:8090/v1/fluree/merge-preview/mydb?source=dev&max_commits=50"
+```
+
 ### GET /fluree/info
 
 Get ledger metadata. Used by the CLI for `info`, `push`, `pull`, and `clone`.

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -122,6 +122,16 @@ listed below and, for JSON-LD bodies, also injects them into `opts`. To be
 CLI-compatible, your server must implement the contract in
 [Policy Enforcement Contract](#policy-enforcement-contract).
 
+### `fluree branch diff` (read-only merge preview)
+
+- `GET {api_base_url}/merge-preview/*ledger?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=`
+
+Returns the rich diff between two branches — ahead/behind commit summaries,
+common ancestor, conflict keys, fast-forward eligibility — without mutating
+any nameservice or content-store state. See
+[Merge Preview Contract](#merge-preview-contract) for the full semantic and
+response-shape spec.
+
 ## Policy Enforcement Contract
 
 CLI policy flags ride on every data API request as both HTTP headers and (for
@@ -202,6 +212,162 @@ The route-level wiring (header merge, gate, force-override, audit log,
 PolicyContext construction) lives in
 `fluree-db-server/src/routes/policy_auth.rs` — useful as a concrete
 implementation reference if you're porting the contract to another server.
+
+## Merge Preview Contract
+
+`fluree branch diff` issues a single read-only request:
+
+```
+GET {api_base_url}/merge-preview/{ledger}?source={source}&target={target}
+   &max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}
+```
+
+| Parameter | Type | Required | Server default | Description |
+|-----------|------|----------|----------------|-------------|
+| `ledger` (path) | string | Yes | — | Ledger name without branch suffix |
+| `source` | string | Yes | — | Source branch to merge **from** |
+| `target` | string | No | source's parent branch | Target branch to merge **into** |
+| `max_commits` | integer | No | `500` | Per-side cap on `ahead.commits` / `behind.commits` |
+| `max_conflict_keys` | integer | No | `200` | Cap on `conflicts.keys` |
+| `include_conflicts` | bool | No | `true` | When `false`, the conflict computation is skipped |
+
+Auth follows the same pattern as `GET /branch/*ledger` (read-only): require
+a Bearer when `data_auth.mode == required`; gate on `can_read(ledger)`;
+return `404` (not `403`) when the bearer cannot read it.
+
+### Required semantics
+
+These rules are not negotiable; the CLI and other clients depend on them:
+
+1. **Source resolution.** `source` must be a branch — its nameservice record
+   must have `source_branch != null`. Otherwise respond `400` with a message
+   containing `"no source branch"` so the CLI's error matcher works.
+2. **Target defaulting.** When `target` is omitted, resolve to
+   `source.source_branch`.
+3. **Self-merge.** If `source == resolved_target`, respond `400` with a
+   message containing `"itself"`.
+4. **Cross-branch ancestor lookup.** `ancestor` is the most recent common
+   commit between `source` HEAD and `target` HEAD. The walk **must** be able
+   to load commit envelopes from both branches' namespaces — sibling
+   branches off `main` must work. The reference implementation builds a
+   union view that fans out through both `BranchedContentStore` ancestries;
+   equivalents are fine.
+5. **Fast-forward predicate.**
+   `fast_forward = (ancestor.commit_id == target_head)` when both heads
+   exist; `true` when both heads are absent; `false` otherwise.
+6. **Per-side walks.** `ahead.count` is the total number of commits on
+   `source` since `ancestor.t` (uncapped). `ahead.commits` is the same set,
+   capped at `max_commits`, **strictly newest-first by `t`**.
+   `truncated = count > commits.len()`. Same shape for `behind`.
+7. **Conflict computation.** When
+   `include_conflicts == true && !fast_forward` and both heads exist:
+   - Walk both deltas: `(s, p, g)` tuples touched on each side since
+     `ancestor.t`.
+   - `conflicts.keys` is the intersection.
+   - **Sort the intersection before truncating** — `HashSet::intersection`
+     order is unspecified, and stable ordering matters for paginated UIs.
+     Lexicographic by `(s, p, g)` is fine; what matters is that two
+     requests against the same state return the same prefix.
+   - `count` is the unbounded intersection size; `truncated = count > cap`.
+8. **No mutations.** Implementations must not write to the nameservice,
+   advance any HEAD, copy commits between namespaces, or update any cache
+   that downstream operations depend on.
+9. **Server-side cap is mandatory.** Even if a client sends
+   `max_commits=10000000`, clamp to a defensive limit. The reference
+   server applies two layers: when no query param is present, it falls
+   back to the recommended defaults (`500` for commits, `200` for
+   conflict keys); when a param **is** present, the server clamps the
+   caller's value with `min(value, hard_max)` where the reference hard
+   maxes are `5_000` for commits and `5_000` for conflict keys
+   (constants `MERGE_PREVIEW_HARD_MAX_COMMITS` and
+   `MERGE_PREVIEW_HARD_MAX_CONFLICT_KEYS` in
+   `fluree-db-server/src/routes/ledger.rs`). The CLI assumes the server
+   enforces a cap, and unbounded responses must not be reachable over
+   HTTP regardless of what the client requests.
+
+   **Scope of the cap.** This bounds the **size of the returned lists**
+   and the per-summary `load_commit_by_id` reads (one full commit blob
+   per summary). It does *not* bound the underlying divergence walk:
+   `count` on each side reflects the unbounded divergence and is computed
+   by walking every commit envelope between HEAD and the ancestor.
+   Likewise, conflict computation walks the full per-side delta when
+   `include_conflicts=true`. If you need to refuse expensive previews,
+   add a separate operational guard before invoking the walk (for
+   example, reject when `target.t - ancestor.t` exceeds some threshold)
+   or document that clients should pass `include_conflicts=false` for a
+   cheaper preview.
+
+### Response (`200 OK`)
+
+```jsonc
+{
+  "source": "feature-x",
+  "target": "main",
+  "ancestor": { "commit_id": "bafy...", "t": 5 },
+  "ahead": {
+    "count": 3,
+    "commits": [
+      {
+        "t": 8,
+        "commit_id": "bafy...",
+        "time": "2026-04-25T12:00:00Z",
+        "asserts": 2,
+        "retracts": 0,
+        "flake_count": 2,
+        "message": null
+      }
+      // ... newest-first
+    ],
+    "truncated": false
+  },
+  "behind": { "count": 1, "commits": [], "truncated": false },
+  "fast_forward": false,
+  "conflicts": { "count": 0, "keys": [], "truncated": false }
+}
+```
+
+`ancestor` is `null` only when both heads are absent. Each `CommitSummary`
+sets `time` to `null` for legacy commits without a timestamp; `message` is
+extracted from `txn_meta` when an entry with predicate `f:message` (Fluree
+DB system namespace, local name `"message"`) and a string value is present.
+Other conventions are not recognized — return `null`.
+
+`ConflictKey` encodes a `(s, p, g)` tuple. The wire shape mirrors
+`fluree_db_core::ConflictKey`:
+
+```jsonc
+{
+  "s": [<namespace_code: u16>, "<local_name>"],
+  "p": [<namespace_code: u16>, "<local_name>"],
+  "g": [<namespace_code: u16>, "<local_name>"]   // or null for the default graph
+}
+```
+
+`Sid`s serialize as `[ns_code, name]` tuples. Changing the encoding will
+break the CLI.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `400` | Source has no parent (e.g., `main`); or `source == target`. Body must include `"no source branch"` or `"itself"` so the CLI's matcher works. |
+| `401` | Bearer required and absent/invalid. |
+| `404` | Ledger or branch does not exist; or the bearer cannot `can_read`. |
+| `5xx` | Storage / nameservice errors. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::merge_preview` |
+| Orchestration | `fluree-db-api/src/merge_preview.rs::merge_preview_with` |
+| Per-commit summary + DAG walk | `fluree-db-core/src/commit.rs::walk_commit_summaries` |
+| Common ancestor (dual-frontier BFS) | `fluree-db-core/src/commit.rs::find_common_ancestor` |
+| Delta-key computation | `fluree-db-novelty/src/delta.rs::compute_delta_keys` |
+
+Validate compatibility by running `fluree branch diff dev --target feature
+--remote your-remote --json` against your server and diffing the response
+against output from the reference server on the same ledger state.
 
 ## Replication Auth Contract
 

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -952,6 +952,130 @@ This design keeps retry/timeout policy out of the database layer. Different
 deployment contexts (Lambda with 100ms backoff, HTTP handler with 5s deadline,
 integration test with immediate assertion) each wrap the same primitive differently.
 
+### Branch Diff (Merge Preview)
+
+`Fluree::merge_preview` returns the rich diff between two branches —
+ahead/behind commit summaries, the common ancestor, conflict keys, and
+fast-forward eligibility — **without mutating any state**. It uses the
+same primitives as `merge_branch` but skips the publish/copy steps,
+making it cheap enough to call on every UI render.
+
+```rust
+use fluree_db_api::{FlureeBuilder, MergePreviewOpts, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // ... create ledger, branch, transact on dev, etc.
+
+    // Default: previewing dev → main with the spec defaults
+    // (cap each commit list at 500, conflict keys at 200, run conflicts).
+    let preview = fluree.merge_preview("mydb", "dev", None).await?;
+
+    println!(
+        "{} ahead, {} behind, fast-forward: {}",
+        preview.ahead.count, preview.behind.count, preview.fast_forward,
+    );
+
+    if preview.fast_forward {
+        println!("merge would advance {} → {}", preview.source, preview.target);
+    } else {
+        println!("merge has {} conflict(s)", preview.conflicts.count);
+        for k in &preview.conflicts.keys {
+            println!("  - s={} p={}", k.s, k.p);
+        }
+    }
+    Ok(())
+}
+```
+
+#### Tuning the preview
+
+`merge_preview_with` takes a `MergePreviewOpts` for callers that need
+control over response size or want to skip the conflict computation:
+
+```rust
+use fluree_db_api::{FlureeBuilder, MergePreviewOpts, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // Cheap preview: counts only, no conflict walks.
+    let counts = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            Some("main"),
+            MergePreviewOpts {
+                max_commits: Some(0),       // counts only — no commit summaries
+                max_conflict_keys: Some(0),
+                include_conflicts: false,
+            },
+        )
+        .await?;
+
+    // Direct Rust callers can opt in to **unbounded** results — useful for
+    // tooling that needs the full divergence. The HTTP layer always supplies
+    // a bound, so this is a Rust-only escape hatch.
+    let full = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                max_commits: None,
+                max_conflict_keys: None,
+                include_conflicts: true,
+            },
+        )
+        .await?;
+
+    Ok(())
+}
+```
+
+#### What the caps do (and don't) control
+
+`max_commits` and `max_conflict_keys` cap the **size of the returned
+lists**, not the cost of computing them:
+
+- `BranchDelta::count` on each side reflects the full unbounded
+  divergence — computed by walking every commit envelope between HEAD and
+  the common ancestor — regardless of `max_commits`.
+- When `include_conflicts: true`, both `compute_delta_keys` walks scan
+  the full per-side delta regardless of `max_conflict_keys`.
+- Set `include_conflicts: false` for a cheap preview on heavily diverged
+  branches; you still get accurate `ahead.count` / `behind.count`.
+
+#### Response shape
+
+| Type | Notable fields |
+|------|----------------|
+| `MergePreview` | `source`, `target`, `ancestor: Option<AncestorRef>`, `ahead`, `behind`, `fast_forward`, `conflicts` |
+| `BranchDelta` | `count` (unbounded), `commits: Vec<CommitSummary>` (newest-first, capped), `truncated` |
+| `CommitSummary` | `t`, `commit_id`, `time`, `asserts`, `retracts`, `flake_count`, `message: Option<String>` (extracted from the `f:message` `txn_meta` entry when present) |
+| `ConflictSummary` | `count` (unbounded), `keys: Vec<ConflictKey>` (sorted, capped), `truncated` |
+| `ConflictKey` | `s: Sid`, `p: Sid`, `g: Option<Sid>` |
+
+All types derive `Serialize` so the response is wire-stable; the HTTP
+endpoint at `GET /fluree/merge-preview/*ledger` returns the same struct.
+See `docs/api/endpoints.md` and `docs/cli/server-integration.md` for the
+HTTP contract.
+
+#### Reusable primitives in `fluree-db-core`
+
+The per-commit summary types and DAG walker are factored into core for
+reuse outside the merge-preview flow (e.g., git-log-style commit history
+viewers, indexer integration). Re-exported from `fluree-db-api`:
+
+- `walk_commit_summaries(store, head, stop_at_t, max) -> Result<(Vec<CommitSummary>, usize)>`
+  — newest-first walk that returns both the (capped) summary list and the
+  unbounded total count.
+- `commit_to_summary(commit) -> CommitSummary` — pure function, no I/O.
+- `find_common_ancestor(store, head_a, head_b)` — dual-frontier BFS.
+
 ### Time Travel Queries
 
 ```rust

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -57,6 +57,7 @@ mod indexer_fulltext_provider;
 mod ledger;
 pub mod ledger_info;
 mod merge;
+mod merge_preview;
 pub mod nameservice_query;
 pub(crate) mod ns_helpers;
 pub mod ontology_imports;
@@ -110,6 +111,10 @@ pub use dataset::{
 };
 pub use error::{ApiError, BuilderError, BuilderErrors, Result};
 pub use fluree_db_core::ContentId;
+pub use fluree_db_core::{
+    commit_to_summary, find_common_ancestor, walk_commit_summaries, CommitSummary, CommonAncestor,
+    ConflictKey,
+};
 pub use format::{AgentJsonContext, FormatError, FormatterConfig, OutputFormat, QueryOutput};
 pub use graph::Graph;
 pub use graph_commit_builder::{CommitBuilder, CommitDetail, ResolvedFlake, ResolvedValue};
@@ -131,6 +136,9 @@ pub use ledger_manager::{
     RemoteWatermark, UpdatePlan,
 };
 pub use merge::MergeReport;
+pub use merge_preview::{
+    AncestorRef, BranchDelta, ConflictSummary, MergePreview, MergePreviewOpts,
+};
 pub use pack::{
     compute_missing_index_artifacts, full_ledger_pack_request, validate_pack_request, PackChunk,
     PackStreamError, PackStreamResult,

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -1,0 +1,372 @@
+//! Read-only branch merge preview.
+//!
+//! Computes the rich diff between two branches — ahead/behind commit lists,
+//! conflict keys, fast-forward eligibility — using the same primitives as
+//! [`crate::Fluree::merge_branch`] but without mutating any nameservice or
+//! content-store state.
+//!
+//! The heavy lifting (per-commit summaries, DAG walking, common-ancestor
+//! discovery, delta-key computation) lives in `fluree-db-core` and
+//! `fluree-db-novelty`. This module orchestrates them: nameservice lookups,
+//! branched-store construction for source/target, and parallel walks.
+
+use crate::error::{ApiError, Result};
+use fluree_db_core::ledger_id::format_ledger_id;
+use fluree_db_core::{
+    find_common_ancestor, walk_commit_summaries, BranchedContentStore, CommitSummary, ConflictKey,
+    ContentId, ContentStore,
+};
+use fluree_db_ledger::LedgerState;
+use fluree_db_novelty::compute_delta_keys;
+use serde::Serialize;
+use std::sync::Arc;
+use tracing::Instrument;
+
+/// Default cap on commits per side returned in [`BranchDelta::commits`].
+pub const DEFAULT_MAX_COMMITS: usize = 500;
+
+/// Default cap on conflict keys returned in [`ConflictSummary::keys`].
+pub const DEFAULT_MAX_CONFLICT_KEYS: usize = 200;
+
+/// Knobs for [`crate::Fluree::merge_preview`].
+///
+/// `MergePreviewOpts::default()` matches the spec: cap each commit list at
+/// 500 entries, cap conflict keys at 200, and run the conflict computation.
+/// Setting `max_commits` or `max_conflict_keys` to `None` explicitly opts in
+/// to **unbounded** results — direct Rust callers can use this for tooling
+/// that needs the full divergence. The HTTP layer always supplies a bound to
+/// protect against pathologically large responses.
+///
+/// ### What the caps do and do not control
+///
+/// `max_commits` and `max_conflict_keys` cap the **size of the returned
+/// lists**, not the cost of computing them:
+///
+/// - The `BranchDelta::count` on each side is the full unbounded divergence,
+///   computed by walking every commit envelope between HEAD and the common
+///   ancestor. A 1M-commit divergence costs 1M envelope reads regardless of
+///   the cap.
+/// - The `ConflictSummary::count` is the full intersection size; both
+///   `compute_delta_keys` walks scan every flake on each side since the
+///   ancestor. Pass [`include_conflicts: false`](Self::include_conflicts) to
+///   skip them entirely when only counts are needed.
+///
+/// To bound the *I/O cost* of the walk itself, callers must pre-check the
+/// divergence (e.g., refuse before invoking when `target.t - ancestor.t`
+/// exceeds some threshold) or use `include_conflicts: false`.
+#[derive(Clone, Debug)]
+pub struct MergePreviewOpts {
+    /// Per side. `Some(n)` caps the returned list at `n`; `None` is
+    /// unbounded. **Does not bound the divergence walk** — see type docs.
+    pub max_commits: Option<usize>,
+    /// Cap on `conflicts.keys`. `None` is unbounded. **Does not bound the
+    /// `compute_delta_keys` walks** — see type docs.
+    pub max_conflict_keys: Option<usize>,
+    /// When `false`, skips the two `compute_delta_keys` walks — the response
+    /// still contains commit counts but `conflicts` will be empty. The
+    /// fastest way to bound preview cost on diverged branches.
+    pub include_conflicts: bool,
+}
+
+impl Default for MergePreviewOpts {
+    fn default() -> Self {
+        Self {
+            max_commits: Some(DEFAULT_MAX_COMMITS),
+            max_conflict_keys: Some(DEFAULT_MAX_CONFLICT_KEYS),
+            include_conflicts: true,
+        }
+    }
+}
+
+/// Common ancestor of source and target HEADs.
+#[derive(Clone, Debug, Serialize)]
+pub struct AncestorRef {
+    pub commit_id: ContentId,
+    pub t: i64,
+}
+
+/// One side of a branch divergence — commits unique to that side since the
+/// common ancestor.
+#[derive(Clone, Debug, Serialize)]
+pub struct BranchDelta {
+    /// Total number of commits on this side of the divergence.
+    pub count: usize,
+    /// Newest-first commit summaries, capped by `max_commits`.
+    pub commits: Vec<CommitSummary>,
+    /// `true` when `count > commits.len()` — the list was truncated.
+    pub truncated: bool,
+}
+
+/// Summary of overlapping `(s, p, g)` tuples touched by both sides since the
+/// common ancestor. Empty when the merge is fast-forward (no real conflicts
+/// possible) or when [`MergePreviewOpts::include_conflicts`] is `false`.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConflictSummary {
+    pub count: usize,
+    pub keys: Vec<ConflictKey>,
+    pub truncated: bool,
+}
+
+impl ConflictSummary {
+    fn empty() -> Self {
+        Self {
+            count: 0,
+            keys: Vec::new(),
+            truncated: false,
+        }
+    }
+}
+
+/// Read-only diff between two branches.
+#[derive(Clone, Debug, Serialize)]
+pub struct MergePreview {
+    pub source: String,
+    pub target: String,
+
+    /// `None` when both heads are absent (the unborn-branches edge case).
+    pub ancestor: Option<AncestorRef>,
+
+    /// Commits on `source` not on `target`.
+    pub ahead: BranchDelta,
+    /// Commits on `target` not on `source`.
+    pub behind: BranchDelta,
+
+    /// `true` iff `target HEAD == ancestor` (or both heads are absent).
+    /// Mirrors the `is_fast_forward` check in `merge_branch_inner`.
+    pub fast_forward: bool,
+
+    /// Always populated. Empty when `fast_forward` (no conflicts possible)
+    /// or when the caller opted out via [`MergePreviewOpts::include_conflicts`].
+    pub conflicts: ConflictSummary,
+}
+
+impl crate::Fluree {
+    /// Compute a preview of merging `source_branch` into `target_branch`.
+    ///
+    /// Read-only: walks both commit DAGs to the common ancestor, returns
+    /// per-side commit lists and conflict keys. No nameservice or content
+    /// store mutations.
+    ///
+    /// If `target_branch` is `None`, the source's parent branch is used,
+    /// matching [`Self::merge_branch`] semantics.
+    pub async fn merge_preview(
+        &self,
+        ledger_name: &str,
+        source_branch: &str,
+        target_branch: Option<&str>,
+    ) -> Result<MergePreview> {
+        self.merge_preview_with(
+            ledger_name,
+            source_branch,
+            target_branch,
+            MergePreviewOpts::default(),
+        )
+        .await
+    }
+
+    /// Like [`Self::merge_preview`] but with explicit knobs.
+    pub async fn merge_preview_with(
+        &self,
+        ledger_name: &str,
+        source_branch: &str,
+        target_branch: Option<&str>,
+        opts: MergePreviewOpts,
+    ) -> Result<MergePreview> {
+        let span =
+            tracing::debug_span!("merge_preview", ledger_name, source_branch, ?target_branch);
+        async move {
+            self.merge_preview_inner(ledger_name, source_branch, target_branch, opts)
+                .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn merge_preview_inner(
+        &self,
+        ledger_name: &str,
+        source_branch: &str,
+        target_branch: Option<&str>,
+        opts: MergePreviewOpts,
+    ) -> Result<MergePreview> {
+        // ---- Resolve records (mirrors merge_branch_inner). ----------------
+        let source_id = format_ledger_id(ledger_name, source_branch);
+        let source_record = self
+            .nameservice()
+            .lookup(&source_id)
+            .await?
+            .ok_or_else(|| ApiError::NotFound(source_id.clone()))?;
+
+        let source_parent = source_record.source_branch.as_deref().ok_or_else(|| {
+            ApiError::InvalidBranch(format!(
+                "Branch {source_branch} has no source branch; \
+                 only branches created from another branch can be previewed"
+            ))
+        })?;
+
+        let resolved_target = target_branch.unwrap_or(source_parent);
+        if source_branch == resolved_target {
+            return Err(ApiError::InvalidBranch(
+                "Cannot merge a branch into itself".to_string(),
+            ));
+        }
+
+        let target_id = format_ledger_id(ledger_name, resolved_target);
+        let target_record = self
+            .nameservice()
+            .lookup(&target_id)
+            .await?
+            .ok_or_else(|| ApiError::NotFound(target_id.clone()))?;
+
+        // ---- Build branched stores. ---------------------------------------
+        // Source is always a branch by definition (we required source_branch above).
+        let source_store = LedgerState::build_branched_store(
+            &self.nameservice_mode,
+            &source_record,
+            self.backend(),
+        )
+        .await?;
+
+        // Target may or may not be a branch — same logic as merge.rs:296-308.
+        // We always wrap as a `BranchedContentStore` (using `leaf` for the
+        // non-branch case) so the union store below can chain it as a parent.
+        let target_branched: BranchedContentStore = if target_record.source_branch.is_some() {
+            LedgerState::build_branched_store(
+                &self.nameservice_mode,
+                &target_record,
+                self.backend(),
+            )
+            .await?
+        } else {
+            BranchedContentStore::leaf(self.content_store(&target_id))
+        };
+
+        let source_head = source_record.commit_head_id.clone();
+        let target_head = target_record.commit_head_id.clone();
+
+        // ---- Find common ancestor. ----------------------------------------
+        // The ancestor walk needs to load both `source_head` and `target_head`,
+        // which may live in disjoint branch namespaces (e.g., two sibling
+        // branches off `main`). We construct a union view that fans out to
+        // both branched stores' ancestry so either head's envelope resolves.
+        let ancestor = match (&source_head, &target_head) {
+            (Some(s), Some(t)) => {
+                let union_store = BranchedContentStore::with_parents(
+                    Arc::new(source_store.clone()) as Arc<dyn ContentStore>,
+                    vec![target_branched.clone()],
+                );
+                Some(find_common_ancestor(&union_store, s, t).await?)
+            }
+            _ => None,
+        };
+
+        // ---- Fast-forward predicate (mirrors merge.rs:135-139). -----------
+        let fast_forward = match (&ancestor, &target_head) {
+            (Some(a), Some(tid)) => a.commit_id == *tid,
+            (None, None) => true,
+            _ => false,
+        };
+
+        let stop_at_t = ancestor.as_ref().map_or(0, |a| a.t);
+
+        // ---- Walk both sides in parallel. ---------------------------------
+        // `opts.max_commits == None` is a deliberate "unbounded" signal — we
+        // pass it through verbatim. The HTTP layer always supplies a bound to
+        // protect against unbounded responses; direct Rust callers can opt in.
+        let ahead_fut = async {
+            match &source_head {
+                Some(head) => {
+                    walk_commit_summaries(&source_store, head, stop_at_t, opts.max_commits)
+                        .await
+                        .map_err(ApiError::from)
+                }
+                None => Ok((Vec::new(), 0)),
+            }
+        };
+
+        let behind_fut = async {
+            match &target_head {
+                Some(head) => {
+                    walk_commit_summaries(&target_branched, head, stop_at_t, opts.max_commits)
+                        .await
+                        .map_err(ApiError::from)
+                }
+                None => Ok((Vec::new(), 0)),
+            }
+        };
+
+        let ((ahead_summaries, ahead_count), (behind_summaries, behind_count)) =
+            tokio::try_join!(ahead_fut, behind_fut)?;
+
+        let ahead = BranchDelta {
+            count: ahead_count,
+            truncated: ahead_count > ahead_summaries.len(),
+            commits: ahead_summaries,
+        };
+        let behind = BranchDelta {
+            count: behind_count,
+            truncated: behind_count > behind_summaries.len(),
+            commits: behind_summaries,
+        };
+
+        // ---- Conflicts (only if relevant). --------------------------------
+        let conflicts = if !opts.include_conflicts || fast_forward {
+            ConflictSummary::empty()
+        } else {
+            match (&source_head, &target_head, &ancestor) {
+                (Some(s_head), Some(t_head), Some(anc)) => {
+                    let s_delta_fut =
+                        compute_delta_keys(source_store.clone(), s_head.clone(), anc.t);
+                    let t_delta_fut =
+                        compute_delta_keys(target_branched.clone(), t_head.clone(), anc.t);
+                    let (s_delta, t_delta) = tokio::try_join!(s_delta_fut, t_delta_fut)?;
+
+                    // Sort lexicographically by (s, p, g) so capped responses
+                    // are stable across builds and across requests — `HashSet`
+                    // intersection order is otherwise unspecified.
+                    let mut keys: Vec<ConflictKey> =
+                        s_delta.intersection(&t_delta).cloned().collect();
+                    keys.sort();
+                    let count = keys.len();
+                    let truncated = match opts.max_conflict_keys {
+                        Some(cap) if count > cap => {
+                            keys.truncate(cap);
+                            true
+                        }
+                        _ => false,
+                    };
+                    ConflictSummary {
+                        count,
+                        keys,
+                        truncated,
+                    }
+                }
+                _ => ConflictSummary::empty(),
+            }
+        };
+
+        // ---- Invariants (debug-only). -------------------------------------
+        debug_assert!(ahead.commits.len() <= ahead.count);
+        debug_assert!(behind.commits.len() <= behind.count);
+        if fast_forward {
+            debug_assert_eq!(behind.count, 0);
+            debug_assert_eq!(conflicts.count, 0);
+        }
+        if source_head.is_some() && target_head.is_some() {
+            debug_assert!(ancestor.is_some());
+        }
+
+        Ok(MergePreview {
+            source: source_branch.to_string(),
+            target: resolved_target.to_string(),
+            ancestor: ancestor.map(|a| AncestorRef {
+                commit_id: a.commit_id,
+                t: a.t,
+            }),
+            ahead,
+            behind,
+            fast_forward,
+            conflicts,
+        })
+    }
+}

--- a/fluree-db-api/tests/it_merge_preview.rs
+++ b/fluree-db-api/tests/it_merge_preview.rs
@@ -1,0 +1,666 @@
+//! Integration tests for `Fluree::merge_preview` — the read-only branch
+//! diff. Mirrors the structure of `it_merge.rs`.
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, MergePreviewOpts};
+use serde_json::json;
+
+// =============================================================================
+// 1. Fast-forward
+// =============================================================================
+
+#[tokio::test]
+async fn preview_fast_forward() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    let dev_data = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:bob", "ex:name": "Bob"}]
+    });
+    fluree.insert(dev_ledger, &dev_data).await.unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    assert_eq!(preview.source, "dev");
+    assert_eq!(preview.target, "main");
+    assert!(preview.fast_forward, "expected fast-forward");
+    assert!(preview.ahead.count > 0, "expected commits ahead");
+    assert_eq!(preview.behind.count, 0, "expected nothing behind");
+    assert!(!preview.ahead.commits.is_empty());
+    assert_eq!(preview.conflicts.count, 0);
+    assert!(preview.ancestor.is_some());
+}
+
+// =============================================================================
+// 2. Diverged, no conflicts
+// =============================================================================
+
+#[tokio::test]
+async fn preview_diverged_no_conflicts() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // Disjoint subjects on each side.
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:bob", "ex:name": "Bob"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    fluree
+        .insert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:carol", "ex:name": "Carol"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    assert!(!preview.fast_forward);
+    assert!(preview.ahead.count > 0);
+    assert!(preview.behind.count > 0);
+    assert_eq!(preview.conflicts.count, 0);
+    assert!(preview.conflicts.keys.is_empty());
+}
+
+// =============================================================================
+// 3. Diverged with conflicts
+// =============================================================================
+
+#[tokio::test]
+async fn preview_diverged_with_conflicts() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // Both branches modify ex:alice / ex:name.
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    fluree
+        .insert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-main"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    assert!(!preview.fast_forward);
+    assert!(
+        preview.conflicts.count > 0,
+        "expected conflicts on ex:alice/ex:name, got {:?}",
+        preview.conflicts
+    );
+    assert!(!preview.conflicts.keys.is_empty());
+}
+
+// =============================================================================
+// 4. Equal heads (no-op)
+// =============================================================================
+
+#[tokio::test]
+async fn preview_equal_heads_is_fast_forward_with_empty_deltas() {
+    // dev branched from main, but neither side advances.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    assert!(preview.fast_forward);
+    assert_eq!(preview.ahead.count, 0);
+    assert_eq!(preview.behind.count, 0);
+    assert_eq!(preview.conflicts.count, 0);
+    assert!(preview.ancestor.is_some());
+}
+
+// =============================================================================
+// 5. Behind only — target advanced, source did not
+// =============================================================================
+
+#[tokio::test]
+async fn preview_behind_only() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // Target advances, source does not.
+    fluree
+        .insert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:carol", "ex:name": "Carol"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    assert_eq!(preview.ahead.count, 0);
+    assert!(preview.behind.count > 0);
+    assert!(!preview.fast_forward);
+    assert_eq!(preview.conflicts.count, 0);
+}
+
+// =============================================================================
+// 6. Default target resolves to source's parent
+// =============================================================================
+
+#[tokio::test]
+async fn preview_default_target_uses_source_parent() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+    assert_eq!(preview.target, "main");
+}
+
+// =============================================================================
+// 7. Self-merge rejected
+// =============================================================================
+
+#[tokio::test]
+async fn preview_self_merge_rejected() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let err = fluree
+        .merge_preview("mydb", "dev", Some("dev"))
+        .await
+        .expect_err("self-merge preview should fail");
+    assert!(
+        err.to_string().contains("itself"),
+        "expected error about merging into itself, got: {err}"
+    );
+}
+
+// =============================================================================
+// 8. Truncation — max_commits caps the list but not the count
+// =============================================================================
+
+#[tokio::test]
+async fn preview_truncation_caps_commits_list() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // Five commits on dev.
+    let mut dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    for (i, name) in ["B", "C", "D", "E", "F"].iter().enumerate() {
+        let data = json!({
+            "@context": {"ex": "http://example.org/ns/"},
+            "@graph": [{"@id": format!("ex:p{i}"), "ex:name": *name}]
+        });
+        dev_ledger = fluree.insert(dev_ledger, &data).await.unwrap().ledger;
+    }
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                max_commits: Some(2),
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(preview.ahead.count, 5, "5 commits diverged on dev");
+    assert_eq!(preview.ahead.commits.len(), 2, "list capped at 2");
+    assert!(preview.ahead.truncated);
+    // Strictly t-descending.
+    for pair in preview.ahead.commits.windows(2) {
+        assert!(pair[0].t > pair[1].t);
+    }
+}
+
+// =============================================================================
+// 9. include_conflicts = false short-circuits the delta walks
+// =============================================================================
+
+#[tokio::test]
+async fn preview_include_conflicts_false_returns_empty_conflicts() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // Real conflict on ex:alice/ex:name.
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev"}]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+        .insert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-main"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflicts: false,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(!preview.fast_forward);
+    assert_eq!(preview.conflicts.count, 0);
+    assert!(preview.conflicts.keys.is_empty());
+    assert!(!preview.conflicts.truncated);
+}
+
+// =============================================================================
+// 10. Read-only invariant — no nameservice mutations
+// =============================================================================
+
+#[tokio::test]
+async fn preview_does_not_mutate_nameservice() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:bob", "ex:name": "Bob"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    fluree
+        .insert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:carol", "ex:name": "Carol"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let pre_main = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    let pre_dev = fluree
+        .nameservice()
+        .lookup("mydb:dev")
+        .await
+        .unwrap()
+        .unwrap();
+
+    let _preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    let post_main = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    let post_dev = fluree
+        .nameservice()
+        .lookup("mydb:dev")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(pre_main.commit_t, post_main.commit_t);
+    assert_eq!(pre_main.commit_head_id, post_main.commit_head_id);
+    assert_eq!(pre_dev.commit_t, post_dev.commit_t);
+    assert_eq!(pre_dev.commit_head_id, post_dev.commit_head_id);
+}
+
+// =============================================================================
+// 11. Source has no source_branch — same error as merge_branch
+// =============================================================================
+
+#[tokio::test]
+async fn preview_main_as_source_refused() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    fluree.create_ledger("mydb").await.unwrap();
+
+    let err = fluree
+        .merge_preview("mydb", "main", None)
+        .await
+        .expect_err("preview of main as source should fail (no source_branch)");
+    assert!(
+        err.to_string().contains("no source branch"),
+        "expected error about missing source branch, got: {err}"
+    );
+}
+
+// =============================================================================
+// 12. Nonexistent source
+// =============================================================================
+
+#[tokio::test]
+async fn preview_nonexistent_source_fails() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    fluree.create_ledger("mydb").await.unwrap();
+
+    let err = fluree
+        .merge_preview("mydb", "nonexistent", None)
+        .await
+        .expect_err("preview of nonexistent branch should fail");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("not found") || msg.contains("nonexistent"),
+        "expected not-found error, got: {err}"
+    );
+}
+
+// =============================================================================
+// 13. Sibling branches — explicit target across branch namespaces
+//
+// Regression test for the cross-branch ancestor lookup bug. Source `dev` and
+// target `feature` are siblings off `main`, both have advanced. The ancestor
+// walk must read commits from both branches' namespaces.
+// =============================================================================
+
+#[tokio::test]
+async fn preview_between_sibling_branches() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    fluree.create_branch("mydb", "feature", None).await.unwrap();
+
+    // Advance dev (source).
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:bob", "ex:name": "Bob"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Advance feature (target).
+    let feature_ledger = fluree.ledger("mydb:feature").await.unwrap();
+    fluree
+        .insert(
+            feature_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:carol", "ex:name": "Carol"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview("mydb", "dev", Some("feature"))
+        .await
+        .unwrap();
+
+    assert_eq!(preview.source, "dev");
+    assert_eq!(preview.target, "feature");
+    assert!(
+        preview.ancestor.is_some(),
+        "ancestor must resolve across sibling branches"
+    );
+    assert!(preview.ahead.count >= 1, "dev has 1 commit");
+    assert!(preview.behind.count >= 1, "feature has 1 commit");
+    assert!(!preview.fast_forward);
+}
+
+// =============================================================================
+// 14. Unbounded — opts.max_commits = None returns the full divergence
+// =============================================================================
+
+#[tokio::test]
+async fn preview_max_commits_none_is_unbounded() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // 5 commits on dev.
+    let mut dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    for (i, name) in ["B", "C", "D", "E", "F"].iter().enumerate() {
+        let data = json!({
+            "@context": {"ex": "http://example.org/ns/"},
+            "@graph": [{"@id": format!("ex:p{i}"), "ex:name": *name}]
+        });
+        dev_ledger = fluree.insert(dev_ledger, &data).await.unwrap().ledger;
+    }
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                max_commits: None,
+                max_conflict_keys: None,
+                include_conflicts: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(preview.ahead.count, 5);
+    assert_eq!(
+        preview.ahead.commits.len(),
+        5,
+        "None should return the full list, not the default cap"
+    );
+    assert!(!preview.ahead.truncated);
+}
+
+// =============================================================================
+// 15. Default opts cap commit lists at 500 (and conflict keys at 200)
+// =============================================================================
+
+#[tokio::test]
+async fn preview_default_opts_carry_caps() {
+    let opts = MergePreviewOpts::default();
+    assert_eq!(opts.max_commits, Some(500));
+    assert_eq!(opts.max_conflict_keys, Some(200));
+    assert!(opts.include_conflicts);
+}
+
+// =============================================================================
+// 16. Conflict keys are sorted (stable across builds)
+// =============================================================================
+
+#[tokio::test]
+async fn preview_conflict_keys_are_sorted() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    // Seed several subjects so we can produce multiple conflicts.
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:name": "Alice"},
+            {"@id": "ex:bob",   "ex:name": "Bob"},
+            {"@id": "ex:carol", "ex:name": "Carol"},
+        ]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    // Modify the same predicate on each subject from both branches.
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "ex:name": "A-dev"},
+                    {"@id": "ex:bob",   "ex:name": "B-dev"},
+                    {"@id": "ex:carol", "ex:name": "C-dev"},
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+        .insert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "ex:name": "A-main"},
+                    {"@id": "ex:bob",   "ex:name": "B-main"},
+                    {"@id": "ex:carol", "ex:name": "C-main"},
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree.merge_preview("mydb", "dev", None).await.unwrap();
+
+    assert!(preview.conflicts.count >= 3);
+    let keys = &preview.conflicts.keys;
+    for pair in keys.windows(2) {
+        assert!(pair[0] <= pair[1], "conflict keys must be sorted");
+    }
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -832,6 +832,45 @@ pub enum BranchAction {
         #[arg(long)]
         remote: Option<String>,
     },
+
+    /// Show a read-only merge preview between two branches
+    ///
+    /// Returns the rich diff (commits ahead/behind, conflict keys,
+    /// fast-forward eligibility) without mutating any state.
+    Diff {
+        /// Source branch name (e.g., "dev", "feature-x")
+        source: String,
+
+        /// Target branch (defaults to source's parent branch)
+        #[arg(long)]
+        target: Option<String>,
+
+        /// Cap on per-side commit list (default: 50 in CLI; 500 over HTTP).
+        /// Pass 0 for unbounded (local mode only).
+        #[arg(long, default_value_t = 50)]
+        max_commits: usize,
+
+        /// Cap on conflict keys returned (default: 50).
+        /// Pass 0 for unbounded (local mode only).
+        #[arg(long, default_value_t = 50)]
+        max_conflict_keys: usize,
+
+        /// Skip the conflict computation when only counts are needed
+        #[arg(long)]
+        no_conflicts: bool,
+
+        /// Emit the raw JSON preview instead of a human-readable summary
+        #[arg(long)]
+        json: bool,
+
+        /// Ledger name (defaults to active ledger)
+        #[arg(long)]
+        ledger: Option<String>,
+
+        /// Execute against a remote server (by remote name, e.g., "origin")
+        #[arg(long)]
+        remote: Option<String>,
+    },
 }
 
 /// Memory subcommands.

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -65,6 +65,32 @@ pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliRes
             )
             .await
         }
+        BranchAction::Diff {
+            source,
+            target,
+            max_commits,
+            max_conflict_keys,
+            no_conflicts,
+            json,
+            ledger,
+            remote,
+        } => {
+            run_diff(
+                &source,
+                target.as_deref(),
+                DiffOpts {
+                    max_commits,
+                    max_conflict_keys,
+                    include_conflicts: !no_conflicts,
+                    json,
+                },
+                ledger.as_deref(),
+                dirs,
+                remote.as_deref(),
+                direct,
+            )
+            .await
+        }
     }
 }
 
@@ -612,4 +638,273 @@ fn print_branch_dropped(result: &serde_json::Value) -> CliResult<()> {
         }
     }
     Ok(())
+}
+
+// =============================================================================
+// Diff (read-only merge preview)
+// =============================================================================
+
+struct DiffOpts {
+    max_commits: usize,
+    max_conflict_keys: usize,
+    include_conflicts: bool,
+    json: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_diff(
+    source: &str,
+    target: Option<&str>,
+    opts: DiffOpts,
+    ledger: Option<&str>,
+    dirs: &FlureeDir,
+    remote_flag: Option<&str>,
+    direct: bool,
+) -> CliResult<()> {
+    // Translate `0` to "unbounded" only for local mode — the HTTP layer
+    // always enforces a hard cap, so requesting unbounded over the wire
+    // collapses to the server-side default.
+    let max_commits = if opts.max_commits == 0 {
+        None
+    } else {
+        Some(opts.max_commits)
+    };
+    let max_conflict_keys = if opts.max_conflict_keys == 0 {
+        None
+    } else {
+        Some(opts.max_conflict_keys)
+    };
+    let include_conflicts = opts.include_conflicts;
+
+    if let Some(remote_name) = remote_flag {
+        let alias = context::resolve_ledger(ledger, dirs)?;
+        let (ledger_name, _) = split_ledger_id(&alias)?;
+        let client = context::build_remote_client(remote_name, dirs).await?;
+        let preview = client
+            .merge_preview(
+                &ledger_name,
+                source,
+                target,
+                max_commits,
+                max_conflict_keys,
+                Some(include_conflicts),
+            )
+            .await?;
+
+        context::persist_refreshed_tokens(&client, remote_name, dirs).await;
+
+        if opts.json {
+            println!("{}", serde_json::to_string_pretty(&preview)?);
+        } else {
+            print_preview_json(&preview)?;
+        }
+        return Ok(());
+    }
+
+    let mode = {
+        let mode = context::resolve_ledger_mode(ledger, dirs).await?;
+        if direct {
+            mode
+        } else {
+            context::try_server_route(mode, dirs)
+        }
+    };
+
+    match mode {
+        LedgerMode::Tracked {
+            client,
+            remote_alias,
+            remote_name,
+            ..
+        } => {
+            let (ledger_name, _) = split_ledger_id(&remote_alias)?;
+            let preview = client
+                .merge_preview(
+                    &ledger_name,
+                    source,
+                    target,
+                    max_commits,
+                    max_conflict_keys,
+                    Some(include_conflicts),
+                )
+                .await?;
+
+            context::persist_refreshed_tokens(&client, &remote_name, dirs).await;
+
+            if opts.json {
+                println!("{}", serde_json::to_string_pretty(&preview)?);
+            } else {
+                print_preview_json(&preview)?;
+            }
+        }
+        LedgerMode::Local { fluree, alias } => {
+            let (ledger_name, _) = split_ledger_id(&alias)?;
+            let preview_opts = fluree_db_api::MergePreviewOpts {
+                max_commits,
+                max_conflict_keys,
+                include_conflicts,
+            };
+
+            let preview = fluree
+                .merge_preview_with(&ledger_name, source, target, preview_opts)
+                .await?;
+
+            if opts.json {
+                let value = serde_json::to_value(&preview)?;
+                println!("{}", serde_json::to_string_pretty(&value)?);
+            } else {
+                print_preview_local(&preview);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_preview_local(p: &fluree_db_api::MergePreview) {
+    println!("source: {}", p.source);
+    println!("target: {}", p.target);
+    if let Some(anc) = &p.ancestor {
+        println!("ancestor: t={} ({})", anc.t, anc.commit_id);
+    } else {
+        println!("ancestor: <none>");
+    }
+    println!(
+        "fast-forward: {}",
+        if p.fast_forward { "yes" } else { "no" }
+    );
+
+    print_delta_local("ahead", &p.ahead);
+    print_delta_local("behind", &p.behind);
+
+    println!(
+        "conflicts: {}{}",
+        p.conflicts.count,
+        if p.conflicts.truncated {
+            format!(" (showing {})", p.conflicts.keys.len())
+        } else {
+            String::new()
+        }
+    );
+    for k in &p.conflicts.keys {
+        println!(
+            "  - s={} p={} g={:?}",
+            k.s,
+            k.p,
+            k.g.as_ref().map(ToString::to_string)
+        );
+    }
+}
+
+fn print_delta_local(label: &str, d: &fluree_db_api::BranchDelta) {
+    println!(
+        "{}: {} commits{}",
+        label,
+        d.count,
+        if d.truncated {
+            format!(" (showing {})", d.commits.len())
+        } else {
+            String::new()
+        }
+    );
+    for c in &d.commits {
+        let msg = c.message.as_deref().unwrap_or("");
+        let asserts = c.asserts;
+        let retracts = c.retracts;
+        let time = c.time.as_deref().unwrap_or("?");
+        if msg.is_empty() {
+            println!(
+                "  t={} +{}/-{} {} {}",
+                c.t, asserts, retracts, time, c.commit_id
+            );
+        } else {
+            println!(
+                "  t={} +{}/-{} {} {} | {}",
+                c.t, asserts, retracts, time, c.commit_id, msg
+            );
+        }
+    }
+}
+
+/// Pretty-print a preview returned from the remote/tracked path
+/// (where we only have a `serde_json::Value`).
+fn print_preview_json(v: &serde_json::Value) -> CliResult<()> {
+    use serde_json::Value;
+    let source = v.get("source").and_then(Value::as_str).unwrap_or("?");
+    let target = v.get("target").and_then(Value::as_str).unwrap_or("?");
+    println!("source: {source}");
+    println!("target: {target}");
+
+    if let Some(anc) = v.get("ancestor").filter(|x| !x.is_null()) {
+        let t = anc.get("t").and_then(Value::as_i64).unwrap_or(0);
+        let id = anc.get("commit_id").and_then(Value::as_str).unwrap_or("?");
+        println!("ancestor: t={t} ({id})");
+    } else {
+        println!("ancestor: <none>");
+    }
+
+    let ff = v
+        .get("fast_forward")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    println!("fast-forward: {}", if ff { "yes" } else { "no" });
+
+    if let Some(ahead) = v.get("ahead") {
+        print_delta_json("ahead", ahead);
+    }
+    if let Some(behind) = v.get("behind") {
+        print_delta_json("behind", behind);
+    }
+
+    if let Some(c) = v.get("conflicts") {
+        let count = c.get("count").and_then(Value::as_u64).unwrap_or(0);
+        let truncated = c.get("truncated").and_then(Value::as_bool).unwrap_or(false);
+        let keys = c.get("keys").and_then(Value::as_array);
+        let shown = keys.map_or(0, Vec::len);
+        println!(
+            "conflicts: {count}{}",
+            if truncated {
+                format!(" (showing {shown})")
+            } else {
+                String::new()
+            }
+        );
+        if let Some(keys) = keys {
+            for k in keys {
+                println!("  - {}", serde_json::to_string(k).unwrap_or_default());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_delta_json(label: &str, d: &serde_json::Value) {
+    use serde_json::Value;
+    let count = d.get("count").and_then(Value::as_u64).unwrap_or(0);
+    let truncated = d.get("truncated").and_then(Value::as_bool).unwrap_or(false);
+    let commits = d.get("commits").and_then(Value::as_array);
+    let shown = commits.map_or(0, Vec::len);
+    println!(
+        "{label}: {count} commits{}",
+        if truncated {
+            format!(" (showing {shown})")
+        } else {
+            String::new()
+        }
+    );
+    if let Some(commits) = commits {
+        for c in commits {
+            let t = c.get("t").and_then(Value::as_i64).unwrap_or(0);
+            let asserts = c.get("asserts").and_then(Value::as_u64).unwrap_or(0);
+            let retracts = c.get("retracts").and_then(Value::as_u64).unwrap_or(0);
+            let time = c.get("time").and_then(Value::as_str).unwrap_or("?");
+            let id = c.get("commit_id").and_then(Value::as_str).unwrap_or("?");
+            let msg = c.get("message").and_then(Value::as_str).unwrap_or("");
+            if msg.is_empty() {
+                println!("  t={t} +{asserts}/-{retracts} {time} {id}");
+            } else {
+                println!("  t={t} +{asserts}/-{retracts} {time} {id} | {msg}");
+            }
+        }
+    }
 }

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -1247,6 +1247,57 @@ impl RemoteLedgerClient {
             .await
     }
 
+    /// Read-only merge preview between two branches on the remote server.
+    ///
+    /// Calls `GET {base_url}/merge-preview/{ledger}?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=`.
+    /// The ledger path segment is URL-encoded (via [`op_url`](Self::op_url))
+    /// so names containing spaces, `?`, `#`, `%`, etc. produce well-formed URLs.
+    pub async fn merge_preview(
+        &self,
+        ledger: &str,
+        source: &str,
+        target: Option<&str>,
+        max_commits: Option<usize>,
+        max_conflict_keys: Option<usize>,
+        include_conflicts: Option<bool>,
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let mut url = self.op_url("merge-preview", ledger);
+        let mut sep = '?';
+        let push = |url: &mut String, sep: &mut char, key: &str, val: String| {
+            url.push(*sep);
+            url.push_str(key);
+            url.push('=');
+            url.push_str(&val);
+            *sep = '&';
+        };
+        push(
+            &mut url,
+            &mut sep,
+            "source",
+            urlencoding::encode(source).into_owned(),
+        );
+        if let Some(t) = target {
+            push(
+                &mut url,
+                &mut sep,
+                "target",
+                urlencoding::encode(t).into_owned(),
+            );
+        }
+        if let Some(n) = max_commits {
+            push(&mut url, &mut sep, "max_commits", n.to_string());
+        }
+        if let Some(n) = max_conflict_keys {
+            push(&mut url, &mut sep, "max_conflict_keys", n.to_string());
+        }
+        if let Some(b) = include_conflicts {
+            push(&mut url, &mut sep, "include_conflicts", b.to_string());
+        }
+
+        self.send_json(reqwest::Method::GET, &url, "application/json", None)
+            .await
+    }
+
     // =========================================================================
     // Push commits
     // =========================================================================
@@ -1520,6 +1571,19 @@ mod tests {
         assert_eq!(
             client.op_url("query", "trigger-test:testing"),
             "http://localhost:8090/fluree/query/trigger-test:testing"
+        );
+    }
+
+    #[test]
+    fn test_op_url_merge_preview_encodes_unsafe_chars() {
+        // Regression: merge-preview previously interpolated the ledger raw,
+        // breaking on names with spaces/?/#/% etc. The implementation now
+        // routes through `op_url` so these get URL-encoded the same as
+        // every other ledger-tailed endpoint.
+        let client = RemoteLedgerClient::new("http://localhost:8090/fluree", None);
+        assert_eq!(
+            client.op_url("merge-preview", "weird name?:branch#x"),
+            "http://localhost:8090/fluree/merge-preview/weird%20name%3F:branch%23x"
         );
     }
 

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -730,6 +730,98 @@ async fn advance_frontier<C: ContentStore>(
     Ok(None)
 }
 
+// =============================================================================
+// CommitSummary - lightweight per-commit info for diff/log views
+// =============================================================================
+
+/// Per-commit summary suitable for diff/log views.
+///
+/// Built by counting [`Flake`] ops on a loaded [`Commit`]. The optional
+/// `message` is extracted from `txn_meta` when an entry with predicate
+/// `f:message` (namespace `FLUREE_DB`, local name `"message"`) is present
+/// and its value is a plain string. Other conventions are not recognized
+/// today.
+#[derive(Clone, Debug, Serialize)]
+pub struct CommitSummary {
+    pub t: i64,
+    pub commit_id: ContentId,
+    /// ISO 8601 from [`Commit::time`]. `None` for legacy commits without a timestamp.
+    pub time: Option<String>,
+    pub asserts: usize,
+    pub retracts: usize,
+    pub flake_count: usize,
+    /// Extracted from [`Commit::txn_meta`] when an `f:message` entry with a
+    /// string value is present. Often `None`.
+    pub message: Option<String>,
+}
+
+/// Build a [`CommitSummary`] from a fully-loaded [`Commit`].
+///
+/// Pure function — no I/O. The `commit.id` must be `Some` (it always is for
+/// commits loaded via [`load_commit_by_id`]).
+pub fn commit_to_summary(commit: &Commit) -> CommitSummary {
+    let commit_id = commit
+        .id
+        .clone()
+        .expect("commit_to_summary requires a Commit with id set (loaded via load_commit_by_id)");
+
+    let mut asserts = 0usize;
+    let mut retracts = 0usize;
+    for f in &commit.flakes {
+        if f.op {
+            asserts += 1;
+        } else {
+            retracts += 1;
+        }
+    }
+
+    let message = commit.txn_meta.iter().find_map(|entry| {
+        if entry.predicate_ns == fluree_vocab::namespaces::FLUREE_DB
+            && entry.predicate_name == "message"
+        {
+            if let TxnMetaValue::String(s) = &entry.value {
+                return Some(s.clone());
+            }
+        }
+        None
+    });
+
+    CommitSummary {
+        t: commit.t,
+        commit_id,
+        time: commit.time.clone(),
+        asserts,
+        retracts,
+        flake_count: commit.flakes.len(),
+        message,
+    }
+}
+
+/// Walk commits from `head` back to `stop_at_t` (exclusive), summarising each.
+///
+/// Returns `(summaries, total_count)`. `summaries` is newest-first (descending
+/// `t`) and capped by `max`. `total_count` always reflects the full divergence
+/// regardless of cap; truncation is implied by `summaries.len() < total_count`.
+///
+/// Reuses [`collect_dag_cids`] (one byte-range envelope read per commit in
+/// the divergence) plus one full [`load_commit_by_id`] per summary returned.
+pub async fn walk_commit_summaries<C: ContentStore>(
+    store: &C,
+    head: &ContentId,
+    stop_at_t: i64,
+    max: Option<usize>,
+) -> Result<(Vec<CommitSummary>, usize)> {
+    let dag = collect_dag_cids(store, head, stop_at_t).await?;
+    let total = dag.len();
+    let take_n = max.map_or(total, |cap| cap.min(total));
+    let mut summaries = Vec::with_capacity(take_n);
+    for (_t, cid) in dag.iter().take(take_n) {
+        let commit = load_commit_by_id(store, cid).await?;
+        summaries.push(commit_to_summary(&commit));
+    }
+    Ok((summaries, total))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1139,5 +1231,184 @@ mod tests {
 
         assert_eq!(ancestor.commit_id, chain[0]);
         assert_eq!(ancestor.t, 1);
+    }
+
+    // =========================================================================
+    // CommitSummary / commit_to_summary / walk_commit_summaries tests
+    // =========================================================================
+
+    fn make_retract_flake(s: i64, p: i64, o: i64, t: i64) -> Flake {
+        Flake::new(
+            Sid::new(s as u16, format!("s{s}")),
+            Sid::new(p as u16, format!("p{p}")),
+            FlakeValue::Long(o),
+            Sid::new(2, "long"),
+            t,
+            false,
+            None,
+        )
+    }
+
+    #[test]
+    fn test_commit_to_summary_counts_asserts_and_retracts() {
+        let cid = make_test_content_id(ContentKind::Commit, "summary-1");
+        let mut commit = Commit::new(
+            7,
+            vec![
+                make_test_flake(1, 2, 10, 7),
+                make_test_flake(1, 3, 11, 7),
+                make_retract_flake(2, 2, 20, 7),
+            ],
+        );
+        commit.id = Some(cid.clone());
+        commit.time = Some("2026-01-01T00:00:00Z".to_string());
+
+        let summary = commit_to_summary(&commit);
+        assert_eq!(summary.t, 7);
+        assert_eq!(summary.commit_id, cid);
+        assert_eq!(summary.asserts, 2);
+        assert_eq!(summary.retracts, 1);
+        assert_eq!(summary.flake_count, 3);
+        assert_eq!(summary.time.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert!(summary.message.is_none());
+    }
+
+    #[test]
+    fn test_commit_to_summary_extracts_f_message() {
+        let cid = make_test_content_id(ContentKind::Commit, "summary-msg");
+        let mut commit = Commit::new(3, vec![]);
+        commit.id = Some(cid);
+        commit.txn_meta = vec![TxnMetaEntry::new(
+            fluree_vocab::namespaces::FLUREE_DB,
+            "message",
+            TxnMetaValue::string("initial commit"),
+        )];
+
+        let summary = commit_to_summary(&commit);
+        assert_eq!(summary.message.as_deref(), Some("initial commit"));
+    }
+
+    #[test]
+    fn test_commit_to_summary_ignores_non_string_message() {
+        let cid = make_test_content_id(ContentKind::Commit, "summary-msg-int");
+        let mut commit = Commit::new(3, vec![]);
+        commit.id = Some(cid);
+        commit.txn_meta = vec![TxnMetaEntry::new(
+            fluree_vocab::namespaces::FLUREE_DB,
+            "message",
+            TxnMetaValue::long(42),
+        )];
+
+        let summary = commit_to_summary(&commit);
+        assert!(summary.message.is_none());
+    }
+
+    #[test]
+    fn test_commit_to_summary_ignores_other_namespace_message() {
+        let cid = make_test_content_id(ContentKind::Commit, "summary-msg-otherns");
+        let mut commit = Commit::new(3, vec![]);
+        commit.id = Some(cid);
+        // Same local name "message" but different namespace — should be ignored.
+        commit.txn_meta = vec![TxnMetaEntry::new(
+            999,
+            "message",
+            TxnMetaValue::string("not-a-commit-message"),
+        )];
+
+        let summary = commit_to_summary(&commit);
+        assert!(summary.message.is_none());
+    }
+
+    #[cfg(feature = "credential")]
+    #[tokio::test]
+    async fn test_walk_commit_summaries_orders_newest_first() {
+        let store = MemoryContentStore::new();
+        let chain = store_chain(&store, 1, 4, None, 1).await;
+
+        let (summaries, total) = walk_commit_summaries(&store, chain.last().unwrap(), 0, None)
+            .await
+            .unwrap();
+
+        assert_eq!(total, 4);
+        assert_eq!(summaries.len(), 4);
+        // Newest-first (descending t).
+        assert_eq!(summaries[0].t, 4);
+        assert_eq!(summaries[1].t, 3);
+        assert_eq!(summaries[2].t, 2);
+        assert_eq!(summaries[3].t, 1);
+        // Each chain commit has one assert flake.
+        assert!(summaries.iter().all(|s| s.asserts == 1 && s.retracts == 0));
+    }
+
+    #[cfg(feature = "credential")]
+    #[tokio::test]
+    async fn test_walk_commit_summaries_respects_stop_at_t() {
+        let store = MemoryContentStore::new();
+        let chain = store_chain(&store, 1, 4, None, 1).await;
+
+        // stop_at_t = 2 → only commits with t > 2 (t=3 and t=4).
+        let (summaries, total) = walk_commit_summaries(&store, chain.last().unwrap(), 2, None)
+            .await
+            .unwrap();
+
+        assert_eq!(total, 2);
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].t, 4);
+        assert_eq!(summaries[1].t, 3);
+    }
+
+    #[cfg(feature = "credential")]
+    #[tokio::test]
+    async fn test_walk_commit_summaries_caps_with_max() {
+        let store = MemoryContentStore::new();
+        let chain = store_chain(&store, 1, 5, None, 1).await;
+
+        // 5 commits in the divergence; cap to 2.
+        let (summaries, total) = walk_commit_summaries(&store, chain.last().unwrap(), 0, Some(2))
+            .await
+            .unwrap();
+
+        assert_eq!(total, 5, "total should reflect the full divergence");
+        assert_eq!(summaries.len(), 2, "summaries should be capped");
+        // Newest first.
+        assert_eq!(summaries[0].t, 5);
+        assert_eq!(summaries[1].t, 4);
+    }
+
+    #[cfg(feature = "credential")]
+    #[tokio::test]
+    async fn test_walk_commit_summaries_handles_merge_commit() {
+        // Build:
+        //   shared: c1
+        //   branch_a: c1 <- a2 <- a3
+        //   branch_b: c1 <- b2
+        //   merge:   m4 with parents [a3, b2]
+        // walk_commit_summaries from m4 with stop_at_t = 0 should visit each of
+        // {m4, a3, a2, b2, c1} exactly once → total = 5.
+        let store = MemoryContentStore::new();
+        let shared = store_chain(&store, 1, 1, None, 1).await;
+        let branch_a = store_chain(&store, 2, 2, Some(shared[0].clone()), 100).await;
+        let branch_b = store_chain(&store, 2, 1, Some(shared[0].clone()), 200).await;
+
+        let merge_commit = Commit::new(4, vec![])
+            .with_previous_ref(CommitRef::new(branch_a.last().unwrap().clone()))
+            .with_previous_ref(CommitRef::new(branch_b[0].clone()));
+        let merge_id = store_commit(&store, &merge_commit).await;
+
+        let (summaries, total) = walk_commit_summaries(&store, &merge_id, 0, None)
+            .await
+            .unwrap();
+
+        assert_eq!(total, 5);
+        assert_eq!(summaries.len(), 5);
+        // Strictly t-descending.
+        for pair in summaries.windows(2) {
+            assert!(
+                pair[0].t >= pair[1].t,
+                "expected newest-first ordering: {} >= {}",
+                pair[0].t,
+                pair[1].t
+            );
+        }
     }
 }

--- a/fluree-db-core/src/conflict_key.rs
+++ b/fluree-db-core/src/conflict_key.rs
@@ -4,10 +4,15 @@
 //! used to detect overlapping modifications between branches during rebase.
 
 use crate::sid::Sid;
+use serde::Serialize;
 
 /// A (subject, predicate, graph) tuple identifying a data point that may conflict
 /// between branch and source during rebase.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+///
+/// `Ord`/`PartialOrd` are derived to support stable, lexicographic ordering
+/// of conflict sets — important for capped/paginated conflict previews where
+/// `HashSet::intersection` order is otherwise unspecified.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct ConflictKey {
     pub s: Sid,
     pub p: Sid,

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -78,10 +78,11 @@ pub use address::{
 };
 pub use coerce::{coerce_json_value, coerce_value, CoercionError, CoercionResult};
 pub use commit::{
-    collect_dag_cids, collect_dag_cids_with_split_mode, find_common_ancestor, load_commit_by_id,
-    load_commit_envelope_by_id, trace_commit_envelopes_by_id, trace_commits_by_id, Commit,
-    CommitEnvelope, CommitRef, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature,
-    MAX_TXN_META_BYTES, MAX_TXN_META_ENTRIES,
+    collect_dag_cids, collect_dag_cids_with_split_mode, commit_to_summary, find_common_ancestor,
+    load_commit_by_id, load_commit_envelope_by_id, trace_commit_envelopes_by_id,
+    trace_commits_by_id, walk_commit_summaries, Commit, CommitEnvelope, CommitRef, CommitSummary,
+    CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature, MAX_TXN_META_BYTES,
+    MAX_TXN_META_ENTRIES,
 };
 pub use comparator::IndexType;
 pub use conflict_key::ConflictKey;

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -1433,6 +1433,128 @@ async fn merge_local(state: Arc<AppState>, request: Request) -> Result<impl Into
     .await
 }
 
+// ============================================================================
+// Merge Preview (read-only)
+// ============================================================================
+
+/// Hard cap on `max_commits` — clamps the per-side commit list returned to
+/// the client regardless of what they request. 10x the recommended default.
+///
+/// **What this protects:** response body size and the per-commit
+/// `load_commit_by_id` reads (one full commit blob loaded per summary
+/// returned).
+///
+/// **What this does NOT protect:** the underlying divergence walk. The
+/// `count` field on each side reflects the full unbounded divergence —
+/// computed by walking every commit envelope between HEAD and the common
+/// ancestor — so a request against branches diverged by N commits costs N
+/// envelope reads regardless of the cap. If you need to reject huge
+/// divergences, add an operational guard before invoking the walk
+/// (e.g., refuse when ancestor.t < target.t - SOME_LIMIT).
+const MERGE_PREVIEW_HARD_MAX_COMMITS: usize = 5_000;
+
+/// Hard cap on `max_conflict_keys`. 25x the recommended default.
+///
+/// **What this protects:** the size of `conflicts.keys` in the response.
+///
+/// **What this does NOT protect:** the conflict computation. When
+/// `include_conflicts=true`, both `compute_delta_keys` walks scan the full
+/// per-side delta regardless of cap. Clients that need a fast preview
+/// should pass `include_conflicts=false`.
+const MERGE_PREVIEW_HARD_MAX_CONFLICT_KEYS: usize = 5_000;
+
+/// Query parameters for [`merge_preview`].
+#[derive(Deserialize)]
+pub struct MergePreviewQuery {
+    /// Source branch.
+    pub source: String,
+    /// Target branch (optional; defaults to the source's parent).
+    #[serde(default)]
+    pub target: Option<String>,
+    /// Cap on per-side commit list. Defaults to 500.
+    #[serde(default)]
+    pub max_commits: Option<usize>,
+    /// Cap on conflict keys returned. Defaults to 200.
+    #[serde(default)]
+    pub max_conflict_keys: Option<usize>,
+    /// Skip the conflict computation when only counts are needed. Defaults to true.
+    #[serde(default)]
+    pub include_conflicts: Option<bool>,
+}
+
+/// Read-only branch merge preview.
+///
+/// GET /fluree/merge-preview/*ledger?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=
+///
+/// Returns a JSON [`fluree_db_api::MergePreview`] with ahead/behind commit
+/// summaries, conflict keys, and fast-forward eligibility — without mutating
+/// any ledger state.
+pub async fn merge_preview(
+    State(state): State<Arc<AppState>>,
+    Path(ledger): Path<String>,
+    Query(params): Query<MergePreviewQuery>,
+    headers: FlureeHeaders,
+    bearer: MaybeDataBearer,
+) -> Result<Json<fluree_db_api::MergePreview>> {
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+
+    let span = create_request_span(
+        "branch:merge-preview",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        Some(&ledger),
+        None,
+        None,
+    );
+    async move {
+        let span = tracing::Span::current();
+
+        // Same auth pattern as list_branches: Bearer required when configured.
+        let data_auth = state.config.data_auth();
+        if data_auth.mode == crate::config::DataAuthMode::Required && bearer.0.is_none() {
+            set_span_error_code(&span, "error:Unauthorized");
+            return Err(ServerError::unauthorized("Bearer token required"));
+        }
+        if let Some(p) = bearer.0.as_ref() {
+            if !p.can_read(&ledger) {
+                set_span_error_code(&span, "error:Forbidden");
+                return Err(ServerError::not_found("Ledger not found"));
+            }
+        }
+
+        // Start from the API's default (which carries the recommended caps)
+        // and override only fields the caller supplied. Caller values are
+        // additionally clamped to the server-side hard maximums so a
+        // request like `max_commits=10000000` cannot blow out the response
+        // body or force unbounded `load_commit_by_id` reads. The
+        // *divergence walk itself* (envelope BFS via `collect_dag_cids`)
+        // is unaffected — see the `MERGE_PREVIEW_HARD_MAX_*` constant
+        // comments above. Contract documented in
+        // docs/cli/server-integration.md (§Merge Preview Contract, rule 9).
+        let mut opts = fluree_db_api::MergePreviewOpts::default();
+        if let Some(n) = params.max_commits {
+            opts.max_commits = Some(n.min(MERGE_PREVIEW_HARD_MAX_COMMITS));
+        }
+        if let Some(n) = params.max_conflict_keys {
+            opts.max_conflict_keys = Some(n.min(MERGE_PREVIEW_HARD_MAX_CONFLICT_KEYS));
+        }
+        if let Some(b) = params.include_conflicts {
+            opts.include_conflicts = b;
+        }
+
+        let preview = state
+            .fluree
+            .merge_preview_with(&ledger, &params.source, params.target.as_deref(), opts)
+            .await
+            .map_err(ServerError::Api)?;
+
+        Ok(Json(preview))
+    }
+    .instrument(span)
+    .await
+}
+
 /// Forward a transaction request to the transaction server (peer mode)
 pub(super) async fn forward_write_request(state: &AppState, request: Request) -> Response {
     let client = match state.forwarding_client.as_ref() {

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -64,6 +64,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/info/*ledger", get(ledger::info_ledger_tail))
         .route("/exists/*ledger", get(ledger::exists_ledger_tail))
         .route("/branch/*ledger", get(ledger::list_branches))
+        .route("/merge-preview/*ledger", get(ledger::merge_preview))
         // Merge admin-protected routes
         .merge(v1_admin_protected_routes)
         // Query endpoints


### PR DESCRIPTION
Adds a read-only "what would a merge look like?" primitive across all three
surfaces — Rust API, HTTP, and CLI — that returns the rich diff between two
branches (ahead/behind commits, common ancestor, conflict keys, fast-forward
eligibility) **without mutating any state**. API callers can consumes it for
branch UI; the standalone server exposes it as an HTTP route; the CLI
ships a `branch diff` subcommand with `--remote` support.

The implementation reuses the same primitives `merge_branch` already calls,
factored into `fluree-db-core` so they're reusable for git-log-style
viewers, indexer status panels, peer-mode diagnostics, and other tooling.

## What's in the PR

### `fluree-db-core` — new reusable primitives

- **`CommitSummary`** struct: `t`, `commit_id`, `time`, `asserts`,
  `retracts`, `flake_count`, `message: Option<String>` (extracted from the
  `f:message` `txn_meta` entry when present).
- **`commit_to_summary(&Commit) -> CommitSummary`** — pure decoder, no I/O.
- **`walk_commit_summaries(store, head, stop_at_t, max) -> Result<(Vec<CommitSummary>, usize)>`**
  — newest-first DAG walk that returns both the (capped) summary list and
  the unbounded total count. Uses byte-range envelope reads for the BFS
  plus one full `load_commit_by_id` per summary returned.
- **`ConflictKey`** gained `Serialize`, `Ord`, `PartialOrd` derives so
  capped responses can be sorted before truncation (stable across builds /
  paginated requests — `HashSet::intersection` order is otherwise
  unspecified).

8 new unit tests cover counting, `f:message` extraction (including a
wrong-namespace negative case), walk ordering, `stop_at_t` exclusivity,
truncation, and merge-commit DAGs.

### `fluree-db-api` — new public surface

- `Fluree::merge_preview(ledger, source, target?) -> MergePreview`
- `Fluree::merge_preview_with(ledger, source, target?, opts) -> MergePreview`
- Types: `MergePreview`, `BranchDelta`, `ConflictSummary`, `AncestorRef`,
  `MergePreviewOpts`
- Constants: `DEFAULT_MAX_COMMITS = 500`, `DEFAULT_MAX_CONFLICT_KEYS = 200`
- Re-exports for embedded callers: `CommitSummary`, `CommonAncestor`,
  `ConflictKey`, `commit_to_summary`, `walk_commit_summaries`,
  `find_common_ancestor`

Mirrors `merge_branch_inner` for source/target resolution and the
fast-forward predicate, but skips publish/copy steps. Walks both sides
with `tokio::try_join!`.

16 integration tests covering: fast-forward, diverged-no-conflicts,
diverged-with-conflicts, equal heads, behind-only, default target,
self-merge rejection, truncation, `include_conflicts=false`, read-only
invariant (pre/post nameservice equality), `main`-as-source rejection,
nonexistent source, **sibling-branch ancestor lookup** (regression),
`max_commits=None` unbounded, default opts carry caps, conflict keys
sorted.

### `fluree-db-server` — HTTP route

`GET /fluree/merge-preview/*ledger?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=`

- Auth pattern matches `list_branches` (Bearer required when
  `data_auth.required`; `404` not `403` when bearer can't read).
- Server-side hard caps (`MERGE_PREVIEW_HARD_MAX_COMMITS = 5_000`,
  `MERGE_PREVIEW_HARD_MAX_CONFLICT_KEYS = 5_000`) clamp caller values via
  `n.min(HARD_MAX)` so `max_commits=10000000` collapses to 5000.
- Defaults applied when query params absent (500 / 200).

### `fluree-db-cli` — `branch diff` subcommand

```
fluree branch diff <source> [--target <name>] [--max-commits N]
                            [--max-conflict-keys N] [--no-conflicts]
                            [--json] [--ledger <name>] [--remote <name>]
```

Mirrors the `rebase` / `merge` command structure: supports local-mode
direct execution, tracked-ledger auto-routing, and explicit `--remote`.
Default output is human-readable; `--json` emits the raw `MergePreview`.

`RemoteClient::merge_preview` issues `GET /merge-preview/{ledger}` via
`op_url` + `encode_ledger_path`, so ledger names with spaces / `?` / `#` /
`%` produce well-formed URLs (regression test included).

## Notable design decisions

### Defaults vs. unbounded

`MergePreviewOpts::default()` carries `Some(500)` / `Some(200)` caps so
the no-arg `merge_preview()` matches the spec defaults. `None` is reserved
as an explicit "unbounded" signal for direct Rust callers (e.g., tooling
that needs the full divergence). The HTTP layer constructs from
`default()` and overrides only when the query param is present, so
unbounded responses cannot leak over the wire.

### Cross-branch ancestor lookup

`find_common_ancestor` needs to load commit envelopes from **both**
branches' namespaces. The first cut walked through `source_store` only,
which fails when the target is a sibling branch with commits in its own
namespace. Fixed by building a union view —
`BranchedContentStore::with_parents(source_store_inner, [target_branched])` —
used only for the ancestor walk; per-side walks and delta computation
still use their own dedicated stores.

### Stable conflict-key ordering

`HashSet::intersection` returns items in arbitrary order. After
truncation, capped responses would surface a non-deterministic subset.
Sort lexicographically by `(s, p, g)` before truncating. `ConflictKey`
gained `Ord`/`PartialOrd` derives.

### Cap semantics — what they protect

`max_commits` and `max_conflict_keys` bound **response size + per-summary
`load_commit_by_id` reads**, not the cost of the underlying envelope BFS
or `compute_delta_keys` walks. The unbounded `count` on each side is
still computed — a 1M-commit divergence costs 1M envelope reads
regardless of cap. Documented prominently in rustdoc, the HTTP doc, and
the server-integration contract; `include_conflicts=false` is the
fast-preview escape hatch for diverged branches.

This is intentional — actual divergence rejection (refusing to preview a
branch that diverged 1M commits ago) is a separate operational concern;
the contract calls out where to add such a guard if needed.

## Documentation

- **`docs/api/endpoints.md`** — new `GET /fluree/merge-preview/{ledger}`
  section with request/response schema, error codes, examples. Cap
  columns explicitly note "bounds response size, not divergence-walk
  cost."
- **`docs/cli/server-integration.md`** — new `## Merge Preview Contract`
  section under the existing custom-server contract doc, alongside
  `## Policy Enforcement Contract` and `## Replication Auth Contract`.
  Spells out the 9 required semantic rules custom servers must honor
  (cross-branch ancestor walk, sort-before-truncate, mandatory
  server-side cap, etc.) plus the wire encoding for `ConflictKey`.
- **`docs/getting-started/rust-api.md`** — new `### Branch Diff
  (Merge Preview)` section under "Advanced Usage" with embedded usage
  examples, response-shape table, and pointers to the reusable
  primitives.
