### PR TITLE
fix: batched join probes ignored time-travel snapshot

### DIFF
--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -83,6 +83,47 @@ async fn seed_invoice_ledger(fluree: &fluree_db_api::Fluree) -> fluree_db_api::L
     ledger2
 }
 
+/// Seed a ledger that exercises the empty-after-retract leaflet case.
+///
+/// At t=1 every invoice has a `ns:legacyFlag "true"` triple. At t=2 the
+/// legacy flag is fully retracted from every invoice (no replacement). The
+/// indexer preserves the now-empty leaflet's metadata (`row_count == 0`
+/// but `history_*` populated) so time-travel can still recover the
+/// retracted state. Historical queries at t=1 must see the legacy flag;
+/// queries at t=2 must not.
+async fn seed_fully_retracted_ledger(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+) -> fluree_db_api::LedgerState {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+
+    // t=1: 5 invoices, all carrying ns:legacyFlag "true" and a status.
+    let mut invoices = Vec::with_capacity(5);
+    for i in 0..5 {
+        invoices.push(json!({
+            "@id": format!("ns:Invoice/inv-{:02}", i),
+            "@type": "ns:Invoice",
+            "ns:status": "paid",
+            "ns:legacyFlag": "true",
+        }));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": invoices});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    support::rebuild_and_publish_index(fluree, ledger_id).await;
+    let l1 = fluree.ledger(ledger_id).await.expect("reload after t=1");
+
+    // t=2: retract every ns:legacyFlag triple — no replacement value.
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {"@id": "?inv", "ns:legacyFlag": "?flag"},
+        "delete": {"@id": "?inv", "ns:legacyFlag": "?flag"}
+    });
+    let l2 = fluree.update(l1, &tx2).await.expect("tx2").ledger;
+    support::rebuild_and_publish_index(fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=2");
+    l2
+}
+
 async fn run_count_sparql(fluree: &fluree_db_api::Fluree, sparql: &str) -> i64 {
     let jsonld = fluree
         .query_from()
@@ -214,6 +255,88 @@ async fn time_travel_type_plus_group_by_property_respects_t() {
         approved,
         Some(2),
         "at t=1, approved count must be 2; full result: {jsonld}"
+    );
+}
+
+/// SPARQL surface regression for time-travel after a full retract.
+///
+/// At t=1 every invoice carries `ns:legacyFlag "true"`; at t=2 the flag
+/// is fully retracted with no replacement. Historical queries at t=1
+/// must still see the flag, queries at t=2 must not.
+///
+/// Note: a *full* `rebuild_index_from_commits` of this small ledger does
+/// not actually produce a `row_count == 0` (empty-after-retract) leaflet
+/// — the rebuild path just omits the predicate from the t=2 index. The
+/// specific empty-leaflet+sidecar shape is covered by
+/// `replay_at_t_reconstructs_empty_after_retract_leaflet` in
+/// `fluree-db-binary-index/src/read/replay.rs`, and the four batched
+/// probe sites + the cursor were updated to not pre-skip those leaflets.
+/// Even so, this end-to-end test locks in the post-retract time-travel
+/// behavior at the SPARQL surface.
+#[tokio::test]
+async fn time_travel_fully_retracted_leaflet_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-bgp-empty:main";
+    let _ledger = seed_fully_retracted_ledger(&fluree, ledger_id).await;
+
+    // Pattern E shape: type-class triple + same-subject literal-object
+    // triple. Goes through `flush_batched_exists_accumulator_binary` →
+    // `batched_subject_probe_binary`.
+    let q_t1 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(
+        run_count_sparql(&fluree, &q_t1).await,
+        5,
+        "at t=1 all 5 invoices carry ns:legacyFlag; the leaflet that was \
+         emptied at t=2 must replay from its sidecar"
+    );
+
+    let q_t2 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{ledger_id}@t:2>
+          WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(
+        run_count_sparql(&fluree, &q_t2).await,
+        0,
+        "at t=2 the legacy flag was fully retracted; count must be 0"
+    );
+
+    // Pattern A shape: type + same-subject ?o triple, GROUP BY ?o. Goes
+    // through `flush_batched_accumulator_binary` → `scan_leaves_into_scatter`.
+    let q_grp_t1 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?flag (COUNT(?inv) AS ?n)
+          FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag ?flag }}
+          GROUP BY ?flag"
+    );
+    let jsonld = fluree
+        .query_from()
+        .sparql(&q_grp_t1)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("group-by sparql should succeed");
+    let rows = jsonld.as_array().expect("array");
+    let true_count = rows.iter().find_map(|row| {
+        let arr = row.as_array()?;
+        if arr[0].as_str()? == "true" {
+            arr[1].as_i64()
+        } else {
+            None
+        }
+    });
+    assert_eq!(
+        true_count,
+        Some(5),
+        "at t=1 group-by must see all 5 retracted-since flags; got {jsonld}"
     );
 }
 

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -471,3 +471,142 @@ async fn time_travel_bench_replay_overhead() {
         to_avg(t_grp_hist) / to_avg(t_grp_latest)
     );
 }
+
+/// Pattern B (control — already worked pre-fix): `?inv a ns:Invoice ;
+/// ns:status ?s . BIND(?s AS ?aliased)` GROUP BY `?aliased`. The BIND
+/// indirection forces this through a different operator shape than
+/// pattern A; the bug report showed it returned the correct historical
+/// counts even before the fix. Lock that in so the fix to A/E doesn't
+/// regress B.
+#[tokio::test]
+async fn time_travel_type_plus_bind_alias_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_invoice_ledger(&fluree).await;
+
+    let sparql_t1 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?aliased (COUNT(?inv) AS ?n)
+          FROM <{LEDGER_ID}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:status ?s . BIND(?s AS ?aliased) }}
+          GROUP BY ?aliased"
+    );
+    let jsonld = fluree
+        .query_from()
+        .sparql(&sparql_t1)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("group-by sparql should succeed");
+
+    let rows = jsonld.as_array().expect("array").clone();
+    let mut paid: Option<i64> = None;
+    let mut approved: Option<i64> = None;
+    for row in &rows {
+        let arr = row.as_array().expect("row");
+        let status = arr[0].as_str().unwrap_or_default();
+        let count = arr[1].as_i64().expect("count");
+        match status {
+            "paid" => paid = Some(count),
+            "approved" => approved = Some(count),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        paid,
+        Some(18),
+        "BIND-alias variant must match pattern A at t=1; full result: {jsonld}"
+    );
+    assert_eq!(
+        approved,
+        Some(2),
+        "BIND-alias variant must match pattern A at t=1; full result: {jsonld}"
+    );
+}
+
+/// `PropertyJoinOperator` SPOT-walk path at a historical `t`.
+///
+/// A 3+ predicate same-subject star with unbound objects and no datatype
+/// constraints meets `can_spot_walk_remaining`, routing the trailing
+/// predicates through `batched_subject_star_spot` rather than the
+/// scatter-side `scan_leaves_into_scatter`. The fix gates the SPOT walk
+/// on `at_latest_t(ctx)`; this test pins that historical queries through
+/// that path return the t=1 state, not the latest state.
+#[tokio::test]
+async fn time_travel_property_join_spot_walk_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_invoice_ledger(&fluree).await;
+
+    // Three same-subject predicates after the type-class triple. With ?status
+    // and ?amount unbound and no FILTER/datatype constraint, this is the
+    // shape `can_spot_walk_remaining` accepts.
+    let sparql_t1 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv ?status ?amount
+          FROM <{LEDGER_ID}@t:1>
+          WHERE {{
+            ?inv a ns:Invoice .
+            ?inv ns:status ?status .
+            ?inv ns:totalAmount ?amount .
+          }}"
+    );
+    let jsonld = fluree
+        .query_from()
+        .sparql(&sparql_t1)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("star sparql should succeed");
+    let rows = jsonld.as_array().expect("array");
+    assert_eq!(
+        rows.len(),
+        20,
+        "expected 20 invoice rows at t=1; got {jsonld}"
+    );
+    let approved_at_t1 = rows
+        .iter()
+        .filter(|row| {
+            row.as_array()
+                .and_then(|a| a.get(1))
+                .and_then(|s| s.as_str())
+                == Some("approved")
+        })
+        .count();
+    assert_eq!(
+        approved_at_t1, 2,
+        "at t=1 the star walk must see the 2 'approved' invoices; got {jsonld}"
+    );
+
+    let sparql_t2 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv ?status ?amount
+          FROM <{LEDGER_ID}@t:2>
+          WHERE {{
+            ?inv a ns:Invoice .
+            ?inv ns:status ?status .
+            ?inv ns:totalAmount ?amount .
+          }}"
+    );
+    let jsonld_t2 = fluree
+        .query_from()
+        .sparql(&sparql_t2)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("star sparql at t=2 should succeed");
+    let rows_t2 = jsonld_t2.as_array().expect("array");
+    let approved_at_t2 = rows_t2
+        .iter()
+        .filter(|row| {
+            row.as_array()
+                .and_then(|a| a.get(1))
+                .and_then(|s| s.as_str())
+                == Some("approved")
+        })
+        .count();
+    assert_eq!(
+        approved_at_t2, 0,
+        "at t=2 no invoice is 'approved' anymore; got {jsonld_t2}"
+    );
+}

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -216,3 +216,135 @@ async fn time_travel_type_plus_group_by_property_respects_t() {
         "at t=1, approved count must be 2; full result: {jsonld}"
     );
 }
