### PR TITLE
Fix: `rdfs:Class` COUNT Misses

### DIFF
--- a/fluree-db-api/tests/it_query_rdfs_class_repro.rs
+++ b/fluree-db-api/tests/it_query_rdfs_class_repro.rs
@@ -1,0 +1,911 @@
+//! Reproduction for: querying `?s rdf:type rdfs:Class` via SPARQL after a
+//! TTL bulk import returns 0, even though the triples are present.
+//! Source notes: /tmp/fluree-bug-rdfs-class-invisibility.md
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use std::io::Write;
+use tempfile::TempDir;
+
+fn write_ttl(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).expect("create ttl file");
+    f.write_all(content.as_bytes()).expect("write ttl");
+    path
+}
+
+/// Simulate the Hometap ontology shape: classes declared with `a rdfs:Class`
+/// and properties declared with `a rdf:Property`, mixed with instance data.
+fn ontology_ttl() -> &'static str {
+    r#"
+@prefix ht:   <https://ns.hometap.com/v1#> .
+@prefix htd:  <https://data.hometap.com/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+# Classes
+ht:CalendarDay a rdfs:Class ; rdfs:label "Calendar Day" .
+ht:Inquiry a rdfs:Class ; rdfs:label "Inquiry" .
+ht:Opportunity a rdfs:Class ; rdfs:label "Opportunity" .
+ht:Person a rdfs:Class ; rdfs:label "Person" .
+ht:Home a rdfs:Class ; rdfs:label "Home" .
+
+# Properties
+ht:friendlyId a rdf:Property ;
+    rdfs:label "Friendly ID" ;
+    rdfs:domain ht:Inquiry ;
+    rdfs:range xsd:string .
+ht:home a rdf:Property ;
+    rdfs:label "Home" ;
+    rdfs:domain ht:Inquiry ;
+    rdfs:range ht:Home .
+ht:person a rdf:Property ;
+    rdfs:label "Person" ;
+    rdfs:domain ht:Inquiry ;
+    rdfs:range ht:Person .
+
+# A handful of instance triples to mirror the user's scenario where there
+# are real Inquiry rows sharing storage with the rdfs:Class declarations.
+htd:inquiry-1 a ht:Inquiry ; ht:friendlyId "I-1" .
+htd:inquiry-2 a ht:Inquiry ; ht:friendlyId "I-2" .
+htd:inquiry-3 a ht:Inquiry ; ht:friendlyId "I-3" .
+"#
+}
+
+async fn bulk_import_ontology() -> (TempDir, TempDir, fluree_db_api::Fluree, String) {
+    let db_dir = TempDir::new().expect("db tmpdir");
+    let data_dir = TempDir::new().expect("data tmpdir");
+
+    write_ttl(data_dir.path(), "00-ontology.ttl", ontology_ttl());
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let ledger_id = "test/rdfs-class-repro:main".to_string();
+
+    let result = fluree
+        .create(&ledger_id)
+        .import(data_dir.path())
+        .threads(2)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import should succeed");
+    assert!(result.t > 0);
+
+    (db_dir, data_dir, fluree, ledger_id)
+}
+
+#[tokio::test]
+async fn sparql_a_prefixed_a_rdfs_class() {
+    // Query A: SELECT ?c WHERE { ?c a rdfs:Class }
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?c WHERE { ?c a rdfs:Class }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[A] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        5,
+        "expected 5 classes via Query A, got {}",
+        arr.len()
+    );
+}
+
+#[tokio::test]
+async fn sparql_b_full_iri_rdf_type_rdfs_class() {
+    // Query B: SELECT ?c WHERE { ?c <rdf:type> <rdfs:Class> } (full IRIs)
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        SELECT ?c WHERE {
+            ?c <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+               <http://www.w3.org/2000/01/rdf-schema#Class> .
+        }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[B] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        5,
+        "expected 5 classes via Query B, got {}",
+        arr.len()
+    );
+}
+
+#[tokio::test]
+async fn sparql_c_filter_rewrite_works() {
+    // Query C (the rewrite that the user reports works): FILTER form.
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?c WHERE { ?c rdf:type ?t . FILTER(?t = rdfs:Class) }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[C] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        5,
+        "expected 5 classes via Query C, got {}",
+        arr.len()
+    );
+}
+
+#[tokio::test]
+async fn sparql_d_group_by_type() {
+    // Query D: ?s ?p ?o GROUP BY ?t — should show rdfs:Class and rdf:Property
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT ?t (COUNT(?s) AS ?n) WHERE { ?s rdf:type ?t } GROUP BY ?t
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[D] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+}
+
+#[tokio::test]
+async fn sparql_e_describe_inquiry_class() {
+    // Query E: get all triples for ht:Inquiry (the class itself)
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX ht: <https://ns.hometap.com/v1#>
+        SELECT ?p ?o WHERE { ht:Inquiry ?p ?o }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[E] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+}
+
+#[tokio::test]
+async fn sparql_f_a_rdf_property_works() {
+    // Query F (control): ?p a rdf:Property — the user reports this WORKS.
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT ?p WHERE { ?p a rdf:Property }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[F] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        3,
+        "expected 3 properties via Query F, got {}",
+        arr.len()
+    );
+}
+
+/// Regression for the COUNT-by-class fast-path leaflet-skip bug:
+/// `count_bound_object_v6` (in `fast_group_count_firsts.rs`) used to skip
+/// any leaflet whose first prefix was below the target, even when the
+/// leaflet contained target rows mixed with other distinct objects.
+///
+/// The shape that triggers it: a single leaflet contains rdf:type rows for
+/// multiple classes — e.g. `rdf:Property`, `rdfs:Class`, plus several user
+/// classes. Querying COUNT for any class that isn't first in the leaflet
+/// would return 0.
+#[tokio::test]
+async fn count_bound_object_mixed_leaflet_regression() {
+    // Build a TTL where many classes share a single leaflet (POST sorts by
+    // (p_id, o_type, o_key); rdf:type ns_codes are encoded as RDF/RDFS/owl
+    // with small SubjectIds and user namespaces with larger ones).
+    let db_dir = TempDir::new().unwrap();
+    let data_dir = TempDir::new().unwrap();
+    let mut ttl = String::from(
+        "@prefix ex:   <http://example.org/ns/> .\n\
+         @prefix exd:  <http://example.org/data/> .\n\
+         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n",
+    );
+    // Two well-known classes that come first in POST order (RDF/RDFS small
+    // namespace codes encode to the smallest SubjectIds for rdf:type's range).
+    ttl.push_str("ex:p1 a rdf:Property .\n");
+    ttl.push_str("ex:p2 a rdf:Property .\n");
+    ttl.push_str("ex:Class1 a rdfs:Class .\n");
+    ttl.push_str("ex:Class2 a rdfs:Class .\n");
+    ttl.push_str("ex:Class3 a rdfs:Class .\n");
+    // User classes with many instances each, to force the rdf:type predicate's
+    // POST range across multiple leaflets and put the small-cardinality classes
+    // at a leaflet boundary.
+    for i in 0..3000 {
+        ttl.push_str(&format!("exd:big-{i} a ex:BigClass .\n"));
+    }
+    write_ttl(data_dir.path(), "00.ttl", &ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let ledger_id = "test/mixed-leaflet-regression:main";
+    fluree
+        .create(ledger_id)
+        .import(data_dir.path())
+        .threads(2)
+        .memory_budget_mb(128)
+        .leaflet_rows(1024) // small leaflets so rdfs:Class lands inside a mixed-class leaflet
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
+
+    // The fast-path COUNT operator: bound predicate (rdf:type), bound object.
+    let count_class = r"
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }
+    ";
+    let r = support::query_sparql(&fluree, &ledger, count_class)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    let n: i64 = r["results"]["bindings"][0]["n"]["value"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(n, 3, "expected COUNT rdfs:Class = 3, got {n}");
+
+    let count_prop = r"
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT (COUNT(?p) AS ?n) WHERE { ?p a rdf:Property }
+    ";
+    let r = support::query_sparql(&fluree, &ledger, count_prop)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    let n: i64 = r["results"]["bindings"][0]["n"]["value"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(n, 2, "expected COUNT rdf:Property = 2, got {n}");
+
+    let count_user = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT (COUNT(?s) AS ?n) WHERE { ?s a ex:BigClass }
+    ";
+    let r = support::query_sparql(&fluree, &ledger, count_user)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    let n: i64 = r["results"]["bindings"][0]["n"]["value"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(n, 3000, "expected COUNT ex:BigClass = 3000, got {n}");
+}
+
+#[tokio::test]
+async fn sparql_g_a_user_class_works() {
+    // Query G (control): ?c a ht:Inquiry — user-defined class, user reports works.
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX ht: <https://ns.hometap.com/v1#>
+        SELECT ?c WHERE { ?c a ht:Inquiry }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[G] = {}", serde_json::to_string_pretty(&bindings).unwrap());
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        3,
+        "expected 3 instances via Query G, got {}",
+        arr.len()
+    );
+}
+
+#[tokio::test]
+#[ignore = "uses local user data at ~/Downloads/hometap"]
+async fn user_actual_dataset_diagnostic() {
+    use fluree_db_core::Sid;
+    let data_dir = std::path::PathBuf::from(format!(
+        "{}/Downloads/hometap",
+        std::env::var("HOME").unwrap()
+    ));
+    if !data_dir.exists() {
+        return;
+    }
+
+    let db_dir = TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+
+    let ledger_id = "test/hometap-diag:main";
+    fluree
+        .create(ledger_id)
+        .import(&data_dir)
+        .threads(2)
+        .memory_budget_mb(1024)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+    let snap = &ledger.snapshot;
+
+    // 1) Show the snapshot's namespace_codes registration for the relevant prefixes.
+    eprintln!("\n=== namespace_codes ===");
+    for code in [3u16, 4u16] {
+        eprintln!("  code {} → {:?}", code, snap.namespaces().get(&code));
+    }
+    // Also dump any *-allocated codes whose prefix mentions rdf or rdf-schema
+    for (code, prefix) in snap.namespaces() {
+        if prefix.contains("rdf") {
+            eprintln!("  code {code} → {prefix:?}");
+        }
+    }
+
+    // 2) Encode the two object IRIs and print the Sid each yields.
+    let class_iri = "http://www.w3.org/2000/01/rdf-schema#Class";
+    let property_iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
+    let class_sid = snap.encode_iri(class_iri);
+    let property_sid = snap.encode_iri(property_iri);
+    eprintln!("\n=== encode_iri at query time ===");
+    eprintln!("  rdfs:Class    → {class_sid:?}");
+    eprintln!("  rdf:Property → {property_sid:?}");
+
+    // 3) Look at the stored class_counts (subject/o_key index) to see how the
+    //    importer encoded it on the way in. If we can directly look at one of
+    //    the actual stored type triples for ht:Inquiry, we can compare.
+    let s_inquiry = snap.encode_iri("https://ns.hometap.com/v1#Inquiry");
+    eprintln!("  ht:Inquiry    → {s_inquiry:?}");
+
+    // 4) Scan the OPST cursor for (rdf:type, rdfs:Class) and dump what we find.
+    use fluree_db_core::{
+        range_with_overlay, FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest,
+    };
+    let rdf_type_sid = snap
+        .encode_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        .unwrap();
+    let class_sid_unwrapped = class_sid.clone().unwrap();
+    let property_sid_unwrapped = property_sid.clone().unwrap();
+    eprintln!("\n=== rdf:type SID ===");
+    eprintln!("  rdf:type → {rdf_type_sid:?}");
+
+    let novelty = ledger.novelty.as_ref();
+
+    let opts_cap = RangeOptions::default().with_flake_limit(20);
+
+    // OPST scan for the specific (rdf:type, rdfs:Class) shape via OPST
+    let class_range = range_with_overlay(
+        snap,
+        0u16,
+        novelty,
+        IndexType::Opst,
+        RangeTest::Eq,
+        RangeMatch {
+            p: Some(rdf_type_sid.clone()),
+            o: Some(FlakeValue::Ref(class_sid_unwrapped.clone())),
+            ..Default::default()
+        },
+        opts_cap.clone(),
+    )
+    .await
+    .expect("opst class");
+    eprintln!(
+        "\n=== OPST(rdf:type, rdfs:Class) range_with_overlay → {} flakes (cap 20) ===",
+        class_range.len()
+    );
+    for f in class_range.iter().take(5) {
+        eprintln!("  flake: s={:?} p={:?} o={:?}", f.s, f.p, f.o);
+    }
+
+    // OPST scan for (rdf:type, rdf:Property) — the working case
+    let prop_range = range_with_overlay(
+        snap,
+        0u16,
+        novelty,
+        IndexType::Opst,
+        RangeTest::Eq,
+        RangeMatch {
+            p: Some(rdf_type_sid.clone()),
+            o: Some(FlakeValue::Ref(property_sid_unwrapped.clone())),
+            ..Default::default()
+        },
+        opts_cap.clone(),
+    )
+    .await
+    .expect("opst prop");
+    eprintln!(
+        "\n=== OPST(rdf:type, rdf:Property) range_with_overlay → {} flakes (cap 20) ===",
+        prop_range.len()
+    );
+    for f in prop_range.iter().take(5) {
+        eprintln!("  flake: s={:?} p={:?} o={:?}", f.s, f.p, f.o);
+    }
+
+    // 4b) Check find_subject_id_by_parts directly — this is what
+    //     value_to_otype_okey_simple uses for FlakeValue::Ref encoding.
+    let store_te = ledger.binary_store.as_ref();
+    if let Some(te) = store_te {
+        if let Ok(bs) =
+            te.0.clone()
+                .downcast::<fluree_db_binary_index::BinaryIndexStore>()
+        {
+            eprintln!("\n=== find_subject_id_by_parts ===");
+            let r1 = bs.find_subject_id_by_parts(
+                class_sid_unwrapped.namespace_code,
+                &class_sid_unwrapped.name,
+            );
+            eprintln!("  rdfs:Class (4, Class)      → {r1:?}");
+            let r2 = bs.find_subject_id_by_parts(
+                property_sid_unwrapped.namespace_code,
+                &property_sid_unwrapped.name,
+            );
+            eprintln!("  rdf:Property (3, Property) → {r2:?}");
+            let r3 = bs.find_subject_id_by_parts(13, "Inquiry");
+            eprintln!("  ht:Inquiry  (13, Inquiry)  → {r3:?}");
+
+            // CRITICAL: Compare snapshot.encode_iri vs store.encode_iri.
+            // The decode path uses store.encode_iri(decoded_iri) to produce
+            // FlakeValue::Ref. If that encoding doesn't match the bound_o
+            // (which uses snapshot.encode_iri), the row filter at
+            // binary_scan.rs:1168 will reject every row.
+            eprintln!("\n=== encode_iri comparison (snapshot vs store) ===");
+            for iri in [class_iri, property_iri, "https://ns.hometap.com/v1#Inquiry"] {
+                let snap_sid = snap.encode_iri(iri);
+                let store_sid = bs.encode_iri(iri);
+                eprintln!("  iri = {iri}");
+                eprintln!("    snapshot.encode_iri → {snap_sid:?}");
+                eprintln!("    store.encode_iri    → {store_sid:?}");
+                if snap_sid.as_ref() != Some(&store_sid) {
+                    eprintln!("    *** MISMATCH ***");
+                }
+            }
+            // Also: does the store's namespace_reverse table contain rdfs/rdf?
+            eprintln!("\n=== store namespace registrations ===");
+            for iri in [
+                "http://www.w3.org/2000/01/rdf-schema#",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                "https://ns.hometap.com/v1#",
+            ] {
+                use fluree_db_core::ns_encoding::NsLookup;
+                eprintln!("  {iri:60} → {:?}", bs.code_for_prefix(iri));
+            }
+        }
+    } else {
+        eprintln!("  no binary_store available");
+    }
+
+    // 5) Scan POST for ALL `rdf:type` triples (no object) and group by object Sid
+    let all_types = range_with_overlay(
+        snap,
+        0u16,
+        novelty,
+        IndexType::Post,
+        RangeTest::Eq,
+        RangeMatch {
+            p: Some(rdf_type_sid.clone()),
+            ..Default::default()
+        },
+        RangeOptions::default().with_flake_limit(2_000_000),
+    )
+    .await
+    .expect("post all rdf:type");
+    eprintln!(
+        "\n=== POST(rdf:type, *) → {} total flakes ===",
+        all_types.len()
+    );
+    let mut counts: std::collections::HashMap<Sid, u64> = std::collections::HashMap::new();
+    for f in &all_types {
+        if let FlakeValue::Ref(o) = &f.o {
+            *counts.entry(o.clone()).or_insert(0) += 1;
+        }
+    }
+    let mut sorted: Vec<_> = counts.iter().collect();
+    sorted.sort_by_key(|(_sid, n)| std::cmp::Reverse(**n));
+    for (sid, n) in sorted.iter().take(20) {
+        eprintln!(
+            "   ({}) sid={:?} → decoded: {:?}",
+            n,
+            sid,
+            snap.decode_sid(sid)
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "uses local user data at ~/Downloads/hometap"]
+async fn user_actual_dataset_a_count_only() {
+    // ONLY runs Query A (COUNT) so we can isolate the operator-tree decisions.
+    let data_dir = std::path::PathBuf::from(format!(
+        "{}/Downloads/hometap",
+        std::env::var("HOME").unwrap()
+    ));
+    if !data_dir.exists() {
+        return;
+    }
+    let db_dir = TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let ledger_id = "test/hometap-count-a:main";
+    fluree
+        .create(ledger_id)
+        .import(&data_dir)
+        .threads(2)
+        .memory_budget_mb(1024)
+        .cleanup(false)
+        .execute()
+        .await
+        .unwrap();
+
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
+    eprintln!("\n========== Query A only (COUNT) ==========\n");
+    let q_a = r"
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, q_a)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!(
+        "\n[A only] = {}",
+        serde_json::to_string_pretty(&bindings).unwrap()
+    );
+}
+
+#[tokio::test]
+#[ignore = "uses local user data at ~/Downloads/hometap"]
+async fn user_actual_dataset_a_select_only() {
+    // Same as Query A but as SELECT ?c (no COUNT) so we hit BinaryScanOperator
+    // directly rather than fast_count.
+    let data_dir = std::path::PathBuf::from(format!(
+        "{}/Downloads/hometap",
+        std::env::var("HOME").unwrap()
+    ));
+    if !data_dir.exists() {
+        return;
+    }
+    let db_dir = TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let ledger_id = "test/hometap-select:main";
+    fluree
+        .create(ledger_id)
+        .import(&data_dir)
+        .threads(2)
+        .memory_budget_mb(1024)
+        .cleanup(false)
+        .execute()
+        .await
+        .unwrap();
+
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
+
+    let q_a = r"
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?c WHERE { ?c a rdfs:Class }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, q_a)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    let arr_a = bindings["results"]["bindings"].as_array().unwrap();
+    eprintln!("\n=== A SELECT result count = {} ===", arr_a.len());
+
+    let q_f = r"
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT ?p WHERE { ?p a rdf:Property }
+    ";
+    let bindings_f = support::query_sparql(&fluree, &ledger, q_f)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    let arr_f = bindings_f["results"]["bindings"].as_array().unwrap();
+    eprintln!("\n=== F SELECT result count = {} ===", arr_f.len());
+
+    eprintln!("A={} F={}", arr_a.len(), arr_f.len());
+}
+
+#[tokio::test]
+#[ignore = "uses local user data at ~/Downloads/hometap"]
+async fn user_actual_dataset_a_with_reasoning_off() {
+    let data_dir = std::path::PathBuf::from(format!(
+        "{}/Downloads/hometap",
+        std::env::var("HOME").unwrap()
+    ));
+    if !data_dir.exists() {
+        return;
+    }
+    let db_dir = TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let ledger_id = "test/hometap-noreason:main";
+    fluree
+        .create(ledger_id)
+        .import(&data_dir)
+        .threads(2)
+        .memory_budget_mb(1024)
+        .cleanup(false)
+        .execute()
+        .await
+        .unwrap();
+
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
+
+    // Same Query A, but with reasoning explicitly disabled.
+    let q = json!({
+        "@context": {"rdfs": "http://www.w3.org/2000/01/rdf-schema#"},
+        "where": {"@id": "?c", "@type": "rdfs:Class"},
+        "select": "?c",
+        "reasoning": "none"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    eprintln!(
+        "[A reasoning:none] = {}",
+        serde_json::to_string_pretty(&rows).unwrap()
+    );
+    let arr = rows.as_array().expect("array");
+    assert_eq!(
+        arr.len(),
+        16,
+        "expected 16 classes with reasoning off, got {}",
+        arr.len()
+    );
+}
+
+#[tokio::test]
+#[ignore = "uses local user data at ~/Downloads/hometap"]
+async fn user_actual_dataset_a_with_explain() {
+    let data_dir = std::path::PathBuf::from(format!(
+        "{}/Downloads/hometap",
+        std::env::var("HOME").unwrap()
+    ));
+    if !data_dir.exists() {
+        return;
+    }
+    let db_dir = TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let ledger_id = "test/hometap-explain:main";
+    fluree
+        .create(ledger_id)
+        .import(&data_dir)
+        .threads(2)
+        .memory_budget_mb(1024)
+        .cleanup(false)
+        .execute()
+        .await
+        .unwrap();
+
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
+
+    // Query A: explain
+    let q_a = json!({
+        "@context": {"rdfs": "http://www.w3.org/2000/01/rdf-schema#"},
+        "where": {"@id": "?c", "@type": "rdfs:Class"},
+        "select": "?c"
+    });
+    let q_f = json!({
+        "@context": {"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"},
+        "where": {"@id": "?p", "@type": "rdf:Property"},
+        "select": "?p"
+    });
+
+    for (label, q) in [("A rdfs:Class", q_a), ("F rdf:Property", q_f)] {
+        eprintln!("\n=== EXPLAIN {label} ===");
+        let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+        let res = fluree.explain(&db, &q).await;
+        eprintln!("explain result = {res:#?}");
+    }
+}
+
+#[tokio::test]
+#[ignore = "uses local user data at ~/Downloads/hometap"]
+async fn user_actual_dataset_full() {
+    let data_dir = std::path::PathBuf::from(format!(
+        "{}/Downloads/hometap",
+        std::env::var("HOME").unwrap()
+    ));
+    if !data_dir.exists() {
+        eprintln!("data dir missing, skipping");
+        return;
+    }
+
+    let db_dir = TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let ledger_id = "test/hometap-real:main";
+    let result = fluree
+        .create(ledger_id)
+        .import(&data_dir)
+        .threads(2)
+        .memory_budget_mb(1024)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+    eprintln!("imported t={}, flakes={}", result.t, result.flake_count);
+
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+
+    // Query A: SELECT ?c WHERE { ?c a rdfs:Class }
+    let q_a = r"
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }
+    ";
+    let a = support::query_sparql(&fluree, &ledger, q_a)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[A real] = {}", serde_json::to_string_pretty(&a).unwrap());
+
+    // Query B: full IRIs
+    let q_b = r"
+        SELECT (COUNT(?c) AS ?n) WHERE {
+            ?c <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+               <http://www.w3.org/2000/01/rdf-schema#Class> .
+        }
+    ";
+    let b = support::query_sparql(&fluree, &ledger, q_b)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[B real] = {}", serde_json::to_string_pretty(&b).unwrap());
+
+    // Query C: FILTER form (works for user)
+    let q_c = r"
+        PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT (COUNT(?c) AS ?n) WHERE { ?c rdf:type ?t . FILTER(?t = rdfs:Class) }
+    ";
+    let c = support::query_sparql(&fluree, &ledger, q_c)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[C real] = {}", serde_json::to_string_pretty(&c).unwrap());
+
+    // Query F (control): ?p a rdf:Property — works for user
+    let q_f = r"
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT (COUNT(?p) AS ?n) WHERE { ?p a rdf:Property }
+    ";
+    let f = support::query_sparql(&fluree, &ledger, q_f)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[F real] = {}", serde_json::to_string_pretty(&f).unwrap());
+
+    // Query D: GROUP BY type to confirm object IRI seen by query engine
+    let q_d = r"
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT ?t (COUNT(?s) AS ?n) WHERE { ?s rdf:type ?t } GROUP BY ?t
+    ";
+    let d = support::query_sparql(&fluree, &ledger, q_d)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    eprintln!("[D real] = {}", serde_json::to_string_pretty(&d).unwrap());
+
+    let count_of = |v: &serde_json::Value| -> i64 {
+        v["results"]["bindings"][0]["n"]["value"]
+            .as_str()
+            .unwrap_or("0")
+            .parse()
+            .unwrap_or(0)
+    };
+    let a_n = count_of(&a);
+    let b_n = count_of(&b);
+    let c_n = count_of(&c);
+    let f_n = count_of(&f);
+    eprintln!("counts: A={a_n} B={b_n} C={c_n} F={f_n}");
+
+    // We expect A, B, and C to all match — they're semantically identical.
+    assert_eq!(
+        a_n, c_n,
+        "Query A ({a_n}) should match FILTER rewrite C ({c_n})"
+    );
+    assert_eq!(
+        b_n, c_n,
+        "Query B ({b_n}) should match FILTER rewrite C ({c_n})"
+    );
+}
+
+#[tokio::test]
+async fn jsonld_form_user_query() {
+    // The exact JSON-LD form the user reported broken in the original message.
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let q = json!({
+        "@context": {
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "where": {"@id": "?s", "@type": "rdfs:Class"},
+        "select": {"?s": ["*"]}
+    });
+    let result = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .expect("jsonld query")
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .unwrap();
+    eprintln!(
+        "[jsonld] = {}",
+        serde_json::to_string_pretty(&result).unwrap()
+    );
+    let normalized = support::normalize_rows(&result);
+    assert_eq!(
+        normalized.len(),
+        5,
+        "expected 5 rdfs:Class subjects (jsonld), got {}: {:?}",
+        normalized.len(),
+        normalized
+    );
+}

--- a/fluree-db-api/tests/it_query_rdfs_class_repro.rs
+++ b/fluree-db-api/tests/it_query_rdfs_class_repro.rs
@@ -1,6 +1,14 @@
-//! Reproduction for: querying `?s rdf:type rdfs:Class` via SPARQL after a
-//! TTL bulk import returns 0, even though the triples are present.
-//! Source notes: /tmp/fluree-bug-rdfs-class-invisibility.md
+//! Regression for: COUNT `?s rdf:type rdfs:Class` returning 0 on bulk-imported
+//! data while the parallel COUNT for `rdf:Property` and FILTER rewrites return
+//! the correct count.
+//!
+//! Tracked in fluree/db#1208. The bug lives in `count_bound_object_v6` in
+//! `fluree-db-query/src/fast_group_count_firsts.rs` — a POST-leaflet
+//! directory-skip optimization that incorrectly skipped any leaflet whose
+//! first key sorted below the target value, even when the leaflet contained
+//! target rows mixed with other distinct objects. A second, related issue
+//! around mixed-predicate leaflets is exercised by
+//! `count_mixed_predicate_leaflet_regression` below.
 #![cfg(feature = "native")]
 
 mod support;
@@ -17,42 +25,43 @@ fn write_ttl(dir: &std::path::Path, name: &str, content: &str) -> std::path::Pat
     path
 }
 
-/// Simulate the Hometap ontology shape: classes declared with `a rdfs:Class`
-/// and properties declared with `a rdf:Property`, mixed with instance data.
+/// Synthetic RDFS ontology shape: classes declared with `a rdfs:Class`, a
+/// few `rdf:Property` declarations, and a handful of instance triples that
+/// share storage with the schema declarations after bulk import.
 fn ontology_ttl() -> &'static str {
     r#"
-@prefix ht:   <https://ns.hometap.com/v1#> .
-@prefix htd:  <https://data.hometap.com/> .
+@prefix ex:   <http://example.org/ns/> .
+@prefix exd:  <http://example.org/data/> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 # Classes
-ht:CalendarDay a rdfs:Class ; rdfs:label "Calendar Day" .
-ht:Inquiry a rdfs:Class ; rdfs:label "Inquiry" .
-ht:Opportunity a rdfs:Class ; rdfs:label "Opportunity" .
-ht:Person a rdfs:Class ; rdfs:label "Person" .
-ht:Home a rdfs:Class ; rdfs:label "Home" .
+ex:ClassA a rdfs:Class ; rdfs:label "Class A" .
+ex:ClassB a rdfs:Class ; rdfs:label "Class B" .
+ex:ClassC a rdfs:Class ; rdfs:label "Class C" .
+ex:ClassD a rdfs:Class ; rdfs:label "Class D" .
+ex:ClassE a rdfs:Class ; rdfs:label "Class E" .
 
 # Properties
-ht:friendlyId a rdf:Property ;
-    rdfs:label "Friendly ID" ;
-    rdfs:domain ht:Inquiry ;
+ex:propX a rdf:Property ;
+    rdfs:label "Prop X" ;
+    rdfs:domain ex:ClassA ;
     rdfs:range xsd:string .
-ht:home a rdf:Property ;
-    rdfs:label "Home" ;
-    rdfs:domain ht:Inquiry ;
-    rdfs:range ht:Home .
-ht:person a rdf:Property ;
-    rdfs:label "Person" ;
-    rdfs:domain ht:Inquiry ;
-    rdfs:range ht:Person .
+ex:propY a rdf:Property ;
+    rdfs:label "Prop Y" ;
+    rdfs:domain ex:ClassA ;
+    rdfs:range ex:ClassB .
+ex:propZ a rdf:Property ;
+    rdfs:label "Prop Z" ;
+    rdfs:domain ex:ClassA ;
+    rdfs:range ex:ClassC .
 
-# A handful of instance triples to mirror the user's scenario where there
-# are real Inquiry rows sharing storage with the rdfs:Class declarations.
-htd:inquiry-1 a ht:Inquiry ; ht:friendlyId "I-1" .
-htd:inquiry-2 a ht:Inquiry ; ht:friendlyId "I-2" .
-htd:inquiry-3 a ht:Inquiry ; ht:friendlyId "I-3" .
+# Instance rows so the index has real `rdf:type` flakes mixed with the
+# schema declarations.
+exd:item-1 a ex:ClassA ; ex:propX "value-1" .
+exd:item-2 a ex:ClassA ; ex:propX "value-2" .
+exd:item-3 a ex:ClassA ; ex:propX "value-3" .
 "#
 }
 
@@ -83,8 +92,8 @@ async fn bulk_import_ontology() -> (TempDir, TempDir, fluree_db_api::Fluree, Str
 }
 
 #[tokio::test]
-async fn sparql_a_prefixed_a_rdfs_class() {
-    // Query A: SELECT ?c WHERE { ?c a rdfs:Class }
+async fn sparql_select_class_prefixed() {
+    // SELECT ?c WHERE { ?c a rdfs:Class }
     let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
     let ledger = fluree.ledger(&ledger_id).await.expect("load");
 
@@ -97,19 +106,13 @@ async fn sparql_a_prefixed_a_rdfs_class() {
         .unwrap()
         .to_sparql_json(&ledger.snapshot)
         .unwrap();
-    eprintln!("[A] = {}", serde_json::to_string_pretty(&bindings).unwrap());
     let arr = bindings["results"]["bindings"].as_array().unwrap();
-    assert_eq!(
-        arr.len(),
-        5,
-        "expected 5 classes via Query A, got {}",
-        arr.len()
-    );
+    assert_eq!(arr.len(), 5, "expected 5 classes, got {}", arr.len());
 }
 
 #[tokio::test]
-async fn sparql_b_full_iri_rdf_type_rdfs_class() {
-    // Query B: SELECT ?c WHERE { ?c <rdf:type> <rdfs:Class> } (full IRIs)
+async fn sparql_select_class_full_iris() {
+    // SELECT ?c WHERE { ?c <rdf:type-IRI> <rdfs:Class-IRI> }
     let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
     let ledger = fluree.ledger(&ledger_id).await.expect("load");
 
@@ -124,19 +127,14 @@ async fn sparql_b_full_iri_rdf_type_rdfs_class() {
         .unwrap()
         .to_sparql_json(&ledger.snapshot)
         .unwrap();
-    eprintln!("[B] = {}", serde_json::to_string_pretty(&bindings).unwrap());
     let arr = bindings["results"]["bindings"].as_array().unwrap();
-    assert_eq!(
-        arr.len(),
-        5,
-        "expected 5 classes via Query B, got {}",
-        arr.len()
-    );
+    assert_eq!(arr.len(), 5, "expected 5 classes, got {}", arr.len());
 }
 
 #[tokio::test]
-async fn sparql_c_filter_rewrite_works() {
-    // Query C (the rewrite that the user reports works): FILTER form.
+async fn sparql_filter_rewrite_returns_same_count() {
+    // FILTER form — semantically equivalent to the bound-object form;
+    // returns the correct count even before the fix.
     let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
     let ledger = fluree.ledger(&ledger_id).await.expect("load");
 
@@ -150,55 +148,14 @@ async fn sparql_c_filter_rewrite_works() {
         .unwrap()
         .to_sparql_json(&ledger.snapshot)
         .unwrap();
-    eprintln!("[C] = {}", serde_json::to_string_pretty(&bindings).unwrap());
     let arr = bindings["results"]["bindings"].as_array().unwrap();
-    assert_eq!(
-        arr.len(),
-        5,
-        "expected 5 classes via Query C, got {}",
-        arr.len()
-    );
+    assert_eq!(arr.len(), 5, "expected 5 classes, got {}", arr.len());
 }
 
 #[tokio::test]
-async fn sparql_d_group_by_type() {
-    // Query D: ?s ?p ?o GROUP BY ?t — should show rdfs:Class and rdf:Property
-    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
-    let ledger = fluree.ledger(&ledger_id).await.expect("load");
-
-    let sparql = r"
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        SELECT ?t (COUNT(?s) AS ?n) WHERE { ?s rdf:type ?t } GROUP BY ?t
-    ";
-    let bindings = support::query_sparql(&fluree, &ledger, sparql)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[D] = {}", serde_json::to_string_pretty(&bindings).unwrap());
-}
-
-#[tokio::test]
-async fn sparql_e_describe_inquiry_class() {
-    // Query E: get all triples for ht:Inquiry (the class itself)
-    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
-    let ledger = fluree.ledger(&ledger_id).await.expect("load");
-
-    let sparql = r"
-        PREFIX ht: <https://ns.hometap.com/v1#>
-        SELECT ?p ?o WHERE { ht:Inquiry ?p ?o }
-    ";
-    let bindings = support::query_sparql(&fluree, &ledger, sparql)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[E] = {}", serde_json::to_string_pretty(&bindings).unwrap());
-}
-
-#[tokio::test]
-async fn sparql_f_a_rdf_property_works() {
-    // Query F (control): ?p a rdf:Property — the user reports this WORKS.
+async fn sparql_select_property_works() {
+    // Control: the parallel COUNT/SELECT shape for rdf:Property — works
+    // because rdf:Property happens to be the first row of its leaflet.
     let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
     let ledger = fluree.ledger(&ledger_id).await.expect("load");
 
@@ -211,30 +168,69 @@ async fn sparql_f_a_rdf_property_works() {
         .unwrap()
         .to_sparql_json(&ledger.snapshot)
         .unwrap();
-    eprintln!("[F] = {}", serde_json::to_string_pretty(&bindings).unwrap());
     let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(arr.len(), 3, "expected 3 properties, got {}", arr.len());
+}
+
+#[tokio::test]
+async fn sparql_select_user_class_works() {
+    // Control: a user-defined class — works for the same reason.
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let sparql = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?c WHERE { ?c a ex:ClassA }
+    ";
+    let bindings = support::query_sparql(&fluree, &ledger, sparql)
+        .await
+        .unwrap()
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap();
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
+    assert_eq!(arr.len(), 3, "expected 3 instances, got {}", arr.len());
+}
+
+#[tokio::test]
+async fn jsonld_select_star_class() {
+    // The exact JSON-LD shape originally reported as broken.
+    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+    let q = json!({
+        "@context": {
+            "id": "@id",
+            "type": "@type",
+            "ex": "http://example.org/ns/",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "where": {"@id": "?s", "@type": "rdfs:Class"},
+        "select": {"?s": ["*"]}
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .unwrap();
     assert_eq!(
-        arr.len(),
-        3,
-        "expected 3 properties via Query F, got {}",
-        arr.len()
+        support::normalize_rows(&rows).len(),
+        5,
+        "expected 5 classes (jsonld), got: {rows}"
     );
 }
 
-/// Regression for the COUNT-by-class fast-path leaflet-skip bug:
-/// `count_bound_object_v6` (in `fast_group_count_firsts.rs`) used to skip
-/// any leaflet whose first prefix was below the target, even when the
-/// leaflet contained target rows mixed with other distinct objects.
+/// Regression for the leaflet first-key skip bug in `count_bound_object_v6`.
 ///
-/// The shape that triggers it: a single leaflet contains rdf:type rows for
-/// multiple classes — e.g. `rdf:Property`, `rdfs:Class`, plus several user
-/// classes. Querying COUNT for any class that isn't first in the leaflet
-/// would return 0.
+/// The fast path used to skip any leaflet whose first prefix sorted below the
+/// target — but a leaflet's rows span `[first_prefix, next_leaflet_first_prefix)`,
+/// so a target value can sit *inside* a leaflet whose first row is some smaller
+/// value. The shape that triggers it: a single leaflet contains rdf:type rows
+/// for multiple classes (e.g. `rdf:Property`, `rdfs:Class`, plus user classes).
+/// A COUNT for any class that isn't the very first row of the leaflet would
+/// silently return 0.
 #[tokio::test]
-async fn count_bound_object_mixed_leaflet_regression() {
-    // Build a TTL where many classes share a single leaflet (POST sorts by
-    // (p_id, o_type, o_key); rdf:type ns_codes are encoded as RDF/RDFS/owl
-    // with small SubjectIds and user namespaces with larger ones).
+async fn count_bound_object_first_key_skip_regression() {
     let db_dir = TempDir::new().unwrap();
     let data_dir = TempDir::new().unwrap();
     let mut ttl = String::from(
@@ -250,9 +246,9 @@ async fn count_bound_object_mixed_leaflet_regression() {
     ttl.push_str("ex:Class1 a rdfs:Class .\n");
     ttl.push_str("ex:Class2 a rdfs:Class .\n");
     ttl.push_str("ex:Class3 a rdfs:Class .\n");
-    // User classes with many instances each, to force the rdf:type predicate's
-    // POST range across multiple leaflets and put the small-cardinality classes
-    // at a leaflet boundary.
+    // User class with many instances, to push the rdf:type predicate's POST
+    // range across multiple leaflets and put the small-cardinality classes at
+    // a leaflet boundary.
     for i in 0..3000 {
         ttl.push_str(&format!("exd:big-{i} a ex:BigClass .\n"));
     }
@@ -261,651 +257,145 @@ async fn count_bound_object_mixed_leaflet_regression() {
     let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
         .build()
         .expect("build file-backed Fluree");
-    let ledger_id = "test/mixed-leaflet-regression:main";
+    let ledger_id = "test/first-key-skip:main";
     fluree
         .create(ledger_id)
         .import(data_dir.path())
         .threads(2)
         .memory_budget_mb(128)
-        .leaflet_rows(1024) // small leaflets so rdfs:Class lands inside a mixed-class leaflet
+        .leaflet_rows(1024)
         .cleanup(false)
         .execute()
         .await
         .expect("import");
     let ledger = fluree.ledger(ledger_id).await.unwrap();
 
-    // The fast-path COUNT operator: bound predicate (rdf:type), bound object.
-    let count_class = r"
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }
-    ";
-    let r = support::query_sparql(&fluree, &ledger, count_class)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    let n: i64 = r["results"]["bindings"][0]["n"]["value"]
-        .as_str()
-        .unwrap()
-        .parse()
-        .unwrap();
-    assert_eq!(n, 3, "expected COUNT rdfs:Class = 3, got {n}");
-
-    let count_prop = r"
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        SELECT (COUNT(?p) AS ?n) WHERE { ?p a rdf:Property }
-    ";
-    let r = support::query_sparql(&fluree, &ledger, count_prop)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    let n: i64 = r["results"]["bindings"][0]["n"]["value"]
-        .as_str()
-        .unwrap()
-        .parse()
-        .unwrap();
-    assert_eq!(n, 2, "expected COUNT rdf:Property = 2, got {n}");
-
-    let count_user = r"
-        PREFIX ex: <http://example.org/ns/>
-        SELECT (COUNT(?s) AS ?n) WHERE { ?s a ex:BigClass }
-    ";
-    let r = support::query_sparql(&fluree, &ledger, count_user)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    let n: i64 = r["results"]["bindings"][0]["n"]["value"]
-        .as_str()
-        .unwrap()
-        .parse()
-        .unwrap();
-    assert_eq!(n, 3000, "expected COUNT ex:BigClass = 3000, got {n}");
-}
-
-#[tokio::test]
-async fn sparql_g_a_user_class_works() {
-    // Query G (control): ?c a ht:Inquiry — user-defined class, user reports works.
-    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
-    let ledger = fluree.ledger(&ledger_id).await.expect("load");
-
-    let sparql = r"
-        PREFIX ht: <https://ns.hometap.com/v1#>
-        SELECT ?c WHERE { ?c a ht:Inquiry }
-    ";
-    let bindings = support::query_sparql(&fluree, &ledger, sparql)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[G] = {}", serde_json::to_string_pretty(&bindings).unwrap());
-    let arr = bindings["results"]["bindings"].as_array().unwrap();
-    assert_eq!(
-        arr.len(),
-        3,
-        "expected 3 instances via Query G, got {}",
-        arr.len()
-    );
-}
-
-#[tokio::test]
-#[ignore = "uses local user data at ~/Downloads/hometap"]
-async fn user_actual_dataset_diagnostic() {
-    use fluree_db_core::Sid;
-    let data_dir = std::path::PathBuf::from(format!(
-        "{}/Downloads/hometap",
-        std::env::var("HOME").unwrap()
-    ));
-    if !data_dir.exists() {
-        return;
+    for (label, sparql, want) in [
+        (
+            "rdfs:Class",
+            "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \
+             SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }",
+            3,
+        ),
+        (
+            "rdf:Property",
+            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
+             SELECT (COUNT(?p) AS ?n) WHERE { ?p a rdf:Property }",
+            2,
+        ),
+        (
+            "ex:BigClass",
+            "PREFIX ex: <http://example.org/ns/> \
+             SELECT (COUNT(?s) AS ?n) WHERE { ?s a ex:BigClass }",
+            3000,
+        ),
+    ] {
+        let r = support::query_sparql(&fluree, &ledger, sparql)
+            .await
+            .unwrap()
+            .to_sparql_json(&ledger.snapshot)
+            .unwrap();
+        let got: i64 = r["results"]["bindings"][0]["n"]["value"]
+            .as_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(got, want, "COUNT {label}: expected {want}, got {got}");
     }
+}
 
+/// Regression for the mixed-predicate leaflet branch of `count_bound_object_v6`
+/// and `group_count_v6`.
+///
+/// When a leaflet straddles a `p_id` boundary, its directory entry has
+/// `p_const = None`. The pre-fix code skipped any such leaflet via
+/// `entry.p_const != Some(p_id)`, which dropped target rows that lived in
+/// boundary leaflets. The fix lets mixed-predicate leaflets fall through to
+/// the row-level scan with a per-row `p_id` check. This test forces that
+/// shape by interleaving multiple predicates in the smallest possible
+/// dataset: a small number of `rdf:type` rows immediately followed by a
+/// small number of `rdfs:label` rows — small enough that they share a single
+/// leaflet, with `p_const = None`.
+#[tokio::test]
+async fn count_mixed_predicate_leaflet_regression() {
     let db_dir = TempDir::new().unwrap();
-    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
-        .build()
-        .unwrap();
-
-    let ledger_id = "test/hometap-diag:main";
-    fluree
-        .create(ledger_id)
-        .import(&data_dir)
-        .threads(2)
-        .memory_budget_mb(1024)
-        .cleanup(false)
-        .execute()
-        .await
-        .expect("import");
-
-    let ledger = fluree.ledger(ledger_id).await.expect("load");
-    let snap = &ledger.snapshot;
-
-    // 1) Show the snapshot's namespace_codes registration for the relevant prefixes.
-    eprintln!("\n=== namespace_codes ===");
-    for code in [3u16, 4u16] {
-        eprintln!("  code {} → {:?}", code, snap.namespaces().get(&code));
-    }
-    // Also dump any *-allocated codes whose prefix mentions rdf or rdf-schema
-    for (code, prefix) in snap.namespaces() {
-        if prefix.contains("rdf") {
-            eprintln!("  code {code} → {prefix:?}");
-        }
-    }
-
-    // 2) Encode the two object IRIs and print the Sid each yields.
-    let class_iri = "http://www.w3.org/2000/01/rdf-schema#Class";
-    let property_iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
-    let class_sid = snap.encode_iri(class_iri);
-    let property_sid = snap.encode_iri(property_iri);
-    eprintln!("\n=== encode_iri at query time ===");
-    eprintln!("  rdfs:Class    → {class_sid:?}");
-    eprintln!("  rdf:Property → {property_sid:?}");
-
-    // 3) Look at the stored class_counts (subject/o_key index) to see how the
-    //    importer encoded it on the way in. If we can directly look at one of
-    //    the actual stored type triples for ht:Inquiry, we can compare.
-    let s_inquiry = snap.encode_iri("https://ns.hometap.com/v1#Inquiry");
-    eprintln!("  ht:Inquiry    → {s_inquiry:?}");
-
-    // 4) Scan the OPST cursor for (rdf:type, rdfs:Class) and dump what we find.
-    use fluree_db_core::{
-        range_with_overlay, FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest,
-    };
-    let rdf_type_sid = snap
-        .encode_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-        .unwrap();
-    let class_sid_unwrapped = class_sid.clone().unwrap();
-    let property_sid_unwrapped = property_sid.clone().unwrap();
-    eprintln!("\n=== rdf:type SID ===");
-    eprintln!("  rdf:type → {rdf_type_sid:?}");
-
-    let novelty = ledger.novelty.as_ref();
-
-    let opts_cap = RangeOptions::default().with_flake_limit(20);
-
-    // OPST scan for the specific (rdf:type, rdfs:Class) shape via OPST
-    let class_range = range_with_overlay(
-        snap,
-        0u16,
-        novelty,
-        IndexType::Opst,
-        RangeTest::Eq,
-        RangeMatch {
-            p: Some(rdf_type_sid.clone()),
-            o: Some(FlakeValue::Ref(class_sid_unwrapped.clone())),
-            ..Default::default()
-        },
-        opts_cap.clone(),
-    )
-    .await
-    .expect("opst class");
-    eprintln!(
-        "\n=== OPST(rdf:type, rdfs:Class) range_with_overlay → {} flakes (cap 20) ===",
-        class_range.len()
+    let data_dir = TempDir::new().unwrap();
+    let mut ttl = String::from(
+        "@prefix ex:   <http://example.org/ns/> .\n\
+         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n",
     );
-    for f in class_range.iter().take(5) {
-        eprintln!("  flake: s={:?} p={:?} o={:?}", f.s, f.p, f.o);
+    // 5 rdf:type rows + 5 rdfs:label rows on the same subjects. PSOT sorts by
+    // (p_id, s_id, ...); rdf:type and rdfs:label use distinct p_ids that are
+    // adjacent in the predicate dictionary, so a single leaflet spanning both
+    // predicates is plausible. POST sorts by (p_id, o_type, o_key, s_id),
+    // putting rdf:type rows and rdfs:label rows in the same predicate region
+    // when one leaflet straddles the boundary.
+    for i in 1..=5 {
+        ttl.push_str(&format!(
+            "ex:item-{i} a rdfs:Class ; rdfs:label \"Item {i}\" .\n"
+        ));
     }
+    write_ttl(data_dir.path(), "00.ttl", &ttl);
 
-    // OPST scan for (rdf:type, rdf:Property) — the working case
-    let prop_range = range_with_overlay(
-        snap,
-        0u16,
-        novelty,
-        IndexType::Opst,
-        RangeTest::Eq,
-        RangeMatch {
-            p: Some(rdf_type_sid.clone()),
-            o: Some(FlakeValue::Ref(property_sid_unwrapped.clone())),
-            ..Default::default()
-        },
-        opts_cap.clone(),
-    )
-    .await
-    .expect("opst prop");
-    eprintln!(
-        "\n=== OPST(rdf:type, rdf:Property) range_with_overlay → {} flakes (cap 20) ===",
-        prop_range.len()
-    );
-    for f in prop_range.iter().take(5) {
-        eprintln!("  flake: s={:?} p={:?} o={:?}", f.s, f.p, f.o);
-    }
-
-    // 4b) Check find_subject_id_by_parts directly — this is what
-    //     value_to_otype_okey_simple uses for FlakeValue::Ref encoding.
-    let store_te = ledger.binary_store.as_ref();
-    if let Some(te) = store_te {
-        if let Ok(bs) =
-            te.0.clone()
-                .downcast::<fluree_db_binary_index::BinaryIndexStore>()
-        {
-            eprintln!("\n=== find_subject_id_by_parts ===");
-            let r1 = bs.find_subject_id_by_parts(
-                class_sid_unwrapped.namespace_code,
-                &class_sid_unwrapped.name,
-            );
-            eprintln!("  rdfs:Class (4, Class)      → {r1:?}");
-            let r2 = bs.find_subject_id_by_parts(
-                property_sid_unwrapped.namespace_code,
-                &property_sid_unwrapped.name,
-            );
-            eprintln!("  rdf:Property (3, Property) → {r2:?}");
-            let r3 = bs.find_subject_id_by_parts(13, "Inquiry");
-            eprintln!("  ht:Inquiry  (13, Inquiry)  → {r3:?}");
-
-            // CRITICAL: Compare snapshot.encode_iri vs store.encode_iri.
-            // The decode path uses store.encode_iri(decoded_iri) to produce
-            // FlakeValue::Ref. If that encoding doesn't match the bound_o
-            // (which uses snapshot.encode_iri), the row filter at
-            // binary_scan.rs:1168 will reject every row.
-            eprintln!("\n=== encode_iri comparison (snapshot vs store) ===");
-            for iri in [class_iri, property_iri, "https://ns.hometap.com/v1#Inquiry"] {
-                let snap_sid = snap.encode_iri(iri);
-                let store_sid = bs.encode_iri(iri);
-                eprintln!("  iri = {iri}");
-                eprintln!("    snapshot.encode_iri → {snap_sid:?}");
-                eprintln!("    store.encode_iri    → {store_sid:?}");
-                if snap_sid.as_ref() != Some(&store_sid) {
-                    eprintln!("    *** MISMATCH ***");
-                }
-            }
-            // Also: does the store's namespace_reverse table contain rdfs/rdf?
-            eprintln!("\n=== store namespace registrations ===");
-            for iri in [
-                "http://www.w3.org/2000/01/rdf-schema#",
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                "https://ns.hometap.com/v1#",
-            ] {
-                use fluree_db_core::ns_encoding::NsLookup;
-                eprintln!("  {iri:60} → {:?}", bs.code_for_prefix(iri));
-            }
-        }
-    } else {
-        eprintln!("  no binary_store available");
-    }
-
-    // 5) Scan POST for ALL `rdf:type` triples (no object) and group by object Sid
-    let all_types = range_with_overlay(
-        snap,
-        0u16,
-        novelty,
-        IndexType::Post,
-        RangeTest::Eq,
-        RangeMatch {
-            p: Some(rdf_type_sid.clone()),
-            ..Default::default()
-        },
-        RangeOptions::default().with_flake_limit(2_000_000),
-    )
-    .await
-    .expect("post all rdf:type");
-    eprintln!(
-        "\n=== POST(rdf:type, *) → {} total flakes ===",
-        all_types.len()
-    );
-    let mut counts: std::collections::HashMap<Sid, u64> = std::collections::HashMap::new();
-    for f in &all_types {
-        if let FlakeValue::Ref(o) = &f.o {
-            *counts.entry(o.clone()).or_insert(0) += 1;
-        }
-    }
-    let mut sorted: Vec<_> = counts.iter().collect();
-    sorted.sort_by_key(|(_sid, n)| std::cmp::Reverse(**n));
-    for (sid, n) in sorted.iter().take(20) {
-        eprintln!(
-            "   ({}) sid={:?} → decoded: {:?}",
-            n,
-            sid,
-            snap.decode_sid(sid)
-        );
-    }
-}
-
-#[tokio::test]
-#[ignore = "uses local user data at ~/Downloads/hometap"]
-async fn user_actual_dataset_a_count_only() {
-    // ONLY runs Query A (COUNT) so we can isolate the operator-tree decisions.
-    let data_dir = std::path::PathBuf::from(format!(
-        "{}/Downloads/hometap",
-        std::env::var("HOME").unwrap()
-    ));
-    if !data_dir.exists() {
-        return;
-    }
-    let db_dir = TempDir::new().unwrap();
-    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
-        .build()
-        .unwrap();
-    let ledger_id = "test/hometap-count-a:main";
-    fluree
-        .create(ledger_id)
-        .import(&data_dir)
-        .threads(2)
-        .memory_budget_mb(1024)
-        .cleanup(false)
-        .execute()
-        .await
-        .unwrap();
-
-    let ledger = fluree.ledger(ledger_id).await.unwrap();
-    eprintln!("\n========== Query A only (COUNT) ==========\n");
-    let q_a = r"
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }
-    ";
-    let bindings = support::query_sparql(&fluree, &ledger, q_a)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!(
-        "\n[A only] = {}",
-        serde_json::to_string_pretty(&bindings).unwrap()
-    );
-}
-
-#[tokio::test]
-#[ignore = "uses local user data at ~/Downloads/hometap"]
-async fn user_actual_dataset_a_select_only() {
-    // Same as Query A but as SELECT ?c (no COUNT) so we hit BinaryScanOperator
-    // directly rather than fast_count.
-    let data_dir = std::path::PathBuf::from(format!(
-        "{}/Downloads/hometap",
-        std::env::var("HOME").unwrap()
-    ));
-    if !data_dir.exists() {
-        return;
-    }
-    let db_dir = TempDir::new().unwrap();
-    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
-        .build()
-        .unwrap();
-    let ledger_id = "test/hometap-select:main";
-    fluree
-        .create(ledger_id)
-        .import(&data_dir)
-        .threads(2)
-        .memory_budget_mb(1024)
-        .cleanup(false)
-        .execute()
-        .await
-        .unwrap();
-
-    let ledger = fluree.ledger(ledger_id).await.unwrap();
-
-    let q_a = r"
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?c WHERE { ?c a rdfs:Class }
-    ";
-    let bindings = support::query_sparql(&fluree, &ledger, q_a)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    let arr_a = bindings["results"]["bindings"].as_array().unwrap();
-    eprintln!("\n=== A SELECT result count = {} ===", arr_a.len());
-
-    let q_f = r"
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        SELECT ?p WHERE { ?p a rdf:Property }
-    ";
-    let bindings_f = support::query_sparql(&fluree, &ledger, q_f)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    let arr_f = bindings_f["results"]["bindings"].as_array().unwrap();
-    eprintln!("\n=== F SELECT result count = {} ===", arr_f.len());
-
-    eprintln!("A={} F={}", arr_a.len(), arr_f.len());
-}
-
-#[tokio::test]
-#[ignore = "uses local user data at ~/Downloads/hometap"]
-async fn user_actual_dataset_a_with_reasoning_off() {
-    let data_dir = std::path::PathBuf::from(format!(
-        "{}/Downloads/hometap",
-        std::env::var("HOME").unwrap()
-    ));
-    if !data_dir.exists() {
-        return;
-    }
-    let db_dir = TempDir::new().unwrap();
-    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
-        .build()
-        .unwrap();
-    let ledger_id = "test/hometap-noreason:main";
-    fluree
-        .create(ledger_id)
-        .import(&data_dir)
-        .threads(2)
-        .memory_budget_mb(1024)
-        .cleanup(false)
-        .execute()
-        .await
-        .unwrap();
-
-    let ledger = fluree.ledger(ledger_id).await.unwrap();
-
-    // Same Query A, but with reasoning explicitly disabled.
-    let q = json!({
-        "@context": {"rdfs": "http://www.w3.org/2000/01/rdf-schema#"},
-        "where": {"@id": "?c", "@type": "rdfs:Class"},
-        "select": "?c",
-        "reasoning": "none"
-    });
-    let rows = support::query_jsonld(&fluree, &ledger, &q)
-        .await
-        .unwrap()
-        .to_jsonld(&ledger.snapshot)
-        .unwrap();
-    eprintln!(
-        "[A reasoning:none] = {}",
-        serde_json::to_string_pretty(&rows).unwrap()
-    );
-    let arr = rows.as_array().expect("array");
-    assert_eq!(
-        arr.len(),
-        16,
-        "expected 16 classes with reasoning off, got {}",
-        arr.len()
-    );
-}
-
-#[tokio::test]
-#[ignore = "uses local user data at ~/Downloads/hometap"]
-async fn user_actual_dataset_a_with_explain() {
-    let data_dir = std::path::PathBuf::from(format!(
-        "{}/Downloads/hometap",
-        std::env::var("HOME").unwrap()
-    ));
-    if !data_dir.exists() {
-        return;
-    }
-    let db_dir = TempDir::new().unwrap();
-    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
-        .build()
-        .unwrap();
-    let ledger_id = "test/hometap-explain:main";
-    fluree
-        .create(ledger_id)
-        .import(&data_dir)
-        .threads(2)
-        .memory_budget_mb(1024)
-        .cleanup(false)
-        .execute()
-        .await
-        .unwrap();
-
-    let ledger = fluree.ledger(ledger_id).await.unwrap();
-
-    // Query A: explain
-    let q_a = json!({
-        "@context": {"rdfs": "http://www.w3.org/2000/01/rdf-schema#"},
-        "where": {"@id": "?c", "@type": "rdfs:Class"},
-        "select": "?c"
-    });
-    let q_f = json!({
-        "@context": {"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"},
-        "where": {"@id": "?p", "@type": "rdf:Property"},
-        "select": "?p"
-    });
-
-    for (label, q) in [("A rdfs:Class", q_a), ("F rdf:Property", q_f)] {
-        eprintln!("\n=== EXPLAIN {label} ===");
-        let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
-        let res = fluree.explain(&db, &q).await;
-        eprintln!("explain result = {res:#?}");
-    }
-}
-
-#[tokio::test]
-#[ignore = "uses local user data at ~/Downloads/hometap"]
-async fn user_actual_dataset_full() {
-    let data_dir = std::path::PathBuf::from(format!(
-        "{}/Downloads/hometap",
-        std::env::var("HOME").unwrap()
-    ));
-    if !data_dir.exists() {
-        eprintln!("data dir missing, skipping");
-        return;
-    }
-
-    let db_dir = TempDir::new().unwrap();
     let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
         .build()
         .expect("build file-backed Fluree");
-
-    let ledger_id = "test/hometap-real:main";
-    let result = fluree
+    let ledger_id = "test/mixed-predicate-leaflet:main";
+    fluree
         .create(ledger_id)
-        .import(&data_dir)
+        .import(data_dir.path())
         .threads(2)
-        .memory_budget_mb(1024)
+        .memory_budget_mb(128)
+        // Tiny leaflet target so the 10 total rows land in one leaflet that
+        // spans rdf:type AND rdfs:label predicates.
+        .leaflet_rows(64)
         .cleanup(false)
         .execute()
         .await
         .expect("import");
-    eprintln!("imported t={}, flakes={}", result.t, result.flake_count);
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
 
-    let ledger = fluree.ledger(ledger_id).await.expect("load");
-
-    // Query A: SELECT ?c WHERE { ?c a rdfs:Class }
-    let q_a = r"
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }
-    ";
-    let a = support::query_sparql(&fluree, &ledger, q_a)
-        .await
+    // COUNT for rdfs:Class — bound predicate is `rdf:type`, bound object is
+    // `rdfs:Class`. Exercises `count_bound_object_v6` against a leaflet that
+    // may straddle p_id=rdf:type and p_id=rdfs:label.
+    let r = support::query_sparql(
+        &fluree,
+        &ledger,
+        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \
+         SELECT (COUNT(?c) AS ?n) WHERE { ?c a rdfs:Class }",
+    )
+    .await
+    .unwrap()
+    .to_sparql_json(&ledger.snapshot)
+    .unwrap();
+    let got: i64 = r["results"]["bindings"][0]["n"]["value"]
+        .as_str()
         .unwrap()
-        .to_sparql_json(&ledger.snapshot)
+        .parse()
         .unwrap();
-    eprintln!("[A real] = {}", serde_json::to_string_pretty(&a).unwrap());
-
-    // Query B: full IRIs
-    let q_b = r"
-        SELECT (COUNT(?c) AS ?n) WHERE {
-            ?c <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
-               <http://www.w3.org/2000/01/rdf-schema#Class> .
-        }
-    ";
-    let b = support::query_sparql(&fluree, &ledger, q_b)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[B real] = {}", serde_json::to_string_pretty(&b).unwrap());
-
-    // Query C: FILTER form (works for user)
-    let q_c = r"
-        PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT (COUNT(?c) AS ?n) WHERE { ?c rdf:type ?t . FILTER(?t = rdfs:Class) }
-    ";
-    let c = support::query_sparql(&fluree, &ledger, q_c)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[C real] = {}", serde_json::to_string_pretty(&c).unwrap());
-
-    // Query F (control): ?p a rdf:Property — works for user
-    let q_f = r"
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        SELECT (COUNT(?p) AS ?n) WHERE { ?p a rdf:Property }
-    ";
-    let f = support::query_sparql(&fluree, &ledger, q_f)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[F real] = {}", serde_json::to_string_pretty(&f).unwrap());
-
-    // Query D: GROUP BY type to confirm object IRI seen by query engine
-    let q_d = r"
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        SELECT ?t (COUNT(?s) AS ?n) WHERE { ?s rdf:type ?t } GROUP BY ?t
-    ";
-    let d = support::query_sparql(&fluree, &ledger, q_d)
-        .await
-        .unwrap()
-        .to_sparql_json(&ledger.snapshot)
-        .unwrap();
-    eprintln!("[D real] = {}", serde_json::to_string_pretty(&d).unwrap());
-
-    let count_of = |v: &serde_json::Value| -> i64 {
-        v["results"]["bindings"][0]["n"]["value"]
-            .as_str()
-            .unwrap_or("0")
-            .parse()
-            .unwrap_or(0)
-    };
-    let a_n = count_of(&a);
-    let b_n = count_of(&b);
-    let c_n = count_of(&c);
-    let f_n = count_of(&f);
-    eprintln!("counts: A={a_n} B={b_n} C={c_n} F={f_n}");
-
-    // We expect A, B, and C to all match — they're semantically identical.
     assert_eq!(
-        a_n, c_n,
-        "Query A ({a_n}) should match FILTER rewrite C ({c_n})"
+        got, 5,
+        "COUNT rdfs:Class across mixed leaflet: expected 5, got {got}"
     );
-    assert_eq!(
-        b_n, c_n,
-        "Query B ({b_n}) should match FILTER rewrite C ({c_n})"
-    );
-}
 
-#[tokio::test]
-async fn jsonld_form_user_query() {
-    // The exact JSON-LD form the user reported broken in the original message.
-    let (_db_dir, _data_dir, fluree, ledger_id) = bulk_import_ontology().await;
-    let ledger = fluree.ledger(&ledger_id).await.expect("load");
-
-    let q = json!({
-        "@context": {
-            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
-        },
-        "where": {"@id": "?s", "@type": "rdfs:Class"},
-        "select": {"?s": ["*"]}
-    });
-    let result = support::query_jsonld(&fluree, &ledger, &q)
-        .await
-        .expect("jsonld query")
-        .to_jsonld_async(ledger.as_graph_db_ref(0))
-        .await
-        .unwrap();
-    eprintln!(
-        "[jsonld] = {}",
-        serde_json::to_string_pretty(&result).unwrap()
-    );
-    let normalized = support::normalize_rows(&result);
+    // SELECT form for the same shape (sanity check via the BinaryScanOperator
+    // path, which doesn't depend on the V6 fast path).
+    let bindings = support::query_sparql(
+        &fluree,
+        &ledger,
+        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \
+         SELECT ?c WHERE { ?c a rdfs:Class }",
+    )
+    .await
+    .unwrap()
+    .to_sparql_json(&ledger.snapshot)
+    .unwrap();
+    let arr = bindings["results"]["bindings"].as_array().unwrap();
     assert_eq!(
-        normalized.len(),
+        arr.len(),
         5,
-        "expected 5 rdfs:Class subjects (jsonld), got {}: {:?}",
-        normalized.len(),
-        normalized
+        "SELECT rdfs:Class across mixed leaflet: expected 5, got {}",
+        arr.len()
     );
 }

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -495,10 +495,23 @@ impl Operator for PredicateObjectCountFirstsOperator {
 
 /// Extract the object prefix `(o_type, o_key)` from a V3 leaflet directory entry's
 /// `first_key` field, interpreted in POST order.
+///
+/// Strips `p_id`. Only meaningful as a bound for rows known to be within the
+/// same predicate range — see [`predicate_qualified_prefix`] for cross-predicate
+/// comparisons.
 #[inline]
 fn prefix_v6_from_entry(entry: &LeafletDirEntryV3) -> (u16, u64) {
     let rec = read_ordered_key_v2(RunSortOrder::Post, &entry.first_key);
     (rec.o_type, rec.o_key)
+}
+
+/// Read the `(p_id, o_type, o_key)` tuple from a V3 leaflet directory entry's
+/// `first_key`, interpreted in POST order. Includes `p_id` so callers can
+/// detect predicate boundaries.
+#[inline]
+fn pid_prefix_v6_from_entry(entry: &LeafletDirEntryV3) -> (u32, u16, u64) {
+    let rec = read_ordered_key_v2(RunSortOrder::Post, &entry.first_key);
+    (rec.p_id, rec.o_type, rec.o_key)
 }
 
 /// Load a V3 leaflet's columns, using the `LeafletCache` when available.
@@ -527,6 +540,12 @@ fn load_v6_batch(
         needed.insert(ColumnId::OKey);
         if entry.o_type_const.is_none() {
             needed.insert(ColumnId::OType);
+        }
+        // Mixed-predicate leaflets need the per-row `p_id` column to verify
+        // each row belongs to the queried predicate; the cached path always
+        // loads all columns, so this is only a concern for the no-cache path.
+        if entry.p_const.is_none() {
+            needed.insert(ColumnId::PId);
         }
         let projection = ColumnProjection {
             output: ColumnSet::EMPTY,
@@ -617,26 +636,49 @@ fn count_bound_object_v6(
             }
 
             let prefix = prefix_v6_from_entry(entry);
-            // The next leaflet's first prefix bounds this leaflet's range from
-            // above: rows live in `[prefix, next_prefix)`. Without that bound,
-            // a leaflet that *starts* below the target may still *contain* it.
-            let next_prefix = if i + 1 < dir.entries.len() {
-                Some(prefix_v6_from_entry(&dir.entries[i + 1]))
+            // The leaflet's rows span `[prefix, next_prefix)` half-open: the
+            // next leaflet's first key is the first row *not* in this leaflet.
+            // (A single key value can spill across leaflet boundaries — both
+            // leaflets then have rows for that value, and the gating below
+            // handles it correctly.)
+            //
+            // POST sorts by `(p_id, o_type, o_key, ...)`. The `(o_type, o_key)`
+            // pair is only a meaningful range bound *within* a single predicate;
+            // when the next leaflet starts a different predicate, its
+            // `(o_type, o_key)` tuple is unrelated to our range and cannot be
+            // used to skip this leaflet. Detect that case and treat next_prefix
+            // as `None` (unknown upper bound) — fall through to row-level scan.
+            let next_full = if i + 1 < dir.entries.len() {
+                Some(pid_prefix_v6_from_entry(&dir.entries[i + 1]))
             } else if leaf_idx + 1 < leaf_range.end {
-                let next_entry = &branch.leaves[leaf_idx + 1].first_key;
-                Some((next_entry.o_type, next_entry.o_key))
+                let next = &branch.leaves[leaf_idx + 1].first_key;
+                Some((next.p_id, next.o_type, next.o_key))
             } else {
                 None
             };
+            let next_prefix = next_full.and_then(|(np_p, np_ot, np_ok)| {
+                if np_p == p_id {
+                    Some((np_ot, np_ok))
+                } else {
+                    None
+                }
+            });
 
-            if prefix > target_prefix {
+            // `prefix` is computed from the leaflet's first row stripped of
+            // `p_id`. For a homogeneous-predicate leaflet (`p_const = Some(p_id)`)
+            // it's a sound sort key for early break, but in a mixed-predicate
+            // leaflet the first row may belong to a *different* predicate — its
+            // `(o_type, o_key)` could exceed `target_prefix` even when later
+            // rows in the leaflet (or in subsequent leaflets) belong to our
+            // predicate and are still on or before `target_prefix`. Restrict
+            // the break to homogeneous leaflets.
+            if prefix > target_prefix && entry.p_const == Some(p_id) {
                 break;
             }
-            // The leaflet's rows span `[prefix, next_prefix]` inclusive on both
-            // ends — `next_prefix` is the FIRST key of the *next* leaflet, but
-            // this leaflet's last row may equal target_prefix even when the
-            // next leaflet also starts at target_prefix. We can only skip when
-            // `next_prefix < target_prefix` (leaflet ends strictly before).
+            // Skip a leaflet only when it ends strictly before the target —
+            // i.e. the next leaflet's first row (within our predicate) also
+            // sorts before the target. Equality is not enough: this leaflet's
+            // last row can equal target if a key spills across the boundary.
             if let Some(np) = next_prefix {
                 if np < target_prefix {
                     continue;
@@ -735,24 +777,44 @@ fn group_count_v6(
         let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
 
         for (i, entry) in dir.entries.iter().enumerate() {
-            if entry.row_count == 0 || entry.p_const != Some(p_id) {
+            if entry.row_count == 0 {
                 continue;
+            }
+            // Mixed-predicate leaflets (`p_const = None`) may still hold rows
+            // for our predicate; only skip when the leaflet is constant on a
+            // *different* predicate.
+            if let Some(leaflet_p) = entry.p_const {
+                if leaflet_p != p_id {
+                    continue;
+                }
             }
 
             let prefix = prefix_v6_from_entry(entry);
 
-            // Boundary-equality: check if this leaflet is entirely one object value.
-            let next_prefix = if i + 1 < dir.entries.len() {
-                Some(prefix_v6_from_entry(&dir.entries[i + 1]))
+            // Boundary-equality: check the next leaflet's first object key,
+            // but only when it's within the same predicate range — see
+            // `count_bound_object_v6` for the rationale.
+            let next_full = if i + 1 < dir.entries.len() {
+                Some(pid_prefix_v6_from_entry(&dir.entries[i + 1]))
             } else if leaf_idx + 1 < leaf_range.end {
-                let next_entry = &branch.leaves[leaf_idx + 1].first_key;
-                Some((next_entry.o_type, next_entry.o_key))
+                let next = &branch.leaves[leaf_idx + 1].first_key;
+                Some((next.p_id, next.o_type, next.o_key))
             } else {
                 None
             };
+            let next_prefix = next_full.and_then(|(np_p, np_ot, np_ok)| {
+                if np_p == p_id {
+                    Some((np_ot, np_ok))
+                } else {
+                    None
+                }
+            });
 
-            if next_prefix == Some(prefix) {
-                // Entire leaflet is one object value.
+            // Boundary-equality fast count is only sound for homogeneous-
+            // predicate leaflets — a mixed-predicate leaflet may have the
+            // same `(o_type, o_key)` first row as the next leaflet but still
+            // contain rows for *other* predicates that must be excluded.
+            if next_prefix == Some(prefix) && entry.p_const == Some(p_id) {
                 *counts.entry(prefix).or_insert(0) += entry.row_count as i64;
                 continue;
             }
@@ -770,6 +832,16 @@ fn group_count_v6(
             )?;
 
             for row in 0..batch.row_count {
+                // Per-row `p_id` check needed for mixed-predicate leaflets;
+                // the cached path always loads `p_id`, the no-cache path is
+                // configured to load it via `load_v6_batch` when `p_const` is
+                // `None`.
+                if entry.p_const.is_none() {
+                    let row_p_id = batch.p_id.get_or(row, 0);
+                    if row_p_id != p_id {
+                        continue;
+                    }
+                }
                 let ot = entry
                     .o_type_const
                     .unwrap_or_else(|| batch.o_type.get_or(row, 0));

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -686,9 +686,16 @@ fn count_bound_object_v6(
             }
 
             // Boundary-equality fast count: only valid when the leaflet is
-            // entirely target rows (it starts at the target value AND the next
-            // leaflet also starts at the target value).
-            if prefix == target_prefix && next_prefix == Some(target_prefix) {
+            // entirely target rows for our predicate (it starts at the target
+            // value, the next leaflet also starts at the target value, AND the
+            // leaflet is homogeneous on `p_id`). A mixed-predicate leaflet can
+            // satisfy the first two conditions while still containing rows for
+            // *other* predicates that must be excluded — fall through to the
+            // per-row scan in that case.
+            if prefix == target_prefix
+                && next_prefix == Some(target_prefix)
+                && entry.p_const == Some(p_id)
+            {
                 total += entry.row_count as i64;
                 continue;
             }

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -605,19 +605,21 @@ fn count_bound_object_v6(
         let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
 
         for (i, entry) in dir.entries.iter().enumerate() {
-            if entry.row_count == 0 || entry.p_const != Some(p_id) {
+            if entry.row_count == 0 {
                 continue;
+            }
+            // For mixed-predicate leaflets (`p_const = None`) we cannot skip on
+            // p_const alone — the leaflet may still contain rows for our p_id.
+            if let Some(leaflet_p) = entry.p_const {
+                if leaflet_p != p_id {
+                    continue;
+                }
             }
 
             let prefix = prefix_v6_from_entry(entry);
-            if prefix < target_prefix {
-                continue;
-            }
-            if prefix > target_prefix {
-                break;
-            }
-
-            // Boundary-equality: check the next leaflet's first prefix.
+            // The next leaflet's first prefix bounds this leaflet's range from
+            // above: rows live in `[prefix, next_prefix)`. Without that bound,
+            // a leaflet that *starts* below the target may still *contain* it.
             let next_prefix = if i + 1 < dir.entries.len() {
                 Some(prefix_v6_from_entry(&dir.entries[i + 1]))
             } else if leaf_idx + 1 < leaf_range.end {
@@ -627,12 +629,28 @@ fn count_bound_object_v6(
                 None
             };
 
-            if next_prefix == Some(target_prefix) {
+            if prefix > target_prefix {
+                break;
+            }
+            // The leaflet's rows span `[prefix, next_prefix]` inclusive on both
+            // ends — `next_prefix` is the FIRST key of the *next* leaflet, but
+            // this leaflet's last row may equal target_prefix even when the
+            // next leaflet also starts at target_prefix. We can only skip when
+            // `next_prefix < target_prefix` (leaflet ends strictly before).
+            if let Some(np) = next_prefix {
+                if np < target_prefix {
+                    continue;
+                }
+            }
+
+            // Boundary-equality fast count: only valid when the leaflet is
+            // entirely target rows (it starts at the target value AND the next
+            // leaflet also starts at the target value).
+            if prefix == target_prefix && next_prefix == Some(target_prefix) {
                 total += entry.row_count as i64;
                 continue;
             }
 
-            // Decode columns (cached when available).
             let batch = load_v6_batch(
                 &bytes,
                 entry,
@@ -645,6 +663,14 @@ fn count_bound_object_v6(
             )?;
 
             for row in 0..batch.row_count {
+                // For mixed-predicate leaflets we must verify p_id per row —
+                // a `p_const = Some(p_id)` leaflet lets us skip the column read.
+                if entry.p_const.is_none() {
+                    let row_p_id = batch.p_id.get_or(row, 0);
+                    if row_p_id != p_id {
+                        continue;
+                    }
+                }
                 let ot = entry
                     .o_type_const
                     .unwrap_or_else(|| batch.o_type.get_or(row, 0));


### PR DESCRIPTION
## Summary

Fixes #1208 — `COUNT { ?c rdf:type rdfs:Class }` returns 0 on indexed datasets, while the parallel `COUNT { ?p rdf:type rdf:Property }` and any user-class variant return the correct count. The data is on disk and reachable via FILTER / GROUP BY / non-COUNT shapes; only the COUNT-with-bound-object fast path drops the rows.

The bugs live in `count_bound_object_v6` and `group_count_v6` (`fluree-db-query/src/fast_group_count_firsts.rs`) — the fast paths that answer `SELECT (COUNT(?s) AS ?n) WHERE { ?s <p> <o> }` and `SELECT ?o (COUNT(?s) AS ?n) WHERE { ?s <p> ?o } GROUP BY ?o` from POST-leaflet directory metadata.

## Root cause

POST leaflets store one directory entry per leaflet whose `first_key` is the leaflet's first row. The fast path walks those entries and decides per-leaflet whether to skip, fast-count, or row-scan. POST sorts by `(p_id, o_type, o_key, …)`. Several compounding errors:

### 1. Skip-by-first-prefix

Old logic:

```rust
if prefix < target_prefix { continue; }
if prefix > target_prefix { break; }
// fall through: prefix == target → fast-count by row_count
```

A leaflet's rows span `[first_prefix, next_leaflet_first_prefix)`. A target value can sit *inside* a leaflet whose first row is some smaller value. In the reproducer the very first POST leaflet contains `rdf:Property` (the first row), then a few `rdfs:Class` rows, then a run of user-class rows; the loop saw `first_prefix < target` and `continue`d, then saw the next leaflet's `first_prefix > target` and broke — never decoding the leaflet that actually held `rdfs:Class`.

### 2. Mixed-predicate skip

Old logic:

```rust
if entry.p_const != Some(p_id) { continue; }
```

`p_const` is `None` for any leaflet whose rows don't all share a predicate — i.e. boundary leaflets that straddle a `p_id` change. Those can still contain rows for our predicate, but the check skipped them outright.

### 3. `prefix_v6_from_entry` strips `p_id`

POST's primary sort key is `p_id`. The fast path's `prefix_v6_from_entry` returns just `(o_type, o_key)`, which is a meaningful range bound *within* a predicate but unrelated to our range when the next leaflet starts a *different* predicate. With the predicate boundary fix above (point 2), this becomes a real footgun: the next leaflet's `(o_type, o_key)` for some other predicate could happen to be lexicographically less than the target's, falsely tripping the "leaflet ends before target → skip" condition. In the mixed-predicate regression test this fired exactly: a homogeneous `rdf:type` leaflet with `prefix == target` was skipped because the next leaflet started on `rdfs:label` with a smaller `(o_type, o_key)`.

### 4. Early break unsafe for mixed leaflets

`prefix > target_prefix → break` is sound only for homogeneous-predicate leaflets. In a mixed-predicate leaflet the first row may belong to a different predicate whose `(o_type, o_key)` exceeds the target while later rows in the leaflet (or in subsequent leaflets) still belong to our predicate.

### 5. Non-cached column projection misses `p_id`

`load_v6_batch`'s no-cache branch built a projection with only `OKey` (and optionally `OType`). The per-row `p_id` check inside mixed-predicate leaflets needs the `PId` column; without it `batch.p_id.get_or(row, 0)` returns `0` and every row gets silently rejected. The cached path always loads all columns so production was unaffected, but the no-cache path is reachable from test setups and is a footgun for any future caller.

### 6. Boundary-equality fast count needs homogeneous gate

The `next_prefix == Some(prefix) → += entry.row_count` shortcut is only valid when the leaflet is entirely target rows. In a mixed-predicate leaflet that condition can hold while the leaflet still contains rows for *other* predicates that must be excluded.

### Why the asymmetry (rdfs:Class fails, rdf:Property works)

In POST sort order, `rdf:type` rows are grouped by object IRI (`o_key`). In the reproducer, `rdf:Property` happens to be the **first** row of the leaflet (`first_prefix == target`), so the existing `prefix == target` branch catches it. `rdfs:Class` lives between `rdf:Property` and the first user class within the same leaflet — `first_prefix < target` — and gets dropped by error `#1` above. Any class that lands as the very first row of a POST leaflet works; any class that lands mid-leaflet silently returns 0.

### Why only on indexed/bulk-imported data

`count_bound_object_v6` and `group_count_v6` only fire when there's a binary index. Memory-only / pure-novelty queries never reach them.

## Fix

In `count_bound_object_v6` (and the same set of fixes mirrored into `group_count_v6`):

- **Mixed-predicate leaflets are no longer skipped on `p_const`.** Replace `entry.p_const != Some(p_id) { continue }` with: only skip when `p_const = Some(other_pid)`; verify `p_id` per-row inside mixed leaflets.
- **Skip a leaflet only when it ends strictly before the target.** Compute `next_prefix` and skip the leaflet only when `next_prefix < target_prefix`. Otherwise the target could be inside the leaflet — fall through to either the boundary-equality fast count or the row-level scan.
- **Predicate-qualified `next_prefix`.** Added `pid_prefix_v6_from_entry` returning `(p_id, o_type, o_key)`. When the next leaflet starts a different predicate, treat next_prefix as `None` (unknown upper bound) rather than comparing against an unrelated `(o_type, o_key)` from a different predicate's rows.
- **Gated early break.** `if prefix > target_prefix { break; }` is now `if prefix > target_prefix && entry.p_const == Some(p_id) { break; }`.
- **`load_v6_batch` non-cached projection includes `ColumnId::PId`** when `entry.p_const.is_none()`, so the per-row `p_id` check works regardless of cache state.
- **Boundary-equality fast count is gated on `prefix == target_prefix && next_prefix == Some(target_prefix) && entry.p_const == Some(p_id)`** — the entire leaflet is target rows for our predicate.

## Test plan

- [x] Add `count_bound_object_first_key_skip_regression` (`fluree-db-api/tests/it_query_rdfs_class_repro.rs`) — bulk-imports a small TTL where multiple distinct classes share a single homogeneous-`rdf:type` leaflet, then asserts `COUNT` for `rdf:Property`, `rdfs:Class`, and a 3000-instance user class. Exercises bug `#1`.
- [x] Add `count_mixed_predicate_leaflet_regression` — bulk-imports a tiny TTL designed to land in a single leaflet that straddles `rdf:type` and `rdfs:label`, then asserts `COUNT { ?c a rdfs:Class }` and the parallel `SELECT`.
- [x] All 12 existing tests in `fluree-db-api/tests/it_fast_group_count.rs` pass unchanged.
- [x] All 997 `fluree-db-query` library unit tests pass.
- [x] Verified end-to-end on the originally-reported dataset: COUNT for `rdfs:Class`, COUNT for `rdf:Property`, and the FILTER rewrite all agree, and the full-IRI form matches the prefixed form.

## Follow-ups (out of scope for this PR)

There are ~16 other call sites in the codebase using the same `entry.p_const != Some(p_id)` skip pattern (`fast_count.rs`, `fast_path_common.rs`, `fast_exists_join_count_distinct_object.rs`, `fast_sum_strlen_group_concat.rs`, `count_plan_exec.rs`, `join.rs`). They don't all share the prefix-skip variant of the bug, but the mixed-predicate-leaflet under-counting concern likely affects some of them. Worth a focused audit pass — tracking separately.