### PR TITLE
feat: Add merge preview conflict details

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -803,6 +803,12 @@ GET  /query?query={urlencoded-sparql}   # SPARQL Protocol GET form
 
 The `GET` form is provided for W3C SPARQL Protocol compliance. It accepts SPARQL queries via the `query` query parameter; the body forms below are preferred for larger queries and for JSON-LD. The same form is available on the ledger-scoped `/query/{ledger}` route.
 
+**Optional Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `default-context` | boolean | `false` | When `true`, use the ledger's stored default JSON-LD context if the request omits its own `@context` (JSON-LD) or `PREFIX` declarations (ledger-scoped SPARQL). |
+
 **Request Headers:**
 ```http
 Content-Type: application/json

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1841,9 +1841,9 @@ curl -X POST http://localhost:8090/v1/fluree/rebase \
 
 ### POST /fluree/merge
 
-Merge a source branch into a target branch (fast-forward only). Admin-protected.
+Merge a source branch into a target branch. Admin-protected.
 
-Currently only fast-forward merges are supported: the target branch must not have any new commits since the source branch was created from it. If the target has diverged, rebase the source branch first, then merge.
+Fast-forward merges copy the source commit chain into the target namespace and advance the target HEAD. When the target has diverged, Fluree performs a general merge: it computes the source and target deltas since their common ancestor, resolves overlapping `(s, p, g)` conflicts according to the requested strategy, and creates a merge commit on the target branch.
 
 **URL:**
 ```
@@ -1856,7 +1856,8 @@ POST /fluree/merge
 {
   "ledger": "mydb",
   "source": "feature-x",
-  "target": "dev"
+  "target": "dev",
+  "strategy": "take-both"
 }
 ```
 
@@ -1865,6 +1866,18 @@ POST /fluree/merge
 | `ledger` | string | Yes | Ledger name without branch suffix (e.g., "mydb") |
 | `source` | string | Yes | Source branch to merge from (e.g., "feature-x") |
 | `target` | string | No | Target branch to merge into (defaults to source's parent branch) |
+| `strategy` | string | No | Conflict resolution strategy for non-fast-forward merges. Defaults to `take-both`. Options: `take-both`, `abort`, `take-source`, `take-branch` |
+
+**Conflict strategies:**
+
+| Strategy | Behavior |
+|----------|----------|
+| `take-both` | Keep source flakes as-is, so both source and target values can coexist |
+| `abort` | Fail if conflicts are detected; no merge commit is created |
+| `take-source` | Source wins: keep source flakes and retract target's conflicting values |
+| `take-branch` | Target wins: drop source flakes for conflicting keys |
+
+`skip` is a rebase-only strategy and is not supported for non-fast-forward merges.
 
 **Response body (200 OK):**
 
@@ -1873,9 +1886,11 @@ POST /fluree/merge
   "ledger_id": "mydb:dev",
   "target": "dev",
   "source": "feature-x",
-  "fast_forward": true,
+  "fast_forward": false,
   "new_head_t": 8,
-  "commits_copied": 3
+  "commits_copied": 3,
+  "conflict_count": 1,
+  "strategy": "take-both"
 }
 ```
 
@@ -1884,16 +1899,18 @@ POST /fluree/merge
 | `ledger_id` | string | Full ledger:branch identifier of the target |
 | `target` | string | Target branch name |
 | `source` | string | Source branch name |
-| `fast_forward` | bool | Always `true` (only fast-forward is supported) |
+| `fast_forward` | bool | Whether this merge advanced the target directly to the source HEAD |
 | `new_head_t` | number | New commit HEAD transaction time of the target |
 | `commits_copied` | number | Number of commit blobs copied to the target namespace |
+| `conflict_count` | number | Number of overlapping `(s, p, g)` keys detected during a non-fast-forward merge |
+| `strategy` | string | Conflict strategy used for a non-fast-forward merge. Omitted for fast-forward merges |
 
 **Status codes:**
 
 - `200 OK` - Merge completed successfully
-- `400 Bad Request` - Source has no branch point (e.g., main), self-merge, or target mismatch
+- `400 Bad Request` - Source has no branch point (e.g., main), self-merge, unknown strategy, or unsupported merge strategy
 - `404 Not Found` - Ledger or branch does not exist
-- `409 Conflict` - Target has diverged; fast-forward not possible
+- `409 Conflict` - Merge aborted due to conflicts when using the `abort` strategy, or the target HEAD changed during commit publishing
 - `500 Internal Server Error` - Server error
 
 **Examples:**
@@ -1908,6 +1925,11 @@ curl -X POST http://localhost:8090/v1/fluree/merge \
 curl -X POST http://localhost:8090/v1/fluree/merge \
   -H "Content-Type: application/json" \
   -d '{"ledger": "mydb", "source": "dev", "target": "main"}'
+
+# Non-fast-forward merge with source-winning conflict resolution
+curl -X POST http://localhost:8090/v1/fluree/merge \
+  -H "Content-Type: application/json" \
+  -d '{"ledger": "mydb", "source": "dev", "target": "main", "strategy": "take-source"}'
 ```
 
 ### GET /fluree/merge-preview/{ledger}
@@ -1918,7 +1940,7 @@ Bearer token required when `data_auth.mode = required`; reads are gated on `bear
 
 **URL:**
 ```
-GET /fluree/merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}
+GET /fluree/merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}&include_conflict_details={bool}&strategy={strategy}
 ```
 
 **Path / Query Parameters:**
@@ -1931,6 +1953,8 @@ GET /fluree/merge-preview/{ledger-name}?source={source}&target={target}&max_comm
 | `max_commits` | number | No | Cap on per-side commit summaries returned (default 500). Server clamps to a hard maximum of 5,000 — values above are silently lowered. Bounds response size, **not** divergence-walk cost (the unbounded `count` is still computed). |
 | `max_conflict_keys` | number | No | Cap on conflict keys returned (default 200). Server clamps to a hard maximum of 5,000. Bounds response size, **not** the conflict-delta walks. |
 | `include_conflicts` | bool | No | When false, skips the conflict computation (default true). Use this to make the preview cheap on diverged branches. |
+| `include_conflict_details` | bool | No | When true, includes source/target flake values for the returned conflict keys. Defaults to false. Details are computed after `max_conflict_keys` is applied. |
+| `strategy` | string | No | Strategy used to annotate conflict details. Defaults to `take-both`. Options: `take-both`, `abort`, `take-source`, `take-branch`. |
 
 **Response body (200 OK):**
 
@@ -1949,10 +1973,24 @@ GET /fluree/merge-preview/{ledger-name}?source={source}&target={target}&max_comm
   },
   "behind": { "count": 1, "commits": [...], "truncated": false },
   "fast_forward": false,
+  "mergeable": true,
   "conflicts": {
-    "count": 0,
-    "keys": [],
-    "truncated": false
+    "count": 1,
+    "keys": [{ "s": [100, "alice"], "p": [100, "status"], "g": null }],
+    "truncated": false,
+    "strategy": "take-source",
+    "details": [
+      {
+        "key": { "s": [100, "alice"], "p": [100, "status"], "g": null },
+        "source_values": [["ex:alice", "ex:status", "active", "xsd:string", true]],
+        "target_values": [["ex:alice", "ex:status", "archived", "xsd:string", true]],
+        "resolution": {
+          "source_action": "kept",
+          "target_action": "retracted",
+          "outcome": "source-wins"
+        }
+      }
+    ]
   }
 }
 ```
@@ -1965,14 +2003,17 @@ GET /fluree/merge-preview/{ledger-name}?source={source}&target={target}&max_comm
 | `ahead` | object | Commits on source not on target (`count`, `commits`, `truncated`) |
 | `behind` | object | Commits on target not on source |
 | `fast_forward` | bool | True when target HEAD == ancestor (or both heads absent) |
+| `mergeable` | bool | False only when the selected preview strategy would abort, e.g. `strategy=abort` with conflicts. This is a strategy/conflict signal, not full transaction validation. `mergeable=true` does not guarantee a subsequent `POST /merge` will succeed; it only reflects the conflict/strategy interaction at preview time. |
 | `conflicts` | object | Overlapping `(s, p, g)` keys touched on both sides since the ancestor. Empty when `fast_forward` or `include_conflicts=false` |
 
 Per-commit summaries (`ahead.commits[]` / `behind.commits[]`) are newest-first and include assert/retract counts plus an optional `message` extracted from `txn_meta` when an `f:message` string entry is present.
 
+When `include_conflict_details=true`, `conflicts.details[]` contains one entry for each returned conflict key. `source_values` and `target_values` are the current asserted values for that key at each branch HEAD, using the same resolved flake tuple format as `/show`: `[subject, predicate, object, datatype, operation]`, with an optional metadata object as the 6th tuple item. The `resolution` object is an annotation only; preview does not apply the strategy or mutate state.
+
 **Status codes:**
 
 - `200 OK` — Preview computed successfully
-- `400 Bad Request` — Source has no branch point (e.g., main) or `source == target`
+- `400 Bad Request` — Source has no branch point (e.g., main), `source == target`, unknown strategy, unsupported preview strategy, `include_conflict_details=true` with `include_conflicts=false`, or `strategy=abort` with `include_conflicts=false`
 - `401 Unauthorized` — Bearer token required
 - `404 Not Found` — Ledger or branch does not exist (or bearer cannot read it)
 
@@ -1987,6 +2028,9 @@ curl "http://localhost:8090/v1/fluree/merge-preview/mydb?source=dev&target=main&
 
 # Cap commit lists at 50 per side
 curl "http://localhost:8090/v1/fluree/merge-preview/mydb?source=dev&max_commits=50"
+
+# Include value details and labels for a source-winning merge
+curl "http://localhost:8090/v1/fluree/merge-preview/mydb?source=dev&target=main&include_conflict_details=true&strategy=take-source"
 ```
 
 ### GET /fluree/info

