### PR TITLE
refactor: Remove `history_mode` from `ExecutionContext` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ __pycache__/
 # Test database (generated data)
 /test-database/
 
+# Benchmark inputs/outputs — never tracked
+/benchmarks/
+
 benchmarks/bsbm/bsbm100m_results_quick.xml
 benchmarks/bsbm/bsbm100m_results_v2.xml
 benchmarks/bsbm/bsbm100m_results.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,20 +1086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bench-filter-query"
-version = "4.0.2"
-dependencies = [
- "fluree-db-api",
- "fluree-db-core",
- "fluree-db-nameservice",
- "fluree-db-novelty",
- "fluree-db-query",
- "rand 0.8.5",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ members = [
     "fluree-search-httpd",
     "fluree-db-cli",
     "fluree-db-memory",
-    "bench-filter-query",
 ]
 exclude = ["testsuite-sparql"]
 

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -10,7 +10,7 @@ use crate::query::helpers::{
 use crate::view::{DataSetDb, QueryInput};
 use crate::{ApiError, ExecutableQuery, Fluree, QueryResult, Result, Tracker, TrackingOptions};
 use fluree_db_query::execute::{
-    execute_prepared, prepare_execution_with_binary_store, ContextConfig,
+    execute_prepared, prepare_execution_with_config, ContextConfig, PrepareConfig,
 };
 use fluree_db_query::r2rml::{R2rmlProvider, R2rmlTableProvider};
 
@@ -575,15 +575,21 @@ impl Fluree {
 
         let db = primary.as_graph_db_ref();
 
-        let prepared =
-            prepare_execution_with_binary_store(db, executable, primary.binary_store.as_ref())
-                .await
-                .map_err(query_error_to_api_error)?;
-
+        // Detect history mode from the dataset spec *before* prepare so the
+        // planner can construct mode-aware operators in a single pass.
         let (from_t, to_t, history_mode) = match dataset.history_time_range() {
             Some((hist_from, hist_to)) => (Some(hist_from), hist_to, true),
             None => (None, primary.t, false),
         };
+
+        let prepare_config = if history_mode {
+            PrepareConfig::history(primary.binary_store.as_ref())
+        } else {
+            PrepareConfig::current(primary.binary_store.as_ref())
+        };
+        let prepared = prepare_execution_with_config(db, executable, &prepare_config)
+            .await
+            .map_err(query_error_to_api_error)?;
 
         // Binary scans rely on a ledger-specific binary index store. For datasets that span
         // multiple ledgers, using only the primary view's store will silently drop results.
@@ -697,14 +703,19 @@ impl Fluree {
 
         let db = primary.as_graph_db_ref();
 
-        let prepared =
-            prepare_execution_with_binary_store(db, executable, primary.binary_store.as_ref())
-                .await?;
-
+        // Detect history mode from the dataset spec *before* prepare so the
+        // planner can construct mode-aware operators in a single pass.
         let (from_t, to_t, history_mode) = match dataset.history_time_range() {
             Some((hist_from, hist_to)) => (Some(hist_from), hist_to, true),
             None => (None, primary.t, false),
         };
+
+        let prepare_config = if history_mode {
+            PrepareConfig::history(primary.binary_store.as_ref())
+        } else {
+            PrepareConfig::current(primary.binary_store.as_ref())
+        };
+        let prepared = prepare_execution_with_config(db, executable, &prepare_config).await?;
 
         let primary_ledger_id: &str = primary.ledger_id.as_ref();
         let is_single_ledger_dataset = dataset

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -659,7 +659,6 @@ impl Fluree {
             fulltext_providers: fulltext_map.as_ref(),
             english_lang_id,
             remote_service: self.remote_service_executor(),
-            history_mode,
             from_t,
             strict_bind_errors: true,
             ..Default::default()
@@ -776,7 +775,6 @@ impl Fluree {
             fulltext_providers: fulltext_map.as_ref(),
             english_lang_id,
             remote_service: self.remote_service_executor(),
-            history_mode,
             from_t,
             strict_bind_errors: true,
             ..Default::default()

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -11,7 +11,7 @@ use crate::query::helpers::{
 use crate::view::{GraphDb, QueryInput};
 use crate::{ApiError, ExecutableQuery, Fluree, QueryResult, Result, Tracker, TrackingOptions};
 use fluree_db_query::execute::{
-    execute_prepared, prepare_execution_with_binary_store, ContextConfig,
+    execute_prepared, prepare_execution_with_config, ContextConfig, PrepareConfig,
 };
 use fluree_db_query::ir::{GraphName, Pattern};
 use fluree_db_query::r2rml::{R2rmlProvider, R2rmlTableProvider};
@@ -603,10 +603,11 @@ impl Fluree {
         r2rml_table_provider: &'b dyn fluree_db_query::r2rml::R2rmlTableProvider,
     ) -> Result<Vec<crate::Batch>> {
         let db_ref = db.as_graph_db_ref();
-        let prepared =
-            prepare_execution_with_binary_store(db_ref, executable, db.binary_store.as_ref())
-                .await
-                .map_err(query_error_to_api_error)?;
+        // Single-graph view: no dataset-level history detection — current state.
+        let prepare_config = PrepareConfig::current(db.binary_store.as_ref());
+        let prepared = prepare_execution_with_config(db_ref, executable, &prepare_config)
+            .await
+            .map_err(query_error_to_api_error)?;
 
         let spatial_map = db.binary_store.as_ref().map(|s| s.spatial_provider_map());
         // Perf guardrail: skip fulltext arena map + `"en"` lang_id resolution
@@ -673,9 +674,9 @@ impl Fluree {
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<Vec<crate::Batch>, fluree_db_query::QueryError> {
         let db_ref = db.as_graph_db_ref();
-        let prepared =
-            prepare_execution_with_binary_store(db_ref, executable, db.binary_store.as_ref())
-                .await?;
+        // Single-graph view: no dataset-level history detection — current state.
+        let prepare_config = PrepareConfig::current(db.binary_store.as_ref());
+        let prepared = prepare_execution_with_config(db_ref, executable, &prepare_config).await?;
 
         let spatial_map = db.binary_store.as_ref().map(|s| s.spatial_provider_map());
         // Perf guardrail: skip fulltext arena map + `"en"` lang_id resolution

--- a/fluree-db-api/tests/it_query_history_combinations.rs
+++ b/fluree-db-api/tests/it_query_history_combinations.rs
@@ -1,0 +1,391 @@
+//! History-mode coverage for compound query shapes: history × {OPTIONAL,
+//! UNION, FILTER NOT EXISTS, count fast path}.
+//!
+//! These exercise the planner-mode refactor's late-builder threading: each
+//! of these patterns constructs subplans inside operator `open()` (e.g.
+//! `OptionalOperator::PlanTreeOptionalBuilder::build`,
+//! `UnionOperator::next_batch`, `ExistsOperator::has_match`). Pre-refactor,
+//! those late builders called `PlanningContext::current()` directly, so a
+//! history-range outer query would silently collapse retracts inside the
+//! compound block. Post-refactor, the `planning` field captured at
+//! construction is threaded into every late `build_where_operators_seeded`
+//! call, so the inner subplans run in the same temporal mode as the outer.
+//!
+//! Each test:
+//! 1. Sets up a small ledger with both asserts and retracts (so history
+//!    mode produces strictly more rows than current mode).
+//! 2. Runs the query in history mode and expects retract events to appear
+//!    inside the compound construct.
+//! 3. Runs the same query in current mode as a baseline so a regression
+//!    would show up as identical row counts in both modes.
+//!
+//! The fast-path test is the inverse: a query shape that *would* normally
+//! trigger a count fast path (`SELECT (COUNT(*) AS ?c) WHERE { ?s <p> <o> }`)
+//! must NOT take the fast path in history mode — it has to plan the full
+//! scan tree so retract events are counted. Verified by checking that
+//! history-mode count > current-mode count when retracts exist.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
+use serde_json::json;
+
+fn ctx() -> serde_json::Value {
+    json!({ "ex": "http://example.org/" })
+}
+
+async fn reindex_to_current(fluree: &fluree_db_api::Fluree, ledger_id: &str) -> i64 {
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    fluree
+        .index_status(ledger_id)
+        .await
+        .expect("index_status")
+        .index_t
+}
+
+/// Three-document fixture used by the OPTIONAL / UNION / FILTER tests.
+///
+/// - `ex:alice`: gets `ex:name = "Alice"` and `ex:tag = "tagged"` at t=1.
+///   At t=2 the name is upserted to "Alice Smith" (retract + new assert).
+///   At t=3 the tag is retracted (no new assert) via a separate
+///   `where`/`delete` update.
+/// - `ex:bob`:   gets `ex:name = "Bob"` at t=1, no tag, no other changes.
+/// - `ex:carol`: gets `ex:age = 30` at t=1 (no `ex:name`, no tag).
+///
+/// The retract-only tag on alice is the key for the FILTER NOT EXISTS
+/// test: in history mode the inner subplan must see the retract event,
+/// while in current mode the tag is gone.
+///
+/// Reindex runs after t=1 and again after t=3 so both the t=2 name retract
+/// and the t=3 tag retract land in the history sidecar rather than in
+/// plain novelty.
+async fn build_three_doc_ledger() -> (fluree_db_api::Fluree, &'static str, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().to_str().unwrap().to_string();
+    let fluree = FlureeBuilder::file(&path).build().expect("build");
+    let ledger_id = "test/history-combos:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    let tx1 = json!({
+        "@context": ctx(),
+        "@graph": [
+            { "@id": "ex:alice", "ex:name": "Alice", "ex:tag": "tagged" },
+            { "@id": "ex:bob",   "ex:name": "Bob" },
+            { "@id": "ex:carol", "ex:age":  30 },
+        ],
+    });
+    let r1 = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    assert_eq!(r1.receipt.t, 1);
+
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 1);
+
+    // t=2: upsert alice.name (retract "Alice", new assert "Alice Smith").
+    // t=3: retract alice.tag via a separate `where`/`delete` update so the
+    // deletion doesn't collide with the upsert.
+    let tx2 = json!({
+        "@context": ctx(),
+        "@id": "ex:alice",
+        "ex:name": "Alice Smith",
+    });
+    let r2 = fluree.upsert(r1.ledger, &tx2).await.expect("tx2");
+    assert_eq!(r2.receipt.t, 2);
+
+    let tx3 = json!({
+        "@context": ctx(),
+        "where":  { "@id": "ex:alice", "ex:tag": "?_tag" },
+        "delete": { "@id": "ex:alice", "ex:tag": "?_tag" },
+    });
+    let r3 = fluree.update(r2.ledger, &tx3).await.expect("delete tag");
+    assert_eq!(r3.receipt.t, 3);
+
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 3);
+
+    (fluree, ledger_id, tmp)
+}
+
+async fn run_query(
+    fluree: &fluree_db_api::Fluree,
+    q: &serde_json::Value,
+) -> Vec<serde_json::Value> {
+    let result = fluree
+        .query_from()
+        .jsonld(q)
+        .format(FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .expect("query");
+    let value = serde_json::to_value(&result.result).expect("serialize");
+    value.as_array().cloned().unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// History × OPTIONAL
+//
+// Outer: every subject. OPTIONAL: `?s ex:name ?n`. Carol has no name so the
+// optional is unbound for her; Alice's name has a retract event at t=2 in
+// history mode.
+//
+// Current mode: 3 outer rows, alice/bob have name bindings, carol's name is
+//   unbound. Alice's name is "Alice Smith" (the live value).
+// History mode: optional inside a history-range outer must capture the
+//   retract at t=2 → alice yields three name events ("Alice" assert@1,
+//   "Alice" retract@2, "Alice Smith" assert@2) instead of one.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn history_optional_emits_retracts_inside_optional_block() {
+    let (fluree, ledger_id, _tmp) = build_three_doc_ledger().await;
+
+    let q_history = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?s", "?n", "?op"],
+        "where": [
+            // Outer pivot: anyone with either name or age. Uses UNION so
+            // we exercise nested late-builder threading too.
+            ["union",
+                [{ "@id": "?s", "ex:name": "?_anyname" }],
+                [{ "@id": "?s", "ex:age":  "?_anyage" }]
+            ],
+            // OPTIONAL is the late-builder seam: pre-refactor this would
+            // silently plan as Current even when the outer is History.
+            ["optional", { "@id": "?s", "ex:name": {"@value": "?n", "@op": "?op"} }],
+        ],
+    });
+
+    let rows = run_query(&fluree, &q_history).await;
+
+    // Count the alice rows that came through the OPTIONAL block. In history
+    // mode we expect both the retract of "Alice" and the assert of "Alice
+    // Smith" at t=2, plus the original "Alice" assert at t=1.
+    let alice_name_events: Vec<_> = rows
+        .iter()
+        .filter(|r| {
+            r.get("?s")
+                .and_then(|s| s.get("@id"))
+                .and_then(|i| i.as_str())
+                .map(|s| s.ends_with("alice"))
+                .unwrap_or(false)
+        })
+        .filter(|r| r.get("?n").and_then(|n| n.get("@value")).is_some())
+        .collect();
+
+    assert!(
+        alice_name_events.len() >= 3,
+        "history × OPTIONAL must surface alice's retract event from inside \
+         the OPTIONAL block (expected ≥3 name events for alice, got {}); \
+         rows: {rows:#?}",
+        alice_name_events.len()
+    );
+
+    let has_retract = alice_name_events.iter().any(|r| {
+        r.get("?op")
+            .and_then(|o| o.get("@value").or(Some(o)))
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
+    });
+    assert!(
+        has_retract,
+        "history × OPTIONAL must include at least one retract (?op=false) \
+         for alice's name; got {alice_name_events:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// History × UNION
+//
+// Each branch of the UNION is its own pattern list, planned at runtime
+// inside `UnionOperator::next_batch` via `build_where_operators_seeded`.
+// In history mode every branch must inherit `History`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn history_union_emits_retracts_in_branches() {
+    let (fluree, ledger_id, _tmp) = build_three_doc_ledger().await;
+
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?s", "?v", "?op"],
+        "where": [
+            ["union",
+                [{ "@id": "?s", "ex:name": {"@value": "?v", "@op": "?op"} }],
+                [{ "@id": "?s", "ex:age":  {"@value": "?v", "@op": "?op"} }]
+            ],
+        ],
+    });
+
+    let rows = run_query(&fluree, &q).await;
+
+    let retracts: Vec<_> = rows
+        .iter()
+        .filter(|r| {
+            r.get("?op")
+                .and_then(|o| o.get("@value").or(Some(o)))
+                .and_then(serde_json::Value::as_bool)
+                == Some(false)
+        })
+        .collect();
+
+    assert!(
+        !retracts.is_empty(),
+        "history × UNION must include at least one retract event from a \
+         branch (alice's name retract at t=2); rows: {rows:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// History × FILTER NOT EXISTS
+//
+// FILTER NOT EXISTS plans a per-row inner subplan via
+// `eval_exists_for_row` → `build_where_operators_seeded`. The inner plan
+// must inherit `History` so its semantics match the outer history-range
+// query.
+//
+// Discriminating shape: alice has a tag asserted at t=1 and retracted at
+// t=3 with no re-assert; bob never has a tag. The expected result with
+// correct History inheritance is `{ex:bob}` only — alice is filtered out
+// because History EXISTS sees her in-range tag events. A regression to
+// `Current` for the inner subplan would also keep alice (her tag is
+// currently gone, so EXISTS would be false), and the assertion below
+// fails with a clear message.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn history_filter_not_exists_inner_inherits_history() {
+    let (fluree, ledger_id, _tmp) = build_three_doc_ledger().await;
+
+    // FILTER NOT EXISTS routes through `filter.rs::eval_exists_for_row` →
+    // `build_where_operators_seeded`. The inner EXISTS subplan must inherit
+    // the outer planning context (History here), or it silently downgrades
+    // to current state and reports the wrong existence.
+    //
+    // Discriminating shape: alice's `ex:tag` was asserted at t=1 and
+    // retracted at t=3 (no new assert). bob never had a tag.
+    //
+    //   Outer: ?s ex:name ?n (history range [1, latest])
+    //     → alice rows: assert@1 "Alice", retract@2 "Alice", assert@2 "Alice Smith"
+    //     → bob row:    assert@1 "Bob"
+    //
+    //   FILTER NOT EXISTS { ?s ex:tag ?_t }:
+    //     - History semantics (correct, what this refactor enforces):
+    //       The inner subquery scans `?s ex:tag ?_t` over the same range.
+    //       For alice the tag has events (assert@1, retract@3), so EXISTS
+    //       holds → NOT EXISTS is false → all alice rows are filtered out.
+    //       For bob there are no tag events → NOT EXISTS holds → bob is
+    //       kept.
+    //     - Current-state regression: the inner EXISTS sees the live
+    //       state. alice's tag is currently retracted, so EXISTS is false
+    //       → NOT EXISTS true → alice rows are kept. The result would
+    //       include alice.
+    //
+    // The discriminating assertion: result subjects must be `{bob}` only.
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?s"],
+        "where": [
+            { "@id": "?s", "ex:name": "?_n" },
+            ["filter",
+                ["not-exists", { "@id": "?s", "ex:tag": "?_t" }]
+            ],
+        ],
+    });
+
+    let rows = run_query(&fluree, &q).await;
+    let subjects: std::collections::BTreeSet<String> = rows
+        .iter()
+        .filter_map(|r| {
+            r.get("?s")
+                .and_then(|s| s.get("@id"))
+                .and_then(|i| i.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+
+    let expected: std::collections::BTreeSet<String> = ["ex:bob".to_string()].into_iter().collect();
+    assert_eq!(
+        subjects, expected,
+        "FILTER NOT EXISTS inner subplan must inherit History — alice's \
+         retracted-but-historically-asserted tag must make EXISTS true and \
+         filter alice out. If the result also contains alice, the inner \
+         EXISTS silently downgraded to Current. Got: {subjects:?}; rows: {rows:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// History × count fast path
+//
+// The query shape `SELECT (COUNT(*) AS ?c) WHERE { ?s <p> ?o }` would
+// normally trigger a count fast path that uses leaflet metadata to skip
+// the scan entirely. In history mode that fast path is wrong (it counts
+// current-state rows, ignoring retracts), so the planner declines to
+// take it (Phase 5 of the refactor).
+//
+// Verification: history-mode count must be strictly greater than
+// current-mode count when retracts exist (the retract event is its own
+// row in history but doesn't count in current state).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn history_count_does_not_take_current_state_fast_path() {
+    let (fluree, ledger_id, _tmp) = build_three_doc_ledger().await;
+
+    // Current-state count: 2 name rows (alice "Alice Smith", bob "Bob").
+    let q_current = json!({
+        "@context": ctx(),
+        "from": ledger_id,
+        "select": ["(as (count *) ?c)"],
+        "where": [{ "@id": "?s", "ex:name": "?n" }],
+    });
+    let current_rows = run_query(&fluree, &q_current).await;
+    let current_count = current_rows
+        .first()
+        .and_then(|r| r.get("?c"))
+        .and_then(|c| c.get("@value"))
+        .and_then(serde_json::Value::as_i64)
+        .expect("current count");
+    assert_eq!(
+        current_count, 2,
+        "current-state count must be 2 (alice's live name + bob's name); \
+         rows: {current_rows:#?}"
+    );
+
+    // History-range count: 4 name events (alice assert@1, alice retract@2,
+    // alice assert@2 "Alice Smith", bob assert@1).
+    let q_history = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["(as (count *) ?c)"],
+        "where": [{ "@id": "?s", "ex:name": "?n" }],
+    });
+    let history_rows = run_query(&fluree, &q_history).await;
+    let history_count = history_rows
+        .first()
+        .and_then(|r| r.get("?c"))
+        .and_then(|c| c.get("@value"))
+        .and_then(serde_json::Value::as_i64)
+        .expect("history count");
+
+    assert!(
+        history_count > current_count,
+        "history-mode count must exceed current-state count (the retract \
+         event is its own row); current={current_count}, history={history_count}; \
+         if these are equal, the fast path is being taken in history mode \
+         (Phase 5 regression)"
+    );
+    assert_eq!(
+        history_count, 4,
+        "expected 4 history events (alice assert@1, retract@2, assert@2, \
+         bob assert@1); got {history_count}; rows: {history_rows:#?}"
+    );
+}

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -1,8 +1,11 @@
 //! Indexed history-range scan operator.
 //!
-//! Wraps `BinaryScanOperator` and, when `ctx.history_mode` is set and a
-//! binary store is attached, replaces its cursor walk with a
-//! three-source merge:
+//! Single-purpose: constructed only when the planner has captured
+//! [`TemporalMode::History`](crate::TemporalMode::History) at scan
+//! construction time. Current-state queries are served by
+//! [`BinaryScanOperator`] directly and never reach this operator.
+//!
+//! Replaces the regular cursor walk with a three-source merge:
 //!
 //! 1. **History sidecar entries** (`HistEntryV2`) for each matching
 //!    leaflet — assert + retract events with explicit op.
@@ -12,9 +15,11 @@
 //!    own `flake.op`.
 //!
 //! The merged flake list is handed to the existing
-//! `flakes_to_bindings` pipeline via `prime_history_flakes`, which is
-//! already history-aware (line ~704 in `binary_scan.rs` copies
-//! `flake.op` onto the emitted `Binding::Lit`).
+//! `flakes_to_bindings` pipeline via `prime_history_flakes`, which
+//! preserves the per-flake `op` on the emitted `Binding::Lit` (the
+//! `op`-emit branch in `binary_scan.rs::flakes_to_bindings` runs
+//! whenever flakes were primed via `prime_history_flakes`, regardless
+//! of any runtime context flag).
 //!
 //! ## Narrowing
 //!
@@ -89,15 +94,14 @@ use crate::operator::Operator;
 use crate::triple::TriplePattern;
 use crate::var_registry::VarId;
 
-/// Scan operator that activates a dedicated history-range walk when
-/// `ctx.history_mode` is true.
+/// Scan operator for history-range queries.
 ///
-/// When history mode is not active, this wrapper transparently delegates
-/// to `BinaryScanOperator::open` — the regular scan path is unchanged.
-/// When history mode is active, the operator runs its own three-source
-/// merge (sidecar + base + novelty) regardless of whether a binary store
-/// is attached: an unindexed ledger just skips the persisted pass and
-/// takes the full event stream from novelty.
+/// Single-purpose: the planner picks this operator only when
+/// [`TemporalMode::History`](crate::TemporalMode::History) is captured at
+/// scan construction. It always runs its own three-source merge — sidecar,
+/// base, and novelty — regardless of whether a binary store is attached.
+/// An unindexed ledger just skips the persisted pass and takes the full
+/// event stream from novelty.
 pub struct BinaryHistoryScanOperator {
     inner: BinaryScanOperator,
     pattern: TriplePattern,
@@ -123,7 +127,7 @@ impl BinaryHistoryScanOperator {
         emit: EmitMask,
         index_hint: Option<IndexType>,
     ) -> Self {
-        let inner = BinaryScanOperator::new_with_emit_and_index(
+        let inner = BinaryScanOperator::for_history_inner(
             pattern.clone(),
             object_bounds.clone(),
             inline_ops,
@@ -422,10 +426,6 @@ impl Operator for BinaryHistoryScanOperator {
     }
 
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
-        if !ctx.history_mode {
-            // Non-history queries go through the unchanged scan path.
-            return self.inner.open(ctx).await;
-        }
         // History mode: we always collect flakes ourselves (with explicit op
         // preservation) rather than going through `BinaryScanOperator::open`.
         // The non-history path in the core `range_with_overlay` genesis
@@ -434,6 +434,11 @@ impl Operator for BinaryHistoryScanOperator {
         // collector handles both the indexed and novelty-only cases
         // correctly. Policy enforcement is applied in
         // `collect_history_flakes` via `filter_flakes_by_policy`.
+        //
+        // Single-purpose: this operator is only constructed by
+        // `ScanDatasetBuilder` when its captured mode is `History`. The
+        // current-state path goes through `BinaryScanOperator` directly and
+        // never reaches this function.
         let flakes = self.collect_history_flakes(ctx).await?;
         self.inner.prime_history_flakes(ctx, flakes)
     }

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -185,10 +185,10 @@ pub struct BinaryScanOperator {
     /// When a bound subject IRI cannot be translated to a persisted `s_id`,
     /// keep a widened base scan correct by checking the resolved subject IRI row-by-row.
     unresolved_bound_subject_iri: Option<Arc<str>>,
-    /// Temporal mode captured at planner-time. Replaces what used to be the
-    /// runtime `ctx.history_mode` read for: `op` field on emitted bindings,
-    /// the `t` column projection, and the `RangeOptions::history_mode`
-    /// pass-through to `range_with_overlay` in the genesis fallback path.
+    /// Temporal mode captured at planner-time. Drives the `op` field on
+    /// emitted bindings, the `t` column projection, and the
+    /// `RangeOptions::history_mode` pass-through to `range_with_overlay` in
+    /// the genesis fallback path.
     ///
     /// Single-purpose: when `mode == History`, this operator is constructed
     /// only as the private inner of `BinaryHistoryScanOperator`. When

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -185,6 +185,16 @@ pub struct BinaryScanOperator {
     /// When a bound subject IRI cannot be translated to a persisted `s_id`,
     /// keep a widened base scan correct by checking the resolved subject IRI row-by-row.
     unresolved_bound_subject_iri: Option<Arc<str>>,
+    /// Temporal mode captured at planner-time. Replaces what used to be the
+    /// runtime `ctx.history_mode` read for: `op` field on emitted bindings,
+    /// the `t` column projection, and the `RangeOptions::history_mode`
+    /// pass-through to `range_with_overlay` in the genesis fallback path.
+    ///
+    /// Single-purpose: when `mode == History`, this operator is constructed
+    /// only as the private inner of `BinaryHistoryScanOperator`. When
+    /// `mode == Current`, it is constructed by `ScanDatasetBuilder` directly
+    /// and emits current-state bindings without the `op` channel.
+    mode: crate::temporal_mode::TemporalMode,
 }
 
 /// A filter that can be evaluated on encoded index columns (no term decoding).
@@ -509,8 +519,10 @@ fn range_contains(ranges: &[(u32, u32)], value: u32) -> bool {
 }
 
 impl BinaryScanOperator {
-    /// Create a new scan operator. The `store` and `g_id` are resolved from
-    /// `ExecutionContext` during `open()`.
+    /// Create a new scan operator for current-state queries.
+    ///
+    /// Equivalent to [`new_with_emit_and_index`](Self::new_with_emit_and_index)
+    /// with default emit/index_hint and [`TemporalMode::Current`](crate::TemporalMode::Current).
     pub fn new(
         pattern: TriplePattern,
         object_bounds: Option<ObjectBounds>,
@@ -519,13 +531,58 @@ impl BinaryScanOperator {
         Self::new_with_emit_and_index(pattern, object_bounds, inline_ops, EmitMask::ALL, None)
     }
 
-    /// Create a scan operator with explicit emit mask and index hint.
+    /// Create a scan operator with explicit emit mask and index hint, for
+    /// current-state queries.
+    ///
+    /// History-range scans go through [`BinaryHistoryScanOperator`](crate::BinaryHistoryScanOperator),
+    /// which constructs its inner `BinaryScanOperator` via
+    /// [`for_history_inner`](Self::for_history_inner).
     pub fn new_with_emit_and_index(
         pattern: TriplePattern,
         object_bounds: Option<ObjectBounds>,
         inline_ops: Vec<InlineOperator>,
         emit: EmitMask,
         index_hint: Option<IndexType>,
+    ) -> Self {
+        Self::with_mode(
+            pattern,
+            object_bounds,
+            inline_ops,
+            emit,
+            index_hint,
+            crate::temporal_mode::TemporalMode::Current,
+        )
+    }
+
+    /// Construct the inner scan that backs a [`BinaryHistoryScanOperator`].
+    ///
+    /// Public-but-restricted: only `BinaryHistoryScanOperator` should call
+    /// this; every other current-state scan goes through the public
+    /// constructors above.
+    pub(crate) fn for_history_inner(
+        pattern: TriplePattern,
+        object_bounds: Option<ObjectBounds>,
+        inline_ops: Vec<InlineOperator>,
+        emit: EmitMask,
+        index_hint: Option<IndexType>,
+    ) -> Self {
+        Self::with_mode(
+            pattern,
+            object_bounds,
+            inline_ops,
+            emit,
+            index_hint,
+            crate::temporal_mode::TemporalMode::History,
+        )
+    }
+
+    fn with_mode(
+        pattern: TriplePattern,
+        object_bounds: Option<ObjectBounds>,
+        inline_ops: Vec<InlineOperator>,
+        emit: EmitMask,
+        index_hint: Option<IndexType>,
+        mode: crate::temporal_mode::TemporalMode,
     ) -> Self {
         let s_bound = pattern.s_bound();
         let p_bound = pattern.p_bound();
@@ -586,6 +643,7 @@ impl BinaryScanOperator {
             check_p_eq_o,
             range_iter: None,
             unresolved_bound_subject_iri: None,
+            mode,
         }
     }
 
@@ -692,7 +750,7 @@ impl BinaryScanOperator {
                     // history mode, where the scan emits both asserts
                     // and retracts; current-state scans only ever see
                     // asserts so the distinction would be misleading.
-                    FlakeValue::Ref(r) if ctx.history_mode => {
+                    FlakeValue::Ref(r) if self.mode.is_history() => {
                         Binding::sid_with_t_op(r.clone(), flake.t, flake.op)
                     }
                     FlakeValue::Ref(r) => Binding::sid_with_t(r.clone(), flake.t),
@@ -710,7 +768,7 @@ impl BinaryScanOperator {
                             val: v.clone(),
                             dtc,
                             t: Some(flake.t),
-                            op: if ctx.history_mode {
+                            op: if self.mode.is_history() {
                                 Some(flake.op)
                             } else {
                                 None
@@ -749,7 +807,7 @@ impl BinaryScanOperator {
             to_t: Some(ctx.to_t),
             from_t: ctx.from_t,
             object_bounds: self.object_bounds.clone(),
-            history_mode: ctx.history_mode,
+            history_mode: self.mode.is_history(),
             ..Default::default()
         };
         let mut flakes = range_with_overlay(
@@ -1649,7 +1707,7 @@ impl Operator for BinaryScanOperator {
         // - `t` is only required for history mode
         let mut output = ColumnSet::CORE;
         output.insert(ColumnId::OI);
-        if ctx.history_mode || inline_ops_need_t(&self.inline_ops) {
+        if self.mode.is_history() || inline_ops_need_t(&self.inline_ops) {
             output.insert(ColumnId::T);
         }
         let projection = ColumnProjection {

--- a/fluree-db-query/src/bm25/operator.rs
+++ b/fluree-db-query/src/bm25/operator.rs
@@ -715,8 +715,14 @@ mod tests {
         // Build operator with explicit seed (EmptyOperator) to mimic runner behavior.
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         let mut ctx = ExecutionContext::new(&snapshot, &vars);
         ctx.bm25_provider = Some(&provider);
@@ -756,8 +762,14 @@ mod tests {
 
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         let mut ctx = ExecutionContext::new(&snapshot, &vars);
         ctx.bm25_provider = Some(&provider);

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -83,9 +83,6 @@ pub struct ExecutionContext<'a> {
     pub active_graph: ActiveGraph,
     /// Optional execution tracker (time/fuel/policy)
     pub tracker: Tracker,
-    /// History mode flag - when true, includes both assertions and retractions
-    /// and captures the op (operation) metadata in bindings for @op support.
-    pub history_mode: bool,
     /// When true, bind evaluation errors are treated as query errors.
     pub strict_bind_errors: bool,
     /// Optional binary columnar index store for fast local-file scans.
@@ -186,7 +183,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: Tracker::disabled(),
-            history_mode: false,
             strict_bind_errors: false,
             binary_store: None,
             binary_g_id: 0,
@@ -234,7 +230,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: Tracker::disabled(),
-            history_mode: false,
             strict_bind_errors: false,
             binary_store,
             binary_g_id: db.g_id,
@@ -286,7 +281,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: Tracker::disabled(),
-            history_mode: false,
             strict_bind_errors: false,
             binary_store,
             binary_g_id: db.g_id,
@@ -327,7 +321,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: Tracker::disabled(),
-            history_mode: false,
             strict_bind_errors: false,
             binary_store: None,
             binary_g_id: 0,
@@ -343,12 +336,6 @@ impl<'a> ExecutionContext<'a> {
             eager_materialization: false,
             original_snapshot: snapshot,
         }
-    }
-
-    /// Enable history mode (include assertions and retractions, capture op metadata)
-    pub fn with_history_mode(mut self) -> Self {
-        self.history_mode = true;
-        self
     }
 
     /// Create a new execution context with an overlay provider (novelty)
@@ -373,7 +360,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: Tracker::disabled(),
-            history_mode: false,
             strict_bind_errors: false,
             binary_store: None,
             binary_g_id: 0,
@@ -415,7 +401,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: Tracker::disabled(),
-            history_mode: false,
             strict_bind_errors: false,
             binary_store: None,
             binary_g_id: 0,
@@ -680,7 +665,7 @@ impl<'a> ExecutionContext<'a> {
     ///
     /// Returns `true` when a binary store is present and the query is in
     /// single-ledger mode. Individual call sites may layer additional
-    /// conditions (e.g. `to_t >= base_t`, `!history_mode`).
+    /// conditions (e.g. `to_t >= base_t`).
     pub fn has_binary_store(&self) -> bool {
         if self.is_multi_ledger() || self.binary_store.is_none() {
             return false;
@@ -783,7 +768,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: self.dataset,
             active_graph,
             tracker: self.tracker.clone(),
-            history_mode: self.history_mode,
             strict_bind_errors: self.strict_bind_errors,
             binary_store: self.binary_store.clone(),
             binary_g_id,
@@ -834,7 +818,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: self.dataset,
             active_graph: ActiveGraph::Default,
             tracker: self.tracker.clone(),
-            history_mode: self.history_mode,
             strict_bind_errors: self.strict_bind_errors,
             binary_store: self.binary_store.clone(),
             binary_g_id,
@@ -881,7 +864,6 @@ impl<'a> ExecutionContext<'a> {
             dataset: None,
             active_graph: ActiveGraph::Default,
             tracker: self.tracker.clone(),
-            history_mode: self.history_mode,
             strict_bind_errors: self.strict_bind_errors,
             binary_store: Self::extract_binary_store(graph.snapshot),
             binary_g_id: graph.g_id,

--- a/fluree-db-query/src/dataset_operator.rs
+++ b/fluree-db-query/src/dataset_operator.rs
@@ -26,13 +26,14 @@ use async_trait::async_trait;
 use fluree_db_core::{IndexType, ObjectBounds, Sid};
 
 use crate::binary_history::BinaryHistoryScanOperator;
-use crate::binary_scan::{schema_from_pattern_with_emit, EmitMask};
+use crate::binary_scan::{schema_from_pattern_with_emit, BinaryScanOperator, EmitMask};
 use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
 use crate::dataset::ActiveGraphs;
 use crate::error::{QueryError, Result};
 use crate::operator::inline::{extend_schema, InlineOperator};
 use crate::operator::{BoxedOperator, Operator, OperatorState};
+use crate::temporal_mode::TemporalMode;
 use crate::triple::TriplePattern;
 use crate::var_registry::VarId;
 
@@ -63,15 +64,19 @@ pub trait DatasetBuilder: Send + Sync {
 
 /// Builder for triple-pattern scans across dataset graphs.
 ///
-/// Produces a [`BinaryScanOperator`] for each graph. This is the primary
-/// builder implementation — other backends (BM25, vector, etc.) will add
-/// their own builders in follow-up steps.
+/// Produces a mode-specific scan operator for each graph:
+/// - [`TemporalMode::Current`] → [`BinaryScanOperator`] directly.
+/// - [`TemporalMode::History`] → [`BinaryHistoryScanOperator`].
+///
+/// Mode is captured at planner-time construction, not read from the runtime
+/// `ExecutionContext` — every operator in the tree is single-purpose.
 pub struct ScanDatasetBuilder {
     pattern: TriplePattern,
     object_bounds: Option<ObjectBounds>,
     inline_ops: Vec<InlineOperator>,
     emit: EmitMask,
     index_hint: Option<IndexType>,
+    mode: TemporalMode,
     schema: Arc<[VarId]>,
 }
 
@@ -82,6 +87,7 @@ impl ScanDatasetBuilder {
         inline_ops: Vec<InlineOperator>,
         emit: EmitMask,
         index_hint: Option<IndexType>,
+        mode: TemporalMode,
     ) -> Self {
         let (base_schema, _, _, _) = schema_from_pattern_with_emit(&pattern, emit);
         let schema: Arc<[VarId]> = extend_schema(&base_schema, &inline_ops).into();
@@ -91,27 +97,38 @@ impl ScanDatasetBuilder {
             inline_ops,
             emit,
             index_hint,
+            mode,
             schema,
         }
+    }
+
+    /// Returns the temporal mode this builder will use when constructing scans.
+    #[inline]
+    pub fn mode(&self) -> TemporalMode {
+        self.mode
     }
 }
 
 impl DatasetBuilder for ScanDatasetBuilder {
     fn build(&self) -> Result<BoxedOperator> {
-        // Use the history-aware wrapper at all scan sites. For non-history
-        // queries it transparently delegates to `BinaryScanOperator::open`
-        // — no behavior change on the hot path. For history queries
-        // (`ctx.history_mode == true`) it runs the dedicated sidecar+base
-        // +novelty merge in its own `open`.
-        Ok(Box::new(
-            BinaryHistoryScanOperator::new_with_emit_and_index(
+        match self.mode {
+            TemporalMode::History => Ok(Box::new(
+                BinaryHistoryScanOperator::new_with_emit_and_index(
+                    self.pattern.clone(),
+                    self.object_bounds.clone(),
+                    self.inline_ops.clone(),
+                    self.emit,
+                    self.index_hint,
+                ),
+            )),
+            TemporalMode::Current => Ok(Box::new(BinaryScanOperator::new_with_emit_and_index(
                 self.pattern.clone(),
                 self.object_bounds.clone(),
                 self.inline_ops.clone(),
                 self.emit,
                 self.index_hint,
-            ),
-        ))
+            ))),
+        }
     }
 
     fn schema(&self) -> &[VarId] {
@@ -163,14 +180,27 @@ impl DatasetOperator {
 
     /// Convenience constructor for a triple-pattern scan wrapped in a
     /// dataset operator.
+    ///
+    /// `mode` must be captured by the caller at planner-time. Late/dynamic
+    /// builders (joins, optionals, EXISTS/MINUS, etc.) capture mode at their
+    /// own construction time and pass it through here — they do not read it
+    /// from the runtime `ExecutionContext`.
     pub fn scan(
         pattern: TriplePattern,
         object_bounds: Option<ObjectBounds>,
         inline_ops: Vec<InlineOperator>,
         emit: EmitMask,
         index_hint: Option<IndexType>,
+        mode: TemporalMode,
     ) -> Self {
-        let builder = ScanDatasetBuilder::new(pattern, object_bounds, inline_ops, emit, index_hint);
+        let builder = ScanDatasetBuilder::new(
+            pattern,
+            object_bounds,
+            inline_ops,
+            emit,
+            index_hint,
+            mode,
+        );
         Self::new(Box::new(builder))
     }
 }
@@ -420,7 +450,14 @@ mod tests {
         let pattern =
             TriplePattern::new(Ref::Var(s), Ref::Sid(Sid::new(100, "name")), Term::Var(o));
 
-        let builder = ScanDatasetBuilder::new(pattern, None, Vec::new(), EmitMask::ALL, None);
+        let builder = ScanDatasetBuilder::new(
+            pattern,
+            None,
+            Vec::new(),
+            EmitMask::ALL,
+            None,
+            TemporalMode::Current,
+        );
 
         let schema = builder.schema();
         assert_eq!(schema.len(), 2);

--- a/fluree-db-query/src/dataset_operator.rs
+++ b/fluree-db-query/src/dataset_operator.rs
@@ -193,14 +193,8 @@ impl DatasetOperator {
         index_hint: Option<IndexType>,
         mode: TemporalMode,
     ) -> Self {
-        let builder = ScanDatasetBuilder::new(
-            pattern,
-            object_bounds,
-            inline_ops,
-            emit,
-            index_hint,
-            mode,
-        );
+        let builder =
+            ScanDatasetBuilder::new(pattern, object_bounds, inline_ops, emit, index_hint, mode);
         Self::new(Box::new(builder))
     }
 }

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -72,7 +72,10 @@ use runner::{
     execute_prepared_with_overlay, execute_prepared_with_overlay_tracked,
     execute_prepared_with_policy, execute_prepared_with_r2rml,
 };
-pub use runner::{prepare_execution, prepare_execution_with_binary_store};
+pub use runner::{
+    prepare_execution, prepare_execution_with_binary_store, prepare_execution_with_config,
+    PrepareConfig,
+};
 
 /// Execute a query with an overlay
 ///
@@ -388,7 +391,12 @@ mod tests {
             post_values: None,
         };
 
-        let result = build_operator_tree(&query, &QueryOptions::default(), None);
+        let result = build_operator_tree(
+            &query,
+            &QueryOptions::default(),
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         match result {
             Err(e) => assert!(e.to_string().contains("not found")),
             Ok(_) => panic!("Expected error for invalid select var"),
@@ -409,7 +417,12 @@ mod tests {
 
         let options = QueryOptions::new().with_order_by(vec![SortSpec::asc(VarId(99))]); // Invalid var
 
-        let result = build_operator_tree(&query, &options, None);
+        let result = build_operator_tree(
+            &query,
+            &options,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         match result {
             Err(e) => assert!(e.to_string().contains("Sort variable")),
             Ok(_) => panic!("Expected error for invalid sort var"),
@@ -420,7 +433,12 @@ mod tests {
     fn test_build_where_operators_single_triple() {
         let patterns = vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))];
 
-        let result = where_plan::build_where_operators(&patterns, None, None);
+        let result = where_plan::build_where_operators(
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         assert!(result.is_ok());
 
         let op = result.unwrap();
@@ -437,7 +455,12 @@ mod tests {
             )),
         ];
 
-        let result = where_plan::build_where_operators(&patterns, None, None);
+        let result = where_plan::build_where_operators(
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         assert!(result.is_ok());
     }
 

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -180,7 +180,17 @@ pub async fn execute_with_dataset_tracked<'a>(
     execute_prepared_with_dataset(db, vars, prepared, dataset, Some(tracker)).await
 }
 
-/// Execute a query against a dataset in history mode
+/// Execute a query against a dataset in history mode.
+///
+/// The `_history` suffix is load-bearing: this helper prepares the operator
+/// tree with [`PrepareConfig::history`] so scan operators emit asserts +
+/// retracts and fast paths are gated off at planner-time. Callers that want
+/// current-state semantics should use [`execute_with_dataset`] instead.
+///
+/// The view layer (`view::dataset_query::query_dataset`) has its own
+/// detection logic and goes through `prepare_execution_with_config`
+/// directly; this top-level helper is for callers that already know they
+/// want history-range semantics without going through the view layer.
 pub async fn execute_with_dataset_history<'a>(
     db: GraphDbRef<'a>,
     vars: &VarRegistry,
@@ -188,8 +198,8 @@ pub async fn execute_with_dataset_history<'a>(
     dataset: &'a DataSet<'a>,
     tracker: Option<&'a Tracker>,
 ) -> Result<Vec<Batch>> {
-    let prepared = prepare_execution(db, query).await?;
-    execute_prepared_with_dataset_history(db, vars, prepared, dataset, tracker, true).await
+    let prepared = prepare_execution_with_config(db, query, &PrepareConfig::history(None)).await?;
+    execute_prepared_with_dataset_history(db, vars, prepared, dataset, tracker).await
 }
 
 /// Execute a query against a dataset (multi-graph) with policy enforcement

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -53,6 +53,7 @@ use crate::project::ProjectOperator;
 use crate::sort::SortDirection;
 use crate::sort::SortOperator;
 use crate::stats_query::StatsCountByPredicateOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::triple::{Ref, Term, TriplePattern};
 use crate::var_registry::VarId;
 use fluree_db_core::StatsView;
@@ -2150,8 +2151,9 @@ pub fn build_operator_tree(
     query: &ParsedQuery,
     options: &QueryOptions,
     stats: Option<Arc<StatsView>>,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
-    build_operator_tree_inner(query, options, stats, true)
+    build_operator_tree_inner(query, options, stats, true, planning)
 }
 
 fn build_operator_tree_inner(
@@ -2159,6 +2161,7 @@ fn build_operator_tree_inner(
     options: &QueryOptions,
     stats: Option<Arc<StatsView>>,
     enable_fused_fast_paths: bool,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
     if enable_fused_fast_paths {
         tracing::debug!(
@@ -2177,7 +2180,7 @@ fn build_operator_tree_inner(
         if let Some((pred, scalar, out_var)) = detect_fused_scan_sum_i64(query, options) {
             // Build fallback operator tree without this fast path to preserve correctness in
             // pre-index / history / policy contexts.
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(fused_scan_sum_i64_operator(
                 pred,
                 scalar,
@@ -2191,7 +2194,7 @@ fn build_operator_tree_inner(
     // for homogeneous numeric predicates, scanning only POST `o_key` values.
     if enable_fused_fast_paths {
         if let Some((pred, out_var)) = detect_predicate_avg_numeric(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(predicate_avg_numeric_operator(
                 pred,
                 out_var,
@@ -2204,7 +2207,7 @@ fn build_operator_tree_inner(
     // by scanning POST and counting distinct encoded object IDs.
     if enable_fused_fast_paths {
         if let Some((pred, out_var)) = detect_predicate_count_distinct_object(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_object_operator(
                 pred,
                 out_var,
@@ -2217,7 +2220,7 @@ fn build_operator_tree_inner(
     // when the object is string-dict-backed. This inspects only POST leaflet directory keys.
     if enable_fused_fast_paths {
         if let Some((pred, mode, out_var)) = detect_predicate_minmax_string(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(predicate_min_max_string_operator(
                 pred,
                 mode,
@@ -2230,7 +2233,7 @@ fn build_operator_tree_inner(
     // Fast-path: `COUNT(*)` over one triple with an anchored string-prefix filter.
     if enable_fused_fast_paths {
         if let Some((pred, prefix, out_var)) = detect_string_prefix_count_all(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(string_prefix_count_all_operator(
                 pred,
                 prefix,
@@ -2243,7 +2246,7 @@ fn build_operator_tree_inner(
     // Fast-path: `SUM(xsd:integer(STRSTARTS(?o, "...")))` over one triple.
     if enable_fused_fast_paths {
         if let Some((pred, prefix, out_var)) = detect_string_prefix_sum_strstarts(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(string_prefix_sum_strstarts_operator(
                 pred,
                 prefix,
@@ -2264,7 +2267,7 @@ fn build_operator_tree_inner(
         if let Some((pred, lang_tag, out_var)) =
             detect_predicate_count_rows_lang_filter(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_lang_filter_operator(
                 pred,
                 lang_tag,
@@ -2278,7 +2281,7 @@ fn build_operator_tree_inner(
         if let Some((pred, compare, threshold, out_var)) =
             detect_predicate_count_rows_numeric_compare(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_numeric_compare_operator(
                 pred,
                 compare,
@@ -2292,7 +2295,7 @@ fn build_operator_tree_inner(
     if enable_fused_fast_paths {
         if let Some((tp, filters, out_var)) = detect_count_rows_with_encoded_filters(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             let inline_ops: Vec<InlineOperator> = filters
                 .into_iter()
                 .map(|expr| InlineOperator::Filter(PreparedBoolExpression::new(expr)))
@@ -2303,7 +2306,12 @@ fn build_operator_tree_inner(
                 o: false,
             };
             let scan: BoxedOperator = Box::new(crate::dataset_operator::DatasetOperator::scan(
-                tp, None, inline_ops, emit, None,
+                tp,
+                None,
+                inline_ops,
+                emit,
+                None,
+                planning.mode(),
             ));
             return Ok(Box::new(CountRowsOperator::new(
                 scan,
@@ -2317,7 +2325,7 @@ fn build_operator_tree_inner(
     // answered from PSOT leaflet directory row counts (no scan / no decoding).
     if enable_fused_fast_paths {
         if let Some((pred, out_var)) = detect_predicate_count_rows(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_operator(pred, out_var, Some(fallback))));
         }
     }
@@ -2327,7 +2335,7 @@ fn build_operator_tree_inner(
     // Fires after trivial metadata-only counts but before the remaining specialized fast paths.
     if enable_fused_fast_paths {
         if let Some(plan) = crate::count_plan::try_build_count_plan(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(crate::count_plan_exec::count_plan_operator(
                 plan,
                 Some(fallback),
@@ -2338,7 +2346,7 @@ fn build_operator_tree_inner(
     // Fast-path: `COUNT(*)` for a 2-pattern multicolumn join `?s p1 ?o . ?s p2 ?o`.
     if enable_fused_fast_paths {
         if let Some((p1, p2, out_var)) = detect_multicolumn_join_count_all(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(multicolumn_join_count_all_operator(
                 p1,
                 p2,
@@ -2353,7 +2361,7 @@ fn build_operator_tree_inner(
         if let Some((count_pred, exists_pred, out_var)) =
             detect_exists_join_count_distinct_object(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(exists_join_count_distinct_object_operator(
                 count_pred,
                 exists_pred,
@@ -2367,7 +2375,7 @@ fn build_operator_tree_inner(
     // answered from SPOT leaflet metadata by scanning the blank-node SubjectId range.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_blank_node_subjects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_blank_node_subjects_operator(
                 out_var,
                 Some(fallback),
@@ -2379,7 +2387,7 @@ fn build_operator_tree_inner(
     // answered from PSOT leaflet metadata by counting non-node-ref `o_type` rows.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_literal_objects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_literal_objects_operator(
                 out_var,
                 Some(fallback),
@@ -2391,7 +2399,7 @@ fn build_operator_tree_inner(
     // answered metadata-only from SPOT leaflet `lead_group_count` + boundary correction.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_distinct_subjects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_subjects_operator(
                 out_var,
                 Some(fallback),
@@ -2403,7 +2411,7 @@ fn build_operator_tree_inner(
     // answered metadata-only from PSOT leaflet `p_const` transitions.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_distinct_predicates(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_predicates_operator(
                 out_var,
                 Some(fallback),
@@ -2415,7 +2423,7 @@ fn build_operator_tree_inner(
     // answered metadata-only by summing leaf row_count across a branch manifest.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_triples(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_triples_operator(out_var, Some(fallback))));
         }
     }
@@ -2426,7 +2434,7 @@ fn build_operator_tree_inner(
         if let Some((p1, p2, p3, out_var)) =
             detect_optional_chain_head_join_count_all(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(predicate_optional_chain_head_count_all(
                 p1,
                 p2,
@@ -2443,7 +2451,7 @@ fn build_operator_tree_inner(
         if let Some((pred_sid, subject, out_var)) =
             detect_property_path_plus_fixed_subject_count_all(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(property_path_plus_count_all_operator(
                 pred_sid,
                 subject,
@@ -2458,7 +2466,7 @@ fn build_operator_tree_inner(
         if let Some((union_preds, extra_preds, mode, out_var)) =
             detect_union_star_count_all(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(UnionStarCountAllOperator::new(
                 union_preds,
                 extra_preds,
@@ -2473,7 +2481,7 @@ fn build_operator_tree_inner(
     // Avoids closure materialization by counting reachability.
     if enable_fused_fast_paths {
         if let Some((p1, p2, out_var)) = detect_transitive_path_plus_count_all(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(transitive_path_plus_count_all_operator(
                 p1,
                 p2,
@@ -2487,7 +2495,7 @@ fn build_operator_tree_inner(
     // answered metadata-only from OPST leaflet `lead_group_count` + boundary correction.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_distinct_objects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_objects_operator(
                 out_var,
                 Some(fallback),
@@ -2498,7 +2506,7 @@ fn build_operator_tree_inner(
     // Fast-path: constant-object star constraints + numeric existence filter + label ORDER BY + LIMIT.
     if enable_fused_fast_paths {
         if let Some(spec) = detect_star_const_numeric_label_order_limit(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             let threshold = match spec.numeric_threshold {
                 Term::Value(v) => v,
                 _ => return Ok(fallback),
@@ -2519,7 +2527,7 @@ fn build_operator_tree_inner(
     // Fast-path: label scan + regex filter + rdf:type membership check.
     if enable_fused_fast_paths {
         if let Some(spec) = detect_label_regex_type(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(label_regex_type_operator(
                 spec.subject_var,
                 spec.label_var,
@@ -2550,7 +2558,7 @@ fn build_operator_tree_inner(
             limit,
         )) = detect_group_by_object_star_topk(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(GroupByObjectStarTopKOperator::new(
                 group_pred,
                 filter_preds,
@@ -2573,7 +2581,12 @@ fn build_operator_tree_inner(
         detect_predicate_group_by_object_count_topk(query, options)
     {
         return Ok(Box::new(PredicateGroupCountFirstsOperator::new(
-            s_var, o_var, count_var, pred, limit,
+            s_var,
+            o_var,
+            count_var,
+            pred,
+            limit,
+            planning.mode(),
         )));
     }
 
@@ -2581,7 +2594,7 @@ fn build_operator_tree_inner(
     if enable_fused_fast_paths {
         if let Some((pred, sep, out_var)) = detect_sum_strlen_group_concat_subquery(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false)?;
+            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(sum_strlen_group_concat_operator(
                 pred,
                 sep,
@@ -2594,7 +2607,11 @@ fn build_operator_tree_inner(
     // Fast-path: `SELECT (COUNT(?s) AS ?c) WHERE { ?s <p> <o> }` using leaflet FIRST headers.
     if let Some((pred, s_var, obj, count_var)) = detect_predicate_object_count(query, options) {
         let mut operator: BoxedOperator = Box::new(PredicateObjectCountFirstsOperator::new(
-            pred, s_var, obj, count_var,
+            pred,
+            s_var,
+            obj,
+            count_var,
+            planning.mode(),
         ));
 
         // ORDER BY
@@ -2700,6 +2717,7 @@ fn build_operator_tree_inner(
         &options.group_by,
         options.distinct,
         required_where_vars,
+        planning,
     )?;
 
     // Apply post-query VALUES clause after the WHERE tree is fully built.
@@ -3125,7 +3143,12 @@ mod tests {
             post_values: None,
         };
 
-        let result = build_operator_tree(&query, &QueryOptions::default(), None);
+        let result = build_operator_tree(
+            &query,
+            &QueryOptions::default(),
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         match result {
             Err(e) => assert!(e.to_string().contains("not found")),
             Ok(_) => panic!("Expected error for invalid select var"),
@@ -3146,7 +3169,12 @@ mod tests {
 
         let options = QueryOptions::new().with_order_by(vec![SortSpec::asc(VarId(99))]); // Invalid var
 
-        let result = build_operator_tree(&query, &options, None);
+        let result = build_operator_tree(
+            &query,
+            &options,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         match result {
             Err(e) => assert!(e.to_string().contains("Sort variable")),
             Ok(_) => panic!("Expected error for invalid sort var"),
@@ -3156,7 +3184,12 @@ mod tests {
     #[test]
     fn test_build_operator_tree_empty_patterns() {
         let query = make_simple_query(vec![], vec![]);
-        let result = build_operator_tree(&query, &QueryOptions::default(), None);
+        let result = build_operator_tree(
+            &query,
+            &QueryOptions::default(),
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         assert!(result.is_ok());
 
         let op = result.unwrap();

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2163,6 +2163,14 @@ fn build_operator_tree_inner(
     enable_fused_fast_paths: bool,
     planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
+    // Phase 5 of the planner-mode refactor: fast paths emit current-state
+    // bindings (no `op` channel, no retract events) and don't consult the
+    // history sidecar. In `History` mode they're semantically wrong, so the
+    // planner declines to construct them at all — this collapses the
+    // optimistic-then-fallback pattern in each operator's `open()` into a
+    // single planner-time decision.
+    let enable_fused_fast_paths = enable_fused_fast_paths && !planning.is_history();
+
     if enable_fused_fast_paths {
         tracing::debug!(
             patterns = ?query.patterns,
@@ -2180,7 +2188,8 @@ fn build_operator_tree_inner(
         if let Some((pred, scalar, out_var)) = detect_fused_scan_sum_i64(query, options) {
             // Build fallback operator tree without this fast path to preserve correctness in
             // pre-index / history / policy contexts.
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(fused_scan_sum_i64_operator(
                 pred,
                 scalar,
@@ -2194,7 +2203,8 @@ fn build_operator_tree_inner(
     // for homogeneous numeric predicates, scanning only POST `o_key` values.
     if enable_fused_fast_paths {
         if let Some((pred, out_var)) = detect_predicate_avg_numeric(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(predicate_avg_numeric_operator(
                 pred,
                 out_var,
@@ -2207,7 +2217,8 @@ fn build_operator_tree_inner(
     // by scanning POST and counting distinct encoded object IDs.
     if enable_fused_fast_paths {
         if let Some((pred, out_var)) = detect_predicate_count_distinct_object(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_object_operator(
                 pred,
                 out_var,
@@ -2220,7 +2231,8 @@ fn build_operator_tree_inner(
     // when the object is string-dict-backed. This inspects only POST leaflet directory keys.
     if enable_fused_fast_paths {
         if let Some((pred, mode, out_var)) = detect_predicate_minmax_string(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(predicate_min_max_string_operator(
                 pred,
                 mode,
@@ -2233,7 +2245,8 @@ fn build_operator_tree_inner(
     // Fast-path: `COUNT(*)` over one triple with an anchored string-prefix filter.
     if enable_fused_fast_paths {
         if let Some((pred, prefix, out_var)) = detect_string_prefix_count_all(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(string_prefix_count_all_operator(
                 pred,
                 prefix,
@@ -2246,7 +2259,8 @@ fn build_operator_tree_inner(
     // Fast-path: `SUM(xsd:integer(STRSTARTS(?o, "...")))` over one triple.
     if enable_fused_fast_paths {
         if let Some((pred, prefix, out_var)) = detect_string_prefix_sum_strstarts(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(string_prefix_sum_strstarts_operator(
                 pred,
                 prefix,
@@ -2267,7 +2281,8 @@ fn build_operator_tree_inner(
         if let Some((pred, lang_tag, out_var)) =
             detect_predicate_count_rows_lang_filter(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_lang_filter_operator(
                 pred,
                 lang_tag,
@@ -2281,7 +2296,8 @@ fn build_operator_tree_inner(
         if let Some((pred, compare, threshold, out_var)) =
             detect_predicate_count_rows_numeric_compare(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_numeric_compare_operator(
                 pred,
                 compare,
@@ -2295,7 +2311,8 @@ fn build_operator_tree_inner(
     if enable_fused_fast_paths {
         if let Some((tp, filters, out_var)) = detect_count_rows_with_encoded_filters(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             let inline_ops: Vec<InlineOperator> = filters
                 .into_iter()
                 .map(|expr| InlineOperator::Filter(PreparedBoolExpression::new(expr)))
@@ -2325,7 +2342,8 @@ fn build_operator_tree_inner(
     // answered from PSOT leaflet directory row counts (no scan / no decoding).
     if enable_fused_fast_paths {
         if let Some((pred, out_var)) = detect_predicate_count_rows(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_operator(pred, out_var, Some(fallback))));
         }
     }
@@ -2335,7 +2353,8 @@ fn build_operator_tree_inner(
     // Fires after trivial metadata-only counts but before the remaining specialized fast paths.
     if enable_fused_fast_paths {
         if let Some(plan) = crate::count_plan::try_build_count_plan(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(crate::count_plan_exec::count_plan_operator(
                 plan,
                 Some(fallback),
@@ -2346,7 +2365,8 @@ fn build_operator_tree_inner(
     // Fast-path: `COUNT(*)` for a 2-pattern multicolumn join `?s p1 ?o . ?s p2 ?o`.
     if enable_fused_fast_paths {
         if let Some((p1, p2, out_var)) = detect_multicolumn_join_count_all(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(multicolumn_join_count_all_operator(
                 p1,
                 p2,
@@ -2361,7 +2381,8 @@ fn build_operator_tree_inner(
         if let Some((count_pred, exists_pred, out_var)) =
             detect_exists_join_count_distinct_object(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(exists_join_count_distinct_object_operator(
                 count_pred,
                 exists_pred,
@@ -2375,7 +2396,8 @@ fn build_operator_tree_inner(
     // answered from SPOT leaflet metadata by scanning the blank-node SubjectId range.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_blank_node_subjects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_blank_node_subjects_operator(
                 out_var,
                 Some(fallback),
@@ -2387,7 +2409,8 @@ fn build_operator_tree_inner(
     // answered from PSOT leaflet metadata by counting non-node-ref `o_type` rows.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_literal_objects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_literal_objects_operator(
                 out_var,
                 Some(fallback),
@@ -2399,7 +2422,8 @@ fn build_operator_tree_inner(
     // answered metadata-only from SPOT leaflet `lead_group_count` + boundary correction.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_distinct_subjects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_subjects_operator(
                 out_var,
                 Some(fallback),
@@ -2411,7 +2435,8 @@ fn build_operator_tree_inner(
     // answered metadata-only from PSOT leaflet `p_const` transitions.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_distinct_predicates(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_predicates_operator(
                 out_var,
                 Some(fallback),
@@ -2423,7 +2448,8 @@ fn build_operator_tree_inner(
     // answered metadata-only by summing leaf row_count across a branch manifest.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_triples(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_triples_operator(out_var, Some(fallback))));
         }
     }
@@ -2434,7 +2460,8 @@ fn build_operator_tree_inner(
         if let Some((p1, p2, p3, out_var)) =
             detect_optional_chain_head_join_count_all(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(predicate_optional_chain_head_count_all(
                 p1,
                 p2,
@@ -2451,7 +2478,8 @@ fn build_operator_tree_inner(
         if let Some((pred_sid, subject, out_var)) =
             detect_property_path_plus_fixed_subject_count_all(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(property_path_plus_count_all_operator(
                 pred_sid,
                 subject,
@@ -2466,7 +2494,8 @@ fn build_operator_tree_inner(
         if let Some((union_preds, extra_preds, mode, out_var)) =
             detect_union_star_count_all(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(UnionStarCountAllOperator::new(
                 union_preds,
                 extra_preds,
@@ -2481,7 +2510,8 @@ fn build_operator_tree_inner(
     // Avoids closure materialization by counting reachability.
     if enable_fused_fast_paths {
         if let Some((p1, p2, out_var)) = detect_transitive_path_plus_count_all(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(transitive_path_plus_count_all_operator(
                 p1,
                 p2,
@@ -2495,7 +2525,8 @@ fn build_operator_tree_inner(
     // answered metadata-only from OPST leaflet `lead_group_count` + boundary correction.
     if enable_fused_fast_paths {
         if let Some(out_var) = detect_count_distinct_objects(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(count_distinct_objects_operator(
                 out_var,
                 Some(fallback),
@@ -2506,7 +2537,8 @@ fn build_operator_tree_inner(
     // Fast-path: constant-object star constraints + numeric existence filter + label ORDER BY + LIMIT.
     if enable_fused_fast_paths {
         if let Some(spec) = detect_star_const_numeric_label_order_limit(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             let threshold = match spec.numeric_threshold {
                 Term::Value(v) => v,
                 _ => return Ok(fallback),
@@ -2527,7 +2559,8 @@ fn build_operator_tree_inner(
     // Fast-path: label scan + regex filter + rdf:type membership check.
     if enable_fused_fast_paths {
         if let Some(spec) = detect_label_regex_type(query, options) {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(label_regex_type_operator(
                 spec.subject_var,
                 spec.label_var,
@@ -2558,7 +2591,8 @@ fn build_operator_tree_inner(
             limit,
         )) = detect_group_by_object_star_topk(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(GroupByObjectStarTopKOperator::new(
                 group_pred,
                 filter_preds,
@@ -2577,24 +2611,29 @@ fn build_operator_tree_inner(
     // Fast-path: `?s <p> ?o GROUP BY ?o COUNT(?s)` top-k using leaflet FIRST headers.
     //
     // This avoids decoding leaflets for long (p,o) runs that span leaflet boundaries.
-    if let Some((pred, s_var, o_var, count_var, limit)) =
-        detect_predicate_group_by_object_count_topk(query, options)
-    {
-        return Ok(Box::new(PredicateGroupCountFirstsOperator::new(
-            s_var,
-            o_var,
-            count_var,
-            pred,
-            limit,
-            planning.mode(),
-        )));
+    // Skipped in `History` mode for the same reason as the fused fast paths above:
+    // the path emits current-state counts and ignores retracts.
+    if !planning.is_history() {
+        if let Some((pred, s_var, o_var, count_var, limit)) =
+            detect_predicate_group_by_object_count_topk(query, options)
+        {
+            return Ok(Box::new(PredicateGroupCountFirstsOperator::new(
+                s_var,
+                o_var,
+                count_var,
+                pred,
+                limit,
+                planning.mode(),
+            )));
+        }
     }
 
     // Fast-path: SUM(STRLEN(GROUP_CONCAT(...))) over a single predicate.
     if enable_fused_fast_paths {
         if let Some((pred, sep, out_var)) = detect_sum_strlen_group_concat_subquery(query, options)
         {
-            let fallback = build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
+            let fallback =
+                build_operator_tree_inner(query, options, stats.clone(), false, planning)?;
             return Ok(Box::new(sum_strlen_group_concat_operator(
                 pred,
                 sep,
@@ -2605,63 +2644,23 @@ fn build_operator_tree_inner(
     }
 
     // Fast-path: `SELECT (COUNT(?s) AS ?c) WHERE { ?s <p> <o> }` using leaflet FIRST headers.
-    if let Some((pred, s_var, obj, count_var)) = detect_predicate_object_count(query, options) {
-        let mut operator: BoxedOperator = Box::new(PredicateObjectCountFirstsOperator::new(
-            pred,
-            s_var,
-            obj,
-            count_var,
-            planning.mode(),
-        ));
-
-        // ORDER BY
-        if !options.order_by.is_empty() {
-            operator = Box::new(SortOperator::new(operator, options.order_by.clone()));
-        }
-
-        // PROJECT
-        if let Some(vars) = query.output.select_vars() {
-            if !vars.is_empty() {
-                operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
-            }
-        }
-
-        // DISTINCT
-        if options.distinct {
-            operator = Box::new(DistinctOperator::new(operator));
-        }
-
-        // OFFSET
-        if let Some(offset) = options.offset {
-            if offset > 0 {
-                operator = Box::new(OffsetOperator::new(operator, offset));
-            }
-        }
-
-        // LIMIT
-        if let Some(limit) = options.limit {
-            operator = Box::new(LimitOperator::new(operator, limit));
-        }
-
-        return Ok(operator);
-    }
-
-    // Fast-path: stats-based count-by-predicate query
-    // This avoids scanning all triples when we can answer directly from IndexStats.
-    if let Some(ref stats_view) = stats {
-        if let Some((pred_var, count_var)) = detect_stats_count_by_predicate(query, options) {
-            let mut operator: BoxedOperator = Box::new(StatsCountByPredicateOperator::new(
-                Arc::clone(stats_view),
-                pred_var,
+    // Skipped in `History` mode (current-state count semantics).
+    if !planning.is_history() {
+        if let Some((pred, s_var, obj, count_var)) = detect_predicate_object_count(query, options) {
+            let mut operator: BoxedOperator = Box::new(PredicateObjectCountFirstsOperator::new(
+                pred,
+                s_var,
+                obj,
                 count_var,
+                planning.mode(),
             ));
 
-            // ORDER BY (on predicate or count)
+            // ORDER BY
             if !options.order_by.is_empty() {
                 operator = Box::new(SortOperator::new(operator, options.order_by.clone()));
             }
 
-            // PROJECT (select specific columns)
+            // PROJECT
             if let Some(vars) = query.output.select_vars() {
                 if !vars.is_empty() {
                     operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
@@ -2670,7 +2669,7 @@ fn build_operator_tree_inner(
 
             // DISTINCT
             if options.distinct {
-                operator = Box::new(crate::distinct::DistinctOperator::new(operator));
+                operator = Box::new(DistinctOperator::new(operator));
             }
 
             // OFFSET
@@ -2686,6 +2685,53 @@ fn build_operator_tree_inner(
             }
 
             return Ok(operator);
+        }
+    }
+
+    // Fast-path: stats-based count-by-predicate query
+    // This avoids scanning all triples when we can answer directly from IndexStats.
+    // Skipped in `History` mode — IndexStats reflects current-state cardinality,
+    // not the asserts + retracts a history-range query needs.
+    if !planning.is_history() {
+        if let Some(ref stats_view) = stats {
+            if let Some((pred_var, count_var)) = detect_stats_count_by_predicate(query, options) {
+                let mut operator: BoxedOperator = Box::new(StatsCountByPredicateOperator::new(
+                    Arc::clone(stats_view),
+                    pred_var,
+                    count_var,
+                ));
+
+                // ORDER BY (on predicate or count)
+                if !options.order_by.is_empty() {
+                    operator = Box::new(SortOperator::new(operator, options.order_by.clone()));
+                }
+
+                // PROJECT (select specific columns)
+                if let Some(vars) = query.output.select_vars() {
+                    if !vars.is_empty() {
+                        operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
+                    }
+                }
+
+                // DISTINCT
+                if options.distinct {
+                    operator = Box::new(crate::distinct::DistinctOperator::new(operator));
+                }
+
+                // OFFSET
+                if let Some(offset) = options.offset {
+                    if offset > 0 {
+                        operator = Box::new(OffsetOperator::new(operator, offset));
+                    }
+                }
+
+                // LIMIT
+                if let Some(limit) = options.limit {
+                    operator = Box::new(LimitOperator::new(operator, limit));
+                }
+
+                return Ok(operator);
+            }
         }
     }
 

--- a/fluree-db-query/src/execute/runner.rs
+++ b/fluree-db-query/src/execute/runner.rs
@@ -457,12 +457,15 @@ pub async fn run_operator(
     ctx: &ExecutionContext<'_>,
 ) -> Result<Vec<Batch>> {
     let op_type = std::any::type_name_of_val(operator.as_ref());
+    // Temporal mode is captured at planner-time inside the operator tree, not on
+    // ExecutionContext, so it is no longer surfaced as a span field here. The
+    // `plan` span (in `prepare_execution_with_config`) records `mode` once at
+    // planning time.
     let span = tracing::debug_span!(
         "query_run",
         operator = op_type,
         to_t = ctx.to_t,
         from_t = tracing::field::Empty,
-        history_mode = ctx.history_mode,
         has_overlay = ctx.overlay.is_some(),
         batch_size = ctx.batch_size,
         open_ms = tracing::field::Empty,
@@ -563,8 +566,6 @@ pub struct ContextConfig<'a, 'b> {
     ///
     /// When set, vector search operators can load indexes from graph sources.
     pub vector_provider: Option<&'b dyn crate::vector::VectorIndexProvider>,
-    /// Enable history mode - captures op metadata in bindings for @op support
-    pub history_mode: bool,
     /// Optional lower time bound for history/range queries.
     /// Defaults to None (no lower bound).
     pub from_t: Option<i64>,
@@ -697,9 +698,6 @@ pub async fn execute_prepared<'a, 'b>(
     }
     if let Some(p) = config.vector_provider {
         ctx = ctx.with_vector_provider(p);
-    }
-    if config.history_mode {
-        ctx = ctx.with_history_mode();
     }
     if config.strict_bind_errors {
         ctx = ctx.with_strict_bind_errors();
@@ -854,17 +852,21 @@ pub async fn execute_prepared_with_dataset<'a>(
     dataset: &'a DataSet<'a>,
     tracker: Option<&'a Tracker>,
 ) -> Result<Vec<Batch>> {
-    execute_prepared_with_dataset_history(db, vars, prepared, dataset, tracker, false).await
+    execute_prepared_with_dataset_history(db, vars, prepared, dataset, tracker).await
 }
 
-/// Execute with dataset (multi-graph query), with optional history mode
+/// Execute against a prepared dataset query.
+///
+/// History mode is captured at planner-time inside `prepared` (see
+/// `prepare_execution_with_config` and `PrepareConfig::history`) — there is
+/// no execution-time history toggle. The function name is preserved for
+/// API stability; behavior is identical to `execute_prepared_with_dataset`.
 pub async fn execute_prepared_with_dataset_history<'a>(
     db: GraphDbRef<'a>,
     vars: &VarRegistry,
     prepared: PreparedExecution,
     dataset: &'a DataSet<'a>,
     tracker: Option<&'a Tracker>,
-    history_mode: bool,
 ) -> Result<Vec<Batch>> {
     execute_prepared(
         db,
@@ -873,7 +875,6 @@ pub async fn execute_prepared_with_dataset_history<'a>(
         ContextConfig {
             tracker,
             dataset: Some(dataset),
-            history_mode,
             strict_bind_errors: true,
             ..Default::default()
         },
@@ -890,13 +891,14 @@ pub async fn execute_prepared_with_dataset_and_policy<'a>(
     policy: &'a fluree_db_policy::PolicyContext,
     tracker: Option<&'a Tracker>,
 ) -> Result<Vec<Batch>> {
-    execute_prepared_with_dataset_and_policy_history(
-        db, vars, prepared, dataset, policy, tracker, false,
-    )
-    .await
+    execute_prepared_with_dataset_and_policy_history(db, vars, prepared, dataset, policy, tracker)
+        .await
 }
 
-/// Execute with dataset and policy, with optional history mode
+/// Execute with dataset and policy.
+///
+/// History mode is captured at planner-time inside `prepared` — see
+/// `execute_prepared_with_dataset_history` for the analogous note.
 pub async fn execute_prepared_with_dataset_and_policy_history<'a>(
     db: GraphDbRef<'a>,
     vars: &VarRegistry,
@@ -904,7 +906,6 @@ pub async fn execute_prepared_with_dataset_and_policy_history<'a>(
     dataset: &'a DataSet<'a>,
     policy: &'a fluree_db_policy::PolicyContext,
     tracker: Option<&'a Tracker>,
-    history_mode: bool,
 ) -> Result<Vec<Batch>> {
     // Create policy enforcer for async f:query support
     let enforcer = Arc::new(crate::policy::QueryPolicyEnforcer::new(Arc::new(
@@ -919,7 +920,6 @@ pub async fn execute_prepared_with_dataset_and_policy_history<'a>(
             tracker,
             policy_enforcer: Some(enforcer),
             dataset: Some(dataset),
-            history_mode,
             strict_bind_errors: true,
             ..Default::default()
         },

--- a/fluree-db-query/src/execute/runner.rs
+++ b/fluree-db-query/src/execute/runner.rs
@@ -137,6 +137,48 @@ pub struct PreparedExecution {
     pub derived_overlay: Option<Arc<DerivedFactsOverlay>>,
 }
 
+/// Inputs that the preparation phase needs to know up front.
+///
+/// Lives here rather than as loose parameters so that future planner inputs
+/// (additional [`PlanningContext`] fields, alternate stats sources, etc.)
+/// don't keep extending the prepare-call signature.
+#[derive(Clone, Copy, Default)]
+pub struct PrepareConfig<'a> {
+    /// Optional shared binary index store used by the planner stats cache
+    /// and by mode-aware scan construction.
+    pub binary_store: Option<&'a Arc<BinaryIndexStore>>,
+    /// Planning-time decisions captured before prepare runs.
+    pub planning: crate::temporal_mode::PlanningContext,
+}
+
+impl<'a> PrepareConfig<'a> {
+    /// Construct a config for current-state queries with the given binary store.
+    ///
+    /// Canonical root for the planner-mode invariant: any production caller
+    /// that knows it wants current-state semantics goes through here. Calling
+    /// `PlanningContext::current()` directly outside of true roots is the
+    /// drift hazard the planner-mode refactor was designed to eliminate.
+    pub fn current(binary_store: Option<&'a Arc<BinaryIndexStore>>) -> Self {
+        Self {
+            binary_store,
+            planning: crate::temporal_mode::PlanningContext::current(),
+        }
+    }
+
+    /// Construct a config for history-range queries with the given binary store.
+    ///
+    /// Canonical root for history-range planning. Detection happens at the
+    /// dataset/view layer (`view::dataset_query::query_dataset` consults
+    /// `dataset.history_time_range()` before prepare runs) — never inside
+    /// the planner or operator construction.
+    pub fn history(binary_store: Option<&'a Arc<BinaryIndexStore>>) -> Self {
+        Self {
+            binary_store,
+            planning: crate::temporal_mode::PlanningContext::history(),
+        }
+    }
+}
+
 /// Prepare query execution with an overlay
 ///
 /// This performs all the common preparation steps:
@@ -152,16 +194,31 @@ pub async fn prepare_execution(
     db: GraphDbRef<'_>,
     query: &ExecutableQuery,
 ) -> Result<PreparedExecution> {
-    prepare_execution_with_binary_store(db, query, None).await
+    prepare_execution_with_config(db, query, &PrepareConfig::default()).await
 }
 
-/// Prepare execution, optionally allowing the planner stats path to reuse the
-/// shared cache attached to a binary store.
+/// Back-compat wrapper. Prefer [`prepare_execution_with_config`] for new code.
 pub async fn prepare_execution_with_binary_store(
     db: GraphDbRef<'_>,
     query: &ExecutableQuery,
     binary_store: Option<&Arc<BinaryIndexStore>>,
 ) -> Result<PreparedExecution> {
+    prepare_execution_with_config(db, query, &PrepareConfig::current(binary_store)).await
+}
+
+/// Prepare execution given an explicit [`PrepareConfig`].
+///
+/// This is the canonical entry point: callers compute the planning context
+/// (in particular [`crate::temporal_mode::TemporalMode`]) before invoking
+/// prepare, so the operator tree can be built mode-aware in subsequent
+/// phases of the planner-mode refactor.
+pub async fn prepare_execution_with_config(
+    db: GraphDbRef<'_>,
+    query: &ExecutableQuery,
+    config: &PrepareConfig<'_>,
+) -> Result<PreparedExecution> {
+    let binary_store = config.binary_store;
+    let planning = config.planning;
     let span = tracing::debug_span!(
         "query_prepare",
         db_t = db.snapshot.t,
@@ -367,13 +424,19 @@ pub async fn prepare_execution_with_binary_store(
         };
 
         // ---- plan: build operator tree from rewritten query ----
+        // Planning context is computed at the dataset/view layer before
+        // `prepare_execution_with_config` runs. The planner branches on
+        // `planning.mode` at scan-construction time (phase 3).
         let operator = {
-            let _plan_span =
-                tracing::debug_span!("plan", pattern_count = rewritten_query.patterns.len(),)
-                    .entered();
+            let _plan_span = tracing::debug_span!(
+                "plan",
+                pattern_count = rewritten_query.patterns.len(),
+                mode = ?planning.mode,
+            )
+            .entered();
 
             let stats_view = cached_stats_view_for_db(db, binary_store);
-            build_operator_tree(&rewritten_query, &query.options, stats_view)?
+            build_operator_tree(&rewritten_query, &query.options, stats_view, &planning)?
         };
 
         Ok(PreparedExecution {

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -29,6 +29,7 @@ use crate::property_path::{PropertyPathOperator, DEFAULT_MAX_VISITED};
 use crate::seed::EmptyOperator;
 use crate::semijoin::SemijoinOperator;
 use crate::subquery::SubqueryOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::triple::{Ref, Term, TriplePattern};
 use crate::union::UnionOperator;
 use crate::values::ValuesOperator;
@@ -666,12 +667,14 @@ fn apply_eligible_binds(
 /// Apply BINDs and FILTERs whose required variables are all bound.
 ///
 /// Returns the updated operator and the remaining items.
+#[allow(clippy::too_many_arguments)]
 fn apply_deferred_patterns(
     child: BoxedOperator,
     bound: &mut HashSet<VarId>,
     pending_binds: Vec<BindPattern>,
     pending_filters: Vec<FilterPattern>,
     filter_idxs_consumed: &[usize],
+    planning: &PlanningContext,
 ) -> (BoxedOperator, Vec<BindPattern>, Vec<FilterPattern>) {
     let (mut child, remaining_binds, pending_filters) = apply_eligible_binds(
         child,
@@ -684,7 +687,7 @@ fn apply_deferred_patterns(
     let (ready, remaining_filters) =
         partition_eligible_filters(pending_filters, bound, filter_idxs_consumed);
     for expr in ready {
-        child = Box::new(FilterOperator::new(child, expr));
+        child = Box::new(FilterOperator::new_with_planning(child, expr, *planning));
     }
 
     (child, remaining_binds, remaining_filters)
@@ -700,6 +703,7 @@ fn apply_all_remaining(
     pending_binds: Vec<BindPattern>,
     pending_filters: Vec<FilterPattern>,
     filter_idxs_consumed: &[usize],
+    planning: &PlanningContext,
 ) -> BoxedOperator {
     let mut bound: HashSet<VarId> = child.schema().iter().copied().collect();
 
@@ -712,7 +716,11 @@ fn apply_all_remaining(
     );
     for pending in remaining_filters {
         if !filter_idxs_consumed.contains(&pending.original_idx) {
-            child = Box::new(FilterOperator::new(child, pending.expr));
+            child = Box::new(FilterOperator::new_with_planning(
+                child,
+                pending.expr,
+                *planning,
+            ));
         }
     }
     child
@@ -728,6 +736,7 @@ fn build_single_pattern(
     var_counts: &HashMap<VarId, usize>,
     protected_vars: &HashSet<VarId>,
     group_by: &[VarId],
+    planning: &PlanningContext,
 ) -> Option<BoxedOperator> {
     match pattern {
         Pattern::Bind { var, expr } => {
@@ -755,6 +764,7 @@ fn build_single_pattern(
             None,
             emit_mask_for_triple(tp, var_counts, protected_vars),
             group_by,
+            planning,
         )),
         _ => operator,
     }
@@ -775,6 +785,7 @@ fn build_property_join_block(
     required_where_vars: Option<&[VarId]>,
     var_counts: &HashMap<VarId, usize>,
     protected_vars: &HashSet<VarId>,
+    planning: &PlanningContext,
 ) -> Result<Option<BoxedOperator>> {
     let mut needed: HashSet<VarId> = HashSet::new();
     if let Some(rwv) = required_where_vars {
@@ -818,6 +829,7 @@ fn build_property_join_block(
         pushdown.object_bounds.clone(),
         Some(&needed),
         inline_ops,
+        planning.mode(),
     )?;
     let mut operator: Option<BoxedOperator> = Some(Box::new(property_join));
 
@@ -833,6 +845,7 @@ fn build_property_join_block(
             pending_binds,
             pending_filters,
             &pushdown.consumed_indices,
+            planning,
         );
         operator = Some(child);
     }
@@ -947,6 +960,7 @@ fn build_sequential_join_block(
     protected_vars: &HashSet<VarId>,
     group_by: &[VarId],
     distinct_query: bool,
+    planning: &PlanningContext,
 ) -> Result<Option<BoxedOperator>> {
     let mut operator = operator;
 
@@ -1018,6 +1032,7 @@ fn build_sequential_join_block(
             live_vars.as_deref(),
             emit,
             group_by,
+            planning,
         );
         bound.extend(op.schema().iter().copied());
         operator = Some(op);
@@ -1029,6 +1044,7 @@ fn build_sequential_join_block(
                 pending_binds,
                 pending_filters,
                 &pushdown.consumed_indices,
+                planning,
             );
             pending_binds = new_binds;
             pending_filters = new_filters;
@@ -1047,6 +1063,7 @@ fn build_sequential_join_block(
             pending_binds,
             pending_filters,
             &pushdown.consumed_indices,
+            planning,
         ));
     }
 
@@ -1061,12 +1078,21 @@ pub fn build_where_operators(
     patterns: &[Pattern],
     stats: Option<Arc<StatsView>>,
     required_where_vars: Option<&[VarId]>,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
     let mut needed: HashSet<VarId> = HashSet::new();
     let mut counts: HashMap<VarId, usize> = HashMap::new();
     collect_var_stats(patterns, &mut counts, &mut needed);
     needed.extend(counts.keys().copied());
-    build_where_operators_with_needed(patterns, stats, &needed, &[], false, required_where_vars)
+    build_where_operators_with_needed(
+        patterns,
+        stats,
+        &needed,
+        &[],
+        false,
+        required_where_vars,
+        planning,
+    )
 }
 
 /// Build WHERE operators with explicit needed-vars and GROUP BY keys.
@@ -1080,6 +1106,7 @@ pub fn build_where_operators_with_needed(
     group_by: &[VarId],
     distinct_query: bool,
     required_where_vars: Option<&[VarId]>,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
     build_where_operators_seeded_with_needed(
         None,
@@ -1089,6 +1116,7 @@ pub fn build_where_operators_with_needed(
         group_by,
         distinct_query,
         required_where_vars,
+        planning,
     )
 }
 
@@ -1172,6 +1200,7 @@ pub fn build_where_operators_seeded(
     patterns: &[Pattern],
     stats: Option<Arc<StatsView>>,
     required_where_vars: Option<&[VarId]>,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
     let mut needed: HashSet<VarId> = HashSet::new();
     let mut counts: HashMap<VarId, usize> = HashMap::new();
@@ -1185,6 +1214,7 @@ pub fn build_where_operators_seeded(
         &[],
         false,
         required_where_vars,
+        planning,
     )
 }
 
@@ -1204,6 +1234,7 @@ pub fn build_where_operators_seeded(
 /// - If `seed` is `Some`, it is used as the starting operator for the pattern list.
 /// - If `seed` is `None` and the first pattern is non-triple, an `EmptyOperator` is used.
 /// - `stats` provides property/class statistics for selectivity-based pattern reordering.
+#[allow(clippy::too_many_arguments)]
 pub fn build_where_operators_seeded_with_needed(
     seed: Option<BoxedOperator>,
     patterns: &[Pattern],
@@ -1212,7 +1243,13 @@ pub fn build_where_operators_seeded_with_needed(
     group_by: &[VarId],
     distinct_query: bool,
     required_where_vars: Option<&[VarId]>,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
+    // `planning` is captured here and threaded into every operator that
+    // builds late subplans (UNION, OPTIONAL, EXISTS, MINUS, GRAPH, SERVICE,
+    // SUBQUERY, FILTER EXISTS, scan/join chain). The invariant: late
+    // builders never call `PlanningContext::current()` themselves —
+    // they capture the value passed here.
     if patterns.is_empty() {
         // Empty patterns = one row with empty schema
         return Ok(seed.unwrap_or_else(|| Box::new(EmptyOperator::new())));
@@ -1286,6 +1323,7 @@ pub fn build_where_operators_seeded_with_needed(
                         &var_counts,
                         &protected_vars,
                         group_by,
+                        planning,
                     );
                     i = start + 1;
                     continue;
@@ -1319,6 +1357,7 @@ pub fn build_where_operators_seeded_with_needed(
                         &protected_vars,
                         group_by,
                         distinct_query,
+                        planning,
                     )?;
                     if values_after_triples {
                         built = apply_values(Some(built), block.values)
@@ -1471,6 +1510,7 @@ pub fn build_where_operators_seeded_with_needed(
                         augmented_ref,
                         &var_counts,
                         &protected_vars,
+                        planning,
                     )?;
                 } else {
                     operator = build_sequential_join_block(
@@ -1485,14 +1525,20 @@ pub fn build_where_operators_seeded_with_needed(
                         &protected_vars,
                         group_by,
                         distinct_query,
+                        planning,
                     )?;
                 }
             }
 
             Pattern::Filter(expr) => {
-                // Wrap current operator with filter
+                // Wrap current operator with filter; FILTER EXISTS subplans
+                // inherit the captured planning context.
                 let child = require_child(operator, "Filter pattern")?;
-                operator = Some(Box::new(FilterOperator::new(child, expr.clone())));
+                operator = Some(Box::new(FilterOperator::new_with_planning(
+                    child,
+                    expr.clone(),
+                    *planning,
+                )));
                 i += 1;
             }
 
@@ -1527,6 +1573,7 @@ pub fn build_where_operators_seeded_with_needed(
                                     inner_patterns.clone(),
                                     true,
                                     stats.clone(),
+                                    *planning,
                                 )));
                                 i += 2;
                                 continue;
@@ -1542,6 +1589,7 @@ pub fn build_where_operators_seeded_with_needed(
                         let builder = GroupedPatternOptionalBuilder::new(
                             required_schema.clone(),
                             grouped_optional_triples,
+                            *planning,
                         )?;
                         operator = Some(Box::new(
                             OptionalOperator::with_builder(
@@ -1559,8 +1607,13 @@ pub fn build_where_operators_seeded_with_needed(
                     if inner_patterns.len() == 1 {
                         if let Some(inner_triple) = inner_patterns[0].as_triple().cloned() {
                             operator = Some(Box::new(
-                                OptionalOperator::new(child, required_schema, inner_triple)
-                                    .with_out_schema(augmented_ref),
+                                OptionalOperator::new(
+                                    child,
+                                    required_schema,
+                                    inner_triple,
+                                    *planning,
+                                )
+                                .with_out_schema(augmented_ref),
                             ));
                             i += 1;
                             continue;
@@ -1573,6 +1626,7 @@ pub fn build_where_operators_seeded_with_needed(
                         required_schema.clone(),
                         inner_patterns.clone(),
                         stats.clone(),
+                        *planning,
                     );
                     operator = Some(Box::new(
                         OptionalOperator::with_builder(child, required_schema, Box::new(builder))
@@ -1598,7 +1652,7 @@ pub fn build_where_operators_seeded_with_needed(
 
                 // Correlated UNION: execute each branch per input row (seeded from child).
                 operator = Some(Box::new(
-                    UnionOperator::new(child, branches.clone(), stats.clone())
+                    UnionOperator::new(child, branches.clone(), stats.clone(), *planning)
                         .with_out_schema(augmented_ref),
                 ));
                 i += 1;
@@ -1611,6 +1665,7 @@ pub fn build_where_operators_seeded_with_needed(
                     child,
                     inner_patterns.clone(),
                     stats.clone(),
+                    *planning,
                 )));
                 i += 1;
             }
@@ -1657,6 +1712,7 @@ pub fn build_where_operators_seeded_with_needed(
                         inner_patterns.clone(),
                         negated,
                         stats.clone(),
+                        *planning,
                     )));
                 } else {
                     // Correlated via produced vars only: SemijoinOperator builds inner
@@ -1667,6 +1723,7 @@ pub fn build_where_operators_seeded_with_needed(
                         key_vars,
                         negated,
                         stats.clone(),
+                        *planning,
                     )));
                 }
                 i += 1;
@@ -1692,7 +1749,7 @@ pub fn build_where_operators_seeded_with_needed(
                 let augmented_ref = augmented_rwv.as_deref();
 
                 operator = Some(Box::new(
-                    SubqueryOperator::new(child, sq.clone(), stats.clone())
+                    SubqueryOperator::new(child, sq.clone(), stats.clone(), *planning)
                         .with_out_schema(augmented_ref),
                 ));
                 i += 1;
@@ -1771,6 +1828,7 @@ pub fn build_where_operators_seeded_with_needed(
                     child,
                     name.clone(),
                     inner_patterns.clone(),
+                    *planning,
                 )));
                 i += 1;
             }
@@ -1781,6 +1839,7 @@ pub fn build_where_operators_seeded_with_needed(
                 operator = Some(Box::new(crate::service::ServiceOperator::new(
                     child,
                     service_pattern.clone(),
+                    *planning,
                 )));
                 i += 1;
             }
@@ -1801,6 +1860,7 @@ fn make_first_scan(
     inline_ops: Vec<InlineOperator>,
     emit: EmitMask,
     group_by: &[VarId],
+    planning: &PlanningContext,
 ) -> BoxedOperator {
     let obj_bounds = tp.o.as_var().and_then(|v| object_bounds.get(&v).cloned());
     let index_hint = scan_index_hint_for_triple(tp, group_by, &inline_ops);
@@ -1810,6 +1870,7 @@ fn make_first_scan(
         inline_ops,
         emit,
         index_hint,
+        planning.mode(),
     ))
 }
 
@@ -1824,6 +1885,7 @@ fn make_first_scan(
 ///
 /// The `inline_ops` are evaluated inline on the operator: baked into the scan
 /// for the first pattern, or evaluated per combined row in `NestedLoopJoinOperator` for joins.
+#[allow(clippy::too_many_arguments)]
 pub fn build_scan_or_join(
     left: Option<BoxedOperator>,
     tp: &TriplePattern,
@@ -1832,9 +1894,10 @@ pub fn build_scan_or_join(
     downstream_vars: Option<&[VarId]>,
     emit: EmitMask,
     group_by: &[VarId],
+    planning: &PlanningContext,
 ) -> BoxedOperator {
     match left {
-        None => make_first_scan(tp, object_bounds, inline_ops, emit, group_by),
+        None => make_first_scan(tp, object_bounds, inline_ops, emit, group_by, planning),
         Some(left) => {
             // Subsequent patterns: use NestedLoopJoinOperator with optional bounds pushdown
             let left_schema: Arc<[VarId]> = Arc::from(left.schema().to_vec().into_boxed_slice());
@@ -1850,6 +1913,7 @@ pub fn build_scan_or_join(
                     bounds,
                     inline_ops,
                     EmitMask::ALL,
+                    planning.mode(),
                 )
                 .with_out_schema(downstream_vars),
             )
@@ -1939,6 +2003,7 @@ pub fn build_triple_operators(
     protected_vars: &HashSet<VarId>,
     group_by: &[VarId],
     distinct_query: bool,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
     if triples.is_empty() {
         return existing
@@ -1973,6 +2038,7 @@ pub fn build_triple_operators(
             &triples_for_exec,
             object_bounds.clone(),
             Some(&needed),
+            planning.mode(),
         )?;
         return Ok(Box::new(pj));
     }
@@ -2001,6 +2067,7 @@ pub fn build_triple_operators(
             live_vars.as_deref(),
             emit,
             group_by,
+            planning,
         ));
 
         // DISTINCT query optimization: if any variables seen so far are no longer live,
@@ -2046,7 +2113,15 @@ mod tests {
         let mut counts: HashMap<VarId, usize> = HashMap::new();
         collect_var_stats(patterns, &mut counts, &mut needed);
         needed.extend(counts.keys().copied());
-        super::build_where_operators_with_needed(patterns, stats, &needed, &[], false, None)
+        super::build_where_operators_with_needed(
+            patterns,
+            stats,
+            &needed,
+            &[],
+            false,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
     }
 
     fn build_triple_operators(
@@ -2076,6 +2151,7 @@ mod tests {
             &protected,
             &[],
             false,
+            &crate::temporal_mode::PlanningContext::current(),
         )
     }
 
@@ -2475,7 +2551,16 @@ mod tests {
         let bounds = HashMap::new();
 
         let op: BoxedOperator =
-            build_scan_or_join(None, &tp, &bounds, Vec::new(), None, EmitMask::ALL, &[]);
+            build_scan_or_join(
+                None,
+                &tp,
+                &bounds,
+                Vec::new(),
+                None,
+                EmitMask::ALL,
+                &[],
+                &crate::temporal_mode::PlanningContext::current(),
+            );
 
         assert_eq!(op.schema(), &[VarId(0), VarId(1)]);
     }
@@ -2487,7 +2572,16 @@ mod tests {
         let bounds = HashMap::new();
 
         let first: BoxedOperator =
-            build_scan_or_join(None, &tp1, &bounds, Vec::new(), None, EmitMask::ALL, &[]);
+            build_scan_or_join(
+                None,
+                &tp1,
+                &bounds,
+                Vec::new(),
+                None,
+                EmitMask::ALL,
+                &[],
+                &crate::temporal_mode::PlanningContext::current(),
+            );
         let second = build_scan_or_join(
             Some(first),
             &tp2,
@@ -2496,6 +2590,7 @@ mod tests {
             None,
             EmitMask::ALL,
             &[],
+            &crate::temporal_mode::PlanningContext::current(),
         );
 
         // Schema should include all vars from both patterns

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -2550,17 +2550,16 @@ mod tests {
         let tp = make_pattern(VarId(0), "name", VarId(1));
         let bounds = HashMap::new();
 
-        let op: BoxedOperator =
-            build_scan_or_join(
-                None,
-                &tp,
-                &bounds,
-                Vec::new(),
-                None,
-                EmitMask::ALL,
-                &[],
-                &crate::temporal_mode::PlanningContext::current(),
-            );
+        let op: BoxedOperator = build_scan_or_join(
+            None,
+            &tp,
+            &bounds,
+            Vec::new(),
+            None,
+            EmitMask::ALL,
+            &[],
+            &crate::temporal_mode::PlanningContext::current(),
+        );
 
         assert_eq!(op.schema(), &[VarId(0), VarId(1)]);
     }
@@ -2571,17 +2570,16 @@ mod tests {
         let tp2 = make_pattern(VarId(0), "age", VarId(2));
         let bounds = HashMap::new();
 
-        let first: BoxedOperator =
-            build_scan_or_join(
-                None,
-                &tp1,
-                &bounds,
-                Vec::new(),
-                None,
-                EmitMask::ALL,
-                &[],
-                &crate::temporal_mode::PlanningContext::current(),
-            );
+        let first: BoxedOperator = build_scan_or_join(
+            None,
+            &tp1,
+            &bounds,
+            Vec::new(),
+            None,
+            EmitMask::ALL,
+            &[],
+            &crate::temporal_mode::PlanningContext::current(),
+        );
         let second = build_scan_or_join(
             Some(first),
             &tp2,

--- a/fluree-db-query/src/exists.rs
+++ b/fluree-db-query/src/exists.rs
@@ -18,6 +18,7 @@ use crate::execute::build_where_operators_seeded;
 use crate::ir::Pattern;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::seed::{EmptyOperator, SeedOperator};
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::StatsView;
@@ -47,6 +48,8 @@ pub struct ExistsOperator {
     uncorrelated_has_match: Option<bool>,
     /// Optional stats for nested query optimization (Arc for cheap cloning in nested operators)
     stats: Option<Arc<StatsView>>,
+    /// Planning context captured at planner-time. Used for the EXISTS subplan.
+    planning: PlanningContext,
 }
 
 impl ExistsOperator {
@@ -63,6 +66,7 @@ impl ExistsOperator {
         exists_patterns: Vec<Pattern>,
         negated: bool,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
         let schema: Arc<[VarId]> = Arc::from(child.schema().to_vec().into_boxed_slice());
 
@@ -84,6 +88,7 @@ impl ExistsOperator {
             uncorrelated,
             uncorrelated_has_match: None,
             stats,
+            planning,
         }
     }
 
@@ -92,8 +97,9 @@ impl ExistsOperator {
         child: BoxedOperator,
         patterns: Vec<Pattern>,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
-        Self::new(child, patterns, true, stats)
+        Self::new(child, patterns, true, stats, planning)
     }
 
     /// Check if the EXISTS subquery produces any results for a given input row
@@ -115,6 +121,7 @@ impl ExistsOperator {
             &self.exists_patterns,
             self.stats.clone(),
             None,
+            &self.planning,
         )?;
 
         exists_op.open(ctx).await?;
@@ -149,6 +156,7 @@ impl Operator for ExistsOperator {
                 &self.exists_patterns,
                 self.stats.clone(),
                 None,
+                &self.planning,
             )?;
             exists_op.open(ctx).await?;
             let has_result = loop {
@@ -250,7 +258,13 @@ mod tests {
             schema: child_schema.clone(),
         });
 
-        let op = ExistsOperator::new(child, vec![], false, None);
+        let op = ExistsOperator::new(
+            child,
+            vec![],
+            false,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Output schema should match child schema (EXISTS doesn't add vars)
         assert_eq!(op.schema(), &*child_schema);
@@ -269,7 +283,12 @@ mod tests {
             Term::Var(VarId(1)),
         ))];
 
-        let op = ExistsOperator::not_exists(child, patterns, None);
+        let op = ExistsOperator::not_exists(
+            child,
+            patterns,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         assert!(op.negated);
     }

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -79,6 +79,8 @@ pub struct PredicateGroupCountFirstsOperator {
     results_v6: Option<Vec<(u16, u64, i64)>>,
     /// Next result to emit
     pos: usize,
+    /// Temporal mode captured at planner-time for the fallback per-row scan.
+    mode: crate::temporal_mode::TemporalMode,
 }
 
 impl PredicateGroupCountFirstsOperator {
@@ -88,6 +90,7 @@ impl PredicateGroupCountFirstsOperator {
         count_var: VarId,
         predicate: crate::triple::Ref,
         limit: usize,
+        mode: crate::temporal_mode::TemporalMode,
     ) -> Self {
         Self {
             schema: Arc::from(vec![object_var, count_var].into_boxed_slice()),
@@ -100,6 +103,7 @@ impl PredicateGroupCountFirstsOperator {
             fallback: None,
             results_v6: None,
             pos: 0,
+            mode,
         }
     }
 
@@ -126,6 +130,7 @@ impl PredicateGroupCountFirstsOperator {
             Vec::new(),
             crate::binary_scan::EmitMask::ALL,
             None,
+            self.mode,
         ));
 
         let agg_specs = vec![StreamingAggSpec {
@@ -328,6 +333,8 @@ pub struct PredicateObjectCountFirstsOperator {
     count: i64,
     /// Whether the single row has been emitted
     emitted: bool,
+    /// Temporal mode captured at planner-time for the fallback scan.
+    mode: crate::temporal_mode::TemporalMode,
 }
 
 impl PredicateObjectCountFirstsOperator {
@@ -336,6 +343,7 @@ impl PredicateObjectCountFirstsOperator {
         subject_var: VarId,
         object: Term,
         count_var: VarId,
+        mode: crate::temporal_mode::TemporalMode,
     ) -> Self {
         Self {
             schema: Arc::from(vec![count_var].into_boxed_slice()),
@@ -347,6 +355,7 @@ impl PredicateObjectCountFirstsOperator {
             fallback: None,
             count: 0,
             emitted: false,
+            mode,
         }
     }
 
@@ -371,6 +380,7 @@ impl PredicateObjectCountFirstsOperator {
             Vec::new(),
             crate::binary_scan::EmitMask::ALL,
             None,
+            self.mode,
         ));
 
         let agg_specs = vec![StreamingAggSpec {

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -40,8 +40,10 @@ fn should_fallback(ctx: &ExecutionContext<'_>) -> bool {
 
 #[inline]
 fn allow_cursor_fast_path(ctx: &ExecutionContext<'_>) -> bool {
+    // History mode is filtered at the planner — see
+    // `execute::operator_tree::build_operator_tree_inner` — so this gate
+    // doesn't duplicate that check.
     !ctx.is_multi_ledger()
-        && !ctx.history_mode
         && ctx.from_t.is_none()
         && ctx.policy_enforcer.as_ref().is_none_or(|p| p.is_root())
 }

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -1696,15 +1696,16 @@ pub fn term_to_ref_s_id(
 
 /// Check whether the execution context allows fast-path operators.
 ///
-/// Fast paths are only valid when not in history mode, no `from_t`, no policy
-/// enforcement (or root policy), and no uncommitted overlay.
+/// Fast paths are only valid when single-ledger, no `from_t`, root (or no)
+/// policy, and no uncommitted overlay. History mode is filtered at the
+/// planner level (in `execute::operator_tree::build_operator_tree_inner`),
+/// so this runtime gate doesn't repeat that check.
 #[inline]
 fn allow_fast_path(ctx: &ExecutionContext<'_>) -> bool {
     // Fast paths rely on a single binary index + single-ledger semantics for encoded IDs.
     // Dataset (multi-ledger) execution can span multiple ledgers/graphs, so disable fast
     // paths for correctness unless/until they are made dataset-aware.
     !ctx.is_multi_ledger()
-        && !ctx.history_mode
         && ctx.from_t.is_none()
         && ctx.policy_enforcer.as_ref().is_none_or(|p| p.is_root())
         && ctx

--- a/fluree-db-query/src/fast_transitive_path_plus_count_all.rs
+++ b/fluree-db-query/src/fast_transitive_path_plus_count_all.rs
@@ -34,10 +34,11 @@ pub fn transitive_path_plus_count_all_operator(
     FastPathOperator::new(
         out_var,
         move |ctx| {
-            // Cursor-based path is overlay-aware, but still requires single-ledger,
-            // non-history, root-policy execution.
+            // Cursor-based path is overlay-aware, but still requires single-ledger
+            // and root-policy execution. History mode is filtered at the planner —
+            // see `execute::operator_tree::build_operator_tree_inner` — so this
+            // gate doesn't duplicate that check.
             let allow_fast = !ctx.is_multi_ledger()
-                && !ctx.history_mode
                 && ctx.from_t.is_none()
                 && ctx.policy_enforcer.as_ref().is_none_or(|p| p.is_root());
             if !allow_fast {

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -94,8 +94,10 @@ impl Operator for UnionStarCountAllOperator {
             return Err(QueryError::OperatorAlreadyOpened);
         }
 
+        // History mode is filtered at the planner — see
+        // `execute::operator_tree::build_operator_tree_inner` — so this gate
+        // doesn't duplicate that check.
         let allow_fast = !ctx.is_multi_ledger()
-            && !ctx.history_mode
             && ctx.from_t.is_none()
             && ctx.policy_enforcer.as_ref().is_none_or(|p| p.is_root());
         if allow_fast {

--- a/fluree-db-query/src/filter.rs
+++ b/fluree-db-query/src/filter.rs
@@ -219,13 +219,7 @@ async fn eval_exists_uncorrelated(
 ) -> Result<bool> {
     #[expect(clippy::box_default)]
     let seed: BoxedOperator = Box::new(EmptyOperator::new());
-    let mut exists_op = build_where_operators_seeded(
-        Some(seed),
-        patterns,
-        None,
-        None,
-        planning,
-    )?;
+    let mut exists_op = build_where_operators_seeded(Some(seed), patterns, None, None, planning)?;
 
     exists_op.open(ctx).await?;
 
@@ -254,13 +248,8 @@ async fn eval_exists_for_row(
     planning: &crate::temporal_mode::PlanningContext,
 ) -> Result<bool> {
     let seed = SeedOperator::from_batch_row(batch, row_idx);
-    let mut exists_op = build_where_operators_seeded(
-        Some(Box::new(seed)),
-        patterns,
-        None,
-        None,
-        planning,
-    )?;
+    let mut exists_op =
+        build_where_operators_seeded(Some(Box::new(seed)), patterns, None, None, planning)?;
 
     exists_op.open(ctx).await?;
 
@@ -291,7 +280,8 @@ fn pre_resolve_uncorrelated<'a>(
         match expr {
             Expression::Exists { patterns, negated } => {
                 if is_uncorrelated_exists(patterns, batch_schema) {
-                    let result = eval_exists_uncorrelated(patterns, *negated, ctx, planning).await?;
+                    let result =
+                        eval_exists_uncorrelated(patterns, *negated, ctx, planning).await?;
                     Ok(Expression::Const(FilterValue::Bool(result)))
                 } else {
                     Ok(expr.clone())
@@ -504,7 +494,11 @@ impl FilterOperator {
     /// [`FilterOperator::new_with_planning`] instead so that FILTER EXISTS
     /// subplans inherit the same temporal mode.
     pub fn new(child: BoxedOperator, expr: Expression) -> Self {
-        Self::new_with_planning(child, expr, crate::temporal_mode::PlanningContext::current())
+        Self::new_with_planning(
+            child,
+            expr,
+            crate::temporal_mode::PlanningContext::current(),
+        )
     }
 
     /// Create a new filter operator that captures a planning context for any

--- a/fluree-db-query/src/filter.rs
+++ b/fluree-db-query/src/filter.rs
@@ -215,10 +215,17 @@ async fn eval_exists_uncorrelated(
     patterns: &[Pattern],
     negated: bool,
     ctx: &ExecutionContext<'_>,
+    planning: &crate::temporal_mode::PlanningContext,
 ) -> Result<bool> {
     #[expect(clippy::box_default)]
     let seed: BoxedOperator = Box::new(EmptyOperator::new());
-    let mut exists_op = build_where_operators_seeded(Some(seed), patterns, None, None)?;
+    let mut exists_op = build_where_operators_seeded(
+        Some(seed),
+        patterns,
+        None,
+        None,
+        planning,
+    )?;
 
     exists_op.open(ctx).await?;
 
@@ -244,9 +251,16 @@ async fn eval_exists_for_row(
     batch: &Batch,
     row_idx: usize,
     ctx: &ExecutionContext<'_>,
+    planning: &crate::temporal_mode::PlanningContext,
 ) -> Result<bool> {
     let seed = SeedOperator::from_batch_row(batch, row_idx);
-    let mut exists_op = build_where_operators_seeded(Some(Box::new(seed)), patterns, None, None)?;
+    let mut exists_op = build_where_operators_seeded(
+        Some(Box::new(seed)),
+        patterns,
+        None,
+        None,
+        planning,
+    )?;
 
     exists_op.open(ctx).await?;
 
@@ -271,12 +285,13 @@ fn pre_resolve_uncorrelated<'a>(
     expr: &'a Expression,
     batch_schema: &'a [VarId],
     ctx: &'a ExecutionContext<'a>,
+    planning: &'a crate::temporal_mode::PlanningContext,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Expression>> + Send + 'a>> {
     Box::pin(async move {
         match expr {
             Expression::Exists { patterns, negated } => {
                 if is_uncorrelated_exists(patterns, batch_schema) {
-                    let result = eval_exists_uncorrelated(patterns, *negated, ctx).await?;
+                    let result = eval_exists_uncorrelated(patterns, *negated, ctx, planning).await?;
                     Ok(Expression::Const(FilterValue::Bool(result)))
                 } else {
                     Ok(expr.clone())
@@ -285,7 +300,8 @@ fn pre_resolve_uncorrelated<'a>(
             Expression::Call { func, args } => {
                 let mut resolved_args = Vec::with_capacity(args.len());
                 for arg in args {
-                    resolved_args.push(pre_resolve_uncorrelated(arg, batch_schema, ctx).await?);
+                    resolved_args
+                        .push(pre_resolve_uncorrelated(arg, batch_schema, ctx, planning).await?);
                 }
                 Ok(Expression::Call {
                     func: func.clone(),
@@ -364,6 +380,7 @@ fn resolve_exists_for_row<'a>(
     row_idx: usize,
     ctx: &'a ExecutionContext<'a>,
     cache: Option<&'a ExistsSemijoinCache>,
+    planning: &'a crate::temporal_mode::PlanningContext,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Expression>> + Send + 'a>> {
     Box::pin(async move {
         match expr {
@@ -376,14 +393,16 @@ fn resolve_exists_for_row<'a>(
                     }
                 }
 
-                let result = eval_exists_for_row(patterns, *negated, batch, row_idx, ctx).await?;
+                let result =
+                    eval_exists_for_row(patterns, *negated, batch, row_idx, ctx, planning).await?;
                 Ok(Expression::Const(FilterValue::Bool(result)))
             }
             Expression::Call { func, args } => {
                 let mut resolved_args = Vec::with_capacity(args.len());
                 for arg in args {
-                    resolved_args
-                        .push(resolve_exists_for_row(arg, batch, row_idx, ctx, cache).await?);
+                    resolved_args.push(
+                        resolve_exists_for_row(arg, batch, row_idx, ctx, cache, planning).await?,
+                    );
                 }
                 Ok(Expression::Call {
                     func: func.clone(),
@@ -410,9 +429,10 @@ async fn filter_batch_with_exists(
     schema: &Arc<[VarId]>,
     ctx: &ExecutionContext<'_>,
     cache: Option<&ExistsSemijoinCache>,
+    planning: &crate::temporal_mode::PlanningContext,
 ) -> Result<Option<Batch>> {
     // Phase 1: resolve uncorrelated EXISTS once for the whole batch
-    let partially_resolved = pre_resolve_uncorrelated(expr, batch.schema(), ctx).await?;
+    let partially_resolved = pre_resolve_uncorrelated(expr, batch.schema(), ctx, planning).await?;
 
     // If no EXISTS nodes remain, we can use the fast synchronous path
     if !contains_exists(&partially_resolved) {
@@ -425,7 +445,8 @@ async fn filter_batch_with_exists(
 
     for row_idx in 0..batch.len() {
         let resolved_expr =
-            resolve_exists_for_row(&partially_resolved, batch, row_idx, ctx, cache).await?;
+            resolve_exists_for_row(&partially_resolved, batch, row_idx, ctx, cache, planning)
+                .await?;
         let Some(row) = batch.row_view(row_idx) else {
             continue;
         };
@@ -472,11 +493,27 @@ pub struct FilterOperator {
     has_exists: bool,
     /// Optional semijoin caches for simple correlated EXISTS patterns.
     exists_semijoin: Option<ExistsSemijoinCache>,
+    /// Planning context captured at planner-time for FILTER EXISTS subplans.
+    planning: crate::temporal_mode::PlanningContext,
 }
 
 impl FilterOperator {
-    /// Create a new filter operator
+    /// Create a new filter operator with current-state planning context.
+    ///
+    /// Construction sites that have a captured [`PlanningContext`] should call
+    /// [`FilterOperator::new_with_planning`] instead so that FILTER EXISTS
+    /// subplans inherit the same temporal mode.
     pub fn new(child: BoxedOperator, expr: Expression) -> Self {
+        Self::new_with_planning(child, expr, crate::temporal_mode::PlanningContext::current())
+    }
+
+    /// Create a new filter operator that captures a planning context for any
+    /// FILTER EXISTS subplans.
+    pub fn new_with_planning(
+        child: BoxedOperator,
+        expr: Expression,
+        planning: crate::temporal_mode::PlanningContext,
+    ) -> Self {
         let schema = Arc::from(child.schema().to_vec().into_boxed_slice());
         let has_exists = contains_exists(&expr);
         let prepared_expr = PreparedBoolExpression::new(expr.clone());
@@ -488,6 +525,7 @@ impl FilterOperator {
             state: OperatorState::Created,
             has_exists,
             exists_semijoin: None,
+            planning,
         }
     }
 
@@ -537,6 +575,7 @@ impl Operator for FilterOperator {
                     &self.schema,
                     ctx,
                     self.exists_semijoin.as_ref(),
+                    &self.planning,
                 )
                 .await?
             } else {

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -34,6 +34,7 @@ use crate::ir::{GraphName, Pattern};
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::r2rml::rewrite_patterns_for_r2rml;
 use crate::seed::SeedOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::DatatypeConstraint;
@@ -62,6 +63,8 @@ pub struct GraphOperator {
     result_buffer: Vec<Vec<Binding>>,
     /// Current position in result buffer
     buffer_pos: usize,
+    /// Planning context captured at planner-time for the per-row inner subplan.
+    planning: PlanningContext,
 }
 
 impl GraphOperator {
@@ -72,7 +75,12 @@ impl GraphOperator {
     /// * `child` - Input solutions operator
     /// * `graph_name` - The graph name (concrete IRI or variable)
     /// * `inner_patterns` - Patterns to execute within the graph context
-    pub fn new(child: BoxedOperator, graph_name: GraphName, inner_patterns: Vec<Pattern>) -> Self {
+    pub fn new(
+        child: BoxedOperator,
+        graph_name: GraphName,
+        inner_patterns: Vec<Pattern>,
+        planning: PlanningContext,
+    ) -> Self {
         // Compute output schema: parent schema + new vars from inner patterns
         let parent_schema: std::collections::HashSet<VarId> =
             child.schema().iter().copied().collect();
@@ -108,6 +116,7 @@ impl GraphOperator {
             state: OperatorState::Created,
             result_buffer: Vec::new(),
             buffer_pos: 0,
+            planning,
         }
     }
 
@@ -177,8 +186,13 @@ impl GraphOperator {
 
         // Build seed operator from parent row (like EXISTS/Subquery)
         let seed = SeedOperator::from_batch_row(parent_batch, row_idx);
-        let mut inner =
-            build_where_operators_seeded(Some(Box::new(seed)), &patterns_to_execute, None, None)?;
+        let mut inner = build_where_operators_seeded(
+            Some(Box::new(seed)),
+            &patterns_to_execute,
+            None,
+            None,
+            &self.planning,
+        )?;
 
         inner.open(&graph_ctx).await?;
 
@@ -482,6 +496,7 @@ mod tests {
             child,
             GraphName::Iri(Arc::from("http://example.org/graph1")),
             patterns,
+            crate::temporal_mode::PlanningContext::current(),
         );
 
         // Output schema should include parent vars + new var from pattern
@@ -504,7 +519,12 @@ mod tests {
         ))];
 
         // Graph variable ?g = VarId(2)
-        let op = GraphOperator::new(child, GraphName::Var(VarId(2)), patterns);
+        let op = GraphOperator::new(
+            child,
+            GraphName::Var(VarId(2)),
+            patterns,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Output schema should include parent var, new var from pattern, and graph var
         assert!(op.schema().contains(&VarId(0)));

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -110,6 +110,7 @@ pub(crate) fn make_dict_overlay(
 ///
 /// Wraps the scan in a [`DatasetOperator`](crate::dataset_operator::DatasetOperator)
 /// so that multi-graph fanout is handled transparently.
+#[allow(clippy::too_many_arguments)]
 fn make_right_scan(
     pattern: TriplePattern,
     object_bounds: Option<ObjectBounds>,
@@ -117,6 +118,7 @@ fn make_right_scan(
     inline_ops: Vec<InlineOperator>,
     index_hint: Option<IndexType>,
     _ctx: &ExecutionContext<'_>,
+    mode: crate::temporal_mode::TemporalMode,
 ) -> Box<dyn Operator> {
     Box::new(crate::dataset_operator::DatasetOperator::scan(
         pattern,
@@ -124,6 +126,7 @@ fn make_right_scan(
         inline_ops,
         emit,
         index_hint,
+        mode,
     ))
 }
 
@@ -355,6 +358,8 @@ pub struct NestedLoopJoinOperator {
     out_schema: Option<Arc<[VarId]>>,
     /// Emit the runtime path decision once per open().
     logged_runtime_mode: bool,
+    /// Temporal mode captured at planner-time for the late per-row right scan.
+    mode: crate::temporal_mode::TemporalMode,
 }
 
 impl NestedLoopJoinOperator {
@@ -414,6 +419,7 @@ impl NestedLoopJoinOperator {
     /// * `right_pattern` - Pattern to execute for each left row
     /// * `object_bounds` - Optional range bounds for object variable (filter pushdown)
     /// * `inline_ops` - Inline operators evaluated on combined rows
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         left: Box<dyn Operator>,
         left_schema: Arc<[VarId]>,
@@ -421,6 +427,7 @@ impl NestedLoopJoinOperator {
         object_bounds: Option<ObjectBounds>,
         inline_ops: Vec<InlineOperator>,
         right_emit: EmitMask,
+        mode: crate::temporal_mode::TemporalMode,
     ) -> Self {
         // Build bind instructions: which left columns bind which right pattern positions
         let mut bind_instructions = Vec::new();
@@ -613,6 +620,7 @@ impl NestedLoopJoinOperator {
             right_index_hint,
             out_schema: None,
             logged_runtime_mode: false,
+            mode,
         }
     }
 
@@ -1176,6 +1184,7 @@ impl Operator for NestedLoopJoinOperator {
                         self.right_scan_inline_ops.clone(),
                         self.right_index_hint,
                         ctx,
+                        self.mode,
                     );
                     right_scan.open(ctx).await?;
                     self.active_right_scan = Some(right_scan);
@@ -1197,6 +1206,7 @@ impl Operator for NestedLoopJoinOperator {
                     self.right_scan_inline_ops.clone(),
                     self.right_index_hint,
                     ctx,
+                    self.mode,
                 );
                 right_scan.open(ctx).await?;
                 self.active_right_scan = Some(right_scan);
@@ -2967,6 +2977,7 @@ mod tests {
             None, // No object bounds
             Vec::new(),
             EmitMask::ALL,
+            crate::temporal_mode::TemporalMode::Current,
         );
 
         // Create a batch with one row that has Poisoned in position 0 (used for binding)
@@ -3056,6 +3067,7 @@ mod tests {
             None, // No object bounds
             Vec::new(),
             EmitMask::ALL,
+            crate::temporal_mode::TemporalMode::Current,
         );
 
         // Verify that ?v is NOT in unify_instructions (it's substituted, not unified)
@@ -3140,6 +3152,7 @@ mod tests {
                 )),
             )],
             EmitMask::ALL,
+            crate::temporal_mode::TemporalMode::Current,
         );
 
         assert_eq!(join.right_index_hint, Some(IndexType::Opst));
@@ -3182,6 +3195,7 @@ mod tests {
                 p: false,
                 o: false,
             },
+            crate::temporal_mode::TemporalMode::Current,
         );
 
         assert!(!join.batched_eligible);
@@ -3228,6 +3242,7 @@ mod tests {
                 )),
             )],
             EmitMask::ALL,
+            crate::temporal_mode::TemporalMode::Current,
         );
 
         assert!(join.right_scan_inline_ops.is_empty());
@@ -3294,6 +3309,7 @@ mod tests {
             None, // No object bounds
             Vec::new(),
             EmitMask::ALL,
+            crate::temporal_mode::TemporalMode::Current,
         );
 
         // No unify_instructions since no shared vars between left [?s] and right [?x, ?y]

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -88,6 +88,7 @@ pub mod sparql_results;
 pub(crate) mod stats_cache;
 pub mod stats_query;
 pub mod subquery;
+pub mod temporal_mode;
 pub mod triple;
 pub mod union;
 pub mod values;
@@ -156,6 +157,7 @@ pub use seed::{EmptyOperator, SeedOperator};
 pub use sort::{compare_bindings, compare_flake_values, SortDirection, SortOperator, SortSpec};
 pub use stats_query::StatsCountByPredicateOperator;
 pub use subquery::SubqueryOperator;
+pub use temporal_mode::{PlanningContext, TemporalMode};
 pub use triple::{Ref, Term, TriplePattern};
 
 // Re-export DatatypeConstraint from fluree-db-core for convenience
@@ -190,7 +192,10 @@ pub async fn execute_pattern(
     pattern: TriplePattern,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref(db, vars);
-    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
+    // Current-state helper: BinaryHistoryScanOperator is single-purpose since the
+    // planner-mode refactor (always emits asserts + retracts), so use the
+    // current-state scan directly here.
+    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -250,7 +255,10 @@ pub async fn execute_pattern_at(
     from_t: Option<i64>,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref_with_from_t(db, vars, from_t);
-    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
+    // Current-state helper: BinaryHistoryScanOperator is single-purpose since the
+    // planner-mode refactor (always emits asserts + retracts), so use the
+    // current-state scan directly here.
+    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -274,7 +282,10 @@ pub async fn execute_pattern_with_overlay(
     pattern: TriplePattern,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref(db, vars);
-    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
+    // Current-state helper: BinaryHistoryScanOperator is single-purpose since the
+    // planner-mode refactor (always emits asserts + retracts), so use the
+    // current-state scan directly here.
+    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -297,7 +308,10 @@ pub async fn execute_pattern_with_overlay_at(
     from_t: Option<i64>,
 ) -> Result<Vec<Batch>> {
     let ctx = ExecutionContext::from_graph_db_ref_with_from_t(db, vars, from_t);
-    let mut scan = BinaryHistoryScanOperator::new(pattern, None, Vec::new());
+    // Current-state helper: BinaryHistoryScanOperator is single-purpose since the
+    // planner-mode refactor (always emits asserts + retracts), so use the
+    // current-state scan directly here.
+    let mut scan = BinaryScanOperator::new(pattern, None, Vec::new());
 
     scan.open(&ctx).await?;
 
@@ -340,7 +354,17 @@ pub async fn execute_where_with_overlay_at(
     }
 
     let ctx = ExecutionContext::from_graph_db_ref_with_from_t(db, vars, from_t);
-    let mut operator = build_where_operators_seeded(None, patterns, None, None)?;
+    // Root: this is a transaction WHERE-clause executor. Even when `from_t` is
+    // set, semantics are "current state at `to_t` with from_t time bound for
+    // novelty visibility" — not a history-range query that emits asserts +
+    // retracts. Always plan as `Current`.
+    let mut operator = build_where_operators_seeded(
+        None,
+        patterns,
+        None,
+        None,
+        &temporal_mode::PlanningContext::current(),
+    )?;
 
     operator.open(&ctx).await?;
     let mut batches = Vec::new();
@@ -366,7 +390,15 @@ pub async fn execute_where_with_overlay_at_strict(
 
     let ctx =
         ExecutionContext::from_graph_db_ref_with_from_t(db, vars, from_t).with_strict_bind_errors();
-    let mut operator = build_where_operators_seeded(None, patterns, None, None)?;
+    // Root: same as `execute_where_with_overlay_at` — transaction WHERE clause,
+    // current-state semantics regardless of `from_t`.
+    let mut operator = build_where_operators_seeded(
+        None,
+        patterns,
+        None,
+        None,
+        &temporal_mode::PlanningContext::current(),
+    )?;
 
     operator.open(&ctx).await?;
     let mut batches = Vec::new();
@@ -402,7 +434,17 @@ pub async fn execute_where_with_overlay_at_strict_in_dataset<'a>(
     if let Some(ds) = dataset {
         ctx = ctx.with_dataset(ds);
     }
-    let mut operator = build_where_operators_seeded(None, patterns, None, None)?;
+    // Root: transaction WHERE clause executor (dataset-aware variant).
+    // History-range planning is detected at the dataset/view layer in
+    // `view::dataset_query` before prepare runs; this transaction-side path
+    // is always current-state.
+    let mut operator = build_where_operators_seeded(
+        None,
+        patterns,
+        None,
+        None,
+        &temporal_mode::PlanningContext::current(),
+    )?;
 
     operator.open(&ctx).await?;
     let mut batches = Vec::new();
@@ -539,7 +581,17 @@ pub async fn execute_where_streaming_in_dataset<'a>(
     if let Some(ds) = dataset {
         ctx = ctx.with_dataset(ds);
     }
-    let mut operator = build_where_operators_seeded(None, patterns, None, None)?;
+    // Root: transaction WHERE clause executor (dataset-aware variant).
+    // History-range planning is detected at the dataset/view layer in
+    // `view::dataset_query` before prepare runs; this transaction-side path
+    // is always current-state.
+    let mut operator = build_where_operators_seeded(
+        None,
+        patterns,
+        None,
+        None,
+        &temporal_mode::PlanningContext::current(),
+    )?;
     operator.open(&ctx).await?;
     Ok(WhereCursor {
         inner: CursorInner::Operator(Box::new(WhereCursorOperator {

--- a/fluree-db-query/src/minus.rs
+++ b/fluree-db-query/src/minus.rs
@@ -17,6 +17,7 @@ use crate::execute::build_where_operators_seeded;
 use crate::ir::Pattern;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::seed::EmptyOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::StatsView;
@@ -73,6 +74,9 @@ pub struct MinusOperator {
     state: OperatorState,
     /// Optional stats for nested query optimization (Arc for cheap cloning in nested operators)
     stats: Option<Arc<StatsView>>,
+    /// Planning context captured at planner-time. Used when building the
+    /// MINUS subtree so it inherits the same temporal mode.
+    planning: PlanningContext,
     /// Hash set of minus rows where ALL shared vars are matchable (common case)
     minus_hash: HashSet<MinusKey>,
     /// Minus rows with >= 1 unbound shared var (wildcard rows, rare)
@@ -92,6 +96,7 @@ impl MinusOperator {
         child: BoxedOperator,
         minus_patterns: Vec<Pattern>,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
         let schema: Arc<[VarId]> = Arc::from(child.schema().to_vec().into_boxed_slice());
         let child_vars: HashSet<VarId> = child.schema().iter().copied().collect();
@@ -110,6 +115,7 @@ impl MinusOperator {
             schema,
             state: OperatorState::Created,
             stats,
+            planning,
             minus_hash: HashSet::new(),
             minus_wildcards: Vec::new(),
         }
@@ -312,6 +318,7 @@ impl Operator for MinusOperator {
                 &self.minus_patterns,
                 self.stats.clone(),
                 None,
+                &self.planning,
             )?;
 
             minus_op.open(ctx).await?;
@@ -474,7 +481,12 @@ mod tests {
             Term::Var(VarId(2)), // ?age - not shared
         ))];
 
-        let op = MinusOperator::new(child, minus_patterns, None);
+        let op = MinusOperator::new(
+            child,
+            minus_patterns,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Only ?s should be shared
         assert_eq!(op.shared_vars.len(), 1);
@@ -488,7 +500,12 @@ mod tests {
             schema: child_schema.clone(),
         });
 
-        let op = MinusOperator::new(child, vec![], None);
+        let op = MinusOperator::new(
+            child,
+            vec![],
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Output schema should match child schema
         assert_eq!(op.schema(), &*child_schema);
@@ -529,6 +546,7 @@ mod tests {
             schema: child_schema,
             state: OperatorState::Created,
             stats: None,
+            planning: crate::temporal_mode::PlanningContext::current(),
             minus_hash: HashSet::new(),
             minus_wildcards: Vec::new(),
         }

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -36,6 +36,7 @@ use crate::operator::{
     compute_trimmed_vars, effective_schema, trim_batch, BoxedOperator, Operator, OperatorState,
 };
 use crate::seed::SeedOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::triple::{Ref, Term, TriplePattern};
 use crate::var_registry::VarId;
 use async_trait::async_trait;
@@ -154,11 +155,17 @@ pub struct PatternOptionalBuilder {
     bind_instructions: Vec<BindInstruction>,
     /// Instructions for unification checks on shared vars
     unify_instructions: Vec<UnifyInstruction>,
+    /// Planning context captured at planner-time for the per-row substituted scan.
+    planning: PlanningContext,
 }
 
 impl PatternOptionalBuilder {
     /// Create a new pattern-based optional builder
-    pub fn new(required_schema: Arc<[VarId]>, pattern: TriplePattern) -> Self {
+    pub fn new(
+        required_schema: Arc<[VarId]>,
+        pattern: TriplePattern,
+        planning: PlanningContext,
+    ) -> Self {
         // Determine optional-only vars (in optional but not in required)
         let required_vars: std::collections::HashSet<_> = required_schema.iter().copied().collect();
         let pattern_vars = pattern.variables();
@@ -184,6 +191,7 @@ impl PatternOptionalBuilder {
             optional_only_vars,
             bind_instructions,
             unify_instructions,
+            planning,
         }
     }
 
@@ -402,6 +410,7 @@ impl OptionalBuilder for PatternOptionalBuilder {
                 Vec::new(),
                 crate::binary_scan::EmitMask::ALL,
                 None,
+                self.planning.mode(),
             ),
         )))
     }
@@ -580,10 +589,16 @@ pub struct GroupedPatternOptionalBuilder {
     triples: Vec<TriplePattern>,
     optional_only_vars: Vec<VarId>,
     subject_left_col: usize,
+    /// Planning context captured at planner-time for the per-row chain.
+    planning: PlanningContext,
 }
 
 impl GroupedPatternOptionalBuilder {
-    pub fn new(required_schema: Arc<[VarId]>, triples: Vec<TriplePattern>) -> Result<Self> {
+    pub fn new(
+        required_schema: Arc<[VarId]>,
+        triples: Vec<TriplePattern>,
+        planning: PlanningContext,
+    ) -> Result<Self> {
         let Some(subject_var) = triples.first().and_then(|tp| tp.s.as_var()) else {
             return Err(QueryError::Internal(
                 "grouped optional builder requires variable subject".into(),
@@ -616,6 +631,7 @@ impl GroupedPatternOptionalBuilder {
             triples,
             optional_only_vars,
             subject_left_col,
+            planning,
         })
     }
 
@@ -665,6 +681,7 @@ impl GroupedPatternOptionalBuilder {
                 op,
                 current_schema.clone(),
                 triple.clone(),
+                self.planning,
             ));
             current_schema = Arc::from(op.schema().to_vec().into_boxed_slice());
         }
@@ -939,6 +956,8 @@ pub struct PlanTreeOptionalBuilder {
     shared_var_indices: Vec<usize>,
     /// Stats for nested query optimization
     stats: Option<Arc<StatsView>>,
+    /// Planning context captured at planner-time for the per-row inner subplan.
+    planning: PlanningContext,
 }
 
 impl PlanTreeOptionalBuilder {
@@ -953,6 +972,7 @@ impl PlanTreeOptionalBuilder {
         required_schema: Arc<[VarId]>,
         inner_patterns: Vec<Pattern>,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
         let required_vars: HashSet<VarId> = required_schema.iter().copied().collect();
 
@@ -1009,6 +1029,7 @@ impl PlanTreeOptionalBuilder {
             unify_instructions,
             shared_var_indices,
             stats,
+            planning,
         }
     }
 
@@ -1050,6 +1071,7 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
             &self.inner_patterns,
             self.stats.clone(),
             None,
+            &self.planning,
         )?;
 
         Ok(Some(op))
@@ -1182,8 +1204,10 @@ impl OptionalOperator {
         required: BoxedOperator,
         required_schema: Arc<[VarId]>,
         optional_pattern: TriplePattern,
+        planning: PlanningContext,
     ) -> Self {
-        let builder = PatternOptionalBuilder::new(required_schema.clone(), optional_pattern);
+        let builder =
+            PatternOptionalBuilder::new(required_schema.clone(), optional_pattern, planning);
         Self::with_builder(required, required_schema, Box::new(builder))
     }
 
@@ -1689,7 +1713,12 @@ mod tests {
             fn close(&mut self) {}
         }
 
-        let op = OptionalOperator::new(Box::new(MockOp), required_schema, optional_pattern);
+        let op = OptionalOperator::new(
+            Box::new(MockOp),
+            required_schema,
+            optional_pattern,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Combined schema should be: [?s, ?name, ?email]
         assert_eq!(op.schema().len(), 3);
@@ -1703,7 +1732,11 @@ mod tests {
         let required_schema: Arc<[VarId]> = Arc::from(vec![VarId(0), VarId(1)].into_boxed_slice());
         let optional_pattern = make_optional_pattern();
 
-        let builder = PatternOptionalBuilder::new(required_schema, optional_pattern);
+        let builder = PatternOptionalBuilder::new(
+            required_schema,
+            optional_pattern,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Check schema
         assert_eq!(builder.schema().len(), 2); // ?s, ?email
@@ -1733,7 +1766,11 @@ mod tests {
         let required_schema: Arc<[VarId]> = Arc::from(vec![VarId(0), VarId(1)].into_boxed_slice());
         let optional_pattern = make_optional_pattern();
 
-        let builder = PatternOptionalBuilder::new(required_schema.clone(), optional_pattern);
+        let builder = PatternOptionalBuilder::new(
+            required_schema.clone(),
+            optional_pattern,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Create a batch with Poisoned in position 0 (which is used for correlation)
         let columns_poisoned = vec![
@@ -1784,7 +1821,12 @@ mod tests {
             fn close(&mut self) {}
         }
 
-        let op = OptionalOperator::new(Box::new(MockOp), required_schema.clone(), optional_pattern);
+        let op = OptionalOperator::new(
+            Box::new(MockOp),
+            required_schema.clone(),
+            optional_pattern,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // Create a required batch with one row
         let columns = vec![
@@ -1826,7 +1868,11 @@ mod tests {
         }
 
         // Create using with_builder
-        let builder = PatternOptionalBuilder::new(required_schema.clone(), optional_pattern);
+        let builder = PatternOptionalBuilder::new(
+            required_schema.clone(),
+            optional_pattern,
+            crate::temporal_mode::PlanningContext::current(),
+        );
         let op =
             OptionalOperator::with_builder(Box::new(MockOp), required_schema, Box::new(builder));
 

--- a/fluree-db-query/src/policy/executor.rs
+++ b/fluree-db-query/src/policy/executor.rs
@@ -184,13 +184,21 @@ impl QueryPolicyExecutor<'_> {
                 .with_graph_id(self.g_id)
         };
 
-        // Build the where clause operators (VALUES is now part of parsed patterns)
-        let mut operator =
-            build_where_operators_seeded(None, &patterns, None, None).map_err(|e| {
-                fluree_db_policy::PolicyError::QueryExecution {
-                    message: e.to_string(),
-                }
-            })?;
+        // Build the where clause operators (VALUES is now part of parsed patterns).
+        //
+        // Root: policy queries always evaluate at `self.to_t` for current state —
+        // they're access-control predicates, not history-range queries. Always
+        // plan as `Current`.
+        let mut operator = build_where_operators_seeded(
+            None,
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .map_err(|e| fluree_db_policy::PolicyError::QueryExecution {
+            message: e.to_string(),
+        })?;
 
         // Execute with limit 1 (we only need to know if there are any results)
         operator

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -1072,7 +1072,8 @@ mod tests {
     #[test]
     fn test_property_join_creation() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         assert_eq!(op.subject_var(), VarId(0));
         assert_eq!(op.predicates.len(), 2);
@@ -1082,7 +1083,8 @@ mod tests {
     #[test]
     fn test_property_join_schema() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let schema = op.output_schema();
         assert_eq!(schema[0], VarId(0)); // subject
@@ -1093,7 +1095,8 @@ mod tests {
     #[test]
     fn test_property_join_schema_with_bound_object_predicate() {
         let patterns = make_property_join_patterns_with_bound_object();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let schema = op.output_schema();
         assert_eq!(&schema[..], &[VarId(0), VarId(1), VarId(2)]);
@@ -1102,7 +1105,8 @@ mod tests {
     #[test]
     fn test_property_join_prefers_bound_object_driver_over_bounds() {
         let patterns = make_property_join_patterns_with_bound_object();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let mut bounds = HashMap::new();
         bounds.insert(VarId(2), ObjectBounds::new());
@@ -1121,7 +1125,8 @@ mod tests {
     #[test]
     fn test_generate_rows_single_values() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let subject_sid = Sid::new(1, "alice");
         let subject_binding = Binding::sid(subject_sid.clone());
@@ -1144,7 +1149,8 @@ mod tests {
     #[test]
     fn test_generate_rows_cartesian_product() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let subject_binding = Binding::sid(Sid::new(1, "alice"));
         let values = vec![
@@ -1172,7 +1178,8 @@ mod tests {
     #[test]
     fn test_generate_rows_empty_pred() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let subject_binding = Binding::sid(Sid::new(1, "alice"));
         let values = vec![

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -34,6 +34,7 @@ use crate::join::{
 };
 use crate::operator::inline::{apply_inline, extend_schema, InlineOperator};
 use crate::operator::{BoxedOperator, Operator, OperatorState};
+use crate::temporal_mode::TemporalMode;
 use crate::triple::{Ref, Term, TriplePattern};
 use crate::var_registry::VarId;
 use async_trait::async_trait;
@@ -64,6 +65,7 @@ fn make_property_join_scan(
     pattern: TriplePattern,
     bounds: Option<ObjectBounds>,
     emit: EmitMask,
+    mode: TemporalMode,
 ) -> BoxedOperator {
     Box::new(crate::dataset_operator::DatasetOperator::scan(
         pattern,
@@ -71,6 +73,7 @@ fn make_property_join_scan(
         Vec::new(),
         emit,
         None,
+        mode,
     ))
 }
 
@@ -122,6 +125,8 @@ pub struct PropertyJoinOperator {
     emitted_required: Vec<bool>,
     /// Row-local filters/binds applied after star rows are assembled.
     inline_ops: Vec<InlineOperator>,
+    /// Temporal mode captured at planner-time for the late per-predicate scans.
+    mode: TemporalMode,
 }
 
 #[derive(Clone, Debug)]
@@ -322,8 +327,9 @@ impl PropertyJoinOperator {
     pub fn new(
         patterns: &[TriplePattern],
         object_bounds: HashMap<VarId, ObjectBounds>,
+        mode: TemporalMode,
     ) -> Result<Self> {
-        Self::new_with_options(patterns, &[], object_bounds, None, Vec::new())
+        Self::new_with_options(patterns, &[], object_bounds, None, Vec::new(), mode)
     }
 
     /// Create a new property-join operator, optionally treating some predicate patterns
@@ -332,8 +338,9 @@ impl PropertyJoinOperator {
         patterns: &[TriplePattern],
         object_bounds: HashMap<VarId, ObjectBounds>,
         needed_vars: Option<&std::collections::HashSet<VarId>>,
+        mode: TemporalMode,
     ) -> Result<Self> {
-        Self::new_with_options(patterns, &[], object_bounds, needed_vars, Vec::new())
+        Self::new_with_options(patterns, &[], object_bounds, needed_vars, Vec::new(), mode)
     }
 
     pub fn new_with_options(
@@ -342,6 +349,7 @@ impl PropertyJoinOperator {
         object_bounds: HashMap<VarId, ObjectBounds>,
         needed_vars: Option<&std::collections::HashSet<VarId>>,
         inline_ops: Vec<InlineOperator>,
+        mode: TemporalMode,
     ) -> Result<Self> {
         if !crate::planner::is_property_join(required_patterns) {
             return Err(QueryError::Internal(
@@ -442,6 +450,7 @@ impl PropertyJoinOperator {
             emit_positions,
             emitted_required,
             inline_ops,
+            mode,
         })
     }
 
@@ -804,7 +813,8 @@ impl Operator for PropertyJoinOperator {
                         o: false,
                     }
                 };
-                let mut scan: BoxedOperator = make_property_join_scan(pattern, bounds, emit);
+                let mut scan: BoxedOperator =
+                    make_property_join_scan(pattern, bounds, emit, self.mode);
                 scan.open(ctx).await?;
 
                 while let Some(batch) = scan.next_batch(ctx).await? {
@@ -1062,7 +1072,7 @@ mod tests {
     #[test]
     fn test_property_join_creation() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         assert_eq!(op.subject_var(), VarId(0));
         assert_eq!(op.predicates.len(), 2);
@@ -1072,7 +1082,7 @@ mod tests {
     #[test]
     fn test_property_join_schema() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let schema = op.output_schema();
         assert_eq!(schema[0], VarId(0)); // subject
@@ -1083,7 +1093,7 @@ mod tests {
     #[test]
     fn test_property_join_schema_with_bound_object_predicate() {
         let patterns = make_property_join_patterns_with_bound_object();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let schema = op.output_schema();
         assert_eq!(&schema[..], &[VarId(0), VarId(1), VarId(2)]);
@@ -1092,7 +1102,7 @@ mod tests {
     #[test]
     fn test_property_join_prefers_bound_object_driver_over_bounds() {
         let patterns = make_property_join_patterns_with_bound_object();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let mut bounds = HashMap::new();
         bounds.insert(VarId(2), ObjectBounds::new());
@@ -1111,7 +1121,7 @@ mod tests {
     #[test]
     fn test_generate_rows_single_values() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let subject_sid = Sid::new(1, "alice");
         let subject_binding = Binding::sid(subject_sid.clone());
@@ -1134,7 +1144,7 @@ mod tests {
     #[test]
     fn test_generate_rows_cartesian_product() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let subject_binding = Binding::sid(Sid::new(1, "alice"));
         let values = vec![
@@ -1162,7 +1172,7 @@ mod tests {
     #[test]
     fn test_generate_rows_empty_pred() {
         let patterns = make_property_join_patterns();
-        let op = PropertyJoinOperator::new(&patterns, HashMap::new()).unwrap();
+        let op = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
 
         let subject_binding = Binding::sid(Sid::new(1, "alice"));
         let values = vec![
@@ -1216,7 +1226,7 @@ mod tests {
                 Term::Var(VarId(3)),
             ),
         ];
-        let result = PropertyJoinOperator::new(&patterns, HashMap::new());
+        let result = PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current);
         assert!(
             result.is_err(),
             "should reject invalid property-join patterns"

--- a/fluree-db-query/src/semijoin.rs
+++ b/fluree-db-query/src/semijoin.rs
@@ -21,6 +21,7 @@ use crate::group_aggregate::{binding_to_group_key_owned, CompositeGroupKey};
 use crate::ir::Pattern;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::seed::{EmptyOperator, SeedOperator};
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::StatsView;
@@ -46,6 +47,8 @@ pub struct SemijoinOperator {
     key_col_indices: Vec<usize>,
     /// Stats for nested query building.
     stats: Option<Arc<StatsView>>,
+    /// Planning context captured at planner-time for the inner subplan.
+    planning: PlanningContext,
 }
 
 impl SemijoinOperator {
@@ -55,6 +58,7 @@ impl SemijoinOperator {
         key_vars: Vec<VarId>,
         negated: bool,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
         let schema: Arc<[VarId]> = Arc::from(child.schema().to_vec().into_boxed_slice());
         Self {
@@ -67,6 +71,7 @@ impl SemijoinOperator {
             key_set: FxHashSet::default(),
             key_col_indices: Vec::new(),
             stats,
+            planning,
         }
     }
 
@@ -104,6 +109,7 @@ impl SemijoinOperator {
             &self.inner_patterns,
             self.stats.clone(),
             None,
+            &self.planning,
         )?;
 
         inner_op.open(ctx).await?;
@@ -141,6 +147,7 @@ impl Operator for SemijoinOperator {
             &self.inner_patterns,
             self.stats.clone(),
             Some(&key_var_slice),
+            &self.planning,
         )?;
 
         // Compute column indices for key vars within the inner operator's schema.

--- a/fluree-db-query/src/service.rs
+++ b/fluree-db-query/src/service.rs
@@ -28,6 +28,7 @@ use crate::ir::{ServiceEndpoint, ServicePattern};
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::remote_service::{is_fluree_remote_endpoint, parse_fluree_remote_ref};
 use crate::seed::SeedOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::DatatypeConstraint;
@@ -56,6 +57,8 @@ pub struct ServiceOperator {
     result_buffer: Vec<Vec<Binding>>,
     /// Current position in result buffer
     buffer_pos: usize,
+    /// Planning context captured at planner-time for the per-row inner subplan.
+    planning: PlanningContext,
 }
 
 impl ServiceOperator {
@@ -65,7 +68,9 @@ impl ServiceOperator {
     ///
     /// * `child` - Input solutions operator
     /// * `service` - The SERVICE pattern (silent, endpoint, patterns)
-    pub fn new(child: BoxedOperator, service: ServicePattern) -> Self {
+    /// * `planning` - Planning context captured at planner-time for the
+    ///   per-row inner subplan
+    pub fn new(child: BoxedOperator, service: ServicePattern, planning: PlanningContext) -> Self {
         // Compute output schema: parent schema + new vars from inner patterns
         let parent_schema: std::collections::HashSet<VarId> =
             child.schema().iter().copied().collect();
@@ -100,6 +105,7 @@ impl ServiceOperator {
             state: OperatorState::Created,
             result_buffer: Vec::new(),
             buffer_pos: 0,
+            planning,
         }
     }
 
@@ -169,8 +175,13 @@ impl ServiceOperator {
 
         // Build seed operator from parent row (like EXISTS/Subquery)
         let seed = SeedOperator::from_batch_row(parent_batch, row_idx);
-        let mut inner =
-            build_where_operators_seeded(Some(Box::new(seed)), &self.service.patterns, None, None)?;
+        let mut inner = build_where_operators_seeded(
+            Some(Box::new(seed)),
+            &self.service.patterns,
+            None,
+            None,
+            &self.planning,
+        )?;
 
         // Create execution context for the target ledger
         // If graph_ref is Some, create a new context; otherwise use the current context (self-reference)

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -37,6 +37,7 @@ use crate::operator::{
 use crate::project::ProjectOperator;
 use crate::seed::{EmptyOperator, SeedOperator};
 use crate::sort::SortOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::StatsView;
@@ -65,6 +66,8 @@ pub struct SubqueryOperator {
     buffer_pos: usize,
     /// Optional stats for selectivity-based pattern reordering in subquery
     stats: Option<Arc<StatsView>>,
+    /// Planning context captured at planner-time for the subquery subplan.
+    planning: PlanningContext,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
 }
@@ -75,6 +78,7 @@ impl SubqueryOperator {
         child: BoxedOperator,
         subquery: SubqueryPattern,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
         let parent_schema: HashSet<VarId> = child.schema().iter().copied().collect();
         let subquery_select_vars: HashSet<VarId> = subquery.select.iter().copied().collect();
@@ -122,6 +126,7 @@ impl SubqueryOperator {
             result_buffer: Vec::new(),
             buffer_pos: 0,
             stats,
+            planning,
             out_schema: None,
         }
     }
@@ -301,6 +306,7 @@ impl SubqueryOperator {
             &self.subquery.patterns,
             self.stats.clone(),
             None,
+            &self.planning,
         )?;
 
         // Apply GROUP BY / aggregates / HAVING for subqueries that use them.
@@ -400,7 +406,12 @@ mod tests {
             vec![], // patterns don't matter for this structural test
         );
 
-        let op = SubqueryOperator::new(Box::new(child), subquery, None);
+        let op = SubqueryOperator::new(
+            Box::new(child),
+            subquery,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
 
         // ?s is in both parent schema and subquery SELECT → correlated
         assert_eq!(op.correlation_vars, vec![v_s]);

--- a/fluree-db-query/src/temporal_mode.rs
+++ b/fluree-db-query/src/temporal_mode.rs
@@ -1,0 +1,92 @@
+//! Temporal mode for query planning.
+//!
+//! [`TemporalMode`] captures whether a query is asking about *current state*
+//! (the snapshot at `to_t`, with retracts already applied) or *history*
+//! (the full event stream of asserts and retracts in `[from_t, to_t]`).
+//!
+//! This is a **planning input**, not a runtime flag. The mode is detected
+//! at the dataset/view layer (see `view::dataset::is_history_mode`) and
+//! threaded into the planner via [`PlanningContext`]. The planner picks
+//! mode-specific operators at construction time; operators do not branch
+//! on temporal mode at runtime.
+//!
+//! Two source-of-truth sites for the underlying decision stay where they
+//! are:
+//! - `view/dataset.rs::is_history_mode()` — derives the mode from the
+//!   dataset spec (two endpoints to the same ledger with explicit times).
+//! - `core/query_bounds.rs::QueryBounds::history_mode` and
+//!   `RangeOptions::history_mode` — published parameters for the
+//!   `range_with_overlay` core API, below the planner.
+
+/// Whether a query is evaluating current state or full history.
+///
+/// History queries return the merged stream of assert + retract events
+/// across `[from_t, to_t]` with explicit `op` on each emitted binding.
+/// Current-state queries collapse retracts and emit only the live state
+/// at `to_t`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+pub enum TemporalMode {
+    /// Snapshot query at `to_t`. Retracts are applied; emitted bindings
+    /// have no `op`. This is the default for all non-history queries.
+    #[default]
+    Current,
+    /// Full history range `[from_t, to_t]`. Asserts and retracts are
+    /// preserved with explicit `op` on each emitted binding.
+    History,
+}
+
+impl TemporalMode {
+    /// Returns `true` for [`TemporalMode::History`].
+    #[inline]
+    pub const fn is_history(self) -> bool {
+        matches!(self, TemporalMode::History)
+    }
+
+    /// Returns `true` for [`TemporalMode::Current`].
+    #[inline]
+    pub const fn is_current(self) -> bool {
+        matches!(self, TemporalMode::Current)
+    }
+}
+
+/// Planning-time context threaded through the operator-tree builder.
+///
+/// Carries decisions that must be made once at planning and captured at
+/// operator construction — never read again at runtime. Currently this
+/// is just [`TemporalMode`]; future planning inputs that want the same
+/// "decide once, capture at construction" discipline should land here.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+pub struct PlanningContext {
+    /// Temporal mode for this query.
+    pub mode: TemporalMode,
+}
+
+impl PlanningContext {
+    /// Construct a planning context for a current-state query.
+    #[inline]
+    pub const fn current() -> Self {
+        Self {
+            mode: TemporalMode::Current,
+        }
+    }
+
+    /// Construct a planning context for a history-range query.
+    #[inline]
+    pub const fn history() -> Self {
+        Self {
+            mode: TemporalMode::History,
+        }
+    }
+
+    /// Returns the temporal mode.
+    #[inline]
+    pub const fn mode(self) -> TemporalMode {
+        self.mode
+    }
+
+    /// Returns `true` if this is a history-mode plan.
+    #[inline]
+    pub const fn is_history(self) -> bool {
+        self.mode.is_history()
+    }
+}

--- a/fluree-db-query/src/union.rs
+++ b/fluree-db-query/src/union.rs
@@ -15,6 +15,7 @@ use crate::execute::build_where_operators_seeded;
 use crate::ir::Pattern;
 use crate::operator::{compute_trimmed_vars, BoxedOperator, Operator, OperatorState};
 use crate::seed::SeedOperator;
+use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::StatsView;
@@ -44,6 +45,9 @@ pub struct UnionOperator {
     input_exhausted: bool,
     /// Optional stats for selectivity-based pattern reordering in branches
     stats: Option<Arc<StatsView>>,
+    /// Planning context captured at planner-time. Used when building the
+    /// per-row branch operator trees so they inherit the same temporal mode.
+    planning: PlanningContext,
     /// Debug counters for low-noise batch fragmentation summaries.
     input_batches_seen: usize,
     input_rows_seen: usize,
@@ -70,6 +74,7 @@ impl UnionOperator {
         child: BoxedOperator,
         branches: Vec<Vec<Pattern>>,
         stats: Option<Arc<StatsView>>,
+        planning: PlanningContext,
     ) -> Self {
         assert!(!branches.is_empty(), "UNION requires at least one branch");
 
@@ -96,6 +101,7 @@ impl UnionOperator {
             current_input_row: 0,
             input_exhausted: false,
             stats,
+            planning,
             input_batches_seen: 0,
             input_rows_seen: 0,
             branch_execs: 0,
@@ -285,6 +291,7 @@ impl Operator for UnionOperator {
                     branch_patterns,
                     self.stats.clone(),
                     branch_downstream_vars,
+                    &self.planning,
                 )?;
 
                 branch_op.open(ctx).await?;
@@ -466,7 +473,12 @@ mod tests {
             ))],
         ];
 
-        let op = UnionOperator::new(child, branches, None);
+        let op = UnionOperator::new(
+            child,
+            branches,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
         assert_eq!(op.schema(), &[VarId(0), VarId(1), VarId(2)]);
     }
 
@@ -477,7 +489,12 @@ mod tests {
         let empty = EmptyOperator::new();
         let child: BoxedOperator = Box::new(empty);
         let branches = vec![vec![], vec![]];
-        let op = UnionOperator::new(child, branches, None);
+        let op = UnionOperator::new(
+            child,
+            branches,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
         assert_eq!(op.schema().len(), 0);
     }
 
@@ -504,8 +521,13 @@ mod tests {
             ))],
         ];
 
-        let op =
-            UnionOperator::new(child, branches, None).with_out_schema(Some(&[VarId(0), VarId(2)]));
+        let op = UnionOperator::new(
+            child,
+            branches,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        )
+        .with_out_schema(Some(&[VarId(0), VarId(2)]));
 
         assert_eq!(op.schema(), &[VarId(0), VarId(2)]);
     }
@@ -523,7 +545,13 @@ mod tests {
             crate::triple::Term::Var(VarId(1)),
         ))]];
 
-        let op = UnionOperator::new(child, branches, None).with_out_schema(None);
+        let op = UnionOperator::new(
+            child,
+            branches,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        )
+        .with_out_schema(None);
 
         assert_eq!(op.schema(), &[VarId(0), VarId(1)]);
     }
@@ -562,7 +590,12 @@ mod tests {
             }],
         ];
 
-        let mut op = UnionOperator::new(child, branches, None);
+        let mut op = UnionOperator::new(
+            child,
+            branches,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        );
         op.open(&ctx).await.unwrap();
 
         let batch1 = op.next_batch(&ctx).await.unwrap().unwrap();

--- a/fluree-db-query/src/vector/operator.rs
+++ b/fluree-db-query/src/vector/operator.rs
@@ -505,8 +505,14 @@ mod tests {
         // Build operator with explicit seed
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         let mut ctx = ExecutionContext::new(&snapshot, &vars);
         ctx.vector_provider = Some(&provider);
@@ -550,8 +556,14 @@ mod tests {
 
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         let mut ctx = ExecutionContext::new(&snapshot, &vars);
         ctx.vector_provider = Some(&provider);
@@ -590,8 +602,14 @@ mod tests {
 
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         let mut ctx = ExecutionContext::new(&snapshot, &vars);
         ctx.vector_provider = Some(&provider);
@@ -619,8 +637,14 @@ mod tests {
 
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         // No vector_provider set
         let ctx = ExecutionContext::new(&snapshot, &vars);
@@ -650,8 +674,14 @@ mod tests {
 
         let empty = EmptyOperator::new();
         let seed: BoxedOperator = Box::new(empty);
-        let mut op = build_where_operators_seeded(Some(seed), &patterns, None, None)
-            .expect("build operators");
+        let mut op = build_where_operators_seeded(
+            Some(seed),
+            &patterns,
+            None,
+            None,
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("build operators");
 
         let mut ctx = ExecutionContext::new(&snapshot, &vars);
         ctx.vector_provider = Some(&provider);

--- a/fluree-db-query/tests/correctness_tests.rs
+++ b/fluree-db-query/tests/correctness_tests.rs
@@ -146,6 +146,7 @@ async fn test_optional_poison_blocks_subsequent() {
         None, // No object bounds
         Vec::new(),
         EmitMask::ALL,
+        fluree_db_query::TemporalMode::Current,
     );
 
     join.open(&ctx).await.unwrap();


### PR DESCRIPTION
This PR follows up on the history-query planning feedback by removing `history_mode` from `ExecutionContext` and making temporal mode a planner-time concern. History-vs-current semantics are now decided before operator construction via `PrepareConfig`/`PlanningContext`, so the planner builds the appropriate operator tree once instead of asking runtime operators to branch on a context flag.

For history queries, scan construction now selects the dedicated history scan path up front, while current-state queries continue to use the normal binary scan operator. Fast paths that only have current-state semantics are gated during planning, so they are not constructed for history-range queries. Late-built subplans such as `OPTIONAL`, `UNION`, `FILTER EXISTS`, `MINUS`, and related operators capture the same planning context to avoid silently falling back to current-state behavior.

The refactor keeps `RangeOptions::history_mode`/`QueryBounds::history_mode` in the core range API, where they remain the lower-level instruction for `range_with_overlay`. The user-facing query execution path no longer carries a runtime history flag through `ExecutionContext`; prepared execution now captures temporal semantics in the planned operator tree.

Test coverage was expanded with history combination cases for `OPTIONAL`, `UNION`, `FILTER NOT EXISTS`, and count fast-path avoidance. These tests specifically guard against the old failure mode where nested or late-built subplans could accidentally plan as current-state and miss retract events.