### PR TITLE
Fix: Reindex Rebuild Performance Regression

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1269,6 +1269,39 @@ mem:fact-01kj8k5nzpe59p5vp7zrehbrr9 a mem:Fact ;
     mem:branch "feature/memory" ;
     mem:createdAt "2026-02-24T19:49:14.358637+00:00"^^xsd:dateTime .
 
+mem:fact-01kqfy6r0w86fcsd9km0707xzg a mem:Fact ;
+    mem:content "v3 commit envelope reader at `legacy_v3.rs:305-309` deliberately stubs `graph_delta = HashMap::new()` since v3 never encoded the field. Envelope-only walkers (`first_t_where_graph_registered`) therefore return `None` on any chain that includes v3 commits, regardless of whether the named graph was actually registered. Callers that rely on the result for short-circuiting must either fall through to a full load on `None`, detect v3 envelopes and signal \"inconclusive\", or accept silent correctness regressions on legacy chains." ;
+    mem:tag "commit-envelope" ;
+    mem:tag "gotcha" ;
+    mem:tag "graph-delta" ;
+    mem:tag "legacy-v3" ;
+    mem:tag "short-circuit" ;
+    mem:tag "v3-compat" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/indexer_fulltext_provider.rs" ;
+    mem:artifactRef "fluree-db-core/src/commit.rs" ;
+    mem:artifactRef "fluree-db-core/src/commit/codec/legacy_v3.rs" ;
+    mem:branch "fix/reindex-pre-build-perf-regression" ;
+    mem:createdAt "2026-04-30T19:35:13.692947+00:00"^^xsd:dateTime ;
+    mem:rationale "Surfaced during PR #1211 review — code returned Vec::new() on None even though the PR description said it falls through to full load. Documenting so future envelope-only short-circuit work doesn't repeat the silent-fail shape." .
+
+mem:fact-01kqfy6txdrjppaf6756xzdz25 a mem:Fact ;
+    mem:content "`Novelty::bulk_apply_commits` is the O(N log N) bulk replacement for per-commit `apply_commit` on first-load / catch-up paths. Identity sort key is `(s, p, o, dt, m, t, op)`; dedup walk drops an assertion iff the prior kept flake for the same `(s, p, o, dt, m)` was also an assertion (mirrors `fact_currently_asserted_in_graph`). Used by `LedgerState::load_novelty` after reversing HEAD→oldest batches and populating dict_novelty in commit order. Delta vs apply_commit: deduped flakes remain in the FlakeStore arena and self.size over-reports — bounded for fresh-load callers but not appropriate for hot-path mutation." ;
+    mem:tag "bulk-apply" ;
+    mem:tag "dedup" ;
+    mem:tag "indexing" ;
+    mem:tag "lambda" ;
+    mem:tag "load-novelty" ;
+    mem:tag "novelty" ;
+    mem:tag "performance" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-core/src/comparator.rs" ;
+    mem:artifactRef "fluree-db-ledger/src/lib.rs" ;
+    mem:artifactRef "fluree-db-novelty/src/lib.rs" ;
+    mem:branch "fix/reindex-pre-build-perf-regression" ;
+    mem:createdAt "2026-04-30T19:35:16.653062+00:00"^^xsd:dateTime ;
+    mem:rationale "Captures the design contract and arena-bloat semantics from PR #1211 so future callers of bulk_apply_commits don't accidentally wire it into a hot-path mutation site." .
+
 mem:constraint-01kjte29y3cp8mae56xy6yfv2n a mem:Constraint ;
     mem:content "SPARQL↔JSON-LD Parity: both compile to the same IR (fluree-db-query/src/ir.rs) and share the entire execution engine. When adding SPARQL features: (1) shared IR changes already affect JSON-LD — verify JSON-LD tests pass, (2) if expressible in JSON-LD, add parallel tests, (3) execution path missing in JSON-LD lower → track follow-up.\n\nSPARQL tests: it_query_sparql.rs | JSON-LD tests: it_query.rs, it_query_analytical.rs, it_query_grouping.rs\nValidate: `cd testsuite-sparql && make test-eval-cat CAT=<cat>` then `cargo test -p fluree-db-api --test it_query`" ;
     mem:tag "compliance" ;

--- a/fluree-db-api/src/indexer_fulltext_provider.rs
+++ b/fluree-db-api/src/indexer_fulltext_provider.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use fluree_db_core::{config_graph_iri, first_t_where_graph_registered};
 use fluree_db_indexer::{ConfiguredFulltextProperty, FulltextConfigProvider};
 use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::NameService;
