### PR TITLE
fix: SPARQL UPDATE commits referencing fresh namespaces aren't queryable post-publish

### DIFF
--- a/docs/reference/vocabulary.md
+++ b/docs/reference/vocabulary.md
@@ -102,6 +102,30 @@ Or with the `@vector` shorthand:
 }
 ```
 
+A property declared with `@type: "@vector"` (or `@type: "f:embeddingVector"`) in the `@context` may also use a bare JSON array as its value — equivalent to the explicit `@value` form above:
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "ex:embedding": { "@type": "@vector" }
+  },
+  "insert": {
+    "@id": "ex:doc1",
+    "ex:embedding": [0.1, 0.2, 0.3]
+  }
+}
+```
+
+### Validation rules
+
+- **Element type:** every element must be a JSON number; non-numeric elements are rejected.
+- **Element range:** values are quantized to `f32` at ingest. Non-finite values (`NaN`, `±Infinity`) and values outside the representable `f32` range are rejected.
+- **Non-empty:** vectors must have at least one element. The empty vector (`[]`) is reserved as an internal max-bound sentinel and is rejected by both the coercion layer and the write-path guard.
+- **Scalar values are rejected:** a single number paired with the `f:embeddingVector` datatype (e.g. `{"@value": 0.1, "@type": "@vector"}`) is rejected; the value must be an array.
+
+The same rules apply to the SPARQL typed-literal form `"[0.1, 0.2, 0.3]"^^f:embeddingVector` and to Turtle.
+
 ---
 
 ## Fulltext datatype

