### PR TITLE
fix: accept time-travel `from` in explain endpoints

### DIFF
--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -435,6 +435,65 @@ impl Fluree {
             .await
     }
 
+    /// Explain a JSON-LD query via connection.
+    ///
+    /// Mirrors [`query_connection`] but emits the query plan rather than
+    /// executing it. The dataset spec (including any time-travel `from`
+    /// suffix like `mydb:main@t:5`) drives snapshot selection, so an
+    /// `--at` explain returns the plan at that historical `t` rather than
+    /// at HEAD.
+    ///
+    /// Multi-ledger dataset specs are rejected — explain is single-ledger
+    /// (consistent with [`Fluree::explain`] taking a `GraphDb`).
+    pub async fn explain_connection(&self, query_json: &JsonValue) -> Result<JsonValue> {
+        let (spec, qc_opts) = parse_dataset_spec(query_json)?;
+
+        if spec.is_empty() {
+            return Err(ApiError::query(
+                "Missing ledger specification in connection explain",
+            ));
+        }
+
+        let Some(view) = self
+            .prepare_single_view_for_connection(&spec, &qc_opts)
+            .await?
+        else {
+            return Err(ApiError::query(
+                "Multi-ledger datasets are not supported for explain; \
+                 specify a single `from` ledger (with optional time-travel suffix).",
+            ));
+        };
+
+        self.explain(&view, query_json).await
+    }
+
+    /// Explain a SPARQL query via connection. SPARQL counterpart to
+    /// [`explain_connection`] — requires exactly one `FROM` (with optional
+    /// time-travel suffix). Rejects `FROM NAMED` and multi-`FROM` queries,
+    /// since the planner is single-ledger.
+    pub async fn explain_connection_sparql(&self, sparql: &str) -> Result<JsonValue> {
+        let ast = parse_and_validate_sparql(sparql)?;
+        let spec = extract_sparql_dataset_spec(&ast)?;
+
+        if spec.is_empty() {
+            return Err(ApiError::query(
+                "Missing dataset specification in SPARQL explain (no FROM)",
+            ));
+        }
+
+        let Some(view) = self
+            .prepare_single_view_for_connection(&spec, &crate::QueryConnectionOptions::default())
+            .await?
+        else {
+            return Err(ApiError::query(
+                "Multi-ledger / FROM NAMED datasets are not supported for SPARQL explain; \
+                 use a single `FROM <ledger:branch>` (with optional time-travel suffix).",
+            ));
+        };
+
+        self.explain_sparql(&view, sparql).await
+    }
+
     /// Execute a SPARQL query via connection (dataset specified via SPARQL `FROM` / `FROM NAMED`).
     ///
     /// Note: SPARQL connection queries allow dataset clauses because the dataset

--- a/fluree-db-core/src/nonempty.rs
+++ b/fluree-db-core/src/nonempty.rs
@@ -35,6 +35,7 @@ impl<T> NonEmpty<T> {
     }
 
     /// Number of elements, always ≥ 1.
+    #[allow(clippy::len_without_is_empty)] // by construction never empty
     pub fn len(&self) -> usize {
         1 + self.tail.len()
     }

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -714,15 +714,41 @@ pub async fn explain_ledger(
                 }
             }
 