@@ -42,6 +43,68 @@ impl std::fmt::Debug for ApiFulltextConfigProvider {
 
 impl ApiFulltextConfigProvider {
     async fn resolve(&self, ledger_id: &str) -> Result<Vec<ConfiguredFulltextProperty>, String> {
+        // 0. Envelope-only short-circuit.
+        //
+        // The config graph (`config_graph_iri(ledger_id)`) must be
+        // registered in some commit's `graph_delta` before any flake can
+        // belong to it. Probe the chain envelope-only (byte-range
+        // ~128 KiB per commit on range-capable backends) — if the IRI
+        // never appears, no `f:LedgerConfig` can exist and we can return
+        // immediately without paying for `LedgerState::load`'s full
+        // chain walk + novelty build.
+        //
+        // This is the common case on a fresh reindex of a ledger that
+        // never set up fulltext config, which is what was driving Lambda
+        // first-reindex past the 900s ceiling — `LedgerState::load`
+        // walked all 787 commits via `load_commit_by_id`
+        // (`read_commit_v4` per commit) just to discover an empty config
+        // graph.
+        //
+        // If the IRI was registered (or we can't determine, e.g. v3
+        // chain that doesn't carry envelope graph_delta), fall through
+        // to the full load path. That path is itself fast now after the
+        // novelty `bulk_apply_commits` switch in `load_novelty`.
+        let record = self
+            .nameservice
+            .lookup(ledger_id)
+            .await
+            .map_err(|e| format!("nameservice lookup: {e}"))?;
+        if let Some(record) = &record {
+            if let Some(head_id) = record.commit_head_id.as_ref() {
+                let cs = if record.source_branch.is_some() {
+                    let branched = fluree_db_nameservice::build_branched_store(
+                        &self.backend,
+                        self.nameservice.as_ref(),
+                        record,
+                    )
+                    .await
+                    .map_err(|e| format!("build_branched_store: {e}"))?;
+                    Arc::new(branched) as Arc<dyn fluree_db_core::ContentStore>
+                } else {
+                    self.backend.content_store(&record.ledger_id)
+                };
+                let cfg_iri = config_graph_iri(ledger_id);
+                let registered = first_t_where_graph_registered(cs.as_ref(), head_id, &cfg_iri)
+                    .await
+                    .map_err(|e| format!("envelope walk for config graph: {e}"))?;
+                if registered.is_none() {
+                    tracing::debug!(
+                        ledger_id,
+                        cfg_iri = %cfg_iri,
+                        "fulltext config provider: config graph never registered; \
+                         skipping LedgerState::load + resolve_ledger_config"
+                    );
+                    return Ok(Vec::new());
+                }
+                tracing::debug!(
+                    ledger_id,
+                    first_t = ?registered,
+                    "fulltext config provider: config graph registered; \
+                     proceeding with full state load + resolve"
+                );
+            }
+        }
+
         // 1. Load ledger state (snapshot + novelty).
         let mut state = LedgerState::load(self.nameservice.as_ref(), ledger_id, &self.backend)
             .await

--- a/fluree-db-api/src/indexer_fulltext_provider.rs
+++ b/fluree-db-api/src/indexer_fulltext_provider.rs
@@ -105,6 +105,18 @@ impl ApiFulltextConfigProvider {
                         return Ok(Vec::new());
                     }
                     GraphRegistrationProbe::Found(t) => {
+                        // FUTURE OPTIMIZATION (per PR #1211 review by @bplatz):
+                        // `t` here is the earliest commit at which the config
+                        // graph was registered — every flake we care about lives
+                        // at `t' >= t`. The `LedgerState::load` call below still
+                        // walks the whole chain (`stop_at_t = 0`) because that's
+                        // the only entry point it currently exposes. Threading
+                        // `t` through as a `stop_at_t` hint, OR moving config
+                        // resolution behind a `g_id`-filtered novelty load,
+                        // would eliminate the redundant pass on registered-
+                        // config ledgers. Tracked as a follow-up; the
+                        // `Found(t)` value here is already plumbed through the
+                        // public API to support that work.
                         tracing::debug!(
                             ledger_id,
                             cfg_iri = %cfg_iri,

--- a/fluree-db-api/src/indexer_fulltext_provider.rs
+++ b/fluree-db-api/src/indexer_fulltext_provider.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use fluree_db_core::{config_graph_iri, first_t_where_graph_registered};
+use fluree_db_core::{config_graph_iri, first_t_where_graph_registered, GraphRegistrationProbe};
 use fluree_db_indexer::{ConfiguredFulltextProperty, FulltextConfigProvider};
 use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::NameService;
@@ -60,10 +60,17 @@ impl ApiFulltextConfigProvider {
         // (`read_commit_v4` per commit) just to discover an empty config
         // graph.
         //
-        // If the IRI was registered (or we can't determine, e.g. v3
-        // chain that doesn't carry envelope graph_delta), fall through
-        // to the full load path. That path is itself fast now after the
-        // novelty `bulk_apply_commits` switch in `load_novelty`.
+        // Only `NotFound` short-circuits. `Found(_)` and `Inconclusive`
+        // fall through to the full-load path:
+        //
+        // - `Found(_)`: the chain definitely registered the config graph,
+        //   so we need to read the actual flakes to extract config.
+        // - `Inconclusive`: at least one v3 envelope on the chain (which
+        //   never encoded `graph_delta`), so we can't tell from envelopes
+        //   alone whether the IRI is registered. Fall through to a full
+        //   `LedgerState::load` so legacy chains don't silently lose
+        //   their fulltext config — the full load is itself fast now
+        //   thanks to `bulk_apply_commits` in `load_novelty`.
         let record = self
             .nameservice
             .lookup(ledger_id)
@@ -84,24 +91,37 @@ impl ApiFulltextConfigProvider {
                     self.backend.content_store(&record.ledger_id)
                 };
                 let cfg_iri = config_graph_iri(ledger_id);
-                let registered = first_t_where_graph_registered(cs.as_ref(), head_id, &cfg_iri)
+                let probe = first_t_where_graph_registered(cs.as_ref(), head_id, &cfg_iri)
                     .await
                     .map_err(|e| format!("envelope walk for config graph: {e}"))?;
-                if registered.is_none() {
-                    tracing::debug!(
-                        ledger_id,
-                        cfg_iri = %cfg_iri,
-                        "fulltext config provider: config graph never registered; \
-                         skipping LedgerState::load + resolve_ledger_config"
-                    );
-                    return Ok(Vec::new());
+                match probe {
+                    GraphRegistrationProbe::NotFound => {
+                        tracing::debug!(
+                            ledger_id,
+                            cfg_iri = %cfg_iri,
+                            "fulltext config provider: config graph never registered; \
+                             skipping LedgerState::load + resolve_ledger_config"
+                        );
+                        return Ok(Vec::new());
+                    }
+                    GraphRegistrationProbe::Found(t) => {
+                        tracing::debug!(
+                            ledger_id,
+                            cfg_iri = %cfg_iri,
+                            first_t = t,
+                            "fulltext config provider: config graph registered; \
+                             proceeding with full state load + resolve"
+                        );
+                    }
+                    GraphRegistrationProbe::Inconclusive => {
+                        tracing::debug!(
+                            ledger_id,
+                            cfg_iri = %cfg_iri,
+                            "fulltext config provider: envelope-only probe inconclusive \
+                             (v3 envelope on chain); falling through to full state load"
+                        );
+                    }
                 }
-                tracing::debug!(
-                    ledger_id,
-                    first_t = ?registered,
-                    "fulltext config provider: config graph registered; \
-                     proceeding with full state load + resolve"
-                );
             }
         }
 

--- a/fluree-db-api/tests/it_reindex_pre_build_perf.rs
+++ b/fluree-db-api/tests/it_reindex_pre_build_perf.rs
@@ -1,0 +1,353 @@
+//! Pre-rebuild performance regression guard for the reindex hot path.
+//!
+//! Two regressions converged to push small-ledger reindexes past the 900s
+//! Lambda ceiling on a 787-commit ledger:
+//!
+//! 1. `Novelty::apply_commit` was called per-commit during
+//!    `LedgerState::load_novelty`'s catch-up, accumulating `O(M·N̄)` work
+//!    via repeated two-way `merge_batch_into_index` calls. Replaced with
+//!    `Novelty::bulk_apply_commits` (`O(N log N)`).
+//!
+//! 2. `ApiFulltextConfigProvider::resolve` always called
+//!    `LedgerState::load`, so even when the config graph had never been
+//!    written the resolver paid for a full chain walk plus full novelty
+//!    build just to discover it was empty. Replaced with an
+//!    envelope-only probe via
+//!    [`first_t_where_graph_registered`] that short-circuits when the
+//!    config graph IRI never appears in any commit's `graph_delta`.
+//!
+//! Tests in this file lock both fixes in:
+//!
+//! - [`first_t_where_graph_registered_no_full_reads_when_iri_absent`] —
+//!   deterministic counting test that asserts the envelope walk uses
+//!   only `get_range`, never `get`, when the target IRI is missing.
+//! - [`first_t_where_graph_registered_returns_lowest_t_when_iri_present`]
+//!   — confirms the helper actually finds the registration `t`.
+//! - [`orchestrator_first_reindex_no_config_completes_quickly`] —
+//!   end-to-end orchestrator-path reindex of a multi-commit ledger
+//!   with no config graph, asserting wall-clock stays well under the
+//!   pre-fix regression scale. Smoke-test for both fixes wired
+//!   together.
+
+#![cfg(feature = "native")]
+
+use async_trait::async_trait;
+use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerState, Novelty};
+use fluree_db_core::error::Result as StorageResult;
+use fluree_db_core::{
+    config_graph_iri, first_t_where_graph_registered, ContentId, ContentKind, ContentStore,
+    LedgerSnapshot,
+};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+mod support;
+
+/// Atomic counters tracking every read through a [`CountingContentStore`].
+#[derive(Default)]
+struct FetchCounters {
+    get_calls: AtomicU64,
+    get_range_calls: AtomicU64,
+}
+
+impl std::fmt::Debug for FetchCounters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FetchCounters")
+            .field("get_calls", &self.get_calls.load(Ordering::Relaxed))
+            .field(
+                "get_range_calls",
+                &self.get_range_calls.load(Ordering::Relaxed),
+            )
+            .finish()
+    }
+}
+
+/// `ContentStore` wrapper that counts read traffic. Mirrors the helper in
+/// `it_rebuild_fetch_counts.rs` but slimmed to just the counters we need
+/// here (envelope-walk verification doesn't care about byte totals).
+#[derive(Clone, Debug)]
+struct CountingContentStore<C> {
+    inner: C,
+    counters: Arc<FetchCounters>,
+}
+
+impl<C: ContentStore> CountingContentStore<C> {
+    fn new(inner: C) -> Self {
+        Self {
+            inner,
+            counters: Arc::new(FetchCounters::default()),
+        }
+    }
+
+    fn counters(&self) -> Arc<FetchCounters> {
+        self.counters.clone()
+    }
+}
+
+#[async_trait]
+impl<C: ContentStore + Send + Sync> ContentStore for CountingContentStore<C> {
+    async fn has(&self, id: &ContentId) -> StorageResult<bool> {
+        self.inner.has(id).await
+    }
+
+    async fn get(&self, id: &ContentId) -> StorageResult<Vec<u8>> {
+        self.counters.get_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.get(id).await
+    }
+
+    async fn put(&self, kind: ContentKind, bytes: &[u8]) -> StorageResult<ContentId> {
+        self.inner.put(kind, bytes).await
+    }
+
+    async fn put_with_id(&self, id: &ContentId, bytes: &[u8]) -> StorageResult<()> {
+        self.inner.put_with_id(id, bytes).await
+    }
+
+    async fn release(&self, id: &ContentId) -> StorageResult<()> {
+        self.inner.release(id).await
+    }
+
+    async fn get_range(
+        &self,
+        id: &ContentId,
+        range: std::ops::Range<u64>,
+    ) -> StorageResult<Vec<u8>> {
+        self.counters
+            .get_range_calls
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.get_range(id, range).await
+    }
+}
+
+/// Seed `n` commits into a fresh in-memory ledger. None of these commits
+/// touch the config graph — they're plain entity inserts, mirroring a
+/// production scenario where no `f:LedgerConfig` ever exists.
+async fn seed_no_config_commits(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+    n: usize,
+) -> LedgerState {
+    let db0 = LedgerSnapshot::genesis(ledger_id);
+    let mut ledger = LedgerState::new(db0, Novelty::new(0));
+    let no_auto = IndexConfig {
+        reindex_min_bytes: 1_000_000_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
+    for i in 0..n {
+        let tx = json!({
+            "@context": { "ex": "http://example.org/" },
+            "@id": format!("ex:entity{i}"),
+            "@type": "ex:Entity",
+            "ex:label": format!("entity {i}"),
+            "ex:value": i as i64,
+        });
+        ledger = fluree
+            .insert_with_opts(
+                ledger,
+                &tx,
+                Default::default(),
+                Default::default(),
+                &no_auto,
+            )
+            .await
+            .expect("insert_with_opts")
+            .ledger;
+    }
+    ledger
+}
+
+#[tokio::test]
+async fn first_t_where_graph_registered_no_full_reads_when_iri_absent() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/envelope-shortcircuit-no-config:main";
+
+    const N: usize = 8;
+    let _ledger = seed_no_config_commits(&fluree, ledger_id, N).await;
+
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("ns record");
+    assert_eq!(record.commit_t, N as i64);
+
+    let counted = CountingContentStore::new(fluree.content_store(ledger_id));
+    let counters = counted.counters();
+    let head = record.commit_head_id.expect("head");
+
+    let cfg_iri = config_graph_iri(ledger_id);
+    let registered = first_t_where_graph_registered(&counted, &head, &cfg_iri)
+        .await
+        .expect("envelope walk");
+
+    assert!(
+        registered.is_none(),
+        "config graph never registered, expected None, got {registered:?}"
+    );
+
+    let get_calls = counters.get_calls.load(Ordering::Relaxed);
+    let get_range_calls = counters.get_range_calls.load(Ordering::Relaxed);
+
+    // Envelope-only probe must use byte-range exclusively. Any future
+    // refactor that re-introduces a full-blob fetch (e.g., reverting to
+    // `load_commit_by_id`) flips `get_calls` non-zero and fails here.
+    assert_eq!(
+        get_calls, 0,
+        "envelope walk must NOT issue full-blob `get` calls; got {get_calls}"
+    );
+    // One envelope range read per commit.
+    assert_eq!(
+        get_range_calls, N as u64,
+        "envelope walk must issue exactly {N} byte-range reads; got {get_range_calls}"
+    );
+}
+
+#[tokio::test]
+async fn first_t_where_graph_registered_returns_lowest_t_when_iri_present() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/envelope-shortcircuit-with-config:main";
+
+    let no_auto = IndexConfig {
+        reindex_min_bytes: 1_000_000_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
+
+    // Genesis: write a single triple to the config graph in the very first
+    // commit. The config graph IRI is `urn:fluree:<ledger_id>#config` per
+    // `config_graph_iri`, so a TriG `GRAPH <…#config>` block lands flakes
+    // there.
+    let cfg_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        "@prefix f: <https://ns.flur.ee/db#> .\n\
+         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+         GRAPH <{cfg_iri}> {{\n\
+            <urn:config:main> rdf:type f:LedgerConfig .\n\
+         }}\n"
+    );
+
+    let db0 = LedgerSnapshot::genesis(ledger_id);
+    let mut ledger = LedgerState::new(db0, Novelty::new(0));
+    ledger = fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("write config commit (t=1)")
+        .ledger;
+
+    // Add a few non-config commits afterwards (t=2..5).
+    for i in 0..4 {
+        let tx = json!({
+            "@context": { "ex": "http://example.org/" },
+            "@id": format!("ex:doc{i}"),
+            "@type": "ex:Doc",
+            "ex:title": format!("Doc {i}"),
+        });
+        ledger = fluree
+            .insert_with_opts(
+                ledger,
+                &tx,
+                Default::default(),
+                Default::default(),
+                &no_auto,
+            )
+            .await
+            .expect("insert_with_opts")
+            .ledger;
+    }
+
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("ns record");
+    let head = record.commit_head_id.expect("head");
+
+    let registered =
+        first_t_where_graph_registered(&fluree.content_store(ledger_id), &head, &cfg_iri)
+            .await
+            .expect("envelope walk");
+
+    assert_eq!(
+        registered,
+        Some(1),
+        "config graph was registered at the genesis commit (t=1)"
+    );
+}
+
+/// End-to-end orchestrator-path reindex on a no-config ledger. Mirrors the
+/// AWS Lambda configuration: `BackgroundIndexerWorker` with the API's
+/// `ApiFulltextConfigProvider` attached, `IndexerHandle::trigger`,
+/// `wait().await`. Asserts wall-clock stays well under the pre-fix
+/// regression scale (production reindexes sat past the 13-min waiter
+/// timeout repeatedly before the fix).
+///
+/// Wall-clock budgets are necessarily soft on CI hardware, but we set the
+/// budget at a level that comfortably passes locally yet would fail under
+/// any reintroduction of the full-chain `LedgerState::load` path on a
+/// no-config ledger.
+#[tokio::test]
+async fn orchestrator_first_reindex_no_config_completes_quickly() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/orchestrator-perf-no-config:main";
+
+    const N: usize = 200;
+    let _ledger = seed_no_config_commits(&fluree, ledger_id, N).await;
+
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("ns record");
+    assert_eq!(record.commit_t, N as i64);
+    assert!(
+        record.index_head_id.is_none(),
+        "expected no prior index — this test exercises the first-build path"
+    );
+
+    // Wire the orchestrator the same way `start_background_indexing_dyn`
+    // does for AWS: provider attached so `build_index_for_record` invokes
+    // it before dispatching.
+    let cfg = fluree_db_indexer::IndexerConfig::small()
+        .with_fulltext_config_provider(fluree.fulltext_config_provider());
+    let (local, handle) = support::start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        cfg,
+    );
+
+    let started = Instant::now();
+    let outcome = local
+        .run_until(async move {
+            let completion = handle.trigger(ledger_id, N as i64).await;
+            completion.wait().await
+        })
+        .await;
+    let elapsed = started.elapsed();
+
+    match outcome {
+        fluree_db_api::IndexOutcome::Completed { index_t, .. } => {
+            assert_eq!(index_t, N as i64);
+        }
+        fluree_db_api::IndexOutcome::Failed(e) => panic!("indexing failed: {e}"),
+        fluree_db_api::IndexOutcome::Cancelled => panic!("indexing cancelled"),
+    }
+
+    // 60s is generous on slow CI but well below the 13-min waiter timeout
+    // that motivated this fix. A regression in either fix (per-commit
+    // novelty O(N²) replay or full LedgerState::load on no-config
+    // ledgers) would push this past the budget on Lambda; on CI the
+    // multi-core machine masks per-commit O(N²) costs somewhat, but a
+    // FULL `LedgerState::load` walk on 200 commits with the provider
+    // attached would still register clearly above the noise floor here.
+    const BUDGET: Duration = Duration::from_secs(60);
+    assert!(
+        elapsed < BUDGET,
+        "orchestrator-path reindex of {N} commits took {elapsed:?}, expected < {BUDGET:?}"
+    );
+}