--- a/fluree-db-api/src/error.rs
+++ b/fluree-db-api/src/error.rs
@@ -391,7 +391,8 @@ impl ApiError {
             ApiError::Transact(
                 fluree_db_transact::TransactError::CommitConflict { .. }
                 | fluree_db_transact::TransactError::CommitIdMismatch { .. }
-                | fluree_db_transact::TransactError::PublishLostRace { .. },
+                | fluree_db_transact::TransactError::PublishLostRace { .. }
+                | fluree_db_transact::TransactError::NamespaceConflict(_),
             ) => 409,
             // Other transaction errors are usually validation failures
             ApiError::Transact(_) => 400,

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1209,7 +1209,26 @@ impl crate::Fluree {
         policy: Option<&crate::PolicyContext>,
         tracker: Option<&Tracker>,
     ) -> Result<StageResult> {
-        let ns_registry = NamespaceRegistry::from_db(&ledger.snapshot);
+        let mut ns_registry = NamespaceRegistry::from_db(&ledger.snapshot);
+
+        // Adopt any namespace allocations the lowering step already made
+        // (e.g. `lower_sparql_update` allocates IRIs against a caller-owned
+        // registry to build the templates' Sids). The staging registry must
+        // both (a) know about the codes for in-session lookups and (b)
+        // record them in its persistence delta so the commit envelope
+        // captures them — otherwise the committed snapshot omits the
+        // mapping and post-commit SELECT can't resolve the predicate IRI
+        // back to the same Sid the flake was stored under.
+        if !txn.namespace_delta.is_empty() {
+            ns_registry
+                .adopt_delta_for_persistence(&txn.namespace_delta)
+                .map_err(|e| {
+                    ApiError::Internal(format!(
+                        "namespace allocations from SPARQL lowering conflict \
+                         with the staging registry: {e}"
+                    ))
+                })?;
+        }
 
         // Extract txn_meta and graph_delta before staging consumes the Txn
         let txn_meta = txn.txn_meta.clone();

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1219,13 +1219,20 @@ impl crate::Fluree {
         // captures them — otherwise the committed snapshot omits the
         // mapping and post-commit SELECT can't resolve the predicate IRI
         // back to the same Sid the flake was stored under.
+        //
+        // Conflicts here are retry-safe: they happen when two concurrent
+        // SPARQL UPDATEs both lower against the same pre-commit snapshot
+        // and pick the same first-time namespace code for different
+        // prefixes. The second writer should re-lower against the latest
+        // snapshot (which now sees the first writer's namespaces) — surface
+        // as `NamespaceConflict` so callers in the same family as
+        // `CommitConflict` / `PublishLostRace` can treat it uniformly.
         if !txn.namespace_delta.is_empty() {
             ns_registry
                 .adopt_delta_for_persistence(&txn.namespace_delta)
                 .map_err(|e| {
-                    ApiError::Internal(format!(
-                        "namespace allocations from SPARQL lowering conflict \
-                         with the staging registry: {e}"
+                    ApiError::Transact(fluree_db_transact::TransactError::NamespaceConflict(
+                        e.to_string(),
                     ))
                 })?;
         }

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1858,7 +1858,7 @@ impl crate::Fluree {
             let _g = parse_span.enter();
             let mut sink = FlakeSink::new(&mut ns_registry, new_t, txn_id);
             fluree_graph_turtle::parse(turtle, &mut sink)?;
-            sink.finish()
+            sink.finish().map_err(ApiError::from)?
         };
         tracing::info!(flake_count = flakes.len(), "turtle parsed to flakes");
 

--- a/fluree-db-api/tests/it_vector_corruption_repro.rs
+++ b/fluree-db-api/tests/it_vector_corruption_repro.rs
@@ -9,20 +9,16 @@
 //! previous corrupt shape of N scalar flakes each tagged with the
 //! vector datatype.
 //!
-//! Two pre-existing concerns surfaced (but not introduced) by the fix
-//! are pinned here as `#[ignore]`'d tests, each with an inline
-//! `TODO(...)` block above its attribute that documents the root cause
-//! and remediation options:
+//! One pre-existing concern surfaced (but not introduced) by the corruption
+//! fix is pinned here as a `#[ignore]`'d test with an inline `TODO(...)`
+//! block above its attribute that documents the root cause and remediation
+//! options:
 //!
 //! - `jsonld_context_vector_bare_array_retracts_after_indexing` —
 //!   SPARQL DELETE WHERE on an indexed vector flake doesn't cancel the
 //!   assertion because the retraction allocates a fresh vector arena
 //!   handle, so index-merge cancellation (which keys on `o_kind/o_key`)
 //!   never pairs them. See `TODO(vector-retraction)`.
-//! - `sparql_insert_data_embedding_vector_literal_round_trips_after_indexing`
-//!   — SPARQL `INSERT DATA` of a vector typed literal commits, but the
-//!   subsequent post-publish SELECT returns no rows. See
-//!   `TODO(sparql-vector-ingest)`.
 
 mod support;
 
@@ -215,37 +211,8 @@ async fn jsonld_context_vector_bare_array_retracts_after_indexing() {
     assert_eq!(count_rows, json!([[0]]));
 }
 
-// TODO(sparql-vector-ingest): `coerce_typed_flake_value` correctly produces
-// `FlakeValue::Vector` for `"[..]"^^f:embeddingVector` (verified by
-// `test_coerce_typed_flake_value_vector_lexical` in
-// `fluree-db-transact/src/lower_sparql_update.rs`), and FlakeGenerator
-// generates the assertion flake (op=true, dt=embeddingVector, val_len=N).
-// But a post-publish `SELECT ?v WHERE { ex:doc1 ex:embedding ?v }` returns
-// no rows, suggesting the SPARQL ingest path doesn't fully register the
-// vector with the indexer's vector arena (or the predicate Sid the SELECT
-// resolves doesn't match the one INSERT stored under). Not investigated
-// in depth; out of scope for the JSON-LD corruption fix.
 #[tokio::test]
-#[ignore = "SPARQL INSERT DATA → post-index SELECT for vectors has separate \
-            downstream wiring issues unrelated to the JSON-LD corruption fix; \
-            see TODO(sparql-vector-ingest) above."]
 async fn sparql_insert_data_embedding_vector_literal_round_trips_after_indexing() {
-    use fluree_db_api::LedgerState;
-    use fluree_db_transact::{NamespaceRegistry, Txn, TxnOpts};
-
-    fn lower_sparql_update(ledger: &LedgerState, sparql: &str) -> Txn {
-        let parsed = fluree_db_sparql::parse_sparql(sparql);
-        assert!(
-            !parsed.has_errors(),
-            "SPARQL parse failed: {:?}",
-            parsed.diagnostics
-        );
-        let ast = parsed.ast.expect("SPARQL AST");
-        let mut ns = NamespaceRegistry::from_db(&ledger.snapshot);
-        fluree_db_transact::lower_sparql_update_ast(&ast, &mut ns, TxnOpts::default())
-            .expect("lower SPARQL update")
-    }
-
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-corruption/sparql-insert:main";
     let ledger0 = support::genesis_ledger(&fluree, ledger_id);
@@ -267,6 +234,13 @@ async fn sparql_insert_data_embedding_vector_literal_round_trips_after_indexing(
     support::rebuild_and_publish_index(&fluree, ledger_id).await;
     let loaded = fluree.ledger(ledger_id).await.expect("load indexed ledger");
 
+    // Pre-fix this returned [] because the lowering step's namespace
+    // allocations (e.g. `ex/` → 13) lived only in the caller-owned
+    // NamespaceRegistry — `stage_transaction_from_txn` built its own
+    // registry from the (pre-commit, empty-namespace) snapshot, never saw
+    // the lowering's allocations, and committed flakes whose namespace
+    // codes the post-commit snapshot couldn't resolve back to IRIs. Fixed
+    // by `Txn.namespace_delta` + `adopt_delta_for_persistence`.
     let select = r"
         PREFIX ex: <http://example.org/>
         SELECT ?v WHERE { ex:doc1 ex:embedding ?v }
@@ -285,4 +259,11 @@ async fn sparql_insert_data_embedding_vector_literal_round_trips_after_indexing(
         .and_then(|value| value.as_array())
         .expect("single vector result row");
     assert_eq!(vector.len(), 4);
+    for (actual, expected) in vector.iter().zip([0.1_f64, 0.2, 0.3, 0.4]) {
+        let actual = actual.as_f64().expect("vector element");
+        assert!(
+            (actual - expected).abs() < 0.000_001,
+            "expected {expected}, got {actual}"
+        );
+    }
 }

--- a/fluree-db-api/tests/it_vector_corruption_repro.rs
+++ b/fluree-db-api/tests/it_vector_corruption_repro.rs
@@ -1,0 +1,288 @@
+#![cfg(feature = "native")]
+
+//! Round-trip tests for vector-typed values across ingest paths.
+//!
+//! These tests pin the post-fix behavior for the vector-corruption bug
+//! (context-coerced bare-array `@vector` and SPARQL `f:embeddingVector`
+//! typed literals). Both ingest paths must now produce a single
+//! `FlakeValue::Vector` flake with `dt = embeddingVector` — never the
+//! previous corrupt shape of N scalar flakes each tagged with the
+//! vector datatype.
+//!
+//! Two pre-existing concerns surfaced (but not introduced) by the fix
+//! are pinned here as `#[ignore]`'d tests, each with an inline
+//! `TODO(...)` block above its attribute that documents the root cause
+//! and remediation options:
+//!
+//! - `jsonld_context_vector_bare_array_retracts_after_indexing` —
+//!   SPARQL DELETE WHERE on an indexed vector flake doesn't cancel the
+//!   assertion because the retraction allocates a fresh vector arena
+//!   handle, so index-merge cancellation (which keys on `o_kind/o_key`)
+//!   never pairs them. See `TODO(vector-retraction)`.
+//! - `sparql_insert_data_embedding_vector_literal_round_trips_after_indexing`
+//!   — SPARQL `INSERT DATA` of a vector typed literal commits, but the
+//!   subsequent post-publish SELECT returns no rows. See
+//!   `TODO(sparql-vector-ingest)`.
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, LedgerState};
+use fluree_db_transact::{NamespaceRegistry, Txn, TxnOpts};
+use serde_json::json;
+
+fn lower_sparql_update(ledger: &LedgerState, sparql: &str) -> Txn {
+    let parsed = fluree_db_sparql::parse_sparql(sparql);
+    assert!(
+        !parsed.has_errors(),
+        "SPARQL parse failed: {:?}",
+        parsed.diagnostics
+    );
+    let ast = parsed.ast.expect("SPARQL AST");
+    let mut ns = NamespaceRegistry::from_db(&ledger.snapshot);
+    fluree_db_transact::lower_sparql_update_ast(&ast, &mut ns, TxnOpts::default())
+        .expect("lower SPARQL update")
+}
+
+#[tokio::test]
+async fn jsonld_context_vector_bare_array_round_trips_after_indexing() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/vector-corruption/jsonld-context:main";
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "ex:embedding": { "@type": "@vector" }
+        },
+        "@graph": [{
+            "@id": "ex:doc1",
+            "@type": "ex:VectorTest",
+            "ex:embedding": [0.1, 0.2, 0.3, 0.4]
+        }]
+    });
+
+    let receipt = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("context-coerced bare-array vector insert");
+    assert_eq!(receipt.receipt.t, 1, "single-flake commit");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let loaded = fluree.ledger(ledger_id).await.expect("load indexed ledger");
+
+    let select = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?v WHERE { ex:doc1 ex:embedding ?v }
+    ";
+    let rows = support::query_sparql(&fluree, &loaded, select)
+        .await
+        .expect("query indexed vector")
+        .to_jsonld_async(loaded.as_graph_db_ref(0))
+        .await
+        .expect("format vector result");
+    // Pre-fix this query failed with "vector handle out of arena" because the
+    // JSON-LD expansion split the array into 4 scalar flakes each tagged with
+    // VECTOR_ID. Post-fix expansion produces ONE FlakeValue::Vector flake
+    // and the index materializes it as a 4-element JSON array.
+    let vector = rows
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.as_array())
+        .and_then(|row| row.first())
+        .and_then(|value| value.as_array())
+        .expect("single vector result row");
+    assert_eq!(vector.len(), 4, "expected 4 vector elements");
+    for (actual, expected) in vector.iter().zip([0.1_f64, 0.2, 0.3, 0.4]) {
+        let actual = actual.as_f64().expect("vector element");
+        assert!(
+            (actual - expected).abs() < 0.000_001,
+            "expected {expected}, got {actual}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn jsonld_context_vector_empty_array_is_rejected() {
+    // Belt-and-suspenders for the user-facing path: an empty `[]` vector
+    // value must fail the insert with a clear error before any flake is
+    // committed. Empty `FlakeValue::Vector(Vec::new())` is reserved as the
+    // `FlakeValue::max()` upper-bound sentinel and is hard-rejected by the
+    // shared vector arena. The corruption fix layered two guards so this
+    // can't sneak through any ingest path:
+    //   1. `core::coerce::coerce_array_to_vector` rejects upstream
+    //      (the live transact JSON-LD path goes through this).
+    //   2. `transact::generate::flakes::validate_value_dt_pair` rejects
+    //      at the write-path bottleneck (catches anything that somehow
+    //      bypassed layer 1).
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/vector-corruption/jsonld-empty:main";
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "ex:embedding": { "@type": "@vector" }
+        },
+        "@graph": [{
+            "@id": "ex:doc1",
+            "ex:embedding": []
+        }]
+    });
+
+    let err = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect_err("empty vector must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("at least one element") || msg.contains("embeddingVector"),
+        "expected empty-vector rejection diagnostic, got: {msg}"
+    );
+}
+
+// TODO(vector-retraction): when SPARQL DELETE WHERE matches an indexed
+// vector flake, materialize_template generates a correct retraction
+// (op=false, dt=embeddingVector, FlakeValue::Vector with the matched values)
+// and the transaction commits. But the index-merge cancellation pairs
+// assertions and retractions by `(s, p, dt, o_kind, o_key)`, and the
+// retraction's vector goes through `VectorArena::insert_f32` which
+// allocates a fresh arena slot — so the retraction's `o_key` (handle) is
+// different from the original assertion's, the pair never matches, and
+// COUNT after delete still returns 1.
+//
+// Two viable remediations (both deferred — out of scope for the JSON-LD
+// corruption fix that landed alongside this test):
+//   1. At retraction time, look up the existing arena handle for the
+//      matched (s, p, value) and reuse it on the retraction flake. Tighter
+//      blast radius; needs an arena→handle reverse-lookup index.
+//   2. For `ObjKind::VECTOR_ID` (and any future arena-handle kind), do
+//      cancellation by decoded value rather than by `o_key`. More general
+//      but slower at merge time.
+//
+// The fix that this test pins (single well-formed FlakeValue::Vector flake
+// with `dt = embeddingVector`) is the prerequisite for either remediation —
+// before it, the corrupt scalar-as-vector flakes couldn't even be matched
+// for retraction.
+#[tokio::test]
+#[ignore = "vector retraction is a separate latent issue surfaced by the \
+            JSON-LD corruption fix; see TODO(vector-retraction) above for \
+            the root cause and remediation options."]
+async fn jsonld_context_vector_bare_array_retracts_after_indexing() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/vector-corruption/jsonld-retract:main";
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "ex:embedding": { "@type": "@vector" }
+        },
+        "@graph": [{
+            "@id": "ex:doc1",
+            "ex:embedding": [0.1, 0.2, 0.3, 0.4]
+        }]
+    });
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert vector");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let loaded = fluree.ledger(ledger_id).await.expect("load");
+
+    let delete = r"
+        PREFIX ex: <http://example.org/>
+        DELETE WHERE { ex:doc1 ex:embedding ?v }
+    ";
+    let txn = lower_sparql_update(&loaded, delete);
+    fluree
+        .stage_owned(loaded)
+        .txn(txn)
+        .execute()
+        .await
+        .expect("DELETE WHERE executes");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let reloaded = fluree.ledger(ledger_id).await.expect("reload");
+
+    let count = r"
+        PREFIX ex: <http://example.org/>
+        SELECT (COUNT(*) AS ?count) WHERE { ex:doc1 ex:embedding ?v }
+    ";
+    let count_rows = support::query_sparql(&fluree, &reloaded, count)
+        .await
+        .expect("count")
+        .to_jsonld_async(reloaded.as_graph_db_ref(0))
+        .await
+        .expect("format");
+    assert_eq!(count_rows, json!([[0]]));
+}
+
+// TODO(sparql-vector-ingest): `coerce_typed_flake_value` correctly produces
+// `FlakeValue::Vector` for `"[..]"^^f:embeddingVector` (verified by
+// `test_coerce_typed_flake_value_vector_lexical` in
+// `fluree-db-transact/src/lower_sparql_update.rs`), and FlakeGenerator
+// generates the assertion flake (op=true, dt=embeddingVector, val_len=N).
+// But a post-publish `SELECT ?v WHERE { ex:doc1 ex:embedding ?v }` returns
+// no rows, suggesting the SPARQL ingest path doesn't fully register the
+// vector with the indexer's vector arena (or the predicate Sid the SELECT
+// resolves doesn't match the one INSERT stored under). Not investigated
+// in depth; out of scope for the JSON-LD corruption fix.
+#[tokio::test]
+#[ignore = "SPARQL INSERT DATA → post-index SELECT for vectors has separate \
+            downstream wiring issues unrelated to the JSON-LD corruption fix; \
+            see TODO(sparql-vector-ingest) above."]
+async fn sparql_insert_data_embedding_vector_literal_round_trips_after_indexing() {
+    use fluree_db_api::LedgerState;
+    use fluree_db_transact::{NamespaceRegistry, Txn, TxnOpts};
+
+    fn lower_sparql_update(ledger: &LedgerState, sparql: &str) -> Txn {
+        let parsed = fluree_db_sparql::parse_sparql(sparql);
+        assert!(
+            !parsed.has_errors(),
+            "SPARQL parse failed: {:?}",
+            parsed.diagnostics
+        );
+        let ast = parsed.ast.expect("SPARQL AST");
+        let mut ns = NamespaceRegistry::from_db(&ledger.snapshot);
+        fluree_db_transact::lower_sparql_update_ast(&ast, &mut ns, TxnOpts::default())
+            .expect("lower SPARQL update")
+    }
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/vector-corruption/sparql-insert:main";
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+
+    let insert = r#"
+        PREFIX ex: <http://example.org/>
+        PREFIX f: <https://ns.flur.ee/db#>
+        INSERT DATA {
+            ex:doc1 ex:embedding "[0.1, 0.2, 0.3, 0.4]"^^f:embeddingVector .
+        }
+    "#;
+    let txn = lower_sparql_update(&ledger0, insert);
+    let _inserted = fluree
+        .stage_owned(ledger0)
+        .txn(txn)
+        .execute()
+        .await
+        .expect("SPARQL vector typed literal insert");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let loaded = fluree.ledger(ledger_id).await.expect("load indexed ledger");
+
+    let select = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?v WHERE { ex:doc1 ex:embedding ?v }
+    ";
+    let rows = support::query_sparql(&fluree, &loaded, select)
+        .await
+        .expect("query should produce results")
+        .to_jsonld_async(loaded.as_graph_db_ref(0))
+        .await
+        .expect("format result");
+    let vector = rows
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.as_array())
+        .and_then(|row| row.first())
+        .and_then(|value| value.as_array())
+        .expect("single vector result row");
+    assert_eq!(vector.len(), 4);
+}

