### PR TITLE
Arch Linux PKGBUILD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,16 +378,60 @@ jobs:
           done
           git push
 
+  # Publish the fluree-bin package to the Arch User Repository (stable releases only).
+  publish-aur:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Configure SSH for AUR
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/id_aur
+          chmod 600 ~/.ssh/id_aur
+          # Pinned AUR host keys. Refresh with `ssh-keyscan aur.archlinux.org`
+          # if upstream rotates them — a mismatch will fail this job loudly.
+          cat > ~/.ssh/known_hosts <<'EOF'
+          aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
+          aur.archlinux.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMiLrP8pVi5BFX2i3vepSUnpedeiewE5XptnUnau+ZoeUOPkpoCgZZuYfpaIQfhhJJI5qgnjJmr4hyJbe/zxow=
+          aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk=
+          EOF
+          chmod 600 ~/.ssh/known_hosts
+          {
+            echo "Host aur.archlinux.org"
+            echo "  IdentityFile ~/.ssh/id_aur"
+            echo "  IdentitiesOnly yes"
+            echo "  User aur"
+          } >> ~/.ssh/config
+          chmod 600 ~/.ssh/config
+      - name: Configure git
+        run: |
+          git config --global user.name  "Fluree Release Bot"
+          git config --global user.email "release-bot@flur.ee"
+      - name: Publish to AUR
+        run: bash contrib/aur/publish.sh "${{ needs.plan.outputs.tag }}"
+
   announce:
     needs:
       - plan
       - host
       - publish-docker
       - publish-homebrew-formula
+      - publish-aur
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-docker.result == 'skipped' || needs.publish-docker.result == 'success') && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-docker.result == 'skipped' || needs.publish-docker.result == 'success') && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-aur.result == 'skipped' || needs.publish-aur.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/contrib/aur/fluree-bin/.SRCINFO
+++ b/contrib/aur/fluree-bin/.SRCINFO
@@ -1,0 +1,20 @@
+pkgbase = fluree-bin
+	pkgdesc = Fluree — semantic graph database (CLI and embedded server)
+	pkgver = 4.0.2
+	pkgrel = 1
+	url = https://flur.ee
+	arch = x86_64
+	arch = aarch64
+	license = custom:BUSL-1.1
+	depends = glibc
+	depends = gcc-libs
+	provides = fluree
+	conflicts = fluree
+	options = !strip
+	options = !debug
+	source_x86_64 = fluree-db-cli-x86_64-unknown-linux-gnu-4.0.2.tar.xz::https://github.com/fluree/db/releases/download/v4.0.2/fluree-db-cli-x86_64-unknown-linux-gnu.tar.xz
+	sha256sums_x86_64 = adb5d43ca58eecca485b4c3b9431d9494d20991b53defc7580a6bc6491da3e4c
+	source_aarch64 = fluree-db-cli-aarch64-unknown-linux-gnu-4.0.2.tar.xz::https://github.com/fluree/db/releases/download/v4.0.2/fluree-db-cli-aarch64-unknown-linux-gnu.tar.xz
+	sha256sums_aarch64 = c927c0c9f27cb172e28d4fb2e8d136c69afbb4b5c9ca4db90495bc612a79f421
+
+pkgname = fluree-bin

--- a/contrib/aur/fluree-bin/PKGBUILD
+++ b/contrib/aur/fluree-bin/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Benjamin Lamothe <blamothe@flur.ee>
+# Maintainer: Fluree <development@flur.ee>
 
 pkgname=fluree-bin
 pkgver=4.0.2

