### PR TITLE
Restructure query output type hierarchy

### DIFF
--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -42,7 +42,17 @@ When querying via the **CLI**, omitting `@context` causes the ledger's [default 
 
 ### select
 
-Specifies which variables to return in results:
+Specifies what to return in results. The shape of `select` determines the shape of each output row.
+
+**Bare variable** — one column, each row is the bound value (not wrapped in an array):
+
+```json
+{
+  "select": "?name"
+}
+```
+
+**Variable list** — each row is `[v1, v2, ...]`:
 
 ```json
 {
@@ -50,7 +60,7 @@ Specifies which variables to return in results:
 }
 ```
 
-**Wildcard Selection:**
+**Wildcard** — every variable bound in the WHERE clause:
 
 ```json
 {
@@ -58,7 +68,41 @@ Specifies which variables to return in results:
 }
 ```
 
-Returns all variables bound in the query.
+**Subject expansion** — return a nested JSON-LD object instead of a flat row. The key is either a variable (the WHERE clause binds it to subjects) or an IRI constant (the named subject is expanded directly, no WHERE needed):
+
+```json
+{
+  "select": { "?person": ["*", { "schema:knows": ["@id", "schema:name"] }] },
+  "where": { "@id": "?person", "@type": "schema:Person" }
+}
+```
+
+```json
+{
+  "select": { "ex:alice": ["*"] }
+}
+```
+
+The array value is the selection spec — `"*"` for all forward properties, individual property names (`"schema:name"`), or nested object forms for sub-selections. Add `"depth": N` at the query top level to bound auto-expansion of unselected references.
+
+**Mixed array** — combine flat variables and subject expansions in one row, in any order. Each object is an independent expansion with its own root and selection spec:
+
+```json
+{
+  "select": [
+    "?age",
+    { "?person": ["@id", "schema:name"] },
+    { "?org": ["@id", "schema:name"] }
+  ],
+  "where": {
+    "@id": "?person",
+    "ex:age": "?age",
+    "ex:worksFor": "?org"
+  }
+}
+```
+
+Each row is `[age, expanded_person, expanded_org]`. When every column is an IRI-constant expansion (no variable dependency anywhere in `select`), the output is independent of the WHERE solution count: the formatter emits one row regardless of how many solutions the WHERE produced.
 
 ### ask
 

--- a/fluree-db-api/src/format/agent_json.rs
+++ b/fluree-db-api/src/format/agent_json.rs
@@ -28,6 +28,7 @@ pub fn format(
     } else {
         Some(result.output.select_vars_or_empty())
     };
+    let select_vars = select_vars.as_deref();
 
     let max_bytes = config.max_bytes;
     let total_row_hint = result

--- a/fluree-db-api/src/format/agent_json.rs
+++ b/fluree-db-api/src/format/agent_json.rs
@@ -26,7 +26,7 @@ pub fn format(
     let select_vars = if result.output.is_wildcard() {
         None
     } else {
-        Some(result.output.select_vars_or_empty())
+        Some(result.output.projected_vars_or_empty())
     };
     let select_vars = select_vars.as_deref();
 

--- a/fluree-db-api/src/format/config.rs
+++ b/fluree-db-api/src/format/config.rs
@@ -138,7 +138,7 @@ pub struct FormatterConfig {
 
     /// Normalize multi-value properties to always use arrays
     ///
-    /// When true, graph crawl results always wrap property values in arrays,
+    /// When true, hydration results always wrap property values in arrays,
     /// even when there is only a single value. This ensures predictable shapes
     /// for programmatic consumers (e.g., deserializing into `Vec<T>` fields).
     ///
@@ -146,7 +146,7 @@ pub struct FormatterConfig {
     /// multi-valued properties return arrays (existing behavior). The
     /// `@container: @set` context annotation still forces arrays per-property.
     ///
-    /// Only affects graph crawl formatting; tabular SELECT results are unaffected.
+    /// Only affects hydration formatting; tabular SELECT results are unaffected.
     pub normalize_arrays: bool,
 
     /// Maximum byte budget for AgentJson output
@@ -227,7 +227,7 @@ impl FormatterConfig {
         self
     }
 
-    /// Enable array normalization for graph crawl results
+    /// Enable array normalization for hydration results
     ///
     /// When enabled, all multi-value properties are wrapped in arrays even
     /// when only a single value exists. This produces predictable shapes for

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -240,7 +240,7 @@ fn reject_non_tabular(result: &QueryResult, delimiter: Delimiter) -> Result<()> 
             "{name} format not supported for ASK queries (boolean result)"
         )));
     }
-    if result.output.hydration().is_some() {
+    if result.output.has_hydration() {
         return Err(FormatError::InvalidBinding(format!(
             "{name} format not supported for hydration queries (use JSON-LD instead)"
         )));

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -285,7 +285,7 @@ fn resolve_select_vars(result: &QueryResult) -> Vec<VarId> {
         pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
         pairs.into_iter().map(|(_, vid)| vid).collect()
     } else {
-        result.output.projected_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty()
     }
 }
 

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -227,7 +227,7 @@ fn format_delimited_limited(
 // Internals
 // ---------------------------------------------------------------------------
 
-/// Reject non-tabular results (CONSTRUCT, graph crawl).
+/// Reject non-tabular results (CONSTRUCT, hydration).
 fn reject_non_tabular(result: &QueryResult, delimiter: Delimiter) -> Result<()> {
     let name = delimiter.name();
     if result.output.is_construct() {
@@ -240,9 +240,9 @@ fn reject_non_tabular(result: &QueryResult, delimiter: Delimiter) -> Result<()> 
             "{name} format not supported for ASK queries (boolean result)"
         )));
     }
-    if result.graph_select.is_some() {
+    if result.output.hydration().is_some() {
         return Err(FormatError::InvalidBinding(format!(
-            "{name} format not supported for graph crawl queries (use JSON-LD instead)"
+            "{name} format not supported for hydration queries (use JSON-LD instead)"
         )));
     }
     Ok(())
@@ -637,7 +637,6 @@ mod tests {
             output: crate::QueryOutput::select(var_ids),
             batches: vec![batch],
             binary_graph: None,
-            graph_select: None,
         }
     }
 

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -634,7 +634,7 @@ mod tests {
             novelty: None,
             context,
             orig_context: None,
-            output: crate::QueryOutput::select_vars(var_ids),
+            output: crate::QueryOutput::select_all(var_ids),
             batches: vec![batch],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -285,7 +285,7 @@ fn resolve_select_vars(result: &QueryResult) -> Vec<VarId> {
         pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
         pairs.into_iter().map(|(_, vid)| vid).collect()
     } else {
-        result.output.select_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty().to_vec()
     }
 }
 
@@ -634,7 +634,7 @@ mod tests {
             novelty: None,
             context,
             orig_context: None,
-            output: crate::QueryOutput::select(var_ids),
+            output: crate::QueryOutput::select_vars(var_ids),
             batches: vec![batch],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -235,7 +235,7 @@ fn reject_non_tabular(result: &QueryResult, delimiter: Delimiter) -> Result<()> 
             "{name} format not supported for CONSTRUCT queries (use JSON-LD instead)"
         )));
     }
-    if result.output.is_boolean() {
+    if result.output.is_ask() {
         return Err(FormatError::InvalidBinding(format!(
             "{name} format not supported for ASK queries (boolean result)"
         )));

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -295,7 +295,18 @@ pub async fn format_async(
     // object per row; multi-column projections emit array rows.
     let single_column = columns.len() == 1;
 
-    for batch in &result.batches {
+    // A projection is "row-independent" when no column reads any solution
+    // binding — every column is a `Root::Sid` hydration. Such a projection
+    // produces the same output for every solution row, so we emit a single
+    // row regardless of how many solutions the WHERE clause yielded (the
+    // WHERE still gates *whether* a row is emitted via row_count == 0
+    // above).
+    let row_dependent = columns.iter().any(|c| match c {
+        Column::Var(_) => true,
+        Column::Hydration(spec) => matches!(spec.root, Root::Var(_)),
+    });
+
+    'rows: for batch in &result.batches {
         for row_idx in 0..batch.len() {
             let mut row_values: Vec<JsonValue> = Vec::with_capacity(columns.len());
 
@@ -324,6 +335,10 @@ pub async fn format_async(
                 rows.push(row_values.into_iter().next().unwrap());
             } else {
                 rows.push(JsonValue::Array(row_values));
+            }
+
+            if !row_dependent {
+                break 'rows;
             }
         }
     }

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -171,9 +171,11 @@ fn resolve_root_sid_from_binding(
 /// `format_results_async()` instead, since hydration requires DB access.
 #[allow(dead_code)]
 pub fn format(result: &QueryResult, _compactor: &IriCompactor) -> Result<JsonValue> {
-    let _spec = result.output.hydration().ok_or_else(|| {
-        FormatError::InvalidBinding("Hydration format called without spec".into())
-    })?;
+    if !result.output.has_hydration() {
+        return Err(FormatError::InvalidBinding(
+            "Hydration format called without any hydration columns".into(),
+        ));
+    }
 
     // Hydration always requires async DB access
     Err(FormatError::InvalidBinding(

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -182,8 +182,7 @@ async fn format_hydration_column<'a>(
     let root_sid: Sid = match &spec.root {
         Root::Sid(sid) => sid.clone(),
         Root::Var(var_id) => {
-            let Some(sid) =
-                resolve_root_sid_from_binding(result, batch.get(row_idx, *var_id))?
+            let Some(sid) = resolve_root_sid_from_binding(result, batch.get(row_idx, *var_id))?
             else {
                 return Ok(JsonValue::Null);
             };
@@ -266,8 +265,10 @@ pub async fn format_async(
                         None => JsonValue::Null,
                     },
                     Column::Hydration(spec) => {
-                        format_hydration_column(&formatter, spec, result, batch, row_idx, &mut cache)
-                            .await?
+                        format_hydration_column(
+                            &formatter, spec, result, batch, row_idx, &mut cache,
+                        )
+                        .await?
                     }
                 };
                 row_values.push(value);

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -26,7 +26,7 @@ use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{Flake, GraphDbRef, Sid, Tracker};
 use fluree_db_policy::{is_schema_flake, PolicyContext};
 use fluree_db_query::binding::Binding;
-use fluree_db_query::ir::{HydrationSpec, NestedSelectSpec, Root, SelectionSpec};
+use fluree_db_query::ir::{ForwardItem, HydrationSpec, NestedSelectSpec, Root};
 use fluree_vocab::namespaces::JSON_LD;
 use fluree_vocab::rdf::{self, TYPE as RDF_TYPE_IRI};
 use futures::future::BoxFuture;
@@ -35,23 +35,10 @@ use serde_json::{json, Value as JsonValue};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Cache key: (Sid, local_spec_hash, depth_remaining)
-/// The local_spec_hash is computed from the current selections/reverse/has_wildcard,
-/// NOT the top-level spec. This ensures different nested hydrations of the same Sid
-/// produce different cache entries.
+/// The local_spec_hash is computed from the current `NestedSelectSpec`,
+/// NOT the top-level spec. This ensures different nested hydrations of
+/// the same Sid produce different cache entries.
 type CacheKey = (Sid, u64, usize);
-
-/// Selection specification for formatting a subject.
-///
-/// Bundles the immutable parameters that define what properties to select
-/// during hydration formatting.
-struct FormatSpec<'a> {
-    /// Forward property selections
-    selections: &'a [SelectionSpec],
-    /// Reverse property selections
-    reverse: &'a HashMap<Sid, Option<Box<NestedSelectSpec>>>,
-    /// Whether wildcard was specified at this level
-    has_wildcard: bool,
-}
 
 /// Context for formatting a specific predicate's values.
 struct PredicateContext<'a> {
@@ -63,89 +50,83 @@ struct PredicateContext<'a> {
     explicit_sub_spec: Option<&'a NestedSelectSpec>,
 }
 
-/// Compute hash for a local selection spec (forward, reverse, has_wildcard)
-///
-/// This is used to generate cache keys that correctly distinguish between
-/// different nested selection specs at the same depth.
-fn compute_local_spec_hash(
-    selections: &[SelectionSpec],
-    reverse: &HashMap<Sid, Option<Box<NestedSelectSpec>>>,
-    has_wildcard: bool,
-) -> u64 {
+/// Hash a `NestedSelectSpec` to a u64 cache key. We can't derive `Hash`
+/// because the nested HashMaps don't implement it; iterate keys in sorted
+/// order for determinism.
+fn compute_level_hash(level: &NestedSelectSpec) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-
-    has_wildcard.hash(&mut hasher);
-    selections.len().hash(&mut hasher);
-
-    // Hash forward selections
-    fn hash_selection(spec: &SelectionSpec, hasher: &mut impl Hasher) {
-        match spec {
-            SelectionSpec::Id => {
-                2u8.hash(hasher);
-            }
-            SelectionSpec::Wildcard => {
-                0u8.hash(hasher);
-            }
-            SelectionSpec::Property {
-                predicate,
-                sub_spec,
-            } => {
-                1u8.hash(hasher);
-                predicate.hash(hasher);
-                if let Some(nested) = sub_spec {
-                    1u8.hash(hasher);
-                    hash_nested_spec(nested, hasher);
-                } else {
-                    0u8.hash(hasher);
-                }
-            }
-        }
-    }
-
-    fn hash_nested_spec(spec: &NestedSelectSpec, hasher: &mut impl Hasher) {
-        spec.has_wildcard.hash(hasher);
-        spec.forward.len().hash(hasher);
-        for sub in &spec.forward {
-            hash_selection(sub, hasher);
-        }
-        spec.reverse.len().hash(hasher);
-        let mut rev_keys: Vec<_> = spec.reverse.keys().collect();
-        rev_keys.sort();
-        for key in rev_keys {
-            key.hash(hasher);
-            if let Some(nested_opt) = spec.reverse.get(key) {
-                if let Some(inner) = nested_opt {
-                    1u8.hash(hasher);
-                    hash_nested_spec(inner, hasher);
-                } else {
-                    0u8.hash(hasher);
-                }
-            }
-        }
-    }
-
-    for sel in selections {
-        hash_selection(sel, &mut hasher);
-    }
-
-    // Hash reverse properties
-    reverse.len().hash(&mut hasher);
-    let mut reverse_keys: Vec<_> = reverse.keys().collect();
-    reverse_keys.sort();
-    for key in reverse_keys {
-        key.hash(&mut hasher);
-        if let Some(nested_opt) = reverse.get(key) {
-            if let Some(spec) = nested_opt {
-                1u8.hash(&mut hasher);
-                hash_nested_spec(spec, &mut hasher);
-            } else {
-                0u8.hash(&mut hasher);
-            }
-        }
-    }
-
+    hash_level(level, &mut hasher);
     hasher.finish()
+}
+
+fn hash_level<H: std::hash::Hasher>(level: &NestedSelectSpec, hasher: &mut H) {
+    use std::hash::Hash;
+    match level {
+        NestedSelectSpec::Wildcard {
+            refinements,
+            reverse,
+        } => {
+            0u8.hash(hasher);
+            let mut keys: Vec<_> = refinements.keys().collect();
+            keys.sort();
+            keys.len().hash(hasher);
+            for key in keys {
+                key.hash(hasher);
+                hash_level(refinements.get(key).unwrap(), hasher);
+            }
+            hash_reverse(reverse, hasher);
+        }
+        NestedSelectSpec::Explicit { forward, reverse } => {
+            1u8.hash(hasher);
+            forward.len().hash(hasher);
+            for item in forward {
+                hash_forward_item(item, hasher);
+            }
+            hash_reverse(reverse, hasher);
+        }
+    }
+}
+
+fn hash_forward_item<H: std::hash::Hasher>(item: &ForwardItem, hasher: &mut H) {
+    use std::hash::Hash;
+    match item {
+        ForwardItem::Id => 0u8.hash(hasher),
+        ForwardItem::Property {
+            predicate,
+            sub_spec,
+        } => {
+            1u8.hash(hasher);
+            predicate.hash(hasher);
+            match sub_spec {
+                None => 0u8.hash(hasher),
+                Some(boxed) => {
+                    1u8.hash(hasher);
+                    hash_level(boxed, hasher);
+                }
+            }
+        }
+    }
+}
+
+fn hash_reverse<H: std::hash::Hasher>(
+    reverse: &HashMap<Sid, Option<Box<NestedSelectSpec>>>,
+    hasher: &mut H,
+) {
+    use std::hash::Hash;
+    let mut keys: Vec<_> = reverse.keys().collect();
+    keys.sort();
+    keys.len().hash(hasher);
+    for key in keys {
+        key.hash(hasher);
+        match reverse.get(key).unwrap() {
+            None => 0u8.hash(hasher),
+            Some(inner) => {
+                1u8.hash(hasher);
+                hash_level(inner, hasher);
+            }
+        }
+    }
 }
 
 /// Format query results with hydration (sync entry point - returns error)
@@ -211,13 +192,8 @@ pub async fn format_async(
         Root::Sid(sid) => {
             // IRI constant root - single subject fetch (no batches needed)
             let mut visited = HashSet::new();
-            let format_spec = FormatSpec {
-                selections: &spec.selections,
-                reverse: &spec.reverse,
-                has_wildcard: spec.has_wildcard,
-            };
             let obj = formatter
-                .format_subject(sid, format_spec, 0, &mut visited, &mut cache)
+                .format_subject(sid, &spec.level, 0, &mut visited, &mut cache)
                 .await?;
             rows.push(obj);
         }
@@ -259,13 +235,8 @@ pub async fn format_async(
                     };
 
                     let mut visited = HashSet::new();
-                    let format_spec = FormatSpec {
-                        selections: &spec.selections,
-                        reverse: &spec.reverse,
-                        has_wildcard: spec.has_wildcard,
-                    };
                     let obj = formatter
-                        .format_subject(&root_sid, format_spec, 0, &mut visited, &mut cache)
+                        .format_subject(&root_sid, &spec.level, 0, &mut visited, &mut cache)
                         .await?;
 
                     if mixed_select {
@@ -349,18 +320,14 @@ impl<'a> HydrationFormatter<'a> {
     fn format_subject<'b>(
         &'b self,
         sid: &'b Sid,
-        spec: FormatSpec<'b>,
+        level: &'b NestedSelectSpec,
         current_depth: usize,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
             let depth_remaining = self.spec.depth.saturating_sub(current_depth);
-            // Use LOCAL spec hash (selections, reverse, has_wildcard) not top-level spec
-            // This ensures different nested hydrations of the same Sid produce different cache entries
-            let spec_hash =
-                compute_local_spec_hash(spec.selections, spec.reverse, spec.has_wildcard);
-            let cache_key = (sid.clone(), spec_hash, depth_remaining);
+            let cache_key = (sid.clone(), compute_level_hash(level), depth_remaining);
 
             // Check cache first (same Sid + spec + depth = same result)
             if let Some(cached) = cache.get(&cache_key) {
@@ -375,14 +342,10 @@ impl<'a> HydrationFormatter<'a> {
             // Build object with sorted keys for determinism (BTreeMap)
             let mut obj: BTreeMap<String, JsonValue> = BTreeMap::new();
 
-            let has_explicit_id = spec
-                .selections
-                .iter()
-                .any(|s| matches!(s, SelectionSpec::Id));
             // @id inclusion:
             // - Always include for nested hydrations (identity of an expanded ref)
             // - Otherwise include when wildcard or explicit @id selection
-            if current_depth > 0 || spec.has_wildcard || has_explicit_id {
+            if current_depth > 0 || level.includes_id() {
                 obj.insert("@id".to_string(), json!(self.compactor.compact_sid(sid)?));
             }
 
@@ -397,13 +360,13 @@ impl<'a> HydrationFormatter<'a> {
 
             // Format each predicate
             for (pred, mut pred_flakes) in by_pred {
-                // Determine whether this predicate was explicitly selected.
-                // NOTE: a property selection like "schema:name" is explicit even when it has no sub-spec.
-                let selected_opt = self.find_selection_for_predicate(&pred, spec.selections);
-                let explicit_sub_spec = selected_opt.flatten();
-                if !spec.has_wildcard && selected_opt.is_none() {
+                // `select_predicate` returns `None` when the level is Explicit
+                // and the predicate isn't listed; otherwise it returns
+                // `Some(sub_spec)` (which may itself be `None` for "select but
+                // don't recurse").
+                let Some(explicit_sub_spec) = level.select_predicate(&pred) else {
                     continue;
-                }
+                };
 
                 // If these flakes represent an ordered list (`@list`), preserve transaction order
                 // by sorting by the list index stored in FlakeMeta.i.
@@ -424,7 +387,7 @@ impl<'a> HydrationFormatter<'a> {
                     explicit_sub_spec,
                 };
                 let values = self
-                    .format_predicate_values(pred_ctx, &spec, current_depth, visited, cache)
+                    .format_predicate_values(pred_ctx, level, current_depth, visited, cache)
                     .await?;
 
                 if !values.is_empty() {
@@ -441,14 +404,14 @@ impl<'a> HydrationFormatter<'a> {
             }
 
             // Format reverse properties
-            for (rev_pred, rev_nested_opt) in spec.reverse {
+            for (rev_pred, rev_nested_opt) in level.reverse() {
                 let rev_flakes = self.fetch_reverse_properties(sid, rev_pred).await?;
                 if !rev_flakes.is_empty() {
                     let values = self
                         .format_reverse_values(
                             &rev_flakes,
                             rev_nested_opt.as_deref(),
-                            &spec,
+                            level,
                             current_depth,
                             visited,
                             cache,
@@ -480,26 +443,6 @@ impl<'a> HydrationFormatter<'a> {
             Ok(result)
         }
         .boxed()
-    }
-
-    /// Find explicit sub-spec for a predicate in the selections
-    fn find_selection_for_predicate<'b>(
-        &self,
-        pred: &Sid,
-        selections: &'b [SelectionSpec],
-    ) -> Option<Option<&'b NestedSelectSpec>> {
-        for sel in selections {
-            if let SelectionSpec::Property {
-                predicate,
-                sub_spec,
-            } = sel
-            {
-                if predicate == pred {
-                    return Some(sub_spec.as_deref());
-                }
-            }
-        }
-        None
     }
 
     /// Whether this compact key should always be represented as an array.
@@ -536,7 +479,7 @@ impl<'a> HydrationFormatter<'a> {
     async fn format_predicate_values<'b>(
         &'b self,
         pred_ctx: PredicateContext<'b>,
-        parent_spec: &FormatSpec<'b>,
+        parent_level: &'b NestedSelectSpec,
         current_depth: usize,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
@@ -554,19 +497,13 @@ impl<'a> HydrationFormatter<'a> {
                     } else {
                         // Hydration decision:
                         // 1. If explicit sub-selection exists → expand with that spec
-                        // 2. Else if current_depth < max_depth → auto-expand with FULL parent spec
+                        // 2. Else if current_depth < max_depth → auto-expand with FULL parent level
                         // 3. Else → just return {"@id": ...}
                         if let Some(nested) = pred_ctx.explicit_sub_spec {
-                            // Case 1: Explicit sub-selection
-                            let nested_spec = FormatSpec {
-                                selections: &nested.forward,
-                                reverse: &nested.reverse,
-                                has_wildcard: nested.has_wildcard,
-                            };
                             values.push(
                                 self.format_subject(
                                     ref_sid,
-                                    nested_spec,
+                                    nested,
                                     current_depth + 1,
                                     visited,
                                     cache,
@@ -574,16 +511,10 @@ impl<'a> HydrationFormatter<'a> {
                                 .await?,
                             );
                         } else if current_depth < self.spec.depth {
-                            // Case 2: Auto-expand with FULL parent spec (forward + reverse!)
-                            let nested_spec = FormatSpec {
-                                selections: parent_spec.selections,
-                                reverse: parent_spec.reverse,
-                                has_wildcard: parent_spec.has_wildcard,
-                            };
                             values.push(
                                 self.format_subject(
                                     ref_sid,
-                                    nested_spec,
+                                    parent_level,
                                     current_depth + 1,
                                     visited,
                                     cache,
@@ -591,7 +522,7 @@ impl<'a> HydrationFormatter<'a> {
                                 .await?,
                             );
                         } else {
-                            // Case 3: Max depth reached, just @id
+                            // Max depth reached, just @id
                             values.push(json!({ "@id": self.compactor.compact_sid(ref_sid)? }));
                         }
                     }
@@ -616,7 +547,7 @@ impl<'a> HydrationFormatter<'a> {
         &'b self,
         flakes: &[Flake],
         nested_spec: Option<&'b NestedSelectSpec>,
-        parent_spec: &FormatSpec<'b>,
+        parent_level: &'b NestedSelectSpec,
         current_depth: usize,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
@@ -626,17 +557,11 @@ impl<'a> HydrationFormatter<'a> {
             // For reverse lookup, subject is the entity that points to our object
             let subject_sid = &flake.s;
 
-            if let Some(spec) = nested_spec {
-                // Explicit sub-selection for reverse - use the full nested spec
-                let nested_spec = FormatSpec {
-                    selections: &spec.forward,
-                    reverse: &spec.reverse,
-                    has_wildcard: spec.has_wildcard,
-                };
+            if let Some(nested) = nested_spec {
                 values.push(
                     self.format_subject(
                         subject_sid,
-                        nested_spec,
+                        nested,
                         current_depth + 1,
                         visited,
                         cache,
@@ -644,16 +569,11 @@ impl<'a> HydrationFormatter<'a> {
                     .await?,
                 );
             } else if current_depth < self.spec.depth {
-                // Auto-expand reverse refs with FULL parent spec
-                let nested_spec = FormatSpec {
-                    selections: parent_spec.selections,
-                    reverse: parent_spec.reverse,
-                    has_wildcard: parent_spec.has_wildcard,
-                };
+                // Auto-expand reverse refs with FULL parent level
                 values.push(
                     self.format_subject(
                         subject_sid,
-                        nested_spec,
+                        parent_level,
                         current_depth + 1,
                         visited,
                         cache,
@@ -904,29 +824,24 @@ impl<'a> HydrationFormatter<'a> {
         let mut want_type = false;
         let mut want_language = false;
 
-        if spec.has_wildcard {
-            want_value = true;
-            want_type = true;
-            want_language = flake.m.as_ref().and_then(|m| m.lang.as_ref()).is_some();
-        } else {
-            for sel in &spec.forward {
-                match sel {
-                    SelectionSpec::Wildcard => {
-                        want_value = true;
-                        want_type = true;
-                        want_language = flake.m.as_ref().and_then(|m| m.lang.as_ref()).is_some();
-                    }
-                    SelectionSpec::Property { predicate, .. }
-                        if predicate.namespace_code == JSON_LD =>
-                    {
-                        match predicate.name.as_ref() {
-                            "value" => want_value = true,
-                            "type" => want_type = true,
-                            "language" => want_language = true,
-                            _ => {}
+        match spec {
+            NestedSelectSpec::Wildcard { .. } => {
+                want_value = true;
+                want_type = true;
+                want_language = flake.m.as_ref().and_then(|m| m.lang.as_ref()).is_some();
+            }
+            NestedSelectSpec::Explicit { forward, .. } => {
+                for item in forward {
+                    if let ForwardItem::Property { predicate, .. } = item {
+                        if predicate.namespace_code == JSON_LD {
+                            match predicate.name.as_ref() {
+                                "value" => want_value = true,
+                                "type" => want_type = true,
+                                "language" => want_language = true,
+                                _ => {}
+                            }
                         }
                     }
-                    _ => {}
                 }
             }
         }
@@ -1135,90 +1050,72 @@ mod tests {
         assert_eq!(key1, key3);
     }
 
-    #[test]
-    fn test_local_spec_hash_different_selections() {
-        // Empty selections
-        let hash_empty = compute_local_spec_hash(&[], &HashMap::new(), false);
+    fn explicit(forward: Vec<ForwardItem>) -> NestedSelectSpec {
+        NestedSelectSpec::Explicit {
+            forward,
+            reverse: HashMap::new(),
+        }
+    }
 
-        // Wildcard only
-        let hash_wildcard =
-            compute_local_spec_hash(&[SelectionSpec::Wildcard], &HashMap::new(), true);
-
-        // Different hashes for different selections
-        assert_ne!(hash_empty, hash_wildcard);
-
-        // Same selections should produce same hash
-        let hash_wildcard2 =
-            compute_local_spec_hash(&[SelectionSpec::Wildcard], &HashMap::new(), true);
-        assert_eq!(hash_wildcard, hash_wildcard2);
-
-        // Different has_wildcard flag should produce different hash
-        let hash_wildcard_false =
-            compute_local_spec_hash(&[SelectionSpec::Wildcard], &HashMap::new(), false);
-        assert_ne!(hash_wildcard, hash_wildcard_false);
+    fn wildcard() -> NestedSelectSpec {
+        NestedSelectSpec::Wildcard {
+            refinements: HashMap::new(),
+            reverse: HashMap::new(),
+        }
     }
 
     #[test]
-    fn test_local_spec_hash_with_property() {
+    fn level_hash_distinguishes_explicit_from_wildcard() {
+        let hash_empty = compute_level_hash(&explicit(vec![]));
+        let hash_wildcard = compute_level_hash(&wildcard());
+        assert_ne!(hash_empty, hash_wildcard);
+        // Same level produces same hash.
+        assert_eq!(compute_level_hash(&wildcard()), hash_wildcard);
+    }
+
+    #[test]
+    fn level_hash_distinguishes_properties() {
         let pred1 = Sid::new(1, "name");
         let pred2 = Sid::new(2, "age");
 
-        // Property without sub-spec
-        let selections1 = vec![SelectionSpec::Property {
+        let hash1 = compute_level_hash(&explicit(vec![ForwardItem::Property {
             predicate: pred1.clone(),
             sub_spec: None,
-        }];
-        let hash1 = compute_local_spec_hash(&selections1, &HashMap::new(), false);
-
-        // Different property
-        let selections2 = vec![SelectionSpec::Property {
+        }]));
+        let hash2 = compute_level_hash(&explicit(vec![ForwardItem::Property {
             predicate: pred2.clone(),
             sub_spec: None,
-        }];
-        let hash2 = compute_local_spec_hash(&selections2, &HashMap::new(), false);
-
+        }]));
         assert_ne!(hash1, hash2);
 
-        // Property with sub-spec should differ from property without
-        let selections3 = vec![SelectionSpec::Property {
+        // Sub-spec presence changes the hash.
+        let hash3 = compute_level_hash(&explicit(vec![ForwardItem::Property {
             predicate: pred1.clone(),
-            sub_spec: Some(Box::new(NestedSelectSpec {
-                forward: vec![SelectionSpec::Wildcard],
-                reverse: HashMap::new(),
-                has_wildcard: true,
-            })),
-        }];
-        let hash3 = compute_local_spec_hash(&selections3, &HashMap::new(), false);
-
+            sub_spec: Some(Box::new(wildcard())),
+        }]));
         assert_ne!(hash1, hash3);
     }
 
     #[test]
-    fn test_local_spec_hash_with_reverse() {
+    fn level_hash_distinguishes_reverse() {
         let rev_pred = Sid::new(10, "friendOf");
 
-        // Empty reverse
-        let hash_no_reverse = compute_local_spec_hash(&[], &HashMap::new(), true);
+        let hash_no_reverse = compute_level_hash(&wildcard());
 
-        // With reverse property (no nested spec)
         let mut reverse1 = HashMap::new();
         reverse1.insert(rev_pred.clone(), None);
-        let hash_with_reverse = compute_local_spec_hash(&[], &reverse1, true);
-
+        let hash_with_reverse = compute_level_hash(&NestedSelectSpec::Wildcard {
+            refinements: HashMap::new(),
+            reverse: reverse1,
+        });
         assert_ne!(hash_no_reverse, hash_with_reverse);
 
-        // With reverse property (with nested spec)
         let mut reverse2 = HashMap::new();
-        reverse2.insert(
-            rev_pred.clone(),
-            Some(Box::new(NestedSelectSpec {
-                forward: vec![SelectionSpec::Wildcard],
-                reverse: HashMap::new(),
-                has_wildcard: true,
-            })),
-        );
-        let hash_with_reverse_nested = compute_local_spec_hash(&[], &reverse2, true);
-
-        assert_ne!(hash_with_reverse, hash_with_reverse_nested);
+        reverse2.insert(rev_pred, Some(Box::new(wildcard())));
+        let hash_nested = compute_level_hash(&NestedSelectSpec::Wildcard {
+            refinements: HashMap::new(),
+            reverse: reverse2,
+        });
+        assert_ne!(hash_with_reverse, hash_nested);
     }
 }

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -223,7 +223,7 @@ pub async fn format_async(
         }
         Root::Var(var_id) => {
             // Variable root - iterate through result batches
-            let select_vars = result.output.select_vars_or_empty();
+            let select_vars = result.output.projected_vars_or_empty();
             let mixed_select = select_vars.len() > 1 || select_vars.first() != Some(var_id);
 
             for batch in &result.batches {

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -54,7 +54,7 @@ struct PredicateContext<'a> {
 /// because the nested HashMaps don't implement it; iterate keys in sorted
 /// order for determinism.
 fn compute_level_hash(level: &NestedSelectSpec) -> u64 {
-    use std::hash::{Hash, Hasher};
+    use std::hash::Hasher;
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     hash_level(level, &mut hasher);
     hasher.finish()
@@ -559,14 +559,8 @@ impl<'a> HydrationFormatter<'a> {
 
             if let Some(nested) = nested_spec {
                 values.push(
-                    self.format_subject(
-                        subject_sid,
-                        nested,
-                        current_depth + 1,
-                        visited,
-                        cache,
-                    )
-                    .await?,
+                    self.format_subject(subject_sid, nested, current_depth + 1, visited, cache)
+                        .await?,
                 );
             } else if current_depth < self.spec.depth {
                 // Auto-expand reverse refs with FULL parent level

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -1,6 +1,12 @@
 //! Hydration formatter — materializes a Sid into a nested JSON-LD object by
 //! recursively fetching its properties.
 //!
+//! Each hydration column carries its own root, level, and depth budget. The
+//! formatter dispatches per column: a variable root reads the row's binding
+//! and expands that subject; an IRI-constant root expands the named subject
+//! directly; non-hydration (`Var`) columns are formatted by the regular
+//! flat-binding formatters.
+//!
 //! # Supported Syntax
 //!
 //! ```json
@@ -13,7 +19,26 @@
 //!
 //! // IRI constant root (no WHERE needed)
 //! {"select": {"ex:alice": ["*"]}}
+//!
+//! // Multiple hydration columns: each row is [expanded_a, expanded_b].
+//! {"select": [{"?person": ["*"]}, {"?org": ["*"]}],
+//!  "where": {"@id": "?person", "ex:worksFor": "?org"}}
+//!
+//! // Hydration columns mixed with flat variables.
+//! {"select": ["?age", {"?person": ["*"]}],
+//!  "where": {"@id": "?person", "ex:age": "?age"}}
 //! ```
+//!
+//! # Output cardinality
+//!
+//! Solution rows generally map 1:1 to output rows, except when no column
+//! depends on any solution binding (every column is an IRI-constant
+//! hydration). In that case the output is independent of the row, so the
+//! formatter emits a single row regardless of how many solutions the WHERE
+//! produced. An empty solution set still produces no rows.
+//!
+//! A variable root that's unbound for a given solution renders as `null` in
+//! that cell rather than dropping the entire row.
 
 use super::config::{FormatterConfig, OutputFormat};
 use super::datatype::is_inferable_datatype;

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -26,7 +26,7 @@ use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{Flake, GraphDbRef, Sid, Tracker};
 use fluree_db_policy::{is_schema_flake, PolicyContext};
 use fluree_db_query::binding::Binding;
-use fluree_db_query::ir::{Column, ForwardItem, NestedSelectSpec, Root};
+use fluree_db_query::ir::{Column, ForwardItem, HydrationSpec, NestedSelectSpec, Root};
 use fluree_vocab::namespaces::JSON_LD;
 use fluree_vocab::rdf::{self, TYPE as RDF_TYPE_IRI};
 use futures::future::BoxFuture;
@@ -165,6 +165,38 @@ fn resolve_root_sid_from_binding(
     }
 }
 
+/// Format one hydration column for one solution row.
+///
+/// Resolves the column's root (variable or IRI constant) into a `Sid` and
+/// expands it via [`HydrationFormatter::format_subject`] using the column's
+/// own level and depth budget. A variable root that's unbound for this row
+/// renders as `null` rather than skipping the row entirely.
+async fn format_hydration_column<'a>(
+    formatter: &HydrationFormatter<'a>,
+    spec: &HydrationSpec,
+    result: &QueryResult,
+    batch: &fluree_db_query::Batch,
+    row_idx: usize,
+    cache: &mut HashMap<CacheKey, JsonValue>,
+) -> Result<JsonValue> {
+    let root_sid: Sid = match &spec.root {
+        Root::Sid(sid) => sid.clone(),
+        Root::Var(var_id) => {
+            let Some(sid) =
+                resolve_root_sid_from_binding(result, batch.get(row_idx, *var_id))?
+            else {
+                return Ok(JsonValue::Null);
+            };
+            sid
+        }
+    };
+
+    let mut visited = HashSet::new();
+    formatter
+        .format_subject(&root_sid, &spec.level, 0, spec.depth, &mut visited, cache)
+        .await
+}
+
 /// Format query results with hydration (sync entry point - returns error)
 ///
 /// The sync entry point always returns an error directing callers to use
@@ -253,43 +285,10 @@ pub async fn format_async(
                         }
                         None => JsonValue::Null,
                     },
-                    Column::Hydration(spec) => match &spec.root {
-                        Root::Sid(sid) => {
-                            let mut visited = HashSet::new();
-                            formatter
-                                .format_subject(
-                                    sid,
-                                    &spec.level,
-                                    0,
-                                    spec.depth,
-                                    &mut visited,
-                                    &mut cache,
-                                )
-                                .await?
-                        }
-                        Root::Var(var_id) => {
-                            let root_sid = resolve_root_sid_from_binding(
-                                result,
-                                batch.get(row_idx, *var_id),
-                            )?;
-                            match root_sid {
-                                Some(sid) => {
-                                    let mut visited = HashSet::new();
-                                    formatter
-                                        .format_subject(
-                                            &sid,
-                                            &spec.level,
-                                            0,
-                                            spec.depth,
-                                            &mut visited,
-                                            &mut cache,
-                                        )
-                                        .await?
-                                }
-                                None => JsonValue::Null,
-                            }
-                        }
-                    },
+                    Column::Hydration(spec) => {
+                        format_hydration_column(&formatter, spec, result, batch, row_idx, &mut cache)
+                            .await?
+                    }
                 };
                 row_values.push(value);
             }

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -1,12 +1,10 @@
-//! Graph crawl formatter - expands Sid bindings to nested JSON-LD objects
-//!
-//! This module handles the graph crawl select syntax which enables nested object
-//! expansion in query results.
+//! Hydration formatter — materializes a Sid into a nested JSON-LD object by
+//! recursively fetching its properties.
 //!
 //! # Supported Syntax
 //!
 //! ```json
-//! // Variable-bound graph crawl
+//! // Variable-bound hydration
 //! {"select": {"?person": ["*", {"ex:friend": ["*"]}]},
 //!  "where": {"@id": "?person", "type": "ex:User"}}
 //!
@@ -28,7 +26,7 @@ use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{Flake, GraphDbRef, Sid, Tracker};
 use fluree_db_policy::{is_schema_flake, PolicyContext};
 use fluree_db_query::binding::Binding;
-use fluree_db_query::ir::{GraphSelectSpec, NestedSelectSpec, Root, SelectionSpec};
+use fluree_db_query::ir::{HydrationSpec, NestedSelectSpec, Root, SelectionSpec};
 use fluree_vocab::namespaces::JSON_LD;
 use fluree_vocab::rdf::{self, TYPE as RDF_TYPE_IRI};
 use futures::future::BoxFuture;
@@ -38,14 +36,14 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Cache key: (Sid, local_spec_hash, depth_remaining)
 /// The local_spec_hash is computed from the current selections/reverse/has_wildcard,
-/// NOT the top-level spec. This ensures different nested expansions of the same Sid
+/// NOT the top-level spec. This ensures different nested hydrations of the same Sid
 /// produce different cache entries.
 type CacheKey = (Sid, u64, usize);
 
 /// Selection specification for formatting a subject.
 ///
 /// Bundles the immutable parameters that define what properties to select
-/// during graph crawl formatting.
+/// during hydration formatting.
 struct FormatSpec<'a> {
     /// Forward property selections
     selections: &'a [SelectionSpec],
@@ -150,27 +148,27 @@ fn compute_local_spec_hash(
     hasher.finish()
 }
 
-/// Format query results with graph crawl expansion (sync entry point - returns error)
+/// Format query results with hydration (sync entry point - returns error)
 ///
 /// The sync entry point always returns an error directing callers to use
-/// `format_results_async()` instead, as graph crawl requires DB access.
+/// `format_results_async()` instead, since hydration requires DB access.
 #[allow(dead_code)]
 pub fn format(result: &QueryResult, _compactor: &IriCompactor) -> Result<JsonValue> {
-    let _spec = result.graph_select.as_ref().ok_or_else(|| {
-        FormatError::InvalidBinding("Graph crawl format called without graph_select spec".into())
+    let _spec = result.output.hydration().ok_or_else(|| {
+        FormatError::InvalidBinding("Hydration format called without spec".into())
     })?;
 
-    // Graph crawl always requires async DB access
+    // Hydration always requires async DB access
     Err(FormatError::InvalidBinding(
-        "Graph crawl formatting requires async database access. \
+        "Hydration formatting requires async database access. \
          Use format_results_async() instead of format_results()."
             .into(),
     ))
 }
 
-/// Async graph crawl formatter entry point.
+/// Async hydration formatter entry point.
 ///
-/// This is the full graph crawl implementation with async database access
+/// This is the full hydration implementation with async database access
 /// for property fetching, depth expansion, and reverse property expansion.
 ///
 /// # Policy Support
@@ -185,8 +183,8 @@ pub async fn format_async(
     policy: Option<&PolicyContext>,
     tracker: Option<&Tracker>,
 ) -> Result<JsonValue> {
-    let spec = result.graph_select.as_ref().ok_or_else(|| {
-        FormatError::InvalidBinding("Graph crawl format called without graph_select spec".into())
+    let spec = result.output.hydration().ok_or_else(|| {
+        FormatError::InvalidBinding("Hydration format called without spec".into())
     })?;
 
     // Attach the tracker to the GraphDbRef so db.range calls inside the
@@ -197,13 +195,13 @@ pub async fn format_async(
         None => db,
     };
 
-    let formatter = GraphCrawlFormatter::new(db, compactor, spec, config, policy, tracker);
+    let formatter = HydrationFormatter::new(db, compactor, spec, config, policy, tracker);
 
     // Shared cache across all rows
     let mut cache: HashMap<CacheKey, JsonValue> = HashMap::new();
     let mut rows = Vec::new();
 
-    // If the underlying query produced no solutions, graph crawl must produce no rows,
+    // If the underlying query produced no solutions, expansion must produce no rows,
     // even when the root is a constant Sid.
     if result.row_count() == 0 {
         return Ok(JsonValue::Array(rows));
@@ -272,7 +270,7 @@ pub async fn format_async(
 
                     if mixed_select {
                         let mut row = Vec::with_capacity(select_vars.len());
-                        for var in select_vars {
+                        for var in &select_vars {
                             if var == var_id {
                                 row.push(obj.clone());
                             } else {
@@ -302,11 +300,11 @@ pub async fn format_async(
     Ok(JsonValue::Array(rows))
 }
 
-/// Graph crawl formatter with async DB access
-struct GraphCrawlFormatter<'a> {
+/// Hydration formatter with async DB access
+struct HydrationFormatter<'a> {
     db: GraphDbRef<'a>,
     compactor: &'a IriCompactor,
-    spec: &'a GraphSelectSpec,
+    spec: &'a HydrationSpec,
     /// Whether to emit typed JSON (`{"@value": ..., "@type": ...}`) for all literals.
     typed: bool,
     /// Whether to always wrap property values in arrays (even single-valued).
@@ -318,11 +316,11 @@ struct GraphCrawlFormatter<'a> {
     tracker: Option<&'a Tracker>,
 }
 
-impl<'a> GraphCrawlFormatter<'a> {
+impl<'a> HydrationFormatter<'a> {
     fn new(
         db: GraphDbRef<'a>,
         compactor: &'a IriCompactor,
-        spec: &'a GraphSelectSpec,
+        spec: &'a HydrationSpec,
         config: &FormatterConfig,
         policy: Option<&'a PolicyContext>,
         tracker: Option<&'a Tracker>,
@@ -359,7 +357,7 @@ impl<'a> GraphCrawlFormatter<'a> {
         async move {
             let depth_remaining = self.spec.depth.saturating_sub(current_depth);
             // Use LOCAL spec hash (selections, reverse, has_wildcard) not top-level spec
-            // This ensures different nested expansions of the same Sid produce different cache entries
+            // This ensures different nested hydrations of the same Sid produce different cache entries
             let spec_hash =
                 compute_local_spec_hash(spec.selections, spec.reverse, spec.has_wildcard);
             let cache_key = (sid.clone(), spec_hash, depth_remaining);
@@ -382,7 +380,7 @@ impl<'a> GraphCrawlFormatter<'a> {
                 .iter()
                 .any(|s| matches!(s, SelectionSpec::Id));
             // @id inclusion:
-            // - Always include for nested expansions (identity of a crawled ref)
+            // - Always include for nested hydrations (identity of an expanded ref)
             // - Otherwise include when wildcard or explicit @id selection
             if current_depth > 0 || spec.has_wildcard || has_explicit_id {
                 obj.insert("@id".to_string(), json!(self.compactor.compact_sid(sid)?));
@@ -554,7 +552,7 @@ impl<'a> GraphCrawlFormatter<'a> {
                         // @type special case: compact IRI string, not {"@id": ...}
                         values.push(json!(self.compactor.compact_sid(ref_sid)?));
                     } else {
-                        // Expansion decision:
+                        // Hydration decision:
                         // 1. If explicit sub-selection exists → expand with that spec
                         // 2. Else if current_depth < max_depth → auto-expand with FULL parent spec
                         // 3. Else → just return {"@id": ...}
@@ -1091,8 +1089,8 @@ impl<'a> GraphCrawlFormatter<'a> {
                 }
 
                 // Get subject classes from cache (empty if not cached)
-                // Note: Graph crawl doesn't pre-populate class cache like BinaryScanOperator.
-                // For graph crawl with class policies, the cache will be empty and
+                // Note: Hydration doesn't pre-populate class cache like BinaryScanOperator.
+                // For hydration with class policies, the cache will be empty and
                 // class policies may not work correctly. This is a known limitation
                 // that can be addressed by pre-populating in format_async if needed.
                 let subject_classes = policy_ctx

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -197,26 +197,6 @@ async fn format_hydration_column<'a>(
         .await
 }
 
-/// Format query results with hydration (sync entry point - returns error)
-///
-/// The sync entry point always returns an error directing callers to use
-/// `format_results_async()` instead, since hydration requires DB access.
-#[allow(dead_code)]
-pub fn format(result: &QueryResult, _compactor: &IriCompactor) -> Result<JsonValue> {
-    if !result.output.has_hydration() {
-        return Err(FormatError::InvalidBinding(
-            "Hydration format called without any hydration columns".into(),
-        ));
-    }
-
-    // Hydration always requires async DB access
-    Err(FormatError::InvalidBinding(
-        "Hydration formatting requires async database access. \
-         Use format_results_async() instead of format_results()."
-            .into(),
-    ))
-}
-
 /// Async hydration formatter entry point.
 ///
 /// This is the full hydration implementation with async database access

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -44,6 +44,46 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 ///   when their levels differ.
 type CacheKey = (Sid, u64, usize);
 
+/// Depth bookkeeping for one hydration call.
+///
+/// Each hydration column carries its own budget; threading the pair as a
+/// single value (instead of two parallel `usize` parameters) keeps the
+/// recursive signatures small and puts the descent / expansion-gate logic
+/// on the type itself.
+#[derive(Copy, Clone)]
+struct DepthBudget {
+    /// Current recursion depth (0 at a column's root).
+    current: usize,
+    /// Auto-expansion budget for this column.
+    max: usize,
+}
+
+impl DepthBudget {
+    /// Budget at a column's root: depth 0, with the column's `max`.
+    fn root(max: usize) -> Self {
+        Self { current: 0, max }
+    }
+
+    /// Budget for one level of recursive descent.
+    fn descend(self) -> Self {
+        Self {
+            current: self.current + 1,
+            max: self.max,
+        }
+    }
+
+    /// Levels of auto-expansion still permitted (for cache keying).
+    fn remaining(self) -> usize {
+        self.max.saturating_sub(self.current)
+    }
+
+    /// Whether auto-expansion (no explicit sub-spec) is still permitted at
+    /// this level — i.e. there's at least one descent left in the budget.
+    fn can_expand(self) -> bool {
+        self.current < self.max
+    }
+}
+
 /// Context for formatting a specific predicate's values.
 struct PredicateContext<'a> {
     /// The predicate SID being formatted.
@@ -171,8 +211,8 @@ fn resolve_root_sid_from_binding(
 /// expands it via [`HydrationFormatter::format_subject`] using the column's
 /// own level and depth budget. A variable root that's unbound for this row
 /// renders as `null` rather than skipping the row entirely.
-async fn format_hydration_column<'a>(
-    formatter: &HydrationFormatter<'a>,
+async fn format_hydration_column(
+    formatter: &HydrationFormatter<'_>,
     spec: &HydrationSpec,
     result: &QueryResult,
     batch: &fluree_db_query::Batch,
@@ -192,7 +232,13 @@ async fn format_hydration_column<'a>(
 
     let mut visited = HashSet::new();
     formatter
-        .format_subject(&root_sid, &spec.level, 0, spec.depth, &mut visited, cache)
+        .format_subject(
+            &root_sid,
+            &spec.level,
+            DepthBudget::root(spec.depth),
+            &mut visited,
+            cache,
+        )
         .await
 }
 
@@ -327,11 +373,7 @@ impl<'a> HydrationFormatter<'a> {
     /// # Arguments
     /// - `sid`: Subject to expand
     /// - `level`: Selection specification (what properties to include)
-    /// - `current_depth`: Current recursion depth
-    /// - `max_depth`: Auto-expansion budget for *this* hydration column. Each
-    ///   column carries its own budget; threading it as a parameter (rather
-    ///   than holding it on the formatter) lets multiple columns with
-    ///   different depths share one formatter.
+    /// - `depth`: Current depth and per-column max — see [`DepthBudget`].
     /// - `visited`: Cycle detection set (per-path)
     /// - `cache`: Result cache (shared across all subjects)
     ///
@@ -340,14 +382,12 @@ impl<'a> HydrationFormatter<'a> {
         &'b self,
         sid: &'b Sid,
         level: &'b NestedSelectSpec,
-        current_depth: usize,
-        max_depth: usize,
+        depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
-            let depth_remaining = max_depth.saturating_sub(current_depth);
-            let cache_key = (sid.clone(), compute_level_hash(level), depth_remaining);
+            let cache_key = (sid.clone(), compute_level_hash(level), depth.remaining());
 
             // Check cache first (same Sid + spec + depth = same result)
             if let Some(cached) = cache.get(&cache_key) {
@@ -365,7 +405,7 @@ impl<'a> HydrationFormatter<'a> {
             // @id inclusion:
             // - Always include for nested hydrations (identity of an expanded ref)
             // - Otherwise include when wildcard or explicit @id selection
-            if current_depth > 0 || level.includes_id() {
+            if depth.current > 0 || level.includes_id() {
                 obj.insert("@id".to_string(), json!(self.compactor.compact_sid(sid)?));
             }
 
@@ -407,14 +447,7 @@ impl<'a> HydrationFormatter<'a> {
                     explicit_sub_spec,
                 };
                 let values = self
-                    .format_predicate_values(
-                        pred_ctx,
-                        level,
-                        current_depth,
-                        max_depth,
-                        visited,
-                        cache,
-                    )
+                    .format_predicate_values(pred_ctx, level, depth, visited, cache)
                     .await?;
 
                 if !values.is_empty() {
@@ -439,8 +472,7 @@ impl<'a> HydrationFormatter<'a> {
                             &rev_flakes,
                             rev_nested_opt.as_deref(),
                             level,
-                            current_depth,
-                            max_depth,
+                            depth,
                             visited,
                             cache,
                         )
@@ -508,8 +540,7 @@ impl<'a> HydrationFormatter<'a> {
         &'b self,
         pred_ctx: PredicateContext<'b>,
         parent_level: &'b NestedSelectSpec,
-        current_depth: usize,
-        max_depth: usize,
+        depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> Result<Vec<JsonValue>> {
@@ -526,27 +557,25 @@ impl<'a> HydrationFormatter<'a> {
                     } else {
                         // Hydration decision:
                         // 1. If explicit sub-selection exists → expand with that spec
-                        // 2. Else if current_depth < max_depth → auto-expand with FULL parent level
+                        // 2. Else if budget permits → auto-expand with FULL parent level
                         // 3. Else → just return {"@id": ...}
                         if let Some(nested) = pred_ctx.explicit_sub_spec {
                             values.push(
                                 self.format_subject(
                                     ref_sid,
                                     nested,
-                                    current_depth + 1,
-                                    max_depth,
+                                    depth.descend(),
                                     visited,
                                     cache,
                                 )
                                 .await?,
                             );
-                        } else if current_depth < max_depth {
+                        } else if depth.can_expand() {
                             values.push(
                                 self.format_subject(
                                     ref_sid,
                                     parent_level,
-                                    current_depth + 1,
-                                    max_depth,
+                                    depth.descend(),
                                     visited,
                                     cache,
                                 )
@@ -579,8 +608,7 @@ impl<'a> HydrationFormatter<'a> {
         flakes: &[Flake],
         nested_spec: Option<&'b NestedSelectSpec>,
         parent_level: &'b NestedSelectSpec,
-        current_depth: usize,
-        max_depth: usize,
+        depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> Result<Vec<JsonValue>> {
@@ -591,28 +619,14 @@ impl<'a> HydrationFormatter<'a> {
 
             if let Some(nested) = nested_spec {
                 values.push(
-                    self.format_subject(
-                        subject_sid,
-                        nested,
-                        current_depth + 1,
-                        max_depth,
-                        visited,
-                        cache,
-                    )
-                    .await?,
+                    self.format_subject(subject_sid, nested, depth.descend(), visited, cache)
+                        .await?,
                 );
-            } else if current_depth < max_depth {
+            } else if depth.can_expand() {
                 // Auto-expand reverse refs with FULL parent level
                 values.push(
-                    self.format_subject(
-                        subject_sid,
-                        parent_level,
-                        current_depth + 1,
-                        max_depth,
-                        visited,
-                        cache,
-                    )
-                    .await?,
+                    self.format_subject(subject_sid, parent_level, depth.descend(), visited, cache)
+                        .await?,
                 );
             } else {
                 // No expansion - just @id

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -26,7 +26,7 @@ use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{Flake, GraphDbRef, Sid, Tracker};
 use fluree_db_policy::{is_schema_flake, PolicyContext};
 use fluree_db_query::binding::Binding;
-use fluree_db_query::ir::{ForwardItem, HydrationSpec, NestedSelectSpec, Root};
+use fluree_db_query::ir::{Column, ForwardItem, NestedSelectSpec, Root};
 use fluree_vocab::namespaces::JSON_LD;
 use fluree_vocab::rdf::{self, TYPE as RDF_TYPE_IRI};
 use futures::future::BoxFuture;
@@ -35,9 +35,13 @@ use serde_json::{json, Value as JsonValue};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Cache key: (Sid, local_spec_hash, depth_remaining)
+///
 /// The local_spec_hash is computed from the current `NestedSelectSpec`,
-/// NOT the top-level spec. This ensures different nested hydrations of
-/// the same Sid produce different cache entries.
+/// NOT any top-level spec. This serves two purposes:
+/// - Different nested hydrations of the same Sid produce different entries.
+/// - Multiple top-level hydration columns share entries when they land on
+///   the same Sid with structurally identical levels, and stay separated
+///   when their levels differ.
 type CacheKey = (Sid, u64, usize);
 
 /// Context for formatting a specific predicate's values.
@@ -129,6 +133,38 @@ fn hash_reverse<H: std::hash::Hasher>(
     }
 }
 
+/// Resolve a hydration root variable's binding into a `Sid` for a single row.
+///
+/// Returns `Ok(None)` when the binding is unbound, poisoned, missing, or not
+/// subject-shaped (literals, IRIs that didn't match a known subject, etc.).
+/// Such columns render as `null` rather than skipping the row entirely.
+fn resolve_root_sid_from_binding(
+    result: &QueryResult,
+    binding: Option<&Binding>,
+) -> Result<Option<Sid>> {
+    match binding {
+        Some(b) if b.is_encoded() => {
+            let materialized = super::materialize::materialize_binding(result, b)?;
+            Ok(match materialized {
+                Binding::Sid { sid, .. } => Some(sid),
+                Binding::IriMatch { primary_sid, .. } => Some(primary_sid),
+                _ => None,
+            })
+        }
+        Some(Binding::Sid { sid, .. }) => Ok(Some(sid.clone())),
+        Some(Binding::IriMatch { primary_sid, .. }) => Ok(Some(primary_sid.clone())),
+        Some(Binding::Unbound | Binding::Poisoned) | None => Ok(None),
+        Some(
+            Binding::Lit { .. }
+            | Binding::Grouped(_)
+            | Binding::Iri(_)
+            | Binding::EncodedLit { .. }
+            | Binding::EncodedSid { .. }
+            | Binding::EncodedPid { .. },
+        ) => Ok(None),
+    }
+}
+
 /// Format query results with hydration (sync entry point - returns error)
 ///
 /// The sync entry point always returns an error directing callers to use
@@ -164,8 +200,13 @@ pub async fn format_async(
     policy: Option<&PolicyContext>,
     tracker: Option<&Tracker>,
 ) -> Result<JsonValue> {
-    let spec = result.output.hydration().ok_or_else(|| {
-        FormatError::InvalidBinding("Hydration format called without spec".into())
+    if !result.output.has_hydration() {
+        return Err(FormatError::InvalidBinding(
+            "Hydration format called without any hydration columns".into(),
+        ));
+    }
+    let columns = result.output.columns().ok_or_else(|| {
+        FormatError::InvalidBinding("Hydration format called on non-Select output".into())
     })?;
 
     // Attach the tracker to the GraphDbRef so db.range calls inside the
@@ -176,94 +217,85 @@ pub async fn format_async(
         None => db,
     };
 
-    let formatter = HydrationFormatter::new(db, compactor, spec, config, policy, tracker);
+    let formatter = HydrationFormatter::new(db, compactor, config, policy, tracker);
 
-    // Shared cache across all rows
+    // Shared cache across all rows and all hydration columns. The cache key
+    // includes a hash of the current `NestedSelectSpec`, so columns with
+    // structurally identical levels share entries; columns with different
+    // levels do not collide.
     let mut cache: HashMap<CacheKey, JsonValue> = HashMap::new();
-    let mut rows = Vec::new();
+    let mut rows: Vec<JsonValue> = Vec::new();
 
-    // If the underlying query produced no solutions, expansion must produce no rows,
-    // even when the root is a constant Sid.
+    // If the underlying query produced no solutions, expansion produces no
+    // rows — even when a column root is a constant Sid.
     if result.row_count() == 0 {
         return Ok(JsonValue::Array(rows));
     }
 
-    match &spec.root {
-        Root::Sid(sid) => {
-            // IRI constant root - single subject fetch (no batches needed)
-            let mut visited = HashSet::new();
-            let obj = formatter
-                .format_subject(sid, &spec.level, 0, &mut visited, &mut cache)
-                .await?;
-            rows.push(obj);
-        }
-        Root::Var(var_id) => {
-            // Variable root - iterate through result batches
-            let select_vars = result.output.projected_vars_or_empty();
-            let mixed_select = select_vars.len() > 1 || select_vars.first() != Some(var_id);
+    // Single-column projections (e.g. `select: {"?x": ["*"]}`) emit a bare
+    // object per row; multi-column projections emit array rows.
+    let single_column = columns.len() == 1;
 
-            for batch in &result.batches {
-                for row_idx in 0..batch.len() {
-                    let root_binding = batch.get(row_idx, *var_id);
+    for batch in &result.batches {
+        for row_idx in 0..batch.len() {
+            let mut row_values: Vec<JsonValue> = Vec::with_capacity(columns.len());
 
-                    let root_sid: Option<Sid> = match root_binding {
-                        Some(binding) if binding.is_encoded() => {
-                            let materialized =
-                                super::materialize::materialize_binding(result, binding)?;
-                            match materialized {
-                                Binding::Sid { sid, .. } => Some(sid),
-                                Binding::IriMatch { primary_sid, .. } => Some(primary_sid),
-                                _ => None,
+            for column in columns {
+                let value = match column {
+                    Column::Var(v) => match batch.get(row_idx, *v) {
+                        Some(binding) if formatter.typed => {
+                            super::typed::format_binding_with_result(result, binding, compactor)?
+                        }
+                        Some(binding) => {
+                            super::jsonld::format_binding_with_result(result, binding, compactor)?
+                        }
+                        None => JsonValue::Null,
+                    },
+                    Column::Hydration(spec) => match &spec.root {
+                        Root::Sid(sid) => {
+                            let mut visited = HashSet::new();
+                            formatter
+                                .format_subject(
+                                    sid,
+                                    &spec.level,
+                                    0,
+                                    spec.depth,
+                                    &mut visited,
+                                    &mut cache,
+                                )
+                                .await?
+                        }
+                        Root::Var(var_id) => {
+                            let root_sid = resolve_root_sid_from_binding(
+                                result,
+                                batch.get(row_idx, *var_id),
+                            )?;
+                            match root_sid {
+                                Some(sid) => {
+                                    let mut visited = HashSet::new();
+                                    formatter
+                                        .format_subject(
+                                            &sid,
+                                            &spec.level,
+                                            0,
+                                            spec.depth,
+                                            &mut visited,
+                                            &mut cache,
+                                        )
+                                        .await?
+                                }
+                                None => JsonValue::Null,
                             }
                         }
-                        Some(Binding::Sid { sid, .. }) => Some(sid.clone()),
-                        Some(Binding::IriMatch { primary_sid, .. }) => Some(primary_sid.clone()),
-                        Some(Binding::Unbound | Binding::Poisoned) | None => None,
-                        Some(
-                            Binding::Lit { .. }
-                            | Binding::Grouped(_)
-                            | Binding::Iri(_)
-                            | Binding::EncodedLit { .. }
-                            | Binding::EncodedSid { .. }
-                            | Binding::EncodedPid { .. },
-                        ) => None,
-                    };
+                    },
+                };
+                row_values.push(value);
+            }
 
-                    let Some(root_sid) = root_sid else {
-                        // Unbound/poisoned root var - skip this row
-                        continue;
-                    };
-
-                    let mut visited = HashSet::new();
-                    let obj = formatter
-                        .format_subject(&root_sid, &spec.level, 0, &mut visited, &mut cache)
-                        .await?;
-
-                    if mixed_select {
-                        let mut row = Vec::with_capacity(select_vars.len());
-                        for var in &select_vars {
-                            if var == var_id {
-                                row.push(obj.clone());
-                            } else {
-                                let value = match batch.get(row_idx, *var) {
-                                    Some(binding) if formatter.typed => {
-                                        super::typed::format_binding_with_result(
-                                            result, binding, compactor,
-                                        )?
-                                    }
-                                    Some(binding) => super::jsonld::format_binding_with_result(
-                                        result, binding, compactor,
-                                    )?,
-                                    None => JsonValue::Null,
-                                };
-                                row.push(value);
-                            }
-                        }
-                        rows.push(JsonValue::Array(row));
-                    } else {
-                        rows.push(obj);
-                    }
-                }
+            if single_column {
+                rows.push(row_values.into_iter().next().unwrap());
+            } else {
+                rows.push(JsonValue::Array(row_values));
             }
         }
     }
@@ -271,11 +303,14 @@ pub async fn format_async(
     Ok(JsonValue::Array(rows))
 }
 
-/// Hydration formatter with async DB access
+/// Hydration formatter with async DB access.
+///
+/// The formatter is spec-agnostic: per-call the caller passes the
+/// `NestedSelectSpec` level and `max_depth` budget. This lets a single
+/// formatter serve multiple hydration columns in the same query.
 struct HydrationFormatter<'a> {
     db: GraphDbRef<'a>,
     compactor: &'a IriCompactor,
-    spec: &'a HydrationSpec,
     /// Whether to emit typed JSON (`{"@value": ..., "@type": ...}`) for all literals.
     typed: bool,
     /// Whether to always wrap property values in arrays (even single-valued).
@@ -291,7 +326,6 @@ impl<'a> HydrationFormatter<'a> {
     fn new(
         db: GraphDbRef<'a>,
         compactor: &'a IriCompactor,
-        spec: &'a HydrationSpec,
         config: &FormatterConfig,
         policy: Option<&'a PolicyContext>,
         tracker: Option<&'a Tracker>,
@@ -299,7 +333,6 @@ impl<'a> HydrationFormatter<'a> {
         Self {
             db,
             compactor,
-            spec,
             typed: config.format == OutputFormat::TypedJson,
             normalize_arrays: config.normalize_arrays,
             policy,
@@ -311,8 +344,12 @@ impl<'a> HydrationFormatter<'a> {
     ///
     /// # Arguments
     /// - `sid`: Subject to expand
-    /// - `spec`: Selection specification (what properties to include)
+    /// - `level`: Selection specification (what properties to include)
     /// - `current_depth`: Current recursion depth
+    /// - `max_depth`: Auto-expansion budget for *this* hydration column. Each
+    ///   column carries its own budget; threading it as a parameter (rather
+    ///   than holding it on the formatter) lets multiple columns with
+    ///   different depths share one formatter.
     /// - `visited`: Cycle detection set (per-path)
     /// - `cache`: Result cache (shared across all subjects)
     ///
@@ -322,11 +359,12 @@ impl<'a> HydrationFormatter<'a> {
         sid: &'b Sid,
         level: &'b NestedSelectSpec,
         current_depth: usize,
+        max_depth: usize,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
-            let depth_remaining = self.spec.depth.saturating_sub(current_depth);
+            let depth_remaining = max_depth.saturating_sub(current_depth);
             let cache_key = (sid.clone(), compute_level_hash(level), depth_remaining);
 
             // Check cache first (same Sid + spec + depth = same result)
@@ -387,7 +425,14 @@ impl<'a> HydrationFormatter<'a> {
                     explicit_sub_spec,
                 };
                 let values = self
-                    .format_predicate_values(pred_ctx, level, current_depth, visited, cache)
+                    .format_predicate_values(
+                        pred_ctx,
+                        level,
+                        current_depth,
+                        max_depth,
+                        visited,
+                        cache,
+                    )
                     .await?;
 
                 if !values.is_empty() {
@@ -413,6 +458,7 @@ impl<'a> HydrationFormatter<'a> {
                             rev_nested_opt.as_deref(),
                             level,
                             current_depth,
+                            max_depth,
                             visited,
                             cache,
                         )
@@ -481,6 +527,7 @@ impl<'a> HydrationFormatter<'a> {
         pred_ctx: PredicateContext<'b>,
         parent_level: &'b NestedSelectSpec,
         current_depth: usize,
+        max_depth: usize,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> Result<Vec<JsonValue>> {
@@ -505,17 +552,19 @@ impl<'a> HydrationFormatter<'a> {
                                     ref_sid,
                                     nested,
                                     current_depth + 1,
+                                    max_depth,
                                     visited,
                                     cache,
                                 )
                                 .await?,
                             );
-                        } else if current_depth < self.spec.depth {
+                        } else if current_depth < max_depth {
                             values.push(
                                 self.format_subject(
                                     ref_sid,
                                     parent_level,
                                     current_depth + 1,
+                                    max_depth,
                                     visited,
                                     cache,
                                 )
@@ -549,6 +598,7 @@ impl<'a> HydrationFormatter<'a> {
         nested_spec: Option<&'b NestedSelectSpec>,
         parent_level: &'b NestedSelectSpec,
         current_depth: usize,
+        max_depth: usize,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> Result<Vec<JsonValue>> {
@@ -559,16 +609,24 @@ impl<'a> HydrationFormatter<'a> {
 
             if let Some(nested) = nested_spec {
                 values.push(
-                    self.format_subject(subject_sid, nested, current_depth + 1, visited, cache)
-                        .await?,
+                    self.format_subject(
+                        subject_sid,
+                        nested,
+                        current_depth + 1,
+                        max_depth,
+                        visited,
+                        cache,
+                    )
+                    .await?,
                 );
-            } else if current_depth < self.spec.depth {
+            } else if current_depth < max_depth {
                 // Auto-expand reverse refs with FULL parent level
                 values.push(
                     self.format_subject(
                         subject_sid,
                         parent_level,
                         current_depth + 1,
+                        max_depth,
                         visited,
                         cache,
                     )

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -28,7 +28,7 @@ pub fn format(
     let select_one = result.output.is_select_one();
     let mut rows = Vec::new();
 
-    let select_vars = result.output.select_vars_or_empty();
+    let select_vars = result.output.projected_vars_or_empty();
     for batch in &result.batches {
         for row_idx in 0..batch.len() {
             let row = if result.output.is_wildcard() {

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -28,19 +28,14 @@ pub fn format(
     let select_one = result.output.is_select_one();
     let mut rows = Vec::new();
 
+    let select_vars = result.output.select_vars_or_empty();
     for batch in &result.batches {
         for row_idx in 0..batch.len() {
             let row = if result.output.is_wildcard() {
                 // Wildcard: use batch schema, return all bound vars as object
                 format_row_wildcard(result, batch, row_idx, &result.vars, compactor)?
             } else {
-                format_row_array(
-                    result,
-                    batch,
-                    row_idx,
-                    result.output.select_vars_or_empty(),
-                    compactor,
-                )?
+                format_row_array(result, batch, row_idx, &select_vars, compactor)?
             };
             rows.push(row);
 

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -392,7 +392,7 @@ mod tests {
             novelty: None,
             context: fluree_graph_json_ld::ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![]),
+            output: QueryOutput::select_vars(vec![]),
             batches: vec![],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! # Sync vs Async Formatting
 //!
-//! Most queries can use the synchronous `format_results()` function. However, **graph crawl
+//! Most queries can use the synchronous `format_results()` function. However, **hydration
 //! queries** require async database access for property expansion and must use
 //! `format_results_async()` instead.
 //!
@@ -31,7 +31,7 @@
 //! // For regular SELECT queries (sync)
 //! let json = format_results(&result, &parsed.context, &ledger.snapshot, &FormatterConfig::jsonld())?;
 //!
-//! // For graph crawl queries (async)
+//! // For hydration queries (async)
 //! let json = format_results_async(&result, &parsed.context, &ledger.snapshot, &FormatterConfig::jsonld()).await?;
 //!
 //! // For TSV/CSV (high-performance)
@@ -44,7 +44,7 @@ pub mod config;
 mod construct;
 pub mod datatype;
 pub mod delimited;
-mod graph_crawl;
+mod hydration;
 pub mod iri;
 mod jsonld;
 mod materialize;
@@ -78,7 +78,7 @@ pub enum FormatError {
     #[error("Invalid binding state: {0}")]
     InvalidBinding(String),
 
-    /// Fuel limit exceeded during formatting (graph crawl)
+    /// Fuel limit exceeded during formatting (expansion)
     #[error(transparent)]
     FuelExceeded(#[from] FuelExceededError),
 }
@@ -137,10 +137,10 @@ pub fn format_results(
         return result;
     }
 
-    // Graph crawl queries require async formatting for database access
-    if result.graph_select.is_some() {
+    // Hydration queries require async formatting for database access
+    if result.output.hydration().is_some() {
         return Err(FormatError::InvalidBinding(
-            "Graph crawl queries require async database access for property expansion. \
+            "Hydration queries require async database access for property expansion. \
              Use format_results_async() instead of format_results()."
                 .to_string(),
         ));
@@ -171,7 +171,7 @@ pub fn format_results(
 /// Convenience function that formats and serializes in one step.
 /// Respects `config.pretty` for formatting.
 ///
-/// Note: For graph crawl queries, use `format_results_string_async()` instead.
+/// Note: For hydration queries, use `format_results_string_async()` instead.
 pub fn format_results_string(
     result: &QueryResult,
     context: &ParsedContext,
@@ -220,16 +220,16 @@ fn format_boolean(result: &QueryResult, config: &FormatterConfig) -> Option<Resu
 }
 
 // ============================================================================
-// Async formatting (required for graph crawl)
+// Async formatting (required for hydration)
 // ============================================================================
 
 /// Format query results to JSON using async database access
 ///
 /// This is the async entry point for formatting. It supports all query types including
-/// **graph crawl queries** which require database access during formatting for property
+/// **hydration queries** which require database access during formatting for property
 /// expansion.
 ///
-/// For non-graph-crawl queries, this delegates to the sync formatters internally.
+/// For non-hydration queries, this delegates to the sync formatters internally.
 ///
 /// # Arguments
 ///
@@ -244,7 +244,7 @@ fn format_boolean(result: &QueryResult, config: &FormatterConfig) -> Option<Resu
 ///
 /// # Policy Support
 ///
-/// When `policy` is `Some`, graph crawl queries filter flakes according to view policies.
+/// When `policy` is `Some`, hydration queries filter flakes according to view policies.
 /// When `policy` is `None`, no filtering is applied (zero overhead for the common case).
 pub async fn format_results_async(
     result: &QueryResult,
@@ -280,22 +280,22 @@ pub async fn format_results_async(
         return result;
     }
 
-    // Graph crawl queries use async formatter with DB access
-    if result.graph_select.is_some() {
+    // Hydration queries use async formatter with DB access
+    if result.output.hydration().is_some() {
         if !matches!(
             config.format,
             OutputFormat::JsonLd | OutputFormat::TypedJson
         ) {
             return Err(FormatError::InvalidBinding(
-                "Graph crawl select only supports JSON-LD and TypedJson output formats".to_string(),
+                "Hydration only supports JSON-LD and TypedJson output formats".to_string(),
             ));
         }
         // For cross-ledger queries (connection/dataset), the result carries a
-        // composite overlay merging data from all queried ledgers. The graph
-        // crawl must use this overlay so it can resolve references that span
-        // ledger boundaries (e.g. a movie's `isBasedOn` pointing to a book in
-        // a different ledger).
-        let crawl_db = match (&result.novelty, result.t) {
+        // composite overlay merging data from all queried ledgers. The
+        // expansion must use this overlay so it can resolve references that
+        // span ledger boundaries (e.g. a movie's `isBasedOn` pointing to a
+        // book in a different ledger).
+        let hydration_db = match (&result.novelty, result.t) {
             (Some(novelty), Some(t)) => GraphDbRef::new(db.snapshot, db.g_id, novelty.as_ref(), t),
             // Multi-ledger dataset results may carry a composite overlay but no
             // meaningful shared `t`; keep the primary view's real bound instead
@@ -303,9 +303,10 @@ pub async fn format_results_async(
             (Some(novelty), None) => GraphDbRef::new(db.snapshot, db.g_id, novelty.as_ref(), db.t),
             (None, _) => db,
         };
-        let v = graph_crawl::format_async(result, crawl_db, &compactor, config, policy, tracker)
-            .await?;
-        // Graph crawl formatter returns an array of rows; honor selectOne by
+        let v =
+            hydration::format_async(result, hydration_db, &compactor, config, policy, tracker)
+                .await?;
+        // Hydration formatter returns an array of rows; honor selectOne by
         // returning the first row (or null if empty).
         return if result.output.is_select_one() {
             match v {
@@ -342,11 +343,11 @@ pub async fn format_results_async(
 /// Async convenience function that formats and serializes in one step.
 /// Respects `config.pretty` for formatting.
 ///
-/// Required for graph crawl queries. For other queries, can use sync version.
+/// Required for hydration queries. For other queries, can use sync version.
 ///
 /// # Policy Support
 ///
-/// When `policy` is `Some`, graph crawl queries filter flakes according to view policies.
+/// When `policy` is `Some`, hydration queries filter flakes according to view policies.
 /// When `policy` is `None`, no filtering is applied (zero overhead).
 pub async fn format_results_string_async(
     result: &QueryResult,
@@ -394,7 +395,6 @@ mod tests {
             output: QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
-            graph_select: None,
         }
     }
 

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -392,7 +392,7 @@ mod tests {
             novelty: None,
             context: fluree_graph_json_ld::ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![]),
+            output: QueryOutput::select_all(vec![]),
             batches: vec![],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -133,7 +133,7 @@ pub fn format_results(
     }
 
     // ASK queries: return boolean based on solution existence
-    if let Some(result) = format_boolean(result, config) {
+    if let Some(result) = format_ask(result, config) {
         return result;
     }
 
@@ -208,8 +208,8 @@ pub fn format_results_string(
 
 /// If this is an ASK/Boolean query, produce the result directly.
 /// Returns `None` for non-Boolean queries (caller continues to normal dispatch).
-fn format_boolean(result: &QueryResult, config: &FormatterConfig) -> Option<Result<JsonValue>> {
-    if !result.output.is_boolean() {
+fn format_ask(result: &QueryResult, config: &FormatterConfig) -> Option<Result<JsonValue>> {
+    if !result.output.is_ask() {
         return None;
     }
     let has_solution = result.batches.iter().any(|b| !b.is_empty());
@@ -276,7 +276,7 @@ pub async fn format_results_async(
     }
 
     // ASK queries: return boolean based on solution existence
-    if let Some(result) = format_boolean(result, config) {
+    if let Some(result) = format_ask(result, config) {
         return result;
     }
 
@@ -399,51 +399,51 @@ mod tests {
     }
 
     #[test]
-    fn format_boolean_returns_none_for_non_boolean() {
+    fn format_ask_returns_none_for_non_boolean() {
         let result = make_test_result();
         let config = FormatterConfig::jsonld();
-        assert!(format_boolean(&result, &config).is_none());
+        assert!(format_ask(&result, &config).is_none());
     }
 
     #[test]
-    fn format_boolean_true_sparql_json() {
+    fn format_ask_true_sparql_json() {
         let mut result = make_test_result();
-        result.output = QueryOutput::Boolean;
+        result.output = QueryOutput::Ask;
         result.batches = vec![fluree_db_query::binding::Batch::single_empty()];
 
         let config = FormatterConfig::sparql_json();
-        let output = format_boolean(&result, &config).unwrap().unwrap();
+        let output = format_ask(&result, &config).unwrap().unwrap();
         assert_eq!(output, json!({"head": {}, "boolean": true}));
     }
 
     #[test]
-    fn format_boolean_false_sparql_json() {
+    fn format_ask_false_sparql_json() {
         let mut result = make_test_result();
-        result.output = QueryOutput::Boolean;
+        result.output = QueryOutput::Ask;
 
         let config = FormatterConfig::sparql_json();
-        let output = format_boolean(&result, &config).unwrap().unwrap();
+        let output = format_ask(&result, &config).unwrap().unwrap();
         assert_eq!(output, json!({"head": {}, "boolean": false}));
     }
 
     #[test]
-    fn format_boolean_true_jsonld() {
+    fn format_ask_true_jsonld() {
         let mut result = make_test_result();
-        result.output = QueryOutput::Boolean;
+        result.output = QueryOutput::Ask;
         result.batches = vec![fluree_db_query::binding::Batch::single_empty()];
 
         let config = FormatterConfig::jsonld();
-        let output = format_boolean(&result, &config).unwrap().unwrap();
+        let output = format_ask(&result, &config).unwrap().unwrap();
         assert_eq!(output, JsonValue::Bool(true));
     }
 
     #[test]
-    fn format_boolean_false_jsonld() {
+    fn format_ask_false_jsonld() {
         let mut result = make_test_result();
-        result.output = QueryOutput::Boolean;
+        result.output = QueryOutput::Ask;
 
         let config = FormatterConfig::jsonld();
-        let output = format_boolean(&result, &config).unwrap().unwrap();
+        let output = format_ask(&result, &config).unwrap().unwrap();
         assert_eq!(output, JsonValue::Bool(false));
     }
 }

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -203,11 +203,11 @@ pub fn format_results_string(
 }
 
 // ============================================================================
-// Boolean (ASK) formatting
+// ASK formatting
 // ============================================================================
 
-/// If this is an ASK/Boolean query, produce the result directly.
-/// Returns `None` for non-Boolean queries (caller continues to normal dispatch).
+/// If this is an ASK query, produce the result directly.
+/// Returns `None` for non-ASK queries (caller continues to normal dispatch).
 fn format_ask(result: &QueryResult, config: &FormatterConfig) -> Option<Result<JsonValue>> {
     if !result.output.is_ask() {
         return None;
@@ -303,9 +303,8 @@ pub async fn format_results_async(
             (Some(novelty), None) => GraphDbRef::new(db.snapshot, db.g_id, novelty.as_ref(), db.t),
             (None, _) => db,
         };
-        let v =
-            hydration::format_async(result, hydration_db, &compactor, config, policy, tracker)
-                .await?;
+        let v = hydration::format_async(result, hydration_db, &compactor, config, policy, tracker)
+            .await?;
         // Hydration formatter returns an array of rows; honor selectOne by
         // returning the first row (or null if empty).
         return if result.output.is_select_one() {

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -138,7 +138,7 @@ pub fn format_results(
     }
 
     // Hydration queries require async formatting for database access
-    if result.output.hydration().is_some() {
+    if result.output.has_hydration() {
         return Err(FormatError::InvalidBinding(
             "Hydration queries require async database access for property expansion. \
              Use format_results_async() instead of format_results()."
@@ -281,7 +281,7 @@ pub async fn format_results_async(
     }
 
     // Hydration queries use async formatter with DB access
-    if result.output.hydration().is_some() {
+    if result.output.has_hydration() {
         if !matches!(
             config.format,
             OutputFormat::JsonLd | OutputFormat::TypedJson

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -462,7 +462,7 @@ mod tests {
             novelty: None,
             context: crate::ParsedContext::default(),
             orig_context: None,
-            output: crate::QueryOutput::select_vars(vec![]),
+            output: crate::QueryOutput::select_all(vec![]),
             batches: vec![],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -465,7 +465,6 @@ mod tests {
             output: crate::QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
-            graph_select: None,
         }
     }
 

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -58,7 +58,7 @@ pub fn format(
                     .collect()
             })
     } else {
-        result.output.projected_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty()
     };
 
     // Order head vars lexicographically by variable name (without '?').

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -58,7 +58,7 @@ pub fn format(
                     .collect()
             })
     } else {
-        result.output.select_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty().to_vec()
     };
 
     // Order head vars lexicographically by variable name (without '?').
@@ -462,7 +462,7 @@ mod tests {
             novelty: None,
             context: crate::ParsedContext::default(),
             orig_context: None,
-            output: crate::QueryOutput::select(vec![]),
+            output: crate::QueryOutput::select_vars(vec![]),
             batches: vec![],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -355,7 +355,7 @@ mod tests {
             novelty: None,
             context: fluree_graph_json_ld::ParsedContext::default(),
             orig_context: None,
-            output: fluree_db_query::ir::QueryOutput::select_vars(vec![]),
+            output: fluree_db_query::ir::QueryOutput::select_all(vec![]),
             batches: vec![],
             binary_graph: None,
         }
@@ -379,7 +379,7 @@ mod tests {
         let mut result = make_test_result();
 
         let s_var = result.vars.get_or_insert("?s");
-        result.output = fluree_db_query::ir::QueryOutput::select_vars(vec![s_var]);
+        result.output = fluree_db_query::ir::QueryOutput::select_all(vec![s_var]);
 
         let schema = std::sync::Arc::from(vec![s_var].into_boxed_slice());
         let sid = Sid::new(100, "alice");

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -68,7 +68,7 @@ pub fn format(
                     .collect()
             })
     } else {
-        result.output.projected_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty()
     };
 
     // Order head vars lexicographically by variable name (without '?') for stability.

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -36,7 +36,7 @@ pub fn format(
         ));
     }
 
-    if result.output.is_boolean() {
+    if result.output.is_ask() {
         let has_solution = result.batches.iter().any(|b| !b.is_empty());
         return Ok(format!(
             r#"<?xml version="1.0" encoding="UTF-8"?><sparql xmlns="{ns}"><head></head><boolean>{val}</boolean></sparql>"#,
@@ -365,7 +365,7 @@ mod tests {
     fn format_ask_true() {
         let compactor = make_test_compactor();
         let mut result = make_test_result();
-        result.output = fluree_db_query::ir::QueryOutput::Boolean;
+        result.output = fluree_db_query::ir::QueryOutput::Ask;
         result.batches = vec![Batch::single_empty()];
 
         let xml = format(&result, &compactor, &FormatterConfig::sparql_xml()).unwrap();

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -68,7 +68,7 @@ pub fn format(
                     .collect()
             })
     } else {
-        result.output.select_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty().to_vec()
     };
 
     // Order head vars lexicographically by variable name (without '?') for stability.
@@ -355,7 +355,7 @@ mod tests {
             novelty: None,
             context: fluree_graph_json_ld::ParsedContext::default(),
             orig_context: None,
-            output: fluree_db_query::ir::QueryOutput::select(vec![]),
+            output: fluree_db_query::ir::QueryOutput::select_vars(vec![]),
             batches: vec![],
             binary_graph: None,
         }
@@ -379,7 +379,7 @@ mod tests {
         let mut result = make_test_result();
 
         let s_var = result.vars.get_or_insert("?s");
-        result.output = fluree_db_query::ir::QueryOutput::select(vec![s_var]);
+        result.output = fluree_db_query::ir::QueryOutput::select_vars(vec![s_var]);
 
         let schema = std::sync::Arc::from(vec![s_var].into_boxed_slice());
         let sid = Sid::new(100, "alice");

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -358,7 +358,6 @@ mod tests {
             output: fluree_db_query::ir::QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
-            graph_select: None,
         }
     }
 

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -32,20 +32,14 @@ pub fn format(
     let select_one = result.output.is_select_one();
     let mut rows = Vec::new();
 
+    let select_vars = result.output.select_vars_or_empty();
     for batch in &result.batches {
         for row_idx in 0..batch.len() {
             let row = if result.output.is_wildcard() {
                 // Wildcard: use batch schema, return all bound vars as object
                 format_row_wildcard(batch, row_idx, &result.vars, compactor, result)?
             } else {
-                format_row(
-                    batch,
-                    row_idx,
-                    result.output.select_vars_or_empty(),
-                    &result.vars,
-                    compactor,
-                    result,
-                )?
+                format_row(batch, row_idx, &select_vars, &result.vars, compactor, result)?
             };
             rows.push(row);
 
@@ -340,7 +334,6 @@ mod tests {
             output: crate::QueryOutput::select(vec![]),
             batches: vec![],
             binary_graph: None,
-            graph_select: None,
         }
     }
 

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -32,7 +32,7 @@ pub fn format(
     let select_one = result.output.is_select_one();
     let mut rows = Vec::new();
 
-    let select_vars = result.output.select_vars_or_empty();
+    let select_vars = result.output.projected_vars_or_empty();
     for batch in &result.batches {
         for row_idx in 0..batch.len() {
             let row = if result.output.is_wildcard() {
@@ -331,7 +331,7 @@ mod tests {
             novelty: None,
             context: crate::ParsedContext::default(),
             orig_context: None,
-            output: crate::QueryOutput::select(vec![]),
+            output: crate::QueryOutput::select_vars(vec![]),
             batches: vec![],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -331,7 +331,7 @@ mod tests {
             novelty: None,
             context: crate::ParsedContext::default(),
             orig_context: None,
-            output: crate::QueryOutput::select_vars(vec![]),
+            output: crate::QueryOutput::select_all(vec![]),
             batches: vec![],
             binary_graph: None,
         }

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -39,7 +39,14 @@ pub fn format(
                 // Wildcard: use batch schema, return all bound vars as object
                 format_row_wildcard(batch, row_idx, &result.vars, compactor, result)?
             } else {
-                format_row(batch, row_idx, &select_vars, &result.vars, compactor, result)?
+                format_row(
+                    batch,
+                    row_idx,
+                    &select_vars,
+                    &result.vars,
+                    compactor,
+                    result,
+                )?
             };
             rows.push(row);
 

--- a/fluree-db-api/src/graph_source/bm25.rs
+++ b/fluree-db-api/src/graph_source/bm25.rs
@@ -220,7 +220,7 @@ impl crate::Fluree {
         // Execute with a wildcard select so the operator pipeline does not project away
         // bindings we need for indexing
         let mut parsed_for_exec = parsed.clone();
-        parsed_for_exec.output = QueryOutput::Wildcard;
+        parsed_for_exec.output = QueryOutput::wildcard();
 
         let executable = ExecutableQuery::simple(parsed_for_exec);
 
@@ -261,7 +261,7 @@ impl crate::Fluree {
         let parsed = parse_query(query_json, view.snapshot.as_ref(), &mut vars, None)?;
 
         let mut parsed_for_exec = parsed.clone();
-        parsed_for_exec.output = QueryOutput::Wildcard;
+        parsed_for_exec.output = QueryOutput::wildcard();
 
         let executable = ExecutableQuery::simple(parsed_for_exec);
 

--- a/fluree-db-api/src/graph_source/bm25.rs
+++ b/fluree-db-api/src/graph_source/bm25.rs
@@ -221,7 +221,6 @@ impl crate::Fluree {
         // bindings we need for indexing
         let mut parsed_for_exec = parsed.clone();
         parsed_for_exec.output = QueryOutput::Wildcard;
-        parsed_for_exec.graph_select = None;
 
         let executable = ExecutableQuery::simple(parsed_for_exec);
 
@@ -263,7 +262,6 @@ impl crate::Fluree {
 
         let mut parsed_for_exec = parsed.clone();
         parsed_for_exec.output = QueryOutput::Wildcard;
-        parsed_for_exec.graph_select = None;
 
         let executable = ExecutableQuery::simple(parsed_for_exec);
 

--- a/fluree-db-api/src/graph_source/vector.rs
+++ b/fluree-db-api/src/graph_source/vector.rs
@@ -244,7 +244,7 @@ impl crate::Fluree {
         let parsed = parse_query(query_json, &ledger.snapshot, &mut vars, None)?;
 
         // Execute with a wildcard select so the operator pipeline does not project away
-        // bindings we need for indexing (Wildcard naturally drops any hydrationion).
+        // bindings we need for indexing (Wildcard naturally drops any hydration).
         let mut parsed_for_exec = parsed.clone();
         parsed_for_exec.output = QueryOutput::wildcard();
 

--- a/fluree-db-api/src/graph_source/vector.rs
+++ b/fluree-db-api/src/graph_source/vector.rs
@@ -246,7 +246,7 @@ impl crate::Fluree {
         // Execute with a wildcard select so the operator pipeline does not project away
         // bindings we need for indexing (Wildcard naturally drops any hydrationion).
         let mut parsed_for_exec = parsed.clone();
-        parsed_for_exec.output = QueryOutput::Wildcard;
+        parsed_for_exec.output = QueryOutput::wildcard();
 
         let executable = ExecutableQuery::simple(parsed_for_exec);
 

--- a/fluree-db-api/src/graph_source/vector.rs
+++ b/fluree-db-api/src/graph_source/vector.rs
@@ -244,10 +244,9 @@ impl crate::Fluree {
         let parsed = parse_query(query_json, &ledger.snapshot, &mut vars, None)?;
 
         // Execute with a wildcard select so the operator pipeline does not project away
-        // bindings we need for indexing
+        // bindings we need for indexing (Wildcard naturally drops any hydrationion).
         let mut parsed_for_exec = parsed.clone();
         parsed_for_exec.output = QueryOutput::Wildcard;
-        parsed_for_exec.graph_select = None;
 
         let executable = ExecutableQuery::simple(parsed_for_exec);
 

--- a/fluree-db-api/src/overlay.rs
+++ b/fluree-db-api/src/overlay.rs
@@ -1,13 +1,13 @@
 //! Overlay utilities for formatting/query results.
 //!
-//! Currently used to support dataset (multi-ledger) graph crawl formatting by
+//! Currently used to support dataset (multi-ledger) hydration formatting by
 //! composing multiple novelty overlays into a single `OverlayProvider`.
 
 use fluree_db_core::{Flake, GraphId, IndexType, OverlayProvider};
 
 /// Composite overlay that merges multiple overlay providers.
 ///
-/// Used when graph crawl formatting needs to "see" unindexed flakes from multiple ledgers
+/// Used when hydration formatting needs to "see" unindexed flakes from multiple ledgers
 /// (dataset mode). This is a correctness-first implementation intended for tests and
 /// low-volume usage: it collects flakes from each overlay, sorts them, then streams them
 /// to the callback.

--- a/fluree-db-api/src/query/bm25.rs
+++ b/fluree-db-api/src/query/bm25.rs
@@ -63,7 +63,7 @@ impl Fluree {
         }
         let batches = execute(db, &vars, &executable, config).await?;
 
-        // Dataset graph crawl formatting may need to see flakes from multiple ledgers (union),
+        // Dataset hydration formatting may need to see flakes from multiple ledgers (union),
         // and each ledger may have a different `t`. We therefore:
         // - use a composite overlay (union of novelty overlays)
         // - omit result `t` unless the dataset resolves to one meaningful ledger/time

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -328,7 +328,7 @@ impl<'a> ViewQueryBuilder<'a> {
     ///
     /// For TSV format: produces TSV directly (fast path, no JSON intermediate).
     /// For JSON formats: produces serialized JSON string via async formatting
-    /// (supports graph crawl and policy-aware queries).
+    /// (supports expansion-aware policies-aware queries).
     pub async fn execute_formatted_string(mut self) -> Result<String> {
         let errs = self.core.validate();
         if !errs.is_empty() {
@@ -577,7 +577,7 @@ impl<'a> DatasetQueryBuilder<'a> {
     ///
     /// For TSV format: produces TSV directly (fast path, no JSON intermediate).
     /// For JSON formats: produces serialized JSON string via async formatting
-    /// (supports graph crawl and policy-aware queries).
+    /// (supports expansion-aware policies-aware queries).
     pub async fn execute_formatted_string(mut self) -> Result<String> {
         let errs = self.core.validate();
         if !errs.is_empty() {
@@ -942,7 +942,7 @@ impl<'a> FromQueryBuilder<'a> {
     ///
     /// For TSV format: produces TSV directly (fast path, no JSON intermediate).
     /// For JSON formats: produces serialized JSON string via async formatting
-    /// (supports graph crawl queries).
+    /// (supports hydration queries).
     pub async fn execute_formatted_string(mut self) -> Result<String> {
         let errs = self.core.validate();
         if !errs.is_empty() {

--- a/fluree-db-api/src/query/helpers.rs
+++ b/fluree-db-api/src/query/helpers.rs
@@ -127,7 +127,6 @@ pub(crate) fn build_query_result(
         output: parsed.output,
         batches,
         binary_graph,
-        graph_select: parsed.graph_select,
     }
 }
 

--- a/fluree-db-api/src/query/mod.rs
+++ b/fluree-db-api/src/query/mod.rs
@@ -38,7 +38,7 @@ pub struct QueryResult {
     pub context: crate::ParsedContext,
     /// Original JSON context from the query (for CONSTRUCT output)
     pub orig_context: Option<JsonValue>,
-    /// Query output specification (select vars, construct template, or boolean/wildcard mode)
+    /// Query output specification (projection, construct template, ASK, or wildcard).
     pub output: QueryOutput,
     /// Result batches
     pub batches: Vec<Batch>,

--- a/fluree-db-api/src/query/mod.rs
+++ b/fluree-db-api/src/query/mod.rs
@@ -60,7 +60,7 @@ impl std::fmt::Debug for QueryResult {
             .field("batches_len", &self.batches.len())
             .field("has_binary_graph", &self.binary_graph.is_some())
             .field("has_novelty", &self.novelty.is_some())
-            .field("has_hydration", &self.output.hydration().is_some())
+            .field("has_hydration", &self.output.has_hydration())
             .finish()
     }
 }

--- a/fluree-db-api/src/query/mod.rs
+++ b/fluree-db-api/src/query/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 use fluree_db_binary_index::BinaryGraphView;
 use fluree_db_core::{GraphDbRef, LedgerSnapshot};
 
-use fluree_db_query::ir::{GraphSelectSpec, QueryOutput};
+use fluree_db_query::ir::QueryOutput;
 
 /// Result of a query execution
 pub struct QueryResult {
@@ -29,9 +29,9 @@ pub struct QueryResult {
     /// queries leave it as `None` because there is no shared ledger-local transaction
     /// number that can be reported or reused safely across ledgers.
     pub t: Option<i64>,
-    /// Novelty overlay used during execution (for graph crawl formatting).
+    /// Novelty overlay used during execution (for hydration formatting).
     ///
-    /// Most query execution runs against `LedgerSnapshot + Novelty` (range_with_overlay). Graph crawl formatting
+    /// Most query execution runs against `LedgerSnapshot + Novelty` (range_with_overlay). Hydration formatting
     /// must use the same overlay to see unindexed flakes in memory-backed tests.
     pub novelty: Option<std::sync::Arc<dyn OverlayProvider>>,
     /// Parsed JSON-LD context from the query (for IRI compaction in formatters)
@@ -49,10 +49,6 @@ pub struct QueryResult {
     /// VECTOR_ID) through the correct arenas.  When absent, all bindings must
     /// already be fully materialized.
     pub binary_graph: Option<BinaryGraphView>,
-    /// Graph crawl select specification (None for flat SELECT or CONSTRUCT)
-    ///
-    /// When present, controls nested JSON-LD object expansion during formatting.
-    pub graph_select: Option<GraphSelectSpec>,
 }
 
 impl std::fmt::Debug for QueryResult {
@@ -64,7 +60,7 @@ impl std::fmt::Debug for QueryResult {
             .field("batches_len", &self.batches.len())
             .field("has_binary_graph", &self.binary_graph.is_some())
             .field("has_novelty", &self.novelty.is_some())
-            .field("has_graph_select", &self.graph_select.is_some())
+            .field("has_hydration", &self.output.hydration().is_some())
             .finish()
     }
 }
@@ -323,12 +319,12 @@ impl QueryResult {
     }
 
     // ========================================================================
-    // Async formatting methods (required for graph crawl queries)
+    // Async formatting methods (required for hydration queries)
     // ========================================================================
 
     /// Format as JSON-LD Query JSON with async DB access
     ///
-    /// This is the async version of `to_jsonld()`. Required for graph crawl
+    /// This is the async version of `to_jsonld()`. Required for hydration
     /// queries which need to fetch additional data from the database during
     /// formatting. For regular SELECT queries, the sync version works fine.
     ///
@@ -340,7 +336,7 @@ impl QueryResult {
     ///     "where": {"@id": "?person", "@type": "ex:User"}
     /// })).await?;
     ///
-    /// // Graph crawl requires async formatting
+    /// // Hydration requires async formatting
     /// let json = result.to_jsonld_async(ledger.as_graph_db_ref(0)).await?;
     /// ```
     pub async fn to_jsonld_async(&self, db: GraphDbRef<'_>) -> format::Result<JsonValue> {
@@ -350,7 +346,7 @@ impl QueryResult {
 
     /// Format as TypedJson with async DB access
     ///
-    /// Async version of `to_typed_json()`. Required for graph crawl queries
+    /// Async version of `to_typed_json()`. Required for hydration queries
     /// which need to fetch additional data from the database during formatting.
     /// Every literal value includes explicit `@type` annotation.
     pub async fn to_typed_json_async(&self, db: GraphDbRef<'_>) -> format::Result<JsonValue> {
@@ -360,7 +356,7 @@ impl QueryResult {
 
     /// Format with custom configuration (async version)
     ///
-    /// Async version of `format()`. Required for graph crawl queries.
+    /// Async version of `format()`. Required for hydration queries.
     pub async fn format_async(
         &self,
         db: GraphDbRef<'_>,
@@ -375,9 +371,9 @@ impl QueryResult {
 
     /// Format as JSON-LD Query JSON with policy filtering (async version)
     ///
-    /// When `policy` is provided, graph crawl queries filter flakes according to
+    /// When `policy` is provided, hydration queries filter flakes according to
     /// view policies during formatting. This ensures that nested objects fetched
-    /// during graph crawl also respect policy restrictions.
+    /// during hydration also respect policy restrictions.
     ///
     /// # Example
     ///
@@ -385,7 +381,7 @@ impl QueryResult {
     /// // Compose a policy-wrapped view, then query it.
     /// let db = fluree_db_api::GraphDb::from_ledger_state(&ledger).with_policy(Arc::new(policy_ctx.clone()));
     /// let result = fluree.query(&db, &query).await?;
-    /// // Graph crawl formatting also applies policy
+    /// // Hydration formatting also applies policy
     /// let json = result.to_jsonld_async_with_policy(db.as_graph_db_ref(), &policy_ctx).await?;
     /// ```
     pub async fn to_jsonld_async_with_policy(
@@ -399,7 +395,7 @@ impl QueryResult {
 
     /// Format with custom configuration and policy filtering (async version)
     ///
-    /// Combines custom formatting options with policy-aware graph crawl.
+    /// Combines custom formatting options with policy-aware hydration.
     pub async fn format_async_with_policy(
         &self,
         db: GraphDbRef<'_>,
@@ -409,7 +405,7 @@ impl QueryResult {
         format::format_results_async(self, &self.context, db, config, Some(policy), None).await
     }
 
-    /// Tracked async JSON-LD formatting (graph crawl counts fuel/policy).
+    /// Tracked async JSON-LD formatting (hydration counts fuel/policy).
     pub async fn to_jsonld_async_tracked(
         &self,
         db: GraphDbRef<'_>,
@@ -419,7 +415,7 @@ impl QueryResult {
         format::format_results_async(self, &self.context, db, &config, None, Some(tracker)).await
     }
 
-    /// Tracked async JSON-LD formatting with policy (graph crawl counts fuel/policy).
+    /// Tracked async JSON-LD formatting with policy (hydration counts fuel/policy).
     pub async fn to_jsonld_async_with_policy_tracked(
         &self,
         db: GraphDbRef<'_>,
@@ -438,7 +434,7 @@ impl QueryResult {
         .await
     }
 
-    /// Tracked async formatting with custom config (graph crawl counts fuel).
+    /// Tracked async formatting with custom config (hydration counts fuel).
     pub async fn format_async_tracked(
         &self,
         db: GraphDbRef<'_>,

--- a/fluree-db-api/src/query/mod.rs
+++ b/fluree-db-api/src/query/mod.rs
@@ -56,7 +56,7 @@ impl std::fmt::Debug for QueryResult {
         f.debug_struct("QueryResult")
             .field("t", &self.t)
             .field("output", &self.output)
-            .field("select_len", &self.output.select_vars_or_empty().len())
+            .field("select_len", &self.output.projected_vars_or_empty().len())
             .field("batches_len", &self.batches.len())
             .field("has_binary_graph", &self.binary_graph.is_some())
             .field("has_novelty", &self.novelty.is_some())

--- a/fluree-db-api/src/view/dataset.rs
+++ b/fluree-db-api/src/view/dataset.rs
@@ -205,7 +205,7 @@ impl DataSetDb {
         ds
     }
 
-    /// Build a composite overlay across all graphs (for graph crawl formatting).
+    /// Build a composite overlay across all graphs (for hydration formatting).
     pub(crate) fn composite_overlay(&self) -> Option<Arc<dyn OverlayProvider>> {
         let mut overlays: Vec<Arc<dyn OverlayProvider>> = Vec::new();
 

--- a/fluree-db-api/src/view/mod.rs
+++ b/fluree-db-api/src/view/mod.rs
@@ -42,7 +42,7 @@
 //! ## Policy (`with_policy`)
 //!
 //! Attaches a `PolicyContext` and `QueryPolicyEnforcer` for access control.
-//! Policy applies to both query execution and result formatting (graph crawl).
+//! Policy applies to both query execution and result formatting (expansion).
 //!
 //! ## Reasoning (`with_reasoning`)
 //!

--- a/fluree-db-api/tests/it_credential.rs
+++ b/fluree-db-api/tests/it_credential.rs
@@ -187,7 +187,7 @@ async fn credential_transact_then_credential_query_enforces_policy() {
         .expect("credential_transact")
         .ledger;
 
-    // Signed credentialed query selecting the root user (graph crawl).
+    // Signed credentialed query selecting the root user (expansion).
     let query = json!({
         "@context": ctx_ct(ns_prefix),
         "from": ledger_id,

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -444,7 +444,7 @@ async fn e2e_r2rml_query_iceberg_table() {
 
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select_vars(vec![airline_var, name_var, country_var]);
+    parsed.output = QueryOutput::select_all(vec![airline_var, name_var, country_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1092,7 +1092,7 @@ async fn engine_e2e_graph_pattern_r2rml_scan() {
     // Build Query with this pattern
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select_vars(vec![subject_var, name_var]);
+    parsed.output = QueryOutput::select_all(vec![subject_var, name_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1208,7 +1208,7 @@ async fn engine_e2e_provider_method_calls() {
 
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select_vars(vec![subject_var]);
+    parsed.output = QueryOutput::select_all(vec![subject_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1841,7 +1841,7 @@ async fn engine_e2e_ref_object_map_join_execution() {
 
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select_vars(vec![route_var, airline_var]);
+    parsed.output = QueryOutput::select_all(vec![route_var, airline_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -444,7 +444,7 @@ async fn e2e_r2rml_query_iceberg_table() {
 
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select(vec![airline_var, name_var, country_var]);
+    parsed.output = QueryOutput::select_vars(vec![airline_var, name_var, country_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1092,7 +1092,7 @@ async fn engine_e2e_graph_pattern_r2rml_scan() {
     // Build Query with this pattern
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select(vec![subject_var, name_var]);
+    parsed.output = QueryOutput::select_vars(vec![subject_var, name_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1208,7 +1208,7 @@ async fn engine_e2e_provider_method_calls() {
 
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select(vec![subject_var]);
+    parsed.output = QueryOutput::select_vars(vec![subject_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();
@@ -1841,7 +1841,7 @@ async fn engine_e2e_ref_object_map_join_execution() {
 
     let mut parsed = Query::new(ParsedContext::default());
     parsed.patterns = vec![graph_pattern];
-    parsed.output = QueryOutput::select(vec![route_var, airline_var]);
+    parsed.output = QueryOutput::select_vars(vec![route_var, airline_var]);
 
     let executable = ExecutableQuery::simple(parsed);
     let tracker = Tracker::disabled();

--- a/fluree-db-api/tests/it_historical_uses_index.rs
+++ b/fluree-db-api/tests/it_historical_uses_index.rs
@@ -4,7 +4,7 @@
 //! `target_t >= index_t` to use the binary index, forcing any query at
 //! `target_t < index_t` to fall back to overlay-only reconstruction
 //! (genesis snapshot + replay of every prior commit). Combined with the
-//! graph-crawl `select {"?s": ["*"]}` path — which issues one `range()`
+//! expansion `select {"?s": ["*"]}` path — which issues one `range()`
 //! call per subject and per reverse property — this turned historical
 //! queries into an O(N × total-overlay) scan that OOMed on real ledgers.
 //!
@@ -13,7 +13,7 @@
 //! replay handles `(index_t, target_t]`.
 //!
 //! This test reproduces the incident: index the ledger, add a commit on
-//! top, then query at `target_t < index_t` with graph-crawl `select *`.
+//! top, then query at `target_t < index_t` with expansion `select *`.
 //! The historical view must use the index (not fall back to genesis),
 //! and results must match what was present at `target_t`.
 
@@ -121,7 +121,7 @@ async fn historical_view_uses_index_when_target_below_index_t() {
         .expect("ledger_view_at t=2");
     assert_eq!(view_at_2.index_t(), 2);
 
-    // ---- Functional assertion: graph-crawl `select *` at t<index_t ----
+    // ---- Functional assertion: expansion `select *` at t<index_t ----
     //
     // This is the exact query shape that OOMed in production. At t=1 we
     // should see all 20 Contacts from tx1 and none from tx2/tx3.
@@ -137,14 +137,14 @@ async fn historical_view_uses_index_when_target_below_index_t() {
         .format(FormatterConfig::typed_json().with_normalize_arrays())
         .execute_tracked()
         .await
-        .expect("graph crawl at t=1");
+        .expect("expansion at t=1");
 
     let value = serde_json::to_value(&result.result).expect("serialize");
     let rows = value.as_array().expect("crawl result is array");
     assert_eq!(
         rows.len(),
         20,
-        "t=1 graph crawl must return exactly the 20 contacts from tx1; got {}",
+        "t=1 expansion must return exactly the 20 contacts from tx1; got {}",
         rows.len()
     );
 
@@ -161,7 +161,7 @@ async fn historical_view_uses_index_when_target_below_index_t() {
         .format(FormatterConfig::typed_json().with_normalize_arrays())
         .execute_tracked()
         .await
-        .expect("graph crawl at t=2");
+        .expect("expansion at t=2");
     let value_t2 = serde_json::to_value(&result_t2.result).expect("serialize");
     assert_eq!(value_t2.as_array().expect("array").len(), 21);
 }

--- a/fluree-db-api/tests/it_indexing_workflow.rs
+++ b/fluree-db-api/tests/it_indexing_workflow.rs
@@ -1032,13 +1032,13 @@ async fn reindex_default_from_t_includes_all_data() {
 /// Graph crawl select (`{"?s": ["*"]}`) must work against an indexed ledger.
 ///
 /// Binary scan operators produce `EncodedSid` bindings for late materialization.
-/// The graph crawl formatter must materialize these before subject property
+/// The expansion formatter must materialize these before subject property
 /// lookup, otherwise every row is silently skipped and the result is `[]`.
 #[tokio::test]
-async fn graph_crawl_select_works_after_indexing() {
+async fn expansion_select_works_after_indexing() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();
-    let ledger_id = "it/graph-crawl-indexed:main";
+    let ledger_id = "it/expansion-indexed:main";
 
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
@@ -1118,7 +1118,7 @@ async fn graph_crawl_select_works_after_indexing() {
             assert_eq!(
                 rows.len(),
                 3,
-                "graph crawl should return 3 persons, got: {json_rows}"
+                "expansion should return 3 persons, got: {json_rows}"
             );
 
             // Each row should be a JSON object with @id and properties

--- a/fluree-db-api/tests/it_policy_class.rs
+++ b/fluree-db-api/tests/it_policy_class.rs
@@ -135,7 +135,7 @@ async fn policy_class_restricts_ssn_to_own_user() {
 
 /// Test: Policy class allows viewing non-restricted properties
 ///
-/// class-policy-query (in a graph crawl restricts)
+/// class-policy-query (in a expansion restricts)
 #[tokio::test]
 async fn policy_class_allows_non_restricted_properties() {
     assert_index_defaults();

--- a/fluree-db-api/tests/it_policy_query_connection.rs
+++ b/fluree-db-api/tests/it_policy_query_connection.rs
@@ -2,7 +2,7 @@
 //!
 //! Focus:
 //! - identity-based policy loading via `f:policyClass` on the identity subject
-//! - view policy enforcement on direct selects and graph crawl formatting
+//! - view policy enforcement on direct selects and expansion formatting
 
 mod support;
 
@@ -62,7 +62,7 @@ async fn policy_inline_denies_restricted_property_in_direct_select() {
 }
 
 #[tokio::test]
-async fn policy_inline_denies_restricted_property_in_graph_crawl() {
+async fn policy_inline_denies_restricted_property_in_expansion() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();
 
@@ -121,7 +121,7 @@ async fn policy_inline_denies_restricted_property_in_graph_crawl() {
     );
 
     // Use the tracked connection query entrypoint, which performs **policy-aware**
-    // graph crawl formatting.
+    // expansion formatting.
     let tracked = fluree
         .query_connection_tracked(&query)
         .await

--- a/fluree-db-api/tests/it_query_jsonld_basic.rs
+++ b/fluree-db-api/tests/it_query_jsonld_basic.rs
@@ -60,6 +60,21 @@ async fn seed_movie_graph() -> (MemoryFluree, MemoryLedger) {
     (fluree, committed.ledger)
 }
 
+/// Extract `(@id of column 0, @id of column 1)` from an array-shaped row,
+/// for use as a stable sort key when asserting on multi-column hydration
+/// outputs.
+fn row_id_pair(row: &JsonValue) -> (String, String) {
+    let cols = row.as_array();
+    let id_at = |idx: usize| -> String {
+        cols.and_then(|cs| cs.get(idx))
+            .and_then(|c| c.get("@id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+    (id_at(0), id_at(1))
+}
+
 fn normalize_object_arrays(value: &mut JsonValue) {
     match value {
         JsonValue::Array(arr) => {
@@ -964,6 +979,91 @@ async fn jsonld_simple_subject_crawl_where_type() {
         }
     ]);
     normalize_object_arrays(&mut expected);
+
+    assert_eq!(json_result, expected);
+}
+
+#[tokio::test]
+async fn jsonld_two_hydration_columns_var_roots() {
+    // Two var-rooted hydration columns in a single select: each row should be
+    // a 2-element array of independently expanded subjects.
+    let (fluree, ledger) = seed_simple_subject_crawl().await;
+
+    let query = json!({
+        "@context": ctx(),
+        "select": [
+            {"?friender": ["@id", "schema:name"]},
+            {"?friend":   ["@id", "schema:name"]}
+        ],
+        "where": {
+            "@id": "?friender",
+            "ex:friend": "?friend"
+        }
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let mut json_result = result
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .expect("to_jsonld_async");
+
+    // Sort top-level rows by (friender @id, friend @id) so the assertion is
+    // independent of solution iteration order.
+    if let JsonValue::Array(rows) = &mut json_result {
+        rows.sort_by_key(|row| row_id_pair(row));
+    }
+
+    let expected = json!([
+        [
+            {"@id": "ex:cam", "schema:name": "Cam"},
+            {"@id": "ex:alice", "schema:name": "Alice"}
+        ],
+        [
+            {"@id": "ex:cam", "schema:name": "Cam"},
+            {"@id": "ex:brian", "schema:name": "Brian"}
+        ],
+        [
+            {"@id": "ex:david", "schema:name": "David"},
+            {"@id": "ex:cam", "schema:name": "Cam"}
+        ]
+    ]);
+
+    assert_eq!(json_result, expected);
+}
+
+#[tokio::test]
+async fn jsonld_two_hydration_columns_different_subspecs() {
+    // Each hydration column may carry its own NestedSelectSpec — different
+    // sub-selections should be honored independently per column.
+    let (fluree, ledger) = seed_simple_subject_crawl().await;
+
+    let query = json!({
+        "@context": ctx(),
+        "select": [
+            {"?friender": ["@id", "schema:name", "schema:age"]},
+            {"?friend":   ["@id"]}
+        ],
+        "where": {
+            "@id": "?friender",
+            "ex:friend": "?friend",
+            "schema:name": "David"
+        }
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_result = result
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .expect("to_jsonld_async");
+
+    let expected = json!([[
+        {"@id": "ex:david", "schema:name": "David", "schema:age": 46},
+        {"@id": "ex:cam"}
+    ]]);
 
     assert_eq!(json_result, expected);
 }

--- a/fluree-db-api/tests/it_query_jsonld_basic.rs
+++ b/fluree-db-api/tests/it_query_jsonld_basic.rs
@@ -26,7 +26,7 @@ async fn seed_movie_graph() -> (MemoryFluree, MemoryLedger) {
 
     let ledger0 = genesis_ledger(&fluree, ledger_id);
 
-    // Minimal “movie -> book -> author” shape to exercise graph crawl + depth.
+    // Minimal “movie -> book -> author” shape to exercise expansion + depth.
     let tx = json!({
         "@context": ctx(),
         "@graph": [
@@ -238,7 +238,7 @@ async fn jsonld_basic_single_subject_query_select_one() {
 }
 
 #[tokio::test]
-async fn jsonld_basic_single_subject_query_graph_crawl() {
+async fn jsonld_basic_single_subject_query_expansion() {
     let (fluree, ledger) = seed_movie_graph().await;
 
     let query = json!({
@@ -273,8 +273,8 @@ async fn jsonld_basic_single_subject_query_graph_crawl() {
 }
 
 #[tokio::test]
-async fn jsonld_basic_single_subject_graph_crawl_with_depth() {
-    // Mirrors the “depth graph crawl” behavior:
+async fn jsonld_basic_single_subject_expansion_with_depth() {
+    // Mirrors the “depth expansion” behavior:
     // with depth=3 and wildcard selection, refs should auto-expand transitively.
     let (fluree, ledger) = seed_movie_graph().await;
 
@@ -317,7 +317,7 @@ async fn jsonld_basic_single_subject_graph_crawl_with_depth() {
 }
 
 #[tokio::test]
-async fn jsonld_basic_single_subject_graph_crawl_with_depth_and_subselection() {
+async fn jsonld_basic_single_subject_expansion_with_depth_and_subselection() {
     let (fluree, ledger) = seed_movie_graph().await;
 
     let query = json!({
@@ -744,7 +744,7 @@ async fn jsonld_rdf_type_query_analytical() {
 }
 
 #[tokio::test]
-async fn jsonld_graph_crawl_nested_subselect_includes_id() {
+async fn jsonld_expansion_nested_subselect_includes_id() {
     let (fluree, ledger) = seed_movie_graph().await;
 
     // Regression: nested ref sub-selects should always include @id for identity,

--- a/fluree-db-api/tests/it_query_jsonld_basic.rs
+++ b/fluree-db-api/tests/it_query_jsonld_basic.rs
@@ -1012,7 +1012,7 @@ async fn jsonld_two_hydration_columns_var_roots() {
     // Sort top-level rows by (friender @id, friend @id) so the assertion is
     // independent of solution iteration order.
     if let JsonValue::Array(rows) = &mut json_result {
-        rows.sort_by_key(|row| row_id_pair(row));
+        rows.sort_by_key(row_id_pair);
     }
 
     let expected = json!([

--- a/fluree-db-api/tests/it_query_jsonld_compound.rs
+++ b/fluree-db-api/tests/it_query_jsonld_compound.rs
@@ -14,7 +14,7 @@ async fn compound_two_tuple_select_with_crawl_and_values() {
     let ledger = seed_people_compound_dataset(&fluree, "query/compound:main").await;
 
     // NOTE: Some clients return tuple rows mixing scalars + a crawled object.
-    // Rust currently formats graph crawl selections as **objects only** (graph crawl output),
+    // Rust currently formats expansion selections as **objects only** (expansion output),
     // so we assert the crawled friends and keep a separate ignored parity test below.
     let q = json!({
         "@context": {"schema":"http://schema.org/","ex":"http://example.org/ns/"},
@@ -274,7 +274,7 @@ async fn compound_group_by_multicard_without_aggregate() {
 }
 
 #[tokio::test]
-async fn compound_s_p_o_and_object_subject_joins_with_graph_crawl() {
+async fn compound_s_p_o_and_object_subject_joins_with_expansion() {
     // Scenario: s/p/o check + object-subject joins
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_people_compound_dataset(&fluree, "query/compound:spo").await;

--- a/fluree-db-api/tests/it_query_misc.rs
+++ b/fluree-db-api/tests/it_query_misc.rs
@@ -133,7 +133,7 @@ async fn class_queries_type_and_all_types() {
 // -----------------------------------------------------------------------------
 
 #[tokio::test]
-async fn result_formatting_graph_crawl_variants() {
+async fn result_formatting_expansion_variants() {
     // Scenario: misc-queries-test/result-formatting (current query section)
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger0 = genesis_ledger(&fluree, "misc/result-formatting:main");
@@ -401,10 +401,10 @@ async fn s_p_o_full_db_queries_parity() {
         ),
     ];
 
-    let rows = r_graph.as_array().expect("graph crawl results array");
+    let rows = r_graph.as_array().expect("expansion results array");
     assert_eq!(rows.len(), 11);
     for row in rows {
-        let obj = row.as_object().expect("graph crawl row object");
+        let obj = row.as_object().expect("expansion row object");
         let canon = canon_person(obj).expect("canonicalize person row");
         assert!(expected.contains(&canon), "unexpected row: {row:?}");
     }

--- a/fluree-db-api/tests/it_query_property.rs
+++ b/fluree-db-api/tests/it_query_property.rs
@@ -86,7 +86,7 @@ async fn subjects_as_predicates_variable_predicate_scan() {
 async fn subjects_as_predicates_reverse_crawl_without_star() {
     // Scenario: subjects-as-predicates / "via reverse no subgraph"
     //
-    // NOTE: We intentionally avoid `["*"]` (graph crawl) here because select [*] graph crawl
+    // NOTE: We intentionally avoid `["*"]` (expansion) here because select [*] expansion
     // parity is still in progress; this test validates reverse traversal + predicate-as-subject.
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_subject_as_predicate(&fluree, "property:reverse-crawl").await;
@@ -96,7 +96,7 @@ async fn subjects_as_predicates_reverse_crawl_without_star() {
 
     let q = json!({
         "@context": ctx,
-        // Include "*" so graph crawl formatter includes @id and we can assert the reverse edge
+        // Include "*" so expansion formatter includes @id and we can assert the reverse edge
         // without relying on explicit "id" selection behavior.
         "select": {"ex:nested": ["*","ex:reversed-pred"]},
         // Our parser requires a WHERE clause; this is equivalent to selecting by subject id.
@@ -117,7 +117,7 @@ async fn subjects_as_predicates_reverse_crawl_without_star() {
 }
 
 #[tokio::test]
-async fn equivalent_properties_equivalent_symmetric_transitive_and_graph_crawl() {
+async fn equivalent_properties_equivalent_symmetric_transitive_and_expansion() {
     // Scenario: equivalent-properties-test
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger0 = genesis_ledger(&fluree, "query/equivalent-properties");
@@ -207,7 +207,7 @@ async fn equivalent_properties_equivalent_symmetric_transitive_and_graph_crawl()
         normalize_rows(&json!(["Ben", "Brian", "Francois"]))
     );
 
-    // Querying with graph crawl.
+    // Querying with expansion.
     let q4 = json!({
         "@context": {
             "ex": "http://example.org/ns/",

--- a/fluree-db-api/tests/it_query_property_path.rs
+++ b/fluree-db-api/tests/it_query_property_path.rs
@@ -100,7 +100,7 @@ async fn property_path_one_or_more_no_vars_matches_transitively() {
     assert!(normalize_rows(&sanity_path_rows).contains(&json!(["ex:f"])));
 
     // Use VALUES to seed a single solution row and treat the (non-)transitive pattern
-    // as a filter, so we can assert reachability without relying on graph crawl output.
+    // as a filter, so we can assert reachability without relying on expansion output.
     let q_non = json!({
         "@context": {"ex":"http://example.org/"},
         "values": [["?dummy"], [[1]]],

--- a/fluree-db-api/tests/it_query_reverse.rs
+++ b/fluree-db-api/tests/it_query_reverse.rs
@@ -63,7 +63,7 @@ async fn seed_reverse_family(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLe
 
 #[tokio::test]
 async fn reverse_predicate_in_where_selects_inverse_edges() {
-    // Scenario: context-reverse-test (adapted: WHERE-based assertion, avoids reverse graph crawl formatting)
+    // Scenario: context-reverse-test (adapted: WHERE-based assertion, avoids reverse expansion formatting)
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_reverse_friends(&fluree, "reverse:friends").await;
 
@@ -97,7 +97,7 @@ async fn reverse_predicate_in_where_selects_inverse_edges() {
 
 #[tokio::test]
 async fn reverse_predicate_in_where_finds_kid() {
-    // Scenario: reverse-preds-in-where-and-select / "where clause" (adapted: avoid graph crawl selector)
+    // Scenario: reverse-preds-in-where-and-select / "where clause" (adapted: avoid expansion selector)
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_reverse_family(&fluree, "reverse:family").await;
 
@@ -171,10 +171,10 @@ async fn forward_at_type_in_where_finds_classes() {
 }
 
 #[tokio::test]
-async fn context_reverse_select_one_graph_crawl() {
+async fn context_reverse_select_one_expansion() {
     // Scenario: context-reverse-test
     let fluree = FlureeBuilder::memory().build_memory();
-    let ledger = seed_reverse_friends(&fluree, "reverse-friends-graph-crawl:main").await;
+    let ledger = seed_reverse_friends(&fluree, "reverse-friends-expansion:main").await;
 
     // 1) single reverse edge, no container
     let q1 = json!({
@@ -319,7 +319,7 @@ async fn type_reverse_and_forward_agree_on_classes() {
 }
 
 #[tokio::test]
-async fn inline_reverse_key_in_graph_crawl_top_level() {
+async fn inline_reverse_key_in_expansion_top_level() {
     // The AST documents {"@reverse:friended": ["*"]} as inline reverse-in-select
     // syntax. Verify it works without needing a context alias.
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -2134,9 +2134,9 @@ async fn sparql_exact_repro_custom_pred_without_type() {
     );
 }
 
-/// Bug 2 repro: JSON-LD graph crawl returns empty for custom namespace type.
+/// Bug 2 repro: JSON-LD expansion returns empty for custom namespace type.
 #[tokio::test]
-async fn jsonld_exact_repro_graph_crawl_custom_type() {
+async fn jsonld_exact_repro_expansion_custom_type() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_exact_repro(&fluree, "repro/bug2:main").await;
 
@@ -2152,7 +2152,7 @@ async fn jsonld_exact_repro_graph_crawl_custom_type() {
 
     let result = support::query_jsonld(&fluree, &ledger, &query)
         .await
-        .expect("graph crawl should not error");
+        .expect("expansion should not error");
     let jsonld = result
         .to_jsonld_async(ledger.as_graph_db_ref(0))
         .await
@@ -2162,7 +2162,7 @@ async fn jsonld_exact_repro_graph_crawl_custom_type() {
     let obj = rows[0].as_object().expect("should be object");
     assert!(
         obj.len() > 1,
-        "graph crawl should return properties, not just @id; got: {obj:?}"
+        "expansion should return properties, not just @id; got: {obj:?}"
     );
 }
 

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -368,15 +368,15 @@ async fn indexed_then_insert_novelty_custom_pred_returns_results() {
 }
 
 // =============================================================================
-// Bug 2 repro: graph crawl empty for custom NS type after index
+// Bug 2 repro: expansion empty for custom NS type after index
 // =============================================================================
 
-/// After index + insert with a custom namespace rdf:type, graph crawl returns
+/// After index + insert with a custom namespace rdf:type, expansion returns
 /// only `{"@id": "..."}` with no properties. The `decode_batch_to_flakes_filtered`
 /// function in `binary_range.rs` only handled REF_ID values through DictOverlay
 /// fallback, missing DictOverlay-assigned string value IDs.
 #[tokio::test]
-async fn indexed_then_insert_graph_crawl_custom_type_returns_properties() {
+async fn indexed_then_insert_expansion_custom_type_returns_properties() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory()
         .with_ledger_cache_config(LedgerManagerConfig::default())
@@ -454,7 +454,7 @@ async fn indexed_then_insert_graph_crawl_custom_type_returns_properties() {
                 "select": {"?s": ["*"]},
                 "values": ["?s", [{"@id": "cbc:assoc/coverage-001"}]]
             });
-            let result: QueryResult = fluree.query(&view, &query).await.expect("graph crawl");
+            let result: QueryResult = fluree.query(&view, &query).await.expect("expansion");
             let jsonld = result
                 .to_jsonld_async(view.as_graph_db_ref())
                 .await
@@ -464,7 +464,7 @@ async fn indexed_then_insert_graph_crawl_custom_type_returns_properties() {
             let obj = rows[0].as_object().expect("object");
             assert!(
                 obj.len() > 1,
-                "graph crawl should return properties, not just @id; got: {obj:?}"
+                "expansion should return properties, not just @id; got: {obj:?}"
             );
         })
         .await;

--- a/fluree-db-api/tests/it_query_typed_json.rs
+++ b/fluree-db-api/tests/it_query_typed_json.rs
@@ -1,7 +1,7 @@
-//! Integration tests for TypedJson graph crawl formatting and normalize_arrays.
+//! Integration tests for TypedJson expansion formatting and normalize_arrays.
 //!
 //! Verifies that `to_typed_json_async()` and `FormatterConfig::typed_json()` produce
-//! explicit `@type` annotations in graph crawl results, and that `normalize_arrays`
+//! explicit `@type` annotations in expansion results, and that `normalize_arrays`
 //! forces array wrapping for single-valued properties.
 
 mod support;
@@ -58,11 +58,11 @@ async fn seed_typed_graph() -> (MemoryFluree, MemoryLedger) {
 }
 
 // ============================================================================
-// TypedJson graph crawl
+// TypedJson expansion
 // ============================================================================
 
 #[tokio::test]
-async fn typed_json_graph_crawl_includes_type_annotations() {
+async fn typed_json_expansion_includes_type_annotations() {
     let (fluree, ledger) = seed_typed_graph().await;
 
     let query = json!({
@@ -74,7 +74,7 @@ async fn typed_json_graph_crawl_includes_type_annotations() {
     let config = FormatterConfig::typed_json();
     let result = query_jsonld_format(&fluree, &ledger, &query, &config)
         .await
-        .expect("typed json graph crawl");
+        .expect("typed json expansion");
 
     let arr = result.as_array().expect("result is array");
     assert_eq!(arr.len(), 1, "single root entity");
@@ -104,7 +104,7 @@ async fn typed_json_graph_crawl_includes_type_annotations() {
 }
 
 #[tokio::test]
-async fn typed_json_graph_crawl_json_datatype_preserved() {
+async fn typed_json_expansion_json_datatype_preserved() {
     let (fluree, ledger) = seed_typed_graph().await;
 
     let query = json!({
@@ -116,7 +116,7 @@ async fn typed_json_graph_crawl_json_datatype_preserved() {
     let config = FormatterConfig::typed_json();
     let result = query_jsonld_format(&fluree, &ledger, &query, &config)
         .await
-        .expect("typed json graph crawl with @json");
+        .expect("typed json expansion with @json");
 
     let arr = result.as_array().expect("result is array");
     let config_obj = &arr[0];
@@ -137,7 +137,7 @@ async fn typed_json_graph_crawl_json_datatype_preserved() {
 
 #[cfg(feature = "native")]
 #[tokio::test]
-async fn typed_json_graph_crawl_novelty_json_value_decodes_via_binary_range_provider() {
+async fn typed_json_expansion_novelty_json_value_decodes_via_binary_range_provider() {
     use fluree_db_api::ReindexOptions;
     use fluree_db_core::comparator::IndexType;
     use fluree_db_core::range::{RangeMatch, RangeTest};
@@ -223,7 +223,7 @@ async fn typed_json_graph_crawl_novelty_json_value_decodes_via_binary_range_prov
         "expected novelty @json value decoded via range provider, got: {flakes:?}"
     );
 
-    // 2) Typed-json graph crawl: should format without failing to resolve novelty string IDs.
+    // 2) Typed-json expansion: should format without failing to resolve novelty string IDs.
     let query = json!({
         "@context": ctx(),
         "select": {"ex:config": ["*"]},
@@ -237,7 +237,7 @@ async fn typed_json_graph_crawl_novelty_json_value_decodes_via_binary_range_prov
         .expect("query")
         .format_async(dbref, &config)
         .await
-        .expect("typed json graph crawl should succeed");
+        .expect("typed json expansion should succeed");
 
     let arr = result.as_array().expect("result array");
     let cfg = &arr[0];
@@ -269,7 +269,7 @@ async fn typed_json_graph_crawl_novelty_json_value_decodes_via_binary_range_prov
 }
 
 #[tokio::test]
-async fn typed_json_graph_crawl_nested_entities_are_typed() {
+async fn typed_json_expansion_nested_entities_are_typed() {
     let (fluree, ledger) = seed_typed_graph().await;
 
     // Graph crawl with nested expansion
@@ -282,7 +282,7 @@ async fn typed_json_graph_crawl_nested_entities_are_typed() {
     let config = FormatterConfig::typed_json();
     let result = query_jsonld_format(&fluree, &ledger, &query, &config)
         .await
-        .expect("typed json nested graph crawl");
+        .expect("typed json nested expansion");
 
     let alice = &result.as_array().unwrap()[0];
     let knows = alice.get("schema:knows").expect("has schema:knows");
@@ -302,11 +302,11 @@ async fn typed_json_graph_crawl_nested_entities_are_typed() {
 }
 
 // ============================================================================
-// JSON-LD graph crawl (default) does NOT include types for inferable datatypes
+// JSON-LD expansion (default) does NOT include types for inferable datatypes
 // ============================================================================
 
 #[tokio::test]
-async fn jsonld_graph_crawl_omits_inferable_types() {
+async fn jsonld_expansion_omits_inferable_types() {
     let (fluree, ledger) = seed_typed_graph().await;
 
     let query = json!({
@@ -317,7 +317,7 @@ async fn jsonld_graph_crawl_omits_inferable_types() {
 
     let result = query_jsonld_formatted(&fluree, &ledger, &query)
         .await
-        .expect("jsonld graph crawl");
+        .expect("jsonld expansion");
 
     let alice = &result.as_array().unwrap()[0];
     let name = alice.get("schema:name").expect("has schema:name");
@@ -345,7 +345,7 @@ async fn normalize_arrays_forces_array_for_single_values() {
     // Without normalize_arrays: single-valued property is a scalar
     let default_result = query_jsonld_formatted(&fluree, &ledger, &query)
         .await
-        .expect("default graph crawl");
+        .expect("default expansion");
     let bob_default = &default_result.as_array().unwrap()[0];
     let single_tag_default = bob_default.get("ex:single_tag").expect("has ex:single_tag");
     assert!(
@@ -357,7 +357,7 @@ async fn normalize_arrays_forces_array_for_single_values() {
     let config = FormatterConfig::jsonld().with_normalize_arrays();
     let norm_result = query_jsonld_format(&fluree, &ledger, &query, &config)
         .await
-        .expect("normalized graph crawl");
+        .expect("normalized expansion");
     let bob_norm = &norm_result.as_array().unwrap()[0];
     let single_tag_norm = bob_norm.get("ex:single_tag").expect("has ex:single_tag");
     assert!(
@@ -380,7 +380,7 @@ async fn normalize_arrays_combined_with_typed_json() {
     let config = FormatterConfig::typed_json().with_normalize_arrays();
     let result = query_jsonld_format(&fluree, &ledger, &query, &config)
         .await
-        .expect("typed + normalized graph crawl");
+        .expect("typed + normalized expansion");
     let bob = &result.as_array().unwrap()[0];
 
     // Single-valued property is an array

--- a/fluree-db-api/tests/it_select_star_novelty_retract.rs
+++ b/fluree-db-api/tests/it_select_star_novelty_retract.rs
@@ -1,11 +1,11 @@
-//! Regression tests for novelty retraction handling in JSON-LD graph crawl.
+//! Regression tests for novelty retraction handling in JSON-LD expansion.
 //!
 //! When an entity is created and then updated (upserted) within novelty
-//! (both transactions after the last index), the graph crawl `select *`
+//! (both transactions after the last index), the expansion `select *`
 //! must only return the current (post-upsert) values, not both old and new.
 //!
 //! SPARQL SELECT handles this correctly because the query engine deduplicates
-//! overlay facts. The JSON-LD graph crawl path goes through BinaryRangeProvider
+//! overlay facts. The JSON-LD expansion path goes through BinaryRangeProvider
 //! which uses BinaryCursor overlay merge — and the cursor does not deduplicate
 //! intra-overlay assert/retract pairs for the same fact.
 
@@ -72,7 +72,7 @@ fn assert_single_string_value(value: &Value, expected: &str, field: &str, node: 
 }
 
 // =============================================================================
-// Core regression test: upsert in novelty → graph crawl must show only new value
+// Core regression test: upsert in novelty → expansion must show only new value
 // =============================================================================
 
 /// Reproduces the bug where JSON-LD `select *` returns both old and new values
@@ -85,7 +85,7 @@ fn assert_single_string_value(value: &Value, expected: &str, field: &str, node: 
 /// 3. Upsert task with description "updated" (novelty only)
 /// 4. JSON-LD `select {IRI: ["*"]}` should return ONLY "updated"
 #[tokio::test]
-async fn graph_crawl_applies_novelty_retractions() {
+async fn expansion_applies_novelty_retractions() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let path = tmp.path().to_str().unwrap();
 
@@ -153,7 +153,7 @@ async fn graph_crawl_applies_novelty_retractions() {
     );
 
     // -------------------------------------------------------------------------
-    // JSON-LD graph crawl: select {IRI: ["*"]}
+    // JSON-LD expansion: select {IRI: ["*"]}
     // -------------------------------------------------------------------------
     let crawl_query = json!({
         "@context": test_context(),
@@ -167,7 +167,7 @@ async fn graph_crawl_applies_novelty_retractions() {
         .format(config)
         .execute_tracked()
         .await
-        .expect("graph crawl query");
+        .expect("expansion query");
 
     let formatted = serde_json::to_value(&crawl_result.result).expect("serialize");
     let node = formatted
@@ -191,7 +191,7 @@ async fn graph_crawl_applies_novelty_retractions() {
 /// and the update happens in novelty. This exercises the cursor merge path
 /// (base rows + overlay retract/assert) rather than the overlay-only path.
 #[tokio::test]
-async fn graph_crawl_applies_novelty_retractions_for_indexed_base_rows() {
+async fn expansion_applies_novelty_retractions_for_indexed_base_rows() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let path = tmp.path().to_str().unwrap();
 
@@ -253,7 +253,7 @@ async fn graph_crawl_applies_novelty_retractions_for_indexed_base_rows() {
         "SPARQL should return only the updated description"
     );
 
-    // JSON-LD graph crawl: select {IRI: ["*"]} should also return only the updated value.
+    // JSON-LD expansion: select {IRI: ["*"]} should also return only the updated value.
     let crawl_query = json!({
         "@context": test_context(),
         "select": { TASK_IRI: ["*"] },
@@ -266,7 +266,7 @@ async fn graph_crawl_applies_novelty_retractions_for_indexed_base_rows() {
         .format(config)
         .execute_tracked()
         .await
-        .expect("graph crawl query");
+        .expect("expansion query");
 
     let formatted = serde_json::to_value(&crawl_result.result).expect("serialize");
     let node = formatted
@@ -289,7 +289,7 @@ async fn graph_crawl_applies_novelty_retractions_for_indexed_base_rows() {
 /// must match the exact fact identity including list index, otherwise stale
 /// values will leak from the base index.
 #[tokio::test]
-async fn graph_crawl_applies_novelty_retractions_for_list_indexed_values() {
+async fn expansion_applies_novelty_retractions_for_list_indexed_values() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let path = tmp.path().to_str().unwrap();
 
@@ -344,7 +344,7 @@ async fn graph_crawl_applies_novelty_retractions_for_list_indexed_values() {
         "SPARQL should return only the updated single description"
     );
 
-    // JSON-LD graph crawl should also contain only one description value.
+    // JSON-LD expansion should also contain only one description value.
     let crawl_query = json!({
         "@context": test_context(),
         "select": { TASK_IRI: ["*"] },
@@ -357,7 +357,7 @@ async fn graph_crawl_applies_novelty_retractions_for_list_indexed_values() {
         .format(config)
         .execute_tracked()
         .await
-        .expect("graph crawl query");
+        .expect("expansion query");
     let formatted = serde_json::to_value(&crawl_result.result).expect("serialize");
     let node = formatted
         .as_array()
@@ -367,7 +367,7 @@ async fn graph_crawl_applies_novelty_retractions_for_list_indexed_values() {
     assert_single_string_value(&node["ex:description"], "desc c", "description", node);
 }
 
-/// Regression: graph crawl must not drop novelty assertions when V3 overlay translation
+/// Regression: expansion must not drop novelty assertions when V3 overlay translation
 /// fails due to missing/invalid dictionary state.
 ///
 /// This simulates a production failure mode where the reader has a binary index
@@ -376,7 +376,7 @@ async fn graph_crawl_applies_novelty_retractions_for_list_indexed_values() {
 /// translation of retractions for indexed (old) string values still succeeds.
 /// If we silently drop the failed assertion, the property disappears entirely.
 #[tokio::test]
-async fn graph_crawl_does_not_drop_overlay_assertions_when_dict_novelty_missing() {
+async fn expansion_does_not_drop_overlay_assertions_when_dict_novelty_missing() {
     use std::sync::Arc;
 
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -453,7 +453,7 @@ async fn graph_crawl_does_not_drop_overlay_assertions_when_dict_novelty_missing(
     let formatted = result
         .format_async(db.as_graph_db_ref(), &config)
         .await
-        .expect("format graph crawl");
+        .expect("format expansion");
 
     let node = formatted
         .as_array()
@@ -471,7 +471,7 @@ async fn graph_crawl_does_not_drop_overlay_assertions_when_dict_novelty_missing(
 /// Same test but with a fresh reader instance (simulates Lambda/separate process).
 /// This is closer to the production scenario where the reader loads state from storage.
 #[tokio::test]
-async fn graph_crawl_novelty_retractions_fresh_reader() {
+async fn expansion_novelty_retractions_fresh_reader() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let path = tmp.path().to_str().unwrap();
 
@@ -522,7 +522,7 @@ async fn graph_crawl_novelty_retractions_fresh_reader() {
         .format(config)
         .execute_tracked()
         .await
-        .expect("graph crawl");
+        .expect("expansion");
 
     let formatted = serde_json::to_value(&result.result).expect("serialize");
     let node = formatted
@@ -541,7 +541,7 @@ async fn graph_crawl_novelty_retractions_fresh_reader() {
 /// Memory-backed baseline: same scenario without binary index.
 /// This should always pass because the overlay-only path uses `remove_stale_flakes`.
 #[tokio::test]
-async fn memory_graph_crawl_novelty_retractions() {
+async fn memory_expansion_novelty_retractions() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger0 = fluree.create_ledger("test:main").await.expect("create");
 
@@ -585,7 +585,7 @@ async fn memory_graph_crawl_novelty_retractions() {
     assert_eq!(
         node["ex:description"],
         json!("updated description"),
-        "Memory-backed graph crawl should return only the updated description.\n\
+        "Memory-backed expansion should return only the updated description.\n\
          Got: {}\nFull: {}",
         node["ex:description"],
         node

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -438,7 +438,7 @@ pub enum Commands {
         #[arg(long, default_value = "table")]
         format: String,
 
-        /// Normalize arrays: always wrap multi-value properties in arrays (graph crawl only)
+        /// Normalize arrays: always wrap multi-value properties in arrays (expansion only)
         #[arg(long)]
         normalize_arrays: bool,
 

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -512,7 +512,7 @@ pub async fn run(
                     format_duration(fmt_elapsed),
                 );
             } else {
-                // JSON-LD queries can produce nested graph crawl results; always render as JSON.
+                // JSON-LD queries can produce nested expansion results; always render as JSON.
                 let display_format = match output_format {
                     OutputFormatKind::TypedJson => OutputFormatKind::TypedJson,
                     _ if query_format == detect::QueryFormat::JsonLd => OutputFormatKind::Json,

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -47,7 +47,7 @@ pub fn format_sparql_table_from_result(
     limit: Option<usize>,
 ) -> CliResult<Option<FormatOutput>> {
     // ASK queries: display boolean result directly instead of an empty table.
-    if result.output.is_boolean() {
+    if result.output.is_ask() {
         let has_solution = result.batches.iter().any(|b| !b.is_empty());
         return Ok(Some(FormatOutput {
             text: has_solution.to_string(),

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -82,7 +82,7 @@ pub fn format_sparql_table_from_result(
                     .collect()
             })
     } else {
-        result.output.select_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty().to_vec()
     };
 
     // Match SPARQL JSON head var behavior: strip '?' and sort lexicographically.

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -82,7 +82,7 @@ pub fn format_sparql_table_from_result(
                     .collect()
             })
     } else {
-        result.output.projected_vars_or_empty().to_vec()
+        result.output.projected_vars_or_empty()
     };
 
     // Match SPARQL JSON head var behavior: strip '?' and sort lexicographically.

--- a/fluree-db-query/src/count_plan.rs
+++ b/fluree-db-query/src/count_plan.rs
@@ -966,7 +966,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![out_var]),
+            output: QueryOutput::select_all(vec![out_var]),
             patterns,
             options: options.clone(),
             post_values: None,

--- a/fluree-db-query/src/count_plan.rs
+++ b/fluree-db-query/src/count_plan.rs
@@ -969,7 +969,6 @@ mod tests {
             output: QueryOutput::select(vec![out_var]),
             patterns,
             options: options.clone(),
-            graph_select: None,
             post_values: None,
         };
         (query, options)

--- a/fluree-db-query/src/count_plan.rs
+++ b/fluree-db-query/src/count_plan.rs
@@ -966,7 +966,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![out_var]),
+            output: QueryOutput::select_vars(vec![out_var]),
             patterns,
             options: options.clone(),
             post_values: None,

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -143,7 +143,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![VarId(99)]), // Variable not in pattern
+            output: QueryOutput::select_all(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,
@@ -166,7 +166,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![VarId(0)]),
+            output: QueryOutput::select_all(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -143,7 +143,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![VarId(99)]), // Variable not in pattern
+            output: QueryOutput::select_vars(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,
@@ -166,7 +166,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![VarId(0)]),
+            output: QueryOutput::select_vars(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -104,7 +104,6 @@ mod tests {
             output: QueryOutput::Wildcard,
             patterns: vec![],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
         let executable = ExecutableQuery::simple(query);
@@ -147,7 +146,6 @@ mod tests {
             output: QueryOutput::select(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
 
@@ -171,7 +169,6 @@ mod tests {
             output: QueryOutput::select(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
 

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -101,7 +101,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::Wildcard,
+            output: QueryOutput::wildcard(),
             patterns: vec![],
             options: QueryOptions::default(),
             post_values: None,

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -122,7 +122,7 @@ mod tests {
             SelectMode::Many => QueryOutput::select_vars(select),
             SelectMode::One => QueryOutput::select_one_var(select),
             SelectMode::Construct => QueryOutput::Construct(ConstructTemplate::new(Vec::new())),
-            SelectMode::Boolean => QueryOutput::Boolean,
+            SelectMode::Ask => QueryOutput::Ask,
         };
         Query {
             context: ParsedContext::default(),
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn none_for_boolean() {
-        let query = make_query(vec![], vec![], SelectMode::Boolean);
+        let query = make_query(vec![], vec![], SelectMode::Ask);
         assert!(compute_variable_deps(&query, &QueryOptions::default()).is_none());
     }
 

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -40,17 +40,8 @@ pub fn compute_variable_deps(query: &Query, options: &QueryOptions) -> Option<Va
 
     // Seed deps from the query output requirements.
     // Wildcard/Boolean return None from `variables()`, disabling trimming.
+    // Selection::Hydration contributes its root variable via bound_var.
     let mut deps: HashSet<VarId> = query.output.variables()?;
-
-    // Graph crawl formatter reads the root variable from result batches
-    // in addition to the SELECT variables (for mixed-select mode).
-    if let Some(root_var) = query
-        .graph_select
-        .as_ref()
-        .and_then(super::super::ir::GraphSelectSpec::root_var)
-    {
-        deps.insert(root_var);
-    }
 
     // ORDER BY vars must survive to the sort operator.
     for spec in &options.order_by {
@@ -140,7 +131,6 @@ mod tests {
             output,
             patterns,
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         }
     }
@@ -261,7 +251,6 @@ mod tests {
             )])),
             patterns: vec![],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
 
@@ -270,32 +259,49 @@ mod tests {
         assert!(deps.required_where_vars.contains(&VarId(1)));
     }
 
-    // ---- graph_select tests ----
+    // ---- hydrationion tests ----
 
-    #[test]
-    fn graph_select_adds_root_var() {
-        // SELECT ?name WHERE { ... } with graph_select rooted at ?s
-        // The formatter needs both ?name (select var) and ?s (root var).
-        let mut query = make_query(vec![VarId(1)], vec![], SelectMode::Many);
-        query.graph_select = Some(crate::ir::GraphSelectSpec::new(
-            crate::ir::Root::Var(VarId(0)),
-            vec![],
-        ));
-
-        let deps = compute_variable_deps(&query, &QueryOptions::default()).unwrap();
-        assert!(deps.required_where_vars.contains(&VarId(0))); // root var
-        assert!(deps.required_where_vars.contains(&VarId(1))); // select var
+    fn make_query_with_selections(selections: Vec<crate::ir::Selection>) -> Query {
+        Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::Select {
+                selections,
+                shape: crate::ir::ProjectionShape::Tuple,
+            },
+            patterns: vec![],
+            options: QueryOptions::default(),
+            post_values: None,
+        }
     }
 
     #[test]
-    fn graph_select_root_already_in_select() {
-        // SELECT ?s WHERE { ... } with graph_select rooted at ?s
-        // Root var is the same as the select var — no extra var needed.
-        let mut query = make_query(vec![VarId(0)], vec![], SelectMode::Many);
-        query.graph_select = Some(crate::ir::GraphSelectSpec::new(
-            crate::ir::Root::Var(VarId(0)),
-            vec![],
-        ));
+    fn hydration_adds_root_var() {
+        // SELECT ?name + hydration rooted at ?s
+        // The formatter needs both ?name (var selection) and ?s (root var).
+        let query = make_query_with_selections(vec![
+            crate::ir::Selection::Var(VarId(1)),
+            crate::ir::Selection::Hydration(crate::ir::HydrationSpec::new(
+                crate::ir::Root::Var(VarId(0)),
+                vec![],
+            )),
+        ]);
+
+        let deps = compute_variable_deps(&query, &QueryOptions::default()).unwrap();
+        assert!(deps.required_where_vars.contains(&VarId(0))); // root var
+        assert!(deps.required_where_vars.contains(&VarId(1))); // var selection
+    }
+
+    #[test]
+    fn hydration_root_already_in_select() {
+        // Var selection ?s + hydration rooted at ?s — only ?s needed.
+        let query = make_query_with_selections(vec![
+            crate::ir::Selection::Var(VarId(0)),
+            crate::ir::Selection::Hydration(crate::ir::HydrationSpec::new(
+                crate::ir::Root::Var(VarId(0)),
+                vec![],
+            )),
+        ]);
 
         let deps = compute_variable_deps(&query, &QueryOptions::default()).unwrap();
         assert!(deps.required_where_vars.contains(&VarId(0)));
@@ -303,30 +309,20 @@ mod tests {
     }
 
     #[test]
-    fn graph_select_sid_root_no_extra_vars() {
-        // SELECT ?name WHERE { ... } with graph_select rooted at an IRI constant
-        // Sid root doesn't reference a variable — only select vars needed.
-        let mut query = make_query(vec![VarId(1)], vec![], SelectMode::Many);
-        query.graph_select = Some(crate::ir::GraphSelectSpec::new(
-            crate::ir::Root::Sid(Sid::new(100, "alice")),
-            vec![],
-        ));
+    fn hydration_sid_root_no_extra_vars() {
+        // SELECT ?name + hydration rooted at an IRI constant.
+        // Sid root binds no variable — only ?name needed.
+        let query = make_query_with_selections(vec![
+            crate::ir::Selection::Var(VarId(1)),
+            crate::ir::Selection::Hydration(crate::ir::HydrationSpec::new(
+                crate::ir::Root::Sid(Sid::new(100, "alice")),
+                vec![],
+            )),
+        ]);
 
         let deps = compute_variable_deps(&query, &QueryOptions::default()).unwrap();
         assert!(deps.required_where_vars.contains(&VarId(1)));
         assert_eq!(deps.required_where_vars.len(), 1);
-    }
-
-    #[test]
-    fn graph_select_wildcard_output_disables_trimming() {
-        // SELECT * WHERE { ... } with graph_select — Wildcard disables trimming.
-        let mut query = make_query(vec![], vec![], SelectMode::Wildcard);
-        query.graph_select = Some(crate::ir::GraphSelectSpec::new(
-            crate::ir::Root::Var(VarId(0)),
-            vec![],
-        ));
-
-        assert!(compute_variable_deps(&query, &QueryOptions::default()).is_none());
     }
 
     // ---- per-operator pipeline deps tests ----

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -269,7 +269,7 @@ mod tests {
         assert!(deps.required_where_vars.contains(&VarId(1)));
     }
 
-    // ---- hydrationion tests ----
+    // ---- hydration tests ----
 
     fn make_query_with_selections(columns: Vec<crate::ir::Column>) -> Query {
         Query {

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -121,7 +121,7 @@ mod tests {
         let output = match select_mode {
             SelectMode::Many => QueryOutput::select(select),
             SelectMode::One => QueryOutput::select_one(select),
-            SelectMode::Wildcard => QueryOutput::Wildcard,
+            SelectMode::Wildcard => QueryOutput::wildcard(),
             SelectMode::Construct => QueryOutput::Construct(ConstructTemplate::new(Vec::new())),
             SelectMode::Boolean => QueryOutput::Boolean,
         };
@@ -261,13 +261,13 @@ mod tests {
 
     // ---- hydrationion tests ----
 
-    fn make_query_with_selections(selections: Vec<crate::ir::Selection>) -> Query {
+    fn make_query_with_selections(columns: Vec<crate::ir::Column>) -> Query {
         Query {
             context: ParsedContext::default(),
             orig_context: None,
             output: QueryOutput::Select {
-                selections,
-                shape: crate::ir::ProjectionShape::Tuple,
+                projection: crate::ir::Projection::Tuple(columns),
+                multiplicity: crate::ir::Multiplicity::All,
             },
             patterns: vec![],
             options: QueryOptions::default(),
@@ -280,8 +280,8 @@ mod tests {
         // SELECT ?name + hydration rooted at ?s
         // The formatter needs both ?name (var selection) and ?s (root var).
         let query = make_query_with_selections(vec![
-            crate::ir::Selection::Var(VarId(1)),
-            crate::ir::Selection::Hydration(crate::ir::HydrationSpec::new(
+            crate::ir::Column::Var(VarId(1)),
+            crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
                 crate::ir::Root::Var(VarId(0)),
                 vec![],
             )),
@@ -296,8 +296,8 @@ mod tests {
     fn hydration_root_already_in_select() {
         // Var selection ?s + hydration rooted at ?s — only ?s needed.
         let query = make_query_with_selections(vec![
-            crate::ir::Selection::Var(VarId(0)),
-            crate::ir::Selection::Hydration(crate::ir::HydrationSpec::new(
+            crate::ir::Column::Var(VarId(0)),
+            crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
                 crate::ir::Root::Var(VarId(0)),
                 vec![],
             )),
@@ -313,8 +313,8 @@ mod tests {
         // SELECT ?name + hydration rooted at an IRI constant.
         // Sid root binds no variable — only ?name needed.
         let query = make_query_with_selections(vec![
-            crate::ir::Selection::Var(VarId(1)),
-            crate::ir::Selection::Hydration(crate::ir::HydrationSpec::new(
+            crate::ir::Column::Var(VarId(1)),
+            crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
                 crate::ir::Root::Sid(Sid::new(100, "alice")),
                 vec![],
             )),

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -119,8 +119,8 @@ mod tests {
 
     fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>, select_mode: SelectMode) -> Query {
         let output = match select_mode {
-            SelectMode::Many => QueryOutput::select_vars(select),
-            SelectMode::One => QueryOutput::select_one_var(select),
+            SelectMode::Many => QueryOutput::select_all(select),
+            SelectMode::One => QueryOutput::select_one(select),
             SelectMode::Construct => QueryOutput::Construct(ConstructTemplate::new(Vec::new())),
             SelectMode::Ask => QueryOutput::Ask,
         };

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -121,7 +121,6 @@ mod tests {
         let output = match select_mode {
             SelectMode::Many => QueryOutput::select_vars(select),
             SelectMode::One => QueryOutput::select_one_var(select),
-            SelectMode::Wildcard => QueryOutput::wildcard(),
             SelectMode::Construct => QueryOutput::Construct(ConstructTemplate::new(Vec::new())),
             SelectMode::Boolean => QueryOutput::Boolean,
         };
@@ -135,13 +134,24 @@ mod tests {
         }
     }
 
+    fn make_wildcard_query(patterns: Vec<Pattern>) -> Query {
+        Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::wildcard(),
+            patterns,
+            options: QueryOptions::default(),
+            post_values: None,
+        }
+    }
+
     fn make_tp(s: VarId, p: &str, o: VarId) -> TriplePattern {
         TriplePattern::new(Ref::Var(s), Ref::Sid(Sid::new(100, p)), Term::Var(o))
     }
 
     #[test]
     fn none_for_wildcard() {
-        let query = make_query(vec![], vec![], SelectMode::Wildcard);
+        let query = make_wildcard_query(vec![]);
         assert!(compute_variable_deps(&query, &QueryOptions::default()).is_none());
     }
 

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -41,7 +41,7 @@ pub fn compute_variable_deps(query: &Query, options: &QueryOptions) -> Option<Va
     // Seed deps from the query output requirements.
     // Wildcard/Boolean return None from `variables()`, disabling trimming.
     // Selection::Hydration contributes its root variable via bound_var.
-    let mut deps: HashSet<VarId> = query.output.variables()?;
+    let mut deps: HashSet<VarId> = query.output.referenced_vars()?;
 
     // ORDER BY vars must survive to the sort operator.
     for spec in &options.order_by {

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -119,8 +119,8 @@ mod tests {
 
     fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>, select_mode: SelectMode) -> Query {
         let output = match select_mode {
-            SelectMode::Many => QueryOutput::select(select),
-            SelectMode::One => QueryOutput::select_one(select),
+            SelectMode::Many => QueryOutput::select_vars(select),
+            SelectMode::One => QueryOutput::select_one_var(select),
             SelectMode::Wildcard => QueryOutput::wildcard(),
             SelectMode::Construct => QueryOutput::Construct(ConstructTemplate::new(Vec::new())),
             SelectMode::Boolean => QueryOutput::Boolean,

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -344,6 +344,34 @@ mod tests {
         assert_eq!(deps.required_where_vars.len(), 1);
     }
 
+    #[test]
+    fn hydration_two_roots_both_added() {
+        // Two hydration columns with distinct variable roots: both root vars
+        // must contribute to required_where_vars so the executor produces
+        // bindings for each.
+        let query = make_query_with_selections(vec![
+            crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
+                crate::ir::Root::Var(VarId(0)),
+                crate::ir::NestedSelectSpec::Explicit {
+                    forward: vec![],
+                    reverse: std::collections::HashMap::new(),
+                },
+            )),
+            crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
+                crate::ir::Root::Var(VarId(1)),
+                crate::ir::NestedSelectSpec::Explicit {
+                    forward: vec![],
+                    reverse: std::collections::HashMap::new(),
+                },
+            )),
+        ]);
+
+        let deps = compute_variable_deps(&query, &QueryOptions::default()).unwrap();
+        assert!(deps.required_where_vars.contains(&VarId(0)));
+        assert!(deps.required_where_vars.contains(&VarId(1)));
+        assert_eq!(deps.required_where_vars.len(), 2);
+    }
+
     // ---- per-operator pipeline deps tests ----
 
     #[test]

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -293,7 +293,10 @@ mod tests {
             crate::ir::Column::Var(VarId(1)),
             crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
                 crate::ir::Root::Var(VarId(0)),
-                vec![],
+                crate::ir::NestedSelectSpec::Explicit {
+                    forward: vec![],
+                    reverse: std::collections::HashMap::new(),
+                },
             )),
         ]);
 
@@ -309,7 +312,10 @@ mod tests {
             crate::ir::Column::Var(VarId(0)),
             crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
                 crate::ir::Root::Var(VarId(0)),
-                vec![],
+                crate::ir::NestedSelectSpec::Explicit {
+                    forward: vec![],
+                    reverse: std::collections::HashMap::new(),
+                },
             )),
         ]);
 
@@ -326,7 +332,10 @@ mod tests {
             crate::ir::Column::Var(VarId(1)),
             crate::ir::Column::Hydration(crate::ir::HydrationSpec::new(
                 crate::ir::Root::Sid(Sid::new(100, "alice")),
-                vec![],
+                crate::ir::NestedSelectSpec::Explicit {
+                    forward: vec![],
+                    reverse: std::collections::HashMap::new(),
+                },
             )),
         ]);
 

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -128,7 +128,7 @@ fn detect_star_const_numeric_label_order_limit(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<StarConstOrderTopKSpec> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.distinct
@@ -154,7 +154,7 @@ fn detect_star_const_numeric_label_order_limit(
     let label_var = ob.var;
 
     // Must select exactly (?s, ?label) in any order.
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 2 || !select_vars.contains(&label_var) {
         return None;
     }
@@ -312,7 +312,7 @@ struct LabelRegexTypeSpec {
 /// `?s rdfs:label ?label . ?s rdf:type <Class> . FILTER regex(?label, "pat"[, "flags"])`
 /// with plain SELECT of exactly `(?s, ?label)` (no ORDER BY/LIMIT/DISTINCT).
 fn detect_label_regex_type(query: &Query, options: &QueryOptions) -> Option<LabelRegexTypeSpec> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if options.distinct
@@ -327,7 +327,7 @@ fn detect_label_regex_type(query: &Query, options: &QueryOptions) -> Option<Labe
         return None;
     }
 
-    let select = query.output.select_vars()?;
+    let select = query.output.projected_vars()?;
     if select.len() != 2 {
         return None;
     }
@@ -441,7 +441,7 @@ fn extract_regex_const_pattern(
 /// - LIMIT >= 1 (or no limit)
 /// - SELECT vars == `[agg.output_var]`
 pub(crate) fn detect_count_all_aggregate(query: &Query, options: &QueryOptions) -> Option<VarId> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -461,7 +461,7 @@ pub(crate) fn detect_count_all_aggregate(query: &Query, options: &QueryOptions) 
     if options.limit == Some(0) {
         return None;
     }
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -480,7 +480,7 @@ fn detect_count_distinct_aggregate(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(VarId, VarId)> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -501,7 +501,7 @@ fn detect_count_distinct_aggregate(
     if options.limit == Some(0) {
         return None;
     }
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -513,7 +513,7 @@ fn detect_count_distinct_aggregate(
 /// Returns `Some((input_var, output_var))` where `input_var` is `None` for `COUNT(*)`.
 /// Same standard constraints as [`detect_count_all_aggregate`].
 fn detect_count_aggregate(query: &Query, options: &QueryOptions) -> Option<(Option<VarId>, VarId)> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -543,7 +543,7 @@ fn detect_count_aggregate(query: &Query, options: &QueryOptions) -> Option<(Opti
     if options.limit == Some(0) {
         return None;
     }
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -659,11 +659,11 @@ fn detect_group_by_object_star_topk(
     Option<VarId>,
     usize,
 )> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     let select_vars: Arc<[VarId]> =
-        Arc::from(query.output.select_vars()?.to_vec().into_boxed_slice());
+        Arc::from(query.output.projected_vars()?.to_vec().into_boxed_slice());
     if options.group_by.len() != 1 {
         return None;
     }
@@ -804,7 +804,7 @@ fn detect_sum_strlen_group_concat_subquery(
 ) -> Option<(Ref, Arc<str>, VarId)> {
     use crate::ir::{Expression, Function, Pattern};
 
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty() {
@@ -903,7 +903,7 @@ fn detect_sum_strlen_group_concat_subquery(
     }
 
     // SELECT must be exactly the aggregate output var.
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != outer_agg.output_var {
         return None;
     }
@@ -1044,7 +1044,7 @@ fn detect_predicate_minmax_string(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, MinMaxMode, VarId)> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     // Must be single aggregate, no grouping/having/binds/etc.
@@ -1085,7 +1085,7 @@ fn detect_predicate_minmax_string(
     }
 
     // SELECT must be exactly the aggregate output var.
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -1094,7 +1094,7 @@ fn detect_predicate_minmax_string(
 }
 
 fn detect_predicate_avg_numeric(query: &Query, options: &QueryOptions) -> Option<(Ref, VarId)> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -1118,7 +1118,7 @@ fn detect_predicate_avg_numeric(query: &Query, options: &QueryOptions) -> Option
     if agg.distinct || !matches!(agg.function, AggregateFn::Avg) || agg.input_var? != o_var {
         return None;
     }
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -1133,7 +1133,7 @@ fn detect_count_rows_with_encoded_filters(
     Vec<crate::ir::Expression>,
     VarId,
 )> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
 
@@ -1243,7 +1243,7 @@ fn detect_count_rows_with_encoded_filters(
     }
 
     // SELECT must be exactly the count output var.
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -1259,7 +1259,7 @@ fn detect_predicate_count_rows_numeric_compare(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, NumericCompareOp, fluree_db_core::FlakeValue, VarId)> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -1297,7 +1297,7 @@ fn detect_predicate_count_rows_numeric_compare(
         return None;
     }
 
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -1331,7 +1331,7 @@ fn detect_string_prefix_sum_strstarts(
 ) -> Option<(Ref, Arc<str>, VarId)> {
     use crate::ir::{Expression, FilterValue, Function};
 
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -1352,7 +1352,7 @@ fn detect_string_prefix_sum_strstarts(
     if agg.distinct || !matches!(agg.function, AggregateFn::Sum) {
         return None;
     }
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
@@ -1545,7 +1545,7 @@ fn detect_fused_scan_sum_i64(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, SumExprI64, VarId)> {
-    if query.output.select_vars().is_none() {
+    if query.output.projected_vars().is_none() {
         return None;
     }
     // Must be single aggregate, no grouping/having/binds/etc.
@@ -1566,7 +1566,7 @@ fn detect_fused_scan_sum_i64(
     }
 
     // SELECT must be exactly the aggregate output var.
-    let select_vars = query.output.select_vars()?;
+    let select_vars = query.output.projected_vars()?;
     let agg = &options.aggregates[0];
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
@@ -2607,7 +2607,7 @@ fn build_operator_tree_inner(
             }
 
             // PROJECT
-            if let Some(vars) = query.output.select_vars() {
+            if let Some(vars) = query.output.projected_vars() {
                 if !vars.is_empty() {
                     operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
                 }
@@ -2653,7 +2653,7 @@ fn build_operator_tree_inner(
                 }
 
                 // PROJECT (select specific columns)
-                if let Some(vars) = query.output.select_vars() {
+                if let Some(vars) = query.output.projected_vars() {
                     if !vars.is_empty() {
                         operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
                     }
@@ -2801,7 +2801,7 @@ fn build_operator_tree_inner(
         // If the SELECT projects any *grouped* variables (non-key, non-aggregate),
         // we must use the traditional GroupByOperator path so those vars become
         // `Binding::Grouped(Vec<Binding>)` and remain selectable.
-        let select_needs_grouped_vars = query.output.select_vars().is_some_and(|vars| {
+        let select_needs_grouped_vars = query.output.projected_vars().is_some_and(|vars| {
             vars.iter().any(|v| {
                 !options.group_by.contains(v)
                     && !options.aggregates.iter().any(|a| a.output_var == *v)
@@ -2897,7 +2897,7 @@ fn build_operator_tree_inner(
     // size (and allow top-k truncation) while preserving semantics:
     // duplicates eliminated by DISTINCT have identical sort keys, so removing
     // them before sorting does not change the ordered set of unique solutions.
-    let select_vars_opt: Option<Vec<VarId>> = query.output.select_vars();
+    let select_vars_opt: Option<Vec<VarId>> = query.output.projected_vars();
     let can_project_distinct_before_sort = options.distinct
         && !options.order_by.is_empty()
         && select_vars_opt.as_ref().is_some_and(|vars| {
@@ -3051,7 +3051,7 @@ mod tests {
         let output = if select.is_empty() {
             QueryOutput::wildcard()
         } else {
-            QueryOutput::select(select)
+            QueryOutput::select_vars(select)
         };
         Query {
             context: ParsedContext::default(),
@@ -3100,7 +3100,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![s, label]),
+            output: QueryOutput::select_vars(vec![s, label]),
             patterns,
             options: QueryOptions::default(),
             post_values: None,
@@ -3126,7 +3126,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![VarId(99)]), // Variable not in pattern
+            output: QueryOutput::select_vars(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,
@@ -3149,7 +3149,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![VarId(0)]),
+            output: QueryOutput::select_vars(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,
@@ -3197,7 +3197,7 @@ mod tests {
         let counted_first = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![out]),
+            output: QueryOutput::select_vars(vec![out]),
             patterns: vec![
                 Pattern::Triple(TriplePattern::new(
                     Ref::Var(s),
@@ -3216,7 +3216,7 @@ mod tests {
         let reversed = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select(vec![out]),
+            output: QueryOutput::select_vars(vec![out]),
             patterns: vec![
                 Pattern::Triple(TriplePattern::new(
                     Ref::Var(s),

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -128,9 +128,6 @@ fn detect_star_const_numeric_label_order_limit(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<StarConstOrderTopKSpec> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.distinct
         || options.offset.is_some()
         || !options.group_by.is_empty()
@@ -312,9 +309,6 @@ struct LabelRegexTypeSpec {
 /// `?s rdfs:label ?label . ?s rdf:type <Class> . FILTER regex(?label, "pat"[, "flags"])`
 /// with plain SELECT of exactly `(?s, ?label)` (no ORDER BY/LIMIT/DISTINCT).
 fn detect_label_regex_type(query: &Query, options: &QueryOptions) -> Option<LabelRegexTypeSpec> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if options.distinct
         || options.limit.is_some()
         || options.offset.is_some()
@@ -441,9 +435,6 @@ fn extract_regex_const_pattern(
 /// - LIMIT >= 1 (or no limit)
 /// - SELECT vars == `[agg.output_var]`
 pub(crate) fn detect_count_all_aggregate(query: &Query, options: &QueryOptions) -> Option<VarId> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
         || options.having.is_some()
@@ -480,9 +471,6 @@ fn detect_count_distinct_aggregate(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(VarId, VarId)> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
         || options.having.is_some()
@@ -513,9 +501,6 @@ fn detect_count_distinct_aggregate(
 /// Returns `Some((input_var, output_var))` where `input_var` is `None` for `COUNT(*)`.
 /// Same standard constraints as [`detect_count_all_aggregate`].
 fn detect_count_aggregate(query: &Query, options: &QueryOptions) -> Option<(Option<VarId>, VarId)> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
         || options.having.is_some()
@@ -591,10 +576,7 @@ fn detect_predicate_group_by_object_count_topk(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, VarId, VarId, VarId, usize)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Ask
-    ) {
+    if matches!(query.output, QueryOutput::Construct(_) | QueryOutput::Ask) {
         return None;
     }
     if query.patterns.len() != 1 {
@@ -659,11 +641,7 @@ fn detect_group_by_object_star_topk(
     Option<VarId>,
     usize,
 )> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
-    let select_vars: Arc<[VarId]> =
-        Arc::from(query.output.projected_vars()?.to_vec().into_boxed_slice());
+    let select_vars: Arc<[VarId]> = Arc::from(query.output.projected_vars()?.into_boxed_slice());
     if options.group_by.len() != 1 {
         return None;
     }
@@ -804,9 +782,6 @@ fn detect_sum_strlen_group_concat_subquery(
 ) -> Option<(Ref, Arc<str>, VarId)> {
     use crate::ir::{Expression, Function, Pattern};
 
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty() {
         return None;
     }
@@ -1044,9 +1019,6 @@ fn detect_predicate_minmax_string(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, MinMaxMode, VarId)> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     // Must be single aggregate, no grouping/having/binds/etc.
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
@@ -1094,9 +1066,6 @@ fn detect_predicate_minmax_string(
 }
 
 fn detect_predicate_avg_numeric(query: &Query, options: &QueryOptions) -> Option<(Ref, VarId)> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
         || options.having.is_some()
@@ -1133,10 +1102,6 @@ fn detect_count_rows_with_encoded_filters(
     Vec<crate::ir::Expression>,
     VarId,
 )> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
-
     // Must be single COUNT aggregate, no grouping/having/binds/etc.
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
@@ -1259,9 +1224,6 @@ fn detect_predicate_count_rows_numeric_compare(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, NumericCompareOp, fluree_db_core::FlakeValue, VarId)> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
         || options.having.is_some()
@@ -1331,9 +1293,6 @@ fn detect_string_prefix_sum_strstarts(
 ) -> Option<(Ref, Arc<str>, VarId)> {
     use crate::ir::{Expression, FilterValue, Function};
 
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1
         || options.having.is_some()
@@ -1545,9 +1504,6 @@ fn detect_fused_scan_sum_i64(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, SumExprI64, VarId)> {
-    if query.output.projected_vars().is_none() {
-        return None;
-    }
     // Must be single aggregate, no grouping/having/binds/etc.
     if !options.group_by.is_empty()
         || options.aggregates.len() != 1

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -128,10 +128,7 @@ fn detect_star_const_numeric_label_order_limit(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<StarConstOrderTopKSpec> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.distinct
@@ -315,10 +312,7 @@ struct LabelRegexTypeSpec {
 /// `?s rdfs:label ?label . ?s rdf:type <Class> . FILTER regex(?label, "pat"[, "flags"])`
 /// with plain SELECT of exactly `(?s, ?label)` (no ORDER BY/LIMIT/DISTINCT).
 fn detect_label_regex_type(query: &Query, options: &QueryOptions) -> Option<LabelRegexTypeSpec> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if options.distinct
@@ -447,10 +441,7 @@ fn extract_regex_const_pattern(
 /// - LIMIT >= 1 (or no limit)
 /// - SELECT vars == `[agg.output_var]`
 pub(crate) fn detect_count_all_aggregate(query: &Query, options: &QueryOptions) -> Option<VarId> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -489,10 +480,7 @@ fn detect_count_distinct_aggregate(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(VarId, VarId)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -525,10 +513,7 @@ fn detect_count_distinct_aggregate(
 /// Returns `Some((input_var, output_var))` where `input_var` is `None` for `COUNT(*)`.
 /// Same standard constraints as [`detect_count_all_aggregate`].
 fn detect_count_aggregate(query: &Query, options: &QueryOptions) -> Option<(Option<VarId>, VarId)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -674,10 +659,7 @@ fn detect_group_by_object_star_topk(
     Option<VarId>,
     usize,
 )> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     let select_vars: Arc<[VarId]> =
@@ -822,10 +804,7 @@ fn detect_sum_strlen_group_concat_subquery(
 ) -> Option<(Ref, Arc<str>, VarId)> {
     use crate::ir::{Expression, Function, Pattern};
 
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty() {
@@ -1065,10 +1044,7 @@ fn detect_predicate_minmax_string(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, MinMaxMode, VarId)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     // Must be single aggregate, no grouping/having/binds/etc.
@@ -1118,10 +1094,7 @@ fn detect_predicate_minmax_string(
 }
 
 fn detect_predicate_avg_numeric(query: &Query, options: &QueryOptions) -> Option<(Ref, VarId)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -1160,10 +1133,7 @@ fn detect_count_rows_with_encoded_filters(
     Vec<crate::ir::Expression>,
     VarId,
 )> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
 
@@ -1289,10 +1259,7 @@ fn detect_predicate_count_rows_numeric_compare(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, NumericCompareOp, fluree_db_core::FlakeValue, VarId)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -1364,10 +1331,7 @@ fn detect_string_prefix_sum_strstarts(
 ) -> Option<(Ref, Arc<str>, VarId)> {
     use crate::ir::{Expression, FilterValue, Function};
 
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     if !options.group_by.is_empty()
@@ -1581,10 +1545,7 @@ fn detect_fused_scan_sum_i64(
     query: &Query,
     options: &QueryOptions,
 ) -> Option<(Ref, SumExprI64, VarId)> {
-    if matches!(
-        query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean | QueryOutput::Wildcard
-    ) {
+    if query.output.select_vars().is_none() {
         return None;
     }
     // Must be single aggregate, no grouping/having/binds/etc.
@@ -3088,7 +3049,7 @@ mod tests {
 
     fn make_simple_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
         let output = if select.is_empty() {
-            QueryOutput::Wildcard
+            QueryOutput::wildcard()
         } else {
             QueryOutput::select(select)
         };

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -3051,7 +3051,7 @@ mod tests {
         let output = if select.is_empty() {
             QueryOutput::wildcard()
         } else {
-            QueryOutput::select_vars(select)
+            QueryOutput::select_all(select)
         };
         Query {
             context: ParsedContext::default(),
@@ -3100,7 +3100,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![s, label]),
+            output: QueryOutput::select_all(vec![s, label]),
             patterns,
             options: QueryOptions::default(),
             post_values: None,
@@ -3126,7 +3126,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![VarId(99)]), // Variable not in pattern
+            output: QueryOutput::select_all(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,
@@ -3149,7 +3149,7 @@ mod tests {
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![VarId(0)]),
+            output: QueryOutput::select_all(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
             post_values: None,
@@ -3197,7 +3197,7 @@ mod tests {
         let counted_first = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![out]),
+            output: QueryOutput::select_all(vec![out]),
             patterns: vec![
                 Pattern::Triple(TriplePattern::new(
                     Ref::Var(s),
@@ -3216,7 +3216,7 @@ mod tests {
         let reversed = Query {
             context: ParsedContext::default(),
             orig_context: None,
-            output: QueryOutput::select_vars(vec![out]),
+            output: QueryOutput::select_all(vec![out]),
             patterns: vec![
                 Pattern::Triple(TriplePattern::new(
                     Ref::Var(s),

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2936,15 +2936,15 @@ fn build_operator_tree_inner(
     // size (and allow top-k truncation) while preserving semantics:
     // duplicates eliminated by DISTINCT have identical sort keys, so removing
     // them before sorting does not change the ordered set of unique solutions.
-    let select_vars_opt: Option<&[VarId]> = query.output.select_vars();
+    let select_vars_opt: Option<Vec<VarId>> = query.output.select_vars();
     let can_project_distinct_before_sort = options.distinct
         && !options.order_by.is_empty()
-        && select_vars_opt.is_some_and(|vars| {
+        && select_vars_opt.as_ref().is_some_and(|vars| {
             !vars.is_empty() && options.order_by.iter().all(|s| vars.contains(&s.var))
         });
 
     // Validate SELECT vars (when present) exist in the post-group schema.
-    if let Some(vars) = select_vars_opt {
+    if let Some(vars) = &select_vars_opt {
         if !vars.is_empty() {
             for var in vars {
                 if !post_group_schema.contains(var) {
@@ -3098,7 +3098,6 @@ mod tests {
             output,
             patterns,
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         }
     }
@@ -3143,7 +3142,6 @@ mod tests {
             output: QueryOutput::select(vec![s, label]),
             patterns,
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
 
@@ -3170,7 +3168,6 @@ mod tests {
             output: QueryOutput::select(vec![VarId(99)]), // Variable not in pattern
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
 
@@ -3194,7 +3191,6 @@ mod tests {
             output: QueryOutput::select(vec![VarId(0)]),
             patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
 
@@ -3254,7 +3250,6 @@ mod tests {
                 )),
             ],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
         let reversed = Query {
@@ -3274,7 +3269,6 @@ mod tests {
                 )),
             ],
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         };
         let options = QueryOptions::new().with_aggregates(vec![crate::aggregate::AggregateSpec {

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -593,7 +593,7 @@ fn detect_predicate_group_by_object_count_topk(
 ) -> Option<(Ref, VarId, VarId, VarId, usize)> {
     if matches!(
         query.output,
-        QueryOutput::Construct(_) | QueryOutput::Boolean
+        QueryOutput::Construct(_) | QueryOutput::Ask
     ) {
         return None;
     }

--- a/fluree-db-query/src/ir.rs
+++ b/fluree-db-query/src/ir.rs
@@ -12,7 +12,7 @@
 //!
 //! # Module layout
 //!
-//! - [`query`] — top-level `Query`, `QueryOutput`, `ProjectionShape`,
+//! - [`query`] — top-level `Query`, `QueryOutput`, `Multiplicity`,
 //!   `ConstructTemplate`: the resolved-and-lowered query that flows through
 //!   parse → plan → execute → format
 //! - [`options`] — `QueryOptions` (LIMIT/OFFSET/ORDER BY/GROUP BY/aggregates/
@@ -20,8 +20,8 @@
 //! - [`triple`] — `TriplePattern`, `Ref`, `Term`: the s/p/o vocabulary used
 //!   by triple patterns (and reused by other pattern variants for s/p
 //!   positions)
-//! - [`projection`] — hydration specs (`HydrationSpec`, `Selection`,
-//!   `NestedSelectSpec`, `SelectionSpec`, `Root`)
+//! - [`projection`] — projection / hydration specs (`Projection`, `Column`,
+//!   `HydrationSpec`, `NestedSelectSpec`, `SelectionSpec`, `Root`)
 //! - [`path`] — property-path patterns (transitive predicate traversal)
 //! - [`adapters`] — scan patterns over non-graph data sources (BM25, vector,
 //!   geo, S2, R2RML) adapted to plug into the pattern tree
@@ -47,6 +47,6 @@ pub use expression::{ArithmeticOp, CompareOp, Expression, FilterValue, Function}
 pub use options::{QueryOptions, ReasoningModes};
 pub use path::{PathModifier, PropertyPathPattern};
 pub use pattern::{GraphName, Pattern, ServiceEndpoint, ServicePattern, SubqueryPattern};
-pub use projection::{HydrationSpec, NestedSelectSpec, Root, Selection, SelectionSpec};
-pub use query::{ConstructTemplate, ProjectionShape, Query, QueryOutput};
+pub use projection::{Column, HydrationSpec, NestedSelectSpec, Projection, Root, SelectionSpec};
+pub use query::{ConstructTemplate, Multiplicity, Query, QueryOutput};
 pub use triple::{Ref, Term, TriplePattern};

--- a/fluree-db-query/src/ir.rs
+++ b/fluree-db-query/src/ir.rs
@@ -21,7 +21,7 @@
 //!   by triple patterns (and reused by other pattern variants for s/p
 //!   positions)
 //! - [`projection`] — projection / hydration specs (`Projection`, `Column`,
-//!   `HydrationSpec`, `NestedSelectSpec`, `SelectionSpec`, `Root`)
+//!   `HydrationSpec`, `NestedSelectSpec`, `ForwardItem`, `Root`)
 //! - [`path`] — property-path patterns (transitive predicate traversal)
 //! - [`adapters`] — scan patterns over non-graph data sources (BM25, vector,
 //!   geo, S2, R2RML) adapted to plug into the pattern tree
@@ -47,6 +47,6 @@ pub use expression::{ArithmeticOp, CompareOp, Expression, FilterValue, Function}
 pub use options::{QueryOptions, ReasoningModes};
 pub use path::{PathModifier, PropertyPathPattern};
 pub use pattern::{GraphName, Pattern, ServiceEndpoint, ServicePattern, SubqueryPattern};
-pub use projection::{Column, HydrationSpec, NestedSelectSpec, Projection, Root, SelectionSpec};
+pub use projection::{Column, ForwardItem, HydrationSpec, NestedSelectSpec, Projection, Root};
 pub use query::{ConstructTemplate, Multiplicity, Query, QueryOutput};
 pub use triple::{Ref, Term, TriplePattern};

--- a/fluree-db-query/src/ir.rs
+++ b/fluree-db-query/src/ir.rs
@@ -6,7 +6,7 @@
 //! # Design
 //!
 //! - `Query` is the top-level structure: output spec, WHERE patterns, options,
-//!   optional expansion spec, optional post-VALUES
+//!   optional post-VALUES
 //! - `Pattern` enum mirrors the where clause structure, preserving order for filter inlining
 //! - The planner chooses physical join operators based on pattern analysis
 //!

--- a/fluree-db-query/src/ir.rs
+++ b/fluree-db-query/src/ir.rs
@@ -6,7 +6,7 @@
 //! # Design
 //!
 //! - `Query` is the top-level structure: output spec, WHERE patterns, options,
-//!   optional graph crawl spec, optional post-VALUES
+//!   optional expansion spec, optional post-VALUES
 //! - `Pattern` enum mirrors the where clause structure, preserving order for filter inlining
 //! - The planner chooses physical join operators based on pattern analysis
 //!
@@ -20,7 +20,7 @@
 //! - [`triple`] — `TriplePattern`, `Ref`, `Term`: the s/p/o vocabulary used
 //!   by triple patterns (and reused by other pattern variants for s/p
 //!   positions)
-//! - [`projection`] — graph-crawl selection specs (`GraphSelectSpec`,
+//! - [`projection`] — hydration specs (`HydrationSpec`, `Selection`,
 //!   `NestedSelectSpec`, `SelectionSpec`, `Root`)
 //! - [`path`] — property-path patterns (transitive predicate traversal)
 //! - [`adapters`] — scan patterns over non-graph data sources (BM25, vector,
@@ -47,6 +47,6 @@ pub use expression::{ArithmeticOp, CompareOp, Expression, FilterValue, Function}
 pub use options::{QueryOptions, ReasoningModes};
 pub use path::{PathModifier, PropertyPathPattern};
 pub use pattern::{GraphName, Pattern, ServiceEndpoint, ServicePattern, SubqueryPattern};
-pub use projection::{GraphSelectSpec, NestedSelectSpec, Root, SelectionSpec};
+pub use projection::{HydrationSpec, NestedSelectSpec, Root, Selection, SelectionSpec};
 pub use query::{ConstructTemplate, ProjectionShape, Query, QueryOutput};
 pub use triple::{Ref, Term, TriplePattern};

--- a/fluree-db-query/src/ir/projection.rs
+++ b/fluree-db-query/src/ir/projection.rs
@@ -120,40 +120,98 @@ impl HydrationSpec {
     }
 }
 
-/// One column of a SELECT/SELECT-ONE projection.
+/// One column of a SELECT projection.
 ///
-/// Selections are ordered: their position determines column order in tabular
+/// Columns are ordered: their position determines column order in tabular
 /// output and JSON-LD array rendering. A single query may mix `Var` columns
-/// (raw bindings) with `Hydrate` columns (the formatter materializes the
+/// (raw bindings) with `Hydration` columns (the formatter materializes the
 /// root variable into a nested JSON-LD object).
 #[derive(Debug, Clone, PartialEq)]
-pub enum Selection {
+pub enum Column {
     /// Project a single variable's binding.
     Var(VarId),
-    /// Hydrate a subject (variable or IRI constant) into a nested JSON-LD
-    /// object. The root variable (when present) is the bound column the
-    /// formatter materializes.
+    /// Materialize a subject (variable or IRI constant) into a nested
+    /// JSON-LD object. When the spec's root is a variable, that variable
+    /// is the projected source; when it's a Sid, no variable is projected
+    /// for this column — the formatter fetches the constant directly.
     Hydration(HydrationSpec),
 }
 
-impl Selection {
-    /// Variable bound for this selection's row column, if any.
+impl Column {
+    /// Variable bound for this column's row position, if any.
     ///
-    /// `Var` returns its variable. `Hydrate` returns its root variable
-    /// (or `None` when the root is an IRI constant — that case projects no
-    /// bound row column; the formatter fetches the constant directly).
+    /// `Var` returns its variable. `Hydration` returns its root variable
+    /// (or `None` when the root is an IRI constant — that case projects
+    /// no bound row column; the formatter fetches the constant directly).
     pub fn bound_var(&self) -> Option<VarId> {
         match self {
-            Selection::Var(v) => Some(*v),
-            Selection::Hydration(spec) => spec.root_var(),
+            Column::Var(v) => Some(*v),
+            Column::Hydration(spec) => spec.root_var(),
         }
     }
 
-    /// Returns the `HydrationSpec` if this is a hydrate selection.
+    /// Returns the `HydrationSpec` if this is a hydration column.
     pub fn as_hydration(&self) -> Option<&HydrationSpec> {
         match self {
-            Selection::Hydration(spec) => Some(spec),
-            Selection::Var(_) => None,
+            Column::Hydration(spec) => Some(spec),
+            Column::Var(_) => None,
         }
+    }
+}
+
+/// The columns a SELECT query produces.
+///
+/// Carries column order for rendering; the SPARQL projection (the bound-var
+/// set) is recoverable via [`Projection::bound_vars`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum Projection {
+    /// SELECT * — all in-scope WHERE-bound variables, rendered raw.
+    Wildcard,
+    /// Array-form rows: each row is `[v1, v2, ...]` of any arity.
+    Tuple(Vec<Column>),
+    /// Bare-value rows from JSON-LD `select: "?x"` — exactly one column,
+    /// each row is just the value (not wrapped in an array).
+    Scalar(Column),
+}
+
+impl Projection {
+    /// Columns in render order. Empty for `Wildcard`.
+    pub fn columns(&self) -> &[Column] {
+        match self {
+            Projection::Wildcard => &[],
+            Projection::Tuple(cs) => cs,
+            Projection::Scalar(c) => std::slice::from_ref(c),
+        }
+    }
+
+    /// Iterator over the bound variables of each column in render order.
+    pub fn var_iter(&self) -> impl Iterator<Item = VarId> + '_ {
+        self.columns().iter().filter_map(Column::bound_var)
+    }
+
+    /// SPARQL projection: variables this projection contributes to the
+    /// row schema. `None` for `Wildcard` (means "all bound WHERE vars").
+    pub fn bound_vars(&self) -> Option<Vec<VarId>> {
+        match self {
+            Projection::Wildcard => None,
+            other => Some(other.var_iter().collect()),
+        }
+    }
+
+    /// The hydration spec embedded in the projection (at most one;
+    /// enforced by the parser).
+    pub fn hydration(&self) -> Option<&HydrationSpec> {
+        self.columns().iter().find_map(Column::as_hydration)
+    }
+
+    /// Returns `true` iff rows should be flattened from `[v]` to `v` at
+    /// format time. Only fires for the bare-string `select: "?x"` form.
+    pub fn is_scalar_var(&self) -> bool {
+        matches!(self, Projection::Scalar(Column::Var(_)))
+    }
+
+    /// Returns `true` for `Wildcard`.
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, Projection::Wildcard)
     }
 }

--- a/fluree-db-query/src/ir/projection.rs
+++ b/fluree-db-query/src/ir/projection.rs
@@ -234,12 +234,6 @@ impl Projection {
         }
     }
 
-    /// The hydration spec embedded in the projection (at most one;
-    /// enforced by the parser).
-    pub fn hydration(&self) -> Option<&HydrationSpec> {
-        self.columns().iter().find_map(Column::as_hydration)
-    }
-
     /// Returns `true` if any column in the projection is a hydration column.
     pub fn has_hydration(&self) -> bool {
         self.columns()

--- a/fluree-db-query/src/ir/projection.rs
+++ b/fluree-db-query/src/ir/projection.rs
@@ -43,7 +43,10 @@ pub enum NestedSelectSpec {
     },
     /// Explicit list of forward items. `@id` is included iff `forward`
     /// contains `ForwardItem::Id`.
-    Explicit { forward: Vec<ForwardItem>, reverse: ReverseMap },
+    Explicit {
+        forward: Vec<ForwardItem>,
+        reverse: ReverseMap,
+    },
 }
 
 impl NestedSelectSpec {
@@ -91,15 +94,17 @@ impl NestedSelectSpec {
     pub fn select_predicate(&self, pred: &Sid) -> Option<Option<&NestedSelectSpec>> {
         match self {
             NestedSelectSpec::Wildcard { refinements, .. } => {
-                Some(refinements.get(pred).map(|b| b.as_ref()))
+                Some(refinements.get(pred).map(|b| &**b))
             }
-            NestedSelectSpec::Explicit { forward, .. } => forward.iter().find_map(|item| match item {
-                ForwardItem::Property {
-                    predicate,
-                    sub_spec,
-                } if predicate == pred => Some(sub_spec.as_deref()),
-                _ => None,
-            }),
+            NestedSelectSpec::Explicit { forward, .. } => {
+                forward.iter().find_map(|item| match item {
+                    ForwardItem::Property {
+                        predicate,
+                        sub_spec,
+                    } if predicate == pred => Some(sub_spec.as_deref()),
+                    _ => None,
+                })
+            }
         }
     }
 }

--- a/fluree-db-query/src/ir/projection.rs
+++ b/fluree-db-query/src/ir/projection.rs
@@ -240,6 +240,13 @@ impl Projection {
         self.columns().iter().find_map(Column::as_hydration)
     }
 
+    /// Returns `true` if any column in the projection is a hydration column.
+    pub fn has_hydration(&self) -> bool {
+        self.columns()
+            .iter()
+            .any(|c| matches!(c, Column::Hydration(_)))
+    }
+
     /// Returns `true` iff rows should be flattened from `[v]` to `v` at
     /// format time. Only fires for the bare-string `select: "?x"` form.
     pub fn is_scalar_var(&self) -> bool {

--- a/fluree-db-query/src/ir/projection.rs
+++ b/fluree-db-query/src/ir/projection.rs
@@ -23,91 +23,122 @@ pub enum Root {
     Sid(Sid),
 }
 
-/// Nested selection specification for sub-hydrations (resolved)
+/// Selection at one level of a hydration (resolved).
 ///
-/// This type captures the full selection state for nested property expansion,
-/// including both forward and reverse properties.
+/// Wildcard-vs-explicit is encoded structurally: the Wildcard variant
+/// includes all forward properties at this level (and `@id` implicitly),
+/// optionally refined per-property; the Explicit variant lists only the
+/// chosen forward items (with `@id` membership tracked by the presence of
+/// `ForwardItem::Id`).
+type ReverseMap = std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>;
+
 #[derive(Debug, Clone, PartialEq)]
-pub struct NestedSelectSpec {
-    /// Forward property selections
-    pub forward: Vec<SelectionSpec>,
-    /// Reverse property selections (predicate Sid → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested hydration
-    pub reverse: std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>,
-    /// Whether wildcard was specified at this level
-    pub has_wildcard: bool,
+pub enum NestedSelectSpec {
+    /// `*` at this level — include all forward properties (and `@id`).
+    /// `refinements` overrides the wildcard default of "include but don't
+    /// recurse" for specific properties.
+    Wildcard {
+        refinements: std::collections::HashMap<Sid, Box<NestedSelectSpec>>,
+        reverse: ReverseMap,
+    },
+    /// Explicit list of forward items. `@id` is included iff `forward`
+    /// contains `ForwardItem::Id`.
+    Explicit { forward: Vec<ForwardItem>, reverse: ReverseMap },
 }
 
 impl NestedSelectSpec {
-    /// Create a new nested select spec
-    pub fn new(
-        forward: Vec<SelectionSpec>,
-        reverse: std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>,
-        has_wildcard: bool,
-    ) -> Self {
-        Self {
-            forward,
-            reverse,
-            has_wildcard,
+    /// Returns `true` if this level is a wildcard.
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, NestedSelectSpec::Wildcard { .. })
+    }
+
+    /// Reverse property selections at this level.
+    pub fn reverse(&self) -> &ReverseMap {
+        match self {
+            NestedSelectSpec::Wildcard { reverse, .. }
+            | NestedSelectSpec::Explicit { reverse, .. } => reverse,
         }
     }
 
-    /// Check if this spec is empty (no selections)
+    /// Returns `true` if the level produces no output (empty Explicit
+    /// selection with no reverse).
     pub fn is_empty(&self) -> bool {
-        self.forward.is_empty() && self.reverse.is_empty()
+        match self {
+            NestedSelectSpec::Wildcard { .. } => false,
+            NestedSelectSpec::Explicit { forward, reverse } => {
+                forward.is_empty() && reverse.is_empty()
+            }
+        }
+    }
+
+    /// Whether this level explicitly includes `@id`.
+    /// Wildcard always does; Explicit does iff `forward` contains `Id`.
+    pub fn includes_id(&self) -> bool {
+        match self {
+            NestedSelectSpec::Wildcard { .. } => true,
+            NestedSelectSpec::Explicit { forward, .. } => {
+                forward.iter().any(|item| matches!(item, ForwardItem::Id))
+            }
+        }
+    }
+
+    /// Resolve a forward predicate against this level.
+    ///
+    /// Returns:
+    /// - `Some(None)`: predicate is selected with no nested expansion.
+    /// - `Some(Some(&nested))`: predicate is selected with explicit nested expansion.
+    /// - `None`: predicate is not selected (only possible for `Explicit`).
+    pub fn select_predicate(&self, pred: &Sid) -> Option<Option<&NestedSelectSpec>> {
+        match self {
+            NestedSelectSpec::Wildcard { refinements, .. } => {
+                Some(refinements.get(pred).map(|b| b.as_ref()))
+            }
+            NestedSelectSpec::Explicit { forward, .. } => forward.iter().find_map(|item| match item {
+                ForwardItem::Property {
+                    predicate,
+                    sub_spec,
+                } if predicate == pred => Some(sub_spec.as_deref()),
+                _ => None,
+            }),
+        }
     }
 }
 
-/// Selection specification for expansion (resolved)
-///
-/// Defines what properties to include at each level of expansion.
+/// One forward item in an explicit (non-wildcard) selection level.
 #[derive(Debug, Clone, PartialEq)]
-pub enum SelectionSpec {
-    /// Explicit @id selection (include @id even when wildcard is not specified)
+pub enum ForwardItem {
+    /// Explicit `@id` selection.
     Id,
-    /// Wildcard - select all properties at this level
-    Wildcard,
-    /// Property selection with optional nested hydration
+    /// A specific property, with optional nested expansion of its values.
     Property {
-        /// Predicate Sid
         predicate: Sid,
-        /// Optional nested selection spec for expanding this property's values
-        /// Uses Box to avoid infinite type recursion
         sub_spec: Option<Box<NestedSelectSpec>>,
     },
 }
 
-/// Hydrationion specification (resolved, with Sids)
+/// Top-level hydration spec (resolved, with Sids).
 ///
-/// This is the resolved form of `UnresolvedHydrationSpec`, with all IRIs
-/// encoded as Sids. Used during result formatting for nested JSON-LD output.
+/// Resolves an [`UnresolvedHydrationSpec`] into IR form: IRIs encoded as
+/// `Sid`s, the root chosen, and the level of selection captured in
+/// `level`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HydrationSpec {
-    /// Root of the hydration - variable or IRI constant
+    /// Root of the hydration — variable or IRI constant.
     pub root: Root,
-    /// Forward property selections
-    pub selections: Vec<SelectionSpec>,
-    /// Reverse property selections (predicate Sid → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested hydration
-    pub reverse: std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>,
-    /// Max depth for auto-expansion (0 = no auto-expand)
+    /// Selection at the top level of the hydration.
+    pub level: NestedSelectSpec,
+    /// Max depth for auto-expansion (0 = no auto-expand).
     pub depth: usize,
-    /// Whether wildcard was specified (controls @id inclusion)
-    pub has_wildcard: bool,
 }
 
 impl HydrationSpec {
-    /// Create a new graph select spec
-    pub fn new(root: Root, selections: Vec<SelectionSpec>) -> Self {
-        let has_wildcard = selections
-            .iter()
-            .any(|s| matches!(s, SelectionSpec::Wildcard));
+    /// Create a hydration with the given root and top-level selection,
+    /// `depth: 0`.
+    pub fn new(root: Root, level: NestedSelectSpec) -> Self {
         Self {
             root,
-            selections,
-            reverse: std::collections::HashMap::new(),
+            level,
             depth: 0,
-            has_wildcard,
         }
     }
 

--- a/fluree-db-query/src/ir/projection.rs
+++ b/fluree-db-query/src/ir/projection.rs
@@ -1,5 +1,5 @@
 //! Selection specs that describe how query results are projected and
-//! crawled into nested JSON-LD form. The canonical resolved-and-lowered
+//! expanded into nested JSON-LD form. The canonical resolved-and-lowered
 //! query type is [`crate::ir::Query`]; this module covers only
 //! the projection-shape types that flow through it.
 
@@ -7,10 +7,10 @@ use crate::var_registry::VarId;
 use fluree_db_core::Sid;
 
 // ============================================================================
-// Graph crawl select types (resolved)
+// Hydration types (resolved)
 // ============================================================================
 
-/// Root of a graph crawl select (resolved)
+/// Root of a hydration (resolved)
 ///
 /// Supports both variable and IRI constant roots:
 /// - Variable root: from query results (e.g., `?person`)
@@ -23,7 +23,7 @@ pub enum Root {
     Sid(Sid),
 }
 
-/// Nested selection specification for sub-crawls (resolved)
+/// Nested selection specification for sub-hydrations (resolved)
 ///
 /// This type captures the full selection state for nested property expansion,
 /// including both forward and reverse properties.
@@ -32,7 +32,7 @@ pub struct NestedSelectSpec {
     /// Forward property selections
     pub forward: Vec<SelectionSpec>,
     /// Reverse property selections (predicate Sid → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested expansion
+    /// None means no sub-selections (just return @id), Some means nested hydration
     pub reverse: std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>,
     /// Whether wildcard was specified at this level
     pub has_wildcard: bool,
@@ -58,7 +58,7 @@ impl NestedSelectSpec {
     }
 }
 
-/// Selection specification for graph crawl (resolved)
+/// Selection specification for expansion (resolved)
 ///
 /// Defines what properties to include at each level of expansion.
 #[derive(Debug, Clone, PartialEq)]
@@ -67,7 +67,7 @@ pub enum SelectionSpec {
     Id,
     /// Wildcard - select all properties at this level
     Wildcard,
-    /// Property selection with optional nested expansion
+    /// Property selection with optional nested hydration
     Property {
         /// Predicate Sid
         predicate: Sid,
@@ -77,18 +77,18 @@ pub enum SelectionSpec {
     },
 }
 
-/// Graph crawl selection specification (resolved, with Sids)
+/// Hydrationion specification (resolved, with Sids)
 ///
-/// This is the resolved form of `UnresolvedGraphSelectSpec`, with all IRIs
+/// This is the resolved form of `UnresolvedHydrationSpec`, with all IRIs
 /// encoded as Sids. Used during result formatting for nested JSON-LD output.
 #[derive(Debug, Clone, PartialEq)]
-pub struct GraphSelectSpec {
-    /// Root of the crawl - variable or IRI constant
+pub struct HydrationSpec {
+    /// Root of the hydration - variable or IRI constant
     pub root: Root,
     /// Forward property selections
     pub selections: Vec<SelectionSpec>,
     /// Reverse property selections (predicate Sid → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested expansion
+    /// None means no sub-selections (just return @id), Some means nested hydration
     pub reverse: std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>,
     /// Max depth for auto-expansion (0 = no auto-expand)
     pub depth: usize,
@@ -96,7 +96,7 @@ pub struct GraphSelectSpec {
     pub has_wildcard: bool,
 }
 
-impl GraphSelectSpec {
+impl HydrationSpec {
     /// Create a new graph select spec
     pub fn new(root: Root, selections: Vec<SelectionSpec>) -> Self {
         let has_wildcard = selections
@@ -116,6 +116,44 @@ impl GraphSelectSpec {
         match &self.root {
             Root::Var(v) => Some(*v),
             Root::Sid(_) => None,
+        }
+    }
+}
+
+/// One column of a SELECT/SELECT-ONE projection.
+///
+/// Selections are ordered: their position determines column order in tabular
+/// output and JSON-LD array rendering. A single query may mix `Var` columns
+/// (raw bindings) with `Hydrate` columns (the formatter materializes the
+/// root variable into a nested JSON-LD object).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Selection {
+    /// Project a single variable's binding.
+    Var(VarId),
+    /// Hydrate a subject (variable or IRI constant) into a nested JSON-LD
+    /// object. The root variable (when present) is the bound column the
+    /// formatter materializes.
+    Hydration(HydrationSpec),
+}
+
+impl Selection {
+    /// Variable bound for this selection's row column, if any.
+    ///
+    /// `Var` returns its variable. `Hydrate` returns its root variable
+    /// (or `None` when the root is an IRI constant — that case projects no
+    /// bound row column; the formatter fetches the constant directly).
+    pub fn bound_var(&self) -> Option<VarId> {
+        match self {
+            Selection::Var(v) => Some(*v),
+            Selection::Hydration(spec) => spec.root_var(),
+        }
+    }
+
+    /// Returns the `HydrationSpec` if this is a hydrate selection.
+    pub fn as_hydration(&self) -> Option<&HydrationSpec> {
+        match self {
+            Selection::Hydration(spec) => Some(spec),
+            Selection::Var(_) => None,
         }
     }
 }

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -77,15 +77,16 @@ pub enum QueryOutput {
 impl QueryOutput {
     /// Construct a `Select` from a variable list (Tuple projection,
     /// `All` multiplicity). Used by SPARQL lowering and fixtures.
-    pub fn select(vars: Vec<VarId>) -> Self {
+    pub fn select_vars(vars: Vec<VarId>) -> Self {
         Self::Select {
             projection: Projection::Tuple(vars.into_iter().map(Column::Var).collect()),
             multiplicity: Multiplicity::All,
         }
     }
 
-    /// Construct a `Select` with `One` multiplicity (`selectOne`).
-    pub fn select_one(vars: Vec<VarId>) -> Self {
+    /// Construct a `Select` from a variable list with `One` multiplicity
+    /// (`selectOne`).
+    pub fn select_one_var(vars: Vec<VarId>) -> Self {
         Self::Select {
             projection: Projection::Tuple(vars.into_iter().map(Column::Var).collect()),
             multiplicity: Multiplicity::One,
@@ -125,13 +126,13 @@ impl QueryOutput {
     /// Bound variables of the projection in column order.
     /// `None` when projection trimming is not applicable (Wildcard,
     /// Construct, Boolean).
-    pub fn select_vars(&self) -> Option<Vec<VarId>> {
+    pub fn projected_vars(&self) -> Option<Vec<VarId>> {
         self.projection()?.bound_vars()
     }
 
     /// Bound select variables, or an empty `Vec` for non-Select outputs.
-    pub fn select_vars_or_empty(&self) -> Vec<VarId> {
-        self.select_vars().unwrap_or_default()
+    pub fn projected_vars_or_empty(&self) -> Vec<VarId> {
+        self.projected_vars().unwrap_or_default()
     }
 
     /// Returns `true` iff rows should be flattened from `[v]` to `v` at

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -2,11 +2,11 @@
 //! parsing through planning, execution, and result formatting.
 //!
 //! `Query` is the canonical query representation. Its `output` field
-//! captures the result-shape decision (SELECT vars, SELECT-one, wildcard,
-//! ASK, CONSTRUCT). `patterns` holds the WHERE clause IR. `options`
-//! carries solution modifiers (limit, offset, order by, group by,
-//! aggregates, having, distinct, ...). `graph_select` carries a graph
-//! crawl spec when the result format is nested JSON-LD rather than tabular.
+//! captures the result-shape decision (SELECT selections, SELECT-one,
+//! wildcard, ASK, CONSTRUCT). `patterns` holds the WHERE clause IR.
+//! `options` carries solution modifiers (limit, offset, order by, group
+//! by, aggregates, having, distinct, ...). Hydration formatting lives
+//! inside the `Selection::Hydration` variant on the SELECT outputs.
 
 use std::collections::HashSet;
 
@@ -14,7 +14,7 @@ use fluree_graph_json_ld::ParsedContext;
 
 use super::options::QueryOptions;
 use super::pattern::Pattern;
-use super::projection::GraphSelectSpec;
+use super::projection::{HydrationSpec, Selection};
 use super::triple::TriplePattern;
 use crate::var_registry::VarId;
 
@@ -62,19 +62,19 @@ impl ConstructTemplate {
 
 /// Describes what the query produces.
 ///
-/// Combines the select mode, selected variables, and construct template into a
+/// Combines the select mode, selections, and construct template into a
 /// single enum so that invalid combinations (e.g. `Construct` without a
-/// template, or `Many` with an empty variable list) are unrepresentable.
+/// template) are unrepresentable.
 #[derive(Debug, Clone)]
 pub enum QueryOutput {
-    /// Normal SELECT with explicit variable list and projection shape.
+    /// Normal SELECT with explicit selection list and projection shape.
     Select {
-        vars: Vec<VarId>,
+        selections: Vec<Selection>,
         shape: ProjectionShape,
     },
     /// selectOne — same as Select but formatters return first row or null.
     SelectOne {
-        vars: Vec<VarId>,
+        selections: Vec<Selection>,
         shape: ProjectionShape,
     },
     /// SELECT * — all bound variables from WHERE.
@@ -86,36 +86,59 @@ pub enum QueryOutput {
 }
 
 impl QueryOutput {
-    /// Construct a `Select` with the default (`Tuple`) shape.
+    /// Construct a `Select` from a variable list with the default (`Tuple`) shape.
     ///
     /// Used by SPARQL lowering and internal fixtures. JSON-LD bare-string
     /// `select: "?x"` builds the struct variant directly with `shape: Scalar`.
     pub fn select(vars: Vec<VarId>) -> Self {
         Self::Select {
-            vars,
+            selections: vars.into_iter().map(Selection::Var).collect(),
             shape: ProjectionShape::Tuple,
         }
     }
 
-    /// Construct a `SelectOne` with the default (`Tuple`) shape.
+    /// Construct a `SelectOne` from a variable list with the default (`Tuple`) shape.
     pub fn select_one(vars: Vec<VarId>) -> Self {
         Self::SelectOne {
-            vars,
+            selections: vars.into_iter().map(Selection::Var).collect(),
             shape: ProjectionShape::Tuple,
         }
     }
 
-    /// Get select vars for Select/SelectOne, `None` otherwise.
-    pub fn select_vars(&self) -> Option<&[VarId]> {
+    /// Get the raw selections for Select/SelectOne, `None` otherwise.
+    pub fn selections(&self) -> Option<&[Selection]> {
         match self {
-            QueryOutput::Select { vars, .. } | QueryOutput::SelectOne { vars, .. } => Some(vars),
+            QueryOutput::Select { selections, .. } | QueryOutput::SelectOne { selections, .. } => {
+                Some(selections)
+            }
             _ => None,
         }
     }
 
-    /// Get select vars, or an empty slice for non-select outputs.
-    pub fn select_vars_or_empty(&self) -> &[VarId] {
-        self.select_vars().unwrap_or(&[])
+    /// Iterator over the bound variables of each selection in column order.
+    ///
+    /// `Selection::Var` yields its variable; `Selection::Hydration` yields its
+    /// root variable when the root is a variable (constant-rooted expansions
+    /// bind no row column and are skipped).
+    pub fn select_var_iter(&self) -> impl Iterator<Item = VarId> + '_ {
+        self.selections()
+            .into_iter()
+            .flatten()
+            .filter_map(Selection::bound_var)
+    }
+
+    /// Collect bound select variables in column order, `None` for non-select outputs.
+    pub fn select_vars(&self) -> Option<Vec<VarId>> {
+        self.selections().map(|sels| {
+            sels.iter()
+                .filter_map(Selection::bound_var)
+                .collect::<Vec<_>>()
+        })
+    }
+
+    /// Collect bound select variables, or an empty `Vec` for non-select outputs.
+    pub fn select_vars_or_empty(&self) -> Vec<VarId> {
+        self.select_vars().unwrap_or_default()
     }
 
     /// Get the projection shape for Select/SelectOne, `None` otherwise.
@@ -131,13 +154,14 @@ impl QueryOutput {
     /// Returns `true` iff rows should be flattened from `[v]` to `v` at format
     /// time. True only when the user opted into scalar output via JSON-LD
     /// `select: "?x"` (bare-string form) AND there is exactly one projected
-    /// variable. Wildcard, Construct, Boolean, and `Tuple`-shaped Select all
-    /// return `false`, so tabular output (SPARQL + JSON-LD array-form select)
-    /// is preserved.
+    /// variable selection (hydrationions never flatten).
     pub fn should_flatten_scalar(&self) -> bool {
         match self {
-            QueryOutput::Select { vars, shape } | QueryOutput::SelectOne { vars, shape } => {
-                *shape == ProjectionShape::Scalar && vars.len() == 1
+            QueryOutput::Select { selections, shape }
+            | QueryOutput::SelectOne { selections, shape } => {
+                *shape == ProjectionShape::Scalar
+                    && selections.len() == 1
+                    && matches!(selections[0], Selection::Var(_))
             }
             _ => false,
         }
@@ -149,6 +173,16 @@ impl QueryOutput {
             QueryOutput::Construct(t) => Some(t),
             _ => None,
         }
+    }
+
+    /// Returns the hydration spec embedded in the selections, if any.
+    ///
+    /// A query carries at most one hydration selection (enforced by the
+    /// parser). Non-Select/SelectOne outputs return `None`.
+    pub fn hydration(&self) -> Option<&HydrationSpec> {
+        self.selections()?
+            .iter()
+            .find_map(Selection::as_hydration)
     }
 
     /// Returns `true` for `SelectOne` output.
@@ -181,13 +215,13 @@ impl QueryOutput {
     pub fn variables(&self) -> Option<HashSet<VarId>> {
         match self {
             QueryOutput::Wildcard | QueryOutput::Boolean => None,
-            QueryOutput::Select { vars, .. } | QueryOutput::SelectOne { vars, .. }
-                if vars.is_empty() =>
+            QueryOutput::Select { selections, .. } | QueryOutput::SelectOne { selections, .. }
+                if selections.is_empty() =>
             {
                 None
             }
-            QueryOutput::Select { vars, .. } | QueryOutput::SelectOne { vars, .. } => {
-                Some(vars.iter().copied().collect())
+            QueryOutput::Select { selections, .. } | QueryOutput::SelectOne { selections, .. } => {
+                Some(selections.iter().filter_map(Selection::bound_var).collect())
             }
             QueryOutput::Construct(t) if t.patterns.is_empty() => None,
             QueryOutput::Construct(t) => Some(t.referenced_vars()),
@@ -205,16 +239,12 @@ pub struct Query {
     pub context: ParsedContext,
     /// Original JSON context from the query (for CONSTRUCT output)
     pub orig_context: Option<serde_json::Value>,
-    /// Query output specification (replaces select, select_mode, construct_template)
+    /// Query output specification (selections, construct template, or boolean/wildcard mode)
     pub output: QueryOutput,
     /// Resolved patterns (triples, filters, optionals, etc.)
     pub patterns: Vec<Pattern>,
     /// Query options (limit, offset, order by, group by, etc.)
     pub options: QueryOptions,
-    /// Graph crawl select specification (None for flat SELECT or CONSTRUCT)
-    ///
-    /// When present, controls nested JSON-LD object expansion during formatting.
-    pub graph_select: Option<GraphSelectSpec>,
     /// Post-query VALUES clause (SPARQL `ValuesClause` after `SolutionModifier`).
     ///
     /// Stored separately from `patterns` so the WHERE-clause planner does not
@@ -232,7 +262,6 @@ impl Query {
             output: QueryOutput::Wildcard,
             patterns: Vec::new(),
             options: QueryOptions::default(),
-            graph_select: None,
             post_values: None,
         }
     }
@@ -248,7 +277,6 @@ impl Query {
             output: self.output.clone(),
             patterns,
             options: self.options.clone(),
-            graph_select: self.graph_select.clone(),
             post_values: self.post_values.clone(),
         }
     }

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -208,7 +208,7 @@ pub struct Query {
     pub context: ParsedContext,
     /// Original JSON context from the query (for CONSTRUCT output)
     pub orig_context: Option<serde_json::Value>,
-    /// Query output specification (selections, construct template, or boolean/wildcard mode)
+    /// Query output specification (projection, construct template, ASK, or wildcard).
     pub output: QueryOutput,
     /// Resolved patterns (triples, filters, optionals, etc.)
     pub patterns: Vec<Pattern>,

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -77,7 +77,7 @@ pub enum QueryOutput {
 impl QueryOutput {
     /// Construct a `Select` from a variable list (Tuple projection,
     /// `All` multiplicity). Used by SPARQL lowering and fixtures.
-    pub fn select_vars(vars: Vec<VarId>) -> Self {
+    pub fn select_all(vars: Vec<VarId>) -> Self {
         Self::Select {
             projection: Projection::Tuple(vars.into_iter().map(Column::Var).collect()),
             multiplicity: Multiplicity::All,
@@ -86,7 +86,7 @@ impl QueryOutput {
 
     /// Construct a `Select` from a variable list with `One` multiplicity
     /// (`selectOne`).
-    pub fn select_one_var(vars: Vec<VarId>) -> Self {
+    pub fn select_one(vars: Vec<VarId>) -> Self {
         Self::Select {
             projection: Projection::Tuple(vars.into_iter().map(Column::Var).collect()),
             multiplicity: Multiplicity::One,

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -174,14 +174,14 @@ impl QueryOutput {
         matches!(self, Self::Construct(_))
     }
 
-    /// Variables the output depends on.
+    /// Variables this output references from the upstream solution stream.
     ///
     /// Returns `None` when dependency trimming is not applicable:
     /// - `Select` with `Wildcard` projection: all WHERE vars are needed
     /// - `Boolean`: all WHERE vars needed for solvability checking
     /// - `Select` with empty projection: no explicit projection
     /// - `Construct` with no template patterns
-    pub fn variables(&self) -> Option<HashSet<VarId>> {
+    pub fn referenced_vars(&self) -> Option<HashSet<VarId>> {
         match self {
             QueryOutput::Boolean => None,
             QueryOutput::Select { projection, .. } => {

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -71,7 +71,7 @@ pub enum QueryOutput {
     /// CONSTRUCT — template patterns instantiated with bindings.
     Construct(ConstructTemplate),
     /// ASK — boolean result.
-    Boolean,
+    Ask,
 }
 
 impl QueryOutput {
@@ -125,7 +125,7 @@ impl QueryOutput {
 
     /// Bound variables of the projection in column order.
     /// `None` when projection trimming is not applicable (Wildcard,
-    /// Construct, Boolean).
+    /// Construct, Ask).
     pub fn projected_vars(&self) -> Option<Vec<VarId>> {
         self.projection()?.bound_vars()
     }
@@ -164,9 +164,9 @@ impl QueryOutput {
         self.projection().is_some_and(Projection::is_wildcard)
     }
 
-    /// Returns `true` for `Boolean` (ASK) output.
-    pub fn is_boolean(&self) -> bool {
-        matches!(self, Self::Boolean)
+    /// Returns `true` for `Ask` output.
+    pub fn is_ask(&self) -> bool {
+        matches!(self, Self::Ask)
     }
 
     /// Returns `true` for `Construct` output.
@@ -178,12 +178,12 @@ impl QueryOutput {
     ///
     /// Returns `None` when dependency trimming is not applicable:
     /// - `Select` with `Wildcard` projection: all WHERE vars are needed
-    /// - `Boolean`: all WHERE vars needed for solvability checking
+    /// - `Ask`: all WHERE vars needed for solvability checking
     /// - `Select` with empty projection: no explicit projection
     /// - `Construct` with no template patterns
     pub fn referenced_vars(&self) -> Option<HashSet<VarId>> {
         match self {
-            QueryOutput::Boolean => None,
+            QueryOutput::Ask => None,
             QueryOutput::Select { projection, .. } => {
                 let vars = projection.bound_vars()?;
                 if vars.is_empty() {

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -14,7 +14,7 @@ use fluree_graph_json_ld::ParsedContext;
 
 use super::options::QueryOptions;
 use super::pattern::Pattern;
-use super::projection::{Column, HydrationSpec, Projection};
+use super::projection::{Column, Projection};
 use super::triple::TriplePattern;
 use crate::var_registry::VarId;
 
@@ -147,11 +147,6 @@ impl QueryOutput {
             QueryOutput::Construct(t) => Some(t),
             _ => None,
         }
-    }
-
-    /// The hydration spec embedded in the projection, if any.
-    pub fn hydration(&self) -> Option<&HydrationSpec> {
-        self.projection()?.hydration()
     }
 
     /// Returns `true` if the output is a SELECT whose projection contains

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -2,11 +2,11 @@
 //! parsing through planning, execution, and result formatting.
 //!
 //! `Query` is the canonical query representation. Its `output` field
-//! captures the result-shape decision (SELECT selections, SELECT-one,
-//! wildcard, ASK, CONSTRUCT). `patterns` holds the WHERE clause IR.
-//! `options` carries solution modifiers (limit, offset, order by, group
-//! by, aggregates, having, distinct, ...). Hydration formatting lives
-//! inside the `Selection::Hydration` variant on the SELECT outputs.
+//! captures the result-shape decision (SELECT, ASK, CONSTRUCT). `patterns`
+//! holds the WHERE clause IR. `options` carries solution modifiers (limit,
+//! offset, order by, group by, aggregates, having, distinct, ...).
+//! Hydration formatting lives inside the `Column::Hydration` variant on
+//! the SELECT projection.
 
 use std::collections::HashSet;
 
@@ -14,24 +14,9 @@ use fluree_graph_json_ld::ParsedContext;
 
 use super::options::QueryOptions;
 use super::pattern::Pattern;
-use super::projection::{HydrationSpec, Selection};
+use super::projection::{Column, HydrationSpec, Projection};
 use super::triple::TriplePattern;
 use crate::var_registry::VarId;
-
-/// Per-row projection shape for tabular output formatters.
-///
-/// Formatters that emit row arrays (jsonld, delimited, etc.) consult this to
-/// decide scalar-vs-tuple rendering. Object-based formatters (typed, agent_json)
-/// ignore it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ProjectionShape {
-    /// Every row is an array, regardless of arity. Default; used by SPARQL
-    /// and JSON-LD array-form select.
-    #[default]
-    Tuple,
-    /// 1-var rows flatten to scalars. JSON-LD bare-string `select: "?x"`.
-    Scalar,
-}
 
 /// Resolved CONSTRUCT template patterns
 ///
@@ -60,25 +45,29 @@ impl ConstructTemplate {
     }
 }
 
-/// Describes what the query produces.
+/// Whether a SELECT returns all solutions or just the first row.
 ///
-/// Combines the select mode, selections, and construct template into a
-/// single enum so that invalid combinations (e.g. `Construct` without a
-/// template) are unrepresentable.
+/// Distinct from `LIMIT 1`: `One` also changes output shape (formatters
+/// return the bare row or null instead of an array of rows).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Multiplicity {
+    /// Return all matching solutions (`select`).
+    #[default]
+    All,
+    /// Return only the first solution (`selectOne`).
+    One,
+}
+
+/// Describes what the query produces.
 #[derive(Debug, Clone)]
 pub enum QueryOutput {
-    /// Normal SELECT with explicit selection list and projection shape.
+    /// SELECT — projects rows from the algebra. The `projection` carries
+    /// column structure (and per-column hydration); the `multiplicity`
+    /// carries the all-vs-first-row distinction.
     Select {
-        selections: Vec<Selection>,
-        shape: ProjectionShape,
+        projection: Projection,
+        multiplicity: Multiplicity,
     },
-    /// selectOne — same as Select but formatters return first row or null.
-    SelectOne {
-        selections: Vec<Selection>,
-        shape: ProjectionShape,
-    },
-    /// SELECT * — all bound variables from WHERE.
-    Wildcard,
     /// CONSTRUCT — template patterns instantiated with bindings.
     Construct(ConstructTemplate),
     /// ASK — boolean result.
@@ -86,88 +75,72 @@ pub enum QueryOutput {
 }
 
 impl QueryOutput {
-    /// Construct a `Select` from a variable list with the default (`Tuple`) shape.
-    ///
-    /// Used by SPARQL lowering and internal fixtures. JSON-LD bare-string
-    /// `select: "?x"` builds the struct variant directly with `shape: Scalar`.
+    /// Construct a `Select` from a variable list (Tuple projection,
+    /// `All` multiplicity). Used by SPARQL lowering and fixtures.
     pub fn select(vars: Vec<VarId>) -> Self {
         Self::Select {
-            selections: vars.into_iter().map(Selection::Var).collect(),
-            shape: ProjectionShape::Tuple,
+            projection: Projection::Tuple(vars.into_iter().map(Column::Var).collect()),
+            multiplicity: Multiplicity::All,
         }
     }
 
-    /// Construct a `SelectOne` from a variable list with the default (`Tuple`) shape.
+    /// Construct a `Select` with `One` multiplicity (`selectOne`).
     pub fn select_one(vars: Vec<VarId>) -> Self {
-        Self::SelectOne {
-            selections: vars.into_iter().map(Selection::Var).collect(),
-            shape: ProjectionShape::Tuple,
+        Self::Select {
+            projection: Projection::Tuple(vars.into_iter().map(Column::Var).collect()),
+            multiplicity: Multiplicity::One,
         }
     }
 
-    /// Get the raw selections for Select/SelectOne, `None` otherwise.
-    pub fn selections(&self) -> Option<&[Selection]> {
+    /// Construct a `Select` with a Wildcard projection (`SELECT *`).
+    pub fn wildcard() -> Self {
+        Self::Select {
+            projection: Projection::Wildcard,
+            multiplicity: Multiplicity::All,
+        }
+    }
+
+    /// The projection of a SELECT output, if any.
+    pub fn projection(&self) -> Option<&Projection> {
         match self {
-            QueryOutput::Select { selections, .. } | QueryOutput::SelectOne { selections, .. } => {
-                Some(selections)
-            }
+            QueryOutput::Select { projection, .. } => Some(projection),
             _ => None,
         }
     }
 
-    /// Iterator over the bound variables of each selection in column order.
-    ///
-    /// `Selection::Var` yields its variable; `Selection::Hydration` yields its
-    /// root variable when the root is a variable (constant-rooted expansions
-    /// bind no row column and are skipped).
-    pub fn select_var_iter(&self) -> impl Iterator<Item = VarId> + '_ {
-        self.selections()
-            .into_iter()
-            .flatten()
-            .filter_map(Selection::bound_var)
+    /// The multiplicity of a SELECT output, if any.
+    pub fn multiplicity(&self) -> Option<Multiplicity> {
+        match self {
+            QueryOutput::Select { multiplicity, .. } => Some(*multiplicity),
+            _ => None,
+        }
     }
 
-    /// Collect bound select variables in column order, `None` for non-select outputs.
+    /// Columns of a SELECT projection. `None` for non-Select outputs;
+    /// empty slice for Wildcard.
+    pub fn columns(&self) -> Option<&[Column]> {
+        self.projection().map(Projection::columns)
+    }
+
+    /// Bound variables of the projection in column order.
+    /// `None` when projection trimming is not applicable (Wildcard,
+    /// Construct, Boolean).
     pub fn select_vars(&self) -> Option<Vec<VarId>> {
-        self.selections().map(|sels| {
-            sels.iter()
-                .filter_map(Selection::bound_var)
-                .collect::<Vec<_>>()
-        })
+        self.projection()?.bound_vars()
     }
 
-    /// Collect bound select variables, or an empty `Vec` for non-select outputs.
+    /// Bound select variables, or an empty `Vec` for non-Select outputs.
     pub fn select_vars_or_empty(&self) -> Vec<VarId> {
         self.select_vars().unwrap_or_default()
     }
 
-    /// Get the projection shape for Select/SelectOne, `None` otherwise.
-    pub fn projection_shape(&self) -> Option<ProjectionShape> {
-        match self {
-            QueryOutput::Select { shape, .. } | QueryOutput::SelectOne { shape, .. } => {
-                Some(*shape)
-            }
-            _ => None,
-        }
-    }
-
-    /// Returns `true` iff rows should be flattened from `[v]` to `v` at format
-    /// time. True only when the user opted into scalar output via JSON-LD
-    /// `select: "?x"` (bare-string form) AND there is exactly one projected
-    /// variable selection (hydrationions never flatten).
+    /// Returns `true` iff rows should be flattened from `[v]` to `v` at
+    /// format time. Only fires for the bare-string `select: "?x"` form.
     pub fn should_flatten_scalar(&self) -> bool {
-        match self {
-            QueryOutput::Select { selections, shape }
-            | QueryOutput::SelectOne { selections, shape } => {
-                *shape == ProjectionShape::Scalar
-                    && selections.len() == 1
-                    && matches!(selections[0], Selection::Var(_))
-            }
-            _ => false,
-        }
+        self.projection().is_some_and(Projection::is_scalar_var)
     }
 
-    /// Get the construct template for Construct, `None` otherwise.
+    /// The construct template, if any.
     pub fn construct_template(&self) -> Option<&ConstructTemplate> {
         match self {
             QueryOutput::Construct(t) => Some(t),
@@ -175,24 +148,19 @@ impl QueryOutput {
         }
     }
 
-    /// Returns the hydration spec embedded in the selections, if any.
-    ///
-    /// A query carries at most one hydration selection (enforced by the
-    /// parser). Non-Select/SelectOne outputs return `None`.
+    /// The hydration spec embedded in the projection, if any.
     pub fn hydration(&self) -> Option<&HydrationSpec> {
-        self.selections()?
-            .iter()
-            .find_map(Selection::as_hydration)
+        self.projection()?.hydration()
     }
 
-    /// Returns `true` for `SelectOne` output.
+    /// Returns `true` for `selectOne`.
     pub fn is_select_one(&self) -> bool {
-        matches!(self, Self::SelectOne { .. })
+        self.multiplicity() == Some(Multiplicity::One)
     }
 
-    /// Returns `true` for `Wildcard` output.
+    /// Returns `true` for `SELECT *`.
     pub fn is_wildcard(&self) -> bool {
-        matches!(self, Self::Wildcard)
+        self.projection().is_some_and(Projection::is_wildcard)
     }
 
     /// Returns `true` for `Boolean` (ASK) output.
@@ -208,20 +176,20 @@ impl QueryOutput {
     /// Variables the output depends on.
     ///
     /// Returns `None` when dependency trimming is not applicable:
-    /// - `Wildcard`: all WHERE vars are needed
+    /// - `Select` with `Wildcard` projection: all WHERE vars are needed
     /// - `Boolean`: all WHERE vars needed for solvability checking
-    /// - Empty `Select`/`SelectOne`: no explicit projection
+    /// - `Select` with empty projection: no explicit projection
     /// - `Construct` with no template patterns
     pub fn variables(&self) -> Option<HashSet<VarId>> {
         match self {
-            QueryOutput::Wildcard | QueryOutput::Boolean => None,
-            QueryOutput::Select { selections, .. } | QueryOutput::SelectOne { selections, .. }
-                if selections.is_empty() =>
-            {
-                None
-            }
-            QueryOutput::Select { selections, .. } | QueryOutput::SelectOne { selections, .. } => {
-                Some(selections.iter().filter_map(Selection::bound_var).collect())
+            QueryOutput::Boolean => None,
+            QueryOutput::Select { projection, .. } => {
+                let vars = projection.bound_vars()?;
+                if vars.is_empty() {
+                    None
+                } else {
+                    Some(vars.into_iter().collect())
+                }
             }
             QueryOutput::Construct(t) if t.patterns.is_empty() => None,
             QueryOutput::Construct(t) => Some(t.referenced_vars()),
@@ -259,7 +227,10 @@ impl Query {
         Self {
             context,
             orig_context: None,
-            output: QueryOutput::Wildcard,
+            output: QueryOutput::Select {
+                projection: Projection::Wildcard,
+                multiplicity: Multiplicity::All,
+            },
             patterns: Vec::new(),
             options: QueryOptions::default(),
             post_values: None,

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -154,6 +154,12 @@ impl QueryOutput {
         self.projection()?.hydration()
     }
 
+    /// Returns `true` if the output is a SELECT whose projection contains
+    /// any hydration column.
+    pub fn has_hydration(&self) -> bool {
+        self.projection().is_some_and(Projection::has_hydration)
+    }
+
     /// Returns `true` for `selectOne`.
     pub fn is_select_one(&self) -> bool {
         self.multiplicity() == Some(Multiplicity::One)

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -720,10 +720,10 @@ impl UnresolvedConstructTemplate {
 }
 
 // ============================================================================
-// Graph crawl select types
+// Hydration types
 // ============================================================================
 
-/// Root of a graph crawl select - can be variable or IRI constant
+/// Root of a hydration - can be variable or IRI constant
 ///
 /// Supports both syntax forms:
 /// - Variable root: `{"?person": ["*", ...]}`
@@ -736,7 +736,7 @@ pub enum UnresolvedRoot {
     Iri(String),
 }
 
-/// Nested selection specification for sub-crawls
+/// Nested selection specification for sub-hydrations
 ///
 /// This type captures the full selection state for nested property expansion,
 /// including both forward and reverse properties. It's used when a property
@@ -746,7 +746,7 @@ pub struct UnresolvedNestedSelectSpec {
     /// Forward property selections
     pub forward: Vec<UnresolvedSelectionSpec>,
     /// Reverse property selections (expanded IRI → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested expansion
+    /// None means no sub-selections (just return @id), Some means nested hydration
     pub reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
     /// Whether wildcard was specified at this level
     pub has_wildcard: bool,
@@ -772,9 +772,9 @@ impl UnresolvedNestedSelectSpec {
     }
 }
 
-/// Selection specification within a graph crawl
+/// Selection specification within a hydration
 ///
-/// Defines what properties to include at each level of the expansion.
+/// Defines what properties to include at each level of the hydration.
 #[derive(Debug, Clone, PartialEq)]
 pub enum UnresolvedSelectionSpec {
     /// Explicit @id selection (include @id even when wildcard is not specified)
@@ -796,18 +796,18 @@ pub enum UnresolvedSelectionSpec {
     },
 }
 
-/// Graph crawl selection specification (formatting-time only)
+/// Hydrationion specification (formatting-time only)
 ///
-/// This captures the graph crawl select syntax for nested JSON-LD object expansion.
+/// This captures the hydration syntax for nested JSON-LD objects.
 /// It is used only during result formatting, not during query execution.
 ///
 /// # Examples
 ///
 /// ```json
-/// // Simple crawl with wildcard
+/// // Simple hydration with wildcard
 /// {"select": {"?person": ["*"]}}
 ///
-/// // Nested crawl
+/// // Nested hydration
 /// {"select": {"?person": ["*", {"ex:friend": ["*"]}]}}
 ///
 /// // With depth parameter
@@ -817,13 +817,13 @@ pub enum UnresolvedSelectionSpec {
 /// {"select": {"ex:alice": ["*"]}}
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub struct UnresolvedGraphSelectSpec {
-    /// Root of the crawl - variable or IRI constant
+pub struct UnresolvedHydrationSpec {
+    /// Root of the hydration - variable or IRI constant
     pub root: UnresolvedRoot,
     /// Forward property selections
     pub selections: Vec<UnresolvedSelectionSpec>,
     /// Reverse property selections (expanded IRI → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested expansion
+    /// None means no sub-selections (just return @id), Some means nested hydration
     ///
     /// Populated from `@reverse` context entries
     pub reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
@@ -833,7 +833,7 @@ pub struct UnresolvedGraphSelectSpec {
     pub has_wildcard: bool,
 }
 
-impl UnresolvedGraphSelectSpec {
+impl UnresolvedHydrationSpec {
     /// Create a new graph select spec with default values
     pub fn new(root: UnresolvedRoot, selections: Vec<UnresolvedSelectionSpec>) -> Self {
         let has_wildcard = selections
@@ -845,6 +845,28 @@ impl UnresolvedGraphSelectSpec {
             reverse: std::collections::HashMap::new(),
             depth: 0,
             has_wildcard,
+        }
+    }
+}
+
+/// One column of a SELECT/SELECT-ONE projection (unresolved).
+///
+/// Lowered into [`crate::ir::Selection`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnresolvedSelection {
+    /// Project a single variable's binding (e.g. `"?name"`).
+    Var(Arc<str>),
+    /// Hydrate a subject (variable or IRI constant) into a nested JSON-LD
+    /// object (e.g. `{"?person": ["*"]}`).
+    Hydration(UnresolvedHydrationSpec),
+}
+
+impl UnresolvedSelection {
+    /// Returns the variable name if this is a `Var` selection.
+    pub fn var_name(&self) -> Option<&str> {
+        match self {
+            UnresolvedSelection::Var(name) => Some(name),
+            UnresolvedSelection::Hydration(_) => None,
         }
     }
 }
@@ -999,11 +1021,8 @@ pub struct UnresolvedQuery {
     pub context: ParsedContext,
     /// Original JSON context from the query (for CONSTRUCT output)
     pub orig_context: Option<serde_json::Value>,
-    /// Selected variables (e.g., ["?name", "?age"])
-    ///
-    /// For graph crawl queries, this still contains the root variable(s)
-    /// needed for execution. The graph_select field controls formatting.
-    pub select: Vec<Arc<str>>,
+    /// Selections in column order (variable names and/or one hydration).
+    pub select: Vec<UnresolvedSelection>,
     /// User-declared projection shape from the input syntax.
     ///
     /// `Scalar` for bare-string select (`select: "?x"`), `Tuple` otherwise
@@ -1017,11 +1036,6 @@ pub struct UnresolvedQuery {
     pub options: UnresolvedOptions,
     /// CONSTRUCT template (None for SELECT queries)
     pub construct_template: Option<UnresolvedConstructTemplate>,
-    /// Graph crawl select specification (None for flat SELECT or CONSTRUCT)
-    ///
-    /// When present, controls nested JSON-LD object expansion during formatting.
-    /// Only one graph-select object is allowed per query.
-    pub graph_select: Option<UnresolvedGraphSelectSpec>,
 }
 
 impl UnresolvedQuery {
@@ -1035,13 +1049,34 @@ impl UnresolvedQuery {
             patterns: Vec::new(),
             options: UnresolvedOptions::default(),
             construct_template: None,
-            graph_select: None,
         }
     }
 
-    /// Add a selected variable
+    /// Add a selected variable.
     pub fn add_select(&mut self, var: impl AsRef<str>) {
-        self.select.push(Arc::from(var.as_ref()));
+        self.select
+            .push(UnresolvedSelection::Var(Arc::from(var.as_ref())));
+    }
+
+    /// Add a hydrationion.
+    pub fn add_hydration(&mut self, spec: UnresolvedHydrationSpec) {
+        self.select.push(UnresolvedSelection::Hydration(spec));
+    }
+
+    /// Returns the (single) hydrationion, if any.
+    pub fn hydration(&self) -> Option<&UnresolvedHydrationSpec> {
+        self.select.iter().find_map(|s| match s {
+            UnresolvedSelection::Hydration(spec) => Some(spec),
+            _ => None,
+        })
+    }
+
+    /// Mutable access to the (single) hydrationion, if any.
+    pub fn hydration_mut(&mut self) -> Option<&mut UnresolvedHydrationSpec> {
+        self.select.iter_mut().find_map(|s| match s {
+            UnresolvedSelection::Hydration(spec) => Some(spec),
+            _ => None,
+        })
     }
 
     /// Add a triple pattern (convenience method that wraps in UnresolvedPattern)

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -738,68 +738,76 @@ pub enum UnresolvedRoot {
 
 /// Nested selection specification for sub-hydrations
 ///
-/// This type captures the full selection state for nested property expansion,
-/// including both forward and reverse properties. It's used when a property
-/// has nested selections like `{"ex:friend": ["*", {"friended": ["*"]}]}`.
+/// Selection at one level of a hydration (unresolved). Mirrors
+/// [`crate::ir::NestedSelectSpec`].
+type UnresolvedReverseMap =
+    std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>;
+
 #[derive(Debug, Clone, PartialEq)]
-pub struct UnresolvedNestedSelectSpec {
-    /// Forward property selections
-    pub forward: Vec<UnresolvedSelectionSpec>,
-    /// Reverse property selections (expanded IRI → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested hydration
-    pub reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
-    /// Whether wildcard was specified at this level
-    pub has_wildcard: bool,
+pub enum UnresolvedNestedSelectSpec {
+    /// `*` at this level — include all forward properties (and `@id`).
+    /// `refinements` overrides the wildcard default of "include but don't
+    /// recurse" for specific properties.
+    Wildcard {
+        refinements:
+            std::collections::HashMap<String, Box<UnresolvedNestedSelectSpec>>,
+        reverse: UnresolvedReverseMap,
+    },
+    /// Explicit list of forward items.
+    Explicit {
+        forward: Vec<UnresolvedForwardItem>,
+        reverse: UnresolvedReverseMap,
+    },
 }
 
 impl UnresolvedNestedSelectSpec {
-    /// Create a new nested select spec
-    pub fn new(
-        forward: Vec<UnresolvedSelectionSpec>,
-        reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
-        has_wildcard: bool,
-    ) -> Self {
-        Self {
-            forward,
-            reverse,
-            has_wildcard,
+    /// Returns `true` if this level is a wildcard.
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, UnresolvedNestedSelectSpec::Wildcard { .. })
+    }
+
+    /// Reverse property selections at this level.
+    pub fn reverse(&self) -> &UnresolvedReverseMap {
+        match self {
+            UnresolvedNestedSelectSpec::Wildcard { reverse, .. }
+            | UnresolvedNestedSelectSpec::Explicit { reverse, .. } => reverse,
         }
     }
 
-    /// Check if this spec is empty (no selections)
+    /// Returns `true` if the level produces no output (empty Explicit
+    /// selection with no reverse).
     pub fn is_empty(&self) -> bool {
-        self.forward.is_empty() && self.reverse.is_empty()
+        match self {
+            UnresolvedNestedSelectSpec::Wildcard { .. } => false,
+            UnresolvedNestedSelectSpec::Explicit { forward, reverse } => {
+                forward.is_empty() && reverse.is_empty()
+            }
+        }
     }
 }
 
-/// Selection specification within a hydration
+/// One forward item in an explicit (non-wildcard) selection level.
 ///
-/// Defines what properties to include at each level of the hydration.
+/// Examples:
+/// - `"ex:name"` → `Property { predicate: "ex:name", sub_spec: None }`
+/// - `{"ex:friend": ["*"]}` → `Property { sub_spec: Some(...) }`
+/// - `"@id"` → `Id`
 #[derive(Debug, Clone, PartialEq)]
-pub enum UnresolvedSelectionSpec {
-    /// Explicit @id selection (include @id even when wildcard is not specified)
+pub enum UnresolvedForwardItem {
+    /// Explicit `@id` selection.
     Id,
-    /// Wildcard - select all properties at this level ("*")
-    Wildcard,
-    /// Property selection - optionally with nested sub-selections
-    ///
-    /// Examples:
-    /// - `"ex:name"` → Property with no sub_spec
-    /// - `{"ex:friend": ["*"]}` → Property with sub_spec containing forward selections
-    /// - `{"ex:friend": ["*", {"@reverse:friended": ["*"]}]}` → Property with both forward and reverse
+    /// A specific property with optional nested expansion of its values.
     Property {
         /// Predicate IRI (expanded)
         predicate: String,
-        /// Optional nested selection spec for expanding this property's values
-        /// Uses Box to avoid infinite type recursion
         sub_spec: Option<Box<UnresolvedNestedSelectSpec>>,
     },
 }
 
-/// Hydrationion specification (formatting-time only)
+/// Hydration spec (unresolved).
 ///
-/// This captures the hydration syntax for nested JSON-LD objects.
-/// It is used only during result formatting, not during query execution.
+/// Captures the hydration syntax for nested JSON-LD objects. Lowered into
+/// [`crate::ir::HydrationSpec`].
 ///
 /// # Examples
 ///
@@ -818,33 +826,22 @@ pub enum UnresolvedSelectionSpec {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnresolvedHydrationSpec {
-    /// Root of the hydration - variable or IRI constant
+    /// Root of the hydration — variable or IRI constant.
     pub root: UnresolvedRoot,
-    /// Forward property selections
-    pub selections: Vec<UnresolvedSelectionSpec>,
-    /// Reverse property selections (expanded IRI → optional nested spec)
-    /// None means no sub-selections (just return @id), Some means nested hydration
-    ///
-    /// Populated from `@reverse` context entries
-    pub reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
-    /// Max depth for auto-expansion (0 = no auto-expand, only explicit)
+    /// Selection at the top level of the hydration.
+    pub level: UnresolvedNestedSelectSpec,
+    /// Max depth for auto-expansion (0 = no auto-expand, only explicit).
     pub depth: usize,
-    /// Whether wildcard was specified (controls @id inclusion)
-    pub has_wildcard: bool,
 }
 
 impl UnresolvedHydrationSpec {
-    /// Create a new graph select spec with default values
-    pub fn new(root: UnresolvedRoot, selections: Vec<UnresolvedSelectionSpec>) -> Self {
-        let has_wildcard = selections
-            .iter()
-            .any(|s| matches!(s, UnresolvedSelectionSpec::Wildcard));
+    /// Create a hydration with the given root and top-level selection,
+    /// `depth: 0`.
+    pub fn new(root: UnresolvedRoot, level: UnresolvedNestedSelectSpec) -> Self {
         Self {
             root,
-            selections,
-            reverse: std::collections::HashMap::new(),
+            level,
             depth: 0,
-            has_wildcard,
         }
     }
 }

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -749,8 +749,7 @@ pub enum UnresolvedNestedSelectSpec {
     /// `refinements` overrides the wildcard default of "include but don't
     /// recurse" for specific properties.
     Wildcard {
-        refinements:
-            std::collections::HashMap<String, Box<UnresolvedNestedSelectSpec>>,
+        refinements: std::collections::HashMap<String, Box<UnresolvedNestedSelectSpec>>,
         reverse: UnresolvedReverseMap,
     },
     /// Explicit list of forward items.
@@ -909,7 +908,9 @@ impl UnresolvedProjection {
 
     /// The hydration spec embedded in the projection, if any.
     pub fn hydration(&self) -> Option<&UnresolvedHydrationSpec> {
-        self.columns().iter().find_map(UnresolvedColumn::as_hydration)
+        self.columns()
+            .iter()
+            .find_map(UnresolvedColumn::as_hydration)
     }
 
     /// Mutable access to the hydration spec, if any.

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -851,7 +851,7 @@ impl UnresolvedHydrationSpec {
 
 /// One column of a SELECT/SELECT-ONE projection (unresolved).
 ///
-/// Lowered into [`crate::ir::Selection`].
+/// Lowered into [`crate::ir::Column`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum UnresolvedSelection {
     /// Project a single variable's binding (e.g. `"?name"`).
@@ -1014,6 +1014,18 @@ impl UnresolvedPattern {
     }
 }
 
+/// User-declared select shape from the input syntax. Parser-only — lowered
+/// into a `Projection` variant in the IR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SelectShape {
+    /// Array-form select: each row is a tuple. Default; SPARQL and JSON-LD
+    /// array-form `select`.
+    #[default]
+    Tuple,
+    /// Bare-string `select: "?x"`: each row is a single bare value.
+    Scalar,
+}
+
 /// Unresolved query - the result of parsing before IRI resolution
 #[derive(Debug, Clone)]
 pub struct UnresolvedQuery {
@@ -1023,13 +1035,13 @@ pub struct UnresolvedQuery {
     pub orig_context: Option<serde_json::Value>,
     /// Selections in column order (variable names and/or one hydration).
     pub select: Vec<UnresolvedSelection>,
-    /// User-declared projection shape from the input syntax.
+    /// User-declared select shape from the input syntax.
     ///
     /// `Scalar` for bare-string select (`select: "?x"`), `Tuple` otherwise
-    /// (array form, or SPARQL, which has no scalar form). Propagated into
-    /// `QueryOutput::Select` / `SelectOne` so formatters can decide rendering
-    /// without inferring from `vars.len()`.
-    pub select_shape: crate::ir::ProjectionShape,
+    /// (array form, or SPARQL, which has no scalar form). Lowered into
+    /// `Projection::Scalar` vs `Projection::Tuple` so formatters can decide
+    /// rendering without inferring from `selections.len()`.
+    pub select_shape: SelectShape,
     /// Ordered patterns in where clause (triples, filters, optionals, etc.)
     pub patterns: Vec<UnresolvedPattern>,
     /// Query options (limit, offset, order by, group by, etc.)
@@ -1045,7 +1057,7 @@ impl UnresolvedQuery {
             context,
             orig_context: None,
             select: Vec::new(),
-            select_shape: crate::ir::ProjectionShape::default(),
+            select_shape: SelectShape::default(),
             patterns: Vec::new(),
             options: UnresolvedOptions::default(),
             construct_template: None,

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -849,11 +849,11 @@ impl UnresolvedHydrationSpec {
     }
 }
 
-/// One column of a SELECT/SELECT-ONE projection (unresolved).
+/// One column of a SELECT projection (unresolved).
 ///
 /// Lowered into [`crate::ir::Column`].
 #[derive(Debug, Clone, PartialEq)]
-pub enum UnresolvedSelection {
+pub enum UnresolvedColumn {
     /// Project a single variable's binding (e.g. `"?name"`).
     Var(Arc<str>),
     /// Hydrate a subject (variable or IRI constant) into a nested JSON-LD
@@ -861,12 +861,72 @@ pub enum UnresolvedSelection {
     Hydration(UnresolvedHydrationSpec),
 }
 
-impl UnresolvedSelection {
-    /// Returns the variable name if this is a `Var` selection.
+impl UnresolvedColumn {
+    /// Returns the variable name if this is a `Var` column.
     pub fn var_name(&self) -> Option<&str> {
         match self {
-            UnresolvedSelection::Var(name) => Some(name),
-            UnresolvedSelection::Hydration(_) => None,
+            UnresolvedColumn::Var(name) => Some(name),
+            UnresolvedColumn::Hydration(_) => None,
+        }
+    }
+
+    /// Returns the hydration spec if this is a `Hydration` column.
+    pub fn as_hydration(&self) -> Option<&UnresolvedHydrationSpec> {
+        match self {
+            UnresolvedColumn::Hydration(spec) => Some(spec),
+            UnresolvedColumn::Var(_) => None,
+        }
+    }
+}
+
+/// The columns a SELECT query produces (unresolved). Mirrors
+/// [`crate::ir::Projection`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnresolvedProjection {
+    /// SELECT * — all in-scope WHERE-bound variables, rendered raw.
+    Wildcard,
+    /// Array-form rows: each row is `[v1, v2, ...]` of any arity.
+    Tuple(Vec<UnresolvedColumn>),
+    /// Bare-value rows from JSON-LD `select: "?x"` — exactly one column,
+    /// each row is a bare value (not wrapped in an array).
+    Scalar(UnresolvedColumn),
+}
+
+impl Default for UnresolvedProjection {
+    /// An empty `Tuple` projection — the parser populates it as columns
+    /// are encountered.
+    fn default() -> Self {
+        UnresolvedProjection::Tuple(Vec::new())
+    }
+}
+
+impl UnresolvedProjection {
+    /// Columns in render order. Empty for `Wildcard`.
+    pub fn columns(&self) -> &[UnresolvedColumn] {
+        match self {
+            UnresolvedProjection::Wildcard => &[],
+            UnresolvedProjection::Tuple(cs) => cs,
+            UnresolvedProjection::Scalar(c) => std::slice::from_ref(c),
+        }
+    }
+
+    /// The hydration spec embedded in the projection, if any.
+    pub fn hydration(&self) -> Option<&UnresolvedHydrationSpec> {
+        self.columns().iter().find_map(UnresolvedColumn::as_hydration)
+    }
+
+    /// Mutable access to the hydration spec, if any.
+    pub fn hydration_mut(&mut self) -> Option<&mut UnresolvedHydrationSpec> {
+        match self {
+            UnresolvedProjection::Wildcard => None,
+            UnresolvedProjection::Tuple(cs) => cs.iter_mut().find_map(|c| match c {
+                UnresolvedColumn::Hydration(spec) => Some(spec),
+                UnresolvedColumn::Var(_) => None,
+            }),
+            UnresolvedProjection::Scalar(c) => match c {
+                UnresolvedColumn::Hydration(spec) => Some(spec),
+                UnresolvedColumn::Var(_) => None,
+            },
         }
     }
 }
@@ -1014,18 +1074,6 @@ impl UnresolvedPattern {
     }
 }
 
-/// User-declared select shape from the input syntax. Parser-only — lowered
-/// into a `Projection` variant in the IR.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum SelectShape {
-    /// Array-form select: each row is a tuple. Default; SPARQL and JSON-LD
-    /// array-form `select`.
-    #[default]
-    Tuple,
-    /// Bare-string `select: "?x"`: each row is a single bare value.
-    Scalar,
-}
-
 /// Unresolved query - the result of parsing before IRI resolution
 #[derive(Debug, Clone)]
 pub struct UnresolvedQuery {
@@ -1033,15 +1081,8 @@ pub struct UnresolvedQuery {
     pub context: ParsedContext,
     /// Original JSON context from the query (for CONSTRUCT output)
     pub orig_context: Option<serde_json::Value>,
-    /// Selections in column order (variable names and/or one hydration).
-    pub select: Vec<UnresolvedSelection>,
-    /// User-declared select shape from the input syntax.
-    ///
-    /// `Scalar` for bare-string select (`select: "?x"`), `Tuple` otherwise
-    /// (array form, or SPARQL, which has no scalar form). Lowered into
-    /// `Projection::Scalar` vs `Projection::Tuple` so formatters can decide
-    /// rendering without inferring from `selections.len()`.
-    pub select_shape: SelectShape,
+    /// Projection (columns + shape). Lowered into [`crate::ir::Projection`].
+    pub select: UnresolvedProjection,
     /// Ordered patterns in where clause (triples, filters, optionals, etc.)
     pub patterns: Vec<UnresolvedPattern>,
     /// Query options (limit, offset, order by, group by, etc.)
@@ -1056,39 +1097,42 @@ impl UnresolvedQuery {
         Self {
             context,
             orig_context: None,
-            select: Vec::new(),
-            select_shape: SelectShape::default(),
+            select: UnresolvedProjection::default(),
             patterns: Vec::new(),
             options: UnresolvedOptions::default(),
             construct_template: None,
         }
     }
 
-    /// Add a selected variable.
+    /// Append a Var column. The projection must be in `Tuple` mode
+    /// (the default for [`Self::new`]).
     pub fn add_select(&mut self, var: impl AsRef<str>) {
-        self.select
-            .push(UnresolvedSelection::Var(Arc::from(var.as_ref())));
+        self.push_column(UnresolvedColumn::Var(Arc::from(var.as_ref())));
     }
 
-    /// Add a hydrationion.
+    /// Append a Hydration column. The projection must be in `Tuple` mode.
     pub fn add_hydration(&mut self, spec: UnresolvedHydrationSpec) {
-        self.select.push(UnresolvedSelection::Hydration(spec));
+        self.push_column(UnresolvedColumn::Hydration(spec));
     }
 
-    /// Returns the (single) hydrationion, if any.
+    /// Append a column to a `Tuple` projection. Panics if `select` is not
+    /// `Tuple` (which only happens after `select` has been finalized to
+    /// `Wildcard` or `Scalar` — neither supports incremental appends).
+    fn push_column(&mut self, column: UnresolvedColumn) {
+        match &mut self.select {
+            UnresolvedProjection::Tuple(cs) => cs.push(column),
+            _ => panic!("cannot append a column to a non-Tuple projection"),
+        }
+    }
+
+    /// Returns the hydration spec embedded in the projection, if any.
     pub fn hydration(&self) -> Option<&UnresolvedHydrationSpec> {
-        self.select.iter().find_map(|s| match s {
-            UnresolvedSelection::Hydration(spec) => Some(spec),
-            _ => None,
-        })
+        self.select.hydration()
     }
 
-    /// Mutable access to the (single) hydrationion, if any.
+    /// Mutable access to the hydration spec, if any.
     pub fn hydration_mut(&mut self) -> Option<&mut UnresolvedHydrationSpec> {
-        self.select.iter_mut().find_map(|s| match s {
-            UnresolvedSelection::Hydration(spec) => Some(spec),
-            _ => None,
-        })
+        self.select.hydration_mut()
     }
 
     /// Add a triple pattern (convenience method that wraps in UnresolvedPattern)

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -906,26 +906,20 @@ impl UnresolvedProjection {
         }
     }
 
-    /// The hydration spec embedded in the projection, if any.
-    pub fn hydration(&self) -> Option<&UnresolvedHydrationSpec> {
-        self.columns()
-            .iter()
-            .find_map(UnresolvedColumn::as_hydration)
+    /// Mutable access to columns in render order. Empty for `Wildcard`.
+    pub fn columns_mut(&mut self) -> &mut [UnresolvedColumn] {
+        match self {
+            UnresolvedProjection::Wildcard => &mut [],
+            UnresolvedProjection::Tuple(cs) => cs.as_mut_slice(),
+            UnresolvedProjection::Scalar(c) => std::slice::from_mut(c),
+        }
     }
 
-    /// Mutable access to the hydration spec, if any.
-    pub fn hydration_mut(&mut self) -> Option<&mut UnresolvedHydrationSpec> {
-        match self {
-            UnresolvedProjection::Wildcard => None,
-            UnresolvedProjection::Tuple(cs) => cs.iter_mut().find_map(|c| match c {
-                UnresolvedColumn::Hydration(spec) => Some(spec),
-                UnresolvedColumn::Var(_) => None,
-            }),
-            UnresolvedProjection::Scalar(c) => match c {
-                UnresolvedColumn::Hydration(spec) => Some(spec),
-                UnresolvedColumn::Var(_) => None,
-            },
-        }
+    /// Returns `true` if any column in the projection is a hydration column.
+    pub fn has_hydration(&self) -> bool {
+        self.columns()
+            .iter()
+            .any(|c| matches!(c, UnresolvedColumn::Hydration(_)))
     }
 }
 
@@ -1123,14 +1117,9 @@ impl UnresolvedQuery {
         }
     }
 
-    /// Returns the hydration spec embedded in the projection, if any.
-    pub fn hydration(&self) -> Option<&UnresolvedHydrationSpec> {
-        self.select.hydration()
-    }
-
-    /// Mutable access to the hydration spec, if any.
-    pub fn hydration_mut(&mut self) -> Option<&mut UnresolvedHydrationSpec> {
-        self.select.hydration_mut()
+    /// Returns `true` if the projection contains any hydration column.
+    pub fn has_hydration(&self) -> bool {
+        self.select.has_hydration()
     }
 
     /// Add a triple pattern (convenience method that wraps in UnresolvedPattern)

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -4,10 +4,10 @@
 //! (with Sids and VarIds) using an IriEncoder.
 
 use super::ast::{
-    LiteralValue, SelectShape, UnresolvedAggregateFn, UnresolvedAggregateSpec,
+    LiteralValue, UnresolvedAggregateFn, UnresolvedAggregateSpec, UnresolvedColumn,
     UnresolvedConstructTemplate, UnresolvedDatatypeConstraint, UnresolvedExpression,
     UnresolvedHydrationSpec, UnresolvedNestedSelectSpec, UnresolvedOptions, UnresolvedPathExpr,
-    UnresolvedPattern, UnresolvedQuery, UnresolvedRoot, UnresolvedSelection,
+    UnresolvedPattern, UnresolvedProjection, UnresolvedQuery, UnresolvedRoot,
     UnresolvedSelectionSpec, UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm,
     UnresolvedTriplePattern, UnresolvedValue,
 };
@@ -87,12 +87,8 @@ pub(crate) fn lower_query<E: IriEncoder>(
 ) -> Result<Query> {
     let mut pp_counter: u32 = 0;
 
-    // Lower columns (variables and any hydration)
-    let columns: Vec<Column> = ast
-        .select
-        .iter()
-        .map(|sel| lower_selection(sel, encoder, vars))
-        .collect::<Result<_>>()?;
+    // Lower the projection (columns + shape)
+    let projection = lower_projection(&ast.select, encoder, vars)?;
 
     // Lower patterns
     let mut patterns = Vec::new();
@@ -108,11 +104,11 @@ pub(crate) fn lower_query<E: IriEncoder>(
     // Build QueryOutput from mode + lowered components
     let output = match select_mode {
         SelectMode::Many => QueryOutput::Select {
-            projection: build_projection(columns, ast.select_shape),
+            projection,
             multiplicity: Multiplicity::All,
         },
         SelectMode::One => QueryOutput::Select {
-            projection: build_projection(columns, ast.select_shape),
+            projection,
             multiplicity: Multiplicity::One,
         },
         SelectMode::Wildcard => QueryOutput::Select {
@@ -139,31 +135,36 @@ pub(crate) fn lower_query<E: IriEncoder>(
     })
 }
 
-fn lower_selection<E: IriEncoder>(
-    sel: &UnresolvedSelection,
+fn lower_column<E: IriEncoder>(
+    col: &UnresolvedColumn,
     encoder: &E,
     vars: &mut VarRegistry,
 ) -> Result<Column> {
-    match sel {
-        UnresolvedSelection::Var(name) => Ok(Column::Var(vars.get_or_insert(name))),
-        UnresolvedSelection::Hydration(spec) => {
+    match col {
+        UnresolvedColumn::Var(name) => Ok(Column::Var(vars.get_or_insert(name))),
+        UnresolvedColumn::Hydration(spec) => {
             Ok(Column::Hydration(lower_hydration(spec, encoder, vars)?))
         }
     }
 }
 
-/// Build the appropriate `Projection` variant from lowered columns and the
-/// user-declared shape from the input syntax (`Tuple` for array form,
-/// `Scalar` for bare-string form).
-fn build_projection(columns: Vec<Column>, shape: SelectShape) -> Projection {
-    match shape {
-        SelectShape::Scalar if columns.len() == 1 => {
-            Projection::Scalar(columns.into_iter().next().unwrap())
+fn lower_projection<E: IriEncoder>(
+    projection: &UnresolvedProjection,
+    encoder: &E,
+    vars: &mut VarRegistry,
+) -> Result<Projection> {
+    match projection {
+        UnresolvedProjection::Wildcard => Ok(Projection::Wildcard),
+        UnresolvedProjection::Tuple(cs) => {
+            let lowered = cs
+                .iter()
+                .map(|c| lower_column(c, encoder, vars))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Projection::Tuple(lowered))
         }
-        // Multi-column scalar is unrepresentable; the parser only sets
-        // Scalar for bare-string `select: "?x"` so this branch is just a
-        // safety net — fall through to Tuple.
-        _ => Projection::Tuple(columns),
+        UnresolvedProjection::Scalar(c) => {
+            Ok(Projection::Scalar(lower_column(c, encoder, vars)?))
+        }
     }
 }
 
@@ -1010,14 +1011,27 @@ fn lower_subquery<E: IriEncoder>(
     vars: &mut VarRegistry,
     pp_counter: &mut u32,
 ) -> Result<SubqueryPattern> {
-    // Lower select list to VarIds (subqueries support variables only, no hydration)
-    let select: Vec<VarId> = subquery
-        .select
+    // Lower select list to VarIds (subqueries support variables only, no
+    // hydration or wildcard)
+    let columns = match &subquery.select {
+        UnresolvedProjection::Tuple(cs) => cs,
+        UnresolvedProjection::Wildcard => {
+            return Err(ParseError::InvalidSelect(
+                "subqueries do not support SELECT *".to_string(),
+            ));
+        }
+        UnresolvedProjection::Scalar(_) => {
+            return Err(ParseError::InvalidSelect(
+                "subqueries do not support scalar select form".to_string(),
+            ));
+        }
+    };
+    let select: Vec<VarId> = columns
         .iter()
-        .map(|sel| match sel {
-            UnresolvedSelection::Var(name) => Ok(vars.get_or_insert(name)),
-            UnresolvedSelection::Hydration(_) => Err(ParseError::InvalidSelect(
-                "hydrationions are not allowed inside subqueries".to_string(),
+        .map(|c| match c {
+            UnresolvedColumn::Var(name) => Ok(vars.get_or_insert(name)),
+            UnresolvedColumn::Hydration(_) => Err(ParseError::InvalidSelect(
+                "hydrations are not allowed inside subqueries".to_string(),
             )),
         })
         .collect::<Result<_>>()?;

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -6,10 +6,10 @@
 use super::ast::{
     LiteralValue, UnresolvedAggregateFn, UnresolvedAggregateSpec, UnresolvedColumn,
     UnresolvedConstructTemplate, UnresolvedDatatypeConstraint, UnresolvedExpression,
-    UnresolvedHydrationSpec, UnresolvedNestedSelectSpec, UnresolvedOptions, UnresolvedPathExpr,
-    UnresolvedPattern, UnresolvedProjection, UnresolvedQuery, UnresolvedRoot,
-    UnresolvedSelectionSpec, UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm,
-    UnresolvedTriplePattern, UnresolvedValue,
+    UnresolvedForwardItem, UnresolvedHydrationSpec, UnresolvedNestedSelectSpec, UnresolvedOptions,
+    UnresolvedPathExpr, UnresolvedPattern, UnresolvedProjection, UnresolvedQuery, UnresolvedRoot,
+    UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm, UnresolvedTriplePattern,
+    UnresolvedValue,
 };
 use super::encode::{IriEncoder, NoEncoder};
 use super::error::{ParseError, Result};
@@ -19,8 +19,8 @@ use crate::context::WellKnownDatatypes;
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::QueryOptions;
 use crate::ir::{
-    Column, ConstructTemplate, HydrationSpec, Multiplicity, NestedSelectSpec, Projection, Query,
-    QueryOutput, Root, SelectionSpec,
+    Column, ConstructTemplate, ForwardItem, HydrationSpec, Multiplicity, NestedSelectSpec,
+    Projection, Query, QueryOutput, Root,
 };
 use crate::ir::{
     Expression, Function, IndexSearchPattern, IndexSearchTarget, PathModifier, Pattern,
@@ -1126,95 +1126,102 @@ fn lower_hydration<E: IriEncoder>(
         }
     };
 
-    // Lower forward selections
-    let selections = spec
-        .selections
-        .iter()
-        .map(|s| lower_selection_spec(s, encoder))
-        .collect::<Result<Vec<_>>>()?;
-
-    // Lower reverse selections
-    let mut reverse = std::collections::HashMap::new();
-    for (iri, nested_opt) in &spec.reverse {
-        let sid = encoder
-            .encode_iri(iri)
-            .ok_or_else(|| ParseError::UnknownNamespace(iri.clone()))?;
-        let lowered_nested = nested_opt
-            .as_ref()
-            .map(|nested| lower_nested_select_spec(nested, encoder))
-            .transpose()?;
-        reverse.insert(sid, lowered_nested);
-    }
+    let level = lower_level(&spec.level, encoder)?;
 
     Ok(HydrationSpec {
         root,
-        selections,
-        reverse,
+        level,
         depth: spec.depth,
-        has_wildcard: spec.has_wildcard,
     })
 }
 
-/// Lower a single selection spec to resolved form
-fn lower_selection_spec<E: IriEncoder>(
-    spec: &UnresolvedSelectionSpec,
+/// Lower one forward item (only meaningful in `Explicit` levels).
+fn lower_forward_item<E: IriEncoder>(
+    item: &UnresolvedForwardItem,
     encoder: &E,
-) -> Result<SelectionSpec> {
-    match spec {
-        UnresolvedSelectionSpec::Id => Ok(SelectionSpec::Id),
-        UnresolvedSelectionSpec::Wildcard => Ok(SelectionSpec::Wildcard),
-        UnresolvedSelectionSpec::Property {
+) -> Result<ForwardItem> {
+    match item {
+        UnresolvedForwardItem::Id => Ok(ForwardItem::Id),
+        UnresolvedForwardItem::Property {
             predicate,
             sub_spec,
         } => {
             let sid = encoder
                 .encode_iri(predicate)
                 .ok_or_else(|| ParseError::UnknownNamespace(predicate.clone()))?;
-
-            // Lower nested spec (includes both forward and reverse)
-            let lowered_sub_spec = sub_spec
+            let lowered_sub = sub_spec
                 .as_ref()
-                .map(|nested| lower_nested_select_spec(nested, encoder))
+                .map(|nested| lower_level_boxed(nested, encoder))
                 .transpose()?;
-
-            Ok(SelectionSpec::Property {
+            Ok(ForwardItem::Property {
                 predicate: sid,
-                sub_spec: lowered_sub_spec,
+                sub_spec: lowered_sub,
             })
         }
     }
 }
 
-/// Lower a nested select spec to resolved form
-fn lower_nested_select_spec<E: IriEncoder>(
-    spec: &UnresolvedNestedSelectSpec,
+/// Lower a reverse map (`predicate IRI -> Option<nested level>`).
+fn lower_reverse_map<E: IriEncoder>(
+    reverse: &std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
     encoder: &E,
-) -> Result<Box<NestedSelectSpec>> {
-    // Lower forward selections
-    let forward = spec
-        .forward
-        .iter()
-        .map(|s| lower_selection_spec(s, encoder))
-        .collect::<Result<Vec<_>>>()?;
-
-    // Lower reverse selections (now carries full nested spec, not just forward)
-    let mut reverse = std::collections::HashMap::new();
-    for (iri, nested_opt) in &spec.reverse {
+) -> Result<std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>> {
+    let mut out = std::collections::HashMap::new();
+    for (iri, nested_opt) in reverse {
         let sid = encoder
             .encode_iri(iri)
             .ok_or_else(|| ParseError::UnknownNamespace(iri.clone()))?;
-        let lowered_nested = nested_opt
+        let lowered = nested_opt
             .as_ref()
-            .map(|nested| lower_nested_select_spec(nested, encoder))
+            .map(|nested| lower_level_boxed(nested, encoder))
             .transpose()?;
-        reverse.insert(sid, lowered_nested);
+        out.insert(sid, lowered);
     }
+    Ok(out)
+}
 
-    Ok(Box::new(NestedSelectSpec::new(
-        forward,
-        reverse,
-        spec.has_wildcard,
-    )))
+/// Lower one selection level into `NestedSelectSpec`.
+fn lower_level<E: IriEncoder>(
+    spec: &UnresolvedNestedSelectSpec,
+    encoder: &E,
+) -> Result<NestedSelectSpec> {
+    match spec {
+        UnresolvedNestedSelectSpec::Wildcard {
+            refinements,
+            reverse,
+        } => {
+            let mut lowered_refinements = std::collections::HashMap::new();
+            for (iri, nested) in refinements {
+                let sid = encoder
+                    .encode_iri(iri)
+                    .ok_or_else(|| ParseError::UnknownNamespace(iri.clone()))?;
+                lowered_refinements.insert(sid, lower_level_boxed(nested, encoder)?);
+            }
+            Ok(NestedSelectSpec::Wildcard {
+                refinements: lowered_refinements,
+                reverse: lower_reverse_map(reverse, encoder)?,
+            })
+        }
+        UnresolvedNestedSelectSpec::Explicit { forward, reverse } => {
+            let lowered_forward = forward
+                .iter()
+                .map(|item| lower_forward_item(item, encoder))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(NestedSelectSpec::Explicit {
+                forward: lowered_forward,
+                reverse: lower_reverse_map(reverse, encoder)?,
+            })
+        }
+    }
+}
+
+/// Lower a level into a `Box<NestedSelectSpec>` (the form used by sub-specs
+/// inside reverse maps and wildcard refinements).
+fn lower_level_boxed<E: IriEncoder>(
+    spec: &UnresolvedNestedSelectSpec,
+    encoder: &E,
+) -> Result<Box<NestedSelectSpec>> {
+    Ok(Box::new(lower_level(spec, encoder)?))
 }
 
 /// Lower an unresolved filter expression to a resolved Expression

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -153,9 +153,7 @@ fn lower_projection<E: IriEncoder>(
                 .collect::<Result<Vec<_>>>()?;
             Ok(Projection::Tuple(lowered))
         }
-        UnresolvedProjection::Scalar(c) => {
-            Ok(Projection::Scalar(lower_column(c, encoder, vars)?))
-        }
+        UnresolvedProjection::Scalar(c) => Ok(Projection::Scalar(lower_column(c, encoder, vars)?)),
     }
 }
 

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -5,10 +5,11 @@
 
 use super::ast::{
     LiteralValue, UnresolvedAggregateFn, UnresolvedAggregateSpec, UnresolvedConstructTemplate,
-    UnresolvedDatatypeConstraint, UnresolvedExpression, UnresolvedGraphSelectSpec,
+    UnresolvedDatatypeConstraint, UnresolvedExpression, UnresolvedHydrationSpec,
     UnresolvedNestedSelectSpec, UnresolvedOptions, UnresolvedPathExpr, UnresolvedPattern,
-    UnresolvedQuery, UnresolvedRoot, UnresolvedSelectionSpec, UnresolvedSortDirection,
-    UnresolvedSortSpec, UnresolvedTerm, UnresolvedTriplePattern, UnresolvedValue,
+    UnresolvedQuery, UnresolvedRoot, UnresolvedSelection, UnresolvedSelectionSpec,
+    UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm, UnresolvedTriplePattern,
+    UnresolvedValue,
 };
 use super::encode::{IriEncoder, NoEncoder};
 use super::error::{ParseError, Result};
@@ -18,7 +19,8 @@ use crate::context::WellKnownDatatypes;
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::QueryOptions;
 use crate::ir::{
-    ConstructTemplate, GraphSelectSpec, NestedSelectSpec, Query, QueryOutput, Root, SelectionSpec,
+    ConstructTemplate, HydrationSpec, NestedSelectSpec, Query, QueryOutput, Root, Selection,
+    SelectionSpec,
 };
 use crate::ir::{
     Expression, Function, IndexSearchPattern, IndexSearchTarget, PathModifier, Pattern,
@@ -85,12 +87,12 @@ pub(crate) fn lower_query<E: IriEncoder>(
 ) -> Result<Query> {
     let mut pp_counter: u32 = 0;
 
-    // Lower select variables
-    let select_vars: Vec<VarId> = ast
+    // Lower selections (variables and any hydration)
+    let selections: Vec<Selection> = ast
         .select
         .iter()
-        .map(|name| vars.get_or_insert(name))
-        .collect();
+        .map(|sel| lower_selection(sel, encoder, vars))
+        .collect::<Result<_>>()?;
 
     // Lower patterns
     let mut patterns = Vec::new();
@@ -106,14 +108,8 @@ pub(crate) fn lower_query<E: IriEncoder>(
     // Build QueryOutput from mode + lowered components
     let shape = ast.select_shape;
     let output = match select_mode {
-        SelectMode::Many => QueryOutput::Select {
-            vars: select_vars,
-            shape,
-        },
-        SelectMode::One => QueryOutput::SelectOne {
-            vars: select_vars,
-            shape,
-        },
+        SelectMode::Many => QueryOutput::Select { selections, shape },
+        SelectMode::One => QueryOutput::SelectOne { selections, shape },
         SelectMode::Wildcard => QueryOutput::Wildcard,
         SelectMode::Construct => {
             let template = match ast.construct_template {
@@ -125,22 +121,27 @@ pub(crate) fn lower_query<E: IriEncoder>(
         SelectMode::Boolean => QueryOutput::Boolean,
     };
 
-    // Lower graph select if present
-    let graph_select = ast
-        .graph_select
-        .as_ref()
-        .map(|gs| lower_graph_select(gs, encoder, vars))
-        .transpose()?;
-
     Ok(Query {
         context: ast.context,
         orig_context: ast.orig_context,
         output,
         patterns,
         options,
-        graph_select,
         post_values: None,
     })
+}
+
+fn lower_selection<E: IriEncoder>(
+    sel: &UnresolvedSelection,
+    encoder: &E,
+    vars: &mut VarRegistry,
+) -> Result<Selection> {
+    match sel {
+        UnresolvedSelection::Var(name) => Ok(Selection::Var(vars.get_or_insert(name))),
+        UnresolvedSelection::Hydration(spec) => {
+            Ok(Selection::Hydration(lower_hydration(spec, encoder, vars)?))
+        }
+    }
 }
 
 /// Lower an unresolved pattern to resolved Pattern(s).
@@ -986,12 +987,17 @@ fn lower_subquery<E: IriEncoder>(
     vars: &mut VarRegistry,
     pp_counter: &mut u32,
 ) -> Result<SubqueryPattern> {
-    // Lower select list to VarIds
+    // Lower select list to VarIds (subqueries support variables only, no hydration)
     let select: Vec<VarId> = subquery
         .select
         .iter()
-        .map(|var_name| vars.get_or_insert(var_name))
-        .collect();
+        .map(|sel| match sel {
+            UnresolvedSelection::Var(name) => Ok(vars.get_or_insert(name)),
+            UnresolvedSelection::Hydration(_) => Err(ParseError::InvalidSelect(
+                "hydrationions are not allowed inside subqueries".to_string(),
+            )),
+        })
+        .collect::<Result<_>>()?;
 
     // Lower WHERE patterns
     let patterns = lower_unresolved_patterns(&subquery.patterns, encoder, vars, pp_counter)?;
@@ -1063,15 +1069,15 @@ fn lower_construct_template<E: IriEncoder>(
 }
 
 // ============================================================================
-// Graph crawl lowering
+// Hydration lowering
 // ============================================================================
 
-/// Lower an unresolved graph select specification to a resolved GraphSelectSpec
-fn lower_graph_select<E: IriEncoder>(
-    spec: &UnresolvedGraphSelectSpec,
+/// Lower an unresolved graph select specification to a resolved HydrationSpec
+fn lower_hydration<E: IriEncoder>(
+    spec: &UnresolvedHydrationSpec,
     encoder: &E,
     vars: &mut VarRegistry,
-) -> Result<GraphSelectSpec> {
+) -> Result<HydrationSpec> {
     // Handle root - variable or IRI constant
     let root = match &spec.root {
         UnresolvedRoot::Var(name) => {
@@ -1112,7 +1118,7 @@ fn lower_graph_select<E: IriEncoder>(
         reverse.insert(sid, lowered_nested);
     }
 
-    Ok(GraphSelectSpec {
+    Ok(HydrationSpec {
         root,
         selections,
         reverse,

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -4,12 +4,12 @@
 //! (with Sids and VarIds) using an IriEncoder.
 
 use super::ast::{
-    LiteralValue, UnresolvedAggregateFn, UnresolvedAggregateSpec, UnresolvedConstructTemplate,
-    UnresolvedDatatypeConstraint, UnresolvedExpression, UnresolvedHydrationSpec,
-    UnresolvedNestedSelectSpec, UnresolvedOptions, UnresolvedPathExpr, UnresolvedPattern,
-    UnresolvedQuery, UnresolvedRoot, UnresolvedSelection, UnresolvedSelectionSpec,
-    UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm, UnresolvedTriplePattern,
-    UnresolvedValue,
+    LiteralValue, SelectShape, UnresolvedAggregateFn, UnresolvedAggregateSpec,
+    UnresolvedConstructTemplate, UnresolvedDatatypeConstraint, UnresolvedExpression,
+    UnresolvedHydrationSpec, UnresolvedNestedSelectSpec, UnresolvedOptions, UnresolvedPathExpr,
+    UnresolvedPattern, UnresolvedQuery, UnresolvedRoot, UnresolvedSelection,
+    UnresolvedSelectionSpec, UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm,
+    UnresolvedTriplePattern, UnresolvedValue,
 };
 use super::encode::{IriEncoder, NoEncoder};
 use super::error::{ParseError, Result};
@@ -19,8 +19,8 @@ use crate::context::WellKnownDatatypes;
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::QueryOptions;
 use crate::ir::{
-    ConstructTemplate, HydrationSpec, NestedSelectSpec, Query, QueryOutput, Root, Selection,
-    SelectionSpec,
+    Column, ConstructTemplate, HydrationSpec, Multiplicity, NestedSelectSpec, Projection, Query,
+    QueryOutput, Root, SelectionSpec,
 };
 use crate::ir::{
     Expression, Function, IndexSearchPattern, IndexSearchTarget, PathModifier, Pattern,
@@ -87,8 +87,8 @@ pub(crate) fn lower_query<E: IriEncoder>(
 ) -> Result<Query> {
     let mut pp_counter: u32 = 0;
 
-    // Lower selections (variables and any hydration)
-    let selections: Vec<Selection> = ast
+    // Lower columns (variables and any hydration)
+    let columns: Vec<Column> = ast
         .select
         .iter()
         .map(|sel| lower_selection(sel, encoder, vars))
@@ -106,11 +106,19 @@ pub(crate) fn lower_query<E: IriEncoder>(
     let options = lower_options(&ast.options, vars)?;
 
     // Build QueryOutput from mode + lowered components
-    let shape = ast.select_shape;
     let output = match select_mode {
-        SelectMode::Many => QueryOutput::Select { selections, shape },
-        SelectMode::One => QueryOutput::SelectOne { selections, shape },
-        SelectMode::Wildcard => QueryOutput::Wildcard,
+        SelectMode::Many => QueryOutput::Select {
+            projection: build_projection(columns, ast.select_shape),
+            multiplicity: Multiplicity::All,
+        },
+        SelectMode::One => QueryOutput::Select {
+            projection: build_projection(columns, ast.select_shape),
+            multiplicity: Multiplicity::One,
+        },
+        SelectMode::Wildcard => QueryOutput::Select {
+            projection: Projection::Wildcard,
+            multiplicity: Multiplicity::All,
+        },
         SelectMode::Construct => {
             let template = match ast.construct_template {
                 Some(ref t) => lower_construct_template(t, encoder, vars)?,
@@ -135,12 +143,27 @@ fn lower_selection<E: IriEncoder>(
     sel: &UnresolvedSelection,
     encoder: &E,
     vars: &mut VarRegistry,
-) -> Result<Selection> {
+) -> Result<Column> {
     match sel {
-        UnresolvedSelection::Var(name) => Ok(Selection::Var(vars.get_or_insert(name))),
+        UnresolvedSelection::Var(name) => Ok(Column::Var(vars.get_or_insert(name))),
         UnresolvedSelection::Hydration(spec) => {
-            Ok(Selection::Hydration(lower_hydration(spec, encoder, vars)?))
+            Ok(Column::Hydration(lower_hydration(spec, encoder, vars)?))
         }
+    }
+}
+
+/// Build the appropriate `Projection` variant from lowered columns and the
+/// user-declared shape from the input syntax (`Tuple` for array form,
+/// `Scalar` for bare-string form).
+fn build_projection(columns: Vec<Column>, shape: SelectShape) -> Projection {
+    match shape {
+        SelectShape::Scalar if columns.len() == 1 => {
+            Projection::Scalar(columns.into_iter().next().unwrap())
+        }
+        // Multi-column scalar is unrepresentable; the parser only sets
+        // Scalar for bare-string `select: "?x"` so this branch is just a
+        // safety net — fall through to Tuple.
+        _ => Projection::Tuple(columns),
     }
 }
 

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -35,10 +35,11 @@ use fluree_db_core::{FlakeValue, Sid};
 use fluree_graph_json_ld::ParsedContext;
 use std::sync::Arc;
 
-/// Select mode determines result shape
+/// Select mode determines result shape.
 ///
-/// This is derived from the parsed query (select vs selectOne vs construct) and controls
-/// whether the formatter returns an array, single value, or JSON-LD graph.
+/// Derived from the parsed query (select / selectOne / construct / ask).
+/// Wildcard (`select: "*"`) is not represented here — it lives entirely in
+/// the projection (`UnresolvedProjection::Wildcard`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum SelectMode {
     /// Normal select: return array of rows
@@ -47,12 +48,6 @@ pub(crate) enum SelectMode {
 
     /// selectOne: return first row or null
     One,
-
-    /// Wildcard (*): return all bound variables as object
-    ///
-    /// Uses `batch.schema()` to get all variables, not just select.
-    /// Omits unbound/poisoned variables from output.
-    Wildcard,
 
     /// CONSTRUCT: return JSON-LD graph `{"@context": ..., "@graph": [...]}`
     ///
@@ -110,10 +105,6 @@ pub(crate) fn lower_query<E: IriEncoder>(
         SelectMode::One => QueryOutput::Select {
             projection,
             multiplicity: Multiplicity::One,
-        },
-        SelectMode::Wildcard => QueryOutput::Select {
-            projection: Projection::Wildcard,
-            multiplicity: Multiplicity::All,
         },
         SelectMode::Construct => {
             let template = match ast.construct_template {

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -1696,7 +1696,7 @@ mod tests {
 
         let query = lower_query(ast, &encoder, &mut vars, SelectMode::Many).unwrap();
 
-        assert_eq!(query.output.select_vars().unwrap().len(), 2);
+        assert_eq!(query.output.projected_vars().unwrap().len(), 2);
         assert_eq!(query.patterns.len(), 1);
         assert_eq!(vars.len(), 2);
         assert!(matches!(query.output, QueryOutput::Select { .. }));

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -59,7 +59,7 @@ pub(crate) enum SelectMode {
     ///
     /// No variables are projected. LIMIT 1 is applied internally for efficiency.
     /// Result format: `{"head": {}, "boolean": true|false}`
-    Boolean,
+    Ask,
 }
 
 /// Lower an unresolved query to a resolved [`Query`]
@@ -113,7 +113,7 @@ pub(crate) fn lower_query<E: IriEncoder>(
             };
             QueryOutput::Construct(template)
         }
-        SelectMode::Boolean => QueryOutput::Boolean,
+        SelectMode::Ask => QueryOutput::Ask,
     };
 
     Ok(Query {

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -157,7 +157,7 @@ fn parse_query_ast_internal(
         )?;
         // LIMIT 1 for efficiency — only need to know if any solution exists
         query.options.limit = Some(1);
-        return Ok((query, SelectMode::Boolean));
+        return Ok((query, SelectMode::Ask));
     }
 
     // Determine select mode based on which key is present.

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -47,9 +47,9 @@ pub use lower::{lower_unresolved_pattern, lower_unresolved_patterns};
 pub use policy::{JsonLdParseCtx, JsonLdParsePolicy};
 pub use where_clause::parse_where_with_counters;
 
-use crate::ir::{Expression, ProjectionShape, Query};
+use crate::ir::{Expression, Query};
 use crate::var_registry::VarRegistry;
-use ast::UnresolvedPathExpr;
+use ast::{SelectShape, UnresolvedPathExpr};
 use fluree_graph_json_ld::{parse_context, ParsedContext};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -552,7 +552,7 @@ fn parse_select(
         JsonValue::Array(arr) => {
             // Record shape: array form always yields tuple rows, regardless of
             // how many items are inside (`["?x"]` → `[[v1],[v2]]`, not `[v1,v2]`).
-            query.select_shape = ProjectionShape::Tuple;
+            query.select_shape = SelectShape::Tuple;
             for item in arr {
                 match item {
                     JsonValue::String(s) => {
@@ -579,7 +579,7 @@ fn parse_select(
 
         // Case 1: Single string form: "?x" — bare variable, scalar shape.
         JsonValue::String(s) => {
-            query.select_shape = ProjectionShape::Scalar;
+            query.select_shape = SelectShape::Scalar;
             parse_select_string(s, query)?;
         }
 

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -192,7 +192,7 @@ fn parse_query_ast_internal(
         parse_select(select, &ctx, &mut query)?;
     }
 
-    // Parse depth parameter and apply to hydrationion if present
+    // Parse depth parameter and apply to hydration if present
     if let Some(gs) = query.hydration_mut() {
         gs.depth = options::parse_depth(obj)?;
     }
@@ -864,9 +864,7 @@ fn parse_hydration_object(
 }
 
 /// Build an optional boxed nested select spec, returning `None` when empty.
-fn make_nested_spec(
-    level: UnresolvedNestedSelectSpec,
-) -> Option<Box<UnresolvedNestedSelectSpec>> {
+fn make_nested_spec(level: UnresolvedNestedSelectSpec) -> Option<Box<UnresolvedNestedSelectSpec>> {
     if level.is_empty() {
         None
     } else {
@@ -901,10 +899,8 @@ fn parse_selection_level(
     let mut forward: Vec<UnresolvedForwardItem> = Vec::new();
     let mut refinements: std::collections::HashMap<String, Box<UnresolvedNestedSelectSpec>> =
         std::collections::HashMap::new();
-    let mut reverse: std::collections::HashMap<
-        String,
-        Option<Box<UnresolvedNestedSelectSpec>>,
-    > = std::collections::HashMap::new();
+    let mut reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>> =
+        std::collections::HashMap::new();
 
     for item in arr {
         match item {
@@ -985,10 +981,12 @@ fn parse_selection_level(
         // `refinements` (they refine the wildcard's per-property recursion).
         // Plain `Id` entries are redundant under wildcard and are dropped.
         for item in forward {
-            if let UnresolvedForwardItem::Property { predicate, sub_spec } = item {
-                if let Some(boxed) = sub_spec {
-                    refinements.insert(predicate, boxed);
-                }
+            if let UnresolvedForwardItem::Property {
+                predicate,
+                sub_spec: Some(boxed),
+            } = item
+            {
+                refinements.insert(predicate, boxed);
             }
         }
         Ok(UnresolvedNestedSelectSpec::Wildcard {
@@ -1369,7 +1367,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type_hydration() {
+    fn test_type_expansion() {
         let json = json!({
             "@context": { "ex": "http://example.org/" },
             "select": ["?s"],
@@ -1481,7 +1479,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vocab_hydration() {
+    fn test_vocab_expansion() {
         let json = json!({
             "@context": {
                 "@vocab": "http://schema.org/"
@@ -1854,7 +1852,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_value_hydration() {
+    fn test_reference_value_expansion() {
         // String values for @id-typed properties should expand to IRIs
         let json = json!({
             "@context": {

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -35,10 +35,10 @@ pub mod where_clause;
 pub use ast::{
     encode_datatype_constraint, LiteralValue, UnresolvedAggregateFn, UnresolvedAggregateSpec,
     UnresolvedConstructTemplate, UnresolvedDatatypeConstraint, UnresolvedExpression,
-    UnresolvedFilterValue, UnresolvedHydrationSpec, UnresolvedNestedSelectSpec,
-    UnresolvedOptions, UnresolvedPattern, UnresolvedQuery, UnresolvedRoot, UnresolvedSelectionSpec,
-    UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm, UnresolvedTriplePattern,
-    UnresolvedValue,
+    UnresolvedFilterValue, UnresolvedForwardItem, UnresolvedHydrationSpec,
+    UnresolvedNestedSelectSpec, UnresolvedOptions, UnresolvedPattern, UnresolvedQuery,
+    UnresolvedRoot, UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm,
+    UnresolvedTriplePattern, UnresolvedValue,
 };
 pub use encode::{IriEncoder, MemoryEncoder, NoEncoder};
 pub use error::{ParseError, Result};
@@ -854,42 +854,24 @@ fn parse_hydration_object(
         ParseError::InvalidSelect("graph-select value must be an array".to_string())
     })?;
 
-    let specs = parse_selection_specs(specs_arr, ctx)?;
+    let level = parse_selection_level(specs_arr, ctx)?;
 
     Ok(UnresolvedHydrationSpec {
         root,
-        selections: specs.forward,
-        reverse: specs.reverse,
+        level,
         depth: 0, // Will be set later from query-level "depth" parameter
-        has_wildcard: specs.has_wildcard,
     })
 }
 
 /// Build an optional boxed nested select spec, returning `None` when empty.
 fn make_nested_spec(
-    forward: Vec<UnresolvedSelectionSpec>,
-    reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
-    has_wildcard: bool,
+    level: UnresolvedNestedSelectSpec,
 ) -> Option<Box<UnresolvedNestedSelectSpec>> {
-    if forward.is_empty() && reverse.is_empty() {
+    if level.is_empty() {
         None
     } else {
-        Some(Box::new(UnresolvedNestedSelectSpec::new(
-            forward,
-            reverse,
-            has_wildcard,
-        )))
+        Some(Box::new(level))
     }
-}
-
-/// Parsed selection specifications with forward and reverse properties separated.
-struct SelectionSpecs {
-    /// Forward (normal) property selections
-    forward: Vec<UnresolvedSelectionSpec>,
-    /// Reverse property selections mapped by predicate IRI
-    reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>>,
-    /// Whether a wildcard (*) was present
-    has_wildcard: bool,
 }
 
 /// If `key` uses the inline `@reverse:...` form, return the target predicate IRI
@@ -909,23 +891,30 @@ fn parse_inline_reverse_key(key: &str, ctx: &JsonLdParseCtx) -> Result<Option<St
     Ok(Some(expanded))
 }
 
-/// Parse selection specs array, separating forward and reverse properties.
-fn parse_selection_specs(arr: &[JsonValue], ctx: &JsonLdParseCtx) -> Result<SelectionSpecs> {
-    let mut forward = Vec::new();
-    let mut reverse: std::collections::HashMap<String, Option<Box<UnresolvedNestedSelectSpec>>> =
+/// Parse a selection-level array (the value of a hydration `{key: [...]}`)
+/// into either a `Wildcard` or `Explicit` level.
+fn parse_selection_level(
+    arr: &[JsonValue],
+    ctx: &JsonLdParseCtx,
+) -> Result<UnresolvedNestedSelectSpec> {
+    let mut wildcard = false;
+    let mut forward: Vec<UnresolvedForwardItem> = Vec::new();
+    let mut refinements: std::collections::HashMap<String, Box<UnresolvedNestedSelectSpec>> =
         std::collections::HashMap::new();
-    let mut has_wildcard = false;
+    let mut reverse: std::collections::HashMap<
+        String,
+        Option<Box<UnresolvedNestedSelectSpec>>,
+    > = std::collections::HashMap::new();
 
     for item in arr {
         match item {
             // Wildcard: "*"
             JsonValue::String(s) if s == "*" => {
-                forward.push(UnresolvedSelectionSpec::Wildcard);
-                has_wildcard = true;
+                wildcard = true;
             }
             // Explicit @id selection
             JsonValue::String(s) if s == "@id" || s == "id" || s == ctx.context.id_key.as_str() => {
-                forward.push(UnresolvedSelectionSpec::Id);
+                forward.push(UnresolvedForwardItem::Id);
             }
             // Property name: "ex:name" or inline "@reverse:ex:friend"
             JsonValue::String(s) => {
@@ -933,13 +922,10 @@ fn parse_selection_specs(arr: &[JsonValue], ctx: &JsonLdParseCtx) -> Result<Sele
                     reverse.insert(rev_iri, None);
                 } else {
                     let (expanded, entry) = ctx.expand_vocab(s)?;
-                    // Check if this is a reverse property from @context
-                    // (reverse field is Option<String> with the reversed property IRI)
                     if let Some(rev_iri) = entry.and_then(|e| e.reverse) {
-                        // Reverse property - key by the *actual* predicate IRI to reverse on.
                         reverse.insert(rev_iri, None);
                     } else {
-                        forward.push(UnresolvedSelectionSpec::Property {
+                        forward.push(UnresolvedForwardItem::Property {
                             predicate: expanded,
                             sub_spec: None,
                         });
@@ -960,23 +946,28 @@ fn parse_selection_specs(arr: &[JsonValue], ctx: &JsonLdParseCtx) -> Result<Sele
                     ParseError::InvalidSelect("nested selection value must be an array".to_string())
                 })?;
 
-                // Recursively parse sub-selections - preserves both forward AND reverse
-                let sub_specs = parse_selection_specs(sub_arr, ctx)?;
-
-                let nested_spec =
-                    make_nested_spec(sub_specs.forward, sub_specs.reverse, sub_specs.has_wildcard);
+                let sub_level = parse_selection_level(sub_arr, ctx)?;
+                let nested = make_nested_spec(sub_level);
 
                 if let Some(rev_iri) = parse_inline_reverse_key(pred_str, ctx)? {
-                    reverse.insert(rev_iri, nested_spec);
+                    reverse.insert(rev_iri, nested);
                 } else {
                     let (expanded, entry) = ctx.expand_vocab(pred_str)?;
                     let context_reverse = entry.as_ref().and_then(|e| e.reverse.as_ref());
                     if let Some(rev_iri) = context_reverse {
-                        reverse.insert(rev_iri.clone(), nested_spec);
-                    } else {
-                        forward.push(UnresolvedSelectionSpec::Property {
+                        reverse.insert(rev_iri.clone(), nested);
+                    } else if let Some(boxed) = nested {
+                        // Wildcard refinements only matter when the parent is
+                        // a wildcard; otherwise it's a regular Property entry.
+                        // Decide based on `wildcard` after the loop completes.
+                        forward.push(UnresolvedForwardItem::Property {
                             predicate: expanded,
-                            sub_spec: nested_spec,
+                            sub_spec: Some(boxed),
+                        });
+                    } else {
+                        forward.push(UnresolvedForwardItem::Property {
+                            predicate: expanded,
+                            sub_spec: None,
                         });
                     }
                 }
@@ -989,11 +980,24 @@ fn parse_selection_specs(arr: &[JsonValue], ctx: &JsonLdParseCtx) -> Result<Sele
         }
     }
 
-    Ok(SelectionSpecs {
-        forward,
-        reverse,
-        has_wildcard,
-    })
+    if wildcard {
+        // For a wildcard level, fold any explicit Property entries back into
+        // `refinements` (they refine the wildcard's per-property recursion).
+        // Plain `Id` entries are redundant under wildcard and are dropped.
+        for item in forward {
+            if let UnresolvedForwardItem::Property { predicate, sub_spec } = item {
+                if let Some(boxed) = sub_spec {
+                    refinements.insert(predicate, boxed);
+                }
+            }
+        }
+        Ok(UnresolvedNestedSelectSpec::Wildcard {
+            refinements,
+            reverse,
+        })
+    } else {
+        Ok(UnresolvedNestedSelectSpec::Explicit { forward, reverse })
+    }
 }
 
 // parse_depth moved to options module

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -559,7 +559,7 @@ fn parse_select(
                         columns.push(parse_select_string(s, &mut query.options.aggregates)?);
                     }
                     JsonValue::Object(map) => {
-                        let spec = parse_hydration_object(map, ctx, query)?;
+                        let spec = parse_hydration_object(map, ctx)?;
                         columns.push(UnresolvedColumn::Hydration(spec));
                     }
                     _ => {
@@ -575,7 +575,7 @@ fn parse_select(
         // Case 4: Single object form: {"?person": ["*"]} — one hydration
         // column wrapped as a Tuple (SPARQL has no scalar object form).
         JsonValue::Object(map) => {
-            let spec = parse_hydration_object(map, ctx, query)?;
+            let spec = parse_hydration_object(map, ctx)?;
             query.select = UnresolvedProjection::Tuple(vec![UnresolvedColumn::Hydration(spec)]);
         }
 
@@ -823,19 +823,15 @@ fn parse_aggregate_fn_and_input(
     Ok((function, input.to_string()))
 }
 
-/// Parse a hydration object like `{"?person": ["*", {"ex:friend": ["*"]}]}`
+/// Parse a hydration object like `{"?person": ["*", {"ex:friend": ["*"]}]}`.
+///
+/// Multiple hydration objects in one select clause are permitted; each
+/// becomes its own `Column::Hydration` and the formatter dispatches per
+/// column.
 fn parse_hydration_object(
     map: &serde_json::Map<String, JsonValue>,
     ctx: &JsonLdParseCtx,
-    query: &UnresolvedQuery,
 ) -> Result<UnresolvedHydrationSpec> {
-    // Error if we already have a hydration (only one allowed)
-    if query.has_hydration() {
-        return Err(ParseError::InvalidSelect(
-            "only one graph-select object allowed per query".to_string(),
-        ));
-    }
-
     // Must have exactly one key
     if map.len() != 1 {
         return Err(ParseError::InvalidSelect(
@@ -3355,6 +3351,118 @@ mod tests {
                 assert_eq!(vsp.metric.as_ref(), "cosine");
             }
             _ => panic!("Expected VectorSearch pattern"),
+        }
+    }
+
+    // ---- multi-hydration parsing ----
+
+    #[test]
+    fn test_parse_two_hydration_columns() {
+        // Two var-rooted hydrations in one select clause.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                {"?person": ["*"]},
+                {"?org": ["*", {"ex:member": ["*"]}]}
+            ],
+            "where": {
+                "@id": "?person",
+                "ex:worksFor": "?org"
+            }
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let columns = ast.select.columns();
+        assert_eq!(columns.len(), 2);
+
+        let spec0 = columns[0]
+            .as_hydration()
+            .expect("first column should be a hydration");
+        assert!(matches!(&spec0.root, UnresolvedRoot::Var(v) if v.as_ref() == "?person"));
+
+        let spec1 = columns[1]
+            .as_hydration()
+            .expect("second column should be a hydration");
+        assert!(matches!(&spec1.root, UnresolvedRoot::Var(v) if v.as_ref() == "?org"));
+    }
+
+    #[test]
+    fn test_parse_mixed_var_and_constant_root_hydrations() {
+        // One var-rooted hydration plus one IRI-constant-rooted hydration.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                {"?person": ["*"]},
+                {"ex:alice": ["ex:name"]}
+            ],
+            "where": { "@id": "?person", "ex:active": true }
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let columns = ast.select.columns();
+        assert_eq!(columns.len(), 2);
+        assert!(matches!(
+            &columns[0].as_hydration().unwrap().root,
+            UnresolvedRoot::Var(_)
+        ));
+        assert!(matches!(
+            &columns[1].as_hydration().unwrap().root,
+            UnresolvedRoot::Iri(_)
+        ));
+    }
+
+    #[test]
+    fn test_parse_mixes_hydration_with_var_columns() {
+        // Hydration columns interleaved with plain variable columns.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                "?age",
+                {"?person": ["*"]},
+                "?title",
+                {"?org": ["*"]}
+            ],
+            "where": {
+                "@id": "?person",
+                "ex:age": "?age",
+                "ex:title": "?title",
+                "ex:worksFor": "?org"
+            }
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let columns = ast.select.columns();
+        assert_eq!(columns.len(), 4);
+        assert_eq!(columns[0].var_name().unwrap(), "?age");
+        assert!(columns[1].as_hydration().is_some());
+        assert_eq!(columns[2].var_name().unwrap(), "?title");
+        assert!(columns[3].as_hydration().is_some());
+    }
+
+    #[test]
+    fn test_depth_option_applies_to_every_hydration_column() {
+        // The query-level `depth` option must reach every hydration spec.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                {"?person": ["*"]},
+                {"?org": ["*"]}
+            ],
+            "depth": 2,
+            "where": {
+                "@id": "?person",
+                "ex:worksFor": "?org"
+            }
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let columns = ast.select.columns();
+        assert_eq!(columns.len(), 2);
+        for column in columns {
+            let spec = column
+                .as_hydration()
+                .expect("every column should be a hydration");
+            assert_eq!(spec.depth, 2);
         }
     }
 }

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -49,7 +49,7 @@ pub use where_clause::parse_where_with_counters;
 
 use crate::ir::{Expression, Query};
 use crate::var_registry::VarRegistry;
-use ast::{SelectShape, UnresolvedPathExpr};
+use ast::{UnresolvedColumn, UnresolvedPathExpr, UnresolvedProjection};
 use fluree_graph_json_ld::{parse_context, ParsedContext};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -278,11 +278,9 @@ fn parse_query_ast_internal(
             let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
             query.options.order_by = query
                 .select
+                .columns()
                 .iter()
-                .filter_map(|sel| match sel {
-                    crate::parse::ast::UnresolvedSelection::Var(name) => Some(name.as_ref()),
-                    crate::parse::ast::UnresolvedSelection::Hydration(_) => None,
-                })
+                .filter_map(UnresolvedColumn::var_name)
                 .filter(|s| s.starts_with('?'))
                 .filter(|s| seen.insert(*s))
                 .map(crate::parse::ast::UnresolvedSortSpec::asc)
@@ -548,11 +546,10 @@ fn parse_select(
     query: &mut UnresolvedQuery,
 ) -> Result<()> {
     match select {
-        // Case 2, 3, 5: Array form - could be simple vars, mixed, or with aggregates
+        // Case 2, 3, 5: Array form — tuple-shaped rows of any arity.
+        // (`["?x"]` → `[[v]]`, `["?x", "?y"]` → `[[v1, v2]]`, etc.)
         JsonValue::Array(arr) => {
-            // Record shape: array form always yields tuple rows, regardless of
-            // how many items are inside (`["?x"]` → `[[v1],[v2]]`, not `[v1,v2]`).
-            query.select_shape = SelectShape::Tuple;
+            // The default UnresolvedProjection is Tuple(empty); push columns in.
             for item in arr {
                 match item {
                     JsonValue::String(s) => {
@@ -572,6 +569,8 @@ fn parse_select(
         }
 
         // Case 4: Single object form: {"?person": ["*"]}
+        // Stored as a one-column Tuple — formatters can't tell this apart
+        // from `["{"?person": ["*"]}"]`, and SPARQL has no scalar form.
         JsonValue::Object(map) => {
             let spec = parse_hydration_object(map, ctx, query)?;
             query.add_hydration(spec);
@@ -579,8 +578,18 @@ fn parse_select(
 
         // Case 1: Single string form: "?x" — bare variable, scalar shape.
         JsonValue::String(s) => {
-            query.select_shape = SelectShape::Scalar;
+            // Promote the (empty) default projection to Scalar by parsing
+            // the column first and then wrapping.
             parse_select_string(s, query)?;
+            // The string may have been an aggregate that registered a
+            // computed output var as a single Var column; either way,
+            // promote that single column into Scalar form.
+            query.select = match std::mem::take(&mut query.select) {
+                UnresolvedProjection::Tuple(mut cs) if cs.len() == 1 => {
+                    UnresolvedProjection::Scalar(cs.pop().unwrap())
+                }
+                other => other,
+            };
         }
 
         _ => {
@@ -1108,8 +1117,8 @@ mod tests {
 
         let (ast, _) = parse_query_ast(&json, None).unwrap();
 
-        assert_eq!(ast.select.len(), 1);
-        assert_eq!(ast.select[0].var_name().unwrap(), "?name");
+        assert_eq!(ast.select.columns().len(), 1);
+        assert_eq!(ast.select.columns()[0].var_name().unwrap(), "?name");
         assert_eq!(ast.patterns.len(), 2); // @type + name
     }
 
@@ -2095,7 +2104,7 @@ mod tests {
 
         // Empty select should parse (though semantically questionable)
         let (ast, _) = parse_query_ast(&json, None).unwrap();
-        assert!(ast.select.is_empty());
+        assert!(ast.select.columns().is_empty());
     }
 
     #[test]
@@ -2143,7 +2152,7 @@ mod tests {
         });
 
         let (ast, _) = parse_query_ast(&json, None).unwrap();
-        assert_eq!(ast.select.len(), 2);
+        assert_eq!(ast.select.columns().len(), 2);
     }
 
     #[test]
@@ -2999,9 +3008,9 @@ mod tests {
         let (ast, _) = parse_query_ast(&json, None).unwrap();
 
         // Check select has both vars
-        assert_eq!(ast.select.len(), 2);
-        assert_eq!(ast.select[0].var_name().unwrap(), "?name");
-        assert_eq!(ast.select[1].var_name().unwrap(), "?count");
+        assert_eq!(ast.select.columns().len(), 2);
+        assert_eq!(ast.select.columns()[0].var_name().unwrap(), "?name");
+        assert_eq!(ast.select.columns()[1].var_name().unwrap(), "?count");
 
         // Check aggregate was parsed
         assert_eq!(ast.options.aggregates.len(), 1);
@@ -3041,8 +3050,8 @@ mod tests {
 
         let (ast, _) = parse_query_ast(&json, None).unwrap();
 
-        assert_eq!(ast.select.len(), 1);
-        assert_eq!(ast.select[0].var_name().unwrap(), "?sum");
+        assert_eq!(ast.select.columns().len(), 1);
+        assert_eq!(ast.select.columns()[0].var_name().unwrap(), "?sum");
 
         assert_eq!(ast.options.aggregates.len(), 1);
         let agg = &ast.options.aggregates[0];

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -35,7 +35,7 @@ pub mod where_clause;
 pub use ast::{
     encode_datatype_constraint, LiteralValue, UnresolvedAggregateFn, UnresolvedAggregateSpec,
     UnresolvedConstructTemplate, UnresolvedDatatypeConstraint, UnresolvedExpression,
-    UnresolvedFilterValue, UnresolvedGraphSelectSpec, UnresolvedNestedSelectSpec,
+    UnresolvedFilterValue, UnresolvedHydrationSpec, UnresolvedNestedSelectSpec,
     UnresolvedOptions, UnresolvedPattern, UnresolvedQuery, UnresolvedRoot, UnresolvedSelectionSpec,
     UnresolvedSortDirection, UnresolvedSortSpec, UnresolvedTerm, UnresolvedTriplePattern,
     UnresolvedValue,
@@ -194,8 +194,8 @@ fn parse_query_ast_internal(
         parse_select(select, &ctx, &mut query)?;
     }
 
-    // Parse depth parameter and apply to graph_select if present
-    if let Some(ref mut gs) = query.graph_select {
+    // Parse depth parameter and apply to hydrationion if present
+    if let Some(gs) = query.hydration_mut() {
         gs.depth = options::parse_depth(obj)?;
     }
 
@@ -210,7 +210,7 @@ fn parse_query_ast_internal(
 
     // Parse where clause.
     //
-    // Graph crawl queries like {"select": {"ex:dan": ["*"]}} are allowed.
+    // Hydration queries like {"select": {"ex:dan": ["*"]}} are allowed.
     // without an explicit WHERE clause (root may be an IRI constant).
     let object_var_parsing = options::parse_object_var_parsing(obj);
     if let Some(where_clause) = obj.get("where") {
@@ -222,9 +222,9 @@ fn parse_query_ast_internal(
             nested_counter,
             object_var_parsing,
         )?;
-    } else if query.graph_select.is_some() {
-        // Allowed: graph crawl-only query with no WHERE.
-        // Execution will produce an empty solution set, and graph crawl formatting will use the root
+    } else if query.hydration().is_some() {
+        // Allowed: hydration-only query with no WHERE.
+        // Execution will produce an empty solution set, and hydration formatting will use the root
         // (constant root emits one row; variable root yields no rows).
     } else if !query
         .patterns
@@ -279,16 +279,13 @@ fn parse_query_ast_internal(
             query.options.order_by = query
                 .select
                 .iter()
-                .filter_map(|v| {
-                    let s = v.as_ref();
-                    if !s.starts_with('?') {
-                        return None;
-                    }
-                    if !seen.insert(s) {
-                        return None;
-                    }
-                    Some(crate::parse::ast::UnresolvedSortSpec::asc(s))
+                .filter_map(|sel| match sel {
+                    crate::parse::ast::UnresolvedSelection::Var(name) => Some(name.as_ref()),
+                    crate::parse::ast::UnresolvedSelection::Hydration(_) => None,
                 })
+                .filter(|s| s.starts_with('?'))
+                .filter(|s| seen.insert(*s))
+                .map(crate::parse::ast::UnresolvedSortSpec::asc)
                 .collect();
         }
     }
@@ -542,8 +539,8 @@ fn parse_construct_template(
 /// Supports five forms:
 /// 1. Single string: `"?x"` - single variable selection (unwrap)
 /// 2. Simple array: `["?x", "?y"]` - flat variable selection
-/// 3. Mixed array: `["?age", {"?person": ["*"]}]` - scalar vars + graph crawl
-/// 4. Single object: `{"?person": ["*"]}` - graph crawl only
+/// 3. Mixed array: `["?age", {"?person": ["*"]}]` - scalar vars + hydration
+/// 4. Single object: `{"?person": ["*"]}` - hydration only
 /// 5. S-expression aggregates: `["?name", "(count ?favNums as ?cnt)"]`
 fn parse_select(
     select: &JsonValue,
@@ -562,8 +559,8 @@ fn parse_select(
                         parse_select_string(s, query)?;
                     }
                     JsonValue::Object(map) => {
-                        let spec = parse_graph_select_object(map, ctx, query)?;
-                        query.graph_select = Some(spec);
+                        let spec = parse_hydration_object(map, ctx, query)?;
+                        query.add_hydration(spec);
                     }
                     _ => {
                         return Err(ParseError::InvalidSelect(
@@ -576,8 +573,8 @@ fn parse_select(
 
         // Case 4: Single object form: {"?person": ["*"]}
         JsonValue::Object(map) => {
-            let spec = parse_graph_select_object(map, ctx, query)?;
-            query.graph_select = Some(spec);
+            let spec = parse_hydration_object(map, ctx, query)?;
+            query.add_hydration(spec);
         }
 
         // Case 1: Single string form: "?x" — bare variable, scalar shape.
@@ -820,16 +817,14 @@ fn parse_aggregate_fn_and_input(
     Ok((function, input.to_string()))
 }
 
-/// Parse a graph crawl select object like `{"?person": ["*", {"ex:friend": ["*"]}]}`
-///
-/// Also adds the root variable to the execution select list.
-fn parse_graph_select_object(
+/// Parse a hydration object like `{"?person": ["*", {"ex:friend": ["*"]}]}`
+fn parse_hydration_object(
     map: &serde_json::Map<String, JsonValue>,
     ctx: &JsonLdParseCtx,
-    query: &mut UnresolvedQuery,
-) -> Result<UnresolvedGraphSelectSpec> {
-    // Error if we already have a graph_select (only one allowed)
-    if query.graph_select.is_some() {
+    query: &UnresolvedQuery,
+) -> Result<UnresolvedHydrationSpec> {
+    // Error if we already have a hydration (only one allowed)
+    if query.hydration().is_some() {
         return Err(ParseError::InvalidSelect(
             "only one graph-select object allowed per query".to_string(),
         ));
@@ -846,8 +841,6 @@ fn parse_graph_select_object(
 
     // Root can be variable OR IRI constant
     let root = if is_variable(root_str) {
-        // Variable root - add to execution select list
-        query.add_select(root_str);
         UnresolvedRoot::Var(Arc::from(root_str.as_str()))
     } else {
         // IRI constant root - expand via @context
@@ -862,7 +855,7 @@ fn parse_graph_select_object(
 
     let specs = parse_selection_specs(specs_arr, ctx)?;
 
-    Ok(UnresolvedGraphSelectSpec {
+    Ok(UnresolvedHydrationSpec {
         root,
         selections: specs.forward,
         reverse: specs.reverse,
@@ -1116,7 +1109,7 @@ mod tests {
         let (ast, _) = parse_query_ast(&json, None).unwrap();
 
         assert_eq!(ast.select.len(), 1);
-        assert_eq!(ast.select[0].as_ref(), "?name");
+        assert_eq!(ast.select[0].var_name().unwrap(), "?name");
         assert_eq!(ast.patterns.len(), 2); // @type + name
     }
 
@@ -1371,7 +1364,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type_expansion() {
+    fn test_type_hydration() {
         let json = json!({
             "@context": { "ex": "http://example.org/" },
             "select": ["?s"],
@@ -1483,7 +1476,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vocab_expansion() {
+    fn test_vocab_hydration() {
         let json = json!({
             "@context": {
                 "@vocab": "http://schema.org/"
@@ -1856,7 +1849,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_value_expansion() {
+    fn test_reference_value_hydration() {
         // String values for @id-typed properties should expand to IRIs
         let json = json!({
             "@context": {
@@ -3007,8 +3000,8 @@ mod tests {
 
         // Check select has both vars
         assert_eq!(ast.select.len(), 2);
-        assert_eq!(ast.select[0].as_ref(), "?name");
-        assert_eq!(ast.select[1].as_ref(), "?count");
+        assert_eq!(ast.select[0].var_name().unwrap(), "?name");
+        assert_eq!(ast.select[1].var_name().unwrap(), "?count");
 
         // Check aggregate was parsed
         assert_eq!(ast.options.aggregates.len(), 1);
@@ -3049,7 +3042,7 @@ mod tests {
         let (ast, _) = parse_query_ast(&json, None).unwrap();
 
         assert_eq!(ast.select.len(), 1);
-        assert_eq!(ast.select[0].as_ref(), "?sum");
+        assert_eq!(ast.select[0].var_name().unwrap(), "?sum");
 
         assert_eq!(ast.options.aggregates.len(), 1);
         let agg = &ast.options.aggregates[0];

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -540,8 +540,12 @@ fn parse_construct_template(
 /// Supports five forms:
 /// 1. Single string: `"?x"` - single variable selection (unwrap)
 /// 2. Simple array: `["?x", "?y"]` - flat variable selection
-/// 3. Mixed array: `["?age", {"?person": ["*"]}]` - scalar vars + hydration
-/// 4. Single object: `{"?person": ["*"]}` - hydration only
+/// 3. Mixed array: `["?age", {"?person": ["*"]}, {"?org": ["*"]}]` - any
+///    combination of variable and hydration columns, in any order; each
+///    object is an independent hydration with its own root, level, and
+///    depth.
+/// 4. Single object: `{"?person": ["*"]}` - one hydration column (rendered
+///    as a bare object per row rather than a single-element array).
 /// 5. S-expression aggregates: `["?name", "(count ?favNums as ?cnt)"]`
 fn parse_select(
     select: &JsonValue,

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -1430,7 +1430,7 @@ mod tests {
         let mut vars = VarRegistry::new();
         let query = parse_query(&json, &encoder, &mut vars, None).unwrap();
 
-        assert_eq!(query.output.select_vars().unwrap().len(), 2);
+        assert_eq!(query.output.projected_vars().unwrap().len(), 2);
         assert_eq!(query.patterns.len(), 1);
 
         // query.patterns now contains Pattern, not TriplePattern

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -177,20 +177,18 @@ fn parse_query_ast_internal(
             implied_distinct = true;
             (select_distinct, SelectMode::Many)
         } else if let Some(select) = obj.get("select") {
-            // Check for wildcard select
-            if select.as_str() == Some("*") {
-                (select, SelectMode::Wildcard)
-            } else {
-                (select, SelectMode::Many)
-            }
+            (select, SelectMode::Many)
         } else {
             return Err(ParseError::MissingField(
                 "select, selectOne, select-one, selectDistinct, select-distinct, construct, or ask",
             ));
         };
 
-    // Parse select clause (skip for wildcard)
-    if select_mode != SelectMode::Wildcard {
+    // Wildcard `select: "*"` lives entirely in the projection; otherwise
+    // dispatch on JSON shape.
+    if select.as_str() == Some("*") {
+        query.select = UnresolvedProjection::Wildcard;
+    } else {
         parse_select(select, &ctx, &mut query)?;
     }
 
@@ -549,15 +547,15 @@ fn parse_select(
         // Case 2, 3, 5: Array form — tuple-shaped rows of any arity.
         // (`["?x"]` → `[[v]]`, `["?x", "?y"]` → `[[v1, v2]]`, etc.)
         JsonValue::Array(arr) => {
-            // The default UnresolvedProjection is Tuple(empty); push columns in.
+            let mut columns = Vec::with_capacity(arr.len());
             for item in arr {
                 match item {
                     JsonValue::String(s) => {
-                        parse_select_string(s, query)?;
+                        columns.push(parse_select_string(s, &mut query.options.aggregates)?);
                     }
                     JsonValue::Object(map) => {
                         let spec = parse_hydration_object(map, ctx, query)?;
-                        query.add_hydration(spec);
+                        columns.push(UnresolvedColumn::Hydration(spec));
                     }
                     _ => {
                         return Err(ParseError::InvalidSelect(
@@ -566,30 +564,20 @@ fn parse_select(
                     }
                 }
             }
+            query.select = UnresolvedProjection::Tuple(columns);
         }
 
-        // Case 4: Single object form: {"?person": ["*"]}
-        // Stored as a one-column Tuple — formatters can't tell this apart
-        // from `["{"?person": ["*"]}"]`, and SPARQL has no scalar form.
+        // Case 4: Single object form: {"?person": ["*"]} — one hydration
+        // column wrapped as a Tuple (SPARQL has no scalar object form).
         JsonValue::Object(map) => {
             let spec = parse_hydration_object(map, ctx, query)?;
-            query.add_hydration(spec);
+            query.select = UnresolvedProjection::Tuple(vec![UnresolvedColumn::Hydration(spec)]);
         }
 
         // Case 1: Single string form: "?x" — bare variable, scalar shape.
         JsonValue::String(s) => {
-            // Promote the (empty) default projection to Scalar by parsing
-            // the column first and then wrapping.
-            parse_select_string(s, query)?;
-            // The string may have been an aggregate that registered a
-            // computed output var as a single Var column; either way,
-            // promote that single column into Scalar form.
-            query.select = match std::mem::take(&mut query.select) {
-                UnresolvedProjection::Tuple(mut cs) if cs.len() == 1 => {
-                    UnresolvedProjection::Scalar(cs.pop().unwrap())
-                }
-                other => other,
-            };
+            let column = parse_select_string(s, &mut query.options.aggregates)?;
+            query.select = UnresolvedProjection::Scalar(column);
         }
 
         _ => {
@@ -602,17 +590,23 @@ fn parse_select(
     Ok(())
 }
 
-/// Parse a string in the select clause
+/// Parse a string item from the select clause into a column.
 ///
-/// Handles three cases:
-/// - Wildcard: `"*"`
+/// Handles two cases:
 /// - Variable: `"?name"`
-/// - S-expression aggregate: `"(count ?x)"` or `"(as (count ?x) ?cnt)"`
-fn parse_select_string(s: &str, query: &mut UnresolvedQuery) -> Result<()> {
+/// - S-expression aggregate: `"(count ?x)"` or `"(as (count ?x) ?cnt)"` —
+///   the spec is appended to `aggregates` and the output var becomes the
+///   returned column.
+///
+/// Wildcard (`"*"`) is rejected here; it must be the entire `select` value
+/// and is handled at the top-level dispatch in `parse_query_inner`.
+fn parse_select_string(
+    s: &str,
+    aggregates: &mut Vec<ast::UnresolvedAggregateSpec>,
+) -> Result<UnresolvedColumn> {
     let trimmed = s.trim();
 
     if trimmed == "*" {
-        // Wildcard select - handled elsewhere
         return Err(ParseError::InvalidSelect(
             "wildcard '*' must be the only select item".to_string(),
         ));
@@ -621,16 +615,14 @@ fn parse_select_string(s: &str, query: &mut UnresolvedQuery) -> Result<()> {
     if trimmed.starts_with('(') {
         // S-expression: aggregate function call
         let agg_spec = parse_aggregate_sexpr(trimmed)?;
-        // Add output var to select
-        query.add_select(&agg_spec.output_var);
-        query.options.aggregates.push(agg_spec);
+        let column = UnresolvedColumn::Var(Arc::from(agg_spec.output_var.as_ref()));
+        aggregates.push(agg_spec);
+        Ok(column)
     } else {
         // Must be a variable - use validate_var_name for consistent error handling
         validate_var_name(trimmed)?;
-        query.add_select(trimmed);
+        Ok(UnresolvedColumn::Var(Arc::from(trimmed)))
     }
-
-    Ok(())
 }
 
 // SexprToken and tokenization moved to sexpr_tokenize module

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -192,9 +192,14 @@ fn parse_query_ast_internal(
         parse_select(select, &ctx, &mut query)?;
     }
 
-    // Parse depth parameter and apply to hydration if present
-    if let Some(gs) = query.hydration_mut() {
-        gs.depth = options::parse_depth(obj)?;
+    // Parse depth parameter and apply to every hydration column.
+    if query.has_hydration() {
+        let depth = options::parse_depth(obj)?;
+        for column in query.select.columns_mut() {
+            if let UnresolvedColumn::Hydration(spec) = column {
+                spec.depth = depth;
+            }
+        }
     }
 
     // Parse top-level VALUES (optional) - mirrors the `:values` initial solution seed.
@@ -220,7 +225,7 @@ fn parse_query_ast_internal(
             nested_counter,
             object_var_parsing,
         )?;
-    } else if query.hydration().is_some() {
+    } else if query.has_hydration() {
         // Allowed: hydration-only query with no WHERE.
         // Execution will produce an empty solution set, and hydration formatting will use the root
         // (constant root emits one row; variable root yields no rows).
@@ -825,7 +830,7 @@ fn parse_hydration_object(
     query: &UnresolvedQuery,
 ) -> Result<UnresolvedHydrationSpec> {
     // Error if we already have a hydration (only one allowed)
-    if query.hydration().is_some() {
+    if query.has_hydration() {
         return Err(ParseError::InvalidSelect(
             "only one graph-select object allowed per query".to_string(),
         ));

--- a/fluree-db-query/src/rewrite.rs
+++ b/fluree-db-query/src/rewrite.rs
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type_expansion() {
+    fn test_type_hydration() {
         let interner = SidInterner::new();
         let animal = interner.intern(100, "Animal");
 
@@ -740,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn test_optional_pattern_expansion() {
+    fn test_optional_pattern_hydration() {
         let interner = SidInterner::new();
         let animal = interner.intern(100, "Animal");
 
@@ -921,7 +921,7 @@ mod tests {
     }
 
     #[test]
-    fn test_predicate_expansion() {
+    fn test_predicate_hydration() {
         let interner = SidInterner::new();
         let has_color = interner.intern(100, "hasColor");
 
@@ -1061,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    fn test_combined_type_and_predicate_expansion() {
+    fn test_combined_type_and_predicate_hydration() {
         // Test that both type and predicate expansion work together
         let interner = SidInterner::new();
 

--- a/fluree-db-query/src/rewrite.rs
+++ b/fluree-db-query/src/rewrite.rs
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type_hydration() {
+    fn test_type_expansion() {
         let interner = SidInterner::new();
         let animal = interner.intern(100, "Animal");
 
@@ -740,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn test_optional_pattern_hydration() {
+    fn test_optional_pattern_expansion() {
         let interner = SidInterner::new();
         let animal = interner.intern(100, "Animal");
 
@@ -921,7 +921,7 @@ mod tests {
     }
 
     #[test]
-    fn test_predicate_hydration() {
+    fn test_predicate_expansion() {
         let interner = SidInterner::new();
         let has_color = interner.intern(100, "hasColor");
 
@@ -1061,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    fn test_combined_type_and_predicate_hydration() {
+    fn test_combined_type_and_predicate_expansion() {
         // Test that both type and predicate expansion work together
         let interner = SidInterner::new();
 

--- a/fluree-db-query/src/rewrite_owl_ql.rs
+++ b/fluree-db-query/src/rewrite_owl_ql.rs
@@ -931,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_ontology_no_expansion() {
+    fn test_empty_ontology_no_hydration() {
         let interner = SidInterner::new();
         let has_friend = interner.intern(100, "hasFriend");
 
@@ -950,7 +950,7 @@ mod tests {
     }
 
     #[test]
-    fn test_inverse_of_expansion() {
+    fn test_inverse_of_hydration() {
         let interner = SidInterner::new();
         let has_friend = interner.intern(100, "hasFriend");
 
@@ -996,7 +996,7 @@ mod tests {
     }
 
     #[test]
-    fn test_domain_type_query_expansion() {
+    fn test_domain_type_query_hydration() {
         let interner = SidInterner::new();
         let person = interner.intern(100, "Person");
 
@@ -1022,7 +1022,7 @@ mod tests {
     }
 
     #[test]
-    fn test_range_type_query_expansion() {
+    fn test_range_type_query_hydration() {
         let interner = SidInterner::new();
         let location = interner.intern(100, "Location");
 
@@ -1098,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_pattern_expansion() {
+    fn test_nested_pattern_hydration() {
         let interner = SidInterner::new();
         let has_friend = interner.intern(100, "hasFriend");
 

--- a/fluree-db-query/src/rewrite_owl_ql.rs
+++ b/fluree-db-query/src/rewrite_owl_ql.rs
@@ -931,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_ontology_no_hydration() {
+    fn test_empty_ontology_no_expansion() {
         let interner = SidInterner::new();
         let has_friend = interner.intern(100, "hasFriend");
 
@@ -950,7 +950,7 @@ mod tests {
     }
 
     #[test]
-    fn test_inverse_of_hydration() {
+    fn test_inverse_of_expansion() {
         let interner = SidInterner::new();
         let has_friend = interner.intern(100, "hasFriend");
 
@@ -996,7 +996,7 @@ mod tests {
     }
 
     #[test]
-    fn test_domain_type_query_hydration() {
+    fn test_domain_type_query_expansion() {
         let interner = SidInterner::new();
         let person = interner.intern(100, "Person");
 
@@ -1022,7 +1022,7 @@ mod tests {
     }
 
     #[test]
-    fn test_range_type_query_hydration() {
+    fn test_range_type_query_expansion() {
         let interner = SidInterner::new();
         let location = interner.intern(100, "Location");
 
@@ -1098,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_pattern_hydration() {
+    fn test_nested_pattern_expansion() {
         let interner = SidInterner::new();
         let has_friend = interner.intern(100, "hasFriend");
 

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -36,7 +36,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
     let output = if select.is_empty() {
         QueryOutput::wildcard()
     } else {
-        QueryOutput::select_vars(select)
+        QueryOutput::select_all(select)
     };
     Query {
         context: ParsedContext::default(),

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -36,7 +36,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
     let output = if select.is_empty() {
         QueryOutput::wildcard()
     } else {
-        QueryOutput::select(select)
+        QueryOutput::select_vars(select)
     };
     Query {
         context: ParsedContext::default(),

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -34,7 +34,7 @@ fn xsd_string() -> Sid {
 
 fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
     let output = if select.is_empty() {
-        QueryOutput::Wildcard
+        QueryOutput::wildcard()
     } else {
         QueryOutput::select(select)
     };

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -44,7 +44,6 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
         output,
         patterns,
         options: QueryOptions::default(),
-        graph_select: None,
         post_values: None,
     }
 }

--- a/fluree-db-query/tests/values_bind_union_tests.rs
+++ b/fluree-db-query/tests/values_bind_union_tests.rs
@@ -34,7 +34,7 @@ fn make_triple_pattern(s_var: VarId, p_name: &str, o_var: VarId) -> TriplePatter
 
 fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
     let output = if select.is_empty() {
-        QueryOutput::Wildcard
+        QueryOutput::wildcard()
     } else {
         QueryOutput::select(select)
     };

--- a/fluree-db-query/tests/values_bind_union_tests.rs
+++ b/fluree-db-query/tests/values_bind_union_tests.rs
@@ -36,7 +36,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
     let output = if select.is_empty() {
         QueryOutput::wildcard()
     } else {
-        QueryOutput::select_vars(select)
+        QueryOutput::select_all(select)
     };
     Query {
         context: ParsedContext::default(),

--- a/fluree-db-query/tests/values_bind_union_tests.rs
+++ b/fluree-db-query/tests/values_bind_union_tests.rs
@@ -36,7 +36,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
     let output = if select.is_empty() {
         QueryOutput::wildcard()
     } else {
-        QueryOutput::select(select)
+        QueryOutput::select_vars(select)
     };
     Query {
         context: ParsedContext::default(),

--- a/fluree-db-query/tests/values_bind_union_tests.rs
+++ b/fluree-db-query/tests/values_bind_union_tests.rs
@@ -44,7 +44,6 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
         output,
         patterns,
         options: QueryOptions::default(),
-        graph_select: None,
         post_values: None,
     }
 }

--- a/fluree-db-sparql/src/lower/ask.rs
+++ b/fluree-db-sparql/src/lower/ask.rs
@@ -33,7 +33,6 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             output: QueryOutput::Boolean,
             patterns,
             options,
-            graph_select: None,
             post_values: None,
         })
     }

--- a/fluree-db-sparql/src/lower/ask.rs
+++ b/fluree-db-sparql/src/lower/ask.rs
@@ -1,6 +1,6 @@
 //! ASK query lowering.
 //!
-//! Converts SPARQL ASK queries to `Query` with `SelectMode::Boolean`.
+//! Converts SPARQL ASK queries to `Query` with `SelectMode::Ask`.
 //! ASK tests whether a graph pattern has any solution — no variables are projected.
 
 use crate::ast::query::AskQuery;
@@ -30,7 +30,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         Ok(Query {
             context: ctx,
             orig_context: None,
-            output: QueryOutput::Boolean,
+            output: QueryOutput::Ask,
             patterns,
             options,
             post_values: None,

--- a/fluree-db-sparql/src/lower/construct.rs
+++ b/fluree-db-sparql/src/lower/construct.rs
@@ -48,7 +48,6 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             output: QueryOutput::Construct(construct_template),
             patterns,
             options,
-            graph_select: None, // SPARQL doesn't support graph crawl
             post_values: None,
         })
     }

--- a/fluree-db-sparql/src/lower/describe.rs
+++ b/fluree-db-sparql/src/lower/describe.rs
@@ -141,7 +141,6 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             output: QueryOutput::Construct(template),
             patterns,
             options: QueryOptions::default(),
-            graph_select: None, // SPARQL doesn't support graph crawl
             post_values: None,
         })
     }

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -239,7 +239,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                 // the `select`/`select_one` helpers).
                 let output = match &select_query.select.variables {
                     SelectVariables::Star => QueryOutput::wildcard(),
-                    _ => QueryOutput::select_vars(select),
+                    _ => QueryOutput::select_all(select),
                 };
 
                 Ok(Query {

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -1081,7 +1081,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(query.output, QueryOutput::Boolean));
+        assert!(matches!(query.output, QueryOutput::Ask));
         assert_eq!(query.options.limit, Some(1), "ASK should inject LIMIT 1");
         assert_eq!(query.patterns.len(), 1);
         assert!(matches!(query.patterns[0], Pattern::Triple(_)));
@@ -1095,7 +1095,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(query.output, QueryOutput::Boolean));
+        assert!(matches!(query.output, QueryOutput::Ask));
         assert_eq!(query.patterns.len(), 2);
     }
 
@@ -1107,7 +1107,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(query.output, QueryOutput::Boolean));
+        assert!(matches!(query.output, QueryOutput::Ask));
         // Patterns: Triple + Filter
         assert!(query.patterns.len() >= 2);
     }

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -248,7 +248,6 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                     output,
                     patterns,
                     options,
-                    graph_select: None, // SPARQL doesn't support graph crawl
                     post_values,
                 })
             }

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -239,7 +239,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                 // the `select`/`select_one` helpers).
                 let output = match &select_query.select.variables {
                     SelectVariables::Star => QueryOutput::wildcard(),
-                    _ => QueryOutput::select(select),
+                    _ => QueryOutput::select_vars(select),
                 };
 
                 Ok(Query {
@@ -351,7 +351,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(query.output.select_vars().unwrap().len(), 2);
+        assert_eq!(query.output.projected_vars().unwrap().len(), 2);
         assert_eq!(query.patterns.len(), 1);
         assert!(matches!(query.patterns[0], Pattern::Triple(_)));
     }
@@ -379,7 +379,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(query.output.select_vars().unwrap().len(), 3);
+        assert_eq!(query.output.projected_vars().unwrap().len(), 3);
         assert_eq!(query.patterns.len(), 2);
     }
 
@@ -1066,7 +1066,7 @@ mod tests {
         .unwrap();
 
         // CONSTRUCT doesn't project variables like SELECT does
-        assert!(query.output.select_vars().is_none());
+        assert!(query.output.projected_vars().is_none());
     }
 
     // =========================================================================
@@ -1222,7 +1222,7 @@ mod tests {
         .unwrap();
 
         // Should parse complex arithmetic without error
-        assert_eq!(query.output.select_vars().unwrap().len(), 1);
+        assert_eq!(query.output.projected_vars().unwrap().len(), 1);
         let has_filter = query
             .patterns
             .iter()

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -238,7 +238,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                 // of bare values. Projection shape is `Tuple` (the default of
                 // the `select`/`select_one` helpers).
                 let output = match &select_query.select.variables {
-                    SelectVariables::Star => QueryOutput::Wildcard,
+                    SelectVariables::Star => QueryOutput::wildcard(),
                     _ => QueryOutput::select(select),
                 };
 
@@ -364,8 +364,8 @@ mod tests {
         )
         .unwrap();
 
-        // SELECT * should produce Wildcard output
-        assert!(matches!(query.output, QueryOutput::Wildcard));
+        // SELECT * should produce Wildcard projection
+        assert!(query.output.is_wildcard());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This branch builds on #1219 and restructures the query output type hierarchy in `fluree-db-query` so that combinations the engine cannot produce are also combinations the type system cannot construct. Eliminates the standalone `graph_select` field that could legally coexist with a `SELECT *`, replaces a parallel `(vars, has_wildcard, hydration_spec)` representation with a single `Projection` enum that mirrors the actual SPARQL semantics, and renames a handful of types and methods so that the names match what they do. Net effect: 53 files changed, ~1,248 insertions / ~1,203 deletions, with no behavior changes.

## Motivation

`QueryOutput::Select { vars: Vec<VarId>, ... }` carried only the bound-variable list. Hydration (the "graph crawl" / nested JSON-LD expansion) lived as a separate `graph_select: Option<HydrationSpec>` field on `Query`. Nothing in the type system prevented `SELECT *` (wildcard) from coexisting with a hydration spec, even though the formatter rejects that combination at runtime — and the parser had to encode wildcard-vs-explicit selection through a `has_wildcard: bool` flag duplicated alongside the actual selection list. `NestedSelectSpec` had the same issue at every level of nested expansion: a `has_wildcard` flag plus a `Vec<SelectionSpec>` that the formatter had to cross-check. `QueryOutput::Boolean` was the only variant whose name didn't match standard SPARQL terminology (everywhere else, `Construct`, `Select`, `Ask`).

## Key changes

- **`QueryOutput::Select` carries `Projection` and `Multiplicity`.** Replaces `Select { vars: Vec<VarId>, ... }` + `graph_select: Option<HydrationSpec>` with `Select { projection: Projection, multiplicity: Multiplicity }`. New types:
  - `Projection { Wildcard, Tuple(Vec<Column>), Scalar(Column) }` — the column structure of the projection. `Wildcard` is now a *variant*, not a flag.
  - `Column { Var(VarId), Hydration(HydrationSpec) }` — what each output column produces. Mixed `Var` + `Hydration` columns in one row are representable by construction.
  - `Multiplicity { All, One }` — replaces the prior `selectOne` discrimination.
- **`NestedSelectSpec` becomes `enum { Wildcard { refinements, reverse }, Explicit { forward, reverse } }`.** Wildcard-vs-explicit is encoded structurally rather than via a `has_wildcard: bool` plus a `Vec<SelectionSpec>` whose contents are interpreted differently depending on the flag. New helpers (`is_wildcard()`, `select_predicate()`, `includes_id()`, `reverse()`) flatten what would otherwise be deep matches in the hydration formatter.
- **`SelectionSpec` deleted, replaced by `ForwardItem { Id, Property { predicate, sub_spec } }`.** The `@id` selection is now its own variant rather than a special-cased `Wildcard` flag.
- **Parse AST mirrors the IR.** `UnresolvedProjection`, `UnresolvedColumn`, `UnresolvedNestedSelectSpec`, `UnresolvedForwardItem` now have the same shape as their IR counterparts, so lowering is a structural translation rather than a multi-source assembly.
- **`SelectMode::Wildcard` dropped.** Wildcard is now reachable via `Projection::Wildcard` directly; the parser-internal `SelectMode` enum no longer has to carry it.
- **`QueryOutput::Boolean` renamed to `Ask`** to match SPARQL terminology and the rest of the variant family.
- **Method renames for clarity.**
  - `QueryOutput::select_vars()` getter → `projected_vars()`
  - `QueryOutput::select_vars_or_empty()` → `projected_vars_or_empty()`
  - `QueryOutput::select(vars)` constructor → `select_vars(vars)` (free of the getter-name collision)
  - `QueryOutput::select_one(vars)` → `select_one_var(vars)`

## Behavior

No semantic changes. Pure type-system tightening: states the engine never produced are no longer expressible. The hydration formatter, planner detect-helpers, and SPARQL/JSON-LD lower paths are migrated to the new shape. All in-workspace consumers (`fluree-db-api/src/{format,view,query,graph_source}/*`, `fluree-db-cli/src/{output,commands}/*`, `fluree-db-sparql/src/lower/*`, the test suites) are updated.

One incidental cleanup: the 13 detect-helper functions in `fluree-db-query/src/execute/operator_tree.rs` previously called `query.output.projected_vars()` twice each (once for an `is_none()` guard, once to bind the variables). The new `projected_vars()` returns an owned `Vec<VarId>` (forced by the `Vec<Column>` storage), so the double call was a double allocation. The early `is_none()` guard was redundant with the existing `?` later in each function — removed.

