### PR TITLE
fix: report tracked transaction fuel

### DIFF
--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -115,6 +115,8 @@ When tracking is enabled, the response includes tracking information as top-leve
 
 The `fuel` value is decimal with up to 3 places of precision. The HTTP `x-fdb-fuel` response header carries the same value.
 
+Tracked transaction responses (`/insert`, `/upsert`, `/update`, including Turtle/TriG and SPARQL UPDATE when tracking headers are used) expose the same top-level `time`, `fuel`, and `policy` fields when present, alongside the transaction receipt fields.
+
 ## Best Practices
 
 ### Tracking

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1808,7 +1808,7 @@ impl crate::Fluree {
         };
 
         let stage_result = self
-            .stage_turtle_insert(ledger, turtle, Some(index_config))
+            .stage_turtle_insert(ledger, turtle, Some(index_config), None)
             .await?;
 
         let StageResult {
@@ -1862,6 +1862,7 @@ impl crate::Fluree {
         ledger: LedgerState,
         turtle: &str,
         index_config: Option<&IndexConfig>,
+        tracker: Option<&Tracker>,
     ) -> Result<StageResult> {
         use fluree_db_transact::{generate_txn_id, stage_flakes, FlakeSink};
 
@@ -1889,10 +1890,15 @@ impl crate::Fluree {
         tracing::info!(flake_count = flakes.len(), "turtle parsed to flakes");
 
         // Stage the flakes (backpressure + optional policy)
-        let options = match index_config {
+        let mut options = match index_config {
             Some(cfg) => StageOptions::new().with_index_config(cfg),
             None => StageOptions::default(),
         };
+        if let Some(tracker) = tracker {
+            if tracker.is_enabled() {
+                options = options.with_tracker(tracker);
+            }
+        }
         let view = stage_flakes(ledger, flakes, options).await?;
 
         // Apply SHACL policy to the staged view. Plain Turtle has no named-graph
@@ -1905,7 +1911,7 @@ impl crate::Fluree {
             StagedShaclContext {
                 graph_delta: None,
                 graph_sids: None,
-                tracker: None,
+                tracker,
             },
         )
         .await

--- a/fluree-db-api/src/tx_builder.rs
+++ b/fluree-db-api/src/tx_builder.rs
@@ -547,9 +547,16 @@ impl<'a> OwnedTransactBuilder<'a> {
 
         // Direct flake path for InsertTurtle
         if let TransactOperation::InsertTurtle(turtle) = op {
+            let tracker = self
+                .core
+                .tracking
+                .clone()
+                .map(Tracker::new)
+                .unwrap_or_else(Tracker::disabled);
+            let tracker_ref = tracker.is_enabled().then_some(&tracker);
             let stage_result = self
                 .fluree
-                .stage_turtle_insert(self.ledger, turtle, Some(&index_config))
+                .stage_turtle_insert(self.ledger, turtle, Some(&index_config), tracker_ref)
                 .await?;
             return Ok(Staged {
                 view: stage_result.view,
@@ -793,8 +800,9 @@ pub(crate) async fn commit_with_handle(
             // Direct flake path for InsertTurtle (bypass JSON-LD / IR)
             if let TransactOperation::InsertTurtle(turtle) = op {
                 let ledger_id = ledger_state.ledger_id().to_string();
+                let tracker_ref = tracker.is_enabled().then_some(&tracker);
                 let stage_result = fluree
-                    .stage_turtle_insert(ledger_state, turtle, Some(&index_config))
+                    .stage_turtle_insert(ledger_state, turtle, Some(&index_config), tracker_ref)
                     .await?;
                 // Spawn raw Turtle upload when explicitly opted-in — overlaps
                 // with the commit prelude (sequencing lookup, envelope apply).
@@ -988,7 +996,7 @@ pub(crate) async fn commit_with_handle(
                     commit_opts_base.clone()
                 };
                 let stage_result = fluree
-                    .stage_turtle_insert(ledger_state, turtle, Some(&index_config))
+                    .stage_turtle_insert(ledger_state, turtle, Some(&index_config), tracker_ref)
                     .await?;
                 (stage_result, TxnType::Insert, commit_opts)
             }

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -33,7 +33,8 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use fluree_db_api::{
     lower_sparql_update, parse_sparql, with_index_request_correlation, CommitOpts,
-    IndexRequestCorrelation, NamespaceRegistry, SparqlQueryBody, TrackingOptions, TxnOpts, TxnType,
+    IndexRequestCorrelation, NamespaceRegistry, PolicyStats, SparqlQueryBody, TrackingOptions,
+    TrackingTally, TxnOpts, TxnType,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -67,6 +68,42 @@ pub struct TransactResponse {
     pub tx_id: String,
     /// Commit information
     pub commit: CommitInfo,
+    /// Execution time when tracking was requested
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time: Option<String>,
+    /// Fuel consumed when tracking was requested
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fuel: Option<f64>,
+    /// Policy stats when policy tracking was requested
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<std::collections::HashMap<String, PolicyStats>>,
+}
+
+fn transact_response(
+    ledger_id: String,
+    t: i64,
+    tx_id: String,
+    commit_hash: String,
+    tally: Option<&TrackingTally>,
+) -> TransactResponse {
+    TransactResponse {
+        ledger_id,
+        t,
+        tx_id,
+        commit: CommitInfo { hash: commit_hash },
+        time: tally.and_then(|t| t.time.clone()),
+        fuel: tally.and_then(|t| t.fuel),
+        policy: tally.and_then(|t| t.policy.clone()),
+    }
+}
+
+fn record_tracking_on_span(span: &tracing::Span, tally: &TrackingTally) {
+    if let Some(ref time) = tally.time {
+        span.record("tracker_time", time.as_str());
+    }
+    if let Some(fuel) = tally.fuel {
+        span.record("tracker_fuel", fuel);
+    }
 }
 
 /// Compute transaction ID from request body (SHA-256 hash)
@@ -686,6 +723,7 @@ async fn insert_local(
                 TxnType::Insert,
                 &turtle,
                 &credential,
+                &headers,
                 author.as_deref(),
             )
             .await;
@@ -831,6 +869,7 @@ async fn upsert_local(
                 TxnType::Upsert,
                 &turtle,
                 &credential,
+                &headers,
                 author.as_deref(),
             )
             .await;
@@ -977,6 +1016,7 @@ async fn insert_ledger_local(
                 TxnType::Insert,
                 &turtle,
                 &credential,
+                &headers,
                 author.as_deref(),
             )
             .await;
@@ -1123,6 +1163,7 @@ async fn upsert_ledger_local(
                 TxnType::Upsert,
                 &turtle,
                 &credential,
+                &headers,
                 author.as_deref(),
             )
             .await;
@@ -1207,8 +1248,13 @@ async fn execute_transaction(
     let qc_opts = fluree_db_api::QueryConnectionOptions::from_json(body).unwrap_or_default();
 
     // Create execution span
-    let span =
-        tracing::debug_span!("transact_execute", ledger_id = ledger_id, txn_type = ?txn_type);
+    let span = tracing::debug_span!(
+        "transact_execute",
+        ledger_id = ledger_id,
+        txn_type = ?txn_type,
+        tracker_time = tracing::field::Empty,
+        tracker_fuel = tracing::field::Empty,
+    );
     async move {
         let span = tracing::Span::current();
 
@@ -1334,19 +1380,21 @@ async fn execute_transaction(
             }
         };
 
-        let response_json = Json(TransactResponse {
-            ledger_id: ledger_id.to_string(),
-            t: result.receipt.t,
+        if let Some(tally) = &result.tally {
+            record_tracking_on_span(&span, tally);
+        }
+        let response_json = Json(transact_response(
+            ledger_id.to_string(),
+            result.receipt.t,
             tx_id,
-            commit: CommitInfo {
-                hash: result.receipt.commit_id.to_string(),
-            },
-        });
+            result.receipt.commit_id.to_string(),
+            result.tally.as_ref(),
+        ));
 
         // Return tracking headers when a tally is present
-        match result.tally {
+        match &result.tally {
             Some(tally) => {
-                let hdrs = tracking_headers(&tally);
+                let hdrs = tracking_headers(tally);
                 Ok((hdrs, response_json).into_response())
             }
             None => Ok(response_json.into_response()),
@@ -1393,13 +1441,21 @@ async fn execute_turtle_transaction(
     txn_type: TxnType,
     turtle: &str,
     credential: &MaybeCredential,
+    headers: &FlureeHeaders,
     author: Option<&str>,
 ) -> Result<Response> {
     let is_trig = credential.is_trig();
 
     // Create execution span
     let format = if is_trig { "trig" } else { "turtle" };
-    let span = tracing::debug_span!("transact_execute", ledger_id = ledger_id, txn_type = ?txn_type, format = format);
+    let span = tracing::debug_span!(
+        "transact_execute",
+        ledger_id = ledger_id,
+        txn_type = ?txn_type,
+        format = format,
+        tracker_time = tracing::field::Empty,
+        tracker_fuel = tracing::field::Empty,
+    );
     async move {
         let span = tracing::Span::current();
 
@@ -1465,6 +1521,9 @@ async fn execute_turtle_transaction(
         if let Some(config) = &state.index_config {
             builder = builder.index_config(config.clone());
         }
+        if headers.has_tracking() {
+            builder = builder.tracking(headers.to_tracking_options());
+        }
 
         let correlation = index_request_correlation(
             &credential.headers,
@@ -1493,18 +1552,20 @@ async fn execute_turtle_transaction(
             }
         };
 
-        let response_json = Json(TransactResponse {
-            ledger_id: ledger_id.to_string(),
-            t: result.receipt.t,
+        if let Some(tally) = &result.tally {
+            record_tracking_on_span(&span, tally);
+        }
+        let response_json = Json(transact_response(
+            ledger_id.to_string(),
+            result.receipt.t,
             tx_id,
-            commit: CommitInfo {
-                hash: result.receipt.commit_id.to_string(),
-            },
-        });
+            result.receipt.commit_id.to_string(),
+            result.tally.as_ref(),
+        ));
 
-        match result.tally {
+        match &result.tally {
             Some(tally) => {
-                let hdrs = tracking_headers(&tally);
+                let hdrs = tracking_headers(tally);
                 Ok((hdrs, response_json).into_response())
             }
             None => Ok(response_json.into_response()),
@@ -1731,6 +1792,9 @@ async fn execute_sparql_update_request(
         if let Some(config) = &state.index_config {
             builder = builder.index_config(config.clone());
         }
+        if headers.has_tracking() {
+            builder = builder.tracking(headers.to_tracking_options());
+        }
         if let Some(ctx) = policy_ctx {
             builder = builder.policy(ctx);
         }
@@ -1776,18 +1840,20 @@ async fn execute_sparql_update_request(
         }
     };
 
-    let response_json = Json(TransactResponse {
+    if let Some(tally) = &result.tally {
+        record_tracking_on_span(parent_span, tally);
+    }
+    let response_json = Json(transact_response(
         ledger_id,
-        t: result.receipt.t,
+        result.receipt.t,
         tx_id,
-        commit: CommitInfo {
-            hash: result.receipt.commit_id.to_string(),
-        },
-    });
+        result.receipt.commit_id.to_string(),
+        result.tally.as_ref(),
+    ));
 
-    match result.tally {
+    match &result.tally {
         Some(tally) => {
-            let hdrs = tracking_headers(&tally);
+            let hdrs = tracking_headers(tally);
             Ok((hdrs, response_json).into_response())
         }
         None => Ok(response_json.into_response()),

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -2338,6 +2338,125 @@ async fn query_with_max_fuel_returns_fuel_header() {
     assert!(json_contains_string(&json, "Bob"));
 }
 
+#[tokio::test]
+async fn json_transaction_with_meta_reports_decimal_fuel() {
+    let (_tmp, state) = test_state().await;
+    let app = build_router(state.clone());
+
+    let create_body = serde_json::json!({ "ledger": "test:txfuel" });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let insert_body = serde_json::json!({
+        "@context": { "ex": "http://example.org/" },
+        "insert": [{ "@id": "ex:alice", "ex:name": "Alice" }],
+        "opts": { "meta": true }
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/insert")
+                .header("content-type", "application/json")
+                .header("fluree-ledger", "test:txfuel")
+                .body(Body::from(insert_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let fuel_header = resp
+        .headers()
+        .get("x-fdb-fuel")
+        .expect("tracked transaction should include x-fdb-fuel")
+        .to_str()
+        .expect("fuel header should be valid ASCII")
+        .parse::<f64>()
+        .expect("fuel header should parse as decimal fuel");
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let fuel = json
+        .get("fuel")
+        .and_then(JsonValue::as_f64)
+        .expect("tracked transaction response should include decimal fuel");
+    assert_eq!(fuel, fuel_header);
+    assert!(
+        (100.0..1000.0).contains(&fuel),
+        "fuel should be reported in fuel units, not raw micro-fuel: {fuel}"
+    );
+}
+
+#[tokio::test]
+async fn sparql_update_with_tracking_header_reports_decimal_fuel() {
+    let (_tmp, state) = test_state().await;
+    let app = build_router(state.clone());
+
+    let create_body = serde_json::json!({ "ledger": "test:sparqlfuel" });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let update = r#"
+        PREFIX ex: <http://example.org/>
+        INSERT DATA { ex:carol ex:name "Carol" . }
+    "#;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/update/test:sparqlfuel")
+                .header("content-type", "application/sparql-update")
+                .header("fluree-track-fuel", "true")
+                .body(Body::from(update))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let fuel_header = resp
+        .headers()
+        .get("x-fdb-fuel")
+        .expect("tracked SPARQL UPDATE should include x-fdb-fuel")
+        .to_str()
+        .expect("fuel header should be valid ASCII")
+        .parse::<f64>()
+        .expect("fuel header should parse as decimal fuel");
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let fuel = json
+        .get("fuel")
+        .and_then(JsonValue::as_f64)
+        .expect("tracked SPARQL UPDATE response should include decimal fuel");
+    assert_eq!(fuel, fuel_header);
+    assert!(
+        (100.0..1000.0).contains(&fuel),
+        "fuel should be reported in fuel units, not raw micro-fuel: {fuel}"
+    );
+}
+
 // ============================================================================
 // Discovery endpoint: /.well-known/fluree.json
 // ============================================================================


### PR DESCRIPTION
## Summary
- Exposes transaction tracking tallies (`time`, `fuel`, `policy`) in HTTP transaction response bodies when tracking is enabled.
- Wires header-driven tracking through SPARQL UPDATE and Turtle/TriG transaction paths.
- Ensures direct Turtle insert staging receives the tracker so transaction fuel is counted consistently.