--- a/fluree-db-core/src/coerce.rs
+++ b/fluree-db-core/src/coerce.rs
@@ -54,7 +54,7 @@ use crate::temporal::{
 };
 use crate::{Date, DateTime, FlakeValue, GeoPointBits, Time};
 use bigdecimal::BigDecimal;
-use fluree_vocab::{errors, geo, rdf, xsd};
+use fluree_vocab::{errors, fluree, geo, rdf, xsd};
 use num_bigint::BigInt;
 use std::str::FromStr;
 
@@ -419,8 +419,12 @@ pub fn coerce_json_value(
 // Internal Coercion Helpers
 // =============================================================================
 
-/// Coerce a string value to the target datatype
-fn coerce_string_value(s: &str, datatype_iri: &str) -> CoercionResult<FlakeValue> {
+/// Coerce a lexical string value to the target datatype.
+///
+/// Public so other crates (e.g. `fluree-db-transact`'s value-convert) can share
+/// the same parsing rules — notably the f32-quantized vector lexical parse for
+/// `f:embeddingVector`.
+pub fn coerce_string_value(s: &str, datatype_iri: &str) -> CoercionResult<FlakeValue> {
     match datatype_iri {
         // String-like types: pass through
         dt if xsd::is_string_like(dt) => Ok(FlakeValue::String(s.to_string())),
@@ -507,6 +511,15 @@ fn coerce_string_value(s: &str, datatype_iri: &str) -> CoercionResult<FlakeValue
             .map(|_| FlakeValue::Json(s.to_string()))
             .map_err(|e| CoercionError::parse_failed(s, "rdf:JSON", Some(&e.to_string()))),
 
+        // f:embeddingVector — parse JSON array lexical form (e.g. "[0.1, 0.2]")
+        // through the same f32-quantization path used for native arrays.
+        dt if dt == fluree::EMBEDDING_VECTOR => {
+            let arr: Vec<serde_json::Value> = serde_json::from_str(s).map_err(|e| {
+                CoercionError::parse_failed(s, "f:embeddingVector", Some(&e.to_string()))
+            })?;
+            coerce_array_to_vector(&arr)
+        }
+
         // geo:wktLiteral - detect POINT and store as GeoPoint, others as string
         geo::WKT_LITERAL => {
             if let Some((lat, lng)) = try_extract_point(s) {
@@ -533,6 +546,17 @@ fn coerce_number_value(n: &serde_json::Number, datatype_iri: &str) -> CoercionRe
             &format!("number {n}"),
             datatype_iri,
             Some(&format!("Use {{\"@value\": \"{n}\"}} instead.")),
+        ));
+    }
+
+    // Number → Vector is invalid: a scalar can never be a vector. This was
+    // previously a silent fall-through to FlakeValue::Long/Double, producing
+    // VECTOR_ID flakes paired with scalar object keys (storage corruption).
+    if datatype_iri == fluree::EMBEDDING_VECTOR {
+        return Err(CoercionError::incompatible(
+            &format!("number {n}"),
+            "f:embeddingVector",
+            Some("Vector values must be a JSON array of numbers."),
         ));
     }
 
@@ -639,6 +663,15 @@ fn coerce_bool_value(b: bool, datatype_iri: &str) -> CoercionResult<FlakeValue> 
         ));
     }
 