-            // For now, explain is ledger-scoped and does not support dataset clauses.
-            if fluree_db_api::sparql_dataset_ledger_ids(&sparql)
-                .map(|v| !v.is_empty())
-                .unwrap_or(false)
-            {
-                return Err(ServerError::bad_request(
-                    "SPARQL FROM/FROM NAMED is not supported for explain on the ledger-scoped endpoint; remove dataset clauses to explain the core plan"
-                        .to_string(),
-                ));
+            // If the SPARQL carries FROM clauses, allow them only when they
+            // target the path ledger (same base) — with an optional
+            // time-travel suffix. That gives `--at` callers a working plan
+            // at the requested `t` while still rejecting attempts to point
+            // explain at a different ledger via FROM. Multi-FROM and FROM
+            // NAMED are still routed through the connection-explain path,
+            // which itself enforces single-ledger.
+            let from_ids = fluree_db_api::sparql_dataset_ledger_ids(&sparql)
+                .unwrap_or_default();
+            let has_dataset_clauses = !from_ids.is_empty();
+            if has_dataset_clauses {
+                let base_path = base_ledger_id(&ledger)?;
+                for from in &from_ids {
+                    let base = base_ledger_id(from)?;
+                    if base != base_path {
+                        set_span_error_code(&span, "error:BadRequest");
+                        return Err(ServerError::bad_request(format!(
+                            "Ledger mismatch: endpoint ledger is '{ledger}' but SPARQL FROM targets '{from}'"
+                        )));
+                    }
+                }
+
+                // Route through the connection-explain path so the time-travel
+                // suffix on FROM <ledger@t:N> drives snapshot selection.
+                let result = state
+                    .fluree
+                    .explain_connection_sparql(&sparql)
+                    .await
+                    .map_err(ServerError::Api)?;
+                tracing::info!(
+                    status = "success",
+                    query_kind = "sparql",
+                    "explain completed (dataset path)"
+                );
+                return Ok(Json(result));
             }
 
             let ledger_id = ledger.clone();
@@ -789,6 +815,37 @@ pub async fn explain_ledger(
             policy_class,
         )
         .await;
+
+        // When the body carries a time-travel `from` (or any other dataset
+        // feature `normalize_ledger_scoped_from` accepted), delegate to the
+        // connection-explain path so the snapshot is resolved at the
+        // requested `t`. The default fast path below loads the ledger at
+        // HEAD, which would silently drop time-travel — exactly the
+        // explain bug the CLI was working around with a hard refusal.
+        if requires_dataset_features(&query_json) {
+            // Ensure the dataset has a default-graph entry pointing at this
+            // ledger if the body omitted `from`. Mirrors execute_query's
+            // dataset routing.
+            if query_json.get("from").is_none() {
+                if let Some(obj) = query_json.as_object_mut() {
+                    obj.insert(
+                        "from".to_string(),
+                        JsonValue::String(ledger_id.to_string()),
+                    );
+                }
+            }
+            let result = state
+                .fluree
+                .explain_connection(&query_json)
+                .await
+                .map_err(ServerError::Api)?;
+            tracing::info!(
+                status = "success",
+                query_kind = "jsonld",
+                "explain completed (dataset path)"
+            );
+            return Ok(Json(result));
+        }
 
         let loaded = if state.config.is_proxy_storage_mode() {
             state.fluree.ledger(&ledger_id).await.map_err(ServerError::Api)?
@@ -1987,33 +2044,51 @@ pub async fn explain(
             log_query_text(&sparql, &state.telemetry_config, &span);
 
             // Determine target ledger: header wins, otherwise require a single FROM ledger id.
-            let ledger_id = if let Some(ref l) = headers.ledger {
+            // FROM may carry a time-travel suffix (`@t:N` / `@iso:` / `@commit:`);
+            // strip it for the auth check so a scoped read token still authorizes.
+            let from_ids_raw = fluree_db_api::sparql_dataset_ledger_ids(&sparql)
+                .unwrap_or_default();
+            let ledger_id_raw = if let Some(ref l) = headers.ledger {
                 l.clone()
+            } else if from_ids_raw.len() == 1 {
+                from_ids_raw[0].clone()
+            } else if from_ids_raw.is_empty() {
+                return Err(ServerError::bad_request(format!(
+                    "Unable to determine ledger for SPARQL explain; include a FROM clause (e.g., FROM <myledger:main>) or send '{}' header.",
+                    FlureeHeaders::LEDGER,
+                )));
             } else {
-                let ledger_ids = fluree_db_api::sparql_dataset_ledger_ids(&sparql).map_err(|e| {
-                    ServerError::bad_request(format!(
-                        "Unable to determine ledger for SPARQL explain; include a FROM clause (e.g., FROM <myledger:main>) or send '{}' header. Details: {}",
-                        FlureeHeaders::LEDGER,
-                        e
-                    ))
-                })?;
-                if ledger_ids.len() != 1 {
-                    return Err(ServerError::bad_request(
-                        "SPARQL explain requires exactly one target ledger (single FROM <ledger>); multi-ledger explain is not supported"
-                            .to_string(),
-                    ));
-                }
-                ledger_ids[0].clone()
+                return Err(ServerError::bad_request(
+                    "SPARQL explain requires exactly one target ledger (single FROM <ledger>); multi-ledger explain is not supported"
+                        .to_string(),
+                ));
             };
+            let ledger_id = base_ledger_id(&ledger_id_raw)?;
             span.record("ledger_id", ledger_id.as_str());
 
-            // Enforce bearer ledger scope for unsigned requests
+            // Enforce bearer ledger scope for unsigned requests. We compare
+            // against the *base* ledger id (sans `@t:` suffix) so scoped
+            // tokens authorize time-travel explains.
             if let Some(p) = bearer.0.as_ref() {
                 if !credential.is_signed() && !p.can_read(&ledger_id) {
                     set_span_error_code(&span, "error:Forbidden");
                     // Avoid existence leak
                     return Err(ServerError::not_found("Ledger not found"));
                 }
+            }
+
+            // If FROM carries a time-travel suffix, route through the
+            // dataset-aware connection-explain path so snapshot selection
+            // honors `@t:N` / ISO / commit-prefix. Otherwise keep the
+            // simple HEAD-load fast path.
+            if ledger_id_raw != ledger_id {
+                let result = state
+                    .fluree
+                    .explain_connection_sparql(&sparql)
+                    .await
+                    .map_err(ServerError::Api)?;
+                tracing::info!(status = "success", "explain completed (dataset path)");
+                return Ok(Json(result));
             }
 
             let loaded = if state.config.is_proxy_storage_mode() {
@@ -2056,8 +2131,10 @@ pub async fn explain(
             }
         }
 
-        // Get ledger id
-        let ledger_id = match get_ledger_id(None, &headers, &query_json) {
+        // Get ledger id (may include `@t:N` suffix when body's `from` is
+        // time-travelled). Use the base for the bearer scope check so
+        // scoped read tokens still authorize.
+        let ledger_id_raw = match get_ledger_id(None, &headers, &query_json) {
             Ok(ledger_id) => {
                 span.record("ledger_id", ledger_id.as_str());
                 ledger_id
@@ -2068,11 +2145,12 @@ pub async fn explain(
                 return Err(e);
             }
         };
+        let ledger_id = base_ledger_id(&ledger_id_raw)?;
 
         // Inject header values into query opts
         inject_headers_into_query(&mut query_json, &headers);
 
-        // Enforce bearer ledger scope for unsigned requests
+        // Enforce bearer ledger scope for unsigned requests (base id only).
         if let Some(p) = bearer.0.as_ref() {
             if !credential.is_signed() && !p.can_read(&ledger_id) {
                 set_span_error_code(&span, "error:Forbidden");
@@ -2093,7 +2171,27 @@ pub async fn explain(
         )
         .await;
 
-        // Execute explain
+        // When the body carries time-travel `from` (or any other dataset
+        // feature parse_dataset_spec recognizes), route through the
+        // dataset-aware connection-explain path so snapshot selection
+        // honors `@t:N` rather than silently loading HEAD.
+        if requires_dataset_features(&query_json) {
+            let result = match state.fluree.explain_connection(&query_json).await {
+                Ok(result) => {
+                    tracing::info!(status = "success", "explain completed (dataset path)");
+                    result
+                }
+                Err(e) => {
+                    let server_error = ServerError::Api(e);
+                    set_span_error_code(&span, "error:InvalidQuery");
+                    tracing::error!(error = %server_error, "explain execution failed");
+                    return Err(server_error);
+                }
+            };
+            return Ok(Json(result));
+        }
+
+        // Execute explain (HEAD fast path)
         let loaded = if state.config.is_proxy_storage_mode() {
             state.fluree.ledger(&ledger_id).await.map_err(ServerError::Api)?
         } else {

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -2820,3 +2820,173 @@ async fn commits_endpoint_without_token_returns_401() {
         "missing token should return 401 when storage proxy is enabled"
     );
 }
+
+// =============================================================================
+// Explain time-travel — server-side honoring of `--at`-style FROM
+// =============================================================================
+//
+// These exercise the fix for explain endpoints silently loading HEAD even
+// when the body carries a time-travel `from` / SPARQL FROM <ledger@t:N>.
+
+async fn explain_test_setup() -> (TempDir, axum::Router) {
+    let (tmp, state) = test_state().await;
+    let app = build_router(state.clone());
+
+    // Create
+    let create_body = serde_json::json!({ "ledger": "tt:main" });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // Insert one triple to produce t=1
+    let insert_body = serde_json::json!({
+        "@context": { "ex": "http://example.org/" },
+        "@id": "ex:alice",
+        "ex:name": "Alice"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/insert/tt:main")
+                .header("content-type", "application/json")
+                .body(Body::from(insert_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    (tmp, app)
+}
+
+#[tokio::test]
+async fn explain_ledger_scoped_jsonld_with_time_travel_returns_plan() {
+    let (_tmp, app) = explain_test_setup().await;
+
+    // JSON-LD explain at t=1 (the head we just created). With the fix,
+    // the body's time-travel `from` is honored — pre-fix it was silently
+    // dropped and explain ran against HEAD.
+    let body = serde_json::json!({
+        "@context": { "ex": "http://example.org/" },
+        "from": "tt:main@t:1",
+        "select": ["?s", "?name"],
+        "where": { "@id": "?s", "ex:name": "?name" }
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/explain/tt:main")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK, "explain failed: {json}");
+    assert!(
+        json.get("plan").is_some() || json.get("optimized").is_some() || !json.is_null(),
+        "explain output should include a plan; got: {json}"
+    );
+}
+
+#[tokio::test]
+async fn explain_ledger_scoped_sparql_with_same_ledger_from_no_longer_rejected() {
+    let (_tmp, app) = explain_test_setup().await;
+
+    // SPARQL with a time-travel FROM that targets the same ledger as the
+    // URL path. Before the fix this returned 400
+    // ("SPARQL FROM/FROM NAMED is not supported for explain on the
+    // ledger-scoped endpoint"). After the fix it routes through the
+    // connection-explain path and returns the plan at the requested t.
+    let sparql = "SELECT ?s ?p ?o FROM <tt:main@t:1> WHERE { ?s ?p ?o }";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/explain/tt:main")
+                .header("content-type", "application/sparql-query")
+                .body(Body::from(sparql.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, json) = json_body(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "ledger-scoped SPARQL explain with same-ledger FROM should succeed; got: {json}"
+    );
+}
+
+#[tokio::test]
+async fn explain_ledger_scoped_sparql_with_cross_ledger_from_rejected() {
+    let (_tmp, app) = explain_test_setup().await;
+
+    // SPARQL FROM targeting a *different* ledger than the URL path should
+    // be rejected with a ledger-mismatch BadRequest — same shape as the
+    // JSON-LD path's `normalize_ledger_scoped_from` does today.
+    let sparql = "SELECT ?s ?p ?o FROM <otherdb:main> WHERE { ?s ?p ?o }";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/explain/tt:main")
+                .header("content-type", "application/sparql-query")
+                .body(Body::from(sparql.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, json) = json_body(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "cross-ledger SPARQL FROM should be rejected; got: {json}"
+    );
+    assert!(
+        json_contains_string(&json, "Ledger mismatch") || json_contains_string(&json, "otherdb"),
+        "error should mention the ledger mismatch; got: {json}"
+    );
+}
+
+#[tokio::test]
+async fn explain_connection_jsonld_with_time_travel_returns_plan() {
+    let (_tmp, app) = explain_test_setup().await;
+
+    // Connection-level JSON-LD explain — uses body's `from` (with
+    // time-travel suffix) to drive both auth scope (via base ledger) and
+    // snapshot selection.
+    let body = serde_json::json!({
+        "@context": { "ex": "http://example.org/" },
+        "from": "tt:main@t:1",
+        "select": ["?s", "?name"],
+        "where": { "@id": "?s", "ex:name": "?name" }
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/explain")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK, "explain failed: {json}");
+}


### PR DESCRIPTION
Two bugs in the explain handlers, plus a small consistency cleanup. The fix is about not rejecting valid requests and not getting auth wrong.

### Bug 1: scoped read tokens fail on `--at` explain (connection-level `/explain`)

The bearer scope check used the raw `body.from` value as the ledger id. When `from` carried a time-travel suffix (`"mydb:main@t:5"`), the check effectively asked "does this token have read on `mydb:main@t:5`?" — which never matches a token scoped to `mydb:main`. Only unscoped/root tokens could explain at a historical `t`.

### Bug 2: SPARQL `FROM/FROM NAMED` rejected outright on ledger-scoped `/explain/{ledger}`

`explain_ledger` returned `400 "SPARQL FROM/FROM NAMED is not supported for explain on the ledger-scoped endpoint"` whenever any FROM was present. That meant `SELECT … FROM <mydb:main@t:5> WHERE { … }` — the natural way to ask for a time-travel explain over SPARQL — was rejected before it could be planned. The JSON-LD side already accepts same-ledger `from` via `normalize_ledger_scoped_from`; SPARQL didn't.

### Cleanup: time-travel `from` was silently dropped

Both explain handlers loaded the path/header ledger at HEAD and ran explain there, regardless of any time-travel suffix in the body. Plans don't materially differ across `t` (see "What this PR is not" below), so this wasn't producing wrong-shape plans — but the server was quietly ignoring an explicit request parameter. Routing through a dataset-aware path keeps the contract honest and aligns explain's plumbing with the query path (which already takes `from` through `query_connection`).

## What changed

### `fluree-db-api`

Two new public methods on `Fluree`, mirroring `query_connection` / `query_connection_sparql` but emitting the plan instead of executing:

- `Fluree::explain_connection(query_json)` — parses dataset spec, builds a view via `prepare_single_view_for_connection`, calls existing `Fluree::explain` against it.
- `Fluree::explain_connection_sparql(sparql)` — SPARQL counterpart; requires exactly one `FROM` (with optional time-travel suffix).

Multi-ledger / `FROM NAMED` explain is rejected — `Fluree::explain` takes a single-ledger `GraphDb`, so it can't honestly explain across multiple datasets.

### `fluree-db-server`

`routes/query.rs::explain_ledger` and `routes/query.rs::explain`:

1. **Auth uses base ledger id.** When body's `from` or SPARQL `FROM` carries a `@t:N` / `@iso:` / `@commit:` suffix, the bearer scope check now compares against the base ledger id (sans suffix). Fixes Bug 1.

2. **SPARQL same-ledger `FROM` accepted on ledger-scoped explain.** The blanket rejection is gone. Cross-ledger `FROM` returns the same `400 Ledger mismatch` shape `normalize_ledger_scoped_from` produces for JSON-LD. Fixes Bug 2.

3. **Time-travel routing.** When the body has dataset features (`requires_dataset_features(query_json)` or a time-suffixed SPARQL FROM), handlers route through the new `explain_connection*` methods so the request is processed via the same plumbing the query path uses. HEAD requests still use the simple fast path.

### `fluree-db-core` (drive-by)

`#[allow(clippy::len_without_is_empty)]` on `NonEmpty::len`. `NonEmpty` can never be empty by construction, so the suggested `is_empty` method would always return `false`. This was failing `cargo clippy -D warnings` workspace-wide on `origin/main`.

## Tests

Four new integration tests in `fluree-db-server/tests/integration.rs`:

| Test | Pins down |
|---|---|
| `explain_ledger_scoped_jsonld_with_time_travel_returns_plan` | `POST /explain/{ledger}` with body `{ "from": "tt:main@t:1", ... }` returns 200 |
| `explain_ledger_scoped_sparql_with_same_ledger_from_no_longer_rejected` | `SELECT … FROM <tt:main@t:1> …` against `/explain/tt:main` returns 200 (was 400 before — Bug 2) |
| `explain_ledger_scoped_sparql_with_cross_ledger_from_rejected` | Cross-ledger `FROM <otherdb:main>` returns 400 `"Ledger mismatch"` (JSON-LD parity) |
| `explain_connection_jsonld_with_time_travel_returns_plan` | `POST /explain` with body's `from` carrying `@t:N` returns 200 |

Full suite: `cargo test -p fluree-db-server` (204 tests) and `cargo test -p fluree-db-api --lib` (425 tests) both pass. `cargo clippy -p fluree-db-server -p fluree-db-api --all-targets -- -D warnings` is clean.

## Performance

The query handler is untouched. Query latency is unchanged.

For explain itself:

- **HEAD explain** (no time-travel `from`): unchanged hot path — same `load_ledger_for_query` + `Fluree::explain` calls as before. Zero new work.
- **`--at` explain**: routes through `Fluree::explain_connection`, which builds a historical view via `load_graph_db_at_t`. That involves one nameservice lookup, one index-root read from CAS (cacheable via the shared `leaflet_cache`), and a dict-novelty overlay setup. Only fires for explicit historical requests. Possible future micro-optimization: a metadata-only loader for explain-only callers, since explain doesn't actually consume the binary store / range provider that the loader builds.

## Compatibility

- No request/response shape changes. Existing callers sending `from: "ledger@t:N"` to `/explain` will start getting 200s where they got 403/400 before.
- One behavior change with intent: ledger-scoped `/explain` no longer 400s SPARQL `FROM` when it targets the same ledger. Cross-ledger `FROM` keeps returning 400.