--- a/contrib/aur/fluree-bin/PKGBUILD
+++ b/contrib/aur/fluree-bin/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Benjamin Lamothe <blamothe@flur.ee>
+
+pkgname=fluree-bin
+pkgver=4.0.2
+pkgrel=1
+pkgdesc='Fluree — semantic graph database (CLI and embedded server)'
+arch=('x86_64' 'aarch64')
+url='https://flur.ee'
+license=('custom:BUSL-1.1')
+depends=('glibc' 'gcc-libs')
+provides=('fluree')
+conflicts=('fluree')
+# Upstream ships a stripped, statically-linked-where-possible binary.
+options=('!strip' '!debug')
+
+_archive_x86_64="fluree-db-cli-x86_64-unknown-linux-gnu"
+_archive_aarch64="fluree-db-cli-aarch64-unknown-linux-gnu"
+_release_url="https://github.com/fluree/db/releases/download/v${pkgver}"
+
+source_x86_64=("${_archive_x86_64}-${pkgver}.tar.xz::${_release_url}/${_archive_x86_64}.tar.xz")
+source_aarch64=("${_archive_aarch64}-${pkgver}.tar.xz::${_release_url}/${_archive_aarch64}.tar.xz")
+
+sha256sums_x86_64=('adb5d43ca58eecca485b4c3b9431d9494d20991b53defc7580a6bc6491da3e4c')
+sha256sums_aarch64=('c927c0c9f27cb172e28d4fb2e8d136c69afbb4b5c9ca4db90495bc612a79f421')
+
+package() {
+  local _archive_var="_archive_${CARCH}"
+  local _archive="${!_archive_var}"
+  local _srcdir="${srcdir}/${_archive}"
+
+  install -Dm755 "${_srcdir}/fluree" "${pkgdir}/usr/bin/fluree"
+  install -Dm644 "${_srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 "${_srcdir}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+
+  install -dm755 "${pkgdir}/usr/share/bash-completion/completions"
+  install -dm755 "${pkgdir}/usr/share/zsh/site-functions"
+  install -dm755 "${pkgdir}/usr/share/fish/vendor_completions.d"
+  "${_srcdir}/fluree" completions bash > "${pkgdir}/usr/share/bash-completion/completions/fluree"
+  "${_srcdir}/fluree" completions zsh  > "${pkgdir}/usr/share/zsh/site-functions/_fluree"
+  "${_srcdir}/fluree" completions fish > "${pkgdir}/usr/share/fish/vendor_completions.d/fluree.fish"
+}

--- a/contrib/aur/publish.sh
+++ b/contrib/aur/publish.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Updates the fluree-bin AUR package for a new upstream release.
+#
+# Usage: publish.sh <tag>           # e.g. publish.sh v4.0.2
+#
+# Expects, in the calling environment:
+#   - SSH access to aur@aur.archlinux.org (key configured + known_hosts pinned).
+#   - docker, available for a one-off makepkg run in an Arch container.
+#   - git user.name / user.email configured.
+set -euo pipefail
+
+TAG="${1:?usage: $0 <tag>}"
+VERSION="${TAG#v}"
+
+REPO_ROOT="$(git -C "$(dirname "$0")/../.." rev-parse --show-toplevel)"
+TEMPLATE="${REPO_ROOT}/contrib/aur/fluree-bin/PKGBUILD"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fetch_sha() {
+  curl -fsSL \
+    "https://github.com/fluree/db/releases/download/${TAG}/fluree-db-cli-${1}-unknown-linux-gnu.tar.xz.sha256" \
+    | awk '{print $1}'
+}
+
+echo "==> Fetching release checksums for ${TAG}"
+SHA_X86="$(fetch_sha x86_64)"
+SHA_ARM="$(fetch_sha aarch64)"
+[[ -n "$SHA_X86" && -n "$SHA_ARM" ]] || { echo "missing sha256 sums" >&2; exit 1; }
+
+echo "==> Cloning AUR repo"
+git clone "ssh://aur@aur.archlinux.org/fluree-bin.git" "${WORK}/aur"
+
+echo "==> Templating PKGBUILD (pkgver=${VERSION})"
+cp "$TEMPLATE" "${WORK}/aur/PKGBUILD"
+sed -i \
+  -e "s/^pkgver=.*/pkgver=${VERSION}/" \
+  -e "s/^pkgrel=.*/pkgrel=1/" \
+  -e "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${SHA_X86}')/" \
+  -e "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${SHA_ARM}')/" \
+  "${WORK}/aur/PKGBUILD"
+
+echo "==> Regenerating .SRCINFO via makepkg in archlinux:base-devel"
+docker run --rm -v "${WORK}/aur:/work" -w /work archlinux:base-devel bash -c '
+  useradd -m builder && chown -R builder /work
+  su builder -c "makepkg --printsrcinfo" > .SRCINFO
+'
+
+cd "${WORK}/aur"
+if git diff --quiet; then
+  echo "==> No changes; AUR already at ${VERSION}"
+  exit 0
+fi
+
+git add PKGBUILD .SRCINFO
+git commit -m "fluree-bin ${VERSION}"
+git push
+echo "==> Pushed fluree-bin ${VERSION} to AUR"