--- a/fluree-db-api/tests/it_reindex_pre_build_perf.rs
+++ b/fluree-db-api/tests/it_reindex_pre_build_perf.rs
@@ -36,7 +36,7 @@ use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerState, Novelty};
 use fluree_db_core::error::Result as StorageResult;
 use fluree_db_core::{
     config_graph_iri, first_t_where_graph_registered, ContentId, ContentKind, ContentStore,
-    LedgerSnapshot,
+    GraphRegistrationProbe, LedgerSnapshot,
 };
 use serde_json::json;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -179,13 +179,15 @@ async fn first_t_where_graph_registered_no_full_reads_when_iri_absent() {
     let head = record.commit_head_id.expect("head");
 
     let cfg_iri = config_graph_iri(ledger_id);
-    let registered = first_t_where_graph_registered(&counted, &head, &cfg_iri)
+    let probe = first_t_where_graph_registered(&counted, &head, &cfg_iri)
         .await
         .expect("envelope walk");
 
-    assert!(
-        registered.is_none(),
-        "config graph never registered, expected None, got {registered:?}"
+    assert_eq!(
+        probe,
+        GraphRegistrationProbe::NotFound,
+        "config graph never registered on a v4-only chain, \
+         expected NotFound; got {probe:?}"
     );
 
     let get_calls = counters.get_calls.load(Ordering::Relaxed);
@@ -267,14 +269,13 @@ async fn first_t_where_graph_registered_returns_lowest_t_when_iri_present() {
         .expect("ns record");
     let head = record.commit_head_id.expect("head");
 
-    let registered =
-        first_t_where_graph_registered(&fluree.content_store(ledger_id), &head, &cfg_iri)
-            .await
-            .expect("envelope walk");
+    let probe = first_t_where_graph_registered(&fluree.content_store(ledger_id), &head, &cfg_iri)
+        .await
+        .expect("envelope walk");
 
     assert_eq!(
-        registered,
-        Some(1),
+        probe,
+        GraphRegistrationProbe::Found(1),
         "config graph was registered at the genesis commit (t=1)"
     );
 }

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -402,6 +402,21 @@ pub async fn load_commit_envelope_by_id<C: ContentStore + ?Sized>(
     store: &C,
     id: &ContentId,
 ) -> Result<CommitEnvelope> {
+    let (envelope, _version) = load_commit_envelope_with_version(store, id).await?;
+    Ok(envelope)
+}
+
+/// Internal sibling of [`load_commit_envelope_by_id`] that also reports the
+/// commit-blob version byte read from the header.
+///
+/// Lets envelope-only walkers (notably [`first_t_where_graph_registered`])
+/// distinguish v4 envelopes (which carry `graph_delta`) from v3 envelopes
+/// (which never encoded it) so they can avoid silently mis-reporting graph
+/// registration on legacy chains.
+async fn load_commit_envelope_with_version<C: ContentStore + ?Sized>(
+    store: &C,
+    id: &ContentId,
+) -> Result<(CommitEnvelope, u8)> {
     use codec::format::{CommitHeader, HEADER_LEN};
 
     let probe = store
@@ -416,6 +431,11 @@ pub async fn load_commit_envelope_by_id<C: ContentStore + ?Sized>(
             probe.len()
         )));
     }