+
+/// Microbench: compare latest vs historical batched-probe timing.
+///
+/// Run with: `cargo test -p fluree-db-api --features native --test
+/// it_query_time_travel_bgp -- --ignored --nocapture
+/// time_travel_bench_replay_overhead`.
+///
+/// Builds a 10k-invoice ledger with ~10% status mutations between t=1 and
+/// t=2. Each query path goes through `flush_batched_exists_accumulator_binary`
+/// (pattern E) and `flush_batched_accumulator_binary` (pattern A). The
+/// historical path additionally runs `replay_leaflet_at_t` per leaflet.
+#[tokio::test]
+#[ignore]
+async fn time_travel_bench_replay_overhead() {
+    use std::time::Instant;
+
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-bgp-bench:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    const N: usize = 10_000;
+    const MUTATED: usize = 1_000; // ~10%
+
+    // t=1: N invoices, last MUTATED status="approved", rest "paid".
+    let mut invoices = Vec::with_capacity(N);
+    for i in 0..N {
+        let status = if i < N - MUTATED { "paid" } else { "approved" };
+        invoices.push(json!({
+            "@id": format!("ns:Invoice/inv-{:06}", i),
+            "@type": "ns:Invoice",
+            "ns:status": status,
+            "ns:totalAmount": 100 + i,
+        }));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": invoices});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let l1 = fluree.ledger(ledger_id).await.unwrap();
+
+    // t=2: flip MUTATED rows from "approved" to "paid".
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {"@id": "?inv", "ns:status": "approved"},
+        "delete": {"@id": "?inv", "ns:status": "approved"},
+        "insert": {"@id": "?inv", "ns:status": "paid"}
+    });
+    fluree.update(l1, &tx2).await.expect("tx2");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+
+    // Pattern E (literal-object exists). At latest expect N paid; at t=1
+    // expect N-MUTATED paid.
+    let q_lit = |t: i64| {
+        format!(
+            r#"PREFIX ns: <http://example.org/ns#>
+              SELECT (COUNT(?inv) AS ?n)
+              FROM <{ledger_id}@t:{t}>
+              WHERE {{ ?inv a ns:Invoice ; ns:status "paid" }}"#
+        )
+    };
+    // Pattern A (group by status). Same shape, different join helper.
+    let q_grp = |t: i64| {
+        format!(
+            r"PREFIX ns: <http://example.org/ns#>
+              SELECT ?status (COUNT(?inv) AS ?n)
+              FROM <{ledger_id}@t:{t}>
+              WHERE {{ ?inv a ns:Invoice ; ns:status ?status }}
+              GROUP BY ?status"
+        )
+    };
+
+    // Warm up caches/dicts.
+    for _ in 0..2 {
+        let _ = run_count_sparql(&fluree, &q_lit(2)).await;
+        let _ = run_count_sparql(&fluree, &q_lit(1)).await;
+    }
+
+    const ITERS: u32 = 30;
+    let mut t_lit_latest = std::time::Duration::ZERO;
+    let mut t_lit_hist = std::time::Duration::ZERO;
+    let mut t_grp_latest = std::time::Duration::ZERO;
+    let mut t_grp_hist = std::time::Duration::ZERO;
+    for _ in 0..ITERS {
+        let q = q_lit(2);
+        let s = Instant::now();
+        let _ = run_count_sparql(&fluree, &q).await;
+        t_lit_latest += s.elapsed();
+
+        let q = q_lit(1);
+        let s = Instant::now();
+        let _ = run_count_sparql(&fluree, &q).await;
+        t_lit_hist += s.elapsed();
+
+        let q = q_grp(2);
+        let s = Instant::now();
+        let _ = fluree
+            .query_from()
+            .sparql(&q)
+            .format(fluree_db_api::FormatterConfig::jsonld())
+            .execute_formatted()
+            .await
+            .unwrap();
+        t_grp_latest += s.elapsed();
+
+        let q = q_grp(1);
+        let s = Instant::now();
+        let _ = fluree
+            .query_from()
+            .sparql(&q)
+            .format(fluree_db_api::FormatterConfig::jsonld())
+            .execute_formatted()
+            .await
+            .unwrap();
+        t_grp_hist += s.elapsed();
+    }
+    let to_avg = |d: std::time::Duration| (d.as_secs_f64() * 1000.0) / f64::from(ITERS);
+    println!(
+        "\n--- batched join probe: latest vs historical ({N} invoices, ~{MUTATED} mutated, {ITERS} iters) ---"
+    );
+    println!(
+        "pattern E (literal-object exists): latest = {:.2} ms/iter, t=1 = {:.2} ms/iter, ratio = {:.2}x",
+        to_avg(t_lit_latest),
+        to_avg(t_lit_hist),
+        to_avg(t_lit_hist) / to_avg(t_lit_latest)
+    );
+    println!(
+        "pattern A (group-by status):       latest = {:.2} ms/iter, t=1 = {:.2} ms/iter, ratio = {:.2}x",
+        to_avg(t_grp_latest),
+        to_avg(t_grp_hist),
+        to_avg(t_grp_hist) / to_avg(t_grp_latest)
+    );
+}

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -1,0 +1,218 @@
+//! Regression tests for time-travel BGP queries that combine a type-class
+//! triple with a same-subject property triple.
+//!
+//! The bug: when a SPARQL BGP combines `?s a <Class>` with a same-subject
+//! triple `?s <p> <literal>` (or `?s <p> ?o` with `?o` projected through a
+//! GROUP BY key), the join path bypasses the time-travel filter and returns
+//! the latest state at every `t`. The same query expressed with a FILTER or
+//! a BIND alias returns the correct historical state.
+//!
+//! Root cause hypothesis: `NestedLoopJoinOperator`'s batched probe paths
+//! (`flush_batched_accumulator_binary` →
+//! `scan_leaves_into_scatter`, `flush_batched_exists_accumulator_binary` →
+//! `batched_subject_probe_binary`) read base leaflet rows directly without
+//! applying the `to_t` filter or replaying the history sidecar — so they
+//! silently return latest-state results for historical snapshots once the
+//! data has been reindexed.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+use support::{assert_index_defaults, genesis_ledger};
+
+const LEDGER_ID: &str = "tt-bgp:main";
+
+fn ctx() -> JsonValue {
+    json!({
+        "ns": "http://example.org/ns#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    })
+}
+
+/// Seed 20 invoices: 18 with status "paid", 2 with status "approved".
+/// Then change the 2 "approved" invoices to "paid" at t=2.
+/// Reindex after each commit so the persisted base index sees t=2 as max.
+async fn seed_invoice_ledger(fluree: &fluree_db_api::Fluree) -> fluree_db_api::LedgerState {
+    let ledger0 = genesis_ledger(fluree, LEDGER_ID);
+
+    // t=1: 20 invoices.
+    let mut invoices = Vec::with_capacity(20);
+    for i in 0..20 {
+        let status = if i < 18 { "paid" } else { "approved" };
+        invoices.push(json!({
+            "@id": format!("ns:Invoice/inv-{:02}", i),
+            "@type": "ns:Invoice",
+            "ns:status": status,
+            "ns:totalAmount": 100 + i,
+        }));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": invoices});
+    let _ledger1 = fluree.insert(ledger0, &tx1).await.expect("tx1").ledger;
+
+    // Rebuild index so the t=1 state is persisted in base leaflets.
+    support::rebuild_and_publish_index(fluree, LEDGER_ID).await;
+
+    // Reload the ledger so the new index is picked up.
+    let ledger1 = fluree.ledger(LEDGER_ID).await.expect("reload after t=1");
+
+    // t=2: change inv-18 and inv-19 from "approved" to "paid".
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {
+            "@id": "?inv",
+            "ns:status": "approved"
+        },
+        "delete": {
+            "@id": "?inv",
+            "ns:status": "approved"
+        },
+        "insert": {
+            "@id": "?inv",
+            "ns:status": "paid"
+        }
+    });
+    let ledger2 = fluree.update(ledger1, &tx2).await.expect("tx2").ledger;
+
+    // Rebuild again so the post-t=2 base index has retracts in the sidecar
+    // and "paid" as the live value for inv-18 / inv-19.
+    support::rebuild_and_publish_index(fluree, LEDGER_ID).await;
+    fluree.ledger(LEDGER_ID).await.expect("reload after t=2");
+    ledger2
+}
+
+async fn run_count_sparql(fluree: &fluree_db_api::Fluree, sparql: &str) -> i64 {
+    let jsonld = fluree
+        .query_from()
+        .sparql(sparql)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("count sparql should succeed");
+
+    let arr = jsonld.as_array().expect("array result");
+    assert_eq!(arr.len(), 1, "expected exactly one row, got {jsonld}");
+    let row = arr[0].as_array().expect("row is array");
+    assert_eq!(row.len(), 1, "expected exactly one column, got {jsonld}");
+    row[0].as_i64().expect("count is integer")
+}
+
+/// Pattern E (broken): `?inv a ns:Invoice ; ns:status "paid"` at t=1
+/// must return 18 (the historical count of paid invoices), not 20 (the
+/// latest count).
+#[tokio::test]
+async fn time_travel_type_plus_literal_object_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_invoice_ledger(&fluree).await;
+
+    let sparql_t1 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{LEDGER_ID}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:status "paid" }}"#
+    );
+    let count_t1 = run_count_sparql(&fluree, &sparql_t1).await;
+    assert_eq!(
+        count_t1, 18,
+        "at t=1 only 18 invoices were paid, but query returned {count_t1} \
+         (likely the latest count of 20 — time-travel filter ignored)"
+    );
+
+    let sparql_t2 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{LEDGER_ID}@t:2>
+          WHERE {{ ?inv a ns:Invoice ; ns:status "paid" }}"#
+    );
+    let count_t2 = run_count_sparql(&fluree, &sparql_t2).await;
+    assert_eq!(count_t2, 20, "at t=2 all 20 invoices are paid");
+}
+
+/// Pattern D (control — already works): `?inv a ns:Invoice ; ns:status ?s
+/// FILTER(?s = "paid")` must return the same 18 / 20 counts as pattern E
+/// at the corresponding t. This locks in the existing correct behavior so
+/// a fix to E does not regress D.
+#[tokio::test]
+async fn time_travel_type_plus_filter_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_invoice_ledger(&fluree).await;
+
+    let sparql_t1 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{LEDGER_ID}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:status ?s . FILTER(?s = "paid") }}"#
+    );
+    let count_t1 = run_count_sparql(&fluree, &sparql_t1).await;
+    assert_eq!(
+        count_t1, 18,
+        "FILTER variant must match literal-object variant at t=1"
+    );
+
+    let sparql_t2 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{LEDGER_ID}@t:2>
+          WHERE {{ ?inv a ns:Invoice ; ns:status ?s . FILTER(?s = "paid") }}"#
+    );
+    let count_t2 = run_count_sparql(&fluree, &sparql_t2).await;
+    assert_eq!(
+        count_t2, 20,
+        "FILTER variant must match literal-object variant at t=2"
+    );
+}
+
+/// Pattern A (broken): `?inv a ns:Invoice ; ns:status ?status` GROUP BY
+/// ?status. At t=1 the "paid" group must have 18 rows, not 20. The bug:
+/// the batched-subject join path for the second triple ignores `to_t`
+/// and reads base leaflet rows directly, returning latest-state status
+/// values regardless of the snapshot time.
+#[tokio::test]
+async fn time_travel_type_plus_group_by_property_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_invoice_ledger(&fluree).await;
+
+    let sparql_t1 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?status (COUNT(?inv) AS ?n)
+          FROM <{LEDGER_ID}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:status ?status }}
+          GROUP BY ?status"
+    );
+    let jsonld = fluree
+        .query_from()
+        .sparql(&sparql_t1)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("group-by sparql should succeed");
+
+    let rows = jsonld.as_array().expect("array").clone();
+    let mut paid: Option<i64> = None;
+    let mut approved: Option<i64> = None;
+    for row in &rows {
+        let arr = row.as_array().expect("row");
+        let status = arr[0].as_str().unwrap_or_default();
+        let count = arr[1].as_i64().expect("count");
+        match status {
+            "paid" => paid = Some(count),
+            "approved" => approved = Some(count),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        paid,
+        Some(18),
+        "at t=1, paid count must be 18; full result: {jsonld}"
+    );
+    assert_eq!(
+        approved,
+        Some(2),
+        "at t=1, approved count must be 2; full result: {jsonld}"
+    );
+}

