### PR TITLE
Structural Aggregate IR Invariants

### DIFF
--- a/fluree-db-core/src/nonempty.rs
+++ b/fluree-db-core/src/nonempty.rs
@@ -65,12 +65,6 @@ impl<T> NonEmpty<T> {
         std::iter::once(&mut self.head).chain(self.tail.iter_mut())
     }
 
-    /// Consume self and iterate over all elements in order, starting with
-    /// the head.
-    pub fn into_iter(self) -> impl DoubleEndedIterator<Item = T> {
-        std::iter::once(self.head).chain(self.tail)
-    }
-
     /// Map `f` over each element, returning a new `NonEmpty<U>`. Length is
     /// preserved (the head is always mapped to a head), so the result is
     /// also non-empty by construction.

--- a/fluree-db-core/src/nonempty.rs
+++ b/fluree-db-core/src/nonempty.rs
@@ -1,16 +1,50 @@
 //! `NonEmpty<T>`: a sequence with a type-level guarantee of at least one element.
 
-/// Sequence with a type-level guarantee of at least one element. The
-/// invariant is structural — `head` is always present — so downstream code
-/// can rely on `first`, `iter`, etc. without empty-checks. Constructed only
-/// at validation boundaries.
+/// Construct a `NonEmpty<T>` from a comma-separated list of values.
+///
+/// Statically requires at least one expression — `nonempty![]` is a
+/// compile error rather than a runtime panic. Useful in tests and other
+/// callers where the non-empty constraint is obvious from context but
+/// going through `try_from_vec(...).unwrap()` is noisy.
+///
+/// ```
+/// use fluree_db_core::{nonempty, NonEmpty};
+/// let xs: NonEmpty<i32> = nonempty![1, 2, 3];
+/// assert_eq!(xs.len(), 3);
+/// ```
+#[macro_export]
+macro_rules! nonempty {
+    ($head:expr $(, $tail:expr)* $(,)?) => {
+        $crate::NonEmpty::from_head_tail($head, vec![$($tail),*])
+    };
+}
+
+/// Sequence with a type-level guarantee of at least one element.
+///
+/// The invariant is structural: `head` is always present. Downstream code
+/// can rely on `first`, `iter`, etc. without empty-checks.
 #[derive(Clone, Debug)]
 pub struct NonEmpty<T> {
+    /// First element. Always present by construction.
     pub head: T,
+    /// Remaining elements (possibly empty).
     pub tail: Vec<T>,
 }
 
 impl<T> NonEmpty<T> {
+    /// Construct from a single element.
+    pub fn singleton(head: T) -> Self {
+        Self {
+            head,
+            tail: Vec::new(),
+        }
+    }
+
+    /// Construct from a head plus a tail of arbitrary length.
+    pub fn from_head_tail(head: T, tail: Vec<T>) -> Self {
+        Self { head, tail }
+    }
+
     /// Construct from a `Vec`, returning `None` if the input is empty.
     pub fn try_from_vec(v: Vec<T>) -> Option<Self> {
         let mut iter = v.into_iter();
@@ -24,6 +58,27 @@ impl<T> NonEmpty<T> {
     /// Iterate over all elements in order, starting with the head.
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = &T> {
         std::iter::once(&self.head).chain(self.tail.iter())
+    }
+
+    /// Iterate mutably over all elements in order, starting with the head.
+    pub fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut T> {
+        std::iter::once(&mut self.head).chain(self.tail.iter_mut())
+    }
+
+    /// Consume self and iterate over all elements in order, starting with
+    /// the head.
+    pub fn into_iter(self) -> impl DoubleEndedIterator<Item = T> {
+        std::iter::once(self.head).chain(self.tail)
+    }
+
+    /// Map `f` over each element, returning a new `NonEmpty<U>`. Length is
+    /// preserved (the head is always mapped to a head), so the result is
+    /// also non-empty by construction.
+    pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> NonEmpty<U> {
+        NonEmpty {
+            head: f(self.head),
+            tail: self.tail.into_iter().map(f).collect(),
+        }
     }
 
     /// Convert into a (necessarily non-empty) `Vec`.
@@ -43,13 +98,66 @@ impl<T> NonEmpty<T> {
     pub fn first(&self) -> &T {
         &self.head
     }
+
+    /// Last element. Always present by construction.
+    pub fn last(&self) -> &T {
+        self.tail.last().unwrap_or(&self.head)
+    }
+
+    /// Append an element to the tail. The non-empty invariant is preserved
+    /// trivially — the head is untouched and growing the tail only adds
+    /// elements.
+    pub fn push(&mut self, value: T) {
+        self.tail.push(value);
+    }
+
+    /// Extend the tail with the contents of an iterator. The non-empty
+    /// invariant is preserved trivially — the head is untouched.
+    pub fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.tail.extend(iter);
+    }
 }
 
 impl<T> From<T> for NonEmpty<T> {
     fn from(t: T) -> Self {
-        Self {
-            head: t,
-            tail: Vec::new(),
+        Self::singleton(t)
+    }
+}
+
+/// Read-only positional access. Out-of-range indices panic just like
+/// `Vec`/`slice` indexing; the invariant guarantees that index 0 always
+/// succeeds.
+impl<T> std::ops::Index<usize> for NonEmpty<T> {
+    type Output = T;
+    fn index(&self, idx: usize) -> &T {
+        if idx == 0 {
+            &self.head
+        } else {
+            &self.tail[idx - 1]
         }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a NonEmpty<T> {
+    type Item = &'a T;
+    type IntoIter = std::iter::Chain<std::iter::Once<&'a T>, std::slice::Iter<'a, T>>;
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(&self.head).chain(self.tail.iter())
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut NonEmpty<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::iter::Chain<std::iter::Once<&'a mut T>, std::slice::IterMut<'a, T>>;
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(&mut self.head).chain(self.tail.iter_mut())
+    }
+}
+
+impl<T> IntoIterator for NonEmpty<T> {
+    type Item = T;
+    type IntoIter = std::iter::Chain<std::iter::Once<T>, std::vec::IntoIter<T>>;
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(self.head).chain(self.tail)
     }
 }

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -79,7 +79,7 @@ impl AggregateOperator {
         let mut group_size_col: Option<usize> = None;
 
         for (agg_idx, spec) in aggregates.iter().enumerate() {
-            match spec.input_var {
+            match spec.function.input_var() {
                 Some(input_var) => {
                     // Regular aggregate with input variable
                     if let Some(col_idx) = child_schema.iter().position(|v| *v == input_var) {
@@ -195,7 +195,7 @@ impl Operator for AggregateOperator {
                         Some(agg_idx) => {
                             // This column needs aggregation
                             let spec = &self.aggregates[agg_idx];
-                            apply_aggregate(&spec.function, input_binding, spec.distinct)
+                            spec.function.apply(input_binding)
                         }
                         None => {
                             // Pass through unchanged
@@ -218,7 +218,7 @@ impl Operator for AggregateOperator {
                         Some(col_idx) => (0..batch.len())
                             .map(|row_idx| {
                                 let input_binding = batch.get_by_col(row_idx, *col_idx);
-                                apply_aggregate(&spec.function, input_binding, spec.distinct)
+                                spec.function.apply(input_binding)
                             })
                             .collect(),
                         None => {
@@ -271,43 +271,54 @@ impl Operator for AggregateOperator {
     }
 }
 
-/// Apply an aggregate function to a binding
-///
-/// If the binding is `Grouped(values)`, compute the aggregate.
-/// Otherwise, pass through unchanged (shouldn't happen in normal usage).
-/// When `distinct` is true, deduplicates values before aggregation.
-pub fn apply_aggregate(func: &AggregateFn, binding: &Binding, distinct: bool) -> Binding {
-    match binding {
-        Binding::Grouped(values) => {
-            if distinct {
-                let mut seen = HashSet::with_capacity(values.len());
-                let deduped: Vec<Binding> =
-                    values.iter().filter(|b| seen.insert(*b)).cloned().collect();
-                compute_aggregate(func, &deduped)
-            } else {
-                compute_aggregate(func, values)
-            }
+impl AggregateFn {
+    /// Apply this aggregate function to a binding.
+    ///
+    /// If the binding is `Grouped(values)`, compute the aggregate;
+    /// non-grouped values pass through (e.g. group-key columns).
+    /// Variants that need an upstream dedup pass (see
+    /// [`Self::needs_input_dedup`]) get one before being handed to
+    /// [`Self::compute`].
+    pub fn apply(&self, binding: &Binding) -> Binding {
+        let Binding::Grouped(values) = binding else {
+            return binding.clone();
+        };
+        if self.needs_input_dedup() {
+            let mut seen = HashSet::with_capacity(values.len());
+            let deduped: Vec<Binding> =
+                values.iter().filter(|b| seen.insert(*b)).cloned().collect();
+            self.compute(&deduped)
+        } else {
+            self.compute(values)
         }
-        // Non-grouped values pass through (e.g., group key columns)
-        other => other.clone(),
     }
-}
 
-/// Compute aggregate over a list of bindings
-fn compute_aggregate(func: &AggregateFn, values: &[Binding]) -> Binding {
-    match func {
-        AggregateFn::Count => agg_count(values),
-        AggregateFn::CountAll => agg_count_all(values),
-        AggregateFn::CountDistinct => agg_count_distinct(values),
-        AggregateFn::Sum => agg_sum(values),
-        AggregateFn::Avg => agg_avg(values),
-        AggregateFn::Min => agg_min(values),
-        AggregateFn::Max => agg_max(values),
-        AggregateFn::Median => agg_median(values),
-        AggregateFn::Variance => agg_variance(values),
-        AggregateFn::Stddev => agg_stddev(values),
-        AggregateFn::GroupConcat { separator } => agg_group_concat(values, separator),
-        AggregateFn::Sample => agg_sample(values),
+    /// Whether [`Self::apply`] must deduplicate input values before
+    /// reducing. True for variants whose [`InputSemantics`] is
+    /// [`InputSemantics::Set`]; false for everything else, including
+    /// [`Self::CountDistinct`] — its streaming state is already a
+    /// `HashSet`, so an additional dedup pass would be redundant.
+    fn needs_input_dedup(&self) -> bool {
+        self.is_distinct() && !matches!(self, AggregateFn::CountDistinct(_))
+    }
+
+    /// Compute the aggregate result over an already-prepared list of
+    /// bindings (deduplicated upstream by [`Self::apply`] if needed).
+    fn compute(&self, values: &[Binding]) -> Binding {
+        match self {
+            Self::Count(_) => agg_count(values),
+            Self::CountAll => agg_count_all(values),
+            Self::CountDistinct(_) => agg_count_distinct(values),
+            Self::Sum { .. } => agg_sum(values),
+            Self::Avg { .. } => agg_avg(values),
+            Self::Min(_) => agg_min(values),
+            Self::Max(_) => agg_max(values),
+            Self::Median { .. } => agg_median(values),
+            Self::Variance { .. } => agg_variance(values),
+            Self::Stddev { .. } => agg_stddev(values),
+            Self::GroupConcat { separator, .. } => agg_group_concat(values, separator),
+            Self::Sample(_) => agg_sample(values),
+        }
     }
 }
 
@@ -591,6 +602,7 @@ fn extract_numbers(values: &[Binding]) -> Vec<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::InputSemantics;
 
     #[test]
     fn test_agg_count() {
@@ -849,11 +861,16 @@ mod tests {
         assert!(matches!(result, Binding::Unbound));
     }
 
+    fn sum_of(input: VarId, distinct: bool) -> AggregateFn {
+        let semantics = if distinct { InputSemantics::Set } else { InputSemantics::List };
+        AggregateFn::Sum(input, semantics)
+    }
+
     #[test]
     fn test_apply_aggregate_non_grouped() {
         // Non-grouped values pass through unchanged
         let binding = Binding::lit(FlakeValue::Long(42), xsd_integer());
-        let result = apply_aggregate(&AggregateFn::Sum, &binding, false);
+        let result = sum_of(VarId(0), false).apply(&binding);
         assert_eq!(result, binding);
     }
 
@@ -865,7 +882,7 @@ mod tests {
             Binding::lit(FlakeValue::Long(3), xsd_integer()),
         ]);
 
-        let result = apply_aggregate(&AggregateFn::Sum, &grouped, false);
+        let result = sum_of(VarId(0), false).apply(&grouped);
         let (val, _) = result.as_lit().unwrap();
         assert_eq!(*val, FlakeValue::Long(6));
     }
@@ -881,7 +898,7 @@ mod tests {
             Binding::lit(FlakeValue::Long(2), xsd_integer()), // duplicate
         ]);
 
-        let result = apply_aggregate(&AggregateFn::Sum, &grouped, true);
+        let result = sum_of(VarId(0), true).apply(&grouped);
         let (val, _) = result.as_lit().unwrap();
         assert_eq!(*val, FlakeValue::Long(6)); // 1+2+3 = 6, not 1+2+1+3+2 = 9
     }

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -862,7 +862,11 @@ mod tests {
     }
 
     fn sum_of(input: VarId, distinct: bool) -> AggregateFn {
-        let semantics = if distinct { InputSemantics::Set } else { InputSemantics::List };
+        let semantics = if distinct {
+            InputSemantics::Set
+        } else {
+            InputSemantics::List
+        };
         AggregateFn::Sum(input, semantics)
     }
 

--- a/fluree-db-query/src/count_plan.rs
+++ b/fluree-db-query/src/count_plan.rs
@@ -958,9 +958,7 @@ mod tests {
                 aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![
                     crate::ir::AggregateSpec {
                         function: AggregateFn::CountAll,
-                        input_var: None,
                         output_var: out_var,
-                        distinct: false,
                     },
                 ])
                 .expect("non-empty"),

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -85,7 +85,7 @@ pub fn compute_variable_deps(query: &Query) -> Option<VariableDeps> {
     // Aggregates: replace output vars with input vars.
     for spec in query.grouping.iter().flat_map(Grouping::aggregates) {
         if deps.remove(&spec.output_var) {
-            if let Some(input_var) = spec.input_var {
+            if let Some(input_var) = spec.function.input_var() {
                 deps.insert(input_var);
             }
         }
@@ -118,7 +118,7 @@ mod tests {
     use crate::ir::triple::{Ref, Term, TriplePattern};
     use crate::ir::{
         AggregateFn, AggregateSpec, Aggregation, ConstructTemplate, Expression, FlakeValue,
-        Pattern, Query, QueryOutput, ReasoningConfig,
+        InputSemantics, Pattern, Query, QueryOutput, ReasoningConfig,
     };
     use crate::parse::SelectMode;
     use crate::sort::SortSpec;
@@ -215,10 +215,8 @@ mod tests {
             group_by: fluree_db_core::NonEmpty::try_from_vec(vec![VarId(2)]).unwrap(),
             aggregation: Some(Aggregation {
                 aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![AggregateSpec {
-                    function: AggregateFn::Avg,
-                    input_var: Some(VarId(1)),
+                    function: AggregateFn::Avg(VarId(1), InputSemantics::List),
                     output_var: VarId(3),
-                    distinct: false,
                 }])
                 .unwrap(),
                 binds: Vec::new(),
@@ -244,10 +242,8 @@ mod tests {
             group_by: fluree_db_core::NonEmpty::try_from_vec(vec![VarId(0)]).unwrap(),
             aggregation: Some(Aggregation {
                 aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![AggregateSpec {
-                    function: AggregateFn::Avg,
-                    input_var: Some(VarId(1)),
+                    function: AggregateFn::Avg(VarId(1), InputSemantics::List),
                     output_var: VarId(2),
-                    distinct: false,
                 }])
                 .unwrap(),
                 binds: vec![(
@@ -442,10 +438,8 @@ mod tests {
             group_by: fluree_db_core::NonEmpty::try_from_vec(vec![VarId(0)]).unwrap(),
             aggregation: Some(Aggregation {
                 aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![AggregateSpec {
-                    function: AggregateFn::Avg,
-                    input_var: Some(VarId(1)),
+                    function: AggregateFn::Avg(VarId(1), InputSemantics::List),
                     output_var: VarId(2),
-                    distinct: false,
                 }])
                 .unwrap(),
                 binds: Vec::new(),
@@ -480,10 +474,8 @@ mod tests {
             group_by: fluree_db_core::NonEmpty::try_from_vec(vec![VarId(0)]).unwrap(),
             aggregation: Some(Aggregation {
                 aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![AggregateSpec {
-                    function: AggregateFn::Avg,
-                    input_var: Some(VarId(1)),
+                    function: AggregateFn::Avg(VarId(1), InputSemantics::List),
                     output_var: VarId(2),
-                    distinct: false,
                 }])
                 .unwrap(),
                 binds: vec![(
@@ -526,10 +518,8 @@ mod tests {
             group_by: fluree_db_core::NonEmpty::try_from_vec(vec![VarId(0)]).unwrap(),
             aggregation: Some(Aggregation {
                 aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![AggregateSpec {
-                    function: AggregateFn::Count,
-                    input_var: Some(VarId(1)),
+                    function: AggregateFn::Count(VarId(1)),
                     output_var: VarId(2),
-                    distinct: false,
                 }])
                 .unwrap(),
                 binds: Vec::new(),

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -43,8 +43,8 @@ use crate::groupby::GroupByOperator;
 use crate::having::HavingOperator;
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::{
-    AggregateFn, AggregateSpec, Aggregation, Expression, Grouping, PathModifier, Pattern, Query,
-    QueryOutput,
+    AggregateFn, AggregateSpec, Aggregation, Expression, Grouping, InputSemantics, PathModifier,
+    Pattern, Query, QueryOutput,
 };
 use crate::limit::LimitOperator;
 use crate::offset::OffsetOperator;
@@ -444,13 +444,13 @@ fn implicit_single_aggregate(query: &Query) -> Option<&AggregateSpec> {
 ///
 /// Returns `Some(output_var)` if the query has:
 /// - SELECT output (not CONSTRUCT/BOOLEAN/WILDCARD)
-/// - Exactly one aggregate: `COUNT(*)` (not distinct, no input var)
+/// - Exactly one aggregate: `COUNT(*)` (`AggregateFn::CountAll`)
 /// - No group_by, having, post-aggregation binds, order_by, offset, or DISTINCT
 /// - LIMIT >= 1 (or no limit)
 /// - SELECT vars == `[agg.output_var]`
 pub(crate) fn detect_count_all_aggregate(query: &Query) -> Option<VarId> {
     let agg = implicit_single_aggregate(query)?;
-    if agg.distinct || !matches!(agg.function, AggregateFn::CountAll) || agg.input_var.is_some() {
+    if !matches!(agg.function, AggregateFn::CountAll) {
         return None;
     }
     let select_vars = query.output.projected_vars()?;
@@ -470,10 +470,9 @@ pub(crate) fn detect_count_all_aggregate(query: &Query) -> Option<VarId> {
 /// - SELECT vars == `[agg.output_var]`
 fn detect_count_distinct_aggregate(query: &Query) -> Option<(VarId, VarId)> {
     let agg = implicit_single_aggregate(query)?;
-    if agg.distinct || !matches!(agg.function, AggregateFn::CountDistinct) {
+    let AggregateFn::CountDistinct(in_var) = agg.function else {
         return None;
-    }
-    let in_var = agg.input_var?;
+    };
     let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
@@ -487,12 +486,9 @@ fn detect_count_distinct_aggregate(query: &Query) -> Option<(VarId, VarId)> {
 /// Same standard constraints as [`detect_count_all_aggregate`].
 fn detect_count_aggregate(query: &Query) -> Option<(Option<VarId>, VarId)> {
     let agg = implicit_single_aggregate(query)?;
-    if agg.distinct {
-        return None;
-    }
     let input_var = match agg.function {
-        AggregateFn::CountAll if agg.input_var.is_none() => None,
-        AggregateFn::Count => Some(agg.input_var?),
+        AggregateFn::CountAll => None,
+        AggregateFn::Count(v) => Some(v),
         _ => return None,
     };
     let select_vars = query.output.projected_vars()?;
@@ -572,15 +568,10 @@ fn detect_predicate_group_by_object_count_topk(
         return None;
     }
     let agg = aggregates.first();
-    if agg.distinct {
-        return None;
-    }
-    let is_count = matches!(agg.function, AggregateFn::Count | AggregateFn::CountAll);
-    if !is_count {
-        return None;
-    }
-    if matches!(agg.function, AggregateFn::Count) && agg.input_var != Some(s_var) {
-        return None;
+    match &agg.function {
+        AggregateFn::CountAll => {}
+        AggregateFn::Count(v) if *v == s_var => {}
+        _ => return None,
     }
     if !binds.is_empty() {
         return None;
@@ -679,9 +670,6 @@ fn detect_group_by_object_star_topk(
     let mut max_out: Option<VarId> = None;
     let mut sample_out: Option<VarId> = None;
     for agg in aggregates.iter() {
-        if agg.distinct {
-            return None;
-        }
         match agg.function {
             AggregateFn::CountAll => {
                 if count_out.is_some() {
@@ -689,29 +677,26 @@ fn detect_group_by_object_star_topk(
                 }
                 count_out = Some(agg.output_var);
             }
-            AggregateFn::Count => {
+            AggregateFn::Count(v) if v == subj_var => {
                 if count_out.is_some() {
-                    return None;
-                }
-                if agg.input_var != Some(subj_var) {
                     return None;
                 }
                 count_out = Some(agg.output_var);
             }
-            AggregateFn::Min => {
-                if min_out.is_some() || agg.input_var != Some(subj_var) {
+            AggregateFn::Min(v) if v == subj_var => {
+                if min_out.is_some() {
                     return None;
                 }
                 min_out = Some(agg.output_var);
             }
-            AggregateFn::Max => {
-                if max_out.is_some() || agg.input_var != Some(subj_var) {
+            AggregateFn::Max(v) if v == subj_var => {
+                if max_out.is_some() {
                     return None;
                 }
                 max_out = Some(agg.output_var);
             }
-            AggregateFn::Sample => {
-                if sample_out.is_some() || agg.input_var != Some(subj_var) {
+            AggregateFn::Sample(v) if v == subj_var => {
+                if sample_out.is_some() {
                     return None;
                 }
                 sample_out = Some(agg.output_var);
@@ -764,10 +749,10 @@ fn detect_sum_strlen_group_concat_subquery(query: &Query) -> Option<(Ref, Arc<st
 
     // Outer aggregate must be SUM(?v) (where ?v is the STRLEN bind var).
     let outer_agg = implicit_single_aggregate(query)?;
-    if outer_agg.distinct || outer_agg.function != AggregateFn::Sum {
-        return None;
-    }
-    let strlen_var = outer_agg.input_var?;
+    let strlen_var = match outer_agg.function {
+        AggregateFn::Sum(input, InputSemantics::List) => input,
+        _ => return None,
+    };
 
     // Patterns: one Subquery + one Bind(strlen_var = STRLEN(?cat)).
     if query.patterns.len() != 2 {
@@ -818,10 +803,14 @@ fn detect_sum_strlen_group_concat_subquery(query: &Query) -> Option<(Ref, Arc<st
     }
     let inner_agg = sq_aggregates.first();
     let (sep, input_var) = match &inner_agg.function {
-        AggregateFn::GroupConcat { separator } => (separator.as_str(), inner_agg.input_var?),
+        AggregateFn::GroupConcat {
+            separator,
+            input,
+            semantics: InputSemantics::List,
+        } => (separator.as_str(), *input),
         _ => return None,
     };
-    if inner_agg.distinct || inner_agg.output_var != *cat_var {
+    if inner_agg.output_var != *cat_var {
         return None;
     }
 
@@ -995,18 +984,12 @@ fn detect_predicate_minmax_string(query: &Query) -> Option<(Ref, MinMaxMode, Var
     };
     let (_s_var, pred, o_var) = validate_simple_triple(tp)?;
 
-    // Aggregate must be MIN(?o) or MAX(?o) (not distinct).
-    if agg.distinct {
-        return None;
-    }
+    // Aggregate must be MIN(?o) or MAX(?o).
     let mode = match agg.function {
-        AggregateFn::Min => MinMaxMode::Min,
-        AggregateFn::Max => MinMaxMode::Max,
+        AggregateFn::Min(v) if v == o_var => MinMaxMode::Min,
+        AggregateFn::Max(v) if v == o_var => MinMaxMode::Max,
         _ => return None,
     };
-    if agg.input_var? != o_var {
-        return None;
-    }
 
     // SELECT must be exactly the aggregate output var.
     let select_vars = query.output.projected_vars()?;
@@ -1026,7 +1009,10 @@ fn detect_predicate_avg_numeric(query: &Query) -> Option<(Ref, VarId)> {
         return None;
     };
     let (_s_var, pred, o_var) = validate_simple_triple(tp)?;
-    if agg.distinct || !matches!(agg.function, AggregateFn::Avg) || agg.input_var? != o_var {
+    let AggregateFn::Avg(input, InputSemantics::List) = agg.function else {
+        return None;
+    };
+    if input != o_var {
         return None;
     }
     let select_vars = query.output.projected_vars()?;
@@ -1045,7 +1031,7 @@ fn detect_count_rows_with_encoded_filters(
 )> {
     // Must be single COUNT aggregate, no grouping/having/binds/etc.
     let agg = implicit_single_aggregate(query)?;
-    if agg.distinct || !matches!(agg.function, AggregateFn::Count | AggregateFn::CountAll) {
+    if !matches!(agg.function, AggregateFn::Count(_) | AggregateFn::CountAll) {
         return None;
     }
 
@@ -1070,7 +1056,7 @@ fn detect_count_rows_with_encoded_filters(
     let (s_var, _pred, o_var) = validate_simple_triple(tp)?;
 
     // COUNT(?s) or COUNT(*) only.
-    if matches!(agg.function, AggregateFn::Count) && agg.input_var != Some(s_var) {
+    if matches!(agg.function, AggregateFn::Count(v) if v != s_var) {
         return None;
     }
 
@@ -1151,7 +1137,7 @@ fn detect_predicate_count_rows_numeric_compare(
     if query.patterns.len() != 2 {
         return None;
     }
-    if agg.distinct || !matches!(agg.function, AggregateFn::Count | AggregateFn::CountAll) {
+    if !matches!(agg.function, AggregateFn::Count(_) | AggregateFn::CountAll) {
         return None;
     }
 
@@ -1162,7 +1148,7 @@ fn detect_predicate_count_rows_numeric_compare(
     };
 
     let (s_var, pred, o_var) = validate_simple_triple(tp)?;
-    if matches!(agg.function, AggregateFn::Count) && agg.input_var != Some(s_var) {
+    if matches!(agg.function, AggregateFn::Count(v) if v != s_var) {
         return None;
     }
 
@@ -1200,9 +1186,9 @@ fn detect_string_prefix_sum_strstarts(query: &Query) -> Option<(Ref, Arc<str>, V
     use crate::ir::{Expression, FlakeValue, Function};
 
     let agg = implicit_single_aggregate(query)?;
-    if agg.distinct || !matches!(agg.function, AggregateFn::Sum) {
+    let AggregateFn::Sum(sum_input, InputSemantics::List) = agg.function else {
         return None;
-    }
+    };
     let select_vars = query.output.projected_vars()?;
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
@@ -1216,7 +1202,7 @@ fn detect_string_prefix_sum_strstarts(query: &Query) -> Option<(Ref, Arc<str>, V
         _ => return None,
     };
     let (_s_var, pred, o_var) = validate_simple_triple(tp)?;
-    if agg.input_var != Some(bind_var) {
+    if sum_input != bind_var {
         return None;
     }
 
@@ -1367,12 +1353,10 @@ fn detect_stats_count_by_predicate(query: &Query) -> Option<(VarId, VarId)> {
         return None;
     }
     let agg = aggregates.first();
-    if !matches!(agg.function, AggregateFn::Count) {
+    let AggregateFn::Count(input_var) = agg.function else {
         return None;
-    }
-
+    };
     // COUNT input must be a non-predicate variable (subject or object)
-    let input_var = agg.input_var?;
     if input_var != *s_var && input_var != *o_var {
         return None;
     }
@@ -1400,9 +1384,9 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
     if select_vars.len() != 1 || select_vars[0] != agg.output_var {
         return None;
     }
-    if agg.distinct || !matches!(agg.function, AggregateFn::Sum) {
+    let AggregateFn::Sum(sum_input, InputSemantics::List) = agg.function else {
         return None;
-    }
+    };
 
     match query.patterns.as_slice() {
         [Pattern::Triple(tp)] => {
@@ -1410,7 +1394,7 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
             let Term::Var(o_var) = &tp.o else {
                 return None;
             };
-            if agg.input_var != Some(*o_var) {
+            if sum_input != *o_var {
                 return None;
             }
             Some((pred, SumExprI64::Identity, agg.output_var))
@@ -1422,7 +1406,7 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
             };
 
             // Bind must define the aggregate input var, and SUM must use it.
-            if agg.input_var != Some(*var) {
+            if sum_input != *var {
                 return None;
             }
 
@@ -2546,7 +2530,7 @@ fn build_operator_tree_inner(
         let mut seen_output_vars: HashSet<VarId> = HashSet::new();
 
         for spec in &aggregates_vec {
-            if let Some(input_var) = spec.input_var {
+            if let Some(input_var) = spec.function.input_var() {
                 if !current_schema.contains(&input_var) {
                     return Err(QueryError::VariableNotFound(format!(
                         "Aggregate input variable {input_var:?} not found in schema"
@@ -2583,13 +2567,13 @@ fn build_operator_tree_inner(
             .iter()
             .map(|spec| {
                 let input_col = spec
-                    .input_var
+                    .function
+                    .input_var()
                     .and_then(|v| current_schema.iter().position(|&sv| sv == v));
                 StreamingAggSpec {
                     function: spec.function.clone(),
                     input_col,
                     output_var: spec.output_var,
-                    distinct: spec.distinct,
                 }
             })
             .collect();
@@ -3001,10 +2985,8 @@ mod tests {
                 aggregation: Aggregation {
                     aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![
                         crate::ir::AggregateSpec {
-                            function: crate::ir::AggregateFn::CountDistinct,
-                            input_var: Some(counted_o),
+                            function: crate::ir::AggregateFn::CountDistinct(counted_o),
                             output_var: out,
-                            distinct: false,
                         },
                     ])
                     .unwrap(),

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -139,7 +139,6 @@ impl PredicateGroupCountFirstsOperator {
             function: AggregateFn::CountAll,
             input_col: None,
             output_var: self.count_var,
-            distinct: false,
         }];
         let grouped: BoxedOperator = Box::new(GroupAggregateOperator::new(
             scan,
@@ -389,7 +388,6 @@ impl PredicateObjectCountFirstsOperator {
             function: AggregateFn::CountAll,
             input_col: None,
             output_var: self.count_var,
-            distinct: false,
         }];
         let mut op: BoxedOperator = Box::new(GroupAggregateOperator::new(
             scan,

--- a/fluree-db-query/src/group_aggregate.rs
+++ b/fluree-db-query/src/group_aggregate.rs
@@ -38,7 +38,7 @@
 use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
-use crate::ir::AggregateFn;
+use crate::ir::{AggregateFn, InputSemantics};
 // Note: JoinKey and Materializer would be used for multi-ledger/dataset mode
 // but for now we use GroupKeyOwned for single-ledger simplicity
 use crate::operator::{
@@ -54,19 +54,21 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::Instrument;
 
-/// Specification for a streaming aggregate
+/// Specification for a streaming aggregate.
+///
+/// `function` carries every variant-correlated input (the read variable,
+/// the `distinct` flag, the GROUP_CONCAT separator); only the columnar
+/// projection (`input_col`) and the output binding (`output_var`) are
+/// extracted here because they're properties of the operator wiring, not
+/// of the aggregate itself.
 #[derive(Debug, Clone)]
 pub struct StreamingAggSpec {
-    /// The aggregate function
+    /// The aggregate function (carries its input variable + distinct flag).
     pub function: AggregateFn,
-    /// Input column index (None for COUNT(*))
+    /// Input column index in the upstream batch (None for COUNT(*)).
     pub input_col: Option<usize>,
-    /// Output variable ID
+    /// Output variable ID.
     pub output_var: VarId,
-    /// Whether DISTINCT was specified (e.g., SUM(DISTINCT ?x)).
-    /// Used by `all_streamable()` to route DISTINCT SUM/AVG to the
-    /// traditional AggregateOperator path which handles deduplication.
-    pub distinct: bool,
 }
 
 /// Per-group streaming aggregate state
@@ -210,24 +212,24 @@ fn materialize_for_minmax(binding: &Binding, gv: Option<&BinaryGraphView>) -> Bi
 impl AggState {
     fn new(func: &AggregateFn) -> Self {
         match func {
-            AggregateFn::Count | AggregateFn::CountAll => AggState::Count { n: 0 },
-            AggregateFn::CountDistinct => AggState::CountDistinct {
+            AggregateFn::Count(_) | AggregateFn::CountAll => AggState::Count { n: 0 },
+            AggregateFn::CountDistinct(_) => AggState::CountDistinct {
                 seen: HashSet::new(),
             },
-            AggregateFn::Sum => AggState::Sum {
+            AggregateFn::Sum { .. } => AggState::Sum {
                 total: 0.0,
                 has_int_only: true,
             },
-            AggregateFn::Avg => AggState::Avg { sum: 0.0, count: 0 },
-            AggregateFn::Min => AggState::Min { min: None },
-            AggregateFn::Max => AggState::Max { max: None },
+            AggregateFn::Avg { .. } => AggState::Avg { sum: 0.0, count: 0 },
+            AggregateFn::Min(_) => AggState::Min { min: None },
+            AggregateFn::Max(_) => AggState::Max { max: None },
             // Non-streamable: collect all values
-            AggregateFn::Median
-            | AggregateFn::Variance
-            | AggregateFn::Stddev
+            AggregateFn::Median { .. }
+            | AggregateFn::Variance { .. }
+            | AggregateFn::Stddev { .. }
             | AggregateFn::GroupConcat { .. } => AggState::Collect { values: Vec::new() },
             // SAMPLE is explicitly arbitrary in SPARQL; we pick the first observed value.
-            AggregateFn::Sample => AggState::Sample { sample: None },
+            AggregateFn::Sample(_) => AggState::Sample { sample: None },
         }
     }
 
@@ -359,7 +361,7 @@ impl AggState {
                 // them to the traditional AggregateOperator instead (via
                 // `all_streamable()` returning false). If a future non-streamable
                 // aggregate needs DISTINCT, pass the spec's distinct flag here.
-                crate::aggregate::apply_aggregate(func, &Binding::Grouped(values), false)
+                func.apply(&Binding::Grouped(values))
             }
         }
     }
@@ -610,29 +612,29 @@ impl GroupAggregateOperator {
         self
     }
 
-    /// Check if all aggregates are streamable (for planner optimization decisions)
+    /// Check if all aggregates are streamable (for planner optimization decisions).
     ///
-    /// DISTINCT SUM/AVG are not streamable because deduplication requires collecting
-    /// all values before computing the aggregate. COUNT(DISTINCT) and MIN/MAX(DISTINCT)
-    /// remain streamable — COUNT(DISTINCT) already tracks a HashSet, and DISTINCT is
-    /// idempotent for MIN/MAX.
+    /// `DISTINCT SUM`/`AVG` aren't streamable because the dedup pass must collect
+    /// every value before reducing. `Median`/`Variance`/`Stddev`/`GroupConcat`
+    /// are non-streamable regardless of DISTINCT — they likewise need every
+    /// value in hand. `COUNT(DISTINCT)` is streamable because its state machine
+    /// is a `HashSet` (the dedup IS the streaming state), and `Min`/`Max`/`Sample`
+    /// don't carry a DISTINCT flag at all.
     pub fn all_streamable(specs: &[StreamingAggSpec]) -> bool {
-        specs.iter().all(|spec| {
-            let is_streamable_fn = matches!(
-                spec.function,
-                AggregateFn::Count
-                    | AggregateFn::CountAll
-                    | AggregateFn::CountDistinct
-                    | AggregateFn::Sum
-                    | AggregateFn::Avg
-                    | AggregateFn::Min
-                    | AggregateFn::Max
-                    | AggregateFn::Sample
-            );
-            // DISTINCT SUM/AVG need to collect all values for dedup — not streamable
-            let distinct_blocks =
-                spec.distinct && matches!(spec.function, AggregateFn::Sum | AggregateFn::Avg);
-            is_streamable_fn && !distinct_blocks
+        specs.iter().all(|spec| match &spec.function {
+            AggregateFn::Count(_)
+            | AggregateFn::CountAll
+            | AggregateFn::CountDistinct(_)
+            | AggregateFn::Min(_)
+            | AggregateFn::Max(_)
+            | AggregateFn::Sample(_) => true,
+            AggregateFn::Sum(_, semantics) | AggregateFn::Avg(_, semantics) => {
+                matches!(semantics, InputSemantics::List)
+            }
+            AggregateFn::Median { .. }
+            | AggregateFn::Variance { .. }
+            | AggregateFn::Stddev { .. }
+            | AggregateFn::GroupConcat { .. } => false,
         })
     }
 
@@ -689,7 +691,6 @@ impl Operator for GroupAggregateOperator {
             && self.group_key_indices.is_empty()
             && self.agg_specs.len() == 1
             && matches!(self.agg_specs[0].function, AggregateFn::CountAll)
-            && !self.agg_specs[0].distinct
         {
             if let Some(count) = self.child.drain_count(ctx).await? {
                 let count_i64 = i64::try_from(count).map_err(|_| {
@@ -1064,10 +1065,9 @@ mod tests {
 
         // GROUP BY ?venue, COUNT(?paper) as ?count
         let agg_specs = vec![StreamingAggSpec {
-            function: AggregateFn::Count,
-            input_col: Some(1), // ?paper
+            function: AggregateFn::Count(VarId(1)), // ?paper
+            input_col: Some(1),
             output_var: VarId(2),
-            distinct: false,
         }];
 
         let mut op = GroupAggregateOperator::new(child, vec![VarId(0)], agg_specs, None, false);
@@ -1175,18 +1175,17 @@ mod tests {
         });
 
         // GROUP BY ?category, SUM(?value), AVG(?value)
+        let list = InputSemantics::List;
         let agg_specs = vec![
             StreamingAggSpec {
-                function: AggregateFn::Sum,
+                function: AggregateFn::Sum(VarId(1), list),
                 input_col: Some(1),
                 output_var: VarId(2),
-                distinct: false,
             },
             StreamingAggSpec {
-                function: AggregateFn::Avg,
+                function: AggregateFn::Avg(VarId(1), list),
                 input_col: Some(1),
                 output_var: VarId(3),
-                distinct: false,
             },
         ];
 
@@ -1228,56 +1227,54 @@ mod tests {
 
     #[test]
     fn test_all_streamable() {
+        let v0 = VarId(0);
         let streamable = vec![
             StreamingAggSpec {
-                function: AggregateFn::Count,
+                function: AggregateFn::Count(v0),
                 input_col: Some(0),
                 output_var: VarId(1),
-                distinct: false,
             },
             StreamingAggSpec {
-                function: AggregateFn::Sum,
+                function: AggregateFn::Sum(v0, InputSemantics::List),
                 input_col: Some(0),
                 output_var: VarId(2),
-                distinct: false,
             },
         ];
         assert!(GroupAggregateOperator::all_streamable(&streamable));
 
         let non_streamable = vec![
             StreamingAggSpec {
-                function: AggregateFn::Count,
+                function: AggregateFn::Count(v0),
                 input_col: Some(0),
                 output_var: VarId(1),
-                distinct: false,
             },
             StreamingAggSpec {
                 function: AggregateFn::GroupConcat {
+                    input: v0,
+                    semantics: InputSemantics::List,
                     separator: ",".to_string(),
                 },
                 input_col: Some(0),
                 output_var: VarId(2),
-                distinct: false,
             },
         ];
         assert!(!GroupAggregateOperator::all_streamable(&non_streamable));
 
         // DISTINCT SUM is not streamable (needs to collect all values for dedup)
         let distinct_sum = vec![StreamingAggSpec {
-            function: AggregateFn::Sum,
+            function: AggregateFn::Sum(v0, InputSemantics::Set),
             input_col: Some(0),
             output_var: VarId(1),
-            distinct: true,
         }];
         assert!(!GroupAggregateOperator::all_streamable(&distinct_sum));
 
-        // DISTINCT MIN is streamable (idempotent)
-        let distinct_min = vec![StreamingAggSpec {
-            function: AggregateFn::Min,
+        // MIN doesn't carry a `distinct` flag — the variant elides it because
+        // DISTINCT has no effect on min/max — so this is just a streamable Min.
+        let plain_min = vec![StreamingAggSpec {
+            function: AggregateFn::Min(v0),
             input_col: Some(0),
             output_var: VarId(1),
-            distinct: true,
         }];
-        assert!(GroupAggregateOperator::all_streamable(&distinct_min));
+        assert!(GroupAggregateOperator::all_streamable(&plain_min));
     }
 }

--- a/fluree-db-query/src/ir.rs
+++ b/fluree-db-query/src/ir.rs
@@ -49,7 +49,7 @@ pub use adapters::{
 };
 pub use expression::{ArithmeticOp, CompareOp, Expression, Function};
 pub use fluree_db_core::value::FlakeValue;
-pub use grouping::{AggregateFn, AggregateSpec, Aggregation, Grouping};
+pub use grouping::{AggregateFn, AggregateSpec, Aggregation, Grouping, InputSemantics};
 pub use path::{PathModifier, PropertyPathPattern};
 pub use pattern::{GraphName, Pattern, ServiceEndpoint, ServicePattern, SubqueryPattern};
 pub use projection::{Column, ForwardItem, HydrationSpec, NestedSelectSpec, Projection, Root};

--- a/fluree-db-query/src/ir/grouping.rs
+++ b/fluree-db-query/src/ir/grouping.rs
@@ -6,54 +6,117 @@ use fluree_db_core::NonEmpty;
 use super::expression::Expression;
 use crate::var_registry::VarId;
 
-/// Aggregate function kinds.
+/// How an aggregate function interprets duplicate input values.
 ///
-/// `DISTINCT` handling is split: `COUNT(DISTINCT)` has a dedicated variant
-/// (`CountDistinct`) because its streaming state uses a `HashSet` rather
-/// than a simple counter. All other DISTINCT aggregates (SUM, AVG, …) use
-/// their normal variant with `AggregateSpec::distinct = true`, and dedup
-/// is applied at execution time.
-#[derive(Debug, Clone, PartialEq)]
-pub enum AggregateFn {
-    /// COUNT — count non-Unbound values of a variable
-    Count,
-    /// COUNT(*) — count all rows in a group regardless of variable values
-    CountAll,
-    /// COUNT(DISTINCT) — count distinct non-Unbound values (dedicated variant
-    /// for streaming HashSet state; `AggregateSpec::distinct` is false here)
-    CountDistinct,
-    /// SUM — numeric sum
-    Sum,
-    /// AVG — numeric average
-    Avg,
-    /// MIN — minimum value by comparison
-    Min,
-    /// MAX — maximum value by comparison
-    Max,
-    /// MEDIAN — median value
-    Median,
-    /// VARIANCE — population variance
-    Variance,
-    /// STDDEV — population standard deviation
-    Stddev,
-    /// GROUP_CONCAT — concatenate strings with separator
-    GroupConcat { separator: String },
-    /// SAMPLE — return an arbitrary value
-    Sample,
+/// SPARQL aggregates can be written with or without the `DISTINCT`
+/// modifier. The modifier doesn't change what the input *is* (the
+/// executor always carries a multiset of `Binding`s) — it changes how
+/// the aggregate *interprets* that input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputSemantics {
+    /// Treat the input as a list — every occurrence counted (default).
+    List,
+    /// Treat the input as a set — duplicates collapsed (`DISTINCT`).
+    Set,
 }
 
-/// Specification for a single aggregate operation.
+/// Aggregate function kinds, with each variant carrying exactly the fields
+/// that variant needs:
+///
+/// - The input variable is part of every variant except [`Self::CountAll`]
+///   (which counts rows regardless of values). Variants that take an input
+///   carry it inline, so "Sum without an input" or "CountAll with an input"
+///   are structurally unrepresentable.
+/// - [`InputSemantics`] rides only on variants where SPARQL's `DISTINCT`
+///   modifier actually changes the result. `Min`, `Max`, and `Sample` omit
+///   it because their values are unchanged by deduplication; `Count` /
+///   `CountDistinct` are separate variants for the same reason plus a
+///   streaming-state distinction (counter vs. `HashSet`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum AggregateFn {
+    /// `COUNT(?x)` — count non-Unbound values of a variable.
+    Count(VarId),
+    /// `COUNT(*)` — count all rows in a group regardless of values.
+    CountAll,
+    /// `COUNT(DISTINCT ?x)` — count distinct non-Unbound values. Separate
+    /// variant because its streaming state uses a `HashSet` rather than a
+    /// counter.
+    CountDistinct(VarId),
+    /// `SUM(?x)` or `SUM(DISTINCT ?x)`.
+    Sum(VarId, InputSemantics),
+    /// `AVG(?x)` or `AVG(DISTINCT ?x)`.
+    Avg(VarId, InputSemantics),
+    /// `MIN(?x)` — DISTINCT is a no-op for min, so no flag.
+    Min(VarId),
+    /// `MAX(?x)` — DISTINCT is a no-op for max, so no flag.
+    Max(VarId),
+    /// `MEDIAN(?x)` or `MEDIAN(DISTINCT ?x)`.
+    Median(VarId, InputSemantics),
+    /// `VARIANCE(?x)` or `VARIANCE(DISTINCT ?x)` — population variance.
+    Variance(VarId, InputSemantics),
+    /// `STDDEV(?x)` or `STDDEV(DISTINCT ?x)` — population standard deviation.
+    Stddev(VarId, InputSemantics),
+    /// `GROUP_CONCAT(?x; SEPARATOR=…)` or its DISTINCT form. Stays in
+    /// struct form because of the extra `separator` field.
+    GroupConcat {
+        input: VarId,
+        semantics: InputSemantics,
+        separator: String,
+    },
+    /// `SAMPLE(?x)` — an arbitrary value; DISTINCT is a no-op.
+    Sample(VarId),
+}
+
+impl AggregateFn {
+    /// Variable this aggregate reads from each row, if any. Returns `None`
+    /// only for [`Self::CountAll`].
+    pub fn input_var(&self) -> Option<VarId> {
+        match self {
+            Self::CountAll => None,
+            Self::Count(v)
+            | Self::CountDistinct(v)
+            | Self::Sum(v, _)
+            | Self::Avg(v, _)
+            | Self::Min(v)
+            | Self::Max(v)
+            | Self::Median(v, _)
+            | Self::Variance(v, _)
+            | Self::Stddev(v, _)
+            | Self::Sample(v) => Some(*v),
+            Self::GroupConcat { input, .. } => Some(*input),
+        }
+    }
+
+    /// Whether `DISTINCT` was requested. `true` for [`Self::CountDistinct`]
+    /// (its own dedicated variant) and for any variant whose
+    /// [`InputSemantics`] is [`InputSemantics::Set`]; always `false` on
+    /// `Min`/`Max`/`Sample`/`Count`/`CountAll`, which don't carry the
+    /// modifier at all.
+    pub fn is_distinct(&self) -> bool {
+        matches!(
+            self,
+            Self::CountDistinct(_)
+                | Self::Sum(_, InputSemantics::Set)
+                | Self::Avg(_, InputSemantics::Set)
+                | Self::Median(_, InputSemantics::Set)
+                | Self::Variance(_, InputSemantics::Set)
+                | Self::Stddev(_, InputSemantics::Set)
+                | Self::GroupConcat {
+                    semantics: InputSemantics::Set,
+                    ..
+                }
+        )
+    }
+}
+
+/// Specification for a single aggregate operation: the function applied to
+/// each group plus the variable the result is bound to.
 #[derive(Debug, Clone)]
 pub struct AggregateSpec {
     /// The aggregate function to apply.
     pub function: AggregateFn,
-    /// Input variable (contains `Grouped` values after GROUP BY). `None`
-    /// for `COUNT(*)`, which counts all rows regardless of values.
-    pub input_var: Option<VarId>,
     /// Output variable for the aggregate result.
     pub output_var: VarId,
-    /// Whether `DISTINCT` was specified (e.g., `SUM(DISTINCT ?x)`).
-    pub distinct: bool,
 }
 
 /// The aggregation stage of a grouping phase: aggregate functions computed

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -94,7 +94,7 @@ pub mod var_registry;
 pub mod vector;
 
 // Re-exports
-pub use aggregate::{apply_aggregate, AggregateOperator};
+pub use aggregate::AggregateOperator;
 pub use binary_history::BinaryHistoryScanOperator;
 pub use binary_range::BinaryRangeProvider;
 pub use binary_scan::BinaryScanOperator;

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -17,7 +17,7 @@ use crate::binding::Binding;
 use crate::context::WellKnownDatatypes;
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::ReasoningConfig;
-use crate::ir::{AggregateFn, AggregateSpec};
+use crate::ir::{AggregateFn, AggregateSpec, InputSemantics};
 use crate::ir::{
     Column, ConstructTemplate, ForwardItem, Grouping, HydrationSpec, NestedSelectSpec, Projection,
     Query, QueryOutput, Restriction, Root,
@@ -1633,44 +1633,49 @@ fn lower_sort_spec(spec: &UnresolvedSortSpec, vars: &mut VarRegistry) -> SortSpe
     SortSpec { var, direction }
 }
 
-/// Lower an unresolved aggregate function to a resolved AggregateFn
-fn lower_aggregate_fn(f: &UnresolvedAggregateFn) -> AggregateFn {
-    match f {
-        UnresolvedAggregateFn::Count => AggregateFn::Count,
-        UnresolvedAggregateFn::CountDistinct => AggregateFn::CountDistinct,
-        UnresolvedAggregateFn::Sum => AggregateFn::Sum,
-        UnresolvedAggregateFn::Avg => AggregateFn::Avg,
-        UnresolvedAggregateFn::Min => AggregateFn::Min,
-        UnresolvedAggregateFn::Max => AggregateFn::Max,
-        UnresolvedAggregateFn::Median => AggregateFn::Median,
-        UnresolvedAggregateFn::Variance => AggregateFn::Variance,
-        UnresolvedAggregateFn::Stddev => AggregateFn::Stddev,
+/// Lower an unresolved aggregate spec to a resolved [`AggregateSpec`].
+///
+/// `spec.input_var == "*"` is the COUNT(*) form and maps to
+/// [`AggregateFn::CountAll`]. Every other form binds the input variable
+/// inside the matching `AggregateFn` variant. JSON-LD has no surface
+/// `DISTINCT` modifier today, so every variant that carries
+/// [`InputSemantics`] is built with [`InputSemantics::List`];
+/// `UnresolvedAggregateFn::CountDistinct` targets the dedicated
+/// [`AggregateFn::CountDistinct`] variant instead.
+fn lower_aggregate_spec(spec: &UnresolvedAggregateSpec, vars: &mut VarRegistry) -> AggregateSpec {
+    let output_var = vars.get_or_insert(&spec.output_var);
+
+    // COUNT(*) — input="*" means count rows regardless of values.
+    if spec.input_var.as_ref() == "*" {
+        return AggregateSpec {
+            function: AggregateFn::CountAll,
+            output_var,
+        };
+    }
+
+    let input = vars.get_or_insert(&spec.input_var);
+    let list = InputSemantics::List;
+    let function = match &spec.function {
+        UnresolvedAggregateFn::Count => AggregateFn::Count(input),
+        UnresolvedAggregateFn::CountDistinct => AggregateFn::CountDistinct(input),
+        UnresolvedAggregateFn::Sum => AggregateFn::Sum(input, list),
+        UnresolvedAggregateFn::Avg => AggregateFn::Avg(input, list),
+        UnresolvedAggregateFn::Min => AggregateFn::Min(input),
+        UnresolvedAggregateFn::Max => AggregateFn::Max(input),
+        UnresolvedAggregateFn::Median => AggregateFn::Median(input, list),
+        UnresolvedAggregateFn::Variance => AggregateFn::Variance(input, list),
+        UnresolvedAggregateFn::Stddev => AggregateFn::Stddev(input, list),
         UnresolvedAggregateFn::GroupConcat { separator } => AggregateFn::GroupConcat {
+            input,
+            semantics: list,
             separator: separator.clone(),
         },
-        UnresolvedAggregateFn::Sample => AggregateFn::Sample,
-    }
-}
+        UnresolvedAggregateFn::Sample => AggregateFn::Sample(input),
+    };
 
-/// Lower an unresolved aggregate spec to a resolved AggregateSpec
-fn lower_aggregate_spec(spec: &UnresolvedAggregateSpec, vars: &mut VarRegistry) -> AggregateSpec {
-    // Handle COUNT(*) - input="*" means count all rows
-    if spec.input_var.as_ref() == "*" {
-        // COUNT(*) uses CountAll function and has no input variable
-        AggregateSpec {
-            function: AggregateFn::CountAll,
-            input_var: None,
-            output_var: vars.get_or_insert(&spec.output_var),
-            distinct: false,
-        }
-    } else {
-        // Regular aggregate with input variable
-        AggregateSpec {
-            function: lower_aggregate_fn(&spec.function),
-            input_var: Some(vars.get_or_insert(&spec.input_var)),
-            output_var: vars.get_or_insert(&spec.output_var),
-            distinct: false,
-        }
+    AggregateSpec {
+        function,
+        output_var,
     }
 }
 

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -12,7 +12,7 @@ use fluree_db_query::context::ExecutionContext;
 use fluree_db_query::execute::{execute, ContextConfig, ExecutableQuery};
 use fluree_db_query::groupby::GroupByOperator;
 use fluree_db_query::ir::ReasoningConfig;
-use fluree_db_query::ir::{AggregateFn, AggregateSpec};
+use fluree_db_query::ir::{AggregateFn, AggregateSpec, InputSemantics};
 use fluree_db_query::ir::{Aggregation, Expression, Grouping, Pattern};
 use fluree_db_query::ir::{Query, QueryOutput};
 use fluree_db_query::operator::Operator;
@@ -141,10 +141,8 @@ async fn test_group_by_with_count() {
     query.grouping = Some(explicit_grouping(
         vec![VarId(0)], // GROUP BY ?city
         vec![AggregateSpec {
-            function: AggregateFn::Count,
-            input_var: Some(VarId(1)), // COUNT(?person)
-            output_var: VarId(1),      // AS ?count (replaces ?person col)
-            distinct: false,
+            function: AggregateFn::Count(VarId(1)), // COUNT(?person)
+            output_var: VarId(1),                   // AS ?count (replaces ?person col)
         }],
     ));
 
@@ -218,10 +216,8 @@ async fn test_group_by_with_sum() {
     query.grouping = Some(explicit_grouping(
         vec![VarId(0)],
         vec![AggregateSpec {
-            function: AggregateFn::Sum,
-            input_var: Some(VarId(1)),
+            function: AggregateFn::Sum(VarId(1), InputSemantics::List),
             output_var: VarId(1),
-            distinct: false,
         }],
     ));
 
@@ -301,10 +297,8 @@ async fn test_group_by_with_having() {
     query.grouping = Some(explicit_grouping_having(
         vec![VarId(0)],
         vec![AggregateSpec {
-            function: AggregateFn::Count,
-            input_var: Some(VarId(1)),
+            function: AggregateFn::Count(VarId(1)),
             output_var: VarId(1),
-            distinct: false,
         }],
         Expression::gt(
             Expression::Var(VarId(1)),
@@ -352,10 +346,8 @@ async fn test_aggregates_without_group_by() {
 
     // No GROUP BY, just SUM — implicit single-group aggregation.
     query.grouping = Some(implicit_grouping(vec![AggregateSpec {
-        function: AggregateFn::Sum,
-        input_var: Some(VarId(0)),
+        function: AggregateFn::Sum(VarId(0), InputSemantics::List),
         output_var: VarId(0),
-        distinct: false,
     }]));
 
     let db = GraphDbRef::new(&snapshot, 0, &NoOverlay, snapshot.t);
@@ -496,10 +488,8 @@ async fn test_aggregate_avg() {
     query.grouping = Some(explicit_grouping(
         vec![VarId(0)],
         vec![AggregateSpec {
-            function: AggregateFn::Avg,
-            input_var: Some(VarId(1)),
+            function: AggregateFn::Avg(VarId(1), InputSemantics::List),
             output_var: VarId(1),
-            distinct: false,
         }],
     ));
 
@@ -552,16 +542,12 @@ async fn test_aggregate_min_max() {
         vec![VarId(0)],
         vec![
             AggregateSpec {
-                function: AggregateFn::Min,
-                input_var: Some(VarId(1)),
+                function: AggregateFn::Min(VarId(1)),
                 output_var: VarId(1),
-                distinct: false,
             },
             AggregateSpec {
-                function: AggregateFn::Max,
-                input_var: Some(VarId(2)),
+                function: AggregateFn::Max(VarId(2)),
                 output_var: VarId(2),
-                distinct: false,
             },
         ],
     ));
@@ -656,10 +642,8 @@ async fn test_aggregate_on_group_by_key_errors() {
     query.grouping = Some(explicit_grouping(
         vec![VarId(0)],
         vec![AggregateSpec {
-            function: AggregateFn::Count,
-            input_var: Some(VarId(0)), // key var
+            function: AggregateFn::Count(VarId(0)), // key var
             output_var: VarId(0),
-            distinct: false,
         }],
     ));
     let options = ReasoningConfig::default();

--- a/fluree-db-sparql/src/lower/aggregate.rs
+++ b/fluree-db-sparql/src/lower/aggregate.rs
@@ -8,7 +8,7 @@ use crate::ast::expr::{AggregateFunction, Expression};
 use crate::ast::query::{SelectClause, SelectVariable, SelectVariables};
 
 use fluree_db_query::ir::Pattern;
-use fluree_db_query::ir::{AggregateFn, AggregateSpec};
+use fluree_db_query::ir::{AggregateFn, AggregateSpec, InputSemantics};
 use fluree_db_query::parse::encode::IriEncoder;
 use fluree_db_query::var_registry::VarId;
 
@@ -219,30 +219,52 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         };
 
         let input_var = self.lower_aggregate_input_var(expr, pre_binds)?;
-        let agg_fn = match expr {
-            Some(_) => self.map_aggregate_function(
-                function,
-                *distinct,
-                separator.as_ref().map(std::convert::AsRef::as_ref),
-            ),
-            None => AggregateFn::CountAll,
+        let semantics = if *distinct {
+            InputSemantics::Set
+        } else {
+            InputSemantics::List
+        };
+        let function = match (function, input_var) {
+            // COUNT(*) — DISTINCT * is not meaningful for COUNT.
+            (AggregateFunction::Count, None) => {
+                if *distinct {
+                    return Err(LowerError::not_implemented("COUNT(DISTINCT *)", *span));
+                }
+                AggregateFn::CountAll
+            }
+            // Every non-COUNT aggregate needs an input variable. The caller
+            // is responsible for ensuring `expr` is `Some(_)`; reaching this
+            // arm with `None` means a malformed AST.
+            (_, None) => {
+                return Err(LowerError::not_implemented(
+                    "aggregate without input expression (only COUNT(*) supports that)",
+                    *span,
+                ));
+            }
+            (AggregateFunction::Count, Some(v)) => {
+                if *distinct {
+                    AggregateFn::CountDistinct(v)
+                } else {
+                    AggregateFn::Count(v)
+                }
+            }
+            (AggregateFunction::Sum, Some(v)) => AggregateFn::Sum(v, semantics),
+            (AggregateFunction::Avg, Some(v)) => AggregateFn::Avg(v, semantics),
+            // DISTINCT is a semantic no-op for Min/Max/Sample; drop it at
+            // the IR boundary so the variant invariant holds.
+            (AggregateFunction::Min, Some(v)) => AggregateFn::Min(v),
+            (AggregateFunction::Max, Some(v)) => AggregateFn::Max(v),
+            (AggregateFunction::Sample, Some(v)) => AggregateFn::Sample(v),
+            (AggregateFunction::GroupConcat, Some(v)) => AggregateFn::GroupConcat {
+                input: v,
+                semantics,
+                separator: separator.as_deref().unwrap_or(" ").to_string(),
+            },
         };
 
-        if matches!(agg_fn, AggregateFn::CountAll) && *distinct {
-            return Err(LowerError::not_implemented("COUNT(DISTINCT *)", *span));
-        }
-
-        // COUNT(DISTINCT) is represented as a dedicated AggregateFn::CountDistinct
-        // variant (with its own streaming HashSet state), so clear the distinct flag
-        // to avoid a redundant double-dedup in AggregateOperator. All other functions
-        // (SUM, AVG, MIN, MAX, etc.) use the flag for dedup at execution time.
-        let distinct = *distinct && !matches!(agg_fn, AggregateFn::CountDistinct);
-
         Ok(AggregateSpec {
-            function: agg_fn,
-            input_var,
+            function,
             output_var,
-            distinct,
         })
     }
 
@@ -371,32 +393,6 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         }
 
         Ok((aggregates, pre_binds))
-    }
-
-    /// Map SPARQL AggregateFunction to engine AggregateFn.
-    fn map_aggregate_function(
-        &self,
-        function: &AggregateFunction,
-        distinct: bool,
-        separator: Option<&str>,
-    ) -> AggregateFn {
-        match function {
-            AggregateFunction::Count => {
-                if distinct {
-                    AggregateFn::CountDistinct
-                } else {
-                    AggregateFn::Count
-                }
-            }
-            AggregateFunction::Sum => AggregateFn::Sum,
-            AggregateFunction::Avg => AggregateFn::Avg,
-            AggregateFunction::Min => AggregateFn::Min,
-            AggregateFunction::Max => AggregateFn::Max,
-            AggregateFunction::GroupConcat => AggregateFn::GroupConcat {
-                separator: separator.unwrap_or(" ").to_string(),
-            },
-            AggregateFunction::Sample => AggregateFn::Sample,
-        }
     }
 
     /// Collect non-aggregate SELECT variables for implicit GROUP BY.

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -330,7 +330,7 @@ mod tests {
     use super::*;
     use crate::parse::parse_sparql;
     use fluree_db_query::ir::triple::{Ref, Term};
-    use fluree_db_query::ir::{AggregateFn, AggregateSpec};
+    use fluree_db_query::ir::{AggregateFn, AggregateSpec, InputSemantics};
     use fluree_db_query::ir::{Expression, Grouping, PathModifier, Pattern};
     use fluree_db_query::parse::encode::MemoryEncoder;
     use fluree_db_query::sort::SortDirection;
@@ -1518,7 +1518,7 @@ mod tests {
 
         assert_eq!(aggregates_of(&query).len(), 1);
         let agg = aggregates_of(&query)[0];
-        assert!(matches!(agg.function, AggregateFn::Count));
+        assert!(matches!(agg.function, AggregateFn::Count(_)));
     }
 
     #[test]
@@ -1531,7 +1531,7 @@ mod tests {
 
         assert_eq!(aggregates_of(&query).len(), 1);
         let agg = aggregates_of(&query)[0];
-        assert!(matches!(agg.function, AggregateFn::CountDistinct));
+        assert!(matches!(agg.function, AggregateFn::CountDistinct(_)));
     }
 
     #[test]
@@ -1546,8 +1546,8 @@ mod tests {
 
         assert_eq!(aggregates_of(&query).len(), 1);
         let agg = aggregates_of(&query)[0];
-        assert!(matches!(agg.function, AggregateFn::CountDistinct));
-        assert!(agg.input_var.is_some()); // Should have resolved the variable
+        assert!(matches!(agg.function, AggregateFn::CountDistinct(_)));
+        assert!(agg.function.input_var().is_some()); // Should have resolved the variable
     }
 
     #[test]
@@ -1562,16 +1562,17 @@ mod tests {
 
         assert_eq!(aggregates_of(&query).len(), 1);
         let agg = aggregates_of(&query)[0];
-        assert!(matches!(agg.function, AggregateFn::CountDistinct));
-        assert!(agg.input_var.is_some());
+        assert!(matches!(agg.function, AggregateFn::CountDistinct(_)));
+        assert!(agg.function.input_var().is_some());
     }
 
     #[test]
     fn test_distinct_flag_count_vs_sum() {
-        // COUNT(DISTINCT) uses a dedicated AggregateFn::CountDistinct variant
-        // with distinct=false (dedup is built into the variant's HashSet state).
-        // SUM(DISTINCT) keeps AggregateFn::Sum with distinct=true (dedup happens
-        // at execution time via HashSet filtering in apply_aggregate).
+        // COUNT(DISTINCT) lowers to the dedicated AggregateFn::CountDistinct
+        // variant (its streaming state uses a HashSet rather than a counter).
+        // SUM(DISTINCT) lowers to AggregateFn::Sum with `distinct: true` —
+        // dedup happens at execution time via HashSet filtering in
+        // apply_aggregate.
         let query = lower_query(
             "PREFIX ex: <http://example.org/>
              SELECT (COUNT(DISTINCT ?s) AS ?c) (SUM(DISTINCT ?v) AS ?t)
@@ -1582,15 +1583,13 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 2);
 
         let count_agg = aggregates_of(&query)[0];
-        assert!(matches!(count_agg.function, AggregateFn::CountDistinct));
-        assert!(
-            !count_agg.distinct,
-            "CountDistinct variant should clear the distinct flag"
-        );
+        assert!(matches!(count_agg.function, AggregateFn::CountDistinct(_)));
 
         let sum_agg = aggregates_of(&query)[1];
-        assert!(matches!(sum_agg.function, AggregateFn::Sum));
-        assert!(sum_agg.distinct, "SUM(DISTINCT) should set distinct=true");
+        assert!(matches!(
+            sum_agg.function,
+            AggregateFn::Sum(_, InputSemantics::Set)
+        ));
     }
 
     #[test]
@@ -1605,9 +1604,9 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 1);
         assert!(matches!(
             aggregates_of(&query)[0].function,
-            AggregateFn::Sum
+            AggregateFn::Sum(..)
         ));
-        assert!(aggregates_of(&query)[0].input_var.is_some());
+        assert!(aggregates_of(&query)[0].function.input_var().is_some());
     }
 
     #[test]
@@ -1621,7 +1620,7 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 1);
         assert!(matches!(
             aggregates_of(&query)[0].function,
-            AggregateFn::Sum
+            AggregateFn::Sum(..)
         ));
     }
 
@@ -1635,9 +1634,12 @@ mod tests {
 
         assert_eq!(aggregates_of(&query).len(), 1);
         let agg = aggregates_of(&query)[0];
-        assert!(matches!(agg.function, AggregateFn::Sum));
+        assert!(matches!(agg.function, AggregateFn::Sum(..)));
 
-        let input_var = agg.input_var.expect("expected aggregate input var");
+        let input_var = agg
+            .function
+            .input_var()
+            .expect("expected aggregate input var");
         let input_name = vars.name(input_var);
         assert!(
             input_name.starts_with("?__agg_expr_"),
@@ -1665,7 +1667,7 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 1);
         assert!(matches!(
             aggregates_of(&query)[0].function,
-            AggregateFn::Avg
+            AggregateFn::Avg(..)
         ));
     }
 
@@ -1680,11 +1682,11 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 2);
         assert!(matches!(
             aggregates_of(&query)[0].function,
-            AggregateFn::Min
+            AggregateFn::Min(_)
         ));
         assert!(matches!(
             aggregates_of(&query)[1].function,
-            AggregateFn::Max
+            AggregateFn::Max(_)
         ));
     }
 
@@ -1699,7 +1701,7 @@ mod tests {
         let aggs = aggregates_of(&query);
         assert_eq!(aggs.len(), 1);
         match &aggs[0].function {
-            AggregateFn::GroupConcat { separator } => {
+            AggregateFn::GroupConcat { separator, .. } => {
                 assert_eq!(separator, ", ");
             }
             _ => panic!("Expected GroupConcat"),
@@ -1717,7 +1719,7 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 1);
         assert!(matches!(
             aggregates_of(&query)[0].function,
-            AggregateFn::Sample
+            AggregateFn::Sample(_)
         ));
     }
 
@@ -1733,7 +1735,10 @@ mod tests {
         assert_eq!(aggregates_of(&query).len(), 1);
         let agg = aggregates_of(&query)[0];
         assert!(matches!(agg.function, AggregateFn::CountAll));
-        assert!(agg.input_var.is_none(), "COUNT(*) should have no input var");
+        assert!(
+            agg.function.input_var().is_none(),
+            "COUNT(*) should have no input var"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refactors the query IR's representation of aggregate functions so that fields previously documented as "this only applies when…" are now carried inline on the variants where they apply. Removes a `distinct: bool` flag and an `input_var: Option<VarId>` from the spec struct in favor of variant-specific data, introduces an explicit `InputSemantics` enum for the `DISTINCT` modifier, and tightens up the inherent API on `NonEmpty<T>` from `fluree-db-core` so it's pleasant enough to use that more of the IR can rely on it going forward.

## Motivation

The previous shape of `AggregateSpec` encoded several invariants by convention rather than by type:

- `input_var: Option<VarId>` was `None` for `COUNT(*)` and `Some(_)` for every other variant. Nothing in the type prevented a `Min` aggregate with `input_var: None` (a runtime panic waiting to happen) or a `CountAll` with `input_var: Some(_)` (meaningless data the executor had to ignore).
- `distinct: bool` rode on every aggregate spec, including variants where `DISTINCT` is a semantic no-op (`MIN`, `MAX`, `SAMPLE`) and one variant — `COUNT(DISTINCT)` — that already has a dedicated streaming-state representation. The SPARQL lowering layer carried a comment apologizing for clearing the flag on `CountDistinct` so the streaming aggregator wouldn't double-dedup.
- Both the JSON-LD parser and the SPARQL lowering pass had to construct the spec and remember to keep these correlations consistent. The planner and executor pattern-matched on the function, then re-read the auxiliary fields to know what was actually being asked for.

This branch makes those correlations structural so that "Sum without an input variable" and "Min with DISTINCT" are no longer states the IR can express.

## Changes

### `AggregateFn` now carries each variant's input variable and DISTINCT mode inline

`fluree-db-query/src/ir/grouping.rs`. The old flat enum (`Count`, `CountDistinct`, `Sum`, `Avg`, `Min`, `Max`, `Sample`, `Median`, `Variance`, `Stddev`, `GroupConcat { separator }`) is replaced with variants that carry their data:

```rust
pub enum AggregateFn {
    Count(VarId),
    CountAll,
    CountDistinct(VarId),
    Sum(VarId, InputSemantics),
    Avg(VarId, InputSemantics),
    Min(VarId),
    Max(VarId),
    Median(VarId, InputSemantics),
    Variance(VarId, InputSemantics),
    Stddev(VarId, InputSemantics),
    GroupConcat { input: VarId, semantics: InputSemantics, separator: String },
    Sample(VarId),
}
```

The input variable is part of every variant except `CountAll`, which counts rows regardless of values. Variants where `DISTINCT` actually changes the result carry an `InputSemantics`; `Min`, `Max`, and `Sample` don't, because their values are unchanged by deduplication. `CountDistinct` stays a separate variant because its streaming state is a `HashSet` rather than a counter — that distinction is real and meaningful even though it parallels `Count(VarId)` + `InputSemantics::Set` at the surface level.

### `InputSemantics` names what `DISTINCT` actually does

```rust
pub enum InputSemantics {
    /// Treat the input as a list — every occurrence counted (default).
    List,
    /// Treat the input as a set — duplicates collapsed (DISTINCT).
    Set,
}
```

The aggregate always receives a multiset of `Binding`s from upstream; what `DISTINCT` changes is how the function interprets that input. Naming it `InputSemantics` rather than `Distinct`/`Multiset`/`Quantifier` captures that the modifier is about input interpretation, not about the input's type or any quantification semantics.

### `AggregateSpec` shrinks to "function plus output binding"

```rust
pub struct AggregateSpec {
    pub function: AggregateFn,
    pub output_var: VarId,
}
```

Everything variant-correlated (input variable, `DISTINCT` mode, `GROUP_CONCAT` separator) lives on `function`. The spec keeps only the output binding — a property of the operator wiring, not of the aggregate itself. The same shrinkage carries through to `StreamingAggSpec` in the executor.

### Methods on `AggregateFn`

- `input_var() -> Option<VarId>` returns the read variable for every variant except `CountAll`.
- `is_distinct() -> bool` returns whether `DISTINCT` was requested — true for `CountDistinct` and for any variant whose `InputSemantics` is `Set`; always false for `Min`/`Max`/`Sample`/`Count`/`CountAll`, which don't carry the modifier at all.
- `apply(&self, &Binding) -> Binding` is the public entry point for computing the aggregate. Replaces the free function `apply_aggregate(func, binding, distinct)` previously re-exported from the crate. Private `needs_input_dedup()` and `compute()` helpers split the dedup pass from the reduction.

### SPARQL `COUNT(DISTINCT *)` is now an explicit error

Folded into the variant-correlated lowering: `COUNT(*) DISTINCT` was previously short-circuited by checking `matches!(agg_fn, AggregateFn::CountAll) && *distinct` after construction. The new lowering rejects it at the AST → IR boundary with a structured `not_implemented` error rather than constructing a degenerate spec.

### Cascading simplifications in the planner and executor

`execute/operator_tree.rs` shrinks by ~100 lines. The aggregate fast-path detectors (`detect_count_all_aggregate`, `detect_count_distinct_aggregate`, `detect_predicate_minmax_string`, `detect_predicate_avg_numeric`, `detect_fused_scan_sum_i64`, `detect_group_by_object_star_topk`, `detect_sum_strlen_group_concat_subquery`, …) now pattern-match directly on `AggregateFn` variants and bind the input variable in the match arm instead of reading `agg.input_var` and checking `agg.distinct` separately. Multiple "is this distinct?" guards collapse to a single match.

`group_aggregate.rs`'s `all_streamable()` check becomes a single match on the function. `DISTINCT SUM/AVG` are still excluded (they need every value collected before reduction), but the routing is now structural.

`execute/dependency.rs`'s aggregate-dep tracing uses `spec.function.input_var()` instead of reading `spec.input_var` directly. The variable-dependency walk no longer has to know that some specs lack input variables.

### `NonEmpty<T>` gets a more complete API

`fluree-db-core/src/nonempty.rs`. Additive: existing callers continue to work. New surface:

- `singleton(head)` and `from_head_tail(head, tail)` as named constructors.
- `nonempty![a, b, c]` macro that statically rejects an empty literal (compile error, not runtime panic).
- `iter_mut()`, `into_iter()` (consuming), `last()`, `push()`, `extend()`, `map()` matching the corresponding `Vec` operations. The non-empty invariant is preserved trivially in each: `push`/`extend` only grow the tail; `map` preserves length; `last()` falls back to `head` when the tail is empty.
- `IntoIterator` impls for `&NonEmpty<T>`, `&mut NonEmpty<T>`, and `NonEmpty<T>`. Lets `for x in &ne { … }` work without going through `.iter()` explicitly.
- `Index<usize>`. Out-of-range panics like `Vec`/slice indexing; index 0 is guaranteed by the invariant.

This is groundwork: the API used to be just `try_from_vec`, `iter`, `first`, `len`, `into_vec`, which made it awkward enough that callers tended to stick with `Vec<T>` even where the non-empty invariant was real.

## What's not in this branch

- Higher-order pattern bodies (`Optional`, `Minus`, `Exists`/`NotExists`, `Union`) remain `Vec<Pattern>`. An earlier attempt to migrate them to `NonEmpty<Pattern>` was reverted: the structural win was real but the iteration-contract change cascaded into perf-sensitive executor code in ways that dwarfed the payoff.
- `Pattern::Union(Vec<Vec<Pattern>>)`, `SubqueryPattern::select: Vec<VarId>`, and `ConstructTemplate::patterns: Vec<TriplePattern>` are all shape-of-cleanups that would similarly want `NonEmpty` and are deferred for the same reason.
- The `Expression::Function` enum's 86 variants are still combined with a free-form `Vec<Expression>` argument list, leaving runtime arity checks scattered across the eval layer. Splitting them by arity is the biggest remaining structural win in the IR but is similarly cascading; not addressed here.

