### PR TITLE
Fix/import issue

### DIFF
--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -3911,7 +3911,6 @@ where
                 let mut per_graph_classes = fluree_db_indexer::stats::build_class_stat_entries(
                     cs,
                     &predicate_sids_v6,
-                    &[],
                     &uploaded_dicts.language_tags,
                     input.run_dir,
                     input.namespace_codes,

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -3923,13 +3923,19 @@ where
                 }
             }
 
-            is::IndexStats {
+            let mut stats = is::IndexStats {
                 flakes: id_stats.total_flakes,
                 size: 0,
                 properties: Some(properties),
                 classes: None,
                 graphs: Some(graphs),
-            }
+            };
+            // Wire `total_commit_size` into `stats.size` and per-graph sizes,
+            // mirroring `root_assembly::compose_root_v6` for the normal indexing
+            // path. Without this, `info` reports `size: 0` everywhere even
+            // though the IndexRoot itself carries `total_commit_size`.
+            stats.distribute_total_size_by_flakes(total_commit_size);
+            stats
         });
 
         // Build CLI import summary before IndexRoot consumes predicate_sids_v6.

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -3519,18 +3519,10 @@ where
                 )
                 .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
 
-                let stats_output = stats_hook.map(|h| {
-                    let stats_finalize_start = Instant::now();
-                    tracing::info!("finalizing import id stats");
-                    let output = h.finalize_with_aggregate_properties();
-                    tracing::info!(
-                        elapsed_ms = stats_finalize_start.elapsed().as_millis(),
-                        "finalized import id stats"
-                    );
-                    (output, spot_class_stats)
-                });
-
-                // Meta chunk is always the last chunk when present.
+                // Meta chunk is always the last chunk when present. We build
+                // it BEFORE stats finalize and share the IdStatsHook so the
+                // g_id=1 records contribute to graph_flakes (otherwise the
+                // per-graph stats entry for txn-meta is missing entirely).
                 let g1_result = if let Some(meta_commit) = commits.last() {
                     let cfg_g1 = fluree_db_indexer::BuildConfig {
                         run_dir: v3_runs_g1,
@@ -3552,13 +3544,24 @@ where
                         fluree_db_indexer::build_indexes_from_commits(
                             std::slice::from_ref(meta_commit),
                             &cfg_g1,
-                            None, // no stats in txn-meta build
+                            stats_hook.as_mut(),
                         )
                         .map_err(|e| ImportError::IndexBuild(e.to_string()))?,
                     )
                 } else {
                     None
                 };
+
+                let stats_output = stats_hook.map(|h| {
+                    let stats_finalize_start = Instant::now();
+                    tracing::info!("finalizing import id stats");
+                    let output = h.finalize_with_aggregate_properties();
+                    tracing::info!(
+                        elapsed_ms = stats_finalize_start.elapsed().as_millis(),
+                        "finalized import id stats"
+                    );
+                    (output, spot_class_stats)
+                });
 
                 // Merge g_id=0 and g_id=1 results for upload/root assembly.
                 let mut order_results = g0_result.order_results;
