### PR TITLE
feat: scalar expressions in JSON-LD `select` (parity with SPARQL)

### DIFF
--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -104,6 +104,47 @@ The array value is the selection spec — `"*"` for all forward properties, indi
 
 Each row is `[age, expanded_person, expanded_org]`. When every column is an IRI-constant expansion (no variable dependency anywhere in `select`), the output is independent of the WHERE solution count: the formatter emits one row regardless of how many solutions the WHERE produced.
 
+**S-expression columns** — a select item that is a string starting with `(` is an S-expression, in two flavors:
+
+*Aggregates*. Auto-aliased (`?count`, `?sum`, etc.) or with an explicit alias via `(as ...)`:
+
+```json
+{
+  "select": ["?category", "(count ?product)"],
+  "groupBy": ["?category"]
+}
+```
+
+```json
+{
+  "select": ["?category", "(as (count ?product) ?total)"],
+  "groupBy": ["?category"]
+}
+```
+
+*Scalar expressions* (COALESCE, IF, arithmetic, string/hash/date functions, …). Always require an explicit alias via `(as <expr> ?alias)`. Mirrors SPARQL `SELECT (expr AS ?alias)`:
+
+```json
+{
+  "select": ["?p", "(as (coalesce ?titleFr ?titleEn \"untitled\") ?title)"]
+}
+```
+
+```json
+{
+  "select": [
+    "?name",
+    "(as (coalesce ?email \"no-email\") ?contact)",
+    "(as (count ?favNums) ?count)"
+  ],
+  "groupBy": ["?name", "?contact"]
+}
+```
+
+Scalar select expressions desugar to a `bind` in the WHERE pattern list. If the expression references an aggregate's output variable (e.g. `(as (+ ?count 1) ?adjusted)`) the bind runs after aggregation; otherwise it runs before, so the alias is also a valid `groupBy` key.
+
+The same expression language is shared with `bind` and `filter`. The one exception is `in` / `not-in`, which require the bracketed-list form and are not accepted in select expressions — rewrite as `(or (= ?x 1) (= ?x 2) …)` instead.
+
 ### ask
 
 Tests whether a set of patterns has any solution, returning `true` or `false`. No variables are projected. Equivalent to SPARQL `ASK`. The value of `ask` is the where clause itself — an array or object of the same patterns accepted by `where`:
@@ -792,7 +833,7 @@ Group results:
 
 ```json
 {
-  "select": ["?category", ["count", "?product"]],
+  "select": ["?category", "(count ?product)"],
   "groupBy": ["?category"],
   "where": [
     { "@id": "?product", "ex:category": "?category" }
@@ -806,7 +847,7 @@ Filter grouped results:
 
 ```json
 {
-  "select": ["?category", ["count", "?product"]],
+  "select": ["?category", "(count ?product)"],
   "groupBy": ["?category"],
   "having": [["filter", "(> (count ?product) 10)"]],
   "where": [
@@ -817,12 +858,17 @@ Filter grouped results:
 
 ## Aggregation Functions
 
-- `(count ?var)` - Count non-null values
-- `(sum ?var)` - Sum numeric values
-- `(avg ?var)` - Average numeric values
-- `(min ?var)` - Minimum value
-- `(max ?var)` - Maximum value
-- `(sample ?var)` - Sample value
+- `(count ?var)` / `(count *)` — count non-null values; `*` counts solution rows
+- `(count-distinct ?var)` — count distinct non-null values
+- `(sum ?var)` — sum numeric values
+- `(avg ?var)` — average numeric values
+- `(min ?var)` / `(max ?var)` — extremum
+- `(median ?var)` — median
+- `(variance ?var)` / `(stddev ?var)` — population variance / standard deviation
+- `(sample ?var)` — implementation-defined sample value
+- `(groupconcat ?var)` / `(groupconcat ?var ", ")` — concatenate string values, optional separator (defaults to a single space)
+
+Each aggregate auto-aliases to `?<fn-name>` (`?count`, `?sum`, …). Use `(as (<fn> ?var) ?alias)` to choose an explicit alias.
 
 ## Time Travel Queries
 
@@ -1083,13 +1129,17 @@ Note: `f:*` keys used for graph source queries should be defined in your `@conte
   "@context": {
     "ex": "http://example.org/ns/"
   },
-  "select": ["?category", ["count", "?product"], ["avg", "?price"]],
+  "select": [
+    "?category",
+    "(as (count ?product) ?count)",
+    "(as (avg ?price) ?avgPrice)"
+  ],
   "groupBy": ["?category"],
   "having": [["filter", "(> (count ?product) 5)"]],
   "where": [
     { "@id": "?product", "ex:category": "?category", "ex:price": "?price" }
   ],
-  "orderBy": [["desc", ["count", "?product"]]]
+  "orderBy": [["desc", "?count"]]
 }
 ```
 

--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -483,3 +483,110 @@ async fn aggregates_count_star_direct() {
         ]))
     );
 }