--- a/docs/cli/branch.md
+++ b/docs/cli/branch.md
@@ -226,9 +226,59 @@ Rebased 'dev': 3 commits replayed, 0 skipped, 1 conflicts, 0 failures.
   New branch point: t=8
 ```
 
+### fluree branch diff
+
+Show a read-only merge preview between two branches.
+
+**Usage:**
+
+```bash
+fluree branch diff <SOURCE> [OPTIONS]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<SOURCE>` | Source branch name to preview merging from (e.g., "dev", "feature-x") |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--target <BRANCH>` | Target branch to preview merging into (defaults to source's parent branch) |
+| `--max-commits <N>` | Cap on per-side commit summaries shown (default: 50; pass 0 for unbounded in local mode) |
+| `--max-conflict-keys <N>` | Cap on conflict keys shown (default: 50; pass 0 for unbounded in local mode) |
+| `--no-conflicts` | Skip conflict computation for a cheaper preview |
+| `--conflict-details` | Include source/target flake values for returned conflict keys |
+| `--strategy <STRATEGY>` | Strategy used for conflict detail labels (default: `take-both`). Options: `take-both`, `abort`, `take-source`, `take-branch` |
+| `--json` | Emit the raw JSON preview |
+| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `--remote <REMOTE>` | Execute against a remote server |
+
+**Description:**
+
+`branch diff` reports ahead/behind commits, fast-forward eligibility, and conflicting `(subject, predicate, graph)` keys without mutating state. With `--conflict-details`, the preview also shows the source and target values for the returned conflict keys and annotates what the selected strategy would do.
+
+**Examples:**
+
+```bash
+# Preview merging dev into its parent
+fluree branch diff dev
+
+# Preview a specific target
+fluree branch diff dev --target main
+
+# Show value details and source-winning labels
+fluree branch diff dev --target main --conflict-details --strategy take-source
+
+# Emit raw JSON for UI tooling
+fluree branch diff dev --conflict-details --json
+```
+
 ### fluree branch merge
 
-Merge a branch into its parent branch (fast-forward only).
+Merge a source branch into a target branch.
 
 **Usage:**
 
@@ -271,6 +321,9 @@ fluree branch merge feature-x --target dev
 # Merge for a specific ledger
 fluree branch merge dev --ledger mydb
 
+# Merge with source-winning conflict resolution
+fluree branch merge dev --target main --strategy take-source
+
 # Merge on a remote server
 fluree branch merge dev --ledger mydb --remote origin
 ```
@@ -279,6 +332,12 @@ fluree branch merge dev --ledger mydb --remote origin
 
 ```
 Merged 'dev' into 'main' (fast-forward to t=8, 3 commits copied).
+```
+
+**Output (non-fast-forward):**
+
+```
+Merged 'dev' into 'main' (t=9, 3 commits copied, 1 conflicts).
 ```
 
 ## See Also

--- a/docs/cli/context.md
+++ b/docs/cli/context.md
@@ -17,7 +17,7 @@ fluree context <COMMAND>
 
 ## Description
 
-Each ledger can have a **default context** — a JSON object mapping prefixes to IRIs (e.g., `{"ex": "http://example.org/"}`). When a JSON-LD query or transaction is sent via the **Fluree server or CLI** and omits its own `@context`, the ledger's default context is injected automatically. When using `fluree-db-api` directly, this injection does not happen unless explicitly opted into.
+Each ledger can have a **default context** — a JSON object mapping prefixes to IRIs (e.g., `{"ex": "http://example.org/"}`). When a JSON-LD query is sent via the **CLI** and omits its own `@context`, the ledger's default context is injected automatically. The HTTP API requires `?default-context=true` to opt in per request, and `fluree-db-api` requires explicit opt-in via its default-context view builders.
 
 Default context is populated automatically during bulk import (from Turtle `@prefix` declarations). This command allows reading or replacing it after the fact.
 

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -122,6 +122,45 @@ listed below and, for JSON-LD bodies, also injects them into `opts`. To be
 CLI-compatible, your server must implement the contract in
 [Policy Enforcement Contract](#policy-enforcement-contract).
 
+### `fluree branch list` (read-only)
+
+- `GET {api_base_url}/branch/{ledger}` — note **singular** `branch`, ledger is a
+  greedy tail segment (`*ledger` in axum), so `mydb` and `org/mydb` both work.
+
+Returns all non-retracted branches for the ledger. Same auth bracket as other
+read endpoints (`GET /branch/*ledger` enforces Bearer when
+`data_auth.mode == required` and `can_read(ledger)`; returns `404` not `403`
+when the bearer cannot read it). See
+[Branch List Contract](#branch-list-contract).
+
+### `fluree branch create --remote <name>` (admin-protected)
+
+- `POST {api_base_url}/branch` with `{ ledger, branch, source? }`
+
+Same admin auth bracket as `/create`, `/drop`, `/reindex`. See
+[Branch Create Contract](#branch-create-contract).
+
+### `fluree branch drop --remote <name>` (admin-protected)
+
+- `POST {api_base_url}/drop-branch` with `{ ledger, branch }`
+
+Same admin auth bracket as `/create`, `/drop`, `/reindex`. See
+[Branch Drop Contract](#branch-drop-contract).
+
+### `fluree branch rebase --remote <name>` (admin-protected)
+
+- `POST {api_base_url}/rebase` with `{ ledger, branch, strategy? }`
+
+Same admin auth bracket as `/create`, `/drop`, `/reindex`. See
+[Rebase Contract](#rebase-contract).
+
+### `fluree branch merge --remote <name>` (admin-protected)
+
+- `POST {api_base_url}/merge` with `{ ledger, source, target?, strategy? }`
+
+Same admin auth bracket as `/create`, `/drop`, `/reindex`. See
+[Merge Contract](#merge-contract).
+
 ### `fluree branch diff` (read-only merge preview)
 
 - `GET {api_base_url}/merge-preview/*ledger?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=`
@@ -407,6 +446,405 @@ time.
 Validate compatibility by running `fluree branch diff dev --target feature
 --remote your-remote --json` against your server and diffing the response
 against output from the reference server on the same ledger state.
+
+## Branch List Contract
+
+`fluree branch list <ledger> --remote <name>` issues:
+
+```
+GET {api_base_url}/branch/{ledger}
+```
+
+The path segment is **singular** `branch` (not `branches`) and uses axum's
+greedy `*ledger` tail capture, so a ledger named `org/mydb` is matched by
+`/branch/org/mydb`. The endpoint takes no query parameters and no body.
+
+### Auth
+
+Read-only. Requires a Bearer when `data_auth.mode == required`; gates on
+`can_read(ledger)`; returns `404` (not `403`) when the bearer cannot read it
+to avoid existence leaks. Admin tokens are NOT required.
+
+### Response (`200 OK`)
+
+A JSON array of `BranchInfo`. Empty array when the ledger has no
+non-retracted branches.
+
+```jsonc
+[
+  {
+    "branch": "main",
+    "ledger_id": "mydb:main",
+    "t": 12,
+    "source": null
+  },
+  {
+    "branch": "feature-x",
+    "ledger_id": "mydb:feature-x",
+    "t": 15,
+    "source": "main"
+  }
+]
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `branch` | string | Branch name. |
+| `ledger_id` | string | Full `ledger:branch` identifier. |
+| `t` | integer | Current commit `t` on this branch. |
+| `source` | string \| null | Parent branch, or `null` for root branches like `main`. Omitted via `skip_serializing_if = "Option::is_none"` when null. |
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `401` | Bearer required and absent/invalid. |
+| `404` | Ledger does not exist; or the bearer cannot `can_read`. |
+| `5xx` | Storage / nameservice errors. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::list_branches` |
+| Response shape | `fluree-db-server/src/routes/ledger.rs::BranchInfo` |
+| Underlying API | `fluree_db_api::Fluree::list_branches` |
+
+## Branch Create Contract
+
+`fluree branch create <name> --remote <name>` issues:
+
+```
+POST {api_base_url}/branch
+Content-Type: application/json
+
+{
+  "ledger": "mydb",
+  "branch": "feature-x",
+  "source": "main"
+}
+```
+
+The body type mirrors `fluree-db-server::routes::ledger::CreateBranchRequest`.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `ledger` | string | Yes | — | Ledger name without branch suffix. |
+| `branch` | string | Yes | — | New branch name. Must pass `validate_branch_name`. |
+| `source` | string | No | `"main"` | Parent branch to fork from. The source must already exist and have at least one commit. |
+
+### Auth
+
+Admin-protected. Same middleware as `POST /create`, `POST /drop`,
+`POST /reindex`, and `POST /iceberg/map` — registered through
+`v1_admin_protected_routes` in `fluree-db-server/src/routes/mod.rs`.
+
+### Response (`201 Created`)
+
+```jsonc
+{
+  "ledger_id": "mydb:feature-x",
+  "branch": "feature-x",
+  "source": "main",
+  "t": 12
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ledger_id` | string | Full `ledger:branch` identifier of the new branch. |
+| `branch` | string | New branch name (echoed). |
+| `source` | string | Resolved parent branch. Empty string if the new record's `source_branch` is unexpectedly null. |
+| `t` | integer | Commit `t` at the branch point (inherited from the source's HEAD). |
+
+The CLI's pretty-printer (`print_branch_created` in
+`fluree-db-cli/src/commands/branch.rs`) reads `branch`, `source`, `t`, and
+`ledger_id` from the response — keep all four populated.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `400` | Invalid branch name (per `validate_branch_name`); malformed JSON body. |
+| `401` / `403` | Admin token required and absent/invalid (see admin-auth middleware). |
+| `404` | Source branch does not exist. |
+| `409` | A branch with this name already exists (`ApiError::LedgerExists` → 409). |
+| `5xx` | Nameservice / storage / index-copy errors. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::create_branch` |
+| Request / response shapes | `CreateBranchRequest`, `CreateBranchResponse` (same file) |
+| Underlying API | `fluree_db_api::Fluree::create_branch` (`fluree-db-api/src/ledger/loading.rs`) |
+
+## Branch Drop Contract
+
+`fluree branch drop <name> --remote <name>` issues:
+
+```
+POST {api_base_url}/drop-branch
+Content-Type: application/json
+
+{
+  "ledger": "mydb",
+  "branch": "feature-x"
+}
+```
+
+Note the endpoint is `/drop-branch` (hyphenated) — separate from the
+ledger-level `POST /drop` endpoint.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ledger` | string | Yes | Ledger name without branch suffix. |
+| `branch` | string | Yes | Branch to drop. Cannot be `"main"`. |
+
+### Auth
+
+Admin-protected (same bracket as `/branch`, `/rebase`, `/merge`,
+`/create`, `/drop`, `/reindex`).
+
+### Behavior
+
+The reference server's `Fluree::drop_branch`:
+
+1. Refuses to drop `"main"` with `400`.
+2. If the branch is **retracted** already → returns status `already_retracted`.
+3. If the branch has children (`branches > 0`) → **soft-retracts** it (preserves
+   storage so children can still resolve), returns `deferred: true`.
+4. If the branch is a leaf → cancels indexing, deletes all storage artifacts
+   (commits, txns, index roots, leaves, branches, dicts, garbage records,
+   config, context), purges the nameservice record, and **cascades upward**
+   to any retracted ancestors that now have zero children.
+
+### Response (`200 OK`)
+
+```jsonc
+{
+  "ledger_id": "mydb:feature-x",
+  "status": "dropped",
+  "deferred": false,
+  "files_deleted": 14,
+  "cascaded": ["mydb:retired-parent"],
+  "warnings": []
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ledger_id` | string | Full `ledger:branch` identifier of the dropped branch. |
+| `status` | string | `"dropped"`, `"already_retracted"`, or `"not_found"`. |
+| `deferred` | bool | `true` when the branch was retracted but storage preserved (had children). |
+| `files_deleted` | integer | Omitted when `0`. |
+| `cascaded` | string[] | Ancestor `ledger_id`s that were cascade-dropped because they were retracted with zero remaining children. Omitted when empty. |
+| `warnings` | string[] | Non-fatal warnings (e.g. partial artifact deletion). Omitted when empty. |
+
+The CLI's `print_branch_dropped` reads `ledger_id`, `deferred`,
+`files_deleted`, `cascaded`, and `warnings` — populate them all.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `400` | Attempting to drop `"main"`; malformed JSON body. |
+| `401` / `403` | Admin token required and absent/invalid. |
+| `404` | Branch not found (the underlying lookup miss surfaces as `ApiError::NotFound` → 404). |
+| `5xx` | Storage / nameservice errors during purge. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::drop_branch` |
+| Request / response shapes | `DropBranchRequest`, `DropBranchResponse` (same file) |
+| Underlying API | `fluree_db_api::Fluree::drop_branch` (`fluree-db-api/src/admin.rs`) |
+| Report struct | `fluree_db_api::BranchDropReport` |
+
+## Rebase Contract
+
+`fluree branch rebase <branch> --remote <name>` issues:
+
+```
+POST {api_base_url}/rebase
+Content-Type: application/json
+
+{
+  "ledger": "mydb",
+  "branch": "feature-x",
+  "strategy": "take-both"
+}
+```
+
+| Field | Type | Required | Server default | Description |
+|-------|------|----------|----------------|-------------|
+| `ledger` | string | Yes | — | Ledger name without branch suffix. |
+| `branch` | string | Yes | — | Branch to rebase. Cannot be `"main"`. |
+| `strategy` | string | No | `"take-both"` | One of `take-both`, `abort`, `take-source`, `take-branch`, `skip`. Parsed by `ConflictStrategy::from_str_name`; unknown values respond `400`. |
+
+### Auth
+
+Admin-protected (same bracket as `/branch`, `/drop-branch`, `/merge`,
+`/create`, `/drop`, `/reindex`).
+
+### Behavior
+
+Replays the branch's unique commits on top of its source branch's current
+HEAD, detecting and resolving conflicts according to `strategy`. The branch's
+own `source_branch` (from its nameservice record) is the rebase target — there
+is no `target` field in the request.
+
+- If the branch is already up-to-date with its source (`branch_head == ancestor`),
+  the operation is a fast-forward: the branch's HEAD is advanced to the source
+  HEAD with no replay, and `fast_forward: true` is returned.
+- If `strategy == "abort"` and **any** branch commit conflicts with the source
+  delta, the rebase aborts up-front with `409 BranchConflict`. No commits are
+  written.
+- Otherwise, the branch's commits are replayed sequentially on top of the
+  source HEAD using the chosen strategy for conflict resolution.
+
+### Response (`200 OK`)
+
+```jsonc
+{
+  "ledger_id": "mydb:feature-x",
+  "branch": "feature-x",
+  "fast_forward": false,
+  "replayed": 3,
+  "skipped": 0,
+  "conflicts": 1,
+  "failures": 0,
+  "total_commits": 3,
+  "source_head_t": 18
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ledger_id` | string | Full `ledger:branch` identifier of the rebased branch. |
+| `branch` | string | Branch name (echoed). |
+| `fast_forward` | bool | `true` when the branch had no unique commits and was just advanced. |
+| `replayed` | integer | Commits successfully replayed onto source HEAD. |
+| `skipped` | integer | Commits skipped (e.g. via `skip` strategy on conflicts). |
+| `conflicts` | integer | Total commits that contained conflicts. Note this is a count, not a list — the underlying `RebaseReport` carries `Vec<RebaseConflict>` and `Vec<RebaseFailure>`, but the HTTP response surfaces only the lengths. |
+| `failures` | integer | Commits that failed to replay (transactional / validation errors). |
+| `total_commits` | integer | Total branch commits considered for replay. |
+| `source_head_t` | integer | Source branch HEAD `t` after rebase. |
+
+The CLI's `print_rebase_result` reads `fast_forward`, `branch`, `source_head_t`,
+`replayed`, `skipped`, `conflicts`, and `failures`.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `400` | Rebasing `"main"` (`InvalidBranch`); branch has no `source_branch` (root branch); unknown / unsupported strategy; malformed JSON body. |
+| `401` / `403` | Admin token required and absent/invalid. |
+| `404` | Branch or its source not found. |
+| `409` | `BranchConflict` — currently raised when `strategy=abort` and any commit conflicts with the source delta. |
+| `5xx` | Storage / nameservice / index-build errors during replay. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::rebase` |
+| Request / response shapes | `RebaseBranchRequest`, `RebaseBranchResponse` (same file) |
+| Underlying API | `fluree_db_api::Fluree::rebase_branch` (`fluree-db-api/src/rebase.rs`) |
+| Report struct | `fluree_db_api::RebaseReport` |
+| Strategy enum | `fluree_db_api::ConflictStrategy` |
+
+## Merge Contract
+
+`fluree branch merge <source> --remote <name>` issues:
+
+```
+POST {api_base_url}/merge
+Content-Type: application/json
+
+{
+  "ledger": "mydb",
+  "source": "feature-x",
+  "target": "main",
+  "strategy": "take-both"
+}
+```
+
+| Field | Type | Required | Server default | Description |
+|-------|------|----------|----------------|-------------|
+| `ledger` | string | Yes | — | Ledger name without branch suffix. |
+| `source` | string | Yes | — | Branch to merge **from**. Must have at least one commit and a `source_branch`. |
+| `target` | string | No | `source.source_branch` | Branch to merge **into**. Defaults to the source's parent branch. Must not equal `source`. |
+| `strategy` | string | No | `"take-both"` | One of `take-both`, `abort`, `take-source`, `take-branch`. Parsed by `ConflictStrategy::from_str_name`. |
+
+### Auth
+
+Admin-protected (same bracket as `/branch`, `/drop-branch`, `/rebase`,
+`/create`, `/drop`, `/reindex`).
+
+### Behavior
+
+- Computes the common ancestor between `source` HEAD and `target` HEAD using
+  a `BranchedContentStore` so sibling branches off `main` work.
+- If `target` HEAD == ancestor, performs a **fast-forward merge**: copies the
+  source's unique commit blobs into the target's namespace and advances the
+  target HEAD. No conflict resolution runs. `fast_forward: true` is reported.
+- Otherwise, performs a **general merge**: stages the union of source and
+  target deltas, resolves overlapping `(s, p, g)` keys via `strategy`, and
+  writes a single new commit on the target. `fast_forward: false` is
+  reported. If `strategy == "abort"` and conflicts exist, the merge fails
+  with `409 BranchConflict` and the target is rolled back to its
+  pre-merge nameservice snapshot.
+
+### Response (`200 OK`)
+
+```jsonc
+{
+  "ledger_id": "mydb:main",
+  "target": "main",
+  "source": "feature-x",
+  "fast_forward": false,
+  "new_head_t": 22,
+  "commits_copied": 4,
+  "conflict_count": 1,
+  "strategy": "take-both"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ledger_id` | string | Full `ledger:branch` identifier of the **target** after merge. |
+| `target` | string | Resolved target branch (echoed; reflects the default if the request omitted it). |
+| `source` | string | Source branch name (echoed). |
+| `fast_forward` | bool | `true` for a fast-forward merge. |
+| `new_head_t` | integer | New commit `t` of the target after merge. |
+| `commits_copied` | integer | Number of commit blobs copied into the target's namespace. For fast-forward this equals the source's unique commits; for general merge this includes the synthesized merge commit. |
+| `conflict_count` | integer | Number of conflicts resolved. `0` for fast-forward. |
+| `strategy` | string \| omitted | Strategy used. Omitted (via `skip_serializing_if`) for fast-forward merges where strategy doesn't apply. |
+
+The CLI's `print_merge_result` reads `source`, `target`, `new_head_t`,
+`commits_copied`, `fast_forward`, and `conflict_count`.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `400` | Source has no `source_branch` (a root branch like `main` cannot be the source); `source == resolved_target`; source has no commits; unknown / unsupported strategy; malformed JSON body. |
+| `401` / `403` | Admin token required and absent/invalid. |
+| `404` | Source or target branch not found. |
+| `409` | `BranchConflict` — currently raised when `strategy=abort` and conflicts exist. |
+| `5xx` | Storage / nameservice / commit-write errors. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::merge` |
+| Request / response shapes | `MergeBranchRequest`, `MergeBranchResponse` (same file) |
+| Underlying API | `fluree_db_api::Fluree::merge_branch` (`fluree-db-api/src/merge.rs`) |
+| Report struct | `fluree_db_api::MergeReport` |
+| Strategy enum | `fluree_db_api::ConflictStrategy` |
 
 ## Replication Auth Contract
 

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -220,6 +220,7 @@ implementation reference if you're porting the contract to another server.
 ```
 GET {api_base_url}/merge-preview/{ledger}?source={source}&target={target}
    &max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}
+   &include_conflict_details={bool}&strategy={strategy}
 ```
 
 | Parameter | Type | Required | Server default | Description |
@@ -230,6 +231,8 @@ GET {api_base_url}/merge-preview/{ledger}?source={source}&target={target}
 | `max_commits` | integer | No | `500` | Per-side cap on `ahead.commits` / `behind.commits` |
 | `max_conflict_keys` | integer | No | `200` | Cap on `conflicts.keys` |
 | `include_conflicts` | bool | No | `true` | When `false`, the conflict computation is skipped |
+| `include_conflict_details` | bool | No | `false` | When `true`, include source/target flake values for the returned conflict keys |
+| `strategy` | string | No | `take-both` | Strategy used for resolution labels in `conflicts.details[].resolution`; one of `take-both`, `abort`, `take-source`, `take-branch` |
 
 Auth follows the same pattern as `GET /branch/*ledger` (read-only): require
 a Bearer when `data_auth.mode == required`; gate on `can_read(ledger)`;
@@ -269,10 +272,18 @@ These rules are not negotiable; the CLI and other clients depend on them:
      Lexicographic by `(s, p, g)` is fine; what matters is that two
      requests against the same state return the same prefix.
    - `count` is the unbounded intersection size; `truncated = count > cap`.
-8. **No mutations.** Implementations must not write to the nameservice,
+8. **Conflict details.** When `include_conflict_details == true`, populate
+   `conflicts.details` for the keys returned in `conflicts.keys` after
+   truncation. Each detail includes `key`, `source_values`, `target_values`,
+   and a `resolution` annotation for the requested `strategy`. The values are
+   the current asserted values for that key at each branch HEAD; preview must
+   not apply the strategy. Use the same
+   resolved flake tuple shape as `/show` (`[s, p, o, dt, op]`, optional
+   metadata as a 6th item).
+9. **No mutations.** Implementations must not write to the nameservice,
    advance any HEAD, copy commits between namespaces, or update any cache
    that downstream operations depend on.
-9. **Server-side cap is mandatory.** Even if a client sends
+10. **Server-side cap is mandatory.** Even if a client sends
    `max_commits=10000000`, clamp to a defensive limit. The reference
    server applies two layers: when no query param is present, it falls
    back to the recommended defaults (`500` for commits, `200` for
@@ -322,7 +333,25 @@ These rules are not negotiable; the CLI and other clients depend on them:
   },
   "behind": { "count": 1, "commits": [], "truncated": false },
   "fast_forward": false,
-  "conflicts": { "count": 0, "keys": [], "truncated": false }
+  "mergeable": true,
+  "conflicts": {
+    "count": 1,
+    "keys": [{ "s": [100, "alice"], "p": [100, "status"], "g": null }],
+    "truncated": false,
+    "strategy": "take-source",
+    "details": [
+      {
+        "key": { "s": [100, "alice"], "p": [100, "status"], "g": null },
+        "source_values": [["ex:alice", "ex:status", "active", "xsd:string", true]],
+        "target_values": [["ex:alice", "ex:status", "archived", "xsd:string", true]],
+        "resolution": {
+          "source_action": "kept",
+          "target_action": "retracted",
+          "outcome": "source-wins"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -346,11 +375,21 @@ Other conventions are not recognized — return `null`.
 `Sid`s serialize as `[ns_code, name]` tuples. Changing the encoding will
 break the CLI.
 
+When `include_conflict_details=false`, `conflicts.details` is omitted. When it
+is true, `source_values` and `target_values` are resolved flake tuples for the
+current asserted values in the same shape returned by `GET /show/*ledger`;
+`resolution` is a label only. `mergeable` is `false` when the chosen strategy
+would abort (currently `strategy=abort` with one or more conflicts). It is not
+full transaction validation for constraints that might fail during the real
+merge commit. `mergeable=true` does not guarantee a subsequent `POST /merge`
+will succeed; it only reflects the conflict/strategy interaction at preview
+time.
+
 ### Error responses
 
 | Status | When |
 |--------|------|
-| `400` | Source has no parent (e.g., `main`); or `source == target`. Body must include `"no source branch"` or `"itself"` so the CLI's matcher works. |
+| `400` | Source has no parent (e.g., `main`); `source == target`; unknown strategy; unsupported strategy; `include_conflict_details=true` with `include_conflicts=false`; `strategy=abort` with `include_conflicts=false`. Body must include `"no source branch"` or `"itself"` for the first two cases so the CLI's matcher works. |
 | `401` | Bearer required and absent/invalid. |
 | `404` | Ledger or branch does not exist; or the bearer cannot `can_read`. |
 | `5xx` | Storage / nameservice errors. |

--- a/docs/concepts/iri-and-context.md
+++ b/docs/concepts/iri-and-context.md
@@ -276,11 +276,13 @@ Each ledger can store a **default context** — a JSON object mapping prefixes t
 
 When using `fluree-db-api` directly (e.g., embedding Fluree in a Rust application), queries must supply their own `@context` (JSON-LD) or `PREFIX` declarations (SPARQL). If a query omits context, IRIs are not compacted and compact IRIs without a matching prefix will produce an error.
 
-To opt in to default context injection when using the API directly, use the `with_default_context` builder:
+To opt in to default context injection when using the API directly, fetch the stored context and use the `with_default_context` builder:
 
 ```rust
+let ctx = fluree.get_default_context("mydb").await?;
+let ledger = fluree.ledger("mydb").await?;
 let view = GraphDb::from_ledger_state(&ledger)
-    .with_default_context(ledger.default_context.clone());
+    .with_default_context(ctx);
 ```
 
 Or use the convenience method:
@@ -291,9 +293,9 @@ let view = fluree.db_with_default_context("mydb").await?;
 
 ### Server and CLI behavior
 
-The **Fluree HTTP server** and **CLI** automatically inject the ledger's default context into queries that don't provide their own. This preserves ergonomic behavior for interactive use.
+The **CLI** automatically injects the ledger's default context into queries that don't provide their own. The HTTP API defaults this behavior off; pass `?default-context=true` on a query request to opt in.
 
-When the server or CLI injects the default context:
+When default context injection is enabled:
 
 1. **Query-level `@context`** (JSON-LD) or **`PREFIX` declarations** (SPARQL) — always win
 2. **Ledger default context** — applied only when the query provides no context of its own
@@ -301,7 +303,7 @@ When the server or CLI injects the default context:
 
 ### Use with SPARQL (server/CLI)
 
-The default context provides prefix definitions for SPARQL queries via the server or CLI, so you don't need to repeat `PREFIX` declarations in every query. If the ledger's default context includes `{"ex": "http://example.org/"}`, then you can write:
+The default context provides prefix definitions for SPARQL queries, so you don't need to repeat `PREFIX` declarations in every query when injection is enabled. If the ledger's default context includes `{"ex": "http://example.org/"}`, then you can write:
 
 ```sparql
 SELECT ?name WHERE {
@@ -309,11 +311,11 @@ SELECT ?name WHERE {
 }
 ```
 
-without an explicit `PREFIX ex: <http://example.org/>` declaration — the server injects it from the default context. If you declare any `PREFIX` in the query, the default context is not used at all — you must declare every prefix you need.
+without an explicit `PREFIX ex: <http://example.org/>` declaration. If you declare any `PREFIX` in the query, the default context is not used at all — you must declare every prefix you need.
 
 ### Use with JSON-LD queries (server/CLI)
 
-Similarly, JSON-LD queries sent to the server that omit `@context` receive the default context:
+Similarly, JSON-LD queries sent through an opt-in surface that omit `@context` receive the default context:
 
 ```json
 {
@@ -348,7 +350,7 @@ See [CLI context command](../cli/context.md) and [API endpoints](../api/endpoint
 
 ### Opting out of the default context
 
-When using the server or CLI, you may want full, unexpanded IRIs in query results — for debugging, interoperability with other RDF tools, or simply to avoid any prefix assumptions. You can opt out of the default context:
+When using a default-context-enabled surface, you may want full, unexpanded IRIs in query results — for debugging, interoperability with other RDF tools, or simply to avoid any prefix assumptions. You can opt out of the default context:
 
 **JSON-LD queries** — pass an empty `@context` object:
 

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -1046,6 +1046,9 @@ lists**, not the cost of computing them:
   the common ancestor — regardless of `max_commits`.
 - When `include_conflicts: true`, both `compute_delta_keys` walks scan
   the full per-side delta regardless of `max_conflict_keys`.
+- When `include_conflict_details: true`, value details are collected only
+  for the returned `conflicts.keys` after the `max_conflict_keys` cap is
+  applied.
 - Set `include_conflicts: false` for a cheap preview on heavily diverged
   branches; you still get accurate `ahead.count` / `behind.count`.
 
@@ -1053,11 +1056,18 @@ lists**, not the cost of computing them:
 
 | Type | Notable fields |
 |------|----------------|
-| `MergePreview` | `source`, `target`, `ancestor: Option<AncestorRef>`, `ahead`, `behind`, `fast_forward`, `conflicts` |
+| `MergePreview` | `source`, `target`, `ancestor: Option<AncestorRef>`, `ahead`, `behind`, `fast_forward`, `conflicts`, `mergeable` |
 | `BranchDelta` | `count` (unbounded), `commits: Vec<CommitSummary>` (newest-first, capped), `truncated` |
 | `CommitSummary` | `t`, `commit_id`, `time`, `asserts`, `retracts`, `flake_count`, `message: Option<String>` (extracted from the `f:message` `txn_meta` entry when present) |
-| `ConflictSummary` | `count` (unbounded), `keys: Vec<ConflictKey>` (sorted, capped), `truncated` |
+| `ConflictSummary` | `count` (unbounded), `keys: Vec<ConflictKey>` (sorted, capped), `truncated`, `strategy`, `details` |
+| `ConflictDetail` | `key`, `source_values`, `target_values`, `resolution` (values are the current asserted values at each branch HEAD) |
 | `ConflictKey` | `s: Sid`, `p: Sid`, `g: Option<Sid>` |
+
+`mergeable` only reflects whether the selected strategy would abort due to
+detected conflicts; it is not full validation of every constraint the eventual
+merge commit may encounter. `mergeable=true` does not guarantee a subsequent
+merge will succeed; it only reflects the conflict/strategy interaction at
+preview time.
 
 All types derive `Serialize` so the response is wire-stable; the HTTP
 endpoint at `GET /fluree/merge-preview/*ledger` returns the same struct.

--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -36,7 +36,7 @@ The `@context` defines namespace mappings for IRI expansion/compaction:
 }
 ```
 
-When querying via the **Fluree HTTP server or CLI**, omitting `@context` causes the ledger's [default context](../concepts/iri-and-context.md#default-context) to be injected automatically. To opt out and get full IRIs in results, pass an empty object: `"@context": {}`. See [opting out of the default context](../concepts/iri-and-context.md#opting-out-of-the-default-context).
+When querying via the **CLI**, omitting `@context` causes the ledger's [default context](../concepts/iri-and-context.md#default-context) to be injected automatically. The HTTP API defaults this behavior off; pass `?default-context=true` to opt in for a request. To opt out explicitly, pass an empty object: `"@context": {}`. See [opting out of the default context](../concepts/iri-and-context.md#opting-out-of-the-default-context).
 
 > **Note:** When using `fluree-db-api` directly (embedded), `@context` is not injected automatically. Queries must supply their own context or use full IRIs. Use `db_with_default_context()` or `GraphDb::with_default_context()` to opt in.
 

--- a/docs/query/sparql.md
+++ b/docs/query/sparql.md
@@ -20,7 +20,7 @@ WHERE {
 
 ### Default Prefixes
 
-When querying via the **Fluree HTTP server or CLI**, a ledger's [default context](../concepts/iri-and-context.md#default-context) prefix mappings are injected into SPARQL queries that have no explicit `PREFIX` declarations. For example, if the default context includes `{"ex": "http://example.org/ns/"}`, this query works without a `PREFIX` line:
+When querying via the **CLI**, a ledger's [default context](../concepts/iri-and-context.md#default-context) prefix mappings are injected into SPARQL queries that have no explicit `PREFIX` declarations. The HTTP API defaults this behavior off; pass `?default-context=true` on ledger-scoped query requests to opt in. For example, if the default context includes `{"ex": "http://example.org/ns/"}`, this query works without a `PREFIX` line when default-context injection is enabled:
 
 ```sparql
 SELECT ?name ?age

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -545,35 +545,7 @@ fn build_commit_detail(
     // Resolve flakes
     let mut flakes = Vec::with_capacity(commit.flakes.len());
     for flake in &commit.flakes {
-        let s = compactor
-            .compact_sid_for_display(&flake.s)
-            .map_err(|e| ApiError::internal(format!("Failed to resolve subject IRI: {e}")))?;
-        let p = compactor
-            .compact_sid_for_display(&flake.p)
-            .map_err(|e| ApiError::internal(format!("Failed to resolve predicate IRI: {e}")))?;
-
-        let (o, dt) = resolve_object_and_dt(compactor, &flake.o, &flake.dt)?;
-
-        let lang = flake.m.as_ref().and_then(|m| m.lang.clone());
-        let i = flake.m.as_ref().and_then(|m| m.i);
-        let graph =
-            match &flake.g {
-                Some(g_sid) => Some(compactor.compact_sid_for_display(g_sid).map_err(|e| {
-                    ApiError::internal(format!("Failed to resolve graph IRI: {e}"))
-                })?),
-                None => None,
-            };
-
-        flakes.push(ResolvedFlake {
-            s,
-            p,
-            o,
-            dt,
-            op: flake.op,
-            lang,
-            i,
-            graph,
-        });
+        flakes.push(resolve_flake(compactor, flake)?);
     }
 
     Ok(CommitDetail {
@@ -591,6 +563,43 @@ fn build_commit_detail(
         retracts,
         context,
         flakes,
+    })
+}
+
+/// Resolve a flake into the same display tuple used by commit detail output.
+pub(crate) fn resolve_flake(
+    compactor: &IriCompactor,
+    flake: &fluree_db_core::Flake,
+) -> Result<ResolvedFlake> {
+    let s = compactor
+        .compact_sid_for_display(&flake.s)
+        .map_err(|e| ApiError::internal(format!("Failed to resolve subject IRI: {e}")))?;
+    let p = compactor
+        .compact_sid_for_display(&flake.p)
+        .map_err(|e| ApiError::internal(format!("Failed to resolve predicate IRI: {e}")))?;
+
+    let (o, dt) = resolve_object_and_dt(compactor, &flake.o, &flake.dt)?;
+
+    let lang = flake.m.as_ref().and_then(|m| m.lang.clone());
+    let i = flake.m.as_ref().and_then(|m| m.i);
+    let graph = match &flake.g {
+        Some(g_sid) => Some(
+            compactor
+                .compact_sid_for_display(g_sid)
+                .map_err(|e| ApiError::internal(format!("Failed to resolve graph IRI: {e}")))?,
+        ),
+        None => None,
+    };
+
+    Ok(ResolvedFlake {
+        s,
+        p,
+        o,
+        dt,
+        op: flake.op,
+        lang,
+        i,
+        graph,
     })
 }
 

--- a/fluree-db-api/src/indexer_fulltext_provider.rs
+++ b/fluree-db-api/src/indexer_fulltext_provider.rs
@@ -17,8 +17,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use fluree_db_binary_index::BinaryIndexStore;
-use fluree_db_core::ContentStore;
 use fluree_db_indexer::{ConfiguredFulltextProperty, FulltextConfigProvider};
 use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::NameService;
@@ -33,6 +31,7 @@ pub(crate) struct ApiFulltextConfigProvider {
     pub(crate) backend: StorageBackend,
     pub(crate) nameservice: Arc<dyn NameService>,
     pub(crate) leaflet_cache: Arc<fluree_db_binary_index::LeafletCache>,
+    pub(crate) cache_dir: std::path::PathBuf,
 }
 
 impl std::fmt::Debug for ApiFulltextConfigProvider {
@@ -53,47 +52,14 @@ impl ApiFulltextConfigProvider {
         //    overlay/novelty entries would be visible — fine for configs
         //    committed since the last index, wrong for configs that have
         //    already been indexed.
-        if let Some(index_cid) = state
-            .ns_record
-            .as_ref()
-            .and_then(|r| r.index_head_id.as_ref())
-            .cloned()
-        {
-            let ns_ledger_id = state
-                .ns_record
-                .as_ref()
-                .map(|r| r.ledger_id.as_str())
-                .unwrap_or(state.snapshot.ledger_id.as_str());
-            let cs = self.backend.content_store(ns_ledger_id);
-            let bytes = cs
-                .get(&index_cid)
-                .await
-                .map_err(|e| format!("read binary index root {index_cid}: {e}"))?;
-            let cache_dir = std::env::temp_dir().join("fluree-cache");
-            let mut binary_index_store = BinaryIndexStore::load_from_root_bytes(
-                Arc::clone(&cs),
-                &bytes,
-                &cache_dir,
-                Some(Arc::clone(&self.leaflet_cache)),
-            )
-            .await
-            .map_err(|e| format!("load binary index store: {e}"))?;
-            crate::ns_helpers::sync_store_and_snapshot_ns(
-                &mut binary_index_store,
-                &mut state.snapshot,
-            )
-            .map_err(|e| format!("sync ns: {e}"))?;
-            let arc_store = Arc::new(binary_index_store);
-            state.binary_store = Some(crate::TypeErasedStore(arc_store.clone()));
-            let ns_fallback = Some(Arc::new(state.snapshot.namespaces().clone()));
-            let provider = fluree_db_query::BinaryRangeProvider::new(
-                Arc::clone(&arc_store),
-                state.dict_novelty.clone(),
-                state.runtime_small_dicts.clone(),
-                ns_fallback,
-            );
-            state.snapshot.range_provider = Some(Arc::new(provider));
-        }
+        crate::ledger_manager::load_and_attach_binary_store(
+            &self.backend,
+            &mut state,
+            &self.cache_dir,
+            Some(Arc::clone(&self.leaflet_cache)),
+        )
+        .await
+        .map_err(|e| format!("load binary index store: {e}"))?;
 
         // 3. Resolve `f:fullTextDefaults` against the loaded state.
         //

--- a/fluree-db-api/src/ledger/loading.rs
+++ b/fluree-db-api/src/ledger/loading.rs
@@ -1,12 +1,39 @@
 use std::sync::Arc;
 
-use crate::{ApiError, Fluree, HistoricalLedgerView, LedgerState, Result, TypeErasedStore};
-use fluree_db_binary_index::BinaryIndexStore;
+use crate::{ApiError, Fluree, HistoricalLedgerView, LedgerState, Result};
 use fluree_db_core::ContentStore;
-use fluree_db_core::DictNovelty;
 use fluree_db_nameservice::{NameServiceError, NsRecord};
 
 impl Fluree {
+    /// Attach a binary index store and range provider to an already-loaded
+    /// ledger state when its nameservice record points at a binary index root.
+    pub(crate) async fn attach_binary_index_store(&self, state: &mut LedgerState) -> Result<()> {
+        crate::ledger_manager::load_and_attach_binary_store(
+            self.backend(),
+            state,
+            &self.binary_store_cache_dir(),
+            Some(Arc::clone(self.leaflet_cache())),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Load a branch-aware ledger state from an already-resolved nameservice
+    /// record and content store, then attach the binary range provider needed
+    /// for any path that will run indexed range queries.
+    pub(crate) async fn load_queryable_state_with_store<C>(
+        &self,
+        store: C,
+        record: NsRecord,
+    ) -> Result<LedgerState>
+    where
+        C: ContentStore + Clone + 'static,
+    {
+        let mut state = LedgerState::load_with_store(store, record).await?;
+        self.attach_binary_index_store(&mut state).await?;
+        Ok(state)
+    }
+
     /// Load a ledger by address (e.g., "mydb:main")
     ///
     /// This loads the ledger state using the connection-wide cache.
@@ -14,145 +41,7 @@ impl Fluree {
     pub async fn ledger(&self, ledger_id: &str) -> Result<LedgerState> {
         let mut state =
             LedgerState::load(&self.nameservice_mode, ledger_id, self.backend()).await?;
-
-        // If nameservice has an index address, require that the binary index root is
-        // readable and loadable. This ensures `fluree.ledger()` always returns a
-        // queryable, indexed LedgerSnapshot after (re)indexing.
-        //
-        // Note: we may already have a `LedgerSnapshot.range_provider` (e.g. attached after `load_ledger_snapshot`),
-        // but we still want `binary_store` so query execution can use `BinaryScanOperator`.
-        if let Some(index_cid) = state
-            .ns_record
-            .as_ref()
-            .and_then(|r| r.index_head_id.as_ref())
-            .cloned()
-        {
-            if state.snapshot.range_provider.is_none() || state.binary_store.is_none() {
-                // Use the NsRecord's ledger_id (canonical namespace) rather than
-                // snapshot.ledger_id, which may reflect the source ledger after
-                // a pack import/clone into a differently-named destination.
-                let ns_ledger_id = state
-                    .ns_record
-                    .as_ref()
-                    .map(|r| r.ledger_id.as_str())
-                    .unwrap_or(state.snapshot.ledger_id.as_str());
-                let cs = self.content_store(ns_ledger_id);
-                let bytes = cs.get(&index_cid).await.map_err(|e| {
-                    ApiError::internal(format!(
-                        "failed to read binary index root for {index_cid}: {e}"
-                    ))
-                })?;
-
-                let cache_dir = std::env::temp_dir().join("fluree-cache");
-
-                // Load BinaryIndexStore from FIR6 root.
-                let mut binary_index_store = BinaryIndexStore::load_from_root_bytes(
-                    Arc::clone(&cs),
-                    &bytes,
-                    &cache_dir,
-                    Some(Arc::clone(&self.leaflet_cache)),
-                )
-                .await
-                .map_err(|e| {
-                    ApiError::internal(format!(
-                        "failed to load binary index store for {index_cid}: {e}"
-                    ))
-                })?;
-
-                crate::ns_helpers::sync_store_and_snapshot_ns(
-                    &mut binary_index_store,
-                    &mut state.snapshot,
-                )?;
-
-                // Extract stats from the FIR6 root if present.
-                // Decode FIR6 root metadata once and apply:
-                // - watermarks (needed for DictNovelty/DictOverlay correctness)
-                // - optional stats + schema (for formatting/reasoning)
-                let root = fluree_db_binary_index::format::index_root::IndexRoot::decode(&bytes)
-                    .map_err(|e| ApiError::internal(format!("failed to decode FIR6 root: {e}")))?;
-
-                // Watermarks + dict novelty.
-                state.snapshot.subject_watermarks = root.subject_watermarks.clone();
-                state.snapshot.string_watermark = root.string_watermark;
-                state.dict_novelty = Arc::new(DictNovelty::with_watermarks(
-                    state.snapshot.subject_watermarks.clone(),
-                    state.snapshot.string_watermark,
-                ));
-                // Re-populate DictNovelty with any already-loaded novelty flakes so
-                // overlay translation (BinaryRangeProvider) can resolve newly-introduced IDs.
-                //
-                // Important: only allocate novelty IDs for entries *not* present in the
-                // persisted dictionaries (canonical IDs must win).
-                if !state.novelty.is_empty() {
-                    let novelty = state.novelty.as_ref();
-                    let dn = Arc::make_mut(&mut state.dict_novelty);
-                    fluree_db_binary_index::dict_novelty_safe::populate_dict_novelty_safe(
-                        dn,
-                        Some(&binary_index_store),
-                        novelty
-                            .iter_index(fluree_db_core::IndexType::Post)
-                            .map(|id| novelty.get_flake(id)),
-                    )
-                    .map_err(|e| ApiError::internal(format!("populate_dict_novelty_safe: {e}")))?;
-                }
-
-                // Stats + schema.
-                if root.stats.is_some() && state.snapshot.stats.is_none() {
-                    state.snapshot.stats = root.stats;
-                    tracing::debug!("loaded stats from FIR6 root");
-                }
-                if root.schema.is_some() && state.snapshot.schema.is_none() {
-                    state.snapshot.schema = root.schema;
-                    tracing::debug!("loaded schema from FIR6 root");
-                }
-
-                let arc_store = Arc::new(binary_index_store);
-                state.binary_store = Some(TypeErasedStore(arc_store.clone()));
-
-                // Reseed runtime small dicts from the binary index store BEFORE
-                // creating the BinaryRangeProvider. The dicts built during
-                // `load_with_store` are unseeded (IDs start at 0) and would
-                // collide with persisted predicate/datatype IDs in the binary
-                // index. Reseeding first ensures novelty-only entries get IDs
-                // above the persisted range.
-                crate::runtime_dicts::reseed_runtime_small_dicts(&mut state, &arc_store);
-
-                // Attach range provider for policy/SHACL/reasoner/property paths.
-                if state.snapshot.range_provider.is_none() {
-                    let ns_fallback = Some(Arc::new(state.snapshot.namespaces().clone()));
-                    let provider = fluree_db_query::BinaryRangeProvider::new(
-                        Arc::clone(&arc_store),
-                        state.dict_novelty.clone(),
-                        state.runtime_small_dicts.clone(),
-                        ns_fallback,
-                    );
-                    state.snapshot.range_provider = Some(Arc::new(provider));
-                }
-                tracing::info!("loaded binary index store");
-            }
-        }
-
-        // Load default context from CAS if the nameservice record has one.
-        if let Some(ctx_id) = state
-            .ns_record
-            .as_ref()
-            .and_then(|r| r.default_context.as_ref())
-        {
-            let ns_ledger_id = state
-                .ns_record
-                .as_ref()
-                .map(|r| r.ledger_id.as_str())
-                .unwrap_or(state.snapshot.ledger_id.as_str());
-            let cs = self.content_store(ns_ledger_id);
-            match cs.get(ctx_id).await {
-                Ok(bytes) => match serde_json::from_slice(&bytes) {
-                    Ok(ctx) => state.default_context = Some(ctx),
-                    Err(e) => tracing::warn!(%e, "failed to parse default context JSON"),
-                },
-                Err(e) => tracing::debug!(%e, cid = %&ctx_id, "could not load default context"),
-            }
-        }
-
+        self.attach_binary_index_store(&mut state).await?;
         Ok(state)
     }
 

--- a/fluree-db-api/src/ledger_manager.rs
+++ b/fluree-db-api/src/ledger_manager.rs
@@ -573,7 +573,15 @@ pub(crate) async fn load_and_attach_binary_store(
         None => return Ok(None),
     };
 
-    let cs: Arc<dyn ContentStore> = backend.content_store(&state.snapshot.ledger_id);
+    // Use the nameservice record's canonical ledger id rather than
+    // snapshot.ledger_id. Imported/cloned index roots may still carry the
+    // source ledger id in their snapshot bytes.
+    let ns_ledger_id = state
+        .ns_record
+        .as_ref()
+        .map(|r| r.ledger_id.as_str())
+        .unwrap_or(state.snapshot.ledger_id.as_str());
+    let cs: Arc<dyn ContentStore> = backend.content_store(ns_ledger_id);
     let bytes = cs
         .get(&index_cid)
         .await
@@ -586,6 +594,14 @@ pub(crate) async fn load_and_attach_binary_store(
         .map_err(|e| ApiError::internal(format!("failed to decode FIR6 root: {e}")))?;
     state.snapshot.subject_watermarks = root.subject_watermarks;
     state.snapshot.string_watermark = root.string_watermark;
+    if root.stats.is_some() && state.snapshot.stats.is_none() {
+        state.snapshot.stats = root.stats;
+        tracing::debug!("loaded stats from FIR6 root");
+    }
+    if root.schema.is_some() && state.snapshot.schema.is_none() {
+        state.snapshot.schema = root.schema;
+        tracing::debug!("loaded schema from FIR6 root");
+    }
     state.dict_novelty = Arc::new(DictNovelty::with_watermarks(
         state.snapshot.subject_watermarks.clone(),
         state.snapshot.string_watermark,
@@ -625,31 +641,14 @@ pub(crate) async fn load_and_attach_binary_store(
         Arc::clone(&state.runtime_small_dicts),
         ns_fallback,
     );
+    // Always rebuild the provider here so it is coherent with the freshly
+    // loaded BinaryIndexStore, DictNovelty, and runtime dictionary state.
     state.snapshot.range_provider = Some(Arc::new(provider));
     // Also attach the type-erased store to the state so transaction staging
     // (which clones LedgerState under the write lock) can construct
     // graph-scoped BinaryRangeProviders (needed for named-graph upsert deletions).
     let te_store: Arc<dyn std::any::Any + Send + Sync> = arc_store.clone();
     state.binary_store = Some(TypeErasedStore(te_store));
-
-    // Load default context from CAS if the nameservice record has one.
-    if state.default_context.is_none() {
-        if let Some(ctx_id) = state
-            .ns_record
-            .as_ref()
-            .and_then(|r| r.default_context.as_ref())
-        {
-            match cs.get(ctx_id).await {
-                Ok(bytes) => match serde_json::from_slice(&bytes) {
-                    Ok(ctx) => state.default_context = Some(ctx),
-                    Err(e) => tracing::warn!(%e, "failed to parse default context JSON"),
-                },
-                Err(e) => {
-                    tracing::debug!(%e, "could not load default context: {}", e);
-                }
-            }
-        }
-    }
 
     Ok(Some(arc_store))
 }

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -2168,6 +2168,11 @@ impl FlureeBuilder {
                     backend: backend.clone(),
                     nameservice: ns_for_provider,
                     leaflet_cache: Arc::new(fluree_db_binary_index::LeafletCache::with_max_mb(64)),
+                    cache_dir: self
+                        .ledger_cache_config
+                        .as_ref()
+                        .map(|config| config.cache_dir.clone())
+                        .unwrap_or_else(|| LedgerManagerConfig::default().cache_dir),
                 },
             ) as Arc<dyn fluree_db_indexer::FulltextConfigProvider>;
             let indexer_config = idx_config
@@ -2634,6 +2639,7 @@ impl Fluree {
                 backend: self.backend.clone(),
                 nameservice: self.nameservice_mode.as_arc_reader(),
                 leaflet_cache: Arc::clone(&self.leaflet_cache),
+                cache_dir: self.binary_store_cache_dir(),
             },
         )
     }

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -137,7 +137,8 @@ pub use ledger_manager::{
 };
 pub use merge::MergeReport;
 pub use merge_preview::{
-    AncestorRef, BranchDelta, ConflictSummary, MergePreview, MergePreviewOpts,
+    AncestorRef, BranchDelta, ConflictDetail, ConflictResolutionPreview, ConflictSummary,
+    MergePreview, MergePreviewOpts,
 };
 pub use pack::{
     compute_missing_index_artifacts, full_ledger_pack_request, validate_pack_request, PackChunk,

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -10,7 +10,7 @@ use fluree_db_core::commit::codec::read_commit_envelope;
 use fluree_db_core::content_kind::ContentKind;
 use fluree_db_core::ledger_id::format_ledger_id;
 use fluree_db_core::{collect_dag_cids, load_commit_by_id, CommonAncestor};
-use fluree_db_core::{ConflictKey, ContentId, ContentStore, Flake};
+use fluree_db_core::{BranchedContentStore, ConflictKey, ContentId, ContentStore, Flake};
 use fluree_db_ledger::{LedgerState, LedgerView};
 use fluree_db_nameservice::{NsRecord, NsRecordSnapshot};
 use fluree_db_novelty::compute_delta_keys;
@@ -293,19 +293,16 @@ impl crate::Fluree {
         let source_delta =
             compute_delta_keys(source_store.clone(), source_head_id.clone(), ancestor.t).await?;
 
-        // Compute target delta. Build a branched store if target is also a branch.
-        let target_delta = if target_record.source_branch.is_some() {
-            let target_store = LedgerState::build_branched_store(
-                &self.nameservice_mode,
-                target_record,
-                self.backend(),
-            )
-            .await?;
-            compute_delta_keys(target_store, target_head_id.clone(), ancestor.t).await?
+        // Compute target delta. Use the same branch-aware store below when
+        // loading the queryable target state for staging.
+        let target_store: BranchedContentStore = if target_record.source_branch.is_some() {
+            LedgerState::build_branched_store(&self.nameservice_mode, target_record, self.backend())
+                .await?
         } else {
-            let target_store = self.content_store(target_id);
-            compute_delta_keys(target_store, target_head_id.clone(), ancestor.t).await?
+            BranchedContentStore::leaf(self.content_store(target_id))
         };
+        let target_delta =
+            compute_delta_keys(target_store.clone(), target_head_id.clone(), ancestor.t).await?;
 
         // Find conflicts: intersection of source and target delta sets.
         let conflicts: Vec<ConflictKey> =
@@ -324,8 +321,9 @@ impl crate::Fluree {
         }
 
         // Load target state for staging the merge commit.
-        let target_state =
-            LedgerState::load(&self.nameservice_mode, target_id, self.backend()).await?;
+        let target_state = self
+            .load_queryable_state_with_store(target_store, target_record.clone())
+            .await?;
 
         // Collect source flakes and metadata: walk source commits from HEAD
         // to ancestor, gathering flakes, namespace deltas, and graph deltas.

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -394,11 +394,11 @@ impl crate::Fluree {
                     };
 
                     let details = if opts.include_conflict_details && !keys.is_empty() {
-                        let source_state_fut = LedgerState::load_with_store(
+                        let source_state_fut = self.load_queryable_state_with_store(
                             source_store.clone(),
                             source_record.clone(),
                         );
-                        let target_state_fut = LedgerState::load_with_store(
+                        let target_state_fut = self.load_queryable_state_with_store(
                             target_branched.clone(),
                             target_record.clone(),
                         );

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -11,13 +11,17 @@
 //! branched-store construction for source/target, and parallel walks.
 
 use crate::error::{ApiError, Result};
+use crate::format::iri::IriCompactor;
+use crate::graph_commit_builder::resolve_flake;
+use crate::rebase::{current_asserted_for_key, ConflictStrategy};
 use fluree_db_core::ledger_id::format_ledger_id;
 use fluree_db_core::{
     find_common_ancestor, walk_commit_summaries, BranchedContentStore, CommitSummary, ConflictKey,
-    ContentId, ContentStore,
+    ContentId, ContentStore, Flake,
 };
 use fluree_db_ledger::LedgerState;
 use fluree_db_novelty::compute_delta_keys;
+use futures::{stream, StreamExt, TryStreamExt};
 use serde::Serialize;
 use std::sync::Arc;
 use tracing::Instrument;
@@ -66,6 +70,12 @@ pub struct MergePreviewOpts {
     /// still contains commit counts but `conflicts` will be empty. The
     /// fastest way to bound preview cost on diverged branches.
     pub include_conflicts: bool,
+    /// When `true`, include source/target flake values for each returned
+    /// conflict key. Details are computed only for `conflicts.keys` after the
+    /// `max_conflict_keys` cap is applied.
+    pub include_conflict_details: bool,
+    /// Strategy used for human-readable conflict resolution labels.
+    pub conflict_strategy: ConflictStrategy,
 }
 
 impl Default for MergePreviewOpts {
@@ -74,6 +84,8 @@ impl Default for MergePreviewOpts {
             max_commits: Some(DEFAULT_MAX_COMMITS),
             max_conflict_keys: Some(DEFAULT_MAX_CONFLICT_KEYS),
             include_conflicts: true,
+            include_conflict_details: false,
+            conflict_strategy: ConflictStrategy::default(),
         }
     }
 }
@@ -105,6 +117,30 @@ pub struct ConflictSummary {
     pub count: usize,
     pub keys: Vec<ConflictKey>,
     pub truncated: bool,
+    /// Strategy used to annotate conflict details. Omitted when conflicts were
+    /// not computed or no conflict keys were returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+    /// Per-key source/target values for the returned conflict keys.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<ConflictDetail>,
+}
+
+/// A conflict key with the source and target flakes that touched it.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConflictDetail {
+    pub key: ConflictKey,
+    pub source_values: Vec<crate::ResolvedFlake>,
+    pub target_values: Vec<crate::ResolvedFlake>,
+    pub resolution: ConflictResolutionPreview,
+}
+
+/// Human-readable strategy annotation for a single conflict row.
+#[derive(Clone, Debug, Serialize)]
+pub struct ConflictResolutionPreview {
+    pub source_action: &'static str,
+    pub target_action: &'static str,
+    pub outcome: &'static str,
 }
 
 impl ConflictSummary {
@@ -113,6 +149,8 @@ impl ConflictSummary {
             count: 0,
             keys: Vec::new(),
             truncated: false,
+            strategy: None,
+            details: Vec::new(),
         }
     }
 }
@@ -138,6 +176,9 @@ pub struct MergePreview {
     /// Always populated. Empty when `fast_forward` (no conflicts possible)
     /// or when the caller opted out via [`MergePreviewOpts::include_conflicts`].
     pub conflicts: ConflictSummary,
+
+    /// Whether the selected strategy can be applied without aborting.
+    pub mergeable: bool,
 }
 
 impl crate::Fluree {
@@ -189,6 +230,22 @@ impl crate::Fluree {
         target_branch: Option<&str>,
         opts: MergePreviewOpts,
     ) -> Result<MergePreview> {
+        if opts.include_conflict_details && !opts.include_conflicts {
+            return Err(ApiError::InvalidBranch(
+                "include_conflict_details requires include_conflicts=true".to_string(),
+            ));
+        }
+        if opts.conflict_strategy == ConflictStrategy::Abort && !opts.include_conflicts {
+            return Err(ApiError::InvalidBranch(
+                "strategy=abort requires include_conflicts=true for mergeable preview".to_string(),
+            ));
+        }
+        if opts.conflict_strategy == ConflictStrategy::Skip {
+            return Err(ApiError::InvalidBranch(
+                "Skip strategy is not supported for merge preview".to_string(),
+            ));
+        }
+
         // ---- Resolve records (mirrors merge_branch_inner). ----------------
         let source_id = format_ledger_id(ledger_name, source_branch);
         let source_record = self
@@ -335,15 +392,47 @@ impl crate::Fluree {
                         }
                         _ => false,
                     };
+
+                    let details = if opts.include_conflict_details && !keys.is_empty() {
+                        let source_state_fut = LedgerState::load_with_store(
+                            source_store.clone(),
+                            source_record.clone(),
+                        );
+                        let target_state_fut = LedgerState::load_with_store(
+                            target_branched.clone(),
+                            target_record.clone(),
+                        );
+                        let (source_state, target_state) =
+                            tokio::try_join!(source_state_fut, target_state_fut)?;
+
+                        build_conflict_details(
+                            &keys,
+                            &source_state,
+                            &target_state,
+                            &opts.conflict_strategy,
+                        )
+                        .await?
+                    } else {
+                        Vec::new()
+                    };
+
                     ConflictSummary {
                         count,
                         keys,
                         truncated,
+                        strategy: if count > 0 {
+                            Some(opts.conflict_strategy.as_str().to_string())
+                        } else {
+                            None
+                        },
+                        details,
                     }
                 }
                 _ => ConflictSummary::empty(),
             }
         };
+
+        let mergeable = opts.conflict_strategy != ConflictStrategy::Abort || conflicts.count == 0;
 
         // ---- Invariants (debug-only). -------------------------------------
         debug_assert!(ahead.commits.len() <= ahead.count);
@@ -367,6 +456,79 @@ impl crate::Fluree {
             behind,
             fast_forward,
             conflicts,
+            mergeable,
         })
+    }
+}
+
+async fn build_conflict_details(
+    keys: &[ConflictKey],
+    source_state: &LedgerState,
+    target_state: &LedgerState,
+    strategy: &ConflictStrategy,
+) -> Result<Vec<ConflictDetail>> {
+    let source_compactor = IriCompactor::from_namespaces(source_state.snapshot.namespaces());
+    let target_compactor = IriCompactor::from_namespaces(target_state.snapshot.namespaces());
+    let resolution = resolution_for_strategy(strategy);
+
+    stream::iter(keys.iter().cloned())
+        .map(|key| {
+            let source_compactor = &source_compactor;
+            let target_compactor = &target_compactor;
+            let resolution = resolution.clone();
+            async move {
+                let (source_flakes, target_flakes) = tokio::try_join!(
+                    current_asserted_for_key(source_state, &key),
+                    current_asserted_for_key(target_state, &key),
+                )?;
+                let source_values = resolve_flake_list(&source_flakes, source_compactor)?;
+                let target_values = resolve_flake_list(&target_flakes, target_compactor)?;
+
+                Ok::<_, ApiError>(ConflictDetail {
+                    key,
+                    source_values,
+                    target_values,
+                    resolution,
+                })
+            }
+        })
+        .buffered(8)
+        .try_collect()
+        .await
+}
+
+fn resolve_flake_list(
+    flakes: &[Flake],
+    compactor: &IriCompactor,
+) -> Result<Vec<crate::ResolvedFlake>> {
+    flakes
+        .iter()
+        .map(|flake| resolve_flake(compactor, flake))
+        .collect()
+}
+
+fn resolution_for_strategy(strategy: &ConflictStrategy) -> ConflictResolutionPreview {
+    match strategy {
+        ConflictStrategy::TakeBoth => ConflictResolutionPreview {
+            source_action: "kept",
+            target_action: "kept",
+            outcome: "both-values-kept",
+        },
+        ConflictStrategy::TakeSource => ConflictResolutionPreview {
+            source_action: "kept",
+            target_action: "retracted",
+            outcome: "source-wins",
+        },
+        ConflictStrategy::TakeBranch => ConflictResolutionPreview {
+            source_action: "dropped",
+            target_action: "kept",
+            outcome: "target-wins",
+        },
+        ConflictStrategy::Abort => ConflictResolutionPreview {
+            source_action: "unchanged",
+            target_action: "unchanged",
+            outcome: "merge-aborts",
+        },
+        ConflictStrategy::Skip => unreachable!("skip strategy is rejected before previewing"),
     }
 }

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -8,7 +8,7 @@ use crate::error::{ApiError, Result};
 use fluree_db_core::ledger_id::format_ledger_id;
 use fluree_db_core::{
     range_with_overlay, ConflictKey, ContentId, Flake, IndexType, RangeMatch, RangeOptions,
-    RangeTest,
+    RangeTest, DEFAULT_GRAPH_ID,
 };
 use fluree_db_core::{trace_commits_by_id, Commit};
 use fluree_db_ledger::{LedgerState, LedgerView};
@@ -42,14 +42,33 @@ pub enum ConflictStrategy {
 }
 
 impl ConflictStrategy {
+    /// Parse a canonical strategy name from a string.
+    ///
+    /// Unlike [`Self::from_str_name`], this intentionally rejects aliases such
+    /// as `ours` and `theirs` for API surfaces that require a strict wire
+    /// contract.
+    pub fn parse_canonical(s: &str) -> std::result::Result<Self, String> {
+        match s {
+            "take-both" => Ok(Self::TakeBoth),
+            "abort" => Ok(Self::Abort),
+            "take-source" => Ok(Self::TakeSource),
+            "take-branch" => Ok(Self::TakeBranch),
+            "skip" => Ok(Self::Skip),
+            _ => Err(format!("Unknown conflict strategy: {s}")),
+        }
+    }
+
     /// Parse a strategy name from a string (case-insensitive).
     pub fn from_str_name(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "take-both" | "takeboth" | "take_both" => Some(Self::TakeBoth),
-            "abort" => Some(Self::Abort),
-            "take-source" | "takesource" | "take_source" | "theirs" => Some(Self::TakeSource),
-            "take-branch" | "takebranch" | "take_branch" | "ours" => Some(Self::TakeBranch),
-            "skip" => Some(Self::Skip),
+        let normalized = s.to_lowercase();
+        if let Ok(strategy) = Self::parse_canonical(&normalized) {
+            return Some(strategy);
+        }
+
+        match normalized.as_str() {
+            "takeboth" | "take_both" => Some(Self::TakeBoth),
+            "takesource" | "take_source" | "theirs" => Some(Self::TakeSource),
+            "takebranch" | "take_branch" | "ours" => Some(Self::TakeBranch),
             _ => None,
         }
     }
@@ -478,45 +497,19 @@ impl crate::Fluree {
         conflicting_keys: &[ConflictKey],
         source_state: &LedgerState,
     ) -> Result<Vec<Flake>> {
-        let t = source_state.t();
         let mut retractions = Vec::new();
 
         for key in conflicting_keys {
-            let g_id = match &key.g {
-                None => fluree_db_core::DEFAULT_GRAPH_ID,
-                Some(g_sid) => source_state
-                    .snapshot
-                    .decode_sid(g_sid)
-                    .and_then(|iri| source_state.snapshot.graph_registry.graph_id_for_iri(&iri))
-                    .unwrap_or(fluree_db_core::DEFAULT_GRAPH_ID),
-            };
-
-            let match_val = RangeMatch::subject_predicate(key.s.clone(), key.p.clone());
-            let opts = RangeOptions {
-                to_t: Some(t),
-                ..Default::default()
-            };
-
-            let source_flakes = range_with_overlay(
-                &source_state.snapshot,
-                g_id,
-                source_state.novelty.as_ref(),
-                IndexType::Spot,
-                RangeTest::Eq,
-                match_val,
-                opts,
-            )
-            .await?;
-
-            for flake in source_flakes {
-                if flake.op && flake.g == key.g {
-                    retractions.push(Flake {
+            retractions.extend(
+                current_asserted_for_key(source_state, key)
+                    .await?
+                    .into_iter()
+                    .map(|flake| Flake {
                         op: false,
                         t: 0, // overwritten by commit
                         ..flake
-                    });
-                }
-            }
+                    }),
+            );
         }
 
         Ok(retractions)
@@ -686,4 +679,43 @@ fn find_conflicting_keys(
             }
         })
         .collect()
+}
+
+pub(crate) async fn current_asserted_for_key(
+    state: &LedgerState,
+    key: &ConflictKey,
+) -> Result<Vec<Flake>> {
+    let g_id = match &key.g {
+        None => DEFAULT_GRAPH_ID,
+        Some(g_sid) => match state
+            .snapshot
+            .decode_sid(g_sid)
+            .and_then(|iri| state.snapshot.graph_registry.graph_id_for_iri(&iri))
+        {
+            Some(g_id) => g_id,
+            None => return Ok(Vec::new()),
+        },
+    };
+
+    let match_val = RangeMatch::subject_predicate(key.s.clone(), key.p.clone());
+    let opts = RangeOptions {
+        to_t: Some(state.t()),
+        ..Default::default()
+    };
+
+    let flakes = range_with_overlay(
+        &state.snapshot,
+        g_id,
+        state.novelty.as_ref(),
+        IndexType::Spot,
+        RangeTest::Eq,
+        match_val,
+        opts,
+    )
+    .await?;
+
+    Ok(flakes
+        .into_iter()
+        .filter(|flake| flake.op && flake.g == key.g)
+        .collect())
 }

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -312,9 +312,11 @@ impl crate::Fluree {
     /// The actual replay loop + finalization, extracted so the caller can
     /// wrap it in a snapshot/rollback guard.
     async fn run_replay(&self, ctx: &ReplayContext<'_>) -> Result<RebaseReport> {
-        let mut current_state =
-            LedgerState::load(&self.nameservice_mode, ctx.source_id, self.backend()).await?;
+        let mut current_state = self.ledger(ctx.source_id).await?;
 
+        // Replay stages commits as writes to the branch. Start from the
+        // source's queryable state, but relabel the snapshot before staging so
+        // commit conflict checks and nameservice updates target the branch.
         current_state.snapshot.ledger_id = ctx.branch_id.to_string();
 
         let mut report = RebaseReport {
@@ -576,9 +578,7 @@ impl crate::Fluree {
             .publish_index(branch_id, index_result.index_t, &index_result.root_id)
             .await?;
 
-        LedgerState::load(&self.nameservice_mode, branch_id, self.backend())
-            .await
-            .map_err(Into::into)
+        self.ledger(branch_id).await
     }
 
     /// Copy index artifacts from source to branch (best-effort).

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -162,61 +162,19 @@ impl Fluree {
         let handle = self.ledger_cached(ledger_id).await?;
         let mut snapshot = handle.snapshot().await;
 
-        // If no binary store attached but nameservice has an index address,
-        // load the BinaryIndexStore and attach BinaryRangeProvider.
-        // This handles the non-cached path (FlureeBuilder::file() without ledger_manager).
-        if snapshot.binary_store.is_none() {
-            if let Some(index_cid) = snapshot
-                .ns_record
-                .as_ref()
-                .and_then(|r| r.index_head_id.as_ref())
-                .cloned()
-            {
-                let cs = self.content_store(&snapshot.snapshot.ledger_id);
-                let bytes = cs
-                    .get(&index_cid)
-                    .await
-                    .map_err(|e| ApiError::internal(format!("read index root: {e}")))?;
-                let cache_dir = std::env::temp_dir().join("fluree-cache");
-                let mut store = BinaryIndexStore::load_from_root_bytes(
-                    cs,
-                    &bytes,
-                    &cache_dir,
-                    Some(Arc::clone(&self.leaflet_cache)),
-                )
-                .await
-                .map_err(|e| ApiError::internal(format!("load binary index: {e}")))?;
-
-                // Sync namespace codes between store and snapshot (bimap validation).
-                crate::ns_helpers::sync_store_and_snapshot_ns(&mut store, &mut snapshot.snapshot)?;
-
-                let arc_store = Arc::new(store);
-                let dn = snapshot.dict_novelty.clone();
-                let runtime_small_dicts = crate::runtime_dicts::build_runtime_small_dicts(
-                    &arc_store,
-                    Some(&snapshot.novelty),
-                );
-                let ns_fallback = Some(Arc::new(snapshot.snapshot.namespaces().clone()));
-                let provider = BinaryRangeProvider::new(
-                    Arc::clone(&arc_store),
-                    dn,
-                    Arc::clone(&runtime_small_dicts),
-                    ns_fallback,
-                );
-                snapshot.snapshot.range_provider = Some(Arc::new(provider));
-                snapshot.binary_store = Some(arc_store);
-                snapshot.runtime_small_dicts = runtime_small_dicts;
-            }
-        }
-
-        // Load default context from CAS if not already loaded.
-        if snapshot.default_context.is_none() {
+        // Default context injection is opt-in for core API callers.
+        if include_default_context && snapshot.default_context.is_none() {
             if let Some(ctx_id) = snapshot
                 .ns_record
                 .as_ref()
                 .and_then(|r| r.default_context.as_ref())
             {
-                let cs = self.content_store(&snapshot.snapshot.ledger_id);
+                let ns_ledger_id = snapshot
+                    .ns_record
+                    .as_ref()
+                    .map(|r| r.ledger_id.as_str())
+                    .unwrap_or(snapshot.snapshot.ledger_id.as_str());
+                let cs = self.content_store(ns_ledger_id);
                 if let Ok(bytes) = cs.get(ctx_id).await {
                     if let Ok(ctx) = serde_json::from_slice(&bytes) {
                         snapshot.default_context = Some(ctx);
@@ -499,9 +457,7 @@ impl Fluree {
         // Historical views don't carry default_context through their own load
         // path, so fetch it from the current head's cached ledger state.
         if view.default_context.is_none() {
-            let handle = self.ledger_cached(parsed_id).await?;
-            let snap = handle.snapshot().await;
-            view = view.with_default_context(snap.default_context.clone());
+            view = view.with_default_context(self.get_default_context(parsed_id).await?);
         }
         Ok(view)
     }

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -265,6 +265,55 @@ async fn merge_diverged_target_general_merge() {
     );
 }
 
+#[tokio::test]
+async fn merge_take_source_works_after_binary_index_reload() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base_data = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base_data).await.unwrap().ledger;
+    support::rebuild_and_publish_index(&fluree, "mydb:main").await;
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    fluree
+        .upsert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-main"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let report = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::TakeSource)
+        .await
+        .unwrap();
+
+    assert!(!report.fast_forward);
+    assert_eq!(report.conflict_count, 1);
+    assert_eq!(report.strategy.as_deref(), Some("take-source"));
+
+    let names = query_all_names(&fluree, "mydb:main").await;
+    assert_eq!(names, vec!["Alice-dev"]);
+}
+
 /// Merging a nonexistent source branch returns NotFound.
 #[tokio::test]
 async fn merge_nonexistent_source_fails() {

--- a/fluree-db-api/tests/it_merge_preview.rs
+++ b/fluree-db-api/tests/it_merge_preview.rs
@@ -3,7 +3,7 @@
 
 mod support;
 
-use fluree_db_api::{FlureeBuilder, MergePreviewOpts};
+use fluree_db_api::{ConflictStrategy, FlureeBuilder, MergePreviewOpts};
 use serde_json::json;
 
 // =============================================================================
@@ -40,6 +40,50 @@ async fn preview_fast_forward() {
     assert!(!preview.ahead.commits.is_empty());
     assert_eq!(preview.conflicts.count, 0);
     assert!(preview.ancestor.is_some());
+}
+
+#[tokio::test]
+async fn preview_fast_forward_with_conflict_details_is_empty_and_mergeable() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:bob", "ex:name": "Bob"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflict_details: true,
+                conflict_strategy: ConflictStrategy::Abort,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(preview.fast_forward);
+    assert_eq!(preview.conflicts.count, 0);
+    assert!(preview.conflicts.details.is_empty());
+    assert!(preview.mergeable);
 }
 
 // =============================================================================
@@ -123,7 +167,7 @@ async fn preview_diverged_with_conflicts() {
         .unwrap();
 
     fluree
-        .insert(
+        .upsert(
             main_ledger,
             &json!({
                 "@context": {"ex": "http://example.org/ns/"},
@@ -142,6 +186,304 @@ async fn preview_diverged_with_conflicts() {
         preview.conflicts
     );
     assert!(!preview.conflicts.keys.is_empty());
+}
+
+#[tokio::test]
+async fn preview_conflict_details_include_values_and_strategy_labels() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let mut dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    dev_ledger = fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev-stale"}]
+            }),
+        )
+        .await
+        .unwrap()
+        .ledger;
+    fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    fluree
+        .upsert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-main"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflict_details: true,
+                conflict_strategy: ConflictStrategy::TakeSource,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(preview.conflicts.strategy.as_deref(), Some("take-source"));
+    assert_eq!(
+        preview.conflicts.details.len(),
+        preview.conflicts.keys.len()
+    );
+
+    let detail = preview
+        .conflicts
+        .details
+        .first()
+        .expect("conflict details should be returned");
+    assert_eq!(detail.resolution.source_action, "kept");
+    assert_eq!(detail.resolution.target_action, "retracted");
+    assert_eq!(detail.resolution.outcome, "source-wins");
+    assert!(preview.mergeable);
+
+    let source_values = serde_json::to_string(&detail.source_values).unwrap();
+    let target_values = serde_json::to_string(&detail.target_values).unwrap();
+    assert!(source_values.contains("Alice-dev"), "{source_values}");
+    assert!(
+        !source_values.contains("Alice-dev-stale"),
+        "{source_values}"
+    );
+    assert!(target_values.contains("Alice-main"), "{target_values}");
+}
+
+#[tokio::test]
+async fn preview_conflict_details_cover_take_branch_and_abort_labels() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev"}]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+        .upsert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-main"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let take_branch = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflict_details: true,
+                conflict_strategy: ConflictStrategy::TakeBranch,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+    let detail = take_branch.conflicts.details.first().unwrap();
+    assert_eq!(detail.resolution.source_action, "dropped");
+    assert_eq!(detail.resolution.target_action, "kept");
+    assert_eq!(detail.resolution.outcome, "target-wins");
+    assert!(take_branch.mergeable);
+
+    let abort = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflict_details: true,
+                conflict_strategy: ConflictStrategy::Abort,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+    let detail = abort.conflicts.details.first().unwrap();
+    assert_eq!(detail.resolution.source_action, "unchanged");
+    assert_eq!(detail.resolution.target_action, "unchanged");
+    assert_eq!(detail.resolution.outcome, "merge-aborts");
+    assert!(!abort.mergeable);
+}
+
+#[tokio::test]
+async fn preview_conflict_details_follow_conflict_key_truncation() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:name": "Alice"},
+            {"@id": "ex:bob", "ex:name": "Bob"}
+        ]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "ex:name": "Alice-dev"},
+                    {"@id": "ex:bob", "ex:name": "Bob-dev"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+        .upsert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "ex:name": "Alice-main"},
+                    {"@id": "ex:bob", "ex:name": "Bob-main"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                max_conflict_keys: Some(1),
+                include_conflict_details: true,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(preview.conflicts.truncated);
+    assert!(preview.conflicts.count >= 2);
+    assert_eq!(preview.conflicts.keys.len(), 1);
+    assert_eq!(preview.conflicts.details.len(), 1);
+    assert_eq!(preview.conflicts.details[0].key, preview.conflicts.keys[0]);
+}
+
+#[tokio::test]
+async fn preview_conflict_details_preserve_key_order() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:name": "Alice"},
+            {"@id": "ex:bob", "ex:name": "Bob"},
+            {"@id": "ex:carol", "ex:name": "Carol"}
+        ]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "ex:name": "Alice-dev"},
+                    {"@id": "ex:bob", "ex:name": "Bob-dev"},
+                    {"@id": "ex:carol", "ex:name": "Carol-dev"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+        .upsert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "ex:name": "Alice-main"},
+                    {"@id": "ex:bob", "ex:name": "Bob-main"},
+                    {"@id": "ex:carol", "ex:name": "Carol-main"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflict_details: true,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(preview.conflicts.keys.len() >= 3);
+    assert_eq!(
+        preview.conflicts.details.len(),
+        preview.conflicts.keys.len()
+    );
+    for (detail, key) in preview
+        .conflicts
+        .details
+        .iter()
+        .zip(&preview.conflicts.keys)
+    {
+        assert_eq!(&detail.key, key);
+    }
 }
 
 // =============================================================================
@@ -364,6 +706,68 @@ async fn preview_include_conflicts_false_returns_empty_conflicts() {
     assert!(!preview.conflicts.truncated);
 }
 
+#[tokio::test]
+async fn preview_conflict_details_require_conflict_computation() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let err = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflicts: false,
+                include_conflict_details: true,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .expect_err("conflict details without conflict computation should fail");
+
+    assert!(err
+        .to_string()
+        .contains("include_conflict_details requires include_conflicts=true"));
+}
+
+#[tokio::test]
+async fn preview_abort_strategy_requires_conflict_computation() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    fluree.insert(ledger, &base).await.unwrap();
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let err = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflicts: false,
+                conflict_strategy: ConflictStrategy::Abort,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .expect_err("abort mergeability requires conflict computation");
+
+    assert!(err
+        .to_string()
+        .contains("strategy=abort requires include_conflicts=true"));
+}
+
 // =============================================================================
 // 10. Read-only invariant — no nameservice mutations
 // =============================================================================
@@ -577,6 +981,7 @@ async fn preview_max_commits_none_is_unbounded() {
                 max_commits: None,
                 max_conflict_keys: None,
                 include_conflicts: true,
+                ..MergePreviewOpts::default()
             },
         )
         .await

--- a/fluree-db-api/tests/it_merge_preview.rs
+++ b/fluree-db-api/tests/it_merge_preview.rs
@@ -486,6 +486,64 @@ async fn preview_conflict_details_preserve_key_order() {
     }
 }
 
+#[tokio::test]
+async fn preview_conflict_details_work_after_binary_index_reload() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+    });
+    let main_ledger = fluree.insert(ledger, &base).await.unwrap().ledger;
+    support::rebuild_and_publish_index(&fluree, "mydb:main").await;
+    fluree.create_branch("mydb", "dev", None).await.unwrap();
+
+    let dev_ledger = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .upsert(
+            dev_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-dev"}]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+        .upsert(
+            main_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice-main"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflict_details: true,
+                conflict_strategy: ConflictStrategy::TakeSource,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(preview.conflicts.count, 1);
+    assert_eq!(preview.conflicts.details.len(), 1);
+    let detail = &preview.conflicts.details[0];
+    let source_values = serde_json::to_string(&detail.source_values).unwrap();
+    let target_values = serde_json::to_string(&detail.target_values).unwrap();
+    assert!(source_values.contains("Alice-dev"), "{source_values}");
+    assert!(target_values.contains("Alice-main"), "{target_values}");
+}
+
 // =============================================================================
 // 4. Equal heads (no-op)
 // =============================================================================

--- a/fluree-db-api/tests/support/mod.rs
+++ b/fluree-db-api/tests/support/mod.rs
@@ -182,6 +182,33 @@ pub async fn seed_user_with_ssn(
     fluree.insert(ledger0, &txn).await.expect("seed").ledger
 }
 
+/// Rebuild and publish a binary index for the ledger's current commit head.
+///
+/// Use this in regression tests that need to exercise the FIR6/binary-only
+/// reload path rather than the purely in-memory novelty path.
+pub async fn rebuild_and_publish_index(fluree: &fluree_db_api::Fluree, ledger_id: &str) {
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("nameservice lookup")
+        .expect("ledger record should exist");
+    let result = fluree_db_indexer::rebuild_index_from_commits(
+        fluree.content_store(ledger_id),
+        ledger_id,
+        &record,
+        fluree_db_indexer::IndexerConfig::default(),
+    )
+    .await
+    .expect("index rebuild should succeed");
+    fluree
+        .publisher()
+        .expect("read-write nameservice")
+        .publish_index(ledger_id, result.index_t, &result.root_id)
+        .await
+        .expect("publish index");
+}
+
 // =============================================================================
 // Indexing helpers (native tests)
 // =============================================================================

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -859,6 +859,15 @@ pub enum BranchAction {
         #[arg(long)]
         no_conflicts: bool,
 
+        /// Include source/target values for returned conflict keys
+        #[arg(long)]
+        conflict_details: bool,
+
+        /// Strategy used to annotate conflict resolution labels
+        /// Options: take-both, abort, take-source, take-branch
+        #[arg(long)]
+        strategy: Option<String>,
+
         /// Emit the raw JSON preview instead of a human-readable summary
         #[arg(long)]
         json: bool,

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -71,6 +71,8 @@ pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliRes
             max_commits,
             max_conflict_keys,
             no_conflicts,
+            conflict_details,
+            strategy,
             json,
             ledger,
             remote,
@@ -82,6 +84,8 @@ pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliRes
                     max_commits,
                     max_conflict_keys,
                     include_conflicts: !no_conflicts,
+                    include_conflict_details: conflict_details,
+                    strategy,
                     json,
                 },
                 ledger.as_deref(),
@@ -648,6 +652,8 @@ struct DiffOpts {
     max_commits: usize,
     max_conflict_keys: usize,
     include_conflicts: bool,
+    include_conflict_details: bool,
+    strategy: Option<String>,
     json: bool,
 }
 
@@ -675,6 +681,23 @@ async fn run_diff(
         Some(opts.max_conflict_keys)
     };
     let include_conflicts = opts.include_conflicts;
+    let include_conflict_details = opts.include_conflict_details;
+    if include_conflict_details && !include_conflicts {
+        return Err(CliError::Config(
+            "--conflict-details requires conflict computation; remove --no-conflicts".to_string(),
+        ));
+    }
+    let conflict_strategy =
+        parse_preview_strategy(opts.strategy.as_deref().unwrap_or("take-both"))?;
+    if conflict_strategy == fluree_db_api::ConflictStrategy::Abort && !include_conflicts {
+        return Err(CliError::Config(
+            "--strategy abort requires conflict computation; remove --no-conflicts".to_string(),
+        ));
+    }
+    let remote_strategy = opts
+        .strategy
+        .as_deref()
+        .or_else(|| include_conflict_details.then_some(conflict_strategy.as_str()));
 
     if let Some(remote_name) = remote_flag {
         let alias = context::resolve_ledger(ledger, dirs)?;
@@ -688,6 +711,8 @@ async fn run_diff(
                 max_commits,
                 max_conflict_keys,
                 Some(include_conflicts),
+                Some(include_conflict_details),
+                remote_strategy,
             )
             .await?;
 
@@ -726,6 +751,8 @@ async fn run_diff(
                     max_commits,
                     max_conflict_keys,
                     Some(include_conflicts),
+                    Some(include_conflict_details),
+                    remote_strategy,
                 )
                 .await?;
 
@@ -743,6 +770,8 @@ async fn run_diff(
                 max_commits,
                 max_conflict_keys,
                 include_conflicts,
+                include_conflict_details,
+                conflict_strategy,
             };
 
             let preview = fluree
@@ -759,6 +788,17 @@ async fn run_diff(
     }
 
     Ok(())
+}
+
+fn parse_preview_strategy(strategy: &str) -> CliResult<fluree_db_api::ConflictStrategy> {
+    let parsed = fluree_db_api::ConflictStrategy::parse_canonical(strategy)
+        .map_err(|_| CliError::Config(format!("Unknown merge preview strategy: {strategy}")))?;
+    if parsed == fluree_db_api::ConflictStrategy::Skip {
+        return Err(CliError::Config(
+            "Skip strategy is not supported for merge preview".to_string(),
+        ));
+    }
+    Ok(parsed)
 }
 
 fn print_preview_local(p: &fluree_db_api::MergePreview) {
@@ -793,6 +833,32 @@ fn print_preview_local(p: &fluree_db_api::MergePreview) {
             k.p,
             k.g.as_ref().map(ToString::to_string)
         );
+    }
+    if !p.conflicts.details.is_empty() {
+        println!(
+            "conflict details (strategy: {}):",
+            p.conflicts.strategy.as_deref().unwrap_or("take-both")
+        );
+        for detail in &p.conflicts.details {
+            println!(
+                "  - {}",
+                serde_json::to_string(&detail.key).unwrap_or_default()
+            );
+            println!(
+                "    resolution: source: {}, target: {}, outcome: {}",
+                detail.resolution.source_action,
+                detail.resolution.target_action,
+                detail.resolution.outcome
+            );
+            println!(
+                "    source: {}",
+                serde_json::to_string(&detail.source_values).unwrap_or_default()
+            );
+            println!(
+                "    target: {}",
+                serde_json::to_string(&detail.target_values).unwrap_or_default()
+            );
+        }
     }
 }
 
@@ -872,6 +938,40 @@ fn print_preview_json(v: &serde_json::Value) -> CliResult<()> {
         if let Some(keys) = keys {
             for k in keys {
                 println!("  - {}", serde_json::to_string(k).unwrap_or_default());
+            }
+        }
+        if let Some(details) = c.get("details").and_then(Value::as_array) {
+            if !details.is_empty() {
+                let strategy = c
+                    .get("strategy")
+                    .and_then(Value::as_str)
+                    .unwrap_or("take-both");
+                println!("conflict details (strategy: {strategy}):");
+                for detail in details {
+                    let key = detail
+                        .get("key")
+                        .map(|k| serde_json::to_string(k).unwrap_or_default())
+                        .unwrap_or_default();
+                    println!("  - {key}");
+                    if let Some(resolution) = detail.get("resolution") {
+                        println!(
+                            "    resolution: {}",
+                            serde_json::to_string(resolution).unwrap_or_default()
+                        );
+                    }
+                    if let Some(source_values) = detail.get("source_values") {
+                        println!(
+                            "    source: {}",
+                            serde_json::to_string(source_values).unwrap_or_default()
+                        );
+                    }
+                    if let Some(target_values) = detail.get("target_values") {
+                        println!(
+                            "    target: {}",
+                            serde_json::to_string(target_values).unwrap_or_default()
+                        );
+                    }
+                }
             }
         }
     }

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -1249,9 +1249,10 @@ impl RemoteLedgerClient {
 
     /// Read-only merge preview between two branches on the remote server.
     ///
-    /// Calls `GET {base_url}/merge-preview/{ledger}?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=`.
+    /// Calls `GET {base_url}/merge-preview/{ledger}?source=&target=&max_commits=&max_conflict_keys=&include_conflicts=&include_conflict_details=&strategy=`.
     /// The ledger path segment is URL-encoded (via [`op_url`](Self::op_url))
     /// so names containing spaces, `?`, `#`, `%`, etc. produce well-formed URLs.
+    #[allow(clippy::too_many_arguments)]
     pub async fn merge_preview(
         &self,
         ledger: &str,
@@ -1260,6 +1261,8 @@ impl RemoteLedgerClient {
         max_commits: Option<usize>,
         max_conflict_keys: Option<usize>,
         include_conflicts: Option<bool>,
+        include_conflict_details: Option<bool>,
+        strategy: Option<&str>,
     ) -> Result<serde_json::Value, RemoteLedgerError> {
         let mut url = self.op_url("merge-preview", ledger);
         let mut sep = '?';
@@ -1292,6 +1295,22 @@ impl RemoteLedgerClient {
         }
         if let Some(b) = include_conflicts {
             push(&mut url, &mut sep, "include_conflicts", b.to_string());
+        }
+        if let Some(b) = include_conflict_details {
+            push(
+                &mut url,
+                &mut sep,
+                "include_conflict_details",
+                b.to_string(),
+            );
+        }
+        if let Some(s) = strategy {
+            push(
+                &mut url,
+                &mut sep,
+                "strategy",
+                urlencoding::encode(s).into_owned(),
+            );
         }
 
         self.send_json(reqwest::Method::GET, &url, "application/json", None)

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -650,6 +650,11 @@ impl RemoteLedgerClient {
         format!("{}/{}", self.base_url, op)
     }
 
+    fn with_default_context_param(mut url: String) -> String {
+        url.push_str("?default-context=true");
+        url
+    }
+
     // =========================================================================
     // Query
     // =========================================================================
@@ -660,7 +665,7 @@ impl RemoteLedgerClient {
         ledger: &str,
         body: &serde_json::Value,
     ) -> Result<serde_json::Value, RemoteLedgerError> {
-        let url = self.op_url("query", ledger);
+        let url = Self::with_default_context_param(self.op_url("query", ledger));
         self.send_json(
             reqwest::Method::POST,
             &url,
@@ -676,7 +681,7 @@ impl RemoteLedgerClient {
         ledger: &str,
         sparql: &str,
     ) -> Result<serde_json::Value, RemoteLedgerError> {
-        let url = self.op_url("query", ledger);
+        let url = Self::with_default_context_param(self.op_url("query", ledger));
         self.send_json(
             reqwest::Method::POST,
             &url,
@@ -696,7 +701,7 @@ impl RemoteLedgerClient {
         sparql: &str,
         accept: &str,
     ) -> Result<bytes::Bytes, RemoteLedgerError> {
-        let url = self.op_url("query", ledger);
+        let url = Self::with_default_context_param(self.op_url("query", ledger));
         let resp = self
             .send_raw(
                 reqwest::Method::POST,
@@ -747,7 +752,7 @@ impl RemoteLedgerClient {
         &self,
         body: &serde_json::Value,
     ) -> Result<serde_json::Value, RemoteLedgerError> {
-        let url = self.op_url_root("query");
+        let url = Self::with_default_context_param(self.op_url_root("query"));
         self.send_json(
             reqwest::Method::POST,
             &url,

--- a/fluree-db-ledger/src/lib.rs
+++ b/fluree-db-ledger/src/lib.rs
@@ -192,7 +192,7 @@ impl LedgerState {
     ///
     /// Shared implementation used by `load` for both regular and branched
     /// ledgers — the only difference is which `ContentStore` is provided.
-    async fn load_with_store<C: ContentStore + Clone + 'static>(
+    pub async fn load_with_store<C: ContentStore + Clone + 'static>(
         store: C,
         record: NsRecord,
     ) -> Result<Self> {

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -242,11 +242,16 @@ impl BinaryHistoryScanOperator {
                             // needed to charge — so we short-circuit before the
                             // sidecar segment / column load on overrun. Overcharges
                             // on filter-rejected rows; that's the guardrail tradeoff.
-                            let sidecar_rows =
-                                if sidecar_in_range { leaflet.history_len as u64 } else { 0 };
+                            let sidecar_rows = if sidecar_in_range {
+                                leaflet.history_len as u64
+                            } else {
+                                0
+                            };
                             let base_rows = leaflet.row_count as u64;
                             ctx.tracker.consume_fuel(
-                                1000u64.saturating_add(sidecar_rows).saturating_add(base_rows),
+                                1000u64
+                                    .saturating_add(sidecar_rows)
+                                    .saturating_add(base_rows),
                             )?;
 
                             if sidecar_in_range {

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -1480,6 +1480,12 @@ pub struct MergePreviewQuery {
     /// Skip the conflict computation when only counts are needed. Defaults to true.
     #[serde(default)]
     pub include_conflicts: Option<bool>,
+    /// Include source/target flake values for returned conflict keys.
+    #[serde(default)]
+    pub include_conflict_details: Option<bool>,
+    /// Strategy used for conflict resolution labels. Defaults to take-both.
+    #[serde(default)]
+    pub strategy: Option<String>,
 }
 
 /// Read-only branch merge preview.
@@ -1531,7 +1537,7 @@ pub async fn merge_preview(
         // *divergence walk itself* (envelope BFS via `collect_dag_cids`)
         // is unaffected — see the `MERGE_PREVIEW_HARD_MAX_*` constant
         // comments above. Contract documented in
-        // docs/cli/server-integration.md (§Merge Preview Contract, rule 9).
+        // docs/cli/server-integration.md (§Merge Preview Contract, rule 10).
         let mut opts = fluree_db_api::MergePreviewOpts::default();
         if let Some(n) = params.max_commits {
             opts.max_commits = Some(n.min(MERGE_PREVIEW_HARD_MAX_COMMITS));
@@ -1541,6 +1547,32 @@ pub async fn merge_preview(
         }
         if let Some(b) = params.include_conflicts {
             opts.include_conflicts = b;
+        }
+        if let Some(b) = params.include_conflict_details {
+            opts.include_conflict_details = b;
+        }
+        if opts.include_conflict_details && !opts.include_conflicts {
+            return Err(ServerError::bad_request(
+                "include_conflict_details requires include_conflicts=true",
+            ));
+        }
+        if let Some(s) = params.strategy.as_deref() {
+            opts.conflict_strategy =
+                fluree_db_api::ConflictStrategy::parse_canonical(s).map_err(|_| {
+                    ServerError::bad_request(format!("Unknown merge preview strategy: {s}"))
+                })?;
+            if opts.conflict_strategy == fluree_db_api::ConflictStrategy::Skip {
+                return Err(ServerError::bad_request(
+                    "Skip strategy is not supported for merge preview",
+                ));
+            }
+        }
+        if opts.conflict_strategy == fluree_db_api::ConflictStrategy::Abort
+            && !opts.include_conflicts
+        {
+            return Err(ServerError::bad_request(
+                "strategy=abort requires include_conflicts=true for mergeable preview",
+            ));
         }
 
         let preview = state

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -46,6 +46,18 @@ use tracing::Instrument;
 pub struct SparqlParams {
     /// The SPARQL query string (URL-encoded)
     pub query: Option<String>,
+    /// Opt in to using the ledger's stored default context for this request.
+    ///
+    /// Defaults to false. For JSON-LD, this injects the context only when the
+    /// query omits `@context`/`context`. For ledger-scoped SPARQL, this makes
+    /// default prefixes available when the query has no explicit `PREFIX`.
+    #[serde(
+        default,
+        alias = "default_context",
+        alias = "use-default-context",
+        alias = "use_default_context"
+    )]
+    pub default_context: bool,
     /// Optional default graph URI (part of W3C SPARQL Protocol).
     // Kept for: full SPARQL Protocol compliance — BSBM and other tools may send this param.
     // Use when: implementing default-graph-uri scoping in query execution.
@@ -171,6 +183,50 @@ fn inject_headers_into_query(query: &mut JsonValue, headers: &FlureeHeaders) {
             headers.inject_into_opts(opts_obj);
         }
     }
+}
+
+fn jsonld_query_has_context(query: &JsonValue) -> bool {
+    query.get("@context").is_some() || query.get("context").is_some()
+}
+
+async fn inject_default_context_if_requested(
+    state: &AppState,
+    ledger_id: &str,
+    query: &mut JsonValue,
+    use_default_context: bool,
+) -> Result<()> {
+    if !use_default_context || jsonld_query_has_context(query) {
+        return Ok(());
+    }
+
+    if let Some(ctx) = state
+        .fluree
+        .get_default_context(ledger_id)
+        .await
+        .map_err(ServerError::Api)?
+    {
+        if let Some(obj) = query.as_object_mut() {
+            obj.insert("@context".to_string(), ctx);
+        }
+    }
+    Ok(())
+}
+
+async fn attach_default_context_to_graph(
+    state: &AppState,
+    ledger_id: &str,
+    graph: GraphDb,
+    use_default_context: bool,
+) -> Result<GraphDb> {
+    if !use_default_context {
+        return Ok(graph);
+    }
+    let ctx = state
+        .fluree
+        .get_default_context(ledger_id)
+        .await
+        .map_err(ServerError::Api)?;
+    Ok(graph.with_default_context(ctx))
 }
 
 /// Execute a query
@@ -378,6 +434,14 @@ pub async fn query(
         )
         .await;
 
+        inject_default_context_if_requested(
+            &state,
+            &ledger_id,
+            &mut query_json,
+            params.default_context,
+        )
+        .await?;
+
         execute_query(&state, &ledger_id, &query_json, delimited).await
     }
     }
@@ -473,7 +537,15 @@ pub async fn query_ledger(
             headers.identity.as_deref(),
         )
         .await;
-        return execute_sparql_ledger(&state, &ledger, &sparql, identity.as_deref(), delimited, &headers)
+        return execute_sparql_ledger(
+            &state,
+            &ledger,
+            &sparql,
+            identity.as_deref(),
+            delimited,
+            &headers,
+            params.default_context,
+        )
             .await;
     }
 
@@ -527,6 +599,14 @@ pub async fn query_ledger(
         policy_class,
     )
     .await;
+
+    inject_default_context_if_requested(
+        &state,
+        &ledger_id,
+        &mut query_json,
+        params.default_context,
+    )
+    .await?;
 
     execute_query(&state, &ledger_id, &query_json, delimited).await
     }
@@ -1211,6 +1291,7 @@ async fn execute_sparql_ledger(
     identity: Option<&str>,
     delimited: Option<DelimitedFormat>,
     headers: &FlureeHeaders,
+    use_default_context: bool,
 ) -> Result<Response> {
     // Create span for peer mode loading
     let span = tracing::debug_span!(
@@ -1295,16 +1376,24 @@ async fn execute_sparql_ledger(
             let result = if qc_opts.has_any_policy_inputs() {
                 let view = state.fluree.db_with_policy(ledger_id, &qc_opts).await
                     .inspect_err(|_| { set_span_error_code(&span, "error:QueryFailed"); })?;
+                let view =
+                    attach_default_context_to_graph(state, ledger_id, view, use_default_context)
+                        .await?;
                 view.query(state.fluree.as_ref())
                     .sparql(sparql)
                     .execute_formatted()
                     .await
                     .inspect_err(|_| { set_span_error_code(&span, "error:QueryFailed"); })?
             } else {
-                state
-                    .fluree
-                    .graph(ledger_id)
-                    .query()
+                let view = if use_default_context {
+                    state.fluree.db_with_default_context(ledger_id).await
+                } else {
+                    state.fluree.db(ledger_id).await
+                }
+                .inspect_err(|_| {
+                    set_span_error_code(&span, "error:QueryFailed");
+                })?;
+                view.query(state.fluree.as_ref())
                     .sparql(sparql)
                     .execute_formatted()
                     .await
@@ -1339,6 +1428,8 @@ async fn execute_sparql_ledger(
             }
             let view = state.fluree.db_with_policy(ledger_id, &qc_opts).await
                 .inspect_err(|_| { set_span_error_code(&span, "error:QueryFailed"); })?;
+            let view = attach_default_context_to_graph(state, ledger_id, view, use_default_context)
+                .await?;
             let result = view.query(state.fluree.as_ref())
                 .sparql(sparql)
                 .execute_formatted()
@@ -1637,7 +1728,13 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
             .inspect_err(|_| {
                 set_span_error_code(&span, "error:LedgerLoad");
             })?;
-        let graph = GraphDb::from_ledger_state(&ledger);
+        let graph = attach_default_context_to_graph(
+            state,
+            ledger_id,
+            GraphDb::from_ledger_state(&ledger),
+            use_default_context,
+        )
+        .await?;
         let fluree = &state.fluree;
 
         // Tracked SPARQL: if tracking headers are present, use tracked execution path


### PR DESCRIPTION
- Extend merge preview across API, HTTP, Rust, and CLI surfaces with optional conflict details, including current asserted source/target values, selected strategy labels, and a `mergeable` signal.
- Tighten the preview contract with canonical strategy parsing, invalid flag validation, unsupported `skip` rejection, stable key/detail ordering, and detail truncation matching returned conflict keys.
- Refresh merge and branch docs to describe general merge behavior, branch diff options, conflict detail semantics, and the limits of `mergeable=true`.