+    // Boolean → Vector is invalid
+    if datatype_iri == fluree::EMBEDDING_VECTOR {
+        return Err(CoercionError::incompatible(
+            &format!("boolean {b}"),
+            "f:embeddingVector",
+            Some("Vector values must be a JSON array of numbers."),
+        ));
+    }
+
     // Boolean → Boolean
     if datatype_iri == xsd::BOOLEAN {
         return Ok(FlakeValue::Boolean(b));
@@ -660,6 +693,17 @@ fn coerce_bool_value(b: bool, datatype_iri: &str) -> CoercionResult<FlakeValue> 
 /// rejected. Users needing higher-precision numeric arrays can use a custom
 /// datatype (stored as a string literal).
 fn coerce_array_to_vector(arr: &[serde_json::Value]) -> CoercionResult<FlakeValue> {
+    // Reject empty arrays. `FlakeValue::Vector(Vec::new())` is reserved as the
+    // upper-bound sentinel by `FlakeValue::max()` (see core/value.rs), and the
+    // shared vector arena (`VectorArena::insert_f32`) hard-rejects empty
+    // vectors anyway. Storing one would either alias the sentinel (corrupting
+    // range scans) or fail at index time (silent partial commit).
+    if arr.is_empty() {
+        return Err(CoercionError::new(
+            "f:embeddingVector requires at least one element; empty vectors \
+             are reserved as a max-bound sentinel and rejected by the vector arena",
+        ));
+    }
     let mut vector = Vec::with_capacity(arr.len());
     for (i, item) in arr.iter().enumerate() {
         match item {
@@ -766,6 +810,14 @@ fn validate_bigint_range(value: &BigInt, datatype_iri: &str) -> CoercionResult<(
     }
     Ok(())
 }
+
+// NOTE: `(datatype, value)` pair invariants for storage (e.g. `f:embeddingVector
+// ⇔ FlakeValue::Vector`) are enforced at the write-path bottleneck via
+// `fluree_db_transact::generate::flakes::validate_value_dt_pair`. That single
+// validator covers all three sinks (FlakeGenerator, ImportSink, FlakeSink) and
+// avoids the drift risk of duplicating the rules at the core/IRI level. If a
+// query-side IRI-based check is needed in the future, factor it back into core
+// here and have the transact validator delegate.
 
 #[cfg(test)]
 mod tests {
@@ -896,5 +948,77 @@ mod tests {
         let result = coerce_value(FlakeValue::BigInt(Box::new(big)), xsd::DOUBLE);
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), FlakeValue::Double(_)));
+    }
+
+    // -------------------------------------------------------------------
+    // f:embeddingVector coercion (regression: see fluree/db-r vector
+    // corruption repro). Scalar Number/Bool with a vector datatype must
+    // be hard-rejected; lexical "[..]" must parse via the shared array
+    // path so JSON-LD/Turtle/SPARQL all share f32 quantization.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn test_coerce_json_array_to_vector() {
+        let json = serde_json::json!([0.1, 0.2, 0.3, 0.4]);
+        let result = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap();
+        match result {
+            FlakeValue::Vector(v) => assert_eq!(v.len(), 4),
+            other => panic!("expected Vector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_coerce_json_number_to_vector_rejects() {
+        let json = serde_json::json!(0.1);
+        let err = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap_err();
+        assert!(err.message.contains("f:embeddingVector"), "{}", err.message);
+    }
+
+    #[test]
+    fn test_coerce_json_bool_to_vector_rejects() {
+        let json = serde_json::json!(true);
+        let err = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap_err();
+        assert!(err.message.contains("f:embeddingVector"), "{}", err.message);
+    }
+
+    #[test]
+    fn test_coerce_string_lexical_to_vector() {
+        let json = serde_json::json!("[0.1, 0.2, 0.3]");
+        let result = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap();
+        match result {
+            FlakeValue::Vector(v) => assert_eq!(v.len(), 3),
+            other => panic!("expected Vector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_coerce_string_lexical_to_vector_invalid_rejects() {
+        let json = serde_json::json!("not-an-array");
+        let err = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap_err();
+        assert!(err.message.contains("f:embeddingVector"), "{}", err.message);
+    }
+
+    #[test]
+    fn test_coerce_empty_array_to_vector_rejects() {
+        // Empty `Vector(Vec::new())` is reserved as the FlakeValue::max() sentinel
+        // and the vector arena rejects it. Coercion must fail upstream.
+        let json = serde_json::json!([]);
+        let err = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap_err();
+        assert!(
+            err.message.contains("at least one element"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_coerce_empty_string_lexical_to_vector_rejects() {
+        let json = serde_json::json!("[]");
+        let err = coerce_json_value(&json, fluree::EMBEDDING_VECTOR).unwrap_err();
+        assert!(
+            err.message.contains("at least one element"),
+            "{}",
+            err.message
+        );
     }
 }

--- a/fluree-db-core/src/ns_encoding.rs
+++ b/fluree-db-core/src/ns_encoding.rs
@@ -589,6 +589,58 @@ impl NamespaceCodes {
         Ok(())
     }
 
+    /// Like [`merge_delta`](Self::merge_delta), but also records the new
+    /// entries in the persistence delta (`self.delta`) so the next
+    /// `take_delta()` includes them in the commit record.
+    ///
+    /// Use this when adopting allocations made by *another* registry that
+    /// must end up persisted in this registry's commit (e.g. SPARQL
+    /// `lower_sparql_update` builds template Sids against a caller-owned
+    /// `NamespaceRegistry`; the staging path adopts those allocations so the
+    /// committed snapshot maps them back to IRIs for query-time lookup).
+    pub fn adopt_delta_for_persistence(
+        &mut self,
+        delta: &HashMap<u16, String>,
+    ) -> Result<(), NsAllocError> {
+        for (&code, prefix) in delta {
+            // Same conflict checks as merge_delta
+            if let Some(existing) = self.code_to_prefix.get(&code) {
+                if existing != prefix {
+                    return Err(NsAllocError::CodeConflict {
+                        code,
+                        new_prefix: prefix.clone(),
+                        existing_prefix: existing.clone(),
+                    });
+                }
+                // Already registered with matching prefix — record in delta only
+                // if this registry hasn't already persisted it.
+                self.delta.entry(code).or_insert_with(|| prefix.clone());
+                continue;
+            }
+
+            if let Some(&existing_code) = self.prefix_to_code.get(prefix.as_str()) {
+                if existing_code != code {
+                    return Err(NsAllocError::PrefixConflict {
+                        prefix: prefix.clone(),
+                        new_code: code,
+                        existing_code,
+                    });
+                }
+                self.delta.entry(code).or_insert_with(|| prefix.clone());
+                continue;
+            }
+
+            // New mapping — insert into both lookup tables AND persistence delta
+            self.prefix_to_code.insert(prefix.clone(), code);
+            self.code_to_prefix.insert(code, prefix.clone());
+            self.delta.insert(code, prefix.clone());
+            if code >= self.next_code && code < OVERFLOW {
+                self.next_code = code + 1;
+            }
+        }
+        Ok(())
+    }
+
     /// Take the accumulated delta (new allocations) and reset it.
     ///
     /// Returns the map of new allocations (`code → prefix`) for inclusion

--- a/fluree-db-core/src/ns_encoding.rs
+++ b/fluree-db-core/src/ns_encoding.rs
@@ -1157,10 +1157,7 @@ mod tests {
         let next_code_after_first = codes.next_code;
         codes.adopt_delta_for_persistence(&delta).unwrap();
         assert_eq!(codes.next_code, next_code_after_first);
-        assert_eq!(
-            codes.get_code("https://idem.example.org/"),
-            Some(150)
-        );
+        assert_eq!(codes.get_code("https://idem.example.org/"), Some(150));
     }
 
     #[test]

--- a/fluree-db-core/src/ns_encoding.rs
+++ b/fluree-db-core/src/ns_encoding.rs
@@ -1093,6 +1093,152 @@ mod tests {
         assert!(!codes.has_delta());
     }
 
+    // ---- adopt_delta_for_persistence ----
+    //
+    // Distinct from merge_delta: also records adopted entries in
+    // `self.delta` so the next take_delta()/commit captures them.
+    // Used by `stage_transaction_from_txn` to persist namespace
+    // allocations made by an upstream registry (e.g. SPARQL lowering).
+
+    #[test]
+    fn test_adopt_delta_records_new_mapping_in_delta() {
+        let mut codes = NamespaceCodes::new();
+        let next_code_before = codes.next_code;
+
+        let mut delta = HashMap::new();
+        delta.insert(next_code_before, "https://new.example.org/".to_string());
+        codes.adopt_delta_for_persistence(&delta).unwrap();
+
+        // Lookup tables updated
+        assert_eq!(
+            codes.get_code("https://new.example.org/"),
+            Some(next_code_before)
+        );
+        assert_eq!(
+            codes.get_prefix(next_code_before),
+            Some("https://new.example.org/")
+        );
+
+        // Persistence delta captured the new entry — this is the contract
+        // that distinguishes adopt_delta_for_persistence from merge_delta.
+        assert!(codes.has_delta());
+        let taken = codes.take_delta();
+        assert_eq!(
+            taken.get(&next_code_before).map(String::as_str),
+            Some("https://new.example.org/")
+        );
+    }
+
+    #[test]
+    fn test_adopt_delta_advances_next_code() {
+        let mut codes = NamespaceCodes::new();
+        let mut delta = HashMap::new();
+        // Adopt a code well above next_code; next_code must jump past it
+        // so subsequent allocations don't collide.
+        delta.insert(200u16, "https://gap.example.org/".to_string());
+        codes.adopt_delta_for_persistence(&delta).unwrap();
+
+        assert_eq!(codes.next_code, 201);
+
+        // The next allocate_prefix should land at 201.
+        let new_code = codes.allocate_prefix("https://after.example.org/").unwrap();
+        assert_eq!(new_code, 201);
+    }
+
+    #[test]
+    fn test_adopt_delta_idempotent_for_same_mapping() {
+        let mut codes = NamespaceCodes::new();
+        let mut delta = HashMap::new();
+        delta.insert(150u16, "https://idem.example.org/".to_string());
+
+        codes.adopt_delta_for_persistence(&delta).unwrap();
+        // Second adopt of the same mapping must succeed and not duplicate
+        // entries or change next_code.
+        let next_code_after_first = codes.next_code;
+        codes.adopt_delta_for_persistence(&delta).unwrap();
+        assert_eq!(codes.next_code, next_code_after_first);
+        assert_eq!(
+            codes.get_code("https://idem.example.org/"),
+            Some(150)
+        );
+    }
+
+    #[test]
+    fn test_adopt_delta_rejects_code_conflict() {
+        let mut codes = NamespaceCodes::new();
+        let mut first = HashMap::new();
+        first.insert(170u16, "https://first.example.org/".to_string());
+        codes.adopt_delta_for_persistence(&first).unwrap();
+
+        // Same code, different prefix → CodeConflict.
+        let mut conflicting = HashMap::new();
+        conflicting.insert(170u16, "https://second.example.org/".to_string());
+        let err = codes
+            .adopt_delta_for_persistence(&conflicting)
+            .expect_err("must reject");
+        match err {
+            NsAllocError::CodeConflict {
+                code,
+                new_prefix,
+                existing_prefix,
+            } => {
+                assert_eq!(code, 170);
+                assert_eq!(new_prefix, "https://second.example.org/");
+                assert_eq!(existing_prefix, "https://first.example.org/");
+            }
+            other => panic!("expected CodeConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_adopt_delta_rejects_prefix_conflict() {
+        let mut codes = NamespaceCodes::new();
+        let mut first = HashMap::new();
+        first.insert(180u16, "https://shared.example.org/".to_string());
+        codes.adopt_delta_for_persistence(&first).unwrap();
+
+        // Same prefix, different code → PrefixConflict.
+        let mut conflicting = HashMap::new();
+        conflicting.insert(181u16, "https://shared.example.org/".to_string());
+        let err = codes
+            .adopt_delta_for_persistence(&conflicting)
+            .expect_err("must reject");
+        match err {
+            NsAllocError::PrefixConflict {
+                prefix,
+                new_code,
+                existing_code,
+            } => {
+                assert_eq!(prefix, "https://shared.example.org/");
+                assert_eq!(new_code, 181);
+                assert_eq!(existing_code, 180);
+            }
+            other => panic!("expected PrefixConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_adopt_delta_records_existing_mapping_in_delta_when_absent() {
+        // Pre-existing mapping (e.g. a default that won't otherwise be in
+        // delta): adopt_delta_for_persistence should still record it so the
+        // commit captures the use site. Avoids losing the binding when the
+        // staging registry inherits from a snapshot but the lowering
+        // registry independently learned of the same mapping.
+        let mut codes = NamespaceCodes::new();
+        let prefix = "https://shared.example.org/";
+        let code = codes.allocate_prefix(prefix).unwrap();
+        // Drain the delta so we can observe whether adopt re-records it.
+        codes.take_delta();
+        assert!(!codes.has_delta());
+
+        let mut delta = HashMap::new();
+        delta.insert(code, prefix.to_string());
+        codes.adopt_delta_for_persistence(&delta).unwrap();
+
+        let taken = codes.take_delta();
+        assert_eq!(taken.get(&code).map(String::as_str), Some(prefix));
+    }
+
     // ---- NsLookup trait ----
 
     #[test]

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -1611,10 +1611,6 @@ async fn execute_sparql_update_request(
         }
     };
 
-    // Get namespace registry from the ledger's snapshot
-    let cached_state = handle.snapshot().await;
-    let mut ns = NamespaceRegistry::from_db(&cached_state.snapshot);
-
     // Resolve the effective identity honoring the root-impersonation semantic.
     // For SPARQL UPDATE, impersonation is driven by the `fluree-identity` header
     // (there is no body-level opts block). Policy-class / policy / policy-values
@@ -1628,14 +1624,6 @@ async fn execute_sparql_update_request(
     )
     .await;
 
-    // TxnOpts no longer carries identity — provenance flows via CommitOpts.
-    let txn_opts = TxnOpts::default();
-
-    // Build PolicyContext from the resolved identity plus all header-supplied
-    // policy fields. SPARQL UPDATE has no body opts block, so headers are the
-    // only transport for `policy-class`, `policy`, `policy-values`, and
-    // `default-allow`. The impersonation gate above already constrained the
-    // identity; the additional fields here apply on top.
     let policy_values_map = match headers.policy_values_map() {
         Ok(v) => v,
         Err(e) => {
@@ -1656,88 +1644,135 @@ async fn execute_sparql_update_request(
         default_allow: headers.default_allow,
         ..Default::default()
     };
-    let policy_ctx = if qc_opts.has_any_policy_inputs() {
-        match fluree_db_api::build_policy_context(
-            &cached_state.snapshot,
-            cached_state.novelty.as_ref(),
-            Some(cached_state.novelty.as_ref()),
-            cached_state.t,
-            &qc_opts,
-        )
-        .await
-        {
-            Ok(ctx) => Some(ctx),
-            Err(e) => {
-                let server_error = ServerError::Api(e);
-                set_span_error_code(parent_span, "error:PolicyBuildFailed");
-                tracing::error!(error = %server_error, "failed to build policy context for SPARQL UPDATE");
-                return Err(server_error);
-            }
-        }
-    } else {
-        None
-    };
 
-    // Lower SPARQL UPDATE to Txn IR
-    let txn = match lower_sparql_update(update_op, &ast.prologue, &mut ns, txn_opts) {
-        Ok(txn) => txn,
-        Err(e) => {
-            set_span_error_code(parent_span, "error:SparqlLower");
-            tracing::warn!(error = %e, "SPARQL UPDATE lowering failed");
-            return Err(ServerError::SparqlUpdateLower(e));
-        }
-    };
-
-    tracing::debug!(
-        tx_id = %tx_id,
-        txn_type = ?txn.txn_type,
-        where_patterns = txn.where_patterns.len(),
-        delete_templates = txn.delete_templates.len(),
-        insert_templates = txn.insert_templates.len(),
-        "SPARQL UPDATE lowered to Txn IR"
-    );
-
-    // Execute the transaction using the Txn IR directly
     let fluree = &state.fluree;
-    let mut builder = fluree.stage(&handle).txn(txn);
-    let mut commit_opts = CommitOpts::default();
-    if let Some(d) = &effective_identity {
-        commit_opts = commit_opts.identity(d.clone());
-    }
-    // If the request was signed, ALWAYS store the original signed envelope for provenance.
-    // Spawn the upload in parallel with the rest of the pipeline.
-    if let Some(raw_txn) = raw_txn_from_credential(credential) {
-        let content_store = fluree.content_store(handle.ledger_id());
-        commit_opts = commit_opts.with_raw_txn_spawned(content_store, raw_txn);
-    }
-    builder = builder.commit_opts(commit_opts);
-    if let Some(config) = &state.index_config {
-        builder = builder.index_config(config.clone());
-    }
-    if let Some(ctx) = policy_ctx {
-        builder = builder.policy(ctx);
-    }
-
     let correlation = index_request_correlation(
         &credential.headers,
         extract_request_id(&credential.headers, &state.telemetry_config),
         "sparql-update",
     );
-    let result = match with_index_request_correlation(correlation, builder.execute()).await {
-        Ok(result) => {
-            tracing::info!(
-                status = "success",
-                commit_t = result.receipt.t,
-                commit_id = %result.receipt.commit_id,
-                "SPARQL UPDATE committed"
-            );
-            result
+
+    // Bounded retry around snapshot fetch + lowering + execute.
+    //
+    // `lower_sparql_update` allocates IRIs against a `NamespaceRegistry` built
+    // from the *current* snapshot to assign Sids to template terms. Two
+    // concurrent SPARQL UPDATEs racing on a fresh namespace can both pick the
+    // same first-time code for *different* prefixes, then the second writer
+    // hits `TransactError::NamespaceConflict` at staging because the staging
+    // registry sees the first writer's commit. The fix: re-fetch the snapshot
+    // and re-lower against the latest namespace allocations. Bounded to 3
+    // attempts to avoid livelock; the conflict is rare (requires concurrent
+    // writers AND first-time-namespace contention), so 1 retry is usually
+    // enough.
+    const MAX_NS_RETRIES: usize = 3;
+    let mut last_error: Option<ServerError> = None;
+    let mut result = None;
+    for attempt in 1..=MAX_NS_RETRIES {
+        let cached_state = handle.snapshot().await;
+        let mut ns = NamespaceRegistry::from_db(&cached_state.snapshot);
+
+        // Build PolicyContext from the resolved identity plus all header-supplied
+        // policy fields. Rebuilt each attempt because it depends on the snapshot.
+        let policy_ctx = if qc_opts.has_any_policy_inputs() {
+            match fluree_db_api::build_policy_context(
+                &cached_state.snapshot,
+                cached_state.novelty.as_ref(),
+                Some(cached_state.novelty.as_ref()),
+                cached_state.t,
+                &qc_opts,
+            )
+            .await
+            {
+                Ok(ctx) => Some(ctx),
+                Err(e) => {
+                    let server_error = ServerError::Api(e);
+                    set_span_error_code(parent_span, "error:PolicyBuildFailed");
+                    tracing::error!(error = %server_error, "failed to build policy context for SPARQL UPDATE");
+                    return Err(server_error);
+                }
+            }
+        } else {
+            None
+        };
+
+        let txn = match lower_sparql_update(update_op, &ast.prologue, &mut ns, TxnOpts::default()) {
+            Ok(txn) => txn,
+            Err(e) => {
+                set_span_error_code(parent_span, "error:SparqlLower");
+                tracing::warn!(error = %e, "SPARQL UPDATE lowering failed");
+                return Err(ServerError::SparqlUpdateLower(e));
+            }
+        };
+
+        tracing::debug!(
+            tx_id = %tx_id,
+            attempt,
+            txn_type = ?txn.txn_type,
+            where_patterns = txn.where_patterns.len(),
+            delete_templates = txn.delete_templates.len(),
+            insert_templates = txn.insert_templates.len(),
+            "SPARQL UPDATE lowered to Txn IR"
+        );
+
+        let mut builder = fluree.stage(&handle).txn(txn);
+        let mut commit_opts = CommitOpts::default();
+        if let Some(d) = &effective_identity {
+            commit_opts = commit_opts.identity(d.clone());
         }
-        Err(e) => {
-            let server_error = ServerError::Api(e);
-            set_span_error_code(parent_span, "error:InvalidTransaction");
-            tracing::error!(error = %server_error, "SPARQL UPDATE failed");
-            return Err(server_error);
+        // If the request was signed, ALWAYS store the original signed envelope
+        // for provenance. Spawn the upload in parallel with the rest of the
+        // pipeline. Re-spawning across retries is harmless: the content store
+        // is content-addressed so duplicate puts are idempotent.
+        if let Some(raw_txn) = raw_txn_from_credential(credential) {
+            let content_store = fluree.content_store(handle.ledger_id());
+            commit_opts = commit_opts.with_raw_txn_spawned(content_store, raw_txn);
+        }
+        builder = builder.commit_opts(commit_opts);
+        if let Some(config) = &state.index_config {
+            builder = builder.index_config(config.clone());
+        }
+        if let Some(ctx) = policy_ctx {
+            builder = builder.policy(ctx);
+        }
+
+        match with_index_request_correlation(correlation.clone(), builder.execute()).await {
+            Ok(r) => {
+                tracing::info!(
+                    status = "success",
+                    attempt,
+                    commit_t = r.receipt.t,
+                    commit_id = %r.receipt.commit_id,
+                    "SPARQL UPDATE committed"
+                );
+                result = Some(r);
+                break;
+            }
+            Err(fluree_db_api::ApiError::Transact(
+                fluree_db_api::TransactError::NamespaceConflict(msg),
+            )) if attempt < MAX_NS_RETRIES => {
+                tracing::warn!(
+                    attempt,
+                    max_attempts = MAX_NS_RETRIES,
+                    %msg,
+                    "SPARQL UPDATE namespace conflict; re-lowering against latest snapshot"
+                );
+                continue;
+            }
+            Err(e) => {
+                let server_error = ServerError::Api(e);
+                set_span_error_code(parent_span, "error:InvalidTransaction");
+                tracing::error!(error = %server_error, attempt, "SPARQL UPDATE failed");
+                last_error = Some(server_error);
+                break;
+            }
+        }
+    }
+    let result = match result {
+        Some(r) => r,
+        None => {
+            return Err(last_error.unwrap_or_else(|| {
+                ServerError::internal("SPARQL UPDATE failed after retries with no captured error")
+            }));
         }
     };
 

--- a/fluree-db-transact/src/error.rs
+++ b/fluree-db-transact/src/error.rs
@@ -65,6 +65,20 @@ pub enum TransactError {
         published_commit_id: String,
     },
 
+    /// Namespace allocations from a pre-built `Txn` (e.g. SPARQL UPDATE
+    /// lowered against a stale snapshot) conflict with the staging
+    /// registry. Retry-safe: re-lower against the latest snapshot.
+    ///
+    /// Triggered when two concurrent SPARQL UPDATEs lower against the same
+    /// pre-commit snapshot, both pick the same first-time namespace code
+    /// for *different* prefixes, and the second writer reaches staging
+    /// after the first has committed.
+    #[error(
+        "Namespace allocation from pre-built Txn conflicts with the staging \
+         registry (likely stale lowering against an out-of-date snapshot): {0}"
+    )]
+    NamespaceConflict(String),
+
     /// Ledger or branch has been retracted (soft-deleted)
     #[error("Ledger has been retracted: {0}")]
     Retracted(String),

--- a/fluree-db-transact/src/flake_sink.rs
+++ b/fluree-db-transact/src/flake_sink.rs
@@ -3,7 +3,8 @@
 //! This bypasses the Graph → JSON-LD → Txn IR → FlakeGenerator pipeline for
 //! Turtle INSERT, converting parsed triples directly into assertion flakes.
 
-use crate::generate::infer_datatype;
+use crate::error::TransactError;
+use crate::generate::{infer_datatype, validate_value_dt_pair};
 use crate::namespace::{NamespaceRegistry, NsAllocator};
 use crate::value_convert::{convert_native_literal, convert_string_literal};
 use fluree_db_core::DatatypeConstraint;
@@ -45,7 +46,7 @@ enum ResolvedTerm {
 /// let mut ns = NamespaceRegistry::from_db(&db);
 /// let mut sink = FlakeSink::new(&mut ns, new_t, txn_id);
 /// fluree_graph_turtle::parse(ttl, &mut sink)?;
-/// let flakes = sink.finish();
+/// let flakes = sink.finish().expect("no invariant violation");
 /// ```
 pub struct FlakeSink<'a> {
     /// Resolved terms indexed by TermId
@@ -62,6 +63,10 @@ pub struct FlakeSink<'a> {
     t: i64,
     /// Transaction ID for blank node skolemization
     txn_id: String,
+    /// First storage-invariant violation observed during parse, if any.
+    /// Surfaced by `finish()` so the caller fails the whole transaction
+    /// rather than silently committing a partial flake set.
+    invariant_error: Option<TransactError>,
 }
 
 impl<'a> FlakeSink<'a> {
@@ -80,12 +85,19 @@ impl<'a> FlakeSink<'a> {
             ns_registry,
             t,
             txn_id,
+            invariant_error: None,
         }
     }
 
-    /// Consume the sink and return the accumulated flakes.
-    pub fn finish(self) -> Vec<Flake> {
-        self.flakes
+    /// Consume the sink and return the accumulated flakes, or surface the
+    /// first storage-invariant violation observed during parsing as a hard
+    /// error. Mirrors [`ImportSink::finish`](crate::import_sink::ImportSink)
+    /// — bad input must fail the transaction, not silently omit a triple.
+    pub fn finish(self) -> Result<Vec<Flake>, TransactError> {
+        if let Some(err) = self.invariant_error {
+            return Err(err);
+        }
+        Ok(self.flakes)
     }
 
     // -- helpers -------------------------------------------------------------
@@ -124,7 +136,7 @@ impl<'a> FlakeSink<'a> {
 
     /// Build a Flake from resolved subject/predicate/object with optional list index.
     fn build_flake(
-        &self,
+        &mut self,
         subject: TermId,
         predicate: TermId,
         object: TermId,
@@ -136,6 +148,19 @@ impl<'a> FlakeSink<'a> {
 
         let dt = dtc.datatype().clone();
         let lang = dtc.lang_tag().map(std::string::ToString::to_string);
+
+        // Late hard guard: refuse to emit (FlakeValue, dt) shapes that would
+        // produce corrupt flakes. Capture the first violation on the sink so
+        // `finish()` can surface it as a hard transaction error — silently
+        // dropping triples would let `stage_turtle_insert` succeed with
+        // partial data, which is worse than failing loudly.
+        if let Err(e) = validate_value_dt_pair(&o, &dt) {
+            tracing::error!("FlakeSink: invariant violation, aborting — {e}");
+            if self.invariant_error.is_none() {
+                self.invariant_error = Some(e);
+            }
+            return None;
+        }
 
         let meta = match (&lang, list_index) {
             (Some(l), Some(i)) => Some(FlakeMeta {
@@ -261,7 +286,7 @@ mod tests {
         let o = sink.term_literal("Alice", Datatype::xsd_string(), None);
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         let f = &flakes[0];
         assert!(f.op); // assertion
@@ -280,7 +305,7 @@ mod tests {
         let o = sink.term_literal_value(LiteralValue::Integer(30), Datatype::xsd_integer());
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Long(30)));
     }
@@ -295,7 +320,7 @@ mod tests {
         let o = sink.term_literal_value(LiteralValue::Double(3.13), Datatype::xsd_double());
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Double(d) if (*d - 3.13).abs() < f64::EPSILON));
     }
@@ -310,7 +335,7 @@ mod tests {
         let o = sink.term_literal_value(LiteralValue::Boolean(true), Datatype::xsd_boolean());
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Boolean(true)));
     }
@@ -325,7 +350,7 @@ mod tests {
         let o = sink.term_literal("Alice", Datatype::rdf_lang_string(), Some("en"));
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         let f = &flakes[0];
         assert!(matches!(&f.o, FlakeValue::String(s) if s == "Alice"));
@@ -363,7 +388,7 @@ mod tests {
         let o = sink.term_iri("http://example.org/bob");
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         let f = &flakes[0];
         assert!(matches!(&f.o, FlakeValue::Ref(_)));
@@ -385,7 +410,7 @@ mod tests {
         sink.emit_list_item(s, p, o1, 1);
         sink.emit_list_item(s, p, o2, 2);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 3);
         for (i, f) in flakes.iter().enumerate() {
             let meta = f.m.as_ref().expect("list items should have meta");
@@ -404,7 +429,7 @@ mod tests {
         let o = sink.term_literal("2024-01-15T10:30:00Z", Datatype::xsd_date_time(), None);
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::DateTime(_)));
     }
@@ -419,7 +444,7 @@ mod tests {
         let o = sink.term_literal("42", Datatype::xsd_integer(), None);
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Long(42)));
     }
@@ -435,11 +460,39 @@ mod tests {
         let o = sink.term_literal("42", Datatype::xsd_long(), None);
         sink.emit_triple(s, p, o);
 
-        let flakes = sink.finish();
+        let flakes = sink.finish().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Long(42)));
         // dt must be xsd:long (declared), not xsd:integer (inferred)
         let expected_dt = ns.sid_for_iri(xsd::LONG);
         assert_eq!(flakes[0].dt, expected_dt);
+    }
+
+    #[test]
+    fn test_invalid_vector_lexical_aborts_finish() {
+        // A Turtle literal `"not-a-vector"^^f:embeddingVector` parses through
+        // convert_string_literal → falls back to FlakeValue::String. The late
+        // guard in build_flake must capture the (String, embeddingVector)
+        // mismatch and surface it from finish() rather than silently dropping
+        // the bad triple — otherwise stage_turtle_insert would commit a
+        // partial flake set with the bad data omitted.
+        let (mut ns, t, txn_id) = make_sink();
+        let mut sink = FlakeSink::new(&mut ns, t, txn_id);
+
+        let s = sink.term_iri("http://example.org/doc1");
+        let p = sink.term_iri("http://example.org/embedding");
+        let o = sink.term_literal(
+            "not-a-vector",
+            Datatype::from_iri(fluree_vocab::fluree::EMBEDDING_VECTOR),
+            None,
+        );
+        sink.emit_triple(s, p, o);
+
+        let err = sink.finish().expect_err("invariant violation must abort");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("embeddingVector"),
+            "expected embeddingVector in error, got: {msg}"
+        );
     }
 }

--- a/fluree-db-transact/src/generate/flakes.rs
+++ b/fluree-db-transact/src/generate/flakes.rs
@@ -184,6 +184,11 @@ impl<'a> FlakeGenerator<'a> {
             _ => return Ok(None),
         };
 
+        // Late hard guard for storage invariants: catches (FlakeValue, dt)
+        // mis-pairings (e.g. scalar object key with VECTOR_ID datatype) before
+        // they hit the index. Bails out the whole transaction.
+        validate_value_dt_pair(&o, &dt)?;
+
         // Create metadata if language tag or list_index is present
         let meta_lang = template_lang.or(bound_lang);
         let meta = match (&meta_lang, &template.list_index) {
@@ -389,6 +394,46 @@ impl<'a> FlakeGenerator<'a> {
     }
 }
 
+/// Hard-fail invariants between the resolved datatype Sid and FlakeValue
+/// shape, run before a flake is committed. Catches mis-paired forms like
+/// `(FlakeValue::Double, dt=embeddingVector)` produced by upstream parsing
+/// bugs — without this guard, those go on to generate VECTOR_ID flakes
+/// pointing at scalar arena handles, corrupting the index.
+pub(crate) fn validate_value_dt_pair(val: &FlakeValue, dt: &Sid) -> Result<()> {
+    let is_vector_dt = dt == &*DT_VECTOR;
+    let is_vector_val = matches!(val, FlakeValue::Vector(_));
+    if is_vector_dt != is_vector_val {
+        return Err(TransactError::FlakeGeneration(format!(
+            "f:embeddingVector must pair only with FlakeValue::Vector \
+             (dt_vector={is_vector_dt}, val_vector={is_vector_val}); \
+             a parser produced a mismatched (value, datatype) shape"
+        )));
+    }
+    // Empty vectors must never reach the indexer: `FlakeValue::Vector(Vec::new())`
+    // is reserved as the `FlakeValue::max()` upper-bound sentinel, and the shared
+    // vector arena hard-rejects them. Catch any path that bypassed
+    // `coerce_array_to_vector`'s upstream check (e.g. a future direct
+    // construction of `FlakeValue::Vector(vec![])`).
+    if is_vector_dt {
+        if let FlakeValue::Vector(v) = val {
+            if v.is_empty() {
+                return Err(TransactError::FlakeGeneration(
+                    "f:embeddingVector flake must have at least one element; \
+                     empty vectors collide with the FlakeValue::max() sentinel \
+                     and the vector arena rejects them"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    if dt == &*DT_JSON && !matches!(val, FlakeValue::Json(_)) {
+        return Err(TransactError::FlakeGeneration(format!(
+            "rdf:JSON must pair only with FlakeValue::Json (got {val:?})"
+        )));
+    }
+    Ok(())
+}
+
 /// Infer datatype from a FlakeValue
 ///
 /// Returns the appropriate XSD/RDF datatype Sid for the given value.
@@ -580,5 +625,37 @@ mod tests {
         let meta = flakes[0].m.as_ref().expect("should have metadata");
         assert_eq!(meta.lang.as_deref(), Some("en"));
         assert_eq!(meta.i, Some(0));
+    }
+
+    #[test]
+    fn test_validate_pair_rejects_vector_dt_with_non_vector_value() {
+        let err = validate_value_dt_pair(
+            &FlakeValue::Double(0.1),
+            &Sid::new(FLUREE_DB, "embeddingVector"),
+        )
+        .expect_err("scalar paired with embeddingVector dt must fail");
+        assert!(format!("{err}").contains("embeddingVector"));
+    }
+
+    #[test]
+    fn test_validate_pair_rejects_empty_vector() {
+        // Empty Vector is reserved as the FlakeValue::max() sentinel and the
+        // vector arena rejects it; the write-path guard must catch it even if
+        // it bypassed coerce_array_to_vector.
+        let err = validate_value_dt_pair(
+            &FlakeValue::Vector(Vec::new()),
+            &Sid::new(FLUREE_DB, "embeddingVector"),
+        )
+        .expect_err("empty vector must be rejected");
+        assert!(format!("{err}").contains("at least one element"), "{err}");
+    }
+
+    #[test]
+    fn test_validate_pair_accepts_non_empty_vector() {
+        validate_value_dt_pair(
+            &FlakeValue::Vector(vec![0.1, 0.2]),
+            &Sid::new(FLUREE_DB, "embeddingVector"),
+        )
+        .expect("non-empty vector with embeddingVector dt is valid");
     }
 }

--- a/fluree-db-transact/src/generate/mod.rs
+++ b/fluree-db-transact/src/generate/mod.rs
@@ -12,7 +12,8 @@ pub use accumulator::FlakeAccumulator;
 pub use cancellation::{apply_cancellation, dedup_retractions};
 pub use flakes::{infer_datatype, FlakeGenerator};
 pub(crate) use flakes::{
-    DT_BOOLEAN, DT_DATE, DT_DATE_TIME, DT_DAY_TIME_DURATION, DT_DECIMAL, DT_DOUBLE, DT_DURATION,
-    DT_G_DAY, DT_G_MONTH, DT_G_MONTH_DAY, DT_G_YEAR, DT_G_YEAR_MONTH, DT_ID, DT_INTEGER, DT_JSON,
-    DT_LANG_STRING, DT_STRING, DT_TIME, DT_WKT_LITERAL, DT_YEAR_MONTH_DURATION,
+    validate_value_dt_pair, DT_BOOLEAN, DT_DATE, DT_DATE_TIME, DT_DAY_TIME_DURATION, DT_DECIMAL,
+    DT_DOUBLE, DT_DURATION, DT_G_DAY, DT_G_MONTH, DT_G_MONTH_DAY, DT_G_YEAR, DT_G_YEAR_MONTH,
+    DT_ID, DT_INTEGER, DT_JSON, DT_LANG_STRING, DT_STRING, DT_TIME, DT_WKT_LITERAL,
+    DT_YEAR_MONTH_DURATION,
 };

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -608,6 +608,19 @@ mod inner {
                 (None, None) => None,
             };
 
+            // Late hard guard: reject (FlakeValue, datatype) shapes that would
+            // produce corrupt flakes (e.g. scalar object key with VECTOR_ID
+            // datatype). Surface as a CommitCodecError so the import fails
+            // loudly rather than silently dropping/storing bad records.
+            if let Err(e) = crate::generate::flakes::validate_value_dt_pair(&o, &dt) {
+                if self.encode_error.is_none() {
+                    let msg = format!("invariant violation: {e}");
+                    tracing::error!("ImportSink: {msg}");
+                    self.encode_error = Some(CommitCodecError::InvalidOp(msg));
+                }
+                return;
+            }
+
             let flake = Flake::new(
                 s.clone(),
                 p.clone(),

--- a/fluree-db-transact/src/ir.rs
+++ b/fluree-db-transact/src/ir.rs
@@ -174,6 +174,22 @@ pub struct Txn {
     /// - `1`: txn-meta graph (`#txn-meta`)
     /// - `2+`: user-defined named graphs
     pub graph_delta: FxHashMap<u16, String>,
+
+    /// Namespace allocations made during lowering that the staging path must
+    /// merge into its own registry before flake generation.
+    ///
+    /// Required when the producer of this `Txn` (e.g. `lower_sparql_update`)
+    /// uses a `NamespaceRegistry` that is independent of the one
+    /// `stage_transaction_from_txn` creates from the ledger snapshot. Without
+    /// this hand-off, IRIs allocated during lowering (e.g. `ex:doc1` →
+    /// `Sid{13, "doc1"}`) get baked into the templates but the staging
+    /// registry never learns about them, so the commit's persisted
+    /// namespace map omits the mapping and post-commit SELECT can't resolve
+    /// the predicate IRI back to the same Sid.
+    ///
+    /// JSON-LD producers (`parse_transaction`) share the staging registry and
+    /// leave this empty.
+    pub namespace_delta: std::collections::HashMap<u16, String>,
 }
 
 impl Txn {
@@ -192,6 +208,7 @@ impl Txn {
             vars: VarRegistry::new(),
             txn_meta: Vec::new(),
             graph_delta: FxHashMap::default(),
+            namespace_delta: std::collections::HashMap::new(),
         }
     }
 

--- a/fluree-db-transact/src/lower_sparql_update.rs
+++ b/fluree-db-transact/src/lower_sparql_update.rs
@@ -234,20 +234,28 @@ pub fn lower_sparql_update(
     let mut vars = VarRegistry::new();
     let mut bnodes = BlankNodeCounter::new();
 
-    match op {
+    let mut txn = match op {
         UpdateOperation::InsertData(insert) => {
-            lower_insert_data(&insert.data, prologue, ns, &mut vars, &mut bnodes, opts)
+            lower_insert_data(&insert.data, prologue, ns, &mut vars, &mut bnodes, opts)?
         }
         UpdateOperation::DeleteData(delete) => {
-            lower_delete_data(&delete.data, prologue, ns, &mut vars, &mut bnodes, opts)
+            lower_delete_data(&delete.data, prologue, ns, &mut vars, &mut bnodes, opts)?
         }
         UpdateOperation::DeleteWhere(delete_where) => {
-            lower_delete_where(&delete_where.pattern, prologue, ns, &mut vars, opts)
+            lower_delete_where(&delete_where.pattern, prologue, ns, &mut vars, opts)?
         }
         UpdateOperation::Modify(modify) => {
-            lower_modify(modify, prologue, ns, &mut vars, &mut bnodes, opts)
+            lower_modify(modify, prologue, ns, &mut vars, &mut bnodes, opts)?
         }
-    }
+    };
+    // Hand off the lowering registry's allocations so `stage_transaction_from_txn`
+    // can merge them into its own snapshot-derived registry. Without this, the
+    // first SPARQL `INSERT DATA` on a fresh ledger commits flakes referencing
+    // namespace codes the staging registry never learned about — the commit's
+    // persisted namespace map omits them, and post-commit SELECT can't resolve
+    // the predicate IRI back to the same Sid.
+    txn.namespace_delta = ns.delta().clone();
+    Ok(txn)
 }
 
 /// Lower INSERT DATA operation.
@@ -276,6 +284,7 @@ fn lower_insert_data(
         vars: mem::take(vars),
         txn_meta: Vec::new(),
         graph_delta: FxHashMap::default(),
+        namespace_delta: std::collections::HashMap::new(),
     })
 }
 
@@ -306,6 +315,7 @@ fn lower_delete_data(
         vars: mem::take(vars),
         txn_meta: Vec::new(),
         graph_delta: FxHashMap::default(),
+        namespace_delta: std::collections::HashMap::new(),
     })
 }
 
@@ -385,6 +395,7 @@ fn lower_delete_where(
         vars: mem::take(vars),
         txn_meta: Vec::new(),
         graph_delta: FxHashMap::default(),
+        namespace_delta: std::collections::HashMap::new(),
     })
 }
 
@@ -485,6 +496,7 @@ fn lower_modify(
         vars: mem::take(vars),
         txn_meta: Vec::new(),
         graph_delta: graph_ids.delta(),
+        namespace_delta: std::collections::HashMap::new(),
     })
 }
 

--- a/fluree-db-transact/src/lower_sparql_update.rs
+++ b/fluree-db-transact/src/lower_sparql_update.rs
@@ -56,7 +56,7 @@ use thiserror::Error;
 
 use crate::ir::{SparqlWhereClause, TemplateTerm, TripleTemplate, Txn, TxnOpts, TxnType};
 use crate::namespace::NamespaceRegistry;
-use fluree_vocab::xsd;
+use fluree_vocab::{fluree, xsd};
 
 /// Result of converting a SPARQL term to an unresolved term with metadata.
 struct UnresolvedTermWithMeta {
@@ -937,6 +937,17 @@ fn coerce_typed_value(lexical: &str, datatype_iri: &str) -> UnresolvedTerm {
                 return UnresolvedTerm::Literal(LiteralValue::Boolean(false));
             }
         }
+        // f:embeddingVector — share the core lexical parser with JSON-LD/Turtle
+        // so f32 quantization is uniform across ingest paths. The query
+        // layer's `LiteralValue::Vector` is lowered to `FlakeValue::Vector`
+        // with the correct datatype Sid in `parse/lower.rs`.
+        fluree::EMBEDDING_VECTOR => {
+            if let Ok(FlakeValue::Vector(v)) =
+                fluree_db_core::coerce::coerce_string_value(lexical, datatype_iri)
+            {
+                return UnresolvedTerm::Literal(LiteralValue::Vector(v));
+            }
+        }
         _ => {}
     }
     // Fall back to string
@@ -962,6 +973,14 @@ fn coerce_typed_flake_value(lexical: &str, datatype_iri: &str) -> FlakeValue {
                 return FlakeValue::Boolean(true);
             } else if lexical == "false" || lexical == "0" {
                 return FlakeValue::Boolean(false);
+            }
+        }
+        // See `coerce_typed_value` — share core's parser for f:embeddingVector.
+        fluree::EMBEDDING_VECTOR => {
+            if let Ok(fv @ FlakeValue::Vector(_)) =
+                fluree_db_core::coerce::coerce_string_value(lexical, datatype_iri)
+            {
+                return fv;
             }
         }
         _ => {}
@@ -1075,5 +1094,29 @@ mod tests {
         assert_eq!(counter.next(), "_:b0");
         assert_eq!(counter.next(), "_:b1");
         assert_eq!(counter.next(), "_:b2");
+    }
+
+    #[test]
+    fn test_coerce_typed_flake_value_vector_lexical() {
+        // Regression for the vector-corruption bug: a SPARQL typed literal
+        // `"[..]"^^f:embeddingVector` must produce FlakeValue::Vector, not
+        // FlakeValue::String — otherwise downstream flake gen pairs a String
+        // value with the embeddingVector datatype and the index decodes
+        // garbage.
+        let result = coerce_typed_flake_value("[0.1, 0.2, 0.3, 0.4]", fluree::EMBEDDING_VECTOR);
+        match result {
+            FlakeValue::Vector(v) => assert_eq!(v.len(), 4),
+            other => panic!("expected FlakeValue::Vector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_coerce_typed_value_vector_lexical_unresolved() {
+        // Same coverage on the UnresolvedTerm path used by literal_to_unresolved.
+        let result = coerce_typed_value("[0.1, 0.2]", fluree::EMBEDDING_VECTOR);
+        match result {
+            UnresolvedTerm::Literal(LiteralValue::Vector(v)) => assert_eq!(v.len(), 2),
+            other => panic!("expected LiteralValue::Vector, got {other:?}"),
+        }
     }
 }

--- a/fluree-db-transact/src/namespace.rs
+++ b/fluree-db-transact/src/namespace.rs
@@ -227,6 +227,22 @@ impl NamespaceRegistry {
         self.codes.merge_delta(&delta)
     }
 
+    /// Adopt namespace allocations made elsewhere AND record them in the
+    /// persistence delta so the next commit includes the mappings.
+    ///
+    /// Distinct from [`ensure_code`](Self::ensure_code), which only updates
+    /// the in-memory lookup tables. Use this when staging a `Txn` whose
+    /// templates reference namespace codes allocated by an upstream registry
+    /// (e.g. `lower_sparql_update`'s caller-owned registry) — without
+    /// persisting those mappings, post-commit reads can't resolve the
+    /// committed flakes' namespace_codes back to IRIs.
+    pub fn adopt_delta_for_persistence(
+        &mut self,
+        delta: &HashMap<u16, String>,
+    ) -> Result<(), NsAllocError> {
+        self.codes.adopt_delta_for_persistence(delta)
+    }
+
     /// Create a Sid for a blank node.
     ///
     /// Blank nodes use the predefined `BLANK_NODE` namespace code and generate

--- a/fluree-db-transact/src/value_convert.rs
+++ b/fluree-db-transact/src/value_convert.rs
@@ -17,7 +17,7 @@ use fluree_db_core::temporal::{
 };
 use fluree_db_core::{FlakeValue, GeoPointBits, Sid};
 use fluree_graph_ir::LiteralValue;
-use fluree_vocab::{geo, rdf, xsd};
+use fluree_vocab::{fluree, geo, rdf, xsd};
 
 /// Fast-path: return cached Sid for the most common datatype IRIs.
 /// Avoids trie lookup + Sid::new() allocation for high-frequency types.
@@ -121,6 +121,16 @@ pub(crate) fn convert_string_literal(
             .map(|v| FlakeValue::YearMonthDuration(Box::new(v)))
             .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
         rdf::JSON => FlakeValue::Json(value.to_string()),
+        fluree::EMBEDDING_VECTOR => {
+            // Delegate to core's shared lexical parser so JSON-LD bulk import,
+            // Turtle, and SPARQL `"[..]"^^f:embeddingVector` all share f32
+            // quantization. On parse failure, fall through to a string literal
+            // — the late `validate_value_dt_pair` guard at the write path
+            // (FlakeGenerator / ImportSink / FlakeSink) rejects the corrupt
+            // (String, embeddingVector) pair as a hard transaction error.
+            fluree_db_core::coerce::coerce_string_value(value, fluree::EMBEDDING_VECTOR)
+                .unwrap_or_else(|_| FlakeValue::String(value.to_string()))
+        }
         rdf::LANG_STRING => {
             // Language goes in FlakeMeta, value is a plain string
             FlakeValue::String(value.to_string())

--- a/fluree-graph-json-ld/src/adapter.rs
+++ b/fluree-graph-json-ld/src/adapter.rs
@@ -433,6 +433,25 @@ fn process_literal<S: GraphSink>(
                     LiteralValue::Json(Arc::from(json_str.as_str())),
                     Datatype::rdf_json(),
                 )))
+            } else if matches!(val, Value::Array(_))
+                && datatype.as_iri() == fluree_vocab::fluree::EMBEDDING_VECTOR
+            {
+                // Vector arrays come through here once JSON-LD expansion produces
+                // {"@value": [...], "@type": f:embeddingVector}. Stringify and
+                // route through the typed-string-literal path so that
+                // value_convert::convert_string_literal (and its core::coerce
+                // delegate) does the f32-quantized parse — keeping JSON-LD,
+                // Turtle, and SPARQL on a single shared parser.
+                let lexical = serde_json::to_string(val).map_err(|e| {
+                    AdapterError::InvalidStructure(format!(
+                        "failed to serialize vector @value: {e}"
+                    ))
+                })?;
+                Ok(ProcessedValue::Single(sink.term_literal(
+                    &lexical,
+                    Datatype::from_iri(fluree_vocab::fluree::EMBEDDING_VECTOR),
+                    None,
+                )))
             } else {
                 // Non-JSON object/array in @value - shouldn't happen
                 Ok(ProcessedValue::None)

--- a/fluree-graph-json-ld/src/expand.rs
+++ b/fluree-graph-json-ld/src/expand.rs
@@ -171,6 +171,15 @@ fn details_dispatch(
     }
 }
 
+/// Detect a context-coerced `@vector` declaration (long or shorthand form).
+fn is_vector_type(type_val: Option<&TypeValue>) -> bool {
+    matches!(
+        type_val,
+        Some(TypeValue::Iri(t))
+            if t == "@vector" || t == fluree_vocab::fluree::EMBEDDING_VECTOR
+    )
+}
+
 /// Check if map is a @list container
 fn is_list_item(map: &Map<String, JsonValue>) -> bool {
     (map.contains_key("@list") || map.contains_key("list"))
@@ -255,6 +264,22 @@ fn parse_node_value(
         }
 
         JsonValue::Array(arr) => {
+            // Context-coerced `@vector` (or `f:embeddingVector`) array values
+            // expand to ONE value-object whose `@value` is the array — matching
+            // the explicit `{"@value": [...], "@type": "@vector"}` form. Without
+            // this, the array would be split into N scalar @value objects, each
+            // tagged with the vector datatype, which downstream commits as
+            // VECTOR_ID flakes pointing at scalar arena handles (storage corruption).
+            if is_vector_type(type_val) {
+                let mut obj = Map::new();
+                obj.insert("@value".to_string(), JsonValue::Array(arr.clone()));
+                obj.insert(
+                    "@type".to_string(),
+                    json!(fluree_vocab::fluree::EMBEDDING_VECTOR),
+                );
+                return Ok(vec![JsonValue::Object(obj)]);
+            }
+
             let mut results = Vec::new();
             for (i, item) in arr.iter().enumerate() {
                 let mut new_idx = idx.to_vec();
@@ -861,6 +886,105 @@ mod tests {
         let obj = result.as_object().unwrap();
 
         assert_eq!(obj["bar"][0]["@value"], false);
+    }
+
+    #[test]
+    fn test_expand_vector_short_form_array_to_single_value_object() {
+        // Context coerces "ex:embedding" to @vector. A bare JSON array must
+        // expand to ONE value-object whose @value is the whole array, with
+        // @type normalized to the full f:embeddingVector IRI.
+        let doc = json!({
+            "@context": {
+                "ex": "http://example.org/",
+                "ex:embedding": {"@type": "@vector"}
+            },
+            "@id": "ex:doc1",
+            "ex:embedding": [0.1, 0.2, 0.3, 0.4]
+        });
+        let result = node(&doc, &ParsedContext::new()).unwrap();
+        let obj = result.as_object().unwrap();
+        let values = obj["http://example.org/embedding"].as_array().unwrap();
+        assert_eq!(values.len(), 1, "vector array must expand as one value");
+        assert_eq!(
+            values[0]["@type"], "https://ns.flur.ee/db#embeddingVector",
+            "@type must be normalized to the full IRI"
+        );
+        assert_eq!(values[0]["@value"], json!([0.1, 0.2, 0.3, 0.4]));
+    }
+
+    #[test]
+    fn test_expand_vector_full_iri_form_array_to_single_value_object() {
+        let doc = json!({
+            "@context": {
+                "ex": "http://example.org/",
+                "ex:embedding": {"@type": "https://ns.flur.ee/db#embeddingVector"}
+            },
+            "@id": "ex:doc1",
+            "ex:embedding": [0.5, 0.6]
+        });
+        let result = node(&doc, &ParsedContext::new()).unwrap();
+        let obj = result.as_object().unwrap();
+        let values = obj["http://example.org/embedding"].as_array().unwrap();
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0]["@value"], json!([0.5, 0.6]));
+        assert_eq!(values[0]["@type"], "https://ns.flur.ee/db#embeddingVector");
+    }
+
+    #[test]
+    fn test_expand_vector_prefixed_iri_form_array_to_single_value_object() {
+        let doc = json!({
+            "@context": {
+                "ex": "http://example.org/",
+                "f": "https://ns.flur.ee/db#",
+                "ex:embedding": {"@type": "f:embeddingVector"}
+            },
+            "@id": "ex:doc1",
+            "ex:embedding": [0.7]
+        });
+        let result = node(&doc, &ParsedContext::new()).unwrap();
+        let obj = result.as_object().unwrap();
+        let values = obj["http://example.org/embedding"].as_array().unwrap();
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0]["@value"], json!([0.7]));
+        assert_eq!(values[0]["@type"], "https://ns.flur.ee/db#embeddingVector");
+    }
+
+    #[test]
+    fn test_expand_non_vector_array_still_produces_n_values() {
+        // Sanity: a normal datatype on an array still expands to N value objects.
+        let doc = json!({
+            "@context": {
+                "ex": "http://example.org/",
+                "xsd": "http://www.w3.org/2001/XMLSchema#",
+                "ex:age": {"@type": "xsd:integer"}
+            },
+            "@id": "ex:doc1",
+            "ex:age": [10, 20, 30]
+        });
+        let result = node(&doc, &ParsedContext::new()).unwrap();
+        let obj = result.as_object().unwrap();
+        let values = obj["http://example.org/age"].as_array().unwrap();
+        assert_eq!(
+            values.len(),
+            3,
+            "non-vector arrays must expand element-wise"
+        );
+    }
+
+    #[test]
+    fn test_expand_vector_explicit_value_wrapper_unchanged() {
+        // The explicit {"@value": [...], "@type": "@vector"} form must continue
+        // to round-trip through expansion as a single value object.
+        let doc = json!({
+            "@context": {"ex": "http://example.org/"},
+            "@id": "ex:doc1",
+            "ex:embedding": {"@value": [0.1, 0.2], "@type": "@vector"}
+        });
+        let result = node(&doc, &ParsedContext::new()).unwrap();
+        let obj = result.as_object().unwrap();
+        let values = obj["http://example.org/embedding"].as_array().unwrap();
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0]["@value"], json!([0.1, 0.2]));
     }
 
     #[test]


### PR DESCRIPTION
SPARQL `INSERT DATA` (or any `lower_sparql_update`-derived `Txn`) committed against a fresh ledger leaves committed flakes whose namespace_codes the post-commit snapshot can't resolve back to IRIs. A subsequent `SELECT` returns no rows — even though the flakes are physically in storage.

In production this is normally masked: JSON-LD inserts pre-allocate the namespaces before any SPARQL touches them, so the staging registry happens to land on the same codes. The bug surfaces when SPARQL is the *first* commit allocating a given namespace.

## Root cause

`lower_sparql_update` allocates IRIs against a **caller-owned** `NamespaceRegistry` to build the templates' `Sid`s (e.g. `ex:doc1` → `Sid{13, "doc1"}`). `stage_transaction_from_txn` then builds an **independent** registry from the ledger snapshot, never sees those allocations, and commits flakes carrying namespace_code 13. The staging registry's persistence delta is empty for `http://example.org/`, so the commit envelope omits the `(13, "http://example.org/")` mapping. On reload, the snapshot's namespace map doesn't contain code 13, and `sid_for_iri("http://example.org/...")` re-allocates fresh — predicate Sid mismatch, no rows.

Verified with diagnostic prints comparing SPARQL vs. JSON-LD commit state on a fresh ledger:

```
SPARQL: snapshot.namespaces() = {... 12: "urn:fluree:"}        ← missing 13
JSON-LD: snapshot.namespaces() = {... 12: "urn:fluree:", 13: "http://example.org/"}
```

## Fix

A two-step handoff so allocations made during lowering survive into the commit's persisted namespace map.

- **`fluree-db-transact/src/ir.rs`** — `Txn` gains a `namespace_delta: HashMap<u16, String>` field, documented as the lowering→staging contract. JSON-LD producers (`parse_transaction`) share the staging registry directly and leave it empty.
- **`fluree-db-transact/src/lower_sparql_update.rs`** — `lower_sparql_update` captures `ns.delta().clone()` into the resulting `Txn.namespace_delta` after the inner lowering call. All four inner Txn literals (`InsertData`, `DeleteData`, `DeleteWhere`, `Modify`) initialize the field.
- **`fluree-db-core/src/ns_encoding.rs`** — new `NamespaceCodes::adopt_delta_for_persistence` adds entries to both the lookup tables AND the persistence delta. Distinct from the existing `merge_delta`, which only updates lookup tables (it's used for post-publish sync from the shared allocator and intentionally skips delta to avoid re-persisting). Same conflict-checking semantics as `merge_delta`.
- **`fluree-db-transact/src/namespace.rs`** — `NamespaceRegistry::adopt_delta_for_persistence` thin wrapper.
- **`fluree-db-api/src/tx.rs`** — `stage_transaction_from_txn` calls `adopt_delta_for_persistence(&txn.namespace_delta)` immediately after building the staging registry. On conflict, surfaces as `ApiError::Internal` (would indicate the caller staged against a stale snapshot).

## Tests

- **`fluree-db-api/tests/it_vector_corruption_repro.rs`** — un-ignores `sparql_insert_data_embedding_vector_literal_round_trips_after_indexing`; tightens it to verify all 4 vector element values, not just length. Updates the module comment to reflect that only one deferred concern remains (vector retraction). The test exercises the fix on a vector typed literal, but the same fix applies to all SPARQL-lowered Txns regardless of value type.

  Pre-fix: `INSERT DATA { ex:doc1 ex:embedding "[0.1, 0.2, 0.3, 0.4]"^^f:embeddingVector }` on a fresh ledger → published commit has the flake → SELECT returns `[]`.
  Post-fix: same flow → SELECT returns `[[[0.1, 0.2, 0.3, 0.4]]]`.

The diagnostic baseline I built during investigation (showing the same bug for a plain string `INSERT DATA { ex:doc1 ex:name "Alice" }` on a fresh ledger) is not committed — the un-ignored vector test exercises the same code path and is sufficient regression coverage.

## Notes for reviewers

- The `merge_delta` vs. `adopt_delta_for_persistence` split is load-bearing. `merge_delta` is called post-publish to sync the serial registry with what the shared allocator already persisted — adding to delta there would double-persist on the next commit. The new method is for the inverse case: adopting allocations that *haven't* been persisted yet.
- The fix is agnostic to value type. The vector typed literal in the test is incidental — any SPARQL-only namespace allocation on a fresh ledger had the same bug. JSON-LD already shared a single registry between parse and stage and was unaffected.
- Existing SPARQL UPDATE tests (e.g. `sparql_update_supports_subquery_aggregate_and_bind` in `fluree-db-server/tests/integration.rs`) didn't catch this because they always seed via JSON-LD INSERT first, pre-allocating the relevant namespaces.
