### PR TITLE
perf: Improve novelty and property-path query performance

### DIFF
--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -985,6 +985,16 @@ impl BinaryScanOperator {
         })
     }
 
+    fn novelty_subject_id(ctx: &ExecutionContext<'_>, sid: &Sid) -> Option<u64> {
+        let dict_novelty = ctx.dict_novelty.as_ref()?;
+        if !dict_novelty.is_initialized() {
+            return None;
+        }
+        dict_novelty
+            .subjects
+            .find_subject(sid.namespace_code, sid.name.as_ref())
+    }
+
     /// Resolve s_id → Sid with caching.
     fn resolve_s_id(&mut self, s_id: u64) -> Result<Sid> {
         if let Some(sid) = self.sid_cache.get(&s_id) {
@@ -1590,6 +1600,13 @@ impl Operator for BinaryScanOperator {
             &p_sid,
         )
         .map_err(|e| QueryError::Internal(format!("build_filter: {e}")))?;
+
+        if filter.s_id.is_none() {
+            if let Some(sid) = s_sid.as_ref() {
+                filter.s_id = Self::novelty_subject_id(ctx, sid);
+            }
+        }
+
         tracing::debug!(
             ?self.pattern,
             s_bound = s_sid.is_some(),

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -624,7 +624,7 @@ pub(crate) fn analyze_property_join_plan(
     let analysis = analyze_property_join(triples_for_exec);
     let (width_score, optional_bonus) =
         property_join_width_score(triples_for_exec, &patterns[block_end_index..]);
-    let meets_width_threshold = width_score > PROPERTY_JOIN_MIN_WIDTH_SCORE;
+    let meets_width_threshold = width_score >= PROPERTY_JOIN_MIN_WIDTH_SCORE;
     let can_property_join = !has_upstream_seed && analysis.eligible() && meets_width_threshold;
     let tail = if can_property_join {
         collect_property_join_tail(patterns, block_end_index, triples_for_exec)
@@ -2842,6 +2842,24 @@ mod tests {
         assert_eq!(optional_bonus, 1.0);
         assert_eq!(score, 4.0);
         assert!(score > PROPERTY_JOIN_MIN_WIDTH_SCORE);
+    }
+
+    #[test]
+    fn test_property_join_plan_accepts_exact_width_threshold() {
+        let s = VarId(0);
+        let triples = vec![
+            make_pattern(s, "type", VarId(1)),
+            make_pattern(s, "text", VarId(2)),
+            make_pattern(s, "vector", VarId(3)),
+        ];
+        let patterns: Vec<Pattern> = triples.iter().cloned().map(Pattern::Triple).collect();
+
+        let (decision, _tail) =
+            analyze_property_join_plan(&patterns, patterns.len(), &triples, false);
+
+        assert_eq!(decision.width_score, PROPERTY_JOIN_MIN_WIDTH_SCORE);
+        assert!(decision.meets_width_threshold);
+        assert!(decision.can_property_join);
     }
 
     #[test]

--- a/fluree-db-query/src/property_path.rs
+++ b/fluree-db-query/src/property_path.rs
@@ -374,12 +374,60 @@ impl PropertyPathOperator {
         start: &Sid,
         target: &Sid,
     ) -> Result<bool> {
-        // Use the same traversal semantics as forward execution and check membership.
-        //
-        // This avoids duplicating BFS logic and ensures cycle/self reachability behavior
-        // matches the variable-binding mode.
-        let reachable = self.traverse_forward(ctx, start).await?;
-        Ok(reachable.iter().any(|sid| sid == target))
+        // ZeroOrMore includes the zero-length path.
+        if self.pattern.modifier == PathModifier::ZeroOrMore && start == target {
+            return Ok(true);
+        }
+
+        let mut visited: HashSet<Sid> = HashSet::new();
+        let mut queue: VecDeque<Sid> = VecDeque::new();
+
+        queue.push_back(start.clone());
+        visited.insert(start.clone());
+
+        while let Some(current) = queue.pop_front() {
+            if visited.len() >= self.max_visited {
+                return Err(QueryError::ResourceLimit(format!(
+                    "Property path exceeded max visited nodes ({})",
+                    self.max_visited
+                )));
+            }
+
+            let range_match = RangeMatch::new()
+                .with_subject(current.clone())
+                .with_predicate(self.pattern.predicate.clone());
+            let (db, overlay, to_t) = ctx.require_single_graph()?;
+            let opts = RangeOptions::new().with_to_t(to_t);
+
+            let flakes = range_with_overlay(
+                db,
+                ctx.binary_g_id,
+                overlay,
+                IndexType::Spot,
+                RangeTest::Eq,
+                range_match,
+                opts,
+            )
+            .await?;
+
+            for flake in flakes {
+                let FlakeValue::Ref(obj_sid) = flake.o else {
+                    continue;
+                };
+
+                // This is a non-zero-length path, so it satisfies OneOrMore
+                // even when the target is the start node reached via a cycle.
+                if &obj_sid == target {
+                    return Ok(true);
+                }
+
+                if visited.insert(obj_sid.clone()) {
+                    queue.push_back(obj_sid);
+                }
+            }
+        }
+
+        Ok(false)
     }
 
     /// Execute unseeded mode (no child operator)


### PR DESCRIPTION

- Resolve novelty-only subjects during binary scans so recent writes can use constrained lookups.
- Enable property joins for exact-threshold star patterns, improving vector similarity query plans.
- Short-circuit bound property-path reachability checks once the target is found.

- Manual benchmark: vector query improved from ~36s to ~720ms warm; bounded inverse `^storage:parent+` folder query runs in ~750-860ms warm versus forward `storage:parent+` timing out through CloudFront.