+
+    // Header byte 4 is the codec version; capture it before the envelope
+    // decode dispatches on it. Re-validated against `CommitHeader::read_from`
+    // (which rejects unknown versions) below.
+    let version_byte = probe[4];
 
     let header =
         CommitHeader::read_from(&probe).map_err(|e| Error::invalid_commit(e.to_string()))?;
@@ -439,7 +459,7 @@ pub async fn load_commit_envelope_by_id<C: ContentStore + ?Sized>(
             tracing::debug_span!("load_commit_envelope_by_id", blob_bytes = data.len()).entered();
         codec::read_commit_envelope(&data).map_err(|e| Error::invalid_commit(e.to_string()))?
     };
-    Ok(envelope)
+    Ok((envelope, version_byte))
 }
 
 /// Walk a commit DAG from a head CID, collecting `(t, ContentId)` pairs for
@@ -473,15 +493,45 @@ pub async fn collect_dag_cids_with_split_mode<C: ContentStore + ?Sized>(
     walk_dag(store, head_id, stop_at_t, true).await
 }
 
+/// Outcome of an envelope-only probe for a named graph's registration.
+///
+/// Returned by [`first_t_where_graph_registered`]. Callers that gate
+/// expensive work on the absence of a registration must distinguish
+/// `NotFound` (definitively absent — safe to skip) from `Inconclusive`
+/// (probe couldn't determine — must fall through to a full-chain check).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GraphRegistrationProbe {
+    /// Graph IRI was registered at this `t`. Smallest `t` observed across
+    /// the walk; later parent paths could not yield a smaller value because
+    /// we visit every ancestor before returning.
+    Found(i64),
+    /// Probe completed and the IRI was not present in any commit's
+    /// `graph_delta`. Safe to short-circuit: no flake belonging to the
+    /// graph can exist in this chain.
+    NotFound,
+    /// Probe could not determine registration status — typically because
+    /// at least one envelope in the chain was a v3 commit, which never
+    /// encoded `graph_delta`. Callers must fall through to a full chain
+    /// load if correctness depends on knowing.
+    Inconclusive,
+}
+
 /// Probe the commit DAG envelope-only to discover whether a named graph
 /// IRI was ever registered, and at what `t` it first appeared.
 ///
-/// Walks the chain via [`load_commit_envelope_by_id`] (byte-range probe,
-/// ~128 KiB per envelope on range-capable backends), inspects each
-/// envelope's `graph_delta` for `graph_iri`, and returns the lowest `t`
-/// where it appears. Returns `Ok(None)` if the IRI never shows up — which
-/// means no flake belonging to that graph can exist anywhere in the chain
-/// (graph registrations are required before flakes can reference them).
+/// Walks the chain via byte-range envelope reads (~128 KiB per envelope on
+/// range-capable backends), inspects each envelope's `graph_delta` for
+/// `graph_iri`, and returns:
+///
+/// - [`Found(t)`](GraphRegistrationProbe::Found) — the smallest `t`
+///   where the IRI appears in any commit's `graph_delta`.
+/// - [`NotFound`](GraphRegistrationProbe::NotFound) — every commit was a
+///   v4 envelope and none registered the IRI.
+/// - [`Inconclusive`](GraphRegistrationProbe::Inconclusive) — at least one
+///   envelope was v3 (or an unknown future version) and could not be
+///   inspected for `graph_delta`. Walk short-circuits and returns
+///   immediately on first such envelope; callers must fall through to a
+///   full-chain load if correctness depends on the answer.
 ///
 /// Used by [`ApiFulltextConfigProvider`][^1] to short-circuit fulltext
 /// config resolution on first-ever reindex when the config graph was
@@ -489,17 +539,22 @@ pub async fn collect_dag_cids_with_split_mode<C: ContentStore + ?Sized>(
 /// avoids the per-commit full-blob read + zstd decompress + flake
 /// construction that `LedgerState::load` would otherwise perform.
 ///
-/// Note: v3 commits do not carry `graph_delta` on the envelope (the
-/// field was added in v4). On a v3 chain this function will always
-/// return `None`; callers that need v3 compatibility should fall back
-/// to a full chain scan.
+/// # Cost contract
+///
+/// Walks the **full DAG** even after a hit because earlier commits on
+/// alternate parent branches may carry an earlier registration; on a
+/// linear chain this is unavoidable. Per-commit cost is one byte-range
+/// envelope read on range-capable backends. The walk is sequential
+/// because each envelope reveals its parents; pipeline support is a
+/// future optimization (see follow-up notes in the PR description that
+/// added this helper).
 ///
 /// [^1]: `fluree-db-api/src/indexer_fulltext_provider.rs`
 pub async fn first_t_where_graph_registered<C: ContentStore + ?Sized>(
     store: &C,
     head_id: &ContentId,
     graph_iri: &str,
-) -> Result<Option<i64>> {
+) -> Result<GraphRegistrationProbe> {
     let mut earliest: Option<i64> = None;
     let mut frontier = vec![head_id.clone()];
     let mut visited = std::collections::HashSet::new();
@@ -508,7 +563,18 @@ pub async fn first_t_where_graph_registered<C: ContentStore + ?Sized>(
         if !visited.insert(cid.clone()) {
             continue;
         }
-        let envelope = load_commit_envelope_by_id(store, &cid).await?;
+        let (envelope, version) = load_commit_envelope_with_version(store, &cid).await?;
+        // V3 envelopes (and any pre-v4 format that did not encode
+        // `graph_delta`) leave `envelope.graph_delta` empty regardless of
+        // what the underlying commit actually registered, so we cannot
+        // distinguish "no registration" from "field absent on the wire."
+        // Bail to `Inconclusive` so the caller falls through to a
+        // correctness-preserving full-chain scan. `CommitBlobVersion::V4`
+        // is the only version known to encode `graph_delta`; any other
+        // is treated conservatively.
+        if version != codec::VERSION {
+            return Ok(GraphRegistrationProbe::Inconclusive);
+        }
         if envelope.graph_delta.values().any(|iri| iri == graph_iri) {
             earliest = Some(match earliest {
                 Some(e) => e.min(envelope.t),
@@ -520,7 +586,10 @@ pub async fn first_t_where_graph_registered<C: ContentStore + ?Sized>(
         }
     }
 
-    Ok(earliest)
+    Ok(match earliest {
+        Some(t) => GraphRegistrationProbe::Found(t),
+        None => GraphRegistrationProbe::NotFound,
+    })
 }
 
 /// Shared DAG walk implementation backing [`collect_dag_cids`] and

--- a/fluree-db-core/src/commit.rs
+++ b/fluree-db-core/src/commit.rs
@@ -352,6 +352,16 @@ pub struct CommitEnvelope {
     /// User-provided transaction metadata (replay-safe)
     pub txn_meta: Vec<TxnMetaEntry>,
 
+    /// Named-graph IRI registrations introduced by this commit.
+    ///
+    /// Same shape as [`Commit::graph_delta`] — `g_id → IRI`. Carried on the
+    /// envelope so envelope-only walkers (`walk_dag`, callers of
+    /// [`load_commit_envelope_by_id`]) can detect that a particular named
+    /// graph has ever been registered without paying for a full ops fetch.
+    /// Used by `ApiFulltextConfigProvider` to short-circuit when the config
+    /// graph was never registered anywhere in the chain.
+    pub graph_delta: HashMap<u16, String>,
+
     /// Ledger-fixed split mode for canonical IRI encoding.
     /// Set once in the genesis commit; absent in subsequent commits.
     pub ns_split_mode: Option<crate::ns_encoding::NsSplitMode>,
@@ -461,6 +471,56 @@ pub async fn collect_dag_cids_with_split_mode<C: ContentStore + ?Sized>(
     stop_at_t: i64,
 ) -> Result<(Vec<(i64, ContentId)>, crate::ns_encoding::NsSplitMode)> {
     walk_dag(store, head_id, stop_at_t, true).await
+}
+
+/// Probe the commit DAG envelope-only to discover whether a named graph
+/// IRI was ever registered, and at what `t` it first appeared.
+///
+/// Walks the chain via [`load_commit_envelope_by_id`] (byte-range probe,
+/// ~128 KiB per envelope on range-capable backends), inspects each
+/// envelope's `graph_delta` for `graph_iri`, and returns the lowest `t`
+/// where it appears. Returns `Ok(None)` if the IRI never shows up — which
+/// means no flake belonging to that graph can exist anywhere in the chain
+/// (graph registrations are required before flakes can reference them).
+///
+/// Used by [`ApiFulltextConfigProvider`][^1] to short-circuit fulltext
+/// config resolution on first-ever reindex when the config graph was
+/// never written to. For a chain with no config graph at all, this
+/// avoids the per-commit full-blob read + zstd decompress + flake
+/// construction that `LedgerState::load` would otherwise perform.
+///
+/// Note: v3 commits do not carry `graph_delta` on the envelope (the
+/// field was added in v4). On a v3 chain this function will always
+/// return `None`; callers that need v3 compatibility should fall back
+/// to a full chain scan.
+///
+/// [^1]: `fluree-db-api/src/indexer_fulltext_provider.rs`
+pub async fn first_t_where_graph_registered<C: ContentStore + ?Sized>(
+    store: &C,
+    head_id: &ContentId,
+    graph_iri: &str,
+) -> Result<Option<i64>> {
+    let mut earliest: Option<i64> = None;
+    let mut frontier = vec![head_id.clone()];
+    let mut visited = std::collections::HashSet::new();
+
+    while let Some(cid) = frontier.pop() {
+        if !visited.insert(cid.clone()) {
+            continue;
+        }
+        let envelope = load_commit_envelope_by_id(store, &cid).await?;
+        if envelope.graph_delta.values().any(|iri| iri == graph_iri) {
+            earliest = Some(match earliest {
+                Some(e) => e.min(envelope.t),
+                None => envelope.t,
+            });
+        }
+        for parent_id in envelope.parent_ids() {
+            frontier.push(parent_id.clone());
+        }
+    }
+
+    Ok(earliest)
 }
 
 /// Shared DAG walk implementation backing [`collect_dag_cids`] and
@@ -867,6 +927,7 @@ mod tests {
             txn: None,
             namespace_delta: HashMap::from([(100, "ex:".to_string())]),
             txn_meta: Vec::new(),
+            graph_delta: HashMap::new(),
             ns_split_mode: None,
         };
 

--- a/fluree-db-core/src/commit/codec/legacy_v3.rs
+++ b/fluree-db-core/src/commit/codec/legacy_v3.rs
@@ -1051,4 +1051,48 @@ mod tests {
             crate::commit::codec::CommitCodecError::UnsupportedVersion(99)
         ));
     }
+
+    /// Regression guard: `first_t_where_graph_registered` must report
+    /// `Inconclusive` (not `NotFound`) when any envelope on the chain is
+    /// v3, because v3 didn't encode `graph_delta` on the wire — a `false`
+    /// answer there would silently lose configured fulltext on legacy
+    /// chains. See PR #1211 review item #1.
+    #[tokio::test]
+    async fn first_t_where_graph_registered_returns_inconclusive_on_v3_envelope() {
+        use crate::storage::MemoryStorage;
+        use crate::{content_store_for, ContentKind, ContentStore, GraphRegistrationProbe};
+
+        // Construct a v3 blob (single trivial flake) and put it in an
+        // in-memory store under its own SHA-256 CID via the v4 CID scheme
+        // (`ContentId::new(Commit, bytes)`). The probe's first action is
+        // `get_range(head_id, ...)`, which the memory store satisfies by
+        // returning the same bytes regardless of version.
+        let flake = test_flake(Sid::new(namespaces::XSD, "string"), 1);
+        let blob = build_v3_test_blob(std::slice::from_ref(&flake), 1);
+        assert_eq!(blob[4], format::VERSION_V3);
+
+        let storage = MemoryStorage::new();
+        let store = content_store_for(storage, "test/v3-probe:main");
+        let cid = store
+            .put(ContentKind::Commit, &blob)
+            .await
+            .expect("put v3 blob");
+
+        let probe = crate::commit::first_t_where_graph_registered(
+            &store,
+            &cid,
+            "urn:fluree:test/v3-probe:main#config",
+        )
+        .await
+        .expect("envelope walk");
+
+        assert_eq!(
+            probe,
+            GraphRegistrationProbe::Inconclusive,
+            "v3 envelopes never carry graph_delta — probe must report \
+             Inconclusive so the caller falls through to a full load \
+             instead of silently treating the chain as having no \
+             registration; got {probe:?}"
+        );
+    }
 }

--- a/fluree-db-core/src/commit/codec/legacy_v3.rs
+++ b/fluree-db-core/src/commit/codec/legacy_v3.rs
@@ -302,6 +302,10 @@ pub fn read_commit_envelope_v3(bytes: &[u8]) -> Result<CommitEnvelope, CommitCod
         txn: env.txn,
         namespace_delta: env.namespace_delta,
         txn_meta,
+        // v3 commits did not encode graph_delta on the envelope; surface as
+        // empty so envelope-only callers don't have to special-case the
+        // version.
+        graph_delta: std::collections::HashMap::new(),
         ns_split_mode: env.ns_split_mode,
     })
 }