+
+// ============================================================================
+// SELECT-clause scalar expressions
+//
+// Mirrors SPARQL's `SELECT (expr AS ?alias)` form so JSON-LD queries can
+// project computed values (COALESCE, IF, arithmetic, hash functions, …)
+// without resorting to a separate `bind` clause in the WHERE.
+// ============================================================================
+
+#[tokio::test]
+async fn select_expr_coalesce_falls_back_to_constant() {
+    // brian and cam have no schema:birthDate; should fall back to "unknown".
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "query/select-expr-coalesce:main").await;
+    let ctx = context_ex_schema();
+
+    let query = json!({
+        "@context": ctx,
+        "select": ["?name", "(as (coalesce ?birthDate \"unknown\") ?dob)"],
+        "where": [
+            {"@id": "?p", "schema:name": "?name"},
+            ["optional", {"@id": "?p", "schema:birthDate": "?birthDate"}]
+        ]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+
+    assert_eq!(
+        normalize_rows(&json_rows),
+        normalize_rows(&json!([
+            ["Alice", {"@value": "1974-09-26", "@type": "xsd:date"}],
+            ["Brian", "unknown"],
+            ["Cam", "unknown"],
+            ["Liam", {"@value": "2011-09-26", "@type": "xsd:date"}]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn select_expr_coalesce_with_count_aggregate() {
+    // Reproduces the user-reported pattern: COALESCE alongside an aggregate
+    // (COUNT) in the same SELECT, with explicit GROUP BY.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "query/select-expr-coalesce-count:main").await;
+    let ctx = context_ex_schema();
+
+    let query = json!({
+        "@context": ctx,
+        "select": [
+            "?name",
+            "(as (coalesce ?email \"no-email\") ?contact)",
+            "(as (count ?favNums) ?count)"
+        ],
+        "where": [
+            {"@id": "?p", "schema:name": "?name", "ex:favNums": "?favNums"},
+            ["optional", {"@id": "?p", "schema:email": "?email"}]
+        ],
+        "groupBy": ["?name", "?contact"]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+
+    assert_eq!(
+        normalize_rows(&json_rows),
+        normalize_rows(&json!([
+            ["Alice", "alice@example.org", 3],
+            ["Brian", "brian@example.org", 1],
+            ["Cam", "cam@example.org", 2],
+            ["Liam", "liam@example.org", 2]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn select_expr_if_branches_on_age() {
+    // IF in SELECT (no aggregate) — desugars to a pre-aggregation BIND.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "query/select-expr-if:main").await;
+    let ctx = context_ex_schema();
+
+    let query = json!({
+        "@context": ctx,
+        "select": ["?name", "(as (if (>= ?age 18) \"adult\" \"minor\") ?label)"],
+        "where": {"schema:name": "?name", "schema:age": "?age"}
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+
+    assert_eq!(
+        normalize_rows(&json_rows),
+        normalize_rows(&json!([
+            ["Alice", "adult"],
+            ["Brian", "adult"],
+            ["Cam", "adult"],
+            ["Liam", "minor"]
+        ]))
+    );
+}

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -862,7 +862,7 @@ pub enum UnresolvedColumn {
     /// `Column::Var(alias)` projection plus a `Pattern::Bind { var: alias, expr }`
     /// injected into the patterns list — or into `options.post_binds` when
     /// the expression references an aggregate output variable.
-    Expr {
+    Computation {
         expr: UnresolvedExpression,
         alias: Arc<str>,
     },
@@ -871,12 +871,12 @@ pub enum UnresolvedColumn {
 impl UnresolvedColumn {
     /// Returns the variable name if this column projects a single variable.
     ///
-    /// `Expr` columns return their alias variable, since after lowering the
-    /// projection is just the alias VarId.
+    /// `Computation` columns return their alias variable, since after
+    /// lowering the projection is just the alias VarId.
     pub fn var_name(&self) -> Option<&str> {
         match self {
             UnresolvedColumn::Var(name) => Some(name),
-            UnresolvedColumn::Expr { alias, .. } => Some(alias),
+            UnresolvedColumn::Computation { alias, .. } => Some(alias),
             UnresolvedColumn::Hydration(_) => None,
         }
     }
@@ -885,7 +885,7 @@ impl UnresolvedColumn {
     pub fn as_hydration(&self) -> Option<&UnresolvedHydrationSpec> {
         match self {
             UnresolvedColumn::Hydration(spec) => Some(spec),
-            UnresolvedColumn::Var(_) | UnresolvedColumn::Expr { .. } => None,
+            UnresolvedColumn::Var(_) | UnresolvedColumn::Computation { .. } => None,
         }
     }
 }

--- a/fluree-db-query/src/parse/ast.rs
+++ b/fluree-db-query/src/parse/ast.rs
@@ -855,13 +855,28 @@ pub enum UnresolvedColumn {
     /// Hydrate a subject (variable or IRI constant) into a nested JSON-LD
     /// object (e.g. `{"?person": ["*"]}`).
     Hydration(UnresolvedHydrationSpec),
+    /// A computed expression with an explicit alias.
+    ///
+    /// Written in the SELECT clause as `(as <expr> ?alias)`, e.g.
+    /// `(as (coalesce ?titleFr ?titleEn) ?title)`. Lowered to a
+    /// `Column::Var(alias)` projection plus a `Pattern::Bind { var: alias, expr }`
+    /// injected into the patterns list — or into `options.post_binds` when
+    /// the expression references an aggregate output variable.
+    Expr {
+        expr: UnresolvedExpression,
+        alias: Arc<str>,
+    },
 }
 
 impl UnresolvedColumn {
-    /// Returns the variable name if this is a `Var` column.
+    /// Returns the variable name if this column projects a single variable.
+    ///
+    /// `Expr` columns return their alias variable, since after lowering the
+    /// projection is just the alias VarId.
     pub fn var_name(&self) -> Option<&str> {
         match self {
             UnresolvedColumn::Var(name) => Some(name),
+            UnresolvedColumn::Expr { alias, .. } => Some(alias),
             UnresolvedColumn::Hydration(_) => None,
         }
     }
@@ -870,7 +885,7 @@ impl UnresolvedColumn {
     pub fn as_hydration(&self) -> Option<&UnresolvedHydrationSpec> {
         match self {
             UnresolvedColumn::Hydration(spec) => Some(spec),
-            UnresolvedColumn::Var(_) => None,
+            UnresolvedColumn::Var(_) | UnresolvedColumn::Expr { .. } => None,
         }
     }
 }

--- a/fluree-db-query/src/parse/filter_sexpr.rs
+++ b/fluree-db-query/src/parse/filter_sexpr.rs
@@ -27,6 +27,7 @@ use super::ast::UnresolvedExpression;
 use super::error::{ParseError, Result};
 use super::filter_common;
 use super::sexpr_tokenize;
+use super::sexpr_tokenize::SexprToken;
 use std::sync::Arc;
 
 /// Parse an S-expression string like "(> ?age 45)" into a filter expression
@@ -238,6 +239,98 @@ fn parse_s_expression_arg(s: &str) -> Result<(UnresolvedExpression, &str)> {
     let atom = &s[..end];
     let expr = parse_s_expression_atom(atom)?;
     Ok((expr, &s[end..]))
+}
+
+/// Convert an already-tokenized S-expression into an [`UnresolvedExpression`].
+///
+/// Used by the SELECT-clause parser, which tokenizes once to dispatch between
+/// aggregate and scalar-expression forms and then needs the scalar form as an
+/// expression tree.
+///
+/// Mirrors the operator handling in [`parse_s_expression`], with one caveat:
+/// `in` / `not-in` are rejected because their bracketed-list form (`[...]`)
+/// is not represented in [`SexprToken`]. Use the string S-expression form
+/// inside BIND/FILTER if `IN` is needed.
+pub fn expr_from_sexpr_token(tok: &SexprToken) -> Result<UnresolvedExpression> {
+    match tok {
+        // Quoted strings are *always* string literals — never reparsed as
+        // booleans, numbers, or variables. This is the only way to write
+        // a literal whose source spelling collides with a keyword
+        // (e.g. `"false"`, `"42"`, `"?notavar"`).
+        SexprToken::String(s) => Ok(UnresolvedExpression::string(s)),
+        SexprToken::Atom(s) => atom_token_to_expr(s),
+        SexprToken::List(items) => list_tokens_to_expr(items),
+    }
+}
+
+fn atom_token_to_expr(s: &str) -> Result<UnresolvedExpression> {
+    if s.starts_with('?') {
+        return Ok(UnresolvedExpression::var(s));
+    }
+    if s == "true" {
+        return Ok(UnresolvedExpression::boolean(true));
+    }
+    if s == "false" {
+        return Ok(UnresolvedExpression::boolean(false));
+    }
+    if let Ok(i) = s.parse::<i64>() {
+        return Ok(UnresolvedExpression::long(i));
+    }
+    if let Ok(f) = s.parse::<f64>() {
+        return Ok(UnresolvedExpression::double(f));
+    }
+    // Unquoted atom that didn't match any other shape — treat as a bare
+    // string. Quoted strings take the explicit `String` path above.
+    Ok(UnresolvedExpression::string(s))
+}
+
+fn list_tokens_to_expr(items: &[SexprToken]) -> Result<UnresolvedExpression> {
+    if items.is_empty() {
+        return Err(ParseError::InvalidSelect(
+            "empty expression in select clause".to_string(),
+        ));
+    }
+
+    let op = items[0].expect_atom("operator")?;
+    let op_lower = op.to_lowercase();
+
+    if matches!(op_lower.as_str(), "in" | "not-in" | "notin") {
+        return Err(ParseError::InvalidSelect(format!(
+            "'{op}' is not supported in select expressions; rewrite using or/and equality (e.g. (or (= ?x 1) (= ?x 2)))"
+        )));
+    }
+
+    let arg_tokens = &items[1..];
+    let clone_expr = |e: &UnresolvedExpression| -> Result<UnresolvedExpression> { Ok(e.clone()) };
+    let parsed: Result<Vec<UnresolvedExpression>> =
+        arg_tokens.iter().map(expr_from_sexpr_token).collect();
+    let args = parsed?;
+
+    match op_lower.as_str() {
+        op @ ("=" | "eq" | "!=" | "<>" | "ne" | "<" | "lt" | "<=" | "le" | ">" | "gt" | ">="
+        | "ge") => {
+            let canonical = filter_common::normalize_op(op);
+            filter_common::build_call(&args, canonical, clone_expr, 1, "comparison operator")
+        }
+        "and" => filter_common::build_and(&args, clone_expr),
+        "or" => filter_common::build_or(&args, clone_expr),
+        "not" => filter_common::build_not(&args, clone_expr),
+        op @ ("+" | "add" | "*" | "mul" | "/" | "div") => {
+            let canonical = filter_common::normalize_op(op);
+            filter_common::build_call(&args, canonical, clone_expr, 1, "arithmetic operator")
+        }
+        "-" | "sub" => {
+            if args.len() == 1 {
+                filter_common::build_call(&args, "negate", clone_expr, 1, "unary negation")
+            } else {
+                filter_common::build_call(&args, "-", clone_expr, 1, "arithmetic operator")
+            }
+        }
+        _ => Ok(UnresolvedExpression::Call {
+            func: Arc::from(op),
+            args,
+        }),
+    }
 }
 
 /// Parse a bracketed list `[...]` as a function call with name "list"

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -82,19 +82,62 @@ pub(crate) fn lower_query<E: IriEncoder>(
 ) -> Result<Query> {
     let mut pp_counter: u32 = 0;
 
-    // Lower the projection (columns + shape)
+    // Lower the projection (columns + shape). For `Expr` columns this only
+    // registers the alias VarId; the expression itself is desugared below.
     let projection = lower_projection(&ast.select, encoder, vars)?;
 
     // Lower patterns
     let mut patterns = Vec::new();
-    for unresolved_pattern in ast.patterns {
-        let lowered =
-            lower_unresolved_pattern(&unresolved_pattern, encoder, vars, &mut pp_counter)?;
+    for unresolved_pattern in &ast.patterns {
+        let lowered = lower_unresolved_pattern(unresolved_pattern, encoder, vars, &mut pp_counter)?;
         patterns.extend(lowered);
     }
 
     // Lower options
-    let options = lower_options(&ast.options, vars)?;
+    let mut options = lower_options(&ast.options, vars)?;
+
+    // Desugar SELECT-clause scalar expressions to BIND patterns.
+    //
+    // Placement rules:
+    //   - An expression that references an aggregate's output variable must
+    //     run *after* aggregation → `options.post_binds`.
+    //   - An expression that references an *earlier* select-expression alias
+    //     that itself landed in `post_binds` is also a post-aggregation
+    //     expression: it depends on a value that doesn't exist until after
+    //     aggregation. Pushing it as a pre-aggregation BIND would compute
+    //     against an unbound variable.
+    //   - Otherwise, it is a pre-aggregation BIND appended to the pattern
+    //     list, where it remains visible to GROUP BY / aggregates that
+    //     reference its alias.
+    //
+    // Mirrors `fluree_db_sparql::lower::select::lower_select_expression_binds`
+    // so SPARQL and JSON-LD queries produce the same IR shape.
+    let aggregate_output_vars: std::collections::HashSet<VarId> = options
+        .aggregates
+        .iter()
+        .map(|spec| spec.output_var)
+        .collect();
+    let mut post_bind_aliases: std::collections::HashSet<VarId> = std::collections::HashSet::new();
+    for column in ast.select.columns() {
+        if let UnresolvedColumn::Expr { expr, alias } = column {
+            let alias_var = vars.get_or_insert(alias);
+            let lowered_expr =
+                lower_filter_expr_with_encoder(expr, vars, encoder, &mut pp_counter)?;
+            let refs_post_value = lowered_expr
+                .referenced_vars()
+                .iter()
+                .any(|v| aggregate_output_vars.contains(v) || post_bind_aliases.contains(v));
+            if refs_post_value {
+                post_bind_aliases.insert(alias_var);
+                options.post_binds.push((alias_var, lowered_expr));
+            } else {
+                patterns.push(Pattern::Bind {
+                    var: alias_var,
+                    expr: lowered_expr,
+                });
+            }
+        }
+    }
 
     // Build QueryOutput from mode + lowered components
     let output = match select_mode {
@@ -135,6 +178,12 @@ fn lower_column<E: IriEncoder>(
         UnresolvedColumn::Var(name) => Ok(Column::Var(vars.get_or_insert(name))),
         UnresolvedColumn::Hydration(spec) => {
             Ok(Column::Hydration(lower_hydration(spec, encoder, vars)?))
+        }
+        UnresolvedColumn::Expr { alias, .. } => {
+            // The inner expression desugars to a `Pattern::Bind` (or to
+            // `options.post_binds`) inside `lower_query`. The projection
+            // itself is just the alias variable.
+            Ok(Column::Var(vars.get_or_insert(alias)))
         }
     }
 }
@@ -981,6 +1030,35 @@ fn path_expr_name(expr: &UnresolvedPathExpr) -> &'static str {
     }
 }
 
+/// Walk an unresolved expression tree and return true if any `Var` reference
+/// matches a name in `targets`.
+///
+/// Used to decide whether a SELECT-clause scalar expression is a pre- or
+/// post-aggregation BIND: if it references any aggregate output variable
+/// (the `targets` set), it must run after aggregation.
+fn expression_references_any(
+    expr: &UnresolvedExpression,
+    targets: &std::collections::HashSet<&Arc<str>>,
+) -> bool {
+    match expr {
+        UnresolvedExpression::Var(name) => targets.contains(name),
+        UnresolvedExpression::Const(_) => false,
+        UnresolvedExpression::And(items) | UnresolvedExpression::Or(items) => {
+            items.iter().any(|e| expression_references_any(e, targets))
+        }
+        UnresolvedExpression::Not(inner) => expression_references_any(inner, targets),
+        UnresolvedExpression::In { expr, values, .. } => {
+            expression_references_any(expr, targets)
+                || values.iter().any(|v| expression_references_any(v, targets))
+        }
+        UnresolvedExpression::Call { args, .. } => {
+            args.iter().any(|a| expression_references_any(a, targets))
+        }
+        // EXISTS subqueries don't bring outer aggregate refs into scope here.
+        UnresolvedExpression::Exists { .. } => false,
+    }
+}
+
 /// Expect a path expression to be a simple IRI. Returns the Arc'd IRI string.
 fn expect_simple_iri(path: &UnresolvedPathExpr) -> Result<&Arc<str>> {
     match path {
@@ -1015,18 +1093,50 @@ fn lower_subquery<E: IriEncoder>(
             ));
         }
     };
+    // Pre-register alias VarIds for any `Expr` columns so the projection has
+    // them, then lower their expressions to a `Pattern::Bind` appended to the
+    // subquery's WHERE patterns below.
     let select: Vec<VarId> = columns
         .iter()
         .map(|c| match c {
             UnresolvedColumn::Var(name) => Ok(vars.get_or_insert(name)),
+            UnresolvedColumn::Expr { alias, .. } => Ok(vars.get_or_insert(alias)),
             UnresolvedColumn::Hydration(_) => Err(ParseError::InvalidSelect(
                 "hydrations are not allowed inside subqueries".to_string(),
             )),
         })
         .collect::<Result<_>>()?;
 
-    // Lower WHERE patterns
-    let patterns = lower_unresolved_patterns(&subquery.patterns, encoder, vars, pp_counter)?;
+    // Lower WHERE patterns, then append select-expression BINDs.
+    let mut patterns = lower_unresolved_patterns(&subquery.patterns, encoder, vars, pp_counter)?;
+
+    let aggregate_output_vars: std::collections::HashSet<&Arc<str>> = subquery
+        .options
+        .aggregates
+        .iter()
+        .map(|spec| &spec.output_var)
+        .collect();
+    for column in columns {
+        if let UnresolvedColumn::Expr { expr, alias } = column {
+            // Subqueries do not currently expose post-aggregation binds, so
+            // disallow expressions that would need to run after aggregation.
+            // This mirrors the limitation of `SubqueryPattern` (no `post_binds`).
+            if aggregate_output_vars.contains(alias)
+                || expression_references_any(expr, &aggregate_output_vars)
+            {
+                return Err(ParseError::InvalidSelect(format!(
+                    "select expression '{alias}' references an aggregate output; \
+                     post-aggregation BINDs are not supported inside subqueries"
+                )));
+            }
+            let alias_var = vars.get_or_insert(alias);
+            let lowered_expr = lower_filter_expr_with_encoder(expr, vars, encoder, pp_counter)?;
+            patterns.push(Pattern::Bind {
+                var: alias_var,
+                expr: lowered_expr,
+            });
+        }
+    }
 
     // Build SubqueryPattern with options
     let mut sq = SubqueryPattern::new(select, patterns);
@@ -1409,6 +1519,16 @@ fn lower_function_name(name: &str) -> Function {
         "bound" => Function::Bound,
         "if" => Function::If,
         "coalesce" => Function::Coalesce,
+        // XSD datatype constructor (cast) functions — W3C SPARQL 1.1 §17.5.
+        // SPARQL routes these through `FunctionName::Extension(iri)`. JSON-LD
+        // queries arrive as a raw operator string, so accept both the compact
+        // prefix form (`xsd:integer`) and the fully-expanded IRI.
+        "xsd:boolean" | "http://www.w3.org/2001/xmlschema#boolean" => Function::XsdBoolean,
+        "xsd:integer" | "http://www.w3.org/2001/xmlschema#integer" => Function::XsdInteger,
+        "xsd:float" | "http://www.w3.org/2001/xmlschema#float" => Function::XsdFloat,
+        "xsd:double" | "http://www.w3.org/2001/xmlschema#double" => Function::XsdDouble,
+        "xsd:decimal" | "http://www.w3.org/2001/xmlschema#decimal" => Function::XsdDecimal,
+        "xsd:string" | "http://www.w3.org/2001/xmlschema#string" => Function::XsdString,
         other => Function::Custom(other.to_string()),
     }
 }

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -96,19 +96,11 @@ pub(crate) fn lower_query<E: IriEncoder>(
     // Lower options
     let mut options = lower_options(&ast.options, vars)?;
 
-    // Desugar SELECT-clause scalar expressions to BIND patterns.
-    //
-    // Placement rules:
-    //   - An expression that references an aggregate's output variable must
-    //     run *after* aggregation → `options.post_binds`.
-    //   - An expression that references an *earlier* select-expression alias
-    //     that itself landed in `post_binds` is also a post-aggregation
-    //     expression: it depends on a value that doesn't exist until after
-    //     aggregation. Pushing it as a pre-aggregation BIND would compute
-    //     against an unbound variable.
-    //   - Otherwise, it is a pre-aggregation BIND appended to the pattern
-    //     list, where it remains visible to GROUP BY / aggregates that
-    //     reference its alias.
+    // Desugar SELECT-clause scalar expressions to BIND patterns. Pre/Post
+    // placement is decided per-column by `lower_select_expr_bind`; we
+    // accumulate post-bind aliases as we go so chained derivations
+    // (`(as (+ ?cnt 1) ?adj) (as (+ ?adj 1) ?again)`) correctly land in
+    // `options.post_binds` in source order.
     //
     // Mirrors `fluree_db_sparql::lower::select::lower_select_expression_binds`
     // so SPARQL and JSON-LD queries produce the same IR shape.
@@ -119,22 +111,27 @@ pub(crate) fn lower_query<E: IriEncoder>(
         .collect();
     let mut post_bind_aliases: std::collections::HashSet<VarId> = std::collections::HashSet::new();
     for column in ast.select.columns() {
-        if let UnresolvedColumn::Expr { expr, alias } = column {
-            let alias_var = vars.get_or_insert(alias);
-            let lowered_expr =
-                lower_filter_expr_with_encoder(expr, vars, encoder, &mut pp_counter)?;
-            let refs_post_value = lowered_expr
-                .referenced_vars()
-                .iter()
-                .any(|v| aggregate_output_vars.contains(v) || post_bind_aliases.contains(v));
-            if refs_post_value {
-                post_bind_aliases.insert(alias_var);
-                options.post_binds.push((alias_var, lowered_expr));
-            } else {
-                patterns.push(Pattern::Bind {
-                    var: alias_var,
-                    expr: lowered_expr,
-                });
+        if let UnresolvedColumn::Computation { expr, alias } = column {
+            let (placement, alias_var, lowered_expr) = lower_select_expr_bind(
+                expr,
+                alias,
+                encoder,
+                vars,
+                &mut pp_counter,
+                &aggregate_output_vars,
+                &post_bind_aliases,
+            )?;
+            match placement {
+                SelectExprPlacement::Post => {
+                    post_bind_aliases.insert(alias_var);
+                    options.post_binds.push((alias_var, lowered_expr));
+                }
+                SelectExprPlacement::Pre => {
+                    patterns.push(Pattern::Bind {
+                        var: alias_var,
+                        expr: lowered_expr,
+                    });
+                }
             }
         }
     }
@@ -179,7 +176,7 @@ fn lower_column<E: IriEncoder>(
         UnresolvedColumn::Hydration(spec) => {
             Ok(Column::Hydration(lower_hydration(spec, encoder, vars)?))
         }
-        UnresolvedColumn::Expr { alias, .. } => {
+        UnresolvedColumn::Computation { alias, .. } => {
             // The inner expression desugars to a `Pattern::Bind` (or to
             // `options.post_binds`) inside `lower_query`. The projection
             // itself is just the alias variable.
@@ -1030,33 +1027,49 @@ fn path_expr_name(expr: &UnresolvedPathExpr) -> &'static str {
     }
 }
 
-/// Walk an unresolved expression tree and return true if any `Var` reference
-/// matches a name in `targets`.
+/// Where a SELECT-clause scalar expression must run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectExprPlacement {
+    /// Pre-aggregation: append to the WHERE pattern list as `Pattern::Bind`.
+    Pre,
+    /// Post-aggregation: append to `options.post_binds`.
+    Post,
+}
+
+/// Lower a single `UnresolvedColumn::Computation` to its placement plus
+/// resolved (alias VarId, Expression).
 ///
-/// Used to decide whether a SELECT-clause scalar expression is a pre- or
-/// post-aggregation BIND: if it references any aggregate output variable
-/// (the `targets` set), it must run after aggregation.
-fn expression_references_any(
+/// The decision is purely about which pipeline stage the BIND belongs to:
+///
+///   - `Post` if the lowered expression references any aggregate output
+///     variable, **or** any earlier-in-this-SELECT post-bind alias (passed
+///     in via `post_bind_aliases` so the caller can chain dependencies).
+///   - `Pre` otherwise.
+///
+/// Both `lower_query` and `lower_subquery` call this. `lower_query` routes
+/// the result by placement; `lower_subquery` errors on `Post` because
+/// [`SubqueryPattern`] has no `post_binds` field.
+fn lower_select_expr_bind<E: IriEncoder>(
     expr: &UnresolvedExpression,
-    targets: &std::collections::HashSet<&Arc<str>>,
-) -> bool {
-    match expr {
-        UnresolvedExpression::Var(name) => targets.contains(name),
-        UnresolvedExpression::Const(_) => false,
-        UnresolvedExpression::And(items) | UnresolvedExpression::Or(items) => {
-            items.iter().any(|e| expression_references_any(e, targets))
-        }
-        UnresolvedExpression::Not(inner) => expression_references_any(inner, targets),
-        UnresolvedExpression::In { expr, values, .. } => {
-            expression_references_any(expr, targets)
-                || values.iter().any(|v| expression_references_any(v, targets))
-        }
-        UnresolvedExpression::Call { args, .. } => {
-            args.iter().any(|a| expression_references_any(a, targets))
-        }
-        // EXISTS subqueries don't bring outer aggregate refs into scope here.
-        UnresolvedExpression::Exists { .. } => false,
-    }
+    alias: &Arc<str>,
+    encoder: &E,
+    vars: &mut VarRegistry,
+    pp_counter: &mut u32,
+    aggregate_output_vars: &std::collections::HashSet<VarId>,
+    post_bind_aliases: &std::collections::HashSet<VarId>,
+) -> Result<(SelectExprPlacement, VarId, Expression)> {
+    let alias_var = vars.get_or_insert(alias);
+    let lowered = lower_filter_expr_with_encoder(expr, vars, encoder, pp_counter)?;
+    let placement = if lowered
+        .referenced_vars()
+        .iter()
+        .any(|v| aggregate_output_vars.contains(v) || post_bind_aliases.contains(v))
+    {
+        SelectExprPlacement::Post
+    } else {
+        SelectExprPlacement::Pre
+    };
+    Ok((placement, alias_var, lowered))
 }
 
 /// Expect a path expression to be a simple IRI. Returns the Arc'd IRI string.
@@ -1100,7 +1113,7 @@ fn lower_subquery<E: IriEncoder>(
         .iter()
         .map(|c| match c {
             UnresolvedColumn::Var(name) => Ok(vars.get_or_insert(name)),
-            UnresolvedColumn::Expr { alias, .. } => Ok(vars.get_or_insert(alias)),
+            UnresolvedColumn::Computation { alias, .. } => Ok(vars.get_or_insert(alias)),
             UnresolvedColumn::Hydration(_) => Err(ParseError::InvalidSelect(
                 "hydrations are not allowed inside subqueries".to_string(),
             )),
@@ -1110,31 +1123,42 @@ fn lower_subquery<E: IriEncoder>(
     // Lower WHERE patterns, then append select-expression BINDs.
     let mut patterns = lower_unresolved_patterns(&subquery.patterns, encoder, vars, pp_counter)?;
 
-    let aggregate_output_vars: std::collections::HashSet<&Arc<str>> = subquery
+    // Subqueries do not currently expose post-aggregation binds, so we use
+    // the shared `lower_select_expr_bind` helper but reject any column it
+    // classifies as `Post`. This mirrors the limitation of `SubqueryPattern`
+    // (no `post_binds` field).
+    let aggregate_output_vars: std::collections::HashSet<VarId> = subquery
         .options
         .aggregates
         .iter()
-        .map(|spec| &spec.output_var)
+        .map(|spec| vars.get_or_insert(&spec.output_var))
         .collect();
+    let empty_post_binds: std::collections::HashSet<VarId> = std::collections::HashSet::new();
     for column in columns {
-        if let UnresolvedColumn::Expr { expr, alias } = column {
-            // Subqueries do not currently expose post-aggregation binds, so
-            // disallow expressions that would need to run after aggregation.
-            // This mirrors the limitation of `SubqueryPattern` (no `post_binds`).
-            if aggregate_output_vars.contains(alias)
-                || expression_references_any(expr, &aggregate_output_vars)
-            {
-                return Err(ParseError::InvalidSelect(format!(
-                    "select expression '{alias}' references an aggregate output; \
-                     post-aggregation BINDs are not supported inside subqueries"
-                )));
+        if let UnresolvedColumn::Computation { expr, alias } = column {
+            let (placement, alias_var, lowered_expr) = lower_select_expr_bind(
+                expr,
+                alias,
+                encoder,
+                vars,
+                pp_counter,
+                &aggregate_output_vars,
+                &empty_post_binds,
+            )?;
+            match placement {
+                SelectExprPlacement::Post => {
+                    return Err(ParseError::InvalidSelect(format!(
+                        "select expression '{alias}' references an aggregate output; \
+                         post-aggregation BINDs are not supported inside subqueries"
+                    )));
+                }
+                SelectExprPlacement::Pre => {
+                    patterns.push(Pattern::Bind {
+                        var: alias_var,
+                        expr: lowered_expr,
+                    });
+                }
             }
-            let alias_var = vars.get_or_insert(alias);
-            let lowered_expr = lower_filter_expr_with_encoder(expr, vars, encoder, pp_counter)?;
-            patterns.push(Pattern::Bind {
-                var: alias_var,
-                expr: lowered_expr,
-            });
         }
     }
 

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -599,13 +599,40 @@ fn parse_select(
     Ok(())
 }
 
+/// Returns true if the given (lowercased) function name is one of the
+/// SELECT-clause aggregate functions recognized by `parse_aggregate_fn_and_input`.
+///
+/// Used to dispatch S-expressions in the select clause between the aggregate
+/// path and the scalar-expression path.
+fn is_aggregate_name(name: &str) -> bool {
+    matches!(
+        name,
+        "count"
+            | "count-distinct"
+            | "countdistinct"
+            | "sum"
+            | "avg"
+            | "min"
+            | "max"
+            | "median"
+            | "variance"
+            | "stddev"
+            | "sample"
+            | "group-concat"
+            | "groupconcat"
+    )
+}
+
 /// Parse a string item from the select clause into a column.
 ///
-/// Handles two cases:
+/// Handles three cases:
 /// - Variable: `"?name"`
 /// - S-expression aggregate: `"(count ?x)"` or `"(as (count ?x) ?cnt)"` —
 ///   the spec is appended to `aggregates` and the output var becomes the
 ///   returned column.
+/// - S-expression scalar with alias: `"(as (coalesce ?a ?b) ?title)"` — the
+///   inner expression is captured as an `UnresolvedColumn::Expr` so lowering
+///   can desugar it to a `Pattern::Bind` with the alias as the projected var.
 ///
 /// Wildcard (`"*"`) is rejected here; it must be the entire `select` value
 /// and is handled at the top-level dispatch in `parse_query_inner`.
@@ -621,115 +648,95 @@ fn parse_select_string(
         ));
     }
 
-    if trimmed.starts_with('(') {
-        // S-expression: aggregate function call
-        let agg_spec = parse_aggregate_sexpr(trimmed)?;
-        let column = UnresolvedColumn::Var(Arc::from(agg_spec.output_var.as_ref()));
-        aggregates.push(agg_spec);
-        Ok(column)
-    } else {
+    if !trimmed.starts_with('(') {
         // Must be a variable - use validate_var_name for consistent error handling
         validate_var_name(trimmed)?;
-        Ok(UnresolvedColumn::Var(Arc::from(trimmed)))
+        return Ok(UnresolvedColumn::Var(Arc::from(trimmed)));
     }
-}
 
-// SexprToken and tokenization moved to sexpr_tokenize module
-
-/// Parse an S-expression aggregate function call
-///
-/// Supports legacy syntax:
-/// - `(count ?x)` - COUNT with auto-generated output var (?count)
-/// - `(as (count ?x) ?cnt)` - COUNT with explicit alias
-/// - `(count *)` - COUNT(*) for all rows
-/// - `(sum ?age)` - SUM
-/// - `(as (avg ?score) ?avgScore)` - AVG with alias
-/// - `(groupconcat ?name ", ")` - GROUP_CONCAT with separator as 2nd arg
-fn parse_aggregate_sexpr(s: &str) -> Result<ast::UnresolvedAggregateSpec> {
-    let trimmed = s.trim();
-
-    // Must start with ( and end with )
-    if !trimmed.starts_with('(') || !trimmed.ends_with(')') {
+    // S-expression form. Tokenize once to peek at the head and decide
+    // between aggregate (existing behavior) and scalar expression (new).
+    if !trimmed.ends_with(')') {
         return Err(ParseError::InvalidSelect(format!(
-            "aggregate expression must be wrapped in parentheses: {s}"
+            "S-expression must be wrapped in parentheses: {s}"
         )));
     }
-
-    // Tokenize the entire expression
     let tokens = sexpr_tokenize::tokenize_sexpr(trimmed)?;
-
-    // Should have exactly one top-level list
     if tokens.len() != 1 {
         return Err(ParseError::InvalidSelect(format!(
             "expected single S-expression, got {} tokens",
             tokens.len()
         )));
     }
-
     let list = tokens[0].as_list()?;
-
     if list.is_empty() {
         return Err(ParseError::InvalidSelect(
-            "empty aggregate expression".to_string(),
+            "empty S-expression in select".to_string(),
         ));
     }
+    let head = list[0].expect_atom("function name")?.to_lowercase();
 
-    // Get the function name (first element)
-    let fn_name = list[0]
-        .expect_atom("aggregate function name")?
-        .to_lowercase();
+    // (as <inner> ?alias) — could wrap an aggregate or a scalar expression.
+    if head == "as" {
+        if list.len() != 3 {
+            return Err(ParseError::InvalidSelect(format!(
+                "(as ...) requires exactly 2 arguments: (as <expr> ?alias), got {} elements",
+                list.len() - 1
+            )));
+        }
+        let inner = list[1].expect_list("first argument to 'as'")?;
+        if inner.is_empty() {
+            return Err(ParseError::InvalidSelect(
+                "empty inner expression in 'as'".to_string(),
+            ));
+        }
+        let inner_head = inner[0].expect_atom("function name")?.to_lowercase();
+        let alias = list[2].expect_atom("alias in 'as'")?;
+        if !is_variable(alias) {
+            return Err(ParseError::InvalidSelect(format!(
+                "alias must be a variable (start with '?'), got: {alias}"
+            )));
+        }
 
-    // Check if this is an `as` wrapper: (as (agg-fn ?var) ?alias)
-    if fn_name == "as" {
-        return parse_as_aggregate(list);
+        if is_aggregate_name(&inner_head) {
+            // Existing aggregate-with-alias path.
+            let (function, input_var) = parse_aggregate_fn_and_input(&inner_head, &inner[1..])?;
+            let agg_spec = ast::UnresolvedAggregateSpec {
+                function,
+                input_var: Arc::from(input_var),
+                output_var: Arc::from(alias),
+            };
+            let column = UnresolvedColumn::Var(Arc::from(alias));
+            aggregates.push(agg_spec);
+            return Ok(column);
+        }
+
+        // Scalar expression with explicit alias — desugars to a BIND.
+        let expr = filter_sexpr::expr_from_sexpr_token(&list[1])?;
+        return Ok(UnresolvedColumn::Expr {
+            expr,
+            alias: Arc::from(alias),
+        });
     }
 
-    // Otherwise, parse as a direct aggregate: (count ?x) or (groupconcat ?x ", ")
-    parse_direct_aggregate(&fn_name, &list[1..])
+    // Direct aggregate: (count ?x) or (groupconcat ?x ", ").
+    if is_aggregate_name(&head) {
+        let agg_spec = parse_direct_aggregate(&head, &list[1..])?;
+        let column = UnresolvedColumn::Var(Arc::from(agg_spec.output_var.as_ref()));
+        aggregates.push(agg_spec);
+        return Ok(column);
+    }
+
+    // Scalar expression without an alias — disallowed: there is no
+    // unambiguous way to name the projected column.
+    Err(ParseError::InvalidSelect(format!(
+        "scalar expression '{head}' in select requires an alias: use (as ({head} ...) ?alias)"
+    )))
 }
 
-/// Parse `(as (agg-fn ?var) ?alias)` form
-fn parse_as_aggregate(list: &[sexpr_tokenize::SexprToken]) -> Result<ast::UnresolvedAggregateSpec> {
-    // Format: (as <inner-aggregate> ?alias)
-    if list.len() != 3 {
-        return Err(ParseError::InvalidSelect(format!(
-            "(as ...) requires exactly 2 arguments: (as (agg ?var) ?alias), got {} elements",
-            list.len() - 1
-        )));
-    }
-
-    // Second element must be the inner aggregate (a list)
-    let inner_agg = list[1].expect_list("first argument to 'as'")?;
-
-    // Third element must be the alias variable
-    let alias = list[2].expect_atom("alias in 'as'")?;
-
-    if !is_variable(alias) {
-        return Err(ParseError::InvalidSelect(format!(
-            "alias must be a variable (start with '?'), got: {alias}"
-        )));
-    }
-
-    // Parse the inner aggregate
-    if inner_agg.is_empty() {
-        return Err(ParseError::InvalidSelect(
-            "empty inner aggregate in 'as'".to_string(),
-        ));
-    }
-
-    let inner_fn_name = inner_agg[0]
-        .expect_atom("aggregate function name")?
-        .to_lowercase();
-
-    // Parse the inner aggregate with explicit output var
-    let (function, input_var) = parse_aggregate_fn_and_input(&inner_fn_name, &inner_agg[1..])?;
-
-    Ok(ast::UnresolvedAggregateSpec {
-        function,
-        input_var: Arc::from(input_var),
-        output_var: Arc::from(alias),
-    })
-}
+// SexprToken and tokenization moved to sexpr_tokenize module.
+// Dispatch between aggregate and scalar-expression S-expressions in select
+// is handled inline by `parse_select_string`.
 
 /// Parse a direct aggregate like `(count ?x)` or `(groupconcat ?x ", ")`
 fn parse_direct_aggregate(
@@ -786,7 +793,9 @@ fn parse_aggregate_fn_and_input(
                 )));
             }
             let separator = if args.len() > 1 {
-                args[1].expect_atom("groupconcat separator")?.to_string()
+                // Accept both quoted and unquoted forms — both express a
+                // string literal here.
+                args[1].as_str()?.to_string()
             } else {
                 " ".to_string() // default separator
             };
@@ -3135,6 +3144,279 @@ mod tests {
             "unexpected error: {msg}"
         );
         assert!(msg.contains("missing closing"), "unexpected error: {msg}");
+    }
+
+    // ==========================================
+    // SELECT-clause scalar expression tests
+    // ==========================================
+
+    #[test]
+    fn test_select_scalar_expr_with_alias_parses_to_expr_column() {
+        // (as (coalesce ?titleFr ?titleEn) ?title) should produce an Expr column.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?scheme", "(as (coalesce ?titleFr ?titleEn) ?title)"],
+            "where": [
+                {"@id": "?scheme", "@type": "ex:Scheme"},
+                ["optional", {"@id": "?scheme", "ex:titleFr": "?titleFr"}],
+                ["optional", {"@id": "?scheme", "ex:titleEn": "?titleEn"}]
+            ]
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        let cols = ast.select.columns();
+        assert_eq!(cols.len(), 2);
+        assert!(matches!(&cols[0], UnresolvedColumn::Var(n) if n.as_ref() == "?scheme"));
+        match &cols[1] {
+            UnresolvedColumn::Expr { expr, alias } => {
+                assert_eq!(alias.as_ref(), "?title");
+                match expr {
+                    UnresolvedExpression::Call { func, args } => {
+                        assert_eq!(func.as_ref(), "coalesce");
+                        assert_eq!(args.len(), 2);
+                    }
+                    other => panic!("expected Call, got {other:?}"),
+                }
+            }
+            other => panic!("expected Expr column, got {other:?}"),
+        }
+        // No aggregates should have been collected.
+        assert!(ast.options.aggregates.is_empty());
+    }
+
+    #[test]
+    fn test_select_scalar_expr_lowers_to_bind() {
+        // The scalar select expression should desugar to a Pattern::Bind in
+        // the IR, with the projection referring to the alias var.
+        use crate::ir::Pattern;
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?scheme", "(as (coalesce ?titleFr ?titleEn) ?title)"],
+            "where": [
+                {"@id": "?scheme", "ex:titleFr": "?titleFr"},
+                {"@id": "?scheme", "ex:titleEn": "?titleEn"}
+            ]
+        });
+
+        let mut vars = VarRegistry::new();
+        let encoder = encode::MemoryEncoder::with_common_namespaces();
+        let query = parse_query(&json, &encoder, &mut vars, None).unwrap();
+
+        // Exactly one Bind pattern, binding the alias to a Coalesce call.
+        let bind_count = query
+            .patterns
+            .iter()
+            .filter(|p| matches!(p, Pattern::Bind { .. }))
+            .count();
+        assert_eq!(
+            bind_count, 1,
+            "expected exactly one BIND pattern from select expression"
+        );
+
+        let title_var = vars.get("?title").expect("alias var registered");
+        let bind = query
+            .patterns
+            .iter()
+            .find_map(|p| match p {
+                Pattern::Bind { var, expr } if *var == title_var => Some(expr),
+                _ => None,
+            })
+            .expect("BIND for ?title");
+        // Expression should be a Coalesce function call.
+        match bind {
+            crate::ir::Expression::Call { func, args } => {
+                assert!(matches!(func, crate::ir::Function::Coalesce));
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected Call(Coalesce), got {other:?}"),
+        }
+        // No post-aggregation binds (no aggregates here).
+        assert!(query.options.post_binds.is_empty());
+    }
+
+    #[test]
+    fn test_select_scalar_expr_post_aggregate_bind() {
+        // (as (+ ?cnt 1) ?adjusted) where ?cnt is an aggregate output should
+        // land in options.post_binds, not in patterns.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                "?name",
+                "(as (count ?favNums) ?cnt)",
+                "(as (+ ?cnt 1) ?adjusted)"
+            ],
+            "where": { "ex:name": "?name", "ex:favNums": "?favNums" },
+            "groupBy": ["?name"]
+        });
+
+        let mut vars = VarRegistry::new();
+        let encoder = encode::MemoryEncoder::with_common_namespaces();
+        let query = parse_query(&json, &encoder, &mut vars, None).unwrap();
+
+        // Aggregate created.
+        assert_eq!(query.options.aggregates.len(), 1);
+        // The (+ ?cnt 1) bind must be post-aggregation.
+        assert_eq!(query.options.post_binds.len(), 1);
+        let adjusted_var = vars.get("?adjusted").expect("?adjusted registered");
+        assert_eq!(query.options.post_binds[0].0, adjusted_var);
+    }
+
+    #[test]
+    fn test_select_scalar_expr_without_alias_errors() {
+        // A bare scalar S-expression in select must require an alias.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?scheme", "(coalesce ?a ?b)"],
+            "where": { "@id": "?scheme", "ex:a": "?a", "ex:b": "?b" }
+        });
+
+        let err = parse_query_ast(&json, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("requires an alias"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_select_scalar_expr_with_if_function() {
+        // IF is a builtin scalar conditional; should also work via (as ... ?alias).
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": ["?p", "(as (if (> ?age 18) \"adult\" \"minor\") ?label)"],
+            "where": { "@id": "?p", "ex:age": "?age" }
+        });
+
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+        match &ast.select.columns()[1] {
+            UnresolvedColumn::Expr { alias, expr } => {
+                assert_eq!(alias.as_ref(), "?label");
+                assert!(
+                    matches!(expr, UnresolvedExpression::Call { func, .. } if func.as_ref() == "if")
+                );
+            }
+            other => panic!("expected Expr column, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_select_scalar_expr_quoted_keyword_stays_string() {
+        // Regression: a quoted "false" / "42" / "?nope" in a select expression
+        // must remain a string literal — not be re-parsed as a boolean,
+        // number, or variable. Regression for the SexprToken atom/string
+        // collapse that earlier versions had.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                "?p",
+                "(as (coalesce ?flag \"false\") ?fallback_bool)",
+                "(as (coalesce ?n \"42\") ?fallback_num)",
+                "(as (coalesce ?v \"?notavar\") ?fallback_varlike)"
+            ],
+            "where": { "@id": "?p", "ex:flag": "?flag", "ex:n": "?n", "ex:v": "?v" }
+        });
+        let (ast, _) = parse_query_ast(&json, None).unwrap();
+
+        // For each Expr column, the second arg of coalesce must be a string Const.
+        for (idx, expected) in [(1, "false"), (2, "42"), (3, "?notavar")] {
+            let col = &ast.select.columns()[idx];
+            let UnresolvedColumn::Expr { expr, .. } = col else {
+                panic!("col {idx}: expected Expr, got {col:?}");
+            };
+            let UnresolvedExpression::Call { func, args } = expr else {
+                panic!("col {idx}: expected Call, got {expr:?}");
+            };
+            assert_eq!(func.as_ref(), "coalesce");
+            match &args[1] {
+                UnresolvedExpression::Const(crate::parse::ast::UnresolvedFilterValue::String(
+                    s,
+                )) => {
+                    assert_eq!(s.as_ref(), expected, "col {idx} second arg");
+                }
+                other => panic!("col {idx} second arg: expected string Const, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_select_scalar_expr_xsd_cast_recognized() {
+        // Parity with SPARQL: xsd:integer / xsd:boolean / etc. cast
+        // constructors must lower to the dedicated `Function::Xsd*` variant
+        // rather than fall through to `Function::Custom`.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                "?p",
+                "(as (xsd:integer ?n) ?asInt)",
+                "(as (xsd:string ?n) ?asStr)"
+            ],
+            "where": { "@id": "?p", "ex:n": "?n" }
+        });
+        let mut vars = VarRegistry::new();
+        let encoder = encode::MemoryEncoder::with_common_namespaces();
+        let query = parse_query(&json, &encoder, &mut vars, None).unwrap();
+
+        let int_var = vars.get("?asInt").expect("?asInt registered");
+        let str_var = vars.get("?asStr").expect("?asStr registered");
+
+        let mut found_int = false;
+        let mut found_str = false;
+        for p in &query.patterns {
+            if let crate::ir::Pattern::Bind { var, expr } = p {
+                if let crate::ir::Expression::Call { func, .. } = expr {
+                    if *var == int_var {
+                        assert!(matches!(func, crate::ir::Function::XsdInteger));
+                        found_int = true;
+                    }
+                    if *var == str_var {
+                        assert!(matches!(func, crate::ir::Function::XsdString));
+                        found_str = true;
+                    }
+                }
+            }
+        }
+        assert!(found_int, "xsd:integer cast did not lower to Function::XsdInteger");
+        assert!(found_str, "xsd:string cast did not lower to Function::XsdString");
+    }
+
+    #[test]
+    fn test_select_scalar_expr_chained_post_binds() {
+        // Regression: an Expr that references a previous Expr alias which
+        // itself landed in post_binds must also land in post_binds. Otherwise
+        // the chained expression evaluates against an unbound variable.
+        let json = json!({
+            "@context": { "ex": "http://example.org/" },
+            "select": [
+                "?name",
+                "(as (count ?favNums) ?cnt)",
+                "(as (+ ?cnt 1) ?adjusted)",
+                "(as (+ ?adjusted 1) ?again)"
+            ],
+            "where": { "ex:name": "?name", "ex:favNums": "?favNums" },
+            "groupBy": ["?name"]
+        });
+
+        let mut vars = VarRegistry::new();
+        let encoder = encode::MemoryEncoder::with_common_namespaces();
+        let query = parse_query(&json, &encoder, &mut vars, None).unwrap();
+
+        // One aggregate, two post-aggregation BINDs (in select order).
+        assert_eq!(query.options.aggregates.len(), 1);
+        assert_eq!(query.options.post_binds.len(), 2);
+
+        let adjusted_var = vars.get("?adjusted").expect("?adjusted registered");
+        let again_var = vars.get("?again").expect("?again registered");
+        assert_eq!(query.options.post_binds[0].0, adjusted_var);
+        assert_eq!(query.options.post_binds[1].0, again_var);
+
+        // No leaked Pattern::Bind for these — they must NOT have been
+        // pre-aggregation.
+        let bind_count = query
+            .patterns
+            .iter()
+            .filter(|p| matches!(p, crate::ir::Pattern::Bind { .. }))
+            .count();
+        assert_eq!(
+            bind_count, 0,
+            "chained post-bind expression must not leak into pre-aggregation patterns"
+        );
     }
 
     // ==========================================

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -631,7 +631,7 @@ fn is_aggregate_name(name: &str) -> bool {
 ///   the spec is appended to `aggregates` and the output var becomes the
 ///   returned column.
 /// - S-expression scalar with alias: `"(as (coalesce ?a ?b) ?title)"` — the
-///   inner expression is captured as an `UnresolvedColumn::Expr` so lowering
+///   inner expression is captured as an `UnresolvedColumn::Computation` so lowering
 ///   can desugar it to a `Pattern::Bind` with the alias as the projected var.
 ///
 /// Wildcard (`"*"`) is rejected here; it must be the entire `select` value
@@ -713,7 +713,7 @@ fn parse_select_string(
 
         // Scalar expression with explicit alias — desugars to a BIND.
         let expr = filter_sexpr::expr_from_sexpr_token(&list[1])?;
-        return Ok(UnresolvedColumn::Expr {
+        return Ok(UnresolvedColumn::Computation {
             expr,
             alias: Arc::from(alias),
         });
@@ -3168,7 +3168,7 @@ mod tests {
         assert_eq!(cols.len(), 2);
         assert!(matches!(&cols[0], UnresolvedColumn::Var(n) if n.as_ref() == "?scheme"));
         match &cols[1] {
-            UnresolvedColumn::Expr { expr, alias } => {
+            UnresolvedColumn::Computation { expr, alias } => {
                 assert_eq!(alias.as_ref(), "?title");
                 match expr {
                     UnresolvedExpression::Call { func, args } => {
@@ -3286,7 +3286,7 @@ mod tests {
 
         let (ast, _) = parse_query_ast(&json, None).unwrap();
         match &ast.select.columns()[1] {
-            UnresolvedColumn::Expr { alias, expr } => {
+            UnresolvedColumn::Computation { alias, expr } => {
                 assert_eq!(alias.as_ref(), "?label");
                 assert!(
                     matches!(expr, UnresolvedExpression::Call { func, .. } if func.as_ref() == "if")
@@ -3317,7 +3317,7 @@ mod tests {
         // For each Expr column, the second arg of coalesce must be a string Const.
         for (idx, expected) in [(1, "false"), (2, "42"), (3, "?notavar")] {
             let col = &ast.select.columns()[idx];
-            let UnresolvedColumn::Expr { expr, .. } = col else {
+            let UnresolvedColumn::Computation { expr, .. } = col else {
                 panic!("col {idx}: expected Expr, got {col:?}");
             };
             let UnresolvedExpression::Call { func, args } = expr else {
@@ -3359,21 +3359,29 @@ mod tests {
         let mut found_int = false;
         let mut found_str = false;
         for p in &query.patterns {
-            if let crate::ir::Pattern::Bind { var, expr } = p {
-                if let crate::ir::Expression::Call { func, .. } = expr {
-                    if *var == int_var {
-                        assert!(matches!(func, crate::ir::Function::XsdInteger));
-                        found_int = true;
-                    }
-                    if *var == str_var {
-                        assert!(matches!(func, crate::ir::Function::XsdString));
-                        found_str = true;
-                    }
+            if let crate::ir::Pattern::Bind {
+                var,
+                expr: crate::ir::Expression::Call { func, .. },
+            } = p
+            {
+                if *var == int_var {
+                    assert!(matches!(func, crate::ir::Function::XsdInteger));
+                    found_int = true;
+                }
+                if *var == str_var {
+                    assert!(matches!(func, crate::ir::Function::XsdString));
+                    found_str = true;
                 }
             }
         }
-        assert!(found_int, "xsd:integer cast did not lower to Function::XsdInteger");
-        assert!(found_str, "xsd:string cast did not lower to Function::XsdString");
+        assert!(
+            found_int,
+            "xsd:integer cast did not lower to Function::XsdInteger"
+        );
+        assert!(
+            found_str,
+            "xsd:string cast did not lower to Function::XsdString"
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/parse/sexpr_tokenize.rs
+++ b/fluree-db-query/src/parse/sexpr_tokenize.rs
@@ -18,42 +18,61 @@ use super::error::{ParseError, Result};
 
 /// Token in an S-expression
 ///
-/// S-expressions are tokenized into nested atoms and lists:
+/// S-expressions are tokenized into nested atoms, quoted strings, and lists:
 /// - `?x` → `Atom("?x")`
+/// - `42` → `Atom("42")`
+/// - `"hello world"` → `String("hello world")`
 /// - `(count ?x)` → `List([Atom("count"), Atom("?x")])`
+///
+/// `Atom` and `String` are kept distinct so callers parsing scalar
+/// expressions can preserve literal type — e.g. `"false"` stays a string,
+/// while bare `false` is a boolean. `as_str` collapses both back to the
+/// underlying text for callers that don't care (e.g. the groupconcat
+/// separator).
 #[derive(Debug, Clone, PartialEq)]
 pub enum SexprToken {
-    /// Atom: variable, symbol, string literal, or number
+    /// Atom: variable, symbol, number, or boolean (unquoted in source).
     Atom(String),
+    /// Quoted string literal. Surrounding `"..."` is stripped; the contents
+    /// are preserved verbatim.
+    String(String),
     /// Nested list (sub-expression)
     List(Vec<SexprToken>),
 }
 
 impl SexprToken {
-    /// Extract atom value, returning error if this is a list
+    /// Extract atom value (unquoted), returning error if this is a list or
+    /// quoted string. Use this when the value must syntactically be an
+    /// identifier — variable, function name, alias, `*`, `as`.
     pub fn as_atom(&self) -> Result<&str> {
         match self {
             SexprToken::Atom(s) => Ok(s),
+            SexprToken::String(s) => Err(ParseError::InvalidSelect(format!(
+                "expected unquoted atom, got string literal: \"{s}\""
+            ))),
             SexprToken::List(_) => Err(ParseError::InvalidSelect(
                 "expected atom, got list".to_string(),
             )),
         }
     }
 
-    /// Extract list contents, returning error if this is an atom
+    /// Extract list contents, returning error if this is an atom or string
     pub fn as_list(&self) -> Result<&[SexprToken]> {
         match self {
             SexprToken::List(tokens) => Ok(tokens),
-            SexprToken::Atom(_) => Err(ParseError::InvalidSelect(
+            SexprToken::Atom(_) | SexprToken::String(_) => Err(ParseError::InvalidSelect(
                 "expected list, got atom".to_string(),
             )),
         }
     }
 
-    /// Extract atom value with custom error context
+    /// Extract atom value with custom error context (rejects strings and lists).
     pub fn expect_atom(&self, context: &str) -> Result<&str> {
         match self {
             SexprToken::Atom(s) => Ok(s),
+            SexprToken::String(s) => Err(ParseError::InvalidSelect(format!(
+                "{context} must be an unquoted atom, got string literal: \"{s}\""
+            ))),
             SexprToken::List(_) => Err(ParseError::InvalidSelect(format!(
                 "{context} must be an atom, not a list"
             ))),
@@ -67,6 +86,22 @@ impl SexprToken {
             SexprToken::Atom(a) => Err(ParseError::InvalidSelect(format!(
                 "{context} must be a list, got atom: {a}"
             ))),
+            SexprToken::String(s) => Err(ParseError::InvalidSelect(format!(
+                "{context} must be a list, got string literal: \"{s}\""
+            ))),
+        }
+    }
+
+    /// Inner text regardless of quoting (atom or string literal). Use for
+    /// values where the syntactic form doesn't change semantics — e.g. the
+    /// groupconcat separator: `(groupconcat ?x ", ")` and
+    /// `(groupconcat ?x ,)` both extract `,`.
+    pub fn as_str(&self) -> Result<&str> {
+        match self {
+            SexprToken::Atom(s) | SexprToken::String(s) => Ok(s),
+            SexprToken::List(_) => Err(ParseError::InvalidSelect(
+                "expected atom or string, got list".to_string(),
+            )),
         }
     }
 }
@@ -75,7 +110,7 @@ impl SexprToken {
 ///
 /// Handles:
 /// - Nested parentheses: `(as (count ?x) ?y)` → `List[Atom("as"), List[Atom("count"), Atom("?x")], Atom("?y")]`
-/// - Quoted strings: `"hello world"` → `Atom("hello world")`
+/// - Quoted strings: `"hello world"` → `String("hello world")` (distinct from `Atom`)
 /// - Symbols and variables: `count`, `?x`, `*`
 ///
 /// # Example
@@ -150,7 +185,7 @@ fn tokenize_sexpr_inner(
                         "unclosed string literal in S-expression (missing closing '\")".to_string(),
                     ));
                 }
-                tokens.push(SexprToken::Atom(string_val));
+                tokens.push(SexprToken::String(string_val));
             }
             c if c.is_whitespace() => {
                 // Push any pending atom
@@ -305,14 +340,31 @@ mod tests {
     }
 
     #[test]
-    fn test_tokenize_quoted_string() {
+    fn test_tokenize_quoted_string_distinct_from_atom() {
         let tokens = tokenize_sexpr(r#"(groupconcat ?x ", ")"#).unwrap();
         assert_eq!(tokens.len(), 1);
         let list = tokens[0].as_list().unwrap();
         assert_eq!(list.len(), 3);
         assert_eq!(list[0].as_atom().unwrap(), "groupconcat");
         assert_eq!(list[1].as_atom().unwrap(), "?x");
-        assert_eq!(list[2].as_atom().unwrap(), ", ");
+        // Quoted string is a `String` variant, not an `Atom`. Strict
+        // accessors reject it; `as_str` normalizes both back to text.
+        assert!(matches!(&list[2], SexprToken::String(s) if s == ", "));
+        assert!(list[2].as_atom().is_err());
+        assert_eq!(list[2].as_str().unwrap(), ", ");
+    }
+
+    #[test]
+    fn test_tokenize_quoted_keyword_not_a_keyword() {
+        // A quoted "false" must remain a string token — it should NOT collapse
+        // into the same shape as the bare boolean atom `false`.
+        let quoted = tokenize_sexpr(r#"(coalesce ?v "false")"#).unwrap();
+        let q_list = quoted[0].as_list().unwrap();
+        assert!(matches!(&q_list[2], SexprToken::String(s) if s == "false"));
+
+        let bare = tokenize_sexpr("(coalesce ?v false)").unwrap();
+        let b_list = bare[0].as_list().unwrap();
+        assert!(matches!(&b_list[2], SexprToken::Atom(s) if s == "false"));
     }
 
     #[test]


### PR DESCRIPTION

`SELECT (expr AS ?alias)` is now expressible in JSON-LD queries via
`(as <expr> ?alias)`. The two languages share the same query IR, so this is
purely a JSON-LD parse/lower change — no SPARQL or executor changes.

```json
{
  "select": ["?p", "(as (coalesce ?titleFr ?titleEn \"untitled\") ?title)"]
}
```

Previously rejected with `Unknown aggregate function: coalesce`, because the
JSON-LD select clause assumed every S-expression item was an aggregate. Now:

- `(<aggregate> ...)` — existing auto-aliased aggregate
- `(as (<aggregate> ...) ?alias)` — existing aliased aggregate
- `(as <expr> ?alias)` — **new**: scalar expression desugared to `Pattern::Bind`

A bare scalar without an alias errors with a clear pointer to the `(as ...)` form.

## Function parity

Every SPARQL `FunctionName` variant has a corresponding name in JSON-LD's
function lookup, including the XSD cast constructors (`xsd:boolean`,
`xsd:integer`, `xsd:float`, `xsd:double`, `xsd:decimal`, `xsd:string` —
both compact and full-IRI forms). The only deliberate exception is
`in`/`not-in` inside select expressions; the bracketed-list syntax they
require can't ride the `SexprToken` channel.

## Bugs fixed in the same change

- **Quoted vs unquoted token collapse.** `SexprToken::Atom` previously held
  both `false` and `"false"`, so a select expression argument lost its
  literal type. Split into `Atom` (unquoted: variables, numbers, booleans,
  symbols) and `String` (quoted literal). Strict accessors (`expect_atom`)
  reject the new `String` variant; new `as_str()` returns inner text from
  either. `(coalesce ?v "false")` now correctly yields the string `"false"`.

- **Chained post-aggregate binds.** A select expression that referenced
  another post-aggregate bind (e.g. `(as (+ ?adjusted 1) ?again)`, where
  `?adjusted` itself was a post-bind) was routed as a *pre*-aggregation
  `Pattern::Bind` and evaluated against an unbound variable. Lowering now
  tracks post-bind aliases as it walks select columns and routes chained
  references to `options.post_binds` in source order.

## Where the lowering happens

- `fluree-db-query/src/parse/ast.rs` — added `UnresolvedColumn::Expr`.
- `fluree-db-query/src/parse/sexpr_tokenize.rs` — split `Atom` / `String`.
- `fluree-db-query/src/parse/filter_sexpr.rs` — `expr_from_sexpr_token` keeps
  literal type for `String` tokens.
- `fluree-db-query/src/parse/mod.rs` — `parse_select_string` dispatches
  aggregate vs scalar after a single tokenize; removed dead helpers; added
  XSD cast names.
- `fluree-db-query/src/parse/lower.rs` — `lower_query` desugars Expr columns
  to `Pattern::Bind` (or `options.post_binds` if the expr references an
  aggregate output or earlier post-bind alias). Mirrors SPARQL's
  `lower_select_expression_binds`.

Subqueries support pre-aggregation expression binds; post-aggregation refs
inside subqueries are explicitly rejected because `SubqueryPattern` has no
`post_binds` field (separate enhancement).

## Tests

`fluree-db-query` unit tests:
- expression-column AST shape, lowering to `Pattern::Bind`
- post-aggregate routing for `(+ ?cnt 1)`
- chained post-binds (`?cnt` → `?adjusted` → `?again`) all in `post_binds`
- quoted `"false"` / `"42"` / `"?notavar"` stay string literals
- XSD cast lowers to `Function::XsdInteger` / `Function::XsdString`
- missing-alias error
- IF function in select
- token-level distinction between `String("false")` and `Atom("false")`

`fluree-db-api` integration tests:
- COALESCE with constant fallback over OPTIONAL
- COALESCE + COUNT in one SELECT with GROUP BY (the user-reported case)
- IF in select producing per-row labels

## Docs

`docs/query/jsonld-query.md`:
- New "S-expression columns" subsection in `select` covering both aggregate
  and scalar forms
- Fixed three stale `["count", "?var"]` examples that the parser actually
  rejects
- Expanded the aggregation function list (count-distinct, median, variance,
  stddev, groupconcat with separator)
