### PR TITLE
fix(query): share EXISTS strategy with OPTIONAL+!bound rewrite

### DIFF
--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -401,6 +401,93 @@ Match data from multiple alternative patterns:
 }
 ```
 
+### Negation Patterns
+
+Restrict results to subjects that *do not* match a given pattern. Two forms
+are available; **prefer `not-exists` for the common "subjects without
+property `p`" case.**
+
+#### `not-exists` (canonical)
+
+`["not-exists", { ... }]` keeps rows for which the inner pattern has **no**
+solution under the current bindings:
+
+```json
+{
+  "where": [
+    { "@id": "?file", "@type": "ex:File" },
+    ["not-exists", { "@id": "?file", "ex:parent": "?p" }]
+  ],
+  "select": "?file"
+}
+```
+
+When the inner pattern is correlated to the outer **only via vars the inner
+itself produces** (here `?file`, produced by both the outer triple and the
+inner triple), and the inner does not reference any outer-only variable
+(e.g. via a `["filter", ...]` mentioning an outer var the inner doesn't
+produce), the planner builds the inner solution set **once** and probes it
+per outer row — the performant path on large outer streams. If either
+condition fails, the inner is rebuilt and re-run per outer row (still
+correct, but linear in the outer cardinality).
+
+`["exists", { ... }]` is the affirmative dual and uses the same dispatch.
+
+#### `OPTIONAL` + `(not (bound ?v))`
+
+The SPARQL-muscle-memory form `OPTIONAL { ... } FILTER (!bound(?v))` is
+spelled in JSON-LD as an `optional` followed by a filter using the supported
+`bound` function:
+
+```json
+{
+  "where": [
+    { "@id": "?file", "@type": "ex:File" },
+    ["optional", { "@id": "?file", "ex:parent": "?p" }],
+    ["filter", "(not (bound ?p))"]
+  ],
+  "select": "?file"
+}
+```
+
+The data filter form is equivalent: `["filter", ["not", ["bound", "?p"]]]`.
+
+When the `optional` block binds `?v`, the filter immediately tests
+`!bound(?v)`, and `?v` is not used after the filter, the planner rewrites
+this shape to a NOT EXISTS and dispatches it through the same strategy
+chooser as `not-exists`. The two forms therefore have the same plan and the
+same performance.
+
+#### `minus`
+
+`["minus", { ... }]` removes solutions whose shared variables match the
+inner pattern. Use when you want set-difference semantics rather than
+negation-as-failure (see SPARQL 1.1 §8.3 for the difference).
+
+#### Filter expression — supported "is-unbound" idioms
+
+The s-expression parser recognizes `not`, `and`, `or` as AST operators and
+`bound` as a function. The following are **not** parser tokens:
+
+| Attempt | Result |
+|---|---|
+| `(not (bound ?p))` | ✅ supported |
+| `["not", ["bound", "?p"]]` | ✅ supported (data filter form) |
+| `(!bound ?p)`, `(! (bound ?p))` | ❌ parse error — use `(not (bound ?p))` |
+| `(nil? ?p)` | ❌ parse error — use `(not (bound ?p))` |
+
+The "Unknown function" parse error includes a hint pointing at
+`(not (bound ?v))` or `["not-exists", ...]` for these common attempts.
+
+#### SPARQL → JSON-LD translation
+
+| SPARQL | JSON-LD |
+|---|---|
+| `FILTER NOT EXISTS { ?s :p ?v }` | `["not-exists", {"@id":"?s","ex:p":"?v"}]` |
+| `FILTER EXISTS { ?s :p ?v }` | `["exists", {"@id":"?s","ex:p":"?v"}]` |
+| `OPTIONAL { ?s :p ?v } FILTER(!bound(?v))` | `["optional", {"@id":"?s","ex:p":"?v"}]` then `["filter", "(not (bound ?v))"]` |
+| `?a :p ?b MINUS { ?a :q ?c }` | `{"@id":"?a","ex:p":"?b"}` then `["minus", {"@id":"?a","ex:q":"?c"}]` |
+
 ### Graph Patterns
 
 Scope patterns to a named graph:
@@ -773,7 +860,9 @@ Function names are case-insensitive. See [Vector Search](../indexing-and-search/
 
 ### Type Functions
 
-- `(bound ?var)` - Variable is bound
+- `(bound ?var)` - Variable is bound. To test for **absence**, see
+  [Negation Patterns](#negation-patterns) — `(not (bound ?v))` after
+  `optional` is supported, or use `["not-exists", ...]` directly.
 - `(isIRI ?x)` - Is an IRI
 - `(isBlank ?x)` - Is a blank node
 - `(isLiteral ?x)` - Is a literal

--- a/docs/transactions/conditional-updates.md
+++ b/docs/transactions/conditional-updates.md
@@ -247,7 +247,12 @@ WHERE {
 
 Create an entity only if it doesn't already exist. Useful for preventing duplicate records.
 
-This pattern uses OPTIONAL + FILTER to check for absence.
+This pattern uses OPTIONAL + FILTER to check for absence. For query-only
+absence tests, `["not-exists", { ... }]` is the canonical form (see
+[Negation Patterns](../query/jsonld-query.md#negation-patterns)). The
+OPTIONAL/BOUND form below is shown here because the example also keeps
+`?existing` available to subsequent BIND/DELETE templates when bob does
+exist — `not-exists` filters rows out and exposes nothing.
 
 ### JSON-LD
 
@@ -469,7 +474,14 @@ After the update, the product has both its new price and a record of the previou
 
 3. **Use BIND for all computed values.** The `["bind", "?var", "(expression)"]` form keeps computation inside the transaction, ensuring atomicity.
 
-4. **Use OPTIONAL + FILTER for absence checks.** The `["optional", ...], ["filter", "(not (bound ?var))"]` pattern is the idiomatic way to test for non-existence.
+4. **Test for absence with the form that fits the update.** Two idioms are
+   supported. `["optional", ...]` followed by `["filter", "(not (bound ?var))"]`
+   leaves the optional variables in scope for downstream BIND/DELETE/INSERT
+   templates — pick this when the update needs the absent variable. For pure
+   "does this exist?" guards where no downstream template needs the variable,
+   `["not-exists", { ... }]` is the canonical query form (see
+   [Negation Patterns](../query/jsonld-query.md#negation-patterns)). Both
+   lower to the same planner strategy chooser.
 
 5. **Leverage Fluree's immutability.** Every transaction creates an immutable commit. Even without explicit audit trail patterns, you can always query previous states using time travel. Use the audit trail pattern when you want the old value readily accessible in the current state.
 

--- a/fluree-db-api/tests/it_query_negation.rs
+++ b/fluree-db-api/tests/it_query_negation.rs
@@ -153,6 +153,70 @@ async fn not_exists_filters_subjects_without_nickname() {
     );
 }
 
+/// `OPTIONAL { ?s p ?v } FILTER(NOT BOUND(?v))` is the SPARQL-muscle-memory
+/// idiom for "subjects without a value for predicate p". It is recognized at
+/// `where_plan.rs:1595-1623` and dispatched through the shared EXISTS strategy
+/// helper, so this query should return the same rows as the pattern-level
+/// `["not-exists", ...]` form above. Inner shares ?person with the outer
+/// triple, so the helper picks `SemijoinOperator` (build-once + hash probe).
+#[tokio::test]
+async fn optional_not_bound_filters_same_as_not_exists() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "negation:people").await;
+    let ctx = ctx_ex();
+
+    let q = json!({
+        "@context": ctx,
+        "select": "?person",
+        "where": [
+            {"@id":"?person","ex:givenName":"?gname"},
+            ["optional", {"@id":"?person","ex:nickname":"?name"}],
+            ["filter", "(not (bound ?name))"]
+        ]
+    });
+
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!(["ex:bob", "ex:carol"]))
+    );
+}
+
+/// Same idiom expressed in the data filter form `["not", ["bound", "?v"]]`
+/// rather than the s-expression form `"(not (bound ?v))"`. Both should parse
+/// to the same `Expression::Not(Expression::Call(Function::Bound, ...))` and
+/// hit the same OPTIONAL+not-bound rewrite.
+#[tokio::test]
+async fn optional_not_bound_data_form_filters_same_as_not_exists() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "negation:people").await;
+    let ctx = ctx_ex();
+
+    let q = json!({
+        "@context": ctx,
+        "select": "?person",
+        "where": [
+            {"@id":"?person","ex:givenName":"?gname"},
+            ["optional", {"@id":"?person","ex:nickname":"?name"}],
+            ["filter", ["not", ["bound", "?name"]]]
+        ]
+    });
+
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!(["ex:bob", "ex:carol"]))
+    );
+}
+
 #[tokio::test]
 async fn not_exists_when_everyone_has_family_name_returns_none() {
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -65,6 +65,131 @@ fn pattern_list_contains_var(patterns: &[Pattern], v: VarId) -> bool {
     patterns.iter().any(|p| p.referenced_vars().contains(&v))
 }
 
+/// Strategy for executing an EXISTS / NOT EXISTS pattern.
+///
+/// Picked by [`choose_exists_strategy`] from the outer schema and the inner
+/// patterns alone — no operator construction, no stats, no I/O. Kept as a
+/// distinct type so unit tests can pin the decision without standing up a
+/// full operator tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExistsStrategy {
+    /// Build the inner solution once into a hash set keyed by `key_vars`,
+    /// probe per outer row. Used when the inner is correlated to the outer
+    /// only via vars the inner itself produces.
+    Semijoin { key_vars: Vec<VarId> },
+    /// Rebuild and re-execute the inner per outer row. Used when the inner
+    /// is uncorrelated (no shared produced vars with outer) or references
+    /// outer-only consumed vars (e.g. `FILTER(?p = ?q)` where `?p` is
+    /// produced only by the outer).
+    Exists {
+        /// Reason recorded for tracing / debugging.
+        reason: ExistsFallbackReason,
+    },
+}
+
+/// Why a strategy fell back to per-row `Exists` rather than `Semijoin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExistsFallbackReason {
+    /// Inner shares no produced vars with the outer schema — fully uncorrelated.
+    Uncorrelated,
+    /// Inner references an outer var it doesn't produce, so it can't run standalone.
+    OuterOnlyConsumed,
+}
+
+/// Pure decision: pick an [`ExistsStrategy`] from the outer schema and the
+/// inner patterns. No side effects, no I/O — unit-testable in isolation.
+pub(crate) fn choose_exists_strategy(
+    outer_schema: &[VarId],
+    inner_patterns: &[Pattern],
+) -> ExistsStrategy {
+    // Vars PRODUCED by inner patterns (Triple, Bind, Values, etc.).
+    // Vars only consumed (e.g. in FILTER expressions) cannot serve as semijoin keys.
+    let inner_produced_vars: HashSet<VarId> = inner_patterns
+        .iter()
+        .flat_map(Pattern::produced_vars)
+        .collect();
+
+    // Key vars in outer schema order (stable, matches column layout).
+    let key_vars: Vec<VarId> = outer_schema
+        .iter()
+        .copied()
+        .filter(|v| inner_produced_vars.contains(v))
+        .collect();
+
+    // Inner references an outer var it doesn't produce (e.g., FILTER(?p = ?q)
+    // where ?p is outer-only): inner cannot run standalone → must seed per row.
+    let outer_set: HashSet<VarId> = outer_schema.iter().copied().collect();
+    let outer_only_consumed = inner_patterns
+        .iter()
+        .flat_map(Pattern::referenced_vars)
+        .any(|v| outer_set.contains(&v) && !inner_produced_vars.contains(&v));
+
+    if outer_only_consumed {
+        ExistsStrategy::Exists {
+            reason: ExistsFallbackReason::OuterOnlyConsumed,
+        }
+    } else if key_vars.is_empty() {
+        ExistsStrategy::Exists {
+            reason: ExistsFallbackReason::Uncorrelated,
+        }
+    } else {
+        ExistsStrategy::Semijoin { key_vars }
+    }
+}
+
+/// Build the operator for an EXISTS / NOT EXISTS using [`choose_exists_strategy`].
+///
+/// Picks `SemijoinOperator` (build-once + hash probe) when the inner pattern is
+/// correlated to the outer solely via produced vars, otherwise `ExistsOperator`
+/// (per-row correlated rebuild). Shared by the pattern-level `Pattern::Exists`
+/// / `Pattern::NotExists` dispatch and the `OPTIONAL { ... } FILTER(!bound(?v))`
+/// rewrite — the latter relied on `ExistsOperator` unconditionally before this
+/// helper existed, which timed out on large outer streams.
+fn build_exists_strategy(
+    child: BoxedOperator,
+    inner_patterns: &[Pattern],
+    negated: bool,
+    stats: Option<Arc<StatsView>>,
+    planning: PlanningContext,
+) -> BoxedOperator {
+    let strategy = choose_exists_strategy(child.schema(), inner_patterns);
+    match strategy {
+        ExistsStrategy::Semijoin { key_vars } => {
+            tracing::debug!(
+                strategy = "semijoin",
+                negated,
+                key_var_count = key_vars.len(),
+                inner_pattern_count = inner_patterns.len(),
+                "exists dispatch",
+            );
+            Box::new(SemijoinOperator::new(
+                child,
+                inner_patterns.to_vec(),
+                key_vars,
+                negated,
+                stats,
+                planning,
+            ))
+        }
+        ExistsStrategy::Exists { reason } => {
+            tracing::debug!(
+                strategy = "exists",
+                negated,
+                reason = ?reason,
+                inner_pattern_count = inner_patterns.len(),
+                "exists dispatch",
+            );
+            Box::new(ExistsOperator::new(
+                child,
+                inner_patterns.to_vec(),
+                negated,
+                stats,
+                planning,
+            ))
+        }
+    }
+}
+
 fn collect_grouped_single_triple_optionals(
     patterns: &[Pattern],
     start: usize,
@@ -1524,24 +1649,24 @@ pub fn build_where_operators_seeded_with_needed(
                 if let Pattern::Optional(inner_patterns) = &patterns[i] {
                     // Optimization: OPTIONAL { ... binds ?v ... } FILTER(!bound(?v))
                     // behaves like NOT EXISTS { ... } for the inner conjunctive block.
-                    //
-                    // We implement this as a correlated NOT EXISTS (ExistsOperator with negation),
-                    // not as a Semijoin build/probe, because the inner-side key set can be huge
-                    // for common predicates (e.g., bsbm:productFeature), while the outer stream is
-                    // typically already selective.
+                    // Dispatch through the shared strategy helper so it picks
+                    // SemijoinOperator (build-once + hash probe) when the inner shares
+                    // produced key vars with the outer schema — the per-row
+                    // ExistsOperator path is reserved for uncorrelated / outer-only-
+                    // consumed cases the helper detects.
                     if let Some(Pattern::Filter(next_filter)) = patterns.get(i + 1) {
                         if let Some(v) = filter_not_bound_var(next_filter) {
                             let v_bound_in_outer = child.schema().contains(&v);
                             let v_appears_later = pattern_list_contains_var(&patterns[i + 2..], v);
                             let v_bound_by_inner = pattern_list_contains_var(inner_patterns, v);
                             if !v_bound_in_outer && !v_appears_later && v_bound_by_inner {
-                                operator = Some(Box::new(ExistsOperator::new(
+                                operator = Some(build_exists_strategy(
                                     child,
-                                    inner_patterns.clone(),
+                                    inner_patterns,
                                     true,
                                     stats.clone(),
                                     *planning,
-                                )));
+                                ));
                                 i += 2;
                                 continue;
                             }
@@ -1637,64 +1762,16 @@ pub fn build_where_operators_seeded_with_needed(
                 i += 1;
             }
 
-            // EXISTS / NOT EXISTS: use SemijoinOperator when correlated (shared vars
-            // between outer and inner), ExistsOperator when uncorrelated.
             Pattern::Exists(inner_patterns) | Pattern::NotExists(inner_patterns) => {
                 let child = require_child(operator, "EXISTS pattern")?;
                 let negated = matches!(&patterns[i], Pattern::NotExists(_));
-
-                // Collect only vars PRODUCED by inner patterns (Triple, Bind, Values, etc.).
-                // Vars only consumed (e.g., in FILTER expressions) require per-row seeding
-                // and cannot serve as semijoin keys.
-                let inner_produced_vars: std::collections::HashSet<VarId> = inner_patterns
-                    .iter()
-                    .flat_map(Pattern::produced_vars)
-                    .collect();
-
-                // Key vars in child schema order (stable, matches column layout).
-                let key_vars: Vec<VarId> = child
-                    .schema()
-                    .iter()
-                    .copied()
-                    .filter(|v| inner_produced_vars.contains(v))
-                    .collect();
-
-                // Check if inner patterns reference outer vars that they don't produce
-                // (e.g., FILTER(?p = ?q) where ?p is outer-only). If so, the inner
-                // patterns can't be executed standalone — fall back to ExistsOperator.
-                let inner_all_vars: std::collections::HashSet<VarId> = inner_patterns
-                    .iter()
-                    .flat_map(super::super::ir::Pattern::referenced_vars)
-                    .collect();
-                let outer_schema: std::collections::HashSet<VarId> =
-                    child.schema().iter().copied().collect();
-                let outer_only_consumed: bool = inner_all_vars
-                    .iter()
-                    .any(|v| outer_schema.contains(v) && !inner_produced_vars.contains(v));
-
-                if key_vars.is_empty() || outer_only_consumed {
-                    // Uncorrelated, or inner depends on outer-only vars (e.g., FILTER
-                    // referencing outer vars): use ExistsOperator for correct per-row
-                    // seeding of all outer bindings.
-                    operator = Some(Box::new(ExistsOperator::new(
-                        child,
-                        inner_patterns.clone(),
-                        negated,
-                        stats.clone(),
-                        *planning,
-                    )));
-                } else {
-                    // Correlated via produced vars only: SemijoinOperator builds inner
-                    // set once, probes per row.
-                    operator = Some(Box::new(SemijoinOperator::new(
-                        child,
-                        inner_patterns.clone(),
-                        key_vars,
-                        negated,
-                        stats.clone(),
-                        *planning,
-                    )));
-                }
+                operator = Some(build_exists_strategy(
+                    child,
+                    inner_patterns,
+                    negated,
+                    stats.clone(),
+                    *planning,
+                ));
                 i += 1;
             }
 
@@ -3289,5 +3366,121 @@ mod tests {
 
         let hint = scan_index_hint_for_triple(&tp, &[], &[filter]);
         assert_eq!(hint, None);
+    }
+
+    // ========================================================================
+    // EXISTS / NOT EXISTS strategy decision
+    //
+    // These pin the dispatch decision independent of operator construction —
+    // a regression to per-row ExistsOperator for the root-level absence shape
+    // would silently slow real workloads (see the OPTIONAL+!bound rewrite at
+    // `Pattern::Optional` dispatch) without changing query results.
+    // ========================================================================
+
+    /// Outer triple binds `?f`; inner triple `?f <parent> ?p` shares `?f` via
+    /// a produced var and introduces fresh `?p`. This is the root-level
+    /// absence shape (`["not-exists", {"@id":"?f","storage:parent":"?p"}]`
+    /// after `{"@id":"?f","@type":"storage:File"}`) — must pick Semijoin so
+    /// the inner is built once instead of rebuilt per outer row.
+    #[test]
+    fn choose_exists_strategy_semijoin_for_root_level_absence_shape() {
+        let f = VarId(0);
+        let p = VarId(1);
+        let outer_schema = [f];
+        let inner = [Pattern::Triple(make_pattern(f, "parent", p))];
+
+        let strategy = choose_exists_strategy(&outer_schema, &inner);
+
+        assert_eq!(
+            strategy,
+            ExistsStrategy::Semijoin { key_vars: vec![f] },
+            "expected Semijoin for shared-produced-var inner, got {strategy:?}"
+        );
+    }
+
+    /// Inner references no outer var: fully uncorrelated → per-row Exists
+    /// is correct (and Semijoin would have an empty key set).
+    #[test]
+    fn choose_exists_strategy_exists_when_uncorrelated() {
+        let outer_schema = [VarId(0)];
+        let inner = [Pattern::Triple(make_pattern(VarId(10), "p", VarId(11)))];
+
+        let strategy = choose_exists_strategy(&outer_schema, &inner);
+
+        assert_eq!(
+            strategy,
+            ExistsStrategy::Exists {
+                reason: ExistsFallbackReason::Uncorrelated,
+            }
+        );
+    }
+
+    /// Inner references an outer-only var via FILTER (not via a producing
+    /// pattern): the inner cannot run standalone, so the strategy must fall
+    /// back to per-row Exists even though there is a shared produced var.
+    #[test]
+    fn choose_exists_strategy_exists_when_outer_only_consumed() {
+        let f = VarId(0);
+        let p = VarId(1);
+        let q = VarId(2); // outer-only — consumed by inner FILTER, not produced
+
+        let outer_schema = [f, q];
+        let filter_eq = Expression::call(
+            crate::ir::Function::Eq,
+            vec![Expression::Var(p), Expression::Var(q)],
+        );
+        let inner = [
+            Pattern::Triple(make_pattern(f, "parent", p)),
+            Pattern::Filter(filter_eq),
+        ];
+
+        let strategy = choose_exists_strategy(&outer_schema, &inner);
+
+        assert_eq!(
+            strategy,
+            ExistsStrategy::Exists {
+                reason: ExistsFallbackReason::OuterOnlyConsumed,
+            },
+            "outer-only consumed must dominate over the shared produced var, got {strategy:?}"
+        );
+    }
+
+    /// Empty outer schema (NotExists at root with no preceding sources) →
+    /// no key vars → per-row Exists.
+    #[test]
+    fn choose_exists_strategy_exists_when_outer_schema_empty() {
+        let outer_schema: [VarId; 0] = [];
+        let inner = [Pattern::Triple(make_pattern(VarId(0), "p", VarId(1)))];
+
+        let strategy = choose_exists_strategy(&outer_schema, &inner);
+
+        assert_eq!(
+            strategy,
+            ExistsStrategy::Exists {
+                reason: ExistsFallbackReason::Uncorrelated,
+            }
+        );
+    }
+
+    /// Key var order tracks the outer schema order (column layout), not the
+    /// order the inner happens to produce them. This is load-bearing for
+    /// `SemijoinOperator`'s column lookup at open time.
+    #[test]
+    fn choose_exists_strategy_semijoin_key_vars_follow_outer_schema_order() {
+        let a = VarId(0);
+        let b = VarId(1);
+        let outer_schema = [a, b];
+        // Inner triple is (?b <p> ?a) — produces both ?b and ?a, but in the
+        // opposite order from the outer schema.
+        let inner = [Pattern::Triple(make_pattern(b, "p", a))];
+
+        let strategy = choose_exists_strategy(&outer_schema, &inner);
+
+        assert_eq!(
+            strategy,
+            ExistsStrategy::Semijoin {
+                key_vars: vec![a, b],
+            },
+        );
     }
 }

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -1429,7 +1429,8 @@ fn lower_filter_expr_inner<E: IriEncoder>(
             let func_name = lower_function_name(func);
             if let Function::Custom(unknown) = &func_name {
                 return Err(ParseError::InvalidFilter(format!(
-                    "Unknown function: {unknown}"
+                    "Unknown function: {unknown}{}",
+                    unknown_function_hint(unknown),
                 )));
             }
             Ok(Expression::Call {
@@ -1554,6 +1555,30 @@ fn lower_function_name(name: &str) -> Function {
         "xsd:decimal" | "http://www.w3.org/2001/xmlschema#decimal" => Function::XsdDecimal,
         "xsd:string" | "http://www.w3.org/2001/xmlschema#string" => Function::XsdString,
         other => Function::Custom(other.to_string()),
+    }
+}
+
+/// Format an actionable hint to append to an "Unknown function" parse error.
+///
+/// Two cases worth catching:
+///
+/// 1. Tokens that *imply* an unbound-variable test (`!bound`, `nil?`,
+///    `not-bound`, …) — point at the supported `bound` function or the
+///    `["not-exists", …]` pattern operator.
+///
+/// 2. Tokens starting with `!` (including a bare `!`) — point at the
+///    s-expression spelling of logical negation, `not`. Bare `!` is *not*
+///    treated as an unbound-test hint because the most common user attempt
+///    is plain negation like `(! (= ?age 18))`, not `(! (bound ?p))`.
+fn unknown_function_hint(name: &str) -> &'static str {
+    let lower = name.to_lowercase();
+    match lower.as_str() {
+        "!bound" | "nil?" | "not-bound" | "notbound" | "unbound" | "missing?" => {
+            " — to test for an unbound variable use `(not (bound ?v))` or the \
+             `[\"not-exists\", {...}]` pattern operator"
+        }
+        _ if lower.starts_with('!') => " — logical negation is spelled `not`, e.g. `(not (...))`",
+        _ => "",
     }
 }
 
@@ -3078,5 +3103,56 @@ mod tests {
         } else {
             panic!("Expected Union, got {:?}", results[0]);
         }
+    }
+
+    #[test]
+    fn unknown_function_hints_point_at_bound() {
+        for name in [
+            "!bound",
+            "nil?",
+            "not-bound",
+            "notbound",
+            "unbound",
+            "missing?",
+        ] {
+            let hint = unknown_function_hint(name);
+            assert!(
+                hint.contains("bound") && hint.contains("not-exists"),
+                "expected hint for {name:?} to mention `bound` and `not-exists`, got: {hint:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_function_hint_for_bang_prefix_points_at_not() {
+        // Bare `!` and arbitrary `!something` both fall through to the
+        // generic logical-negation hint — `!` is the natural typo for
+        // SPARQL `!`-style negation like `(! (= ?age 18))`, NOT a typo for
+        // `(! (bound ?p))`, so we don't push users toward an unbound-test
+        // they didn't ask for.
+        for name in ["!", "!foo", "!(= ?x 1)"] {
+            let hint = unknown_function_hint(name);
+            assert!(
+                hint.contains("not") && !hint.contains("bound"),
+                "expected {name:?} hint to mention `not` (no `bound`), got: {hint:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_function_hint_for_explicit_bound_attempts() {
+        // Tokens that *imply* an unbound test should get the bound/not-exists
+        // hint, not the generic negation hint.
+        let hint = unknown_function_hint("!bound");
+        assert!(
+            hint.contains("bound") && hint.contains("not-exists"),
+            "expected !bound hint to mention bound + not-exists, got: {hint:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_function_hint_empty_for_unrelated_names() {
+        assert_eq!(unknown_function_hint("frobnicate"), "");
+        assert_eq!(unknown_function_hint("strlen2"), "");
     }
 }


### PR DESCRIPTION
- Fix the `OPTIONAL { ...binds ?v... } FILTER(!bound(?v))` planner, which unconditionally chose per-row `ExistsOperator` and timed out on large outer streams. Both the pattern-level `Pattern::Exists` / `Pattern::NotExists` dispatch and this rewrite now share one strategy chooser, so the rewrite picks `SemijoinOperator` (build-once + hash probe) when the inner shares produced key vars with the outer schema.
- Append an actionable hint to the "Unknown function" parse error covering common query attempts (`!bound`, `nil?`, `not-bound`, …) without misleading users who try bare `!` for plain logical negation.
- Document `not-exists`, `(not (bound ?v))`, and the SPARQL → JSON-LD translation in `docs/query/jsonld-query.md`; reconcile the conditional-updates doc.

## Why

The rewrite at `fluree-db-query/src/execute/where_plan.rs` recognised the shape but unconditionally dispatched it through `ExistsOperator`, citing a "outer is selective, inner may be large" heuristic that doesn't hold when the outer is a full class scan. `ExistsOperator::has_match` rebuilds and re-executes the inner operator tree per outer row, so a n-row outer drives n subquery plan-and-executes.

The pattern-level `Pattern::NotExists` dispatch already had the right logic — pick `SemijoinOperator` when the inner is correlated only via produced vars. Two callers, one decision, one helper.

## What changed

### Code

- **`fluree-db-query/src/execute/where_plan.rs`** — introduce `ExistsStrategy { Semijoin { key_vars } | Exists { reason } }` and `choose_exists_strategy(outer_schema, inner_patterns) -> ExistsStrategy`. The chooser is pure (no operator construction, no stats, no I/O), unit-testable in isolation. `build_exists_strategy` is the thin wrapper that calls it, emits `tracing::debug!(strategy, …, "exists dispatch")`, and constructs the operator. The pattern-level `Pattern::Exists` / `Pattern::NotExists` dispatch and the OPTIONAL+!bound rewrite both call it.

- **`fluree-db-query/src/parse/lower.rs`** — `unknown_function_hint(name)` appended to the "Unknown function" parse error. Bound-test hint for `!bound`, `nil?`, `not-bound`, `notbound`, `unbound`, `missing?`. Generic "spelled `not`" hint for bare `!` and any other `!`-prefixed token (so `(! (= ?age 18))` doesn't get pushed toward bound-testing).

### Tests

- Five new unit tests in `where_plan.rs` pinning the strategy decision:
  - `choose_exists_strategy_semijoin_for_root_level_absence_shape` — regression guard for the OPTIONAL+!bound rewrite
  - `choose_exists_strategy_exists_when_uncorrelated`
  - `choose_exists_strategy_exists_when_outer_only_consumed`
  - `choose_exists_strategy_exists_when_outer_schema_empty`
  - `choose_exists_strategy_semijoin_key_vars_follow_outer_schema_order`
- Two new integration tests in `it_query_negation.rs` asserting `OPTIONAL + (not (bound ?v))` returns the same rows as the equivalent `["not-exists", ...]`, in both s-expression and `["not", ["bound", "?v"]]` data filter forms.
- Four hint unit tests in `lower.rs`.

### Docs

- **`docs/query/jsonld-query.md`** — new "Negation Patterns" section: `not-exists` (canonical), `OPTIONAL + (not (bound ?v))`, `minus`, supported-vs-unsupported filter idiom table, SPARQL → JSON-LD translation table. The perf note states the precise strategy condition (inner-produced shared vars + no outer-only consumed vars) rather than the broader "shares a variable" wording.
- **`docs/transactions/conditional-updates.md`** — reconciled with the new query docs. Best-practice guidance now describes both supported absence idioms and when to pick each.

## Behaviour

- Correctness is unchanged for any query: `ExistsOperator` and `SemijoinOperator` produce the same solutions for every input the chooser distinguishes. The fix is purely about which one runs.
- The `OPTIONAL + (not (bound ?v))` shape now plans the same as `["not-exists", { ... }]` whenever the inner shares an inner-produced var with the outer and references no outer-only var.
- Failure cases that legitimately need per-row evaluation (uncorrelated inner, or inner referencing outer-only consumed vars via a filter) still get `ExistsOperator` — confirmed by `choose_exists_strategy_exists_when_outer_only_consumed`.