--- a/fluree-db-core/src/commit/codec/reader.rs
+++ b/fluree-db-core/src/commit/codec/reader.rs
@@ -205,6 +205,7 @@ pub(crate) fn read_commit_envelope_v4(bytes: &[u8]) -> Result<CommitEnvelope, Co
         txn: env.txn,
         namespace_delta: env.namespace_delta,
         txn_meta: env.txn_meta,
+        graph_delta: env.graph_delta,
         ns_split_mode: env.ns_split_mode,
     })
 }

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -81,8 +81,8 @@ pub use commit::{
     collect_dag_cids, collect_dag_cids_with_split_mode, commit_to_summary, find_common_ancestor,
     first_t_where_graph_registered, load_commit_by_id, load_commit_envelope_by_id,
     trace_commit_envelopes_by_id, trace_commits_by_id, walk_commit_summaries, Commit,
-    CommitEnvelope, CommitSummary, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature,
-    MAX_TXN_META_BYTES, MAX_TXN_META_ENTRIES,
+    CommitEnvelope, CommitSummary, CommonAncestor, GraphRegistrationProbe, TxnMetaEntry,
+    TxnMetaValue, TxnSignature, MAX_TXN_META_BYTES, MAX_TXN_META_ENTRIES,
 };
 pub use comparator::IndexType;
 pub use conflict_key::ConflictKey;

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -79,10 +79,10 @@ pub use address::{
 pub use coerce::{coerce_json_value, coerce_value, CoercionError, CoercionResult};
 pub use commit::{
     collect_dag_cids, collect_dag_cids_with_split_mode, commit_to_summary, find_common_ancestor,
-    load_commit_by_id, load_commit_envelope_by_id, trace_commit_envelopes_by_id,
-    trace_commits_by_id, walk_commit_summaries, Commit, CommitEnvelope, CommitSummary,
-    CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature, MAX_TXN_META_BYTES,
-    MAX_TXN_META_ENTRIES,
+    first_t_where_graph_registered, load_commit_by_id, load_commit_envelope_by_id,
+    trace_commit_envelopes_by_id, trace_commits_by_id, walk_commit_summaries, Commit,
+    CommitEnvelope, CommitSummary, CommonAncestor, TxnMetaEntry, TxnMetaValue, TxnSignature,
+    MAX_TXN_META_BYTES, MAX_TXN_META_ENTRIES,
 };
 pub use comparator::IndexType;
 pub use conflict_key::ConflictKey;

--- a/fluree-db-core/src/storage.rs
+++ b/fluree-db-core/src/storage.rs
@@ -806,6 +806,29 @@ impl ContentStore for BranchedContentStore {
             .resolve_local_path(id)
             .or_else(|| self.parents.iter().find_map(|p| p.resolve_local_path(id)))
     }
+
+    async fn get_range(&self, id: &ContentId, range: std::ops::Range<u64>) -> Result<Vec<u8>> {
+        // Mirror `get` semantics: try this branch first, then walk parents on
+        // NotFound. Forward `get_range` natively at every step so range-capable
+        // backends (S3, file) keep their byte-range optimization across the
+        // ancestry chain. Without this, the trait default falls back to a full
+        // `get` + slice — which silently nullifies envelope-only probes
+        // (`load_commit_envelope_by_id`) for branched ledgers.
+        match self.branch_store.get_range(id, range.clone()).await {
+            Ok(bytes) => return Ok(bytes),
+            Err(e) if self.parents.is_empty() => return Err(e),
+            Err(e) if !matches!(e, crate::error::Error::NotFound(_)) => return Err(e),
+            Err(_) => {}
+        }
+        let mut last_err = None;
+        for parent in &self.parents {
+            match parent.get_range(id, range.clone()).await {
+                Ok(bytes) => return Ok(bytes),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| crate::error::Error::not_found(id.to_string())))
+    }
 }
 
 // ============================================================================

--- a/fluree-db-ledger/src/lib.rs
+++ b/fluree-db-ledger/src/lib.rs
@@ -331,14 +331,25 @@ impl LedgerState {
             }
         }
 
-        // Replay oldest→newest (walk was HEAD→oldest, so reverse)
+        // Replay oldest→newest (walk was HEAD→oldest, so reverse).
         commit_batches.reverse();