### PR DESCRIPTION
## Summary

Adds an Arch Linux binary package (`fluree-bin`) for the AUR so Arch users can install Fluree with a standard pacman AUR helper (e.g. `paru -S fluree-bin`, `yay -S fluree-bin`). The package consumes the same prebuilt Linux tarballs that `dist` already publishes to GitHub Releases — no extra build artifacts required upstream. A new `publish-aur` job in the existing release workflow keeps the AUR copy in lockstep with each stable release alongside the existing Docker and Homebrew publish jobs.

## What's added

**`contrib/aur/fluree-bin/PKGBUILD`** — the AUR recipe. Pulls `fluree-db-cli-{x86_64,aarch64}-unknown-linux-gnu.tar.xz` from the matching GitHub release, installs `/usr/bin/fluree`, the BUSL-1.1 LICENSE, the README, and bash/zsh/fish shell completions (generated via the binary's own `fluree completions <shell>` command). Declares `glibc` and `gcc-libs` as runtime deps (verified via `ldd` — no other shared libs), and uses `provides=fluree` / `conflicts=fluree` so the package can coexist with a future source-build variant. Skips the strip step (`options=('!strip' '!debug')`) because `dist` already ships a stripped binary.

**`contrib/aur/fluree-bin/.SRCINFO`** — generated from the PKGBUILD via `makepkg --printsrcinfo`. Required by AUR alongside the PKGBUILD.

**`contrib/aur/publish.sh`** — the release-time updater. Given a tag (e.g. `v4.0.2`), it fetches both per-arch `.sha256` siblings from the GitHub release, sed-substitutes `pkgver`, `pkgrel`, and the two `sha256sums_*` lines into the in-tree PKGBUILD template, regenerates `.SRCINFO` by running `makepkg --printsrcinfo` inside a one-shot `archlinux:base-devel` container (so the runner doesn't need pacman/makepkg installed), then commits and pushes to `ssh://aur@aur.archlinux.org/fluree-bin.git`. No-ops cleanly when the AUR repo already matches the requested version.

**`.github/workflows/release.yml`** — new `publish-aur` job modeled on the existing `publish-docker` job. Runs after `host` (so the GitHub release and its `.sha256` files exist), gated on `!announcement_is_prerelease` so prereleases skip, sets up SSH with pinned AUR host keys (rotation will fail loudly rather than silent-TOFU), then invokes `bash contrib/aur/publish.sh "$TAG"`. Wired into `announce`'s `needs` and `if` clauses with the same `skipped || success` allowance the other publish jobs use.

## One-time setup required before merge takes effect (Done)

1. Generate a dedicated SSH key (ed25519, no passphrase) for the AUR release bot.
2. Register the public half on a Fluree-owned AUR account.
3. Add the private half to GitHub repo secrets as `AUR_SSH_PRIVATE_KEY` (`gh secret set` or web UI).
4. Bootstrap the AUR repo by pushing the initial PKGBUILD + .SRCINFO from a workstation — AUR creates the repo on first push, the workflow only updates it on subsequent releases.

## Notes

- The in-tree `contrib/aur/fluree-bin/PKGBUILD` will go stale relative to AUR after each release — the workflow only updates the AUR copy, not the in-tree template. This is harmless since users install via AUR rather than checking out a tag, but is worth knowing. If we want the in-tree file to always reflect the latest published version, a follow-up can add a step to `publish-aur` that opens a PR back to `main` with the bumped values.
- `.github/workflows/release.yml` is autogenerated by `dist`, but `allow-dirty = ["ci"]` is already set in `dist-workspace.toml` so `dist generate` will not clobber the new job. Anyone running `dist init` from scratch would need to re-add it.
- Validation done: PKGBUILD checksums match upstream's published `.sha256` files for v4.0.2; full `makepkg` build produces a `.pkg.tar.zst` with the expected layout (`/usr/bin/fluree`, completions in their standard system paths, LICENSE under `/usr/share/licenses/fluree-bin/`); workflow YAML parses cleanly; `publish.sh` passes `bash -n` and its sed substitutions produce the expected pinned values when dry-run against the live v4.0.2 release artifacts.