--- a/fluree-db-binary-index/src/lib.rs
+++ b/fluree-db-binary-index/src/lib.rs
@@ -21,7 +21,7 @@ pub use read::binary_cursor::BinaryCursor;
 pub use read::binary_index_store::{BinaryGraphView, BinaryIndexStore};
 pub use read::column_types::{BinaryFilter, ColumnBatch, ColumnData, ColumnProjection, ColumnSet};
 pub use read::leaflet_cache::{LeafletCache, LeafletCacheKey, V3BatchCacheKey};
-pub use read::replay::replay_leaflet;
+pub use read::replay::{batch_has_rows_above_t, replay_leaflet, replay_leaflet_at_t};
 
 // ── Format types ────────────────────────────────────────────────────────────
 pub use format::branch::{BranchManifest, LeafEntry};

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -228,7 +228,15 @@ impl BinaryCursor {
                     if !has_ov && self.filter.skip_leaflet(entry.p_const, entry.o_type_const) {
                         continue;
                     }
-                    if entry.row_count == 0 && !has_ov {
+                    // An empty-after-retract leaflet (`row_count == 0`) is preserved
+                    // by the indexer with its history sidecar segment so time-travel
+                    // can recover fully-retracted facts. Don't pre-skip it when we
+                    // need replay and the sidecar carries events past `to_t`.
+                    let to_t_u32 = u32::try_from(self.to_t).unwrap_or(u32::MAX);
+                    let needs_history_replay = self.need_replay()
+                        && entry.history_len > 0
+                        && entry.history_max_t > to_t_u32;
+                    if entry.row_count == 0 && !has_ov && !needs_history_replay {
                         continue;
                     }
 

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -23,7 +23,7 @@ use crate::read::types::{cmp_row_vs_overlay, OverlayOp};
 use super::binary_index_store::BinaryIndexStore;
 use super::column_loader::load_columns_cached_via_handle;
 use super::column_types::{BinaryFilter, ColumnBatch, ColumnData, ColumnProjection};
-use super::replay::replay_leaflet;
+use super::replay::{batch_has_rows_above_t, replay_leaflet};
 
 // ============================================================================
 // BinaryCursor
@@ -627,15 +627,6 @@ fn push_overlay_row(
 
 /// Apply the filter to a batch, returning only matching rows.
 /// Returns the batch unchanged if all rows match (avoids copy).
-/// Check if any row in the batch has `t > t_target`.
-fn batch_has_rows_above_t(batch: &ColumnBatch, t_target: u32) -> bool {
-    match &batch.t {
-        ColumnData::Block(ts) => ts.iter().any(|&t| t > t_target),
-        ColumnData::Const(t) => *t > t_target,
-        ColumnData::AbsentDefault => false,
-    }
-}
-
 fn filter_batch(filter: &BinaryFilter, batch: &ColumnBatch) -> ColumnBatch {
     let mut matching: Vec<usize> = Vec::new();
     for i in 0..batch.row_count {

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -543,7 +543,11 @@ impl BinaryIndexStore {
     }
 
     /// Fetch sidecar bytes by CID (full object, sync).
-    fn fetch_sidecar_bytes_sync(
+    ///
+    /// Used by both the cursor (`open_leaf_handle`) and external callers
+    /// that walk leaflet base columns directly (batched join probes) and
+    /// need to reconstruct historical state via `replay_leaflet_at_t`.
+    pub fn fetch_sidecar_bytes_sync(
         &self,
         sidecar_cid: Option<&ContentId>,
     ) -> io::Result<Option<Vec<u8>>> {

--- a/fluree-db-binary-index/src/read/replay.rs
+++ b/fluree-db-binary-index/src/read/replay.rs
@@ -13,9 +13,11 @@
 //! 3. Derive exclude/include sets and three-way merge into output `ColumnBatch`
 
 use std::collections::HashMap;
+use std::io;
 use std::sync::Arc;
 
-use crate::format::history_sidecar::HistEntryV2;
+use crate::format::history_sidecar::{decode_history_segment, HistEntryV2, HistorySegmentRef};
+use crate::format::leaf::LeafletDirEntryV3;
 use crate::format::run_record::RunSortOrder;
 use crate::format::run_record_v2::{cmp_v2_for_order, RunRecordV2};
 use crate::read::column_types::{ColumnBatch, ColumnData};
@@ -86,6 +88,72 @@ struct FactState {
 // ============================================================================
 // Public API
 // ============================================================================
+
+/// Check if any row in the batch has `t > t_target`.
+///
+/// Used as a quick gate: a leaflet whose history sidecar doesn't extend
+/// past `t_target` AND whose base rows are all `<= t_target` needs no
+/// replay.
+#[inline]
+pub fn batch_has_rows_above_t(batch: &ColumnBatch, t_target: u32) -> bool {
+    match &batch.t {
+        ColumnData::Block(ts) => ts.iter().any(|&t| t > t_target),
+        ColumnData::Const(t) => *t > t_target,
+        ColumnData::AbsentDefault => false,
+    }
+}
+
+/// Apply time-travel replay to a freshly-loaded leaflet `batch`.
+///
+/// This is the helper used by callers that walk leaflet base columns
+/// directly (e.g. batched join probes) and need correct historical
+/// semantics. It mirrors what [`crate::read::binary_cursor::BinaryCursor`]
+/// does internally:
+///
+/// 1. Quick-skip: if the leaflet's history doesn't extend past `to_t` and
+///    no base rows have `t > to_t`, return `Ok(None)` (no replay needed).
+/// 2. If `entry.history_len > 0`, decode the sidecar segment from
+///    `sidecar_bytes` and call [`replay_leaflet`].
+/// 3. If no sidecar but base rows have `t > to_t`, call
+///    [`replay_leaflet`] with an empty history slice (filters those rows).
+///
+/// Returns `Ok(Some(replayed))` when replay produced a different batch,
+/// `Ok(None)` when the input batch is correct as-is.
+///
+/// `sidecar_bytes` may be `None` when the caller knows the leaf has no
+/// sidecar; in that case the helper degrades to the empty-history filter
+/// path described above.
+pub fn replay_leaflet_at_t(
+    batch: &ColumnBatch,
+    entry: &LeafletDirEntryV3,
+    sidecar_bytes: Option<&[u8]>,
+    to_t: i64,
+    order: RunSortOrder,
+) -> io::Result<Option<ColumnBatch>> {
+    let to_t_u32 = u32::try_from(to_t).unwrap_or(u32::MAX);
+    let needs_replay = entry.history_max_t > to_t_u32 || batch_has_rows_above_t(batch, to_t_u32);
+    if !needs_replay {
+        return Ok(None);
+    }
+    if entry.history_len > 0 {
+        let sc_bytes = sidecar_bytes.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "history replay requires sidecar bytes but none were provided",
+            )
+        })?;
+        let seg = HistorySegmentRef {
+            offset: entry.history_offset,
+            len: entry.history_len,
+            min_t: entry.history_min_t,
+            max_t: entry.history_max_t,
+        };
+        let history = decode_history_segment(sc_bytes, &seg)?;
+        return Ok(replay_leaflet(batch, &history, to_t, order));
+    }
+    // No sidecar, but base rows have t > to_t — filter them out.
+    Ok(replay_leaflet(batch, &[], to_t, order))
+}
 
 /// Replay a V3 leaflet to reconstruct its state at `t_target`.
 ///

--- a/fluree-db-binary-index/src/read/replay.rs
+++ b/fluree-db-binary-index/src/read/replay.rs
@@ -272,8 +272,18 @@ pub fn replay_leaflet(
             let (_, row_idx) = base_entry.unwrap();
             exclude_indices.push(*row_idx);
         } else if !in_base && state.present {
-            // Was NOT in base, should be present → include from source.
-            if let Some(src) = &state.include_src {
+            // Was NOT in base, should be present → restore from history.
+            // Prefer the most recent assert with `t ≤ t_target` so the
+            // reconstructed row carries the original assert transaction
+            // rather than the retract event's `t`. Downstream consumers
+            // (`T(?val)`, history-range bindings) observe this `t`, and
+            // a retract `t` here would place the row outside the queried
+            // snapshot's `to_t`. Fall back to `state.include_src` only
+            // when no prior assert is recorded in this leaflet's sidecar
+            // — for example when the assert lives in a different segment.
+            if let Some(src) = find_base_assert_at_target(key, history, t_target_u32) {
+                includes.push(hist_entry_to_record(&src));
+            } else if let Some(src) = &state.include_src {
                 includes.push(hist_entry_to_record(src));
             }
         } else if in_base && state.present {
@@ -584,11 +594,15 @@ mod tests {
         let replayed = result.unwrap();
         assert_eq!(replayed.row_count, 2);
         // Should have both s=1 and s=2 (restored).
-        let s_ids: Vec<u64> = (0..replayed.row_count)
-            .map(|i| replayed.s_id.get(i))
+        let rows: Vec<(u64, u32)> = (0..replayed.row_count)
+            .map(|i| (replayed.s_id.get(i), replayed.t.get_or(i, 0)))
             .collect();
-        assert!(s_ids.contains(&1));
-        assert!(s_ids.contains(&2));
+        assert!(rows.contains(&(1, 3)), "s=1 retains base t=3");
+        // The restored fact must carry its assert t (=2), not the retract t (=5).
+        assert!(
+            rows.contains(&(2, 2)),
+            "s=2 must be restored with the assert t=2, got rows {rows:?}"
+        );
     }
 
     #[test]
@@ -694,6 +708,16 @@ mod tests {
         assert_eq!(replayed.row_count, 1, "the retracted assert is restored");
         assert_eq!(replayed.s_id.get(0), 1);
         assert_eq!(replayed.o_key.get(0), ObjKey::encode_i64(10).as_u64());
+        // The reconstructed row's `t` must be the original assert
+        // transaction (t=2), not the retract transaction (t=5).
+        // Downstream consumers — `T(?val)` in queries, history-range
+        // bindings, etc. — observe this `t`, and a value of 5 would
+        // place the row outside the queried snapshot's `to_t == 3`.
+        assert_eq!(
+            replayed.t.get(0),
+            2,
+            "restored row must carry the assert transaction t, not the retract t"
+        );
 
         // At t_target=5 the retract is in effect: nothing to restore.
         let result = replay_leaflet_at_t(

--- a/fluree-db-binary-index/src/read/replay.rs
+++ b/fluree-db-binary-index/src/read/replay.rs
@@ -635,4 +635,82 @@ mod tests {
             "t_target > u32::MAX means no replay needed"
         );
     }
+
+    /// Empty-after-retract leaflet: base columns are empty (`row_count == 0`)
+    /// because every fact in the leaflet was retracted. The history sidecar
+    /// still carries the original asserts, so time-travel to a `t` before
+    /// the retract must reconstruct the leaflet from history alone.
+    ///
+    /// This locks in the contract that `replay_leaflet_at_t` callers
+    /// (e.g. batched join probes) must NOT pre-skip leaflets with
+    /// `row_count == 0` when their sidecar carries events past `to_t`.
+    #[test]
+    fn replay_at_t_reconstructs_empty_after_retract_leaflet() {
+        use crate::format::history_sidecar::HistSidecarBuilder;
+        use crate::format::leaf::LeafletDirEntryV3;
+
+        // Build a sidecar segment containing one assert at t=2 and the
+        // matching retract at t=5, mirroring what the indexer writes when
+        // an entire leaflet is retracted.
+        let mut builder = HistSidecarBuilder::new();
+        builder.start_leaflet();
+        builder.push_entry(make_hist(1, 10, 2, 1)); // assert at t=2
+        builder.push_entry(make_hist(1, 10, 5, 0)); // retract at t=5
+        let (sidecar_bytes, segs) = builder.build();
+        assert_eq!(segs.len(), 1);
+        let seg = &segs[0];
+
+        // Synthesize the directory entry the indexer would write for the
+        // empty-after-retract leaflet (`row_count == 0` but `history_*`
+        // populated; key range and `p_const` preserved for routing).
+        let entry = LeafletDirEntryV3 {
+            row_count: 0,
+            lead_group_count: 0,
+            first_key: [0u8; 26],
+            last_key: [0u8; 26],
+            p_const: Some(1),
+            o_type_const: None,
+            flags: 0,
+            payload_offset: 0,
+            payload_len: 0,
+            column_refs: Vec::new(),
+            history_offset: seg.offset,
+            history_len: seg.len,
+            history_min_t: seg.min_t,
+            history_max_t: seg.max_t,
+        };
+
+        // At t_target=3 the retract has not yet happened: the assert from
+        // t=2 must be restored.
+        let result = replay_leaflet_at_t(
+            &ColumnBatch::empty(),
+            &entry,
+            Some(&sidecar_bytes),
+            3,
+            RunSortOrder::Spot,
+        )
+        .expect("replay should succeed");
+        let replayed = result.expect("history past to_t must produce replay");
+        assert_eq!(replayed.row_count, 1, "the retracted assert is restored");
+        assert_eq!(replayed.s_id.get(0), 1);
+        assert_eq!(replayed.o_key.get(0), ObjKey::encode_i64(10).as_u64());
+
+        // At t_target=5 the retract is in effect: nothing to restore.
+        let result = replay_leaflet_at_t(
+            &ColumnBatch::empty(),
+            &entry,
+            Some(&sidecar_bytes),
+            5,
+            RunSortOrder::Spot,
+        )
+        .expect("replay should succeed");
+        // Either Ok(None) (history.max_t == to_t, quick-skip) or an empty
+        // batch — both reflect "nothing live at t=5". The quick-skip path
+        // returns None because `entry.history_max_t == to_t_u32` is not
+        // strictly greater.
+        assert!(
+            result.as_ref().is_none_or(|b| b.row_count == 0),
+            "at to_t == retract_t no rows should be restored"
+        );
+    }
 }

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1530,16 +1530,28 @@ impl NestedLoopJoinOperator {
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
                 leaflets_scanned += 1;
-                if entry.row_count == 0 {
+                // An empty-after-retract leaflet (`row_count == 0`) is preserved
+                // by the indexer for time-travel replay. Skip only when there is
+                // also no history past `to_t` to reconstruct.
+                let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
+                let needs_history_replay =
+                    need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
+                if entry.row_count == 0 && !needs_history_replay {
                     continue;
                 }
-                // Skip leaflets that don't contain our predicate.
+                // Skip leaflets that don't contain our predicate. The indexer
+                // preserves `p_const` on empty-after-retract leaflets so this
+                // filter is still safe.
                 if entry.p_const.is_some() && entry.p_const != Some(p_id) {
                     continue;
                 }
 
                 // Load all columns via V3 column loader (cached when available).
-                let batch = if let Some(c) = &cache {
+                // For empty-after-retract leaflets we start from an empty batch
+                // and let `replay_leaflet_at_t` reconstruct rows from the sidecar.
+                let batch = if entry.row_count == 0 {
+                    fluree_db_binary_index::ColumnBatch::empty()
+                } else if let Some(c) = &cache {
                     load_leaflet_columns_cached(
                         &leaf_bytes,
                         entry,
@@ -2106,7 +2118,10 @@ impl NestedLoopJoinOperator {
             };
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
-                if entry.row_count == 0 {
+                let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
+                let needs_history_replay =
+                    need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
+                if entry.row_count == 0 && !needs_history_replay {
                     continue;
                 }
                 if entry.p_const.is_some() && entry.p_const != Some(p_id) {
@@ -2142,7 +2157,9 @@ impl NestedLoopJoinOperator {
                         internal: fluree_db_binary_index::read::column_types::ColumnSet::EMPTY,
                     }
                 };
-                let batch = if let Some(c) = &cache {
+                let batch = if entry.row_count == 0 {
+                    fluree_db_binary_index::ColumnBatch::empty()
+                } else if let Some(c) = &cache {
                     let key = fluree_db_binary_index::read::leaflet_cache::V3BatchCacheKey {
                         leaf_id,
                         leaflet_idx: u32::try_from(leaflet_idx).map_err(|_| {
@@ -2592,14 +2609,19 @@ pub(crate) fn batched_subject_probe_binary(
         let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
 
         for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
-            if entry.row_count == 0 {
+            let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
+            let needs_history_replay =
+                need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
+            if entry.row_count == 0 && !needs_history_replay {
                 continue;
             }
             if entry.p_const.is_some() && entry.p_const != Some(p_id) {
                 continue;
             }
 
-            let batch = if let Some(c) = &cache {
+            let batch = if entry.row_count == 0 {
+                fluree_db_binary_index::ColumnBatch::empty()
+            } else if let Some(c) = &cache {
                 load_leaflet_columns_cached(
                     &leaf_bytes,
                     entry,
@@ -2804,11 +2826,16 @@ pub(crate) fn batched_subject_star_spot(
         let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
 
         for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
-            if entry.row_count == 0 {
+            let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
+            let needs_history_replay =
+                need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
+            if entry.row_count == 0 && !needs_history_replay {
                 continue;
             }
 
-            let batch = if let Some(c) = &cache {
+            let batch = if entry.row_count == 0 {
+                fluree_db_binary_index::ColumnBatch::empty()
+            } else if let Some(c) = &cache {
                 load_leaflet_columns_cached(
                     &leaf_bytes,
                     entry,

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1000,9 +1000,21 @@ impl Operator for NestedLoopJoinOperator {
         // - Binary store must be available (batched path reads leaf files directly)
         // - Single-db mode (ActiveGraphs::Single), subjects are Binding::Sid
         // - Dataset mode with exactly one graph (ActiveGraphs::Many len==1), subjects are Binding::IriMatch
+        // - `to_t == store.max_t()` (latest snapshot only). The batched probes
+        //   (`scan_leaves_into_scatter`, `batched_subject_probe_binary`) read
+        //   base leaflet rows directly without applying the `to_t` filter or
+        //   replaying the history sidecar, so they would silently return
+        //   latest-state results for historical snapshots. Fall back to the
+        //   per-row scan path which uses `BinaryCursor::set_to_t` and proper
+        //   sidecar replay.
+        let at_latest_t = ctx
+            .binary_store
+            .as_ref()
+            .is_some_and(|s| s.max_t() == ctx.to_t);
         let use_batched =
             (self.batched_eligible || self.batched_object_eligible || self.batched_exists_eligible)
                 && ctx.binary_store.is_some()
+                && at_latest_t
                 && match ctx.active_graphs() {
                     // Object-batched path currently emits `Binding::EncodedSid` for the new
                     // subject var. Keep it single-ledger only to avoid dataset-mode IriMatch

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1000,21 +1000,13 @@ impl Operator for NestedLoopJoinOperator {
         // - Binary store must be available (batched path reads leaf files directly)
         // - Single-db mode (ActiveGraphs::Single), subjects are Binding::Sid
         // - Dataset mode with exactly one graph (ActiveGraphs::Many len==1), subjects are Binding::IriMatch
-        // - `to_t == store.max_t()` (latest snapshot only). The batched probes
-        //   (`scan_leaves_into_scatter`, `batched_subject_probe_binary`) read
-        //   base leaflet rows directly without applying the `to_t` filter or
-        //   replaying the history sidecar, so they would silently return
-        //   latest-state results for historical snapshots. Fall back to the
-        //   per-row scan path which uses `BinaryCursor::set_to_t` and proper
-        //   sidecar replay.
-        let at_latest_t = ctx
-            .binary_store
-            .as_ref()
-            .is_some_and(|s| s.max_t() == ctx.to_t);
+        //
+        // Historical snapshots (`to_t < store.max_t()`) are handled inside each
+        // batched flush helper via `replay_leaflet_at_t`, which reconstructs
+        // leaflet state at `to_t` from the history sidecar.
         let use_batched =
             (self.batched_eligible || self.batched_object_eligible || self.batched_exists_eligible)
                 && ctx.binary_store.is_some()
-                && at_latest_t
                 && match ctx.active_graphs() {
                     // Object-batched path currently emits `Binding::EncodedSid` for the new
                     // subject var. Keep it single-ledger only to avoid dataset-mode IriMatch
@@ -1512,6 +1504,7 @@ impl NestedLoopJoinOperator {
 
         let mut leaflets_scanned: u64 = 0;
         let mut matched_rows: u64 = 0;
+        let need_replay = ctx.to_t < store.max_t();
 
         for leaf_idx in leaf_range {
             let leaf_entry = &branch.leaves[leaf_idx];
@@ -1524,6 +1517,16 @@ impl NestedLoopJoinOperator {
             let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
                 .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
             let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
+            // Fetch sidecar bytes once per leaf when we need historical replay.
+            // The leaflet base columns are content-addressed (immutable); the
+            // sidecar is what carries retracts, so we only need it for `to_t < max_t`.
+            let sidecar_bytes: Option<Vec<u8>> = if need_replay {
+                store
+                    .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
+                    .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
+            } else {
+                None
+            };
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
                 leaflets_scanned += 1;
@@ -1559,6 +1562,26 @@ impl NestedLoopJoinOperator {
                         header.order,
                     )
                     .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+                };
+
+                // Apply time-travel replay when querying a historical snapshot.
+                // The cached `batch` reflects latest base state; `replay_leaflet_at_t`
+                // reconstructs the state at `ctx.to_t` using the history sidecar.
+                let batch = if need_replay {
+                    match fluree_db_binary_index::replay_leaflet_at_t(
+                        &batch,
+                        entry,
+                        sidecar_bytes.as_deref(),
+                        ctx.to_t,
+                        header.order,
+                    )
+                    .map_err(|e| QueryError::Internal(format!("replay leaflet: {e}")))?
+                    {
+                        Some(replayed) => replayed,
+                        None => batch,
+                    }
+                } else {
+                    batch
                 };
 
                 let row_count = batch.row_count;
@@ -2060,6 +2083,7 @@ impl NestedLoopJoinOperator {
         leaf_indices.dedup();
 
         let cache = store.leaflet_cache();
+        let need_replay = ctx.to_t < store.max_t();
         for leaf_idx in leaf_indices {
             let leaf_entry = &branch.leaves[leaf_idx];
             let leaf_bytes = store
@@ -2071,6 +2095,15 @@ impl NestedLoopJoinOperator {
             let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
                 .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
             let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
+            // Fetch sidecar bytes once per leaf for historical replay (see
+            // `scan_leaves_into_scatter` for the rationale).
+            let sidecar_bytes: Option<Vec<u8>> = if need_replay {
+                store
+                    .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
+                    .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
+            } else {
+                None
+            };
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
                 if entry.row_count == 0 {
@@ -2098,11 +2131,16 @@ impl NestedLoopJoinOperator {
                     continue;
                 }
 
-                // We only need core identity columns for this join. Avoid decoding all
-                // columns on cache miss (the cache stores full batches).
-                let core_proj = fluree_db_binary_index::read::column_types::ColumnProjection {
-                    output: fluree_db_binary_index::read::column_types::ColumnSet::CORE,
-                    internal: fluree_db_binary_index::read::column_types::ColumnSet::EMPTY,
+                // We only need core identity columns for this join, but for
+                // historical snapshots we also need `T` so `replay_leaflet_at_t`
+                // can detect base rows that postdate `to_t`.
+                let proj = if need_replay {
+                    fluree_db_binary_index::read::column_types::ColumnProjection::all()
+                } else {
+                    fluree_db_binary_index::read::column_types::ColumnProjection {
+                        output: fluree_db_binary_index::read::column_types::ColumnSet::CORE,
+                        internal: fluree_db_binary_index::read::column_types::ColumnSet::EMPTY,
+                    }
                 };
                 let batch = if let Some(c) = &cache {
                     let key = fluree_db_binary_index::read::leaflet_cache::V3BatchCacheKey {
@@ -2118,20 +2156,32 @@ impl NestedLoopJoinOperator {
                             &leaf_bytes,
                             entry,
                             dir.payload_base,
-                            &core_proj,
+                            &proj,
                             header.order,
                         )
                         .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                     }
                 } else {
-                    load_leaflet_columns(
-                        &leaf_bytes,
+                    load_leaflet_columns(&leaf_bytes, entry, dir.payload_base, &proj, header.order)
+                        .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+                };
+
+                // Apply time-travel replay when querying a historical snapshot.
+                let batch = if need_replay {
+                    match fluree_db_binary_index::replay_leaflet_at_t(
+                        &batch,
                         entry,
-                        dir.payload_base,
-                        &core_proj,
+                        sidecar_bytes.as_deref(),
+                        ctx.to_t,
                         header.order,
                     )
-                    .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+                    .map_err(|e| QueryError::Internal(format!("replay leaflet: {e}")))?
+                    {
+                        Some(replayed) => replayed,
+                        None => batch,
+                    }
+                } else {
+                    batch
                 };
 
                 // OPST leaflets are ordered by (o_type, o_key, p_id, s_id, t...).
@@ -2520,6 +2570,7 @@ pub(crate) fn batched_subject_probe_binary(
     };
     let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
     let cache = store.leaflet_cache();
+    let need_replay = ctx.to_t < store.max_t();
     let mut out = Vec::new();
 
     for leaf_idx in leaf_range {
@@ -2527,6 +2578,13 @@ pub(crate) fn batched_subject_probe_binary(
         let leaf_bytes = store
             .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
             .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
+        let sidecar_bytes: Option<Vec<u8>> = if need_replay {
+            store
+                .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
+                .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
+        } else {
+            None
+        };
         let header = decode_leaf_header_v3(&leaf_bytes)
             .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
         let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
@@ -2563,6 +2621,24 @@ pub(crate) fn batched_subject_probe_binary(
                     header.order,
                 )
                 .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+            };
+
+            // Apply time-travel replay when querying a historical snapshot.
+            let batch = if need_replay {
+                match fluree_db_binary_index::replay_leaflet_at_t(
+                    &batch,
+                    entry,
+                    sidecar_bytes.as_deref(),
+                    ctx.to_t,
+                    header.order,
+                )
+                .map_err(|e| QueryError::Internal(format!("replay leaflet: {e}")))?
+                {
+                    Some(replayed) => replayed,
+                    None => batch,
+                }
+            } else {
+                batch
             };
 
             let row_count = batch.row_count;
@@ -2706,6 +2782,7 @@ pub(crate) fn batched_subject_star_spot(
     };
     let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
     let cache = store.leaflet_cache();
+    let need_replay = ctx.to_t < store.max_t();
     let mut out = Vec::new();
 
     for leaf_idx in leaf_range {
@@ -2713,6 +2790,13 @@ pub(crate) fn batched_subject_star_spot(
         let leaf_bytes = store
             .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
             .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
+        let sidecar_bytes: Option<Vec<u8>> = if need_replay {
+            store
+                .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
+                .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
+        } else {
+            None
+        };
         let header = decode_leaf_header_v3(&leaf_bytes)
             .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
         let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
@@ -2746,6 +2830,24 @@ pub(crate) fn batched_subject_star_spot(
                     header.order,
                 )
                 .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+            };
+
+            // Apply time-travel replay when querying a historical snapshot.
+            let batch = if need_replay {
+                match fluree_db_binary_index::replay_leaflet_at_t(
+                    &batch,
+                    entry,
+                    sidecar_bytes.as_deref(),
+                    ctx.to_t,
+                    header.order,
+                )
+                .map_err(|e| QueryError::Internal(format!("replay leaflet: {e}")))?
+                {
+                    Some(replayed) => replayed,
+                    None => batch,
+                }
+            } else {
+                batch
             };
 
             let row_count = batch.row_count;

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -30,6 +30,57 @@ use tracing::Instrument;
 const BATCHED_EXISTS_DEBUG_MIN_ACCUM: usize = 8;
 const BATCHED_EXISTS_DEBUG_MIN_MS: u64 = 10;
 
+/// Prepared per-leaf inputs shared by every batched-probe path
+/// (`scan_leaves_into_scatter`, `flush_batched_object_accumulator_binary`,
+/// `batched_subject_probe_binary`, `batched_subject_star_spot`). Owns the
+/// leaf blob, decoded header/dir, the leaf-id hash, and the optional
+/// sidecar bytes — the leaflet loop body destructures this and proceeds
+/// without repeating the fetch+decode dance at each site.
+struct LeafScan {
+    leaf_bytes: Vec<u8>,
+    header: fluree_db_binary_index::format::leaf::LeafHeaderV3,
+    dir: fluree_db_binary_index::format::leaf::DecodedLeafDirV3,
+    leaf_id: u128,
+    /// Sidecar bytes for time-travel replay. `None` at `max_t` (the base
+    /// leaflet alone is authoritative); always fetched when `need_replay`
+    /// is true so `replay_leaflet_at_t` can reconstruct historical state.
+    sidecar_bytes: Option<Vec<u8>>,
+}
+
+fn prepare_leaf_for_scan(
+    store: &BinaryIndexStore,
+    leaf_entry: &fluree_db_binary_index::format::branch::LeafEntry,
+    need_replay: bool,
+) -> Result<LeafScan> {
+    use fluree_db_binary_index::format::leaf::{
+        decode_leaf_dir_v3_with_base, decode_leaf_header_v3,
+    };
+
+    let leaf_bytes = store
+        .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
+        .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
+    let sidecar_bytes: Option<Vec<u8>> = if need_replay {
+        store
+            .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
+            .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
+    } else {
+        None
+    };
+    let header = decode_leaf_header_v3(&leaf_bytes)
+        .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
+    let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
+        .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
+    let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
+
+    Ok(LeafScan {
+        leaf_bytes,
+        header,
+        dir,
+        leaf_id,
+        sidecar_bytes,
+    })
+}
+
 /// Binary search for the first row in `batch.s_id[start..end]` where `s_id >= target`.
 #[inline]
 fn lower_bound_s_id(
@@ -1493,9 +1544,6 @@ impl NestedLoopJoinOperator {
         scatter: &mut [Vec<Vec<Binding>>],
         dict_overlay: &Option<crate::dict_overlay::DictOverlay>,
     ) -> Result<()> {
-        use fluree_db_binary_index::format::leaf::{
-            decode_leaf_dir_v3_with_base, decode_leaf_header_v3,
-        };
         use fluree_db_binary_index::read::column_loader::load_leaflet_columns_cached;
         use fluree_db_core::o_type::OType;
 
@@ -1509,25 +1557,13 @@ impl NestedLoopJoinOperator {
 
         for leaf_idx in leaf_range {
             let leaf_entry = &branch.leaves[leaf_idx];
-            let leaf_bytes = store
-                .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
-                .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
-
-            let header = decode_leaf_header_v3(&leaf_bytes)
-                .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
-            let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
-                .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
-            let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
-            // Fetch sidecar bytes once per leaf when we need historical replay.
-            // The leaflet base columns are content-addressed (immutable); the
-            // sidecar is what carries retracts, so we only need it for `to_t < max_t`.
-            let sidecar_bytes: Option<Vec<u8>> = if need_replay {
-                store
-                    .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
-                    .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
-            } else {
-                None
-            };
+            let LeafScan {
+                leaf_bytes,
+                header,
+                dir,
+                leaf_id,
+                sidecar_bytes,
+            } = prepare_leaf_for_scan(store, leaf_entry, need_replay)?;
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
                 leaflets_scanned += 1;
@@ -2009,9 +2045,6 @@ impl NestedLoopJoinOperator {
         &mut self,
         ctx: &ExecutionContext<'_>,
     ) -> Result<()> {
-        use fluree_db_binary_index::format::leaf::{
-            decode_leaf_dir_v3_with_base, decode_leaf_header_v3,
-        };
         use fluree_db_binary_index::format::run_record_v2::{
             cmp_v2_for_order, read_ordered_key_v2, RunRecordV2,
         };
@@ -2099,24 +2132,13 @@ impl NestedLoopJoinOperator {
         let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
         for leaf_idx in leaf_indices {
             let leaf_entry = &branch.leaves[leaf_idx];
-            let leaf_bytes = store
-                .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
-                .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
-
-            let header = decode_leaf_header_v3(&leaf_bytes)
-                .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
-            let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
-                .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
-            let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
-            // Fetch sidecar bytes once per leaf for historical replay (see
-            // `scan_leaves_into_scatter` for the rationale).
-            let sidecar_bytes: Option<Vec<u8>> = if need_replay {
-                store
-                    .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
-                    .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
-            } else {
-                None
-            };
+            let LeafScan {
+                leaf_bytes,
+                header,
+                dir,
+                leaf_id,
+                sidecar_bytes,
+            } = prepare_leaf_for_scan(&store, leaf_entry, need_replay)?;
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
                 let needs_history_replay =
@@ -2541,9 +2563,6 @@ pub(crate) fn batched_subject_probe_binary(
     store: &Arc<BinaryIndexStore>,
     params: &SubjectProbeParams<'_>,
 ) -> Result<Vec<BatchedSubjectProbeMatch>> {
-    use fluree_db_binary_index::format::leaf::{
-        decode_leaf_dir_v3_with_base, decode_leaf_header_v3,
-    };
     use fluree_db_binary_index::format::run_record_v2::{cmp_v2_for_order, RunRecordV2};
     use fluree_db_binary_index::read::column_loader::load_leaflet_columns_cached;
     use fluree_db_binary_index::{ColumnProjection, RunSortOrder};
@@ -2593,21 +2612,13 @@ pub(crate) fn batched_subject_probe_binary(
 
     for leaf_idx in leaf_range {
         let leaf_entry = &branch.leaves[leaf_idx];
-        let leaf_bytes = store
-            .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
-            .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
-        let sidecar_bytes: Option<Vec<u8>> = if need_replay {
-            store
-                .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
-                .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
-        } else {
-            None
-        };
-        let header = decode_leaf_header_v3(&leaf_bytes)
-            .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
-        let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
-            .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
-        let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
+        let LeafScan {
+            leaf_bytes,
+            header,
+            dir,
+            leaf_id,
+            sidecar_bytes,
+        } = prepare_leaf_for_scan(store, leaf_entry, need_replay)?;
 
         for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
             let needs_history_replay =
@@ -2750,9 +2761,6 @@ pub(crate) fn batched_subject_star_spot(
     predicates: &[SpotStarPredicateParams<'_>],
     dict_overlay: Option<&crate::dict_overlay::DictOverlay>,
 ) -> Result<Vec<BatchedSpotStarMatch>> {
-    use fluree_db_binary_index::format::leaf::{
-        decode_leaf_dir_v3_with_base, decode_leaf_header_v3,
-    };
     use fluree_db_binary_index::format::run_record_v2::{cmp_v2_for_order, RunRecordV2};
     use fluree_db_binary_index::read::column_loader::load_leaflet_columns_cached;
     use fluree_db_binary_index::{ColumnProjection, RunSortOrder};
@@ -2810,21 +2818,13 @@ pub(crate) fn batched_subject_star_spot(
 
     for leaf_idx in leaf_range {
         let leaf_entry = &branch.leaves[leaf_idx];
-        let leaf_bytes = store
-            .get_leaf_bytes_sync(&leaf_entry.leaf_cid)
-            .map_err(|e| QueryError::Internal(format!("fetch leaf: {e}")))?;
-        let sidecar_bytes: Option<Vec<u8>> = if need_replay {
-            store
-                .fetch_sidecar_bytes_sync(leaf_entry.sidecar_cid.as_ref())
-                .map_err(|e| QueryError::Internal(format!("fetch sidecar: {e}")))?
-        } else {
-            None
-        };
-        let header = decode_leaf_header_v3(&leaf_bytes)
-            .map_err(|e| QueryError::Internal(format!("read leaf header: {e}")))?;
-        let dir = decode_leaf_dir_v3_with_base(&leaf_bytes, &header)
-            .map_err(|e| QueryError::Internal(format!("decode leaf dir: {e}")))?;
-        let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
+        let LeafScan {
+            leaf_bytes,
+            header,
+            dir,
+            leaf_id,
+            sidecar_bytes,
+        } = prepare_leaf_for_scan(store, leaf_entry, need_replay)?;
 
         for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
             let needs_history_replay =

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1505,6 +1505,7 @@ impl NestedLoopJoinOperator {
         let mut leaflets_scanned: u64 = 0;
         let mut matched_rows: u64 = 0;
         let need_replay = ctx.to_t < store.max_t();
+        let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
 
         for leaf_idx in leaf_range {
             let leaf_entry = &branch.leaves[leaf_idx];
@@ -1533,7 +1534,6 @@ impl NestedLoopJoinOperator {
                 // An empty-after-retract leaflet (`row_count == 0`) is preserved
                 // by the indexer for time-travel replay. Skip only when there is
                 // also no history past `to_t` to reconstruct.
-                let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
                 let needs_history_replay =
                     need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
                 if entry.row_count == 0 && !needs_history_replay {
@@ -2096,6 +2096,7 @@ impl NestedLoopJoinOperator {
 
         let cache = store.leaflet_cache();
         let need_replay = ctx.to_t < store.max_t();
+        let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
         for leaf_idx in leaf_indices {
             let leaf_entry = &branch.leaves[leaf_idx];
             let leaf_bytes = store
@@ -2118,7 +2119,6 @@ impl NestedLoopJoinOperator {
             };
 
             for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
-                let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
                 let needs_history_replay =
                     need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
                 if entry.row_count == 0 && !needs_history_replay {
@@ -2588,6 +2588,7 @@ pub(crate) fn batched_subject_probe_binary(
     let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
     let cache = store.leaflet_cache();
     let need_replay = ctx.to_t < store.max_t();
+    let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
     let mut out = Vec::new();
 
     for leaf_idx in leaf_range {
@@ -2609,7 +2610,6 @@ pub(crate) fn batched_subject_probe_binary(
         let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
 
         for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
-            let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
             let needs_history_replay =
                 need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
             if entry.row_count == 0 && !needs_history_replay {
@@ -2805,6 +2805,7 @@ pub(crate) fn batched_subject_star_spot(
     let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
     let cache = store.leaflet_cache();
     let need_replay = ctx.to_t < store.max_t();
+    let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
     let mut out = Vec::new();
 
     for leaf_idx in leaf_range {
@@ -2826,7 +2827,6 @@ pub(crate) fn batched_subject_star_spot(
         let leaf_id = xxhash_rust::xxh3::xxh3_128(leaf_entry.leaf_cid.to_bytes().as_ref());
 
         for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
-            let to_t_u32 = u32::try_from(ctx.to_t).unwrap_or(u32::MAX);
             let needs_history_replay =
                 need_replay && entry.history_len > 0 && entry.history_max_t > to_t_u32;
             if entry.row_count == 0 && !needs_history_replay {

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -308,10 +308,25 @@ impl PropertyJoinOperator {
         driver_subject_ids.is_some()
             && !ctx.is_multi_ledger()
             && ctx.binary_store.is_some()
+            && Self::at_latest_t(ctx)
             && !remaining_predicates.is_empty()
             && remaining_predicates
                 .iter()
                 .all(|&idx| self.predicates[idx].dtc.is_none())
+    }
+
+    /// Whether the query is targeting the latest snapshot.
+    ///
+    /// `batched_subject_probe_binary` and `batched_subject_star_spot` read
+    /// base leaflet rows directly without applying the `to_t` filter or
+    /// replaying the history sidecar. Disable those paths for historical
+    /// snapshots and let the planned per-predicate scans (which use
+    /// `BinaryCursor::set_to_t` + sidecar replay) handle correctness.
+    #[inline]
+    fn at_latest_t(ctx: &ExecutionContext<'_>) -> bool {
+        ctx.binary_store
+            .as_ref()
+            .is_some_and(|s| s.max_t() == ctx.to_t)
     }
 
     /// Create a new property-join operator from patterns
@@ -697,10 +712,13 @@ impl Operator for PropertyJoinOperator {
                 // If we have a driver subject set and we're in the right execution mode,
                 // try a batched subject probe for this predicate.
                 // Batched probe requires binary store with batched_lookup support.
+                // Time-travel queries fall back to the planned per-predicate scan
+                // path (`BinaryCursor::set_to_t` + sidecar replay); see `at_latest_t`.
                 let can_batched_probe = order_pos > 0
                     && driver_subject_ids.is_some()
                     && !ctx.is_multi_ledger()
                     && ctx.binary_store.is_some()
+                    && Self::at_latest_t(ctx)
                     && predicate.dtc.is_none();
 
                 if can_batched_probe {

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -308,25 +308,10 @@ impl PropertyJoinOperator {
         driver_subject_ids.is_some()
             && !ctx.is_multi_ledger()
             && ctx.binary_store.is_some()
-            && Self::at_latest_t(ctx)
             && !remaining_predicates.is_empty()
             && remaining_predicates
                 .iter()
                 .all(|&idx| self.predicates[idx].dtc.is_none())
-    }
-
-    /// Whether the query is targeting the latest snapshot.
-    ///
-    /// `batched_subject_probe_binary` and `batched_subject_star_spot` read
-    /// base leaflet rows directly without applying the `to_t` filter or
-    /// replaying the history sidecar. Disable those paths for historical
-    /// snapshots and let the planned per-predicate scans (which use
-    /// `BinaryCursor::set_to_t` + sidecar replay) handle correctness.
-    #[inline]
-    fn at_latest_t(ctx: &ExecutionContext<'_>) -> bool {
-        ctx.binary_store
-            .as_ref()
-            .is_some_and(|s| s.max_t() == ctx.to_t)
     }
 
     /// Create a new property-join operator from patterns
@@ -712,13 +697,12 @@ impl Operator for PropertyJoinOperator {
                 // If we have a driver subject set and we're in the right execution mode,
                 // try a batched subject probe for this predicate.
                 // Batched probe requires binary store with batched_lookup support.
-                // Time-travel queries fall back to the planned per-predicate scan
-                // path (`BinaryCursor::set_to_t` + sidecar replay); see `at_latest_t`.
+                // Historical snapshots (`to_t < max_t`) are handled inside the
+                // probe helpers via `replay_leaflet_at_t`.
                 let can_batched_probe = order_pos > 0
                     && driver_subject_ids.is_some()
                     && !ctx.is_multi_ledger()
                     && ctx.binary_store.is_some()
-                    && Self::at_latest_t(ctx)
                     && predicate.dtc.is_none();
 
                 if can_batched_probe {


### PR DESCRIPTION
SPARQL/JSON-LD time-travel queries silently returned latest-state results
when the WHERE clause combined `?s a <Class>` with a same-subject triple
whose object was a literal (`?s :status "paid"`) or a variable joined to
the type pattern. The `@t:N` snapshot qualifier on the dataset was ignored
in those shapes, so historical UIs showed the same data at every `t`.

This change gates the affected batched-probe paths on
`to_t == store.max_t()` and falls back to the per-row scan path
(`BinaryCursor::set_to_t` + history-sidecar replay) for historical
snapshots.

## Reproduction (from the bug report)

Ledger with two commits where one entity's `ns:status` changes from
`"approved"` (t=1) to `"paid"` (t=2). 18 invoices were paid at t=1, 20 at
t=2.

| # | Pattern | t=1 (expected 18) | t=2 (expected 20) | Verdict |
|---|---------|-------------------|-------------------|---------|
| A | `?inv a ns:Invoice ; ns:status ?status` GROUP BY `?status` | **20** | 20 | ❌ latest |
| B | `... ; ns:status ?s . BIND(?s AS ?aliased)` GROUP BY `?aliased` | 18 | 20 | ✓ |
| C | No `?s a <Class>` triple | 28 | 30 | ✓ |
| D | `... ; ns:status ?s . FILTER(?s = "paid")` | 18 | 20 | ✓ |
| E | `?inv a ns:Invoice ; ns:status "paid"` | **20** | 20 | ❌ latest |

Patterns A and E were broken; B, C, D worked.

## Root cause

The query engine has three batched probe helpers in `fluree-db-query` that
walk base leaflet rows directly via `load_leaflet_columns_cached` and
`decode_leaf_dir_v3_with_base`:

- `batched_subject_probe_binary` — used by
  `flush_batched_exists_accumulator_binary` (pattern E:
  `?s p <literal>`).
- `scan_leaves_into_scatter` — used by
  `flush_batched_accumulator_binary` (pattern A:
  `?s p ?o` joined to a type triple).
- `batched_subject_star_spot` — used by `PropertyJoinOperator`'s
  same-subject star walk.

None of them apply `ctx.to_t` filtering or replay the FIR6 history
sidecar. The base index only stores the *live* state at `max_t`; retracts
go in the sidecar. So a historical query routed through any of these
helpers gets latest-state rows back.

Pattern D worked only because FILTER pushdown turned the literal match
into an inline op evaluated by per-row `BinaryScanOperator` scans, which
*do* honor `ctx.to_t` via `BinaryCursor::set_to_t`.

The `fast_path_*` operators are already gated on `to_t == max_t` via
`fast_path_store(ctx)`. The bug is specifically in the join-side batched
probes that bypassed that gate.

## Fix

Disable the batched probe paths when `to_t < store.max_t()` and let the
per-row scan path handle correctness. Two crates touched:

### `fluree-db-query/src/join.rs`

`NestedLoopJoinOperator::next_batch` — extend the runtime `use_batched`
gate with `at_latest_t` so all three batched modes
(`batched_eligible`, `batched_object_eligible`,
`batched_exists_eligible`) fall through to per-row scans for historical
snapshots.

### `fluree-db-query/src/property_join.rs`

- Add `PropertyJoinOperator::at_latest_t(ctx)` helper.
- Gate `can_batched_probe` (per-predicate batched probe) on it.
- Gate `can_spot_walk_remaining` (driver-side SPOT star walk) on it.

The fallback per-row path was already correct; this just routes
historical queries to it.

## Performance impact

Historical queries (`to_t < max_t`) now fall back to per-row scans for
the affected join shapes. They were silently incorrect before, so this
is a correctness regression on the latency dimension only when applied
to historical snapshots — the expected and now-tested behavior. Latest
queries (`to_t == max_t`, the common case) take the same fast path as
before.