-        for (flakes, commit_t) in commit_batches {
-            // Populate dict_novelty with subjects/strings from replayed commits so
-            // overlay translation can resolve IDs for unindexed commits.
-            dict_novelty.populate_from_flakes(&flakes);
-            novelty.apply_commit(flakes, commit_t, &reverse_graph)?;
+
+        // Populate dict_novelty in commit order so overlay translation can
+        // resolve IDs for unindexed commits. Doing this before bulk-apply
+        // matches the ordering invariants the per-commit `apply_commit`
+        // path used to provide.
+        for (flakes, _t) in &commit_batches {
+            dict_novelty.populate_from_flakes(flakes);
         }
+
+        // Bulk-load mode: previously this loop called `Novelty::apply_commit`
+        // per commit, whose `merge_batch_into_index` is `O(target+batch)`
+        // per call, accumulating to `O(M·N̄)` over the chain. For a fresh
+        // reindex with thousands of commits that grew to many minutes on
+        // single-CPU lambdas. `bulk_apply_commits` instead does one
+        // identity-key sort + linear set-semantics dedup + four index
+        // sorts, totaling `O(N log N)` regardless of M.
+        novelty.bulk_apply_commits(commit_batches, &reverse_graph)?;
 
         Ok((novelty, Some(head_cid.clone())))
     }

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -396,6 +396,25 @@ impl Novelty {
     ///
     /// `epoch` bumps once per call, regardless of how many commits were
     /// merged. `t` advances to `max(self.t, max_commit_t)`.
+    ///
+    /// # Memory contract — differs from [`apply_commit`]
+    ///
+    /// Unlike [`apply_commit`] (which checks `fact_currently_asserted_in_graph`
+    /// **before** pushing into the arena, so deduped duplicates never enter
+    /// the [`FlakeStore`]), this method pushes every incoming flake into the
+    /// arena in Phase 1 and only drops `FlakeId`s during the post-sort
+    /// dedup walk. The underlying `Flake` records and their per-flake
+    /// sizes remain in [`FlakeStore::flakes`] / `FlakeStore::sizes` for
+    /// the lifetime of the [`Novelty`], and `self.size` (the
+    /// backpressure-relevant total) accounts for them.
+    ///
+    /// For the design call site (one fresh-load chain walk feeding an
+    /// otherwise-empty arena, after which the [`Novelty`] is consumed and
+    /// dropped), this bloat is bounded and operationally negligible — the
+    /// dedup count is logged at the end of every call so the cost stays
+    /// observable. **Do not wire this into hot-path mutation code without
+    /// either redesigning the dedup to gate `push_with_size` or adding a
+    /// post-walk arena rebuild.**
     pub fn bulk_apply_commits<I>(
         &mut self,
         commit_batches: I,
@@ -1321,5 +1340,116 @@ mod tests {
 
         assert_eq!(store.get(0).s.namespace_code, 1);
         assert_eq!(store.get(1).s.namespace_code, 2);
+    }
+
+    /// Drift guard: the file-local `cmp_object` / `cmp_meta` /
+    /// `same_identity` helpers exist because `fluree_db_core::comparator`'s
+    /// equivalents are private. They MUST stay byte-for-byte consistent
+    /// with the `(s, p, o, dt, t, op, m)` ordering encoded in
+    /// `IndexType::Spot.compare`, since [`Novelty::bulk_apply_commits`]'s
+    /// set-semantics dedup depends on `same_identity` matching the
+    /// identity used by `fact_currently_asserted_in_graph` in
+    /// [`Novelty::apply_commit`].
+    ///
+    /// If either side ever drifts, this test fires loudly. Symptoms of a
+    /// silent drift would be silently dropped or duplicated assertions
+    /// during first-load catch-up — extremely hard to track down at
+    /// runtime — so a deterministic compile-and-run guard is worth it.
+    #[test]
+    fn local_identity_helpers_match_core_spot_comparator_semantics() {
+        use fluree_db_core::IndexType;
+
+        // Two flakes that share `(s, p, o, dt, m)` but differ in `(t, op)`
+        // — `same_identity` must say `true`, and SPOT comparator must
+        // disagree only on the t/op tail.
+        let id_a = make_flake(101, 200, 42, 1, true);
+        let id_b = make_flake(101, 200, 42, 5, false);
+        assert!(
+            same_identity(&id_a, &id_b),
+            "same (s, p, o, dt, m) must be one identity"
+        );
+        let cmp = IndexType::Spot.compare(&id_a, &id_b);
+        assert_eq!(
+            cmp,
+            Ordering::Less,
+            "within an identity group, SPOT must order by ascending t"
+        );
+
+        // Differing on each prefix component must break identity.
+        let other_s = make_flake(102, 200, 42, 1, true);
+        let other_p = make_flake(101, 201, 42, 1, true);
+        let other_o = make_flake(101, 200, 99, 1, true);
+        for (label, b) in [
+            ("subject", other_s),
+            ("predicate", other_p),
+            ("object", other_o),
+        ] {
+            assert!(
+                !same_identity(&id_a, &b),
+                "identity must NOT collapse across differing {label}"
+            );
+            assert_ne!(
+                IndexType::Spot.compare(&id_a, &b),
+                Ordering::Equal,
+                "SPOT comparator must disagree when {label} differs"
+            );
+        }
+
+        // `cmp_meta` ordering: None < Some, and Some<m1> < Some<m2>
+        // when m1 < m2. Construct two flakes with explicit metadata
+        // and verify both `cmp_meta` and the SPOT tail behavior.
+        let m_lo = FlakeMeta::with_lang("aa");
+        let m_hi = FlakeMeta::with_lang("zz");
+        let f_none = make_flake_with_meta(101, 200, 42, 1, true, None);
+        let f_lo = make_flake_with_meta(101, 200, 42, 1, true, Some(m_lo.clone()));
+        let f_hi = make_flake_with_meta(101, 200, 42, 1, true, Some(m_hi.clone()));
+        assert_eq!(cmp_meta(&f_none, &f_lo), Ordering::Less);
+        assert_eq!(cmp_meta(&f_lo, &f_hi), Ordering::Less);
+        assert_eq!(cmp_meta(&f_lo, &f_lo), Ordering::Equal);
+        // `same_identity` must split on metadata: same (s,p,o,dt) but
+        // distinct m means distinct identity, just like `apply_commit`'s
+        // `fact_currently_asserted_in_graph` walks (s,p,o,dt) and then
+        // matches `existing.m == flake.m`.
+        assert!(
+            !same_identity(&f_none, &f_lo),
+            "identity must split on metadata"
+        );
+        assert!(
+            !same_identity(&f_lo, &f_hi),
+            "identity must split on differing metadata values"
+        );
+
+        // `cmp_object` mixes value and datatype: equal value + differing
+        // datatype must order. Use distinct datatype Sids on otherwise
+        // identical flakes.
+        let dt_long = Sid::new(2, "long");
+        let dt_int = Sid::new(2, "integer");
+        let with_long = Flake::new(
+            Sid::new(101, "s101"),
+            Sid::new(200, "p200"),
+            FlakeValue::Long(42),
+            dt_long,
+            1,
+            true,
+            None,
+        );
+        let with_int = Flake::new(
+            Sid::new(101, "s101"),
+            Sid::new(200, "p200"),
+            FlakeValue::Long(42),
+            dt_int,
+            1,
+            true,
+            None,
+        );
+        assert_ne!(
+            cmp_object(&with_long, &with_int),
+            Ordering::Equal,
+            "cmp_object must distinguish equal values across differing datatypes"
+        );
+        assert!(
+            !same_identity(&with_long, &with_int),
+            "datatype is part of identity — must split"
+        );
     }
 }

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -363,6 +363,202 @@ impl Novelty {
         Ok(())
     }
 
+    /// Bulk-apply many commits' flakes in a single pass.
+    ///
+    /// Designed for first-load / catch-up paths (e.g. `LedgerState::load_novelty`
+    /// walking a long commit chain) where calling [`apply_commit`] per commit
+    /// degrades to O(N²) cumulative cost: each call's
+    /// `merge_batch_into_index` is O(target.len() + batch.len()), so over
+    /// `M` commits with average batch `B` it accrues `O(M·N̄)` work, where
+    /// `N̄` is the running novelty size.
+    ///
+    /// This method instead:
+    /// 1. Routes every flake into a per-graph bucket in one ingest pass.
+    /// 2. Sorts each graph's flakes once (parallel) by an identity-then-t
+    ///    key (`s, p, o, dt, m, t, op`).
+    /// 3. Walks each `(s, p, o, dt, m)` group linearly to apply set
+    ///    semantics — assertion is dropped iff the prior kept flake for the
+    ///    same identity was also an assertion (mirroring
+    ///    [`apply_commit`]'s `fact_currently_asserted_in_graph` skip rule);
+    ///    retractions are always kept.
+    /// 4. Re-sorts the deduped set into the 4 index orders (SPOT, PSOT,
+    ///    POST, OPST) once each.
+    ///
+    /// Total cost is `O(N log N)` over the merged set instead of `O(N²)` —
+    /// for a 787-commit / ~7M-flake chain this drops the catch-up from
+    /// minutes to seconds on Lambda single-CPU.
+    ///
+    /// Existing graph contents (if any) are preserved by merging their
+    /// alive `FlakeId`s into the dedup pass alongside the incoming batches,
+    /// so the post-condition matches what a sequential per-commit
+    /// `apply_commit` chain would have produced — minus retraction-noise
+    /// duplicates that the per-commit path never emits anyway.
+    ///
+    /// `epoch` bumps once per call, regardless of how many commits were
+    /// merged. `t` advances to `max(self.t, max_commit_t)`.
+    pub fn bulk_apply_commits<I>(
+        &mut self,
+        commit_batches: I,
+        reverse_graph: &HashMap<Sid, GraphId>,
+    ) -> Result<()>
+    where
+        I: IntoIterator<Item = (Vec<Flake>, i64)>,
+    {
+        use rayon::prelude::*;
+
+        let span = tracing::debug_span!(
+            "novelty_bulk_apply_commits",
+            rayon_threads = rayon::current_num_threads()
+        );
+        let _guard = span.enter();
+
+        let started = std::time::Instant::now();
+
+        // ---- Phase 1: ingest into arena, partition by graph ----
+        let mut per_graph: HashMap<GraphId, Vec<FlakeId>> = HashMap::new();
+        let mut max_t = self.t;
+        let mut commit_count: u64 = 0;
+        let mut total_flakes: usize = 0;
+
+        for (flakes, commit_t) in commit_batches {
+            if flakes.is_empty() {
+                commit_count += 1;
+                max_t = max_t.max(commit_t);
+                continue;
+            }
+            let new_count = self.store.len() + flakes.len();
+            if new_count > MAX_FLAKE_ID as usize {
+                return Err(NoveltyError::overflow(
+                    "FlakeId overflow during bulk apply: too many flakes in novelty, trigger reindex",
+                ));
+            }
+            commit_count += 1;
+            total_flakes += flakes.len();
+            max_t = max_t.max(commit_t);
+
+            for flake in flakes {
+                let g_id = Self::resolve_flake_g_id(&flake, reverse_graph)?;
+                let size = flake.size_bytes();
+                self.size += size;
+                let id = self.store.push_with_size(flake, size);
+                per_graph.entry(g_id).or_default().push(id);
+            }
+        }
+
+        if per_graph.is_empty() {
+            self.t = max_t;
+            self.epoch += 1;
+            return Ok(());
+        }
+
+        // Ensure graph slots so we can take existing index vectors.
+        for &g_id in per_graph.keys() {
+            self.ensure_graph(g_id);
+        }
+
+        // ---- Phase 2: per-graph dedup + 4-index sort ----
+        let store = &self.store;
+        let mut total_dedup: u64 = 0;
+
+        for (g_id, mut new_ids) in per_graph {
+            // Pull in the graph's existing alive FlakeIds (any prior
+            // novelty content) so the dedup pass sees the full universe.
+            // SPOT/PSOT/POST/OPST have identical alive sets (apply_commit
+            // pushes the same batch_ids to all four), so taking SPOT is
+            // the canonical choice.
+            let graph_vecs = self.graphs[g_id as usize]
+                .as_mut()
+                .expect("ensure_graph above");
+            let existing_spot = std::mem::take(&mut graph_vecs.spot);
+            // Other indexes get rebuilt below; clear them so we don't
+            // double-count if the dedup walk drops some.
+            graph_vecs.psot.clear();
+            graph_vecs.post.clear();
+            graph_vecs.opst.clear();
+
+            let mut combined = existing_spot;
+            combined.append(&mut new_ids);
+
+            // Sort by (s, p, o, dt, m, t, op) so each (s, p, o, dt, m)
+            // identity forms a contiguous t-ascending run.
+            combined.par_sort_unstable_by(|&a, &b| {
+                let fa = store.get(a);
+                let fb = store.get(b);
+                fa.s.cmp(&fb.s)
+                    .then_with(|| fa.p.cmp(&fb.p))
+                    .then_with(|| cmp_object(fa, fb))
+                    .then_with(|| cmp_meta(fa, fb))
+                    .then_with(|| fa.t.cmp(&fb.t))
+                    .then_with(|| fa.op.cmp(&fb.op))
+            });
+
+            // Linear set-semantics dedup: for each (s, p, o, dt, m)
+            // identity group, walk in ascending t and drop any assertion
+            // whose prior kept flake for the same identity was also an
+            // assertion. Retractions are always kept.
+            let mut kept: Vec<FlakeId> = Vec::with_capacity(combined.len());
+            let mut group_start = 0usize;
+            while group_start < combined.len() {
+                let head = store.get(combined[group_start]);
+                let mut group_end = group_start + 1;
+                while group_end < combined.len() {
+                    let f = store.get(combined[group_end]);
+                    if !same_identity(head, f) {
+                        break;
+                    }
+                    group_end += 1;
+                }
+                let mut currently_asserted = false;
+                for &id in &combined[group_start..group_end] {
+                    let f = store.get(id);
+                    if !f.op {
+                        kept.push(id);
+                        currently_asserted = false;
+                    } else if !currently_asserted {
+                        kept.push(id);
+                        currently_asserted = true;
+                    } else {
+                        total_dedup += 1;
+                    }
+                }
+                group_start = group_end;
+            }
+
+            // Build the 4 sorted index vectors from the deduped set. Each
+            // sort is independently O(N log N); kept.clone() copies only
+            // the small `FlakeId` (u32) array, not the underlying flakes.
+            let mut spot = kept.clone();
+            spot.par_sort_unstable_by(|&a, &b| IndexType::Spot.compare(store.get(a), store.get(b)));
+            let mut psot = kept.clone();
+            psot.par_sort_unstable_by(|&a, &b| IndexType::Psot.compare(store.get(a), store.get(b)));
+            let mut post = kept.clone();
+            post.par_sort_unstable_by(|&a, &b| IndexType::Post.compare(store.get(a), store.get(b)));
+            let mut opst = kept;
+            opst.par_sort_unstable_by(|&a, &b| IndexType::Opst.compare(store.get(a), store.get(b)));
+
+            let graph_vecs = self.graphs[g_id as usize]
+                .as_mut()
+                .expect("ensure_graph above");
+            graph_vecs.spot = spot;
+            graph_vecs.psot = psot;
+            graph_vecs.post = post;
+            graph_vecs.opst = opst;
+        }
+
+        self.t = max_t;
+        self.epoch += 1;
+
+        tracing::debug!(
+            commits = commit_count,
+            total_flakes,
+            deduped = total_dedup,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "novelty bulk apply complete"
+        );
+
+        Ok(())
+    }
+
     /// Clear flakes with t <= cutoff_t (after index merge)
     ///
     /// Uses bitmap instead of HashSet for cache-friendly O(n) clear.
@@ -567,6 +763,38 @@ impl OverlayProvider for Novelty {
 // =============================================================================
 // Parallel merge helpers (read-only store + disjoint mutable index vectors)
 // =============================================================================
+
+/// Compare two flakes by their object value (datatype-aware).
+///
+/// Mirrors the hidden `cmp_object` in `fluree_db_core::comparator` so the
+/// bulk-apply identity sort can group flakes by `(s, p, o, dt, m)` without
+/// reaching into core's private comparators.
+fn cmp_object(f1: &Flake, f2: &Flake) -> Ordering {
+    f1.o.cmp(&f2.o).then_with(|| f1.dt.cmp(&f2.dt))
+}
+
+/// Compare two flakes by their metadata (None < Some, then m1 < m2).
+///
+/// Mirrors `fluree_db_core::comparator::cmp_meta` for the same reason as
+/// [`cmp_object`].
+fn cmp_meta(f1: &Flake, f2: &Flake) -> Ordering {
+    match (&f1.m, &f2.m) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(m1), Some(m2)) => m1.cmp(m2),
+    }
+}
+
+/// True iff `a` and `b` have identical `(s, p, o, dt, m)` — the fact
+/// identity used by [`Novelty::apply_commit`]'s `fact_currently_asserted_in_graph`
+/// dedup rule and the [`Novelty::bulk_apply_commits`] dedup walk.
+fn same_identity(a: &Flake, b: &Flake) -> bool {
+    a.s == b.s
+        && a.p == b.p
+        && cmp_object(a, b) == Ordering::Equal
+        && cmp_meta(a, b) == Ordering::Equal
+}
 
 /// LSM-style merge: sort batch by index comparator, then merge with existing target.
 fn merge_batch_into_index(


### PR DESCRIPTION
Fixes the regression that pushed first-time reindex on the large dataset indexing Lambda past the 13-minute waiter timeout repeatedly. Two stacked slowdowns were hitting any reindex of a ledger with no prior index; this PR addresses both, plus a defensive fix for branched ledgers and regression guards so neither can re-emerge silently.

## Background

CloudWatch logs for a particular indexing lambda showed 787-commit reindexes of a dataset consistently timing out at 13 minutes:

- 24-30s of preamble (then silence in the default INFO log filter)
- 1574 = 2 × 787 `read_commit_v4` debug events when DEBUG was bumped
- 11+ minutes of total silence after that — no Phase A/B/C/D progress
- Repeated `Index trigger timed out` waits, identical retry pattern across cold starts

Two distinct regressions, both shipped via PR #1199 / commit `5985d0f01 fluree v4 baseline`:

1. **`Novelty::apply_commit` called per-commit during `LedgerState::load_novelty`.** The `merge_batch_into_index` two-way merge accrued `O(M·N̄)` over the chain. For 787 commits × ~9k ops this measured ~11 minutes on Lambda single-vCPU. Silent in logs because `apply_commit`'s span lives in `fluree_db_novelty`, not in any rebuild target most filters include.

2. **`ApiFulltextConfigProvider::resolve` always loaded full `LedgerState`.** Even when the ledger had never written `f:LedgerConfig`, `resolve` walked every commit via `load_commit_by_id` (`read_commit_v4`) just to discover the config graph was empty. ~30s of wasted full-blob reads + zstd decompresses + flake construction before the rebuild even started.

The provider regression originated in fluree/db-r commit `4d6ff8fc "fulltext fixes/enahnce"` on the unmerged `misc/fixes` branch (a fix for the "Solo bug report 2026-04-23" referenced in `fluree-db-api/tests/it_query_fulltext.rs:863-868`). The novelty regression has been there longer but only surfaced once the provider started forcing it on every reindex.

`BranchedContentStore` separately doesn't implement `get_range`, so PR fluree/db-r#158's envelope-only byte-range probe falls back to full-blob fetch via the trait default for branched ledgers. The dataset-in-question's main branch isn't branched so this isn't the blocking cause for them, but it's a regression vector waiting for the next branched ledger reindex.

## Changes

### `Novelty::bulk_apply_commits` (commit 1, `51217f33b`)

`fluree-db-novelty/src/lib.rs` — new bulk path designed for first-load / catch-up. One ingest pass routes flakes per-graph, parallel sort by identity-then-t, linear set-semantics dedup walk (matches `apply_commit`'s `fact_currently_asserted_in_graph` skip rule for assertions; always keeps retractions), then four parallel sorts to build SPOT/PSOT/POST/OPST. `O(N log N)` total regardless of commit count.

`fluree-db-ledger/src/lib.rs::load_novelty` — switches the deferred-batch replay loop from per-commit `apply_commit` to a single `bulk_apply_commits` call. dict-novelty population still runs per-batch in commit order so overlay translation invariants are preserved.

### Range-aware `BranchedContentStore` (commit 1, `51217f33b`)

`fluree-db-core/src/storage.rs` — implements `ContentStore::get_range` on `BranchedContentStore`. Mirrors `get`'s ancestry-fallback semantics, calling `get_range` natively on each ancestor so range-capable backends keep their byte-range optimization across the entire chain.

### Envelope-only short-circuit (commit 2, `d5e03c27d`)

`fluree-db-core/src/commit.rs` — surfaces `graph_delta` on the public `CommitEnvelope` (the binary envelope already encoded it; the v4 reader was dropping it on the floor). Adds new public helper `first_t_where_graph_registered<C: ContentStore>(store, head, iri)` that walks the DAG via `load_commit_envelope_by_id` (byte-range ~128 KiB per envelope) and returns the lowest `t` where `iri` appears in any commit's `graph_delta`, or `None` if it never does. v3 chains return `None` (v3 envelopes never carried `graph_delta`) — callers fall through to a full load on `None`.

`fluree-db-api/src/indexer_fulltext_provider.rs::resolve` — runs the envelope-only probe before `LedgerState::load`. If `config_graph_iri(ledger_id)` is never registered in any commit's `graph_delta`, returns an empty configured-properties list immediately. No `LedgerState::load`, no novelty build, no full commit reads. If the IRI is found, falls through to the existing load + `resolve_ledger_config` path — which is itself fast now thanks to `bulk_apply_commits`.

### Regression tests (commit 3)

`fluree-db-api/tests/it_reindex_pre_build_perf.rs` (new):

- **`first_t_where_graph_registered_no_full_reads_when_iri_absent`** — deterministic `CountingContentStore` test asserting the envelope walk uses only `get_range`, never `get`, when the target IRI is missing.
- **`first_t_where_graph_registered_returns_lowest_t_when_iri_present`** — confirms the helper finds the earliest registration `t`.
- **`orchestrator_first_reindex_no_config_completes_quickly`** — end-to-end orchestrator-path reindex of a 200-commit no-config ledger via `BackgroundIndexerWorker` matching the AWS Lambda wiring (`with_fulltext_config_provider`), with a 60s wall-clock budget far below the 13-minute Lambda waiter that motivated the fix.

## Effect on the original reindex scenario

Pre-fix (CloudWatch evidence, requestId `6e44e74e-1c8e-411b-a8b7-b73d8b268db8`, cold start `2026-04-30T16:21:35`):

- `LedgerState::load_novelty` walked all 787 commits via `read_commit_v4` in 29s
- `apply_commit` × 787 in `O(N²)` replay then ran for 11+ minutes silently
- Lambda waiter timed out at 13 minutes
- Lambda function timed out at 15 minutes before any rebuild progress

Post-fix (projected from in-process timings + Lambda ratios):

- Envelope-only probe — ~787 byte-range reads, ~5-8s end-to-end on Lambda
- `first_t_where_graph_registered` returns `None`. It has no `f:LedgerConfig` — verified via DynamoDB query of nameservice, where `pk=dataset:main, sk=config` shows `config_v: 0` and no `config_id` field.
- `ApiFulltextConfigProvider::resolve` returns `Vec::new()` immediately. No `LedgerState::load`, no novelty build.
- Rebuild proceeds normally — Phase A 31s, Phase B ~10s with K=3, Phase C tiny, Phase D 12s. Total reindex 60-90s, well under 900s.

For ledgers with config in commits (test path `fulltext_configured_property_first_build_via_provider`, `fulltext_configured_property_picked_up_by_build_index_for_ledger`, etc.), the envelope walk falls through to the full load path — which is now fast thanks to `bulk_apply_commits`. Behavior unchanged from a correctness standpoint.

## Diagnosis methodology

Iteratively bumped Lambda `RUST_LOG` across cold starts to localize the silent stretch:

1. `INFO` baseline — only orchestrator + waiter messages visible, the 13-minute stretch invisible.
2. `info,fluree_db_indexer=debug,fluree_db_core::commit=debug,...` — surfaced the 1574 = 2 × 787 `read_commit_v4` events, bounded the catch-up at 29s. Span tag `name:"load_commit"` on every event traced the calls to `load_commit_by_id`.
3. Code audit (`fluree-db-indexer/src/lib.rs:122-126` → `fluree-db-api/src/indexer_fulltext_provider.rs:43-82` → `fluree-db-ledger/src/lib.rs::load_novelty:284`) located both regressions.
4. DynamoDB inspection of the symptomatic NsRecord confirmed `config_id: None`, validating the envelope-short-circuit fast path.

Audit of the proposed fix by an independent agent caught one early incorrect direction (skipping the provider on `index_head_id.is_none()` would have silently broken config-via-commits on first build, failing `fulltext_configured_property_first_build_via_provider`). The final shape preserves correctness for that path while still avoiding the slow walk for no-config ledgers.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 6014/6014 tests pass (11 skipped — feature-gated S3 testcontainers paths run separately)
- [x] Existing `fulltext_configured_property_first_build_via_provider` and friends still pass — confirms config-via-commits fulltext path on first reindex is preserved
- [x] Existing `it_rebuild_fetch_counts.rs` still passes — confirms Phase A/B fetch contract from PR #158 is preserved
- [x] Existing `it_indexing_workflow.rs` passes — confirms orchestrator + manual-trigger paths unchanged
- [x] New `it_reindex_pre_build_perf.rs`: `first_t_where_graph_registered_no_full_reads_when_iri_absent`, `first_t_where_graph_registered_returns_lowest_t_when_iri_present`, `orchestrator_first_reindex_no_config_completes_quickly`
- [ ] **Lambda smoke test on original dataset** — after this PR merges and the indexing Lambda redeploys, confirm the reindex completes well under 900s

## Notes

Read-path only on the `BranchedContentStore` change. No on-disk format changes. `CommitEnvelope::graph_delta` is a new public field, but the binary encoding already carried it — only the v4 reader surfaced it on the public type.

v3 chains never encoded `graph_delta` on the envelope and will always return `None` from `first_t_where_graph_registered`. Callers that need v3 compatibility should fall back to a full load on `None`, which `ApiFulltextConfigProvider` already does.

Out of scope, follow-up candidates:

- Parallelize the envelope walk in `first_t_where_graph_registered` via `buffered(K)` for very long chains.
- Extend the orchestrator to expose its content store for test instrumentation so the wall-clock budget test can also assert fetch counts deterministically.
- Audit other `LedgerState::load` callers (`merge.rs:543`, `rebase.rs:348`, `ledger_info.rs:539`) for similar slow-path opportunities now that the bulk-load infrastructure exists.