@@ -3850,7 +3853,9 @@ where
 
             (class_counts, class_ref_targets)
         } else {
-            (id_hook_class_counts, id_hook_class_ref_targets)
+            // Clone — the uncapped id_hook_class_ref_targets is also used
+            // below as the authoritative source for class stats ref_classes.
+            (id_hook_class_counts, id_hook_class_ref_targets.clone())
         };
 
         let stats_v6: Option<fluree_db_core::IndexStats> = id_stats_result.map(|id_stats| {
@@ -3912,6 +3917,10 @@ where
                     cs,
                     &predicate_sids_v6,
                     &uploaded_dicts.language_tags,
+                    // Use the uncapped per-class ref-targets from IdStatsHook
+                    // instead of `cs.class_prop_refs` (which is populated via
+                    // the 64-class-capped ClassBitsetTable).
+                    Some(&id_hook_class_ref_targets),
                     input.run_dir,
                     input.namespace_codes,
                 )

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -290,6 +290,25 @@ ex:bob a ex:User ;
     let stats = ledger.snapshot.stats.as_ref().unwrap();
     assert!(stats.flakes > 0, "should have flake count in stats");
 
+    // Regression: `stats.size` and per-graph `graphs[*].size` must be wired
+    // from the IndexRoot's `total_commit_size`. Without the
+    // `distribute_total_size_by_flakes` call in the import path, both
+    // surface as 0 in `info` even though the commit blobs do have bytes.
+    assert!(
+        stats.size > 0,
+        "stats.size should reflect total commit blob bytes, got 0"
+    );
+    let graphs = stats.graphs.as_ref().expect("graphs should be present");
+    let default_graph_size = graphs
+        .iter()
+        .find(|g| g.g_id == 0)
+        .map(|g| g.size)
+        .unwrap_or(0);
+    assert!(
+        default_graph_size > 0,
+        "default graph (g_id=0) size should be > 0"
+    );
+
     // Property stats: schema:name should have count=2 (Alice, Bob)
     let name_count = property_count(&ledger.snapshot, "http://schema.org/name");
     assert_eq!(name_count, Some(2), "schema:name should have count=2");

--- a/fluree-db-api/tests/it_import_class_stats.rs
+++ b/fluree-db-api/tests/it_import_class_stats.rs
@@ -1,0 +1,237 @@
+//! Regression tests for class stats and txn-meta output of the bulk import path
+//! (`fluree.create(id).import(path).execute()`).
+//!
+//! These tests demonstrate two distinct bugs observed on enterprise ontologies:
+//!
+//! 1. `ref-classes` capped at 64 distinct target classes (`ClassBitsetTable`),
+//!    producing incomplete schema-discovery output on ledgers with many classes.
+//! 2. `txn-meta` graph reports 0 flakes in per-graph stats even though the
+//!    import path builds a g_id=1 meta chunk. This test splits the question
+//!    into "is the data queryable?" vs "do stats reflect it?" so we know
+//!    whether the bug is in named-graph routing or in stats collection.
+//!
+//! Both tests are expected to FAIL on the current code and PASS once the fixes
+//! land.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use fluree_db_core::{
+    range_with_overlay, FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest, Sid,
+    TXN_META_GRAPH_ID,
+};
+use fluree_vocab::namespaces::{FLUREE_COMMIT, FLUREE_DB};
+use std::collections::HashSet;
+use std::io::Write;
+
+fn write_file(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).expect("create file");
+    f.write_all(content.as_bytes()).expect("write file");
+    path
+}
+
+/// Generate a TTL string with `n_classes` distinct classes, each with one
+/// instance, and ref edges that form a cycle across all classes.
+///
+/// Class `C0` → `C1`, `C1` → `C2`, …, `C_{n-1}` → `C0`. This guarantees that
+/// every class is referenced as a target by exactly one property, so an
+/// uncapped ref-class rollup must see `n` distinct target classes. With the
+/// 64-cap, only the first ~64 (in encounter order) will appear.
+fn generate_many_class_ttl(n_classes: usize) -> String {
+    let mut out = String::new();
+    out.push_str("@prefix ex: <http://example.org/> .\n");
+    out.push_str("@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\n");
+    for i in 0..n_classes {
+        let next = (i + 1) % n_classes;
+        out.push_str(&format!(
+            "ex:s{i} a ex:C{i} ;\n    ex:linksTo ex:s{next} .\n\n",
+        ));
+    }
+    out
+}
+
+// =============================================================================
+// Test 1: ref-classes coverage on >64-class ledgers
+// =============================================================================
+
+/// Regression: bulk import of a ledger with more than 64 distinct classes
+/// must report ref-class targets for every referenced class, not just the
+/// first 64 encountered.
+///
+/// Currently fails: `ClassBitsetTable` caps the bitset width at 64, so only
+/// the first ~64 target classes ever appear in any `ref_classes` value.
+#[tokio::test]
+async fn bulk_import_ref_classes_covers_more_than_64_classes() {
+    const N_CLASSES: usize = 80;
+
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    let ttl = generate_many_class_ttl(N_CLASSES);
+    let ttl_path = write_file(data_dir.path(), "many_classes.ttl", &ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build fluree");
+
+    fluree
+        .create("test/many-classes:main")
+        .import(&ttl_path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .collect_id_stats(true)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+
+    let ledger = fluree.ledger("test/many-classes:main").await.expect("load");
+    let stats = ledger
+        .snapshot
+        .stats
+        .as_ref()
+        .expect("stats should be present");
+    let graphs = stats.graphs.as_ref().expect("graphs should be present");
+    let default_graph = graphs
+        .iter()
+        .find(|g| g.g_id == 0)
+        .expect("default graph should be present");
+    let classes = default_graph
+        .classes
+        .as_ref()
+        .expect("default graph should have classes");
+
+    // Sanity: we got at least N_CLASSES class entries (one per distinct rdf:type).
+    assert!(
+        classes.len() >= N_CLASSES,
+        "expected at least {N_CLASSES} class entries, got {}",
+        classes.len()
+    );
+
+    // Collect every distinct (source, property, target) class triple across the
+    // ref_classes rollup. The cap shows up as "fewer than N_CLASSES distinct
+    // targets" — every class is the target of `ex:linksTo` exactly once, so an
+    // uncapped rollup must show all N_CLASSES distinct targets.
+    let mut distinct_targets: HashSet<Sid> = HashSet::new();
+    let mut total_target_appearances = 0usize;
+    for class in classes {
+        for prop in &class.properties {
+            for target in &prop.ref_classes {
+                distinct_targets.insert(target.class_sid.clone());
+                total_target_appearances += 1;
+            }
+        }
+    }
+
+    assert!(
+        distinct_targets.len() >= N_CLASSES,
+        "expected ref-class rollup to cover all {N_CLASSES} target classes, \
+         got {} distinct targets ({} total appearances). \
+         This is the 64-class ClassBitsetTable cap leaking into stats.",
+        distinct_targets.len(),
+        total_target_appearances
+    );
+}
+
+// =============================================================================
+// Test 2: txn-meta queryable AND counted
+// =============================================================================
+
+/// Regression: after a bulk import, the `#txn-meta` named graph must
+/// (a) contain queryable commit-metadata flakes, and
+/// (b) be reflected in per-graph stats with non-zero flake counts.
+///
+/// Splitting the question: if (a) passes but (b) fails, the bug is in stats
+/// collection only; if (a) also fails, the meta chunk isn't landing in the
+/// final index at all.
+#[tokio::test]
+async fn bulk_import_emits_queryable_txn_meta_with_stats() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let ttl = "\
+@prefix ex: <http://example.org/> .
+
+ex:alice a ex:Person ;
+    ex:name \"Alice\" .
+
+ex:bob a ex:Person ;
+    ex:name \"Bob\" .
+";
+    let ttl_path = write_file(data_dir.path(), "people.ttl", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build fluree");
+
+    let result = fluree
+        .create("test/txn-meta-import:main")
+        .import(&ttl_path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .collect_id_stats(true)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+
+    assert!(result.t > 0, "import should produce at least one commit");
+    let import_t = result.t;
+
+    let ledger = fluree
+        .ledger("test/txn-meta-import:main")
+        .await
+        .expect("load");
+
+    // (a) The txn-meta named graph must contain queryable commit-metadata.
+    // We probe the POST index for `db:t == import_t` scoped to the txn-meta
+    // graph id, matching the pattern in it_graph_commit.rs.
+    let predicate = Sid::new(FLUREE_DB, fluree_vocab::db::T);
+    let range_match = RangeMatch::predicate_object(predicate, FlakeValue::Long(import_t));
+    let opts = RangeOptions::default()
+        .with_to_t(ledger.t())
+        .with_flake_limit(16);
+    let flakes = range_with_overlay(
+        &ledger.snapshot,
+        TXN_META_GRAPH_ID,
+        ledger.novelty.as_ref(),
+        IndexType::Post,
+        RangeTest::Eq,
+        range_match,
+        opts,
+    )
+    .await
+    .expect("txn-meta POST lookup");
+
+    let queryable_meta = flakes.iter().any(|f| {
+        f.p.namespace_code == FLUREE_DB
+            && f.p.name.as_ref() == fluree_vocab::db::T
+            && f.o == FlakeValue::Long(import_t)
+            && f.s.namespace_code == FLUREE_COMMIT
+    });
+    assert!(
+        queryable_meta,
+        "after bulk import, the txn-meta graph should contain a `db:t` flake \
+         for the import commit (t={import_t}); got {} flakes: {flakes:?}",
+        flakes.len()
+    );
+
+    // (b) Per-graph stats must reflect those flakes.
+    let stats = ledger.snapshot.stats.as_ref().expect("stats");
+    let graphs = stats.graphs.as_ref().expect("graphs");
+    let txn_meta_entry = graphs.iter().find(|g| g.g_id == TXN_META_GRAPH_ID);
+    assert!(
+        txn_meta_entry.is_some(),
+        "per-graph stats should contain an entry for txn-meta (g_id={TXN_META_GRAPH_ID})"
+    );
+    let txn_meta_entry = txn_meta_entry.unwrap();
+    assert!(
+        txn_meta_entry.flakes > 0,
+        "per-graph stats for txn-meta should report > 0 flakes after bulk import, got {}. \
+         If the queryable assertion above passed, this is a stats omission \
+         in the bulk-import path (meta chunk produced but not counted).",
+        txn_meta_entry.flakes
+    );
+}

--- a/fluree-db-api/tests/it_reindex_class_stats.rs
+++ b/fluree-db-api/tests/it_reindex_class_stats.rs
@@ -258,6 +258,8 @@ async fn reindex_class_stats_report_correct_datatypes() {
                 "ex:active": true,
                 "ex:created": { "@value": "2024-01-02T03:04:05Z", "@type": "xsd:dateTime" },
                 "ex:start":   { "@value": "2024-01-02", "@type": "xsd:date" },
+                "ex:moon":    { "@value": "2024-03", "@type": "xsd:gYearMonth" },
+                "ex:anniv":   { "@value": "--03-15", "@type": "xsd:gMonthDay" },
                 "ex:peer": { "@id": "ex:thing2" }
             },
             {
@@ -268,6 +270,8 @@ async fn reindex_class_stats_report_correct_datatypes() {
                 "ex:active": false,
                 "ex:created": { "@value": "2024-02-03T04:05:06Z", "@type": "xsd:dateTime" },
                 "ex:start":   { "@value": "2024-02-03", "@type": "xsd:date" },
+                "ex:moon":    { "@value": "2024-04", "@type": "xsd:gYearMonth" },
+                "ex:anniv":   { "@value": "--07-04", "@type": "xsd:gMonthDay" },
                 "ex:peer": { "@id": "ex:thing1" }
             }
         ]
@@ -346,6 +350,16 @@ async fn reindex_class_stats_report_correct_datatypes() {
         lookup_tag("http://example.org/start"),
         ValueTypeTag::DATE.as_u8(),
         "ex:start should be xsd:date"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/moon"),
+        ValueTypeTag::G_YEAR_MONTH.as_u8(),
+        "ex:moon should be xsd:gYearMonth"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/anniv"),
+        ValueTypeTag::G_MONTH_DAY.as_u8(),
+        "ex:anniv should be xsd:gMonthDay"
     );
     assert_eq!(
         lookup_tag("http://example.org/peer"),

--- a/fluree-db-api/tests/it_reindex_class_stats.rs
+++ b/fluree-db-api/tests/it_reindex_class_stats.rs
@@ -229,3 +229,127 @@ async fn reindex_class_stats_survive_retraction() {
     // If Person class disappeared entirely (0 instances → no entry), that's also acceptable
     // since build_class_stat_entries only emits classes with count > 0.
 }
+
+// Regression: SpotClassStatsCollector stores ValueTypeTag values into the
+// per-class `prop_dts` map (keyed by `ValueTypeTag::as_u8() as u16`). A prior
+// version of `build_class_stat_entries` mis-interpreted those keys as
+// `DatatypeDictId` indices into a `dt_tags` lookup table, producing wrong tags
+// post-reindex (xsd:integer→xsd:boolean, xsd:date→rdf:langString, …) and
+// `UNKNOWN` on the import path (which passed `&[]` for dt_tags).
+#[tokio::test]
+async fn reindex_class_stats_report_correct_datatypes() {
+    use fluree_db_core::value_id::ValueTypeTag;
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/reindex-class-stats-datatypes:main";
+
+    let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+    let tx = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:thing1",
+                "@type": "ex:Thing",
+                "ex:label": "first",
+                "ex:count": 7,
+                "ex:active": true,
+                "ex:created": { "@value": "2024-01-02T03:04:05Z", "@type": "xsd:dateTime" },
+                "ex:start":   { "@value": "2024-01-02", "@type": "xsd:date" },
+                "ex:peer": { "@id": "ex:thing2" }
+            },
+            {
+                "@id": "ex:thing2",
+                "@type": "ex:Thing",
+                "ex:label": "second",
+                "ex:count": 11,
+                "ex:active": false,
+                "ex:created": { "@value": "2024-02-03T04:05:06Z", "@type": "xsd:dateTime" },
+                "ex:start":   { "@value": "2024-02-03", "@type": "xsd:date" },
+                "ex:peer": { "@id": "ex:thing1" }
+            }
+        ]
+    });
+
+    let _ = fluree
+        .insert_with_opts(
+            ledger0,
+            &tx,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &fluree_db_api::IndexConfig {
+                reindex_min_bytes: 1_000_000_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
+        )
+        .await
+        .expect("insert");
+
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    let loaded = fluree.ledger(ledger_id).await.expect("load ledger");
+    let stats = loaded
+        .snapshot
+        .stats
+        .as_ref()
+        .expect("stats should be present after reindex");
+    let classes = stats.classes.as_ref().expect("classes should be present");
+
+    let thing = classes
+        .iter()
+        .find(|c| {
+            loaded.snapshot.decode_sid(&c.class_sid).as_deref() == Some("http://example.org/Thing")
+        })
+        .expect("Thing class should exist");
+
+    let lookup_tag = |iri: &str| -> u8 {
+        let p = thing
+            .properties
+            .iter()
+            .find(|p| loaded.snapshot.decode_sid(&p.property_sid).as_deref() == Some(iri))
+            .unwrap_or_else(|| panic!("missing property {iri}"));
+        assert_eq!(
+            p.datatypes.len(),
+            1,
+            "property {iri} should have exactly one datatype, got {:?}",
+            p.datatypes
+        );
+        p.datatypes[0].0
+    };
+
+    assert_eq!(
+        lookup_tag("http://example.org/label"),
+        ValueTypeTag::STRING.as_u8(),
+        "ex:label should be xsd:string"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/count"),
+        ValueTypeTag::INTEGER.as_u8(),
+        "ex:count should be xsd:integer"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/active"),
+        ValueTypeTag::BOOLEAN.as_u8(),
+        "ex:active should be xsd:boolean"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/created"),
+        ValueTypeTag::DATE_TIME.as_u8(),
+        "ex:created should be xsd:dateTime"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/start"),
+        ValueTypeTag::DATE.as_u8(),
+        "ex:start should be xsd:date"
+    );
+    assert_eq!(
+        lookup_tag("http://example.org/peer"),
+        ValueTypeTag::JSON_LD_ID.as_u8(),
+        "ex:peer (reference) should be JSON_LD_ID / @id"
+    );
+}

--- a/fluree-db-core/src/index_stats.rs
+++ b/fluree-db-core/src/index_stats.rs
@@ -68,6 +68,41 @@ pub struct IndexStats {
     pub graphs: Option<Vec<GraphStatsEntry>>,
 }
 
+impl IndexStats {
+    /// Set `self.size` to `total_commit_size` and proportionally distribute it
+    /// across `self.graphs[*].size` based on each graph's flake count.
+    ///
+    /// The per-graph allocation is an estimate (not exact storage bytes), but
+    /// it avoids reporting 0 and stays consistent across the root_assembly,
+    /// incremental, and import code paths. The last graph absorbs the
+    /// remainder so the sum equals `total_commit_size` exactly.
+    ///
+    /// No-op for the per-graph distribution if there are no graphs, no flakes,
+    /// or `total_commit_size` is zero; `self.size` is still set in all cases.
+    pub fn distribute_total_size_by_flakes(&mut self, total_commit_size: u64) {
+        self.size = total_commit_size;
+        let Some(graphs) = self.graphs.as_mut() else {
+            return;
+        };
+        let total_flakes: u64 = graphs.iter().map(|g| g.flakes).sum();
+        if total_flakes == 0 || total_commit_size == 0 {
+            return;
+        }
+        let n = graphs.len();
+        let mut assigned: u64 = 0;
+        for (i, g) in graphs.iter_mut().enumerate() {
+            if i + 1 == n {
+                g.size = total_commit_size.saturating_sub(assigned);
+            } else {
+                let part = ((total_commit_size as u128) * (g.flakes as u128)
+                    / (total_flakes as u128)) as u64;
+                g.size = part;
+                assigned = assigned.saturating_add(part);
+            }
+        }
+    }
+}
+
 // === Class-Property Statistics ===
 
 /// Statistics for a single class (rdf:type target).

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2348,26 +2348,7 @@ pub async fn incremental_index(
         let mut final_root = new_root;
         final_root.garbage = Some(BinaryGarbageRef { id: garbage_cid });
         if let Some(stats) = final_root.stats.as_mut() {
-            stats.size = final_root.total_commit_size;
-            if let Some(graphs) = stats.graphs.as_mut() {
-                let total_flakes: u64 = graphs.iter().map(|g| g.flakes).sum();
-                if total_flakes > 0 && stats.size > 0 {
-                    let total_size = stats.size;
-                    let n = graphs.len();
-                    let mut assigned: u64 = 0;
-                    for (i, g) in graphs.iter_mut().enumerate() {
-                        if i + 1 == n {
-                            g.size = total_size.saturating_sub(assigned);
-                        } else {
-                            let part = ((total_size as u128) * (g.flakes as u128)
-                                / (total_flakes as u128))
-                                as u64;
-                            g.size = part;
-                            assigned = assigned.saturating_add(part);
-                        }
-                    }
-                }
-            }
+            stats.distribute_total_size_by_flakes(final_root.total_commit_size);
         }
 
         super::root_assembly::reconcile_ns_at_publish(
@@ -2404,26 +2385,7 @@ pub async fn incremental_index(
     } else {
         let mut final_root = new_root;
         if let Some(stats) = final_root.stats.as_mut() {
-            stats.size = final_root.total_commit_size;
-            if let Some(graphs) = stats.graphs.as_mut() {
-                let total_flakes: u64 = graphs.iter().map(|g| g.flakes).sum();
-                if total_flakes > 0 && stats.size > 0 {
-                    let total_size = stats.size;
-                    let n = graphs.len();
-                    let mut assigned: u64 = 0;
-                    for (i, g) in graphs.iter_mut().enumerate() {
-                        if i + 1 == n {
-                            g.size = total_size.saturating_sub(assigned);
-                        } else {
-                            let part = ((total_size as u128) * (g.flakes as u128)
-                                / (total_flakes as u128))
-                                as u64;
-                            g.size = part;
-                            assigned = assigned.saturating_add(part);
-                        }
-                    }
-                }
-            }
+            stats.distribute_total_size_by_flakes(final_root.total_commit_size);
         }
 
         super::root_assembly::reconcile_ns_at_publish(

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -881,6 +881,7 @@ where
                     &spot_class_stats,
                     &predicate_sids,
                     &language_tags,
+                    None, // rebuild path still uses cs.class_prop_refs (64-capped); separate follow-up.
                     &run_dir,
                     &shared.ns_prefixes,
                 )

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -880,7 +880,6 @@ where
                 let mut per_graph_classes = crate::stats::build_class_stat_entries(
                     &spot_class_stats,
                     &predicate_sids,
-                    &shared.dt_tags,
                     &language_tags,
                     &run_dir,
                     &shared.ns_prefixes,

--- a/fluree-db-indexer/src/build/root_assembly.rs
+++ b/fluree-db-indexer/src/build/root_assembly.rs
@@ -294,32 +294,7 @@ pub(crate) async fn encode_and_write_root_v6(
     // `IndexStats.size` is defined as total commit data size (bytes) for the ledger.
     // The root carries this as `total_commit_size`; ensure stats reflect it.
     if let Some(stats) = root.stats.as_mut() {
-        stats.size = root.total_commit_size;
-
-        // Populate per-graph `stats.graphs[*].size` as a proportional allocation of
-        // total commit size based on each graph's flake count.
-        //
-        // This is an estimate (not exact storage bytes), but it avoids reporting 0
-        // and remains consistent across rebuild/incremental paths.
-        if let Some(graphs) = stats.graphs.as_mut() {
-            let total_flakes: u64 = graphs.iter().map(|g| g.flakes).sum();
-            if total_flakes > 0 && stats.size > 0 {
-                let total_size = stats.size;
-                let n = graphs.len();
-                let mut assigned: u64 = 0;
-                for (i, g) in graphs.iter_mut().enumerate() {
-                    if i + 1 == n {
-                        // Last graph gets remainder so sums match exactly.
-                        g.size = total_size.saturating_sub(assigned);
-                    } else {
-                        let part = ((total_size as u128) * (g.flakes as u128)
-                            / (total_flakes as u128)) as u64;
-                        g.size = part;
-                        assigned = assigned.saturating_add(part);
-                    }
-                }
-            }
-        }
+        stats.distribute_total_size_by_flakes(root.total_commit_size);
     }
 
     // Attach garbage manifest and prev_index if provided.

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -482,11 +482,23 @@ pub fn build_indexes_from_commits(
             let remap_progress = config.remap_progress.clone();
             let target_g_id = config.g_id;
             let collect_stats = stats_hook.is_some();
+            // Propagate rdf:type p_id so the worker hook can track per-subject
+            // class membership and ref history. Without this, `on_record`
+            // short-circuits at the `rdf_type_p_id` check and
+            // `subject_ref_history` stays empty even when
+            // `track_ref_targets` is true.
+            let worker_rdf_type_pid = spot_rdf_type_p_id;
 
             handles.push(scope.spawn(
                 move || -> io::Result<(u64, Option<crate::stats::IdStatsHook>)> {
                     let mut local_total = 0u64;
-                    let mut worker_hook = collect_stats.then(crate::stats::IdStatsHook::new);
+                    let mut worker_hook = collect_stats.then(|| {
+                        let mut h = crate::stats::IdStatsHook::new();
+                        if let Some(pid) = worker_rdf_type_pid {
+                            h.set_rdf_type_p_id(pid);
+                        }
+                        h
+                    });
                     loop {
                         let pos = next_chunk.fetch_add(1, Ordering::Relaxed);
                         if pos >= commits_ref.len() {

--- a/fluree-db-indexer/src/stats/class_stats.rs
+++ b/fluree-db-indexer/src/stats/class_stats.rs
@@ -9,6 +9,14 @@ use fluree_db_core::value_id::ValueTypeTag;
 use fluree_db_core::GraphId;
 use rustc_hash::FxHashMap;
 
+/// Uncapped per-class ref-target counts, keyed by
+/// `(g_id, class_sid64) -> p_id -> target_class_sid64 -> delta`. Produced by
+/// [`crate::stats::IdStatsHook::finalize_with_aggregate_properties`].
+pub type ClassRefTargets = HashMap<(GraphId, u64), HashMap<u32, HashMap<u64, i64>>>;
+
+/// FxHashMap-keyed variant used internally to match `SpotClassStats.class_prop_refs`.
+type ClassRefTargetsFx = FxHashMap<(GraphId, u64), FxHashMap<u32, FxHashMap<u64, u64>>>;
+
 /// Sentinel datatype value used in [`SpotClassStats`] for object-reference
 /// properties (`ObjKind::REF_ID`). Displayed as `@id` in stats output.
 pub const DT_REF_ID: u16 = u16::MAX;
@@ -175,10 +183,18 @@ pub fn build_class_stats_json(
 ///
 /// Parallel to `build_class_stats_json` but returns typed structs suitable for
 /// binary stats encoding in `IndexRoot`.
+/// `class_ref_targets_override`: when `Some`, this uncapped
+/// `(g_id, class_sid64) -> p_id -> target_class_sid64 -> count` map (e.g. from
+/// `IdStatsHook::finalize_with_aggregate_properties`) is used to derive
+/// `ref_classes`. When `None`, the function falls back to
+/// `cs.class_prop_refs`, which is populated via the legacy 64-class-capped
+/// `ClassBitsetTable` path and yields incomplete ref-class rollups on
+/// ledgers with more than 64 distinct classes.
 pub fn build_class_stat_entries(
     cs: &SpotClassStats,
     predicate_sids: &[(u16, String)],
     language_tags: &[String],
+    class_ref_targets_override: Option<&ClassRefTargets>,
     run_dir: &std::path::Path,
     namespace_codes: &HashMap<u16, String>,
 ) -> std::io::Result<HashMap<GraphId, Vec<fluree_db_core::ClassStatEntry>>> {
@@ -226,7 +242,27 @@ pub fn build_class_stat_entries(
     let mut class_entries: Vec<(&(GraphId, u64), &u64)> = cs.class_counts.iter().collect();
     class_entries.sort_by_key(|&(key, _)| *key);
 
-    let class_refs = &cs.class_prop_refs;
+    // Adapt the override map (counts: i64 deltas, may be negative) to the
+    // FxHashMap<u64, u64> shape that `cs.class_prop_refs` uses, so the
+    // inner property loop is identical regardless of source. Non-positive
+    // deltas are filtered.
+    let override_fx: Option<ClassRefTargetsFx> = class_ref_targets_override.map(|src| {
+        src.iter()
+            .map(|(&key, prop_map)| {
+                let converted: FxHashMap<u32, FxHashMap<u64, u64>> = prop_map
+                    .iter()
+                    .map(|(&p_id, target_map)| {
+                        let targets: FxHashMap<u64, u64> = target_map
+                            .iter()
+                            .filter_map(|(&t_sid, &d)| (d > 0).then_some((t_sid, d as u64)))
+                            .collect();
+                        (p_id, targets)
+                    })
+                    .collect();
+                (key, converted)
+            })
+            .collect()
+    });
 
     let mut per_graph: HashMap<GraphId, Vec<ClassStatEntry>> = HashMap::new();
 
@@ -235,7 +271,10 @@ pub fn build_class_stat_entries(
             Some(s) => s,
             None => continue,
         };
-        let ref_map = class_refs.get(&(g_id, class_sid64));
+        let ref_map = match override_fx {
+            Some(ref m) => m.get(&(g_id, class_sid64)),
+            None => cs.class_prop_refs.get(&(g_id, class_sid64)),
+        };
 
         let properties: Vec<ClassPropertyUsage> =
             if let Some(prop_map) = cs.class_prop_dts.get(&(g_id, class_sid64)) {

--- a/fluree-db-indexer/src/stats/class_stats.rs
+++ b/fluree-db-indexer/src/stats/class_stats.rs
@@ -21,8 +21,10 @@ pub const DT_REF_ID: u16 = u16::MAX;
 ///
 /// # Datatype keys
 ///
-/// The inner `u16` key is a `DatatypeDictId` for literal values, or
-/// [`DT_REF_ID`] (`u16::MAX`) for object references (`@id`).
+/// The inner `u16` key holds a [`ValueTypeTag`] value (`as_u8() as u16`) for
+/// literal values, or [`DT_REF_ID`] (`u16::MAX`) for object references (`@id`).
+/// Stored in the `ValueTypeTag` domain because the SPOT-merge collector only
+/// has access to the per-flake `o_type` byte, not the datatype dictionary.
 #[derive(Debug, Default)]
 pub struct SpotClassStats {
     /// (g_id, class_sid64) → instance count (number of subjects with this rdf:type)
@@ -44,7 +46,6 @@ pub struct SpotClassStats {
 pub fn build_class_stats_json(
     cs: &SpotClassStats,
     predicate_sids: &[(u16, String)],
-    dt_tags: &[ValueTypeTag],
     run_dir: &std::path::Path,
     namespace_codes: &HashMap<u16, String>,
 ) -> std::io::Result<Vec<serde_json::Value>> {
@@ -145,10 +146,8 @@ pub fn build_class_stats_json(
                                 .map(|&(&dt, &count)| {
                                     if dt == DT_REF_ID {
                                         serde_json::json!(["@id", count])
-                                    } else if let Some(tag) = dt_tags.get(dt as usize) {
-                                        serde_json::json!([tag.as_u8(), count])
                                     } else {
-                                        serde_json::json!([dt, count])
+                                        serde_json::json!([dt as u8, count])
                                     }
                                 })
                                 .collect();
@@ -179,7 +178,6 @@ pub fn build_class_stats_json(
 pub fn build_class_stat_entries(
     cs: &SpotClassStats,
     predicate_sids: &[(u16, String)],
-    dt_tags: &[ValueTypeTag],
     language_tags: &[String],
     run_dir: &std::path::Path,
     namespace_codes: &HashMap<u16, String>,
@@ -250,19 +248,17 @@ pub fn build_class_stat_entries(
                         let psid_pair = predicate_sids.get(p_id as usize)?;
                         let property_sid = Sid::new(psid_pair.0, &psid_pair.1);
 
-                        // Build per-datatype counts.
+                        // Build per-datatype counts. The collector stores
+                        // `ValueTypeTag::as_u8() as u16` (or `DT_REF_ID` for
+                        // refs), so we can cast directly back to u8 — no
+                        // dictionary lookup needed.
                         let mut datatypes: Vec<(u8, u64)> = dt_map
                             .iter()
-                            .map(|(&dt_dict_id, &count)| {
-                                let tag = if dt_dict_id == DT_REF_ID {
-                                    fluree_db_core::value_id::ValueTypeTag::JSON_LD_ID.as_u8()
+                            .map(|(&dt_value, &count)| {
+                                let tag = if dt_value == DT_REF_ID {
+                                    ValueTypeTag::JSON_LD_ID.as_u8()
                                 } else {
-                                    dt_tags
-                                        .get(dt_dict_id as usize)
-                                        .map(|t| t.as_u8())
-                                        .unwrap_or(
-                                            fluree_db_core::value_id::ValueTypeTag::UNKNOWN.as_u8(),
-                                        )
+                                    dt_value as u8
                                 };
                                 (tag, count)
                             })

--- a/fluree-db-indexer/src/stats/id_hook.rs
+++ b/fluree-db-indexer/src/stats/id_hook.rs
@@ -179,12 +179,22 @@ fn otype_to_value_type_tag(ot: fluree_db_core::o_type::OType) -> ValueTypeTag {
         OType::XSD_DOUBLE => ValueTypeTag::DOUBLE,
         OType::XSD_FLOAT => ValueTypeTag::FLOAT,
         OType::XSD_DECIMAL => ValueTypeTag::DECIMAL,
+        // NUM_BIG_OVERFLOW is intentionally NOT mapped here: it carries both
+        // `FlakeValue::Decimal` (arbitrary-precision xsd:decimal) and
+        // `FlakeValue::BigInt` (xsd:integer overflow > i64) — they share
+        // `ObjKind::NUM_BIG`. Disambiguating requires inspecting the NumBig
+        // arena entry (`StoredBigValue::BigDec` vs `BigInt`), which is not
+        // available here. Falling through to UNKNOWN is the honest answer
+        // until the collector is plumbed with arena access or the semantic
+        // dt tag is preserved alongside the o_type byte.
         OType::XSD_DATE => ValueTypeTag::DATE,
         OType::XSD_TIME => ValueTypeTag::TIME,
         OType::XSD_DATE_TIME => ValueTypeTag::DATE_TIME,
         OType::XSD_G_YEAR => ValueTypeTag::G_YEAR,
+        OType::XSD_G_YEAR_MONTH => ValueTypeTag::G_YEAR_MONTH,
         OType::XSD_G_MONTH => ValueTypeTag::G_MONTH,
         OType::XSD_G_DAY => ValueTypeTag::G_DAY,
+        OType::XSD_G_MONTH_DAY => ValueTypeTag::G_MONTH_DAY,
         OType::XSD_STRING => ValueTypeTag::STRING,
         OType::XSD_ANY_URI => ValueTypeTag::ANY_URI,
         OType::XSD_NORMALIZED_STRING => ValueTypeTag::NORMALIZED_STRING,


### PR DESCRIPTION
Fixes incorrect datatype labels in per-class stats (`stats.classes[*].properties[*].types`).

The class stats collector stores datatype buckets as `ValueTypeTag` values, but the stats builder was treating those values as `DatatypeDictId` indices. This caused initial imports to report literal property types as `UNKNOWN`, and rebuilds to report deterministic but wrong labels like `@id`, `xsd:boolean`, or `rdf:langString`.

This PR keeps the class stats path consistently in the `ValueTypeTag` domain and removes the now-misleading `dt_tags` lookup. It also adds missing unambiguous `OType` mappings for `xsd:gYearMonth` and `xsd:gMonthDay`, while intentionally leaving ambiguous carriers like `NUM_BIG_OVERFLOW` as `UNKNOWN` until they can be disambiguated with arena access or preserved semantic datatype tags.

## Test Plan

- Added regression coverage for per-class datatype stats across import/reindex paths.
- Verified literal properties report the expected `ValueTypeTag` values, including string, integer, boolean, dateTime, date, gYearMonth, and `@id` references.