### PR TITLE
fix: Make hard ledger drop fully clean up on S3 + DynamoDB

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1203,7 +1203,7 @@ curl -X POST http://localhost:8090/v1/fluree/create \
 
 ### POST /drop
 
-Drop (delete) a ledger.
+Drop a ledger or graph source.
 
 **URL:**
 ```
@@ -1224,31 +1224,31 @@ POST /drop
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `ledger` | string | Yes | Ledger ID (e.g., "mydb" or "mydb:main") |
-| `hard` | boolean | No | If `true`, permanently delete all storage files. Default: `false` (soft drop) |
+| `hard` | boolean | No | If `true`, delete managed storage artifacts and purge the nameservice record where the backend supports purge. Default: `false` (soft drop) |
 
 **Drop Modes:**
 
-- **Soft drop** (`hard: false`, default): Retracts the ledger from the nameservice but preserves all data files. The ledger can potentially be recovered.
-- **Hard drop** (`hard: true`): Permanently deletes all commit and index files. **This is irreversible.**
+- **Soft drop** (`hard: false`, default): Marks the ledger as retracted in the nameservice and preserves storage artifacts. The alias remains reserved; normal create/load paths treat the ledger as unavailable.
+- **Hard drop** (`hard: true`): Deletes managed storage artifacts, then purges the nameservice record so the alias can be reused on backends with purge support. **This is irreversible for deleted artifacts.**
+
+If no ledger is found, the server tries the same name as a graph source on branch `main`. Graph source hard-drop cleanup is best effort and may be implementation-specific; graph-source fallback responses currently omit `files_deleted`.
 
 **Response:**
 
 ```json
 {
-  "ledger": "mydb:main",
+  "ledger_id": "mydb:main",
   "status": "dropped",
-  "files_deleted": {
-    "commit": 15,
-    "index": 8
-  }
+  "files_deleted": 23
 }
 ```
 
-| Field | Description |
-|-------|-------------|
-| `ledger` | Normalized ledger ID |
-| `status` | One of: `"dropped"`, `"already_retracted"`, `"not_found"` |
-| `files_deleted` | File counts (only populated for hard drop) |
+| Field | Type | Description |
+|-------|------|-------------|
+| `ledger_id` | string | Normalized ledger ID, or graph source ID if the graph-source fallback handled the request |
+| `status` | string | One of: `"dropped"`, `"already_retracted"`, `"not_found"` |
+| `files_deleted` | integer | Number of managed storage artifacts deleted; omitted when zero |
+| `warnings` | string[] | Non-fatal cleanup warnings; omitted when empty |
 
 **Status Codes:**
 - `200 OK` - Drop successful (or already dropped/not found)
@@ -1261,25 +1261,25 @@ POST /drop
 1. Normalizes the ledger ID (ensures branch suffix like `:main`)
 2. Cancels any pending background indexing
 3. Waits for in-progress indexing to complete
-4. In hard mode: deletes all storage artifacts (commits + indexes)
-5. Retracts from nameservice
+4. In hard mode: deletes managed storage artifacts (commits, txns, indexes, config/context blobs, and related content)
+5. In soft mode: retracts from nameservice; in hard mode: purges the nameservice record where supported
 6. Disconnects from ledger cache
 
 **Idempotency:**
 
 Safe to call multiple times:
 - Returns `"already_retracted"` if the ledger was previously dropped
-- Hard mode still attempts file deletion even for already-retracted ledgers (useful for cleanup)
+- Hard mode still attempts artifact deletion even for already-retracted or not-found ledgers (useful for cleanup)
 
 **Examples:**
 
 ```bash
-# Soft drop (retract only, preserve files)
+# Soft drop (retract only, preserve storage artifacts)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
   -d '{"ledger": "mydb:main"}'
 
-# Hard drop (delete all files - IRREVERSIBLE)
+# Hard drop (delete managed storage artifacts - IRREVERSIBLE)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
   -d '{"ledger": "mydb:main", "hard": true}'
@@ -1532,9 +1532,9 @@ POST /drop-branch
 ```json
 {
   "ledger_id": "mydb:feature-x",
-  "status": "Dropped",
+  "status": "dropped",
   "deferred": false,
-  "artifacts_deleted": 5,
+  "files_deleted": 5,
   "cascaded": [],
   "warnings": []
 }
@@ -1542,12 +1542,12 @@ POST /drop-branch
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `ledger_id` | Full ledger:branch identifier of the dropped branch |
-| `status` | Drop status (`"Dropped"`, `"AlreadyRetracted"`, `"NotFound"`) |
-| `deferred` | `true` if the branch has children — retracted but storage preserved |
-| `artifacts_deleted` | Number of storage artifacts removed |
-| `cascaded` | List of ancestor branch ledger_ids that were cascade-dropped |
-| `warnings` | Any non-fatal warnings during the drop |
+| `ledger_id` | string | Full ledger:branch identifier of the dropped branch |
+| `status` | string | Drop status (`"dropped"`, `"already_retracted"`, `"not_found"`) |
+| `deferred` | boolean | `true` if the branch has children — retracted but storage preserved |
+| `files_deleted` | integer | Number of storage artifacts removed; omitted when zero |
+| `cascaded` | string[] | List of ancestor branch ledger_ids that were cascade-dropped; omitted when empty |
+| `warnings` | string[] | Any non-fatal warnings during the drop; omitted when empty |
 
 **Behavior:**
 

--- a/docs/cli/drop.md
+++ b/docs/cli/drop.md
@@ -1,6 +1,6 @@
 # fluree drop
 
-Drop (delete) a ledger or graph source.
+Hard-drop a ledger or graph source.
 
 ## Usage
 
@@ -22,9 +22,13 @@ fluree drop <NAME> --force
 
 ## Description
 
-Permanently deletes a ledger or graph source. The `--force` flag is required to prevent accidental deletion.
+Deletes a ledger using the same hard-drop mode as `POST /drop` with `"hard": true`. For managed storage backends, Fluree deletes storage artifacts and removes the nameservice record where the backend supports purge, allowing the alias to be reused. Deleted artifacts are irreversible.
 
 The command first tries to drop the name as a ledger. If no ledger is found, it tries to drop it as a graph source. This means `fluree drop` works uniformly for both ledgers and graph sources like Iceberg mappings.
+
+The `--force` flag is required to prevent accidental deletion. There is no CLI soft-drop flag; use the HTTP or Rust API if you need to retract a ledger while preserving artifacts.
+
+Graph source cleanup is implementation-specific. The command retracts the graph source record and performs any available hard-drop cleanup for that graph source type; warnings are printed when cleanup is partial.
 
 ## Examples
 
@@ -41,6 +45,11 @@ fluree drop warehouse-orders --force
 Ledger:
 ```
 Dropped ledger 'oldledger'
+```
+
+Ledger with artifact cleanup:
+```
+Dropped ledger 'oldledger' (deleted 23 artifacts)
 ```
 
 Graph source:

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -1044,7 +1044,7 @@ Existing endpoint, extended with graph source fallback. Request body is unchange
 2. If the ledger drop report has `status: "not_found"`, try dropping as a **graph source** (default branch `"main"`)
 3. If both return not found, return the not-found response
 
-**Response:** Same schema as ledger drop: `{ "ledger_id": "name:branch", "status": "dropped"|"already_retracted"|"not_found", "warnings": [...] }`. For graph sources, `ledger_id` contains the graph source ID (e.g., `"warehouse-orders:main"`).
+**Response:** Same schema as ledger drop: `{ "ledger_id": "name:branch", "status": "dropped"|"already_retracted"|"not_found", "files_deleted": 23, "warnings": [...] }`. `files_deleted` is omitted when zero and is currently omitted for graph-source fallback responses. For graph sources, `ledger_id` contains the graph source ID (e.g., `"warehouse-orders:main"`).
 
 ### `fluree iceberg map` (Iceberg graph source creation)
 

--- a/docs/concepts/ledgers-and-nameservice.md
+++ b/docs/concepts/ledgers-and-nameservice.md
@@ -53,9 +53,9 @@ Ledgers are created implicitly through the first transaction and persist until e
 
 Ledgers can be marked as retracted (soft delete), which:
 - Marks the ledger as inactive in the nameservice
-- Preserves all historical data
-- Prevents new transactions (but allows historical queries)
-- Can be reversed if needed
+- Preserves storage artifacts
+- Prevents normal load/create/write paths from treating the alias as active
+- Keeps the alias reserved until an administrator purges or otherwise repairs the nameservice record
 
 ## The Nameservice
 
@@ -286,12 +286,12 @@ curl http://localhost:8090/v1/fluree/ledgers
 
 #### Retraction
 
-Mark ledgers as inactive:
+Mark ledgers as inactive without deleting storage artifacts:
 
 ```rust
 // Pseudo-code
 nameservice.retract("mydb:old-branch").await?;
-// Sets retracted=true, prevents new transactions
+// Sets retracted=true; the alias remains reserved.
 ```
 
 ### Storage Backends
@@ -726,9 +726,9 @@ Understanding how records evolve:
    - Large gaps indicate indexing lag
    - May need to tune indexing frequency or resources
 
-3. **Handle Retraction Carefully**: Retracted ledgers preserve history
+3. **Handle Retraction Carefully**: Retracted ledgers preserve storage artifacts
    - Use for soft deletes, not hard deletes
-   - Historical queries still work on retracted ledgers
+   - Do not assume normal query/load APIs will open a retracted ledger; administrative recovery may require nameservice repair or purge
 
 ### Performance Considerations
 

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -730,7 +730,7 @@ async fn main() -> Result<()> {
 
 #### Dropping Ledgers
 
-Use `drop_ledger` to permanently remove a ledger:
+Use `drop_ledger` to retract a ledger or to permanently remove its managed storage artifacts:
 
 ```rust
 use fluree_db_api::{FlureeBuilder, DropMode, DropStatus, Result};
@@ -739,7 +739,7 @@ use fluree_db_api::{FlureeBuilder, DropMode, DropStatus, Result};
 async fn main() -> Result<()> {
     let fluree = FlureeBuilder::file("./data").build()?;
 
-    // Soft drop: retract from nameservice, preserve files
+    // Soft drop: retract from nameservice, preserve storage artifacts
     let report = fluree.drop_ledger("mydb:main", DropMode::Soft).await?;
     match report.status {
         DropStatus::Dropped => println!("Ledger dropped"),
@@ -747,11 +747,9 @@ async fn main() -> Result<()> {
         DropStatus::NotFound => println!("Ledger not found"),
     }
 
-    // Hard drop: delete all files (IRREVERSIBLE)
+    // Hard drop: delete managed storage artifacts (IRREVERSIBLE)
     let report = fluree.drop_ledger("mydb:main", DropMode::Hard).await?;
-    println!("Deleted {} commit files, {} index files",
-        report.commit_files_deleted,
-        report.index_files_deleted);
+    println!("Deleted {} storage artifacts", report.artifacts_deleted);
 
     Ok(())
 }
@@ -761,16 +759,16 @@ async fn main() -> Result<()> {
 
 | Mode | Behavior | Reversible |
 |------|----------|------------|
-| `DropMode::Soft` (default) | Retracts from nameservice only, files remain | Yes |
-| `DropMode::Hard` | Retracts + deletes all storage artifacts | **No** |
+| `DropMode::Soft` (default) | Marks the ledger retracted in the nameservice; artifacts remain and the alias stays reserved | Partially; requires administrative recovery |
+| `DropMode::Hard` | Deletes managed storage artifacts and purges the nameservice record where supported | **No** for deleted artifacts |
 
 **Drop Sequence:**
 
 1. Normalizes the ledger ID (ensures `:main` suffix)
 2. Cancels any pending background indexing
 3. Waits for in-progress indexing to complete
-4. In hard mode: deletes all commit and index files
-5. Retracts from nameservice
+4. In hard mode: deletes managed storage artifacts (commits, txns, indexes, config/context blobs, and related content)
+5. In soft mode: retracts from nameservice; in hard mode: purges the nameservice record where supported
 6. Disconnects from ledger cache (if caching enabled)
 
 **When to use `drop_ledger`:**

--- a/docs/operations/admin-and-health.md
+++ b/docs/operations/admin-and-health.md
@@ -236,15 +236,15 @@ See [Admin Authentication](../api/endpoints.md#admin-authentication) for details
 
 ### POST /v1/fluree/drop
 
-Drop (delete) a ledger:
+Drop a ledger or graph source:
 
 ```bash
-# Soft drop (retract from nameservice, preserve files)
+# Soft drop (retract from nameservice, preserve storage artifacts)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
   -d '{"ledger": "mydb:main"}'
 
-# Hard drop (delete all files - IRREVERSIBLE)
+# Hard drop (delete managed storage artifacts - IRREVERSIBLE)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
   -d '{"ledger": "mydb:main", "hard": true}'
@@ -253,7 +253,7 @@ curl -X POST http://localhost:8090/v1/fluree/drop \
 **Response:**
 ```json
 {
-  "ledger": "mydb:main",
+  "ledger_id": "mydb:main",
   "status": "dropped",
   "files_deleted": 23
 }
@@ -268,8 +268,10 @@ curl -X POST http://localhost:8090/v1/fluree/drop \
 **Authentication:** When `--admin-auth-mode=required`, requires Bearer token from a trusted issuer.
 
 **Drop Modes:**
-- **Soft** (default): Retracts from nameservice, files remain (recoverable)
-- **Hard**: Deletes all files (irreversible)
+- **Soft** (default): Marks the ledger retracted in the nameservice; artifacts remain and the alias stays reserved.
+- **Hard**: Deletes managed storage artifacts and purges the nameservice record where supported, allowing alias reuse. Deleted artifacts are irreversible.
+
+If no ledger is found, the endpoint tries the same name as a graph source on branch `main`.
 
 See [Dropping Ledgers](../getting-started/rust-api.md#dropping-ledgers) for more details.
 

--- a/docs/operations/dynamodb-guide.md
+++ b/docs/operations/dynamodb-guide.md
@@ -437,8 +437,10 @@ Full permissions (recommended):
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
         "dynamodb:Query",
-        "dynamodb:BatchGetItem"
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem"
       ],
       "Resource": [
         "arn:aws:dynamodb:*:*:table/fluree-nameservice",
@@ -461,8 +463,10 @@ If you also use `ensure_table()` for automated table creation (development/testi
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
         "dynamodb:Query",
         "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
         "dynamodb:CreateTable",
         "dynamodb:DescribeTable"
       ],
@@ -475,7 +479,7 @@ If you also use `ensure_table()` for automated table creation (development/testi
 }
 ```
 
-Minimal permissions (if not using `all_records`, `all_graph_source_records`, or graph sources):
+Minimal runtime permissions (if not using `all_records`, `all_graph_source_records`, graph sources, or hard-drop purge):
 
 ```json
 {
@@ -494,6 +498,8 @@ Minimal permissions (if not using `all_records`, `all_graph_source_records`, or 
   ]
 }
 ```
+
+Hard drops and branch-drop cascade cleanup require `dynamodb:DeleteItem`. Backends that purge all nameservice items for a ledger partition also need `dynamodb:BatchWriteItem`.
 
 ## Local Development
 

--- a/docs/operations/storage.md
+++ b/docs/operations/storage.md
@@ -272,19 +272,29 @@ See [Storage Encryption](../security/encryption.md) for full documentation.
 │   │   └── dev.json
 │   └── customers/
 │       └── main.json
-├── commit/                   # Transaction commits
-│   ├── abc123def456.commit
-│   └── def456abc789.commit
-├── index/                    # Index snapshots
-│   ├── mydb-main-t100.idx
-│   └── mydb-main-t150.idx
+├── mydb/
+│   ├── main/
+│   │   ├── commit/          # Commit blobs (*.fcv2)
+│   │   ├── txn/             # Transaction metadata (*.json)
+│   │   ├── config/          # Ledger config blobs
+│   │   └── index/
+│   │       ├── roots/       # Index root descriptors (*.fir6)
+│   │       ├── objects/
+│   │       │   ├── branches/
+│   │       │   ├── leaves/
+│   │       │   └── history/
+│   │       ├── garbage/
+│   │       ├── stats/
+│   │       └── spatial/
+│   ├── dev/
+│   │   └── ...
+│   └── @shared/
+│       └── dicts/           # Dictionaries shared by all branches
 └── graph-sources/            # Graph sources
     └── products-search/
         └── main/
-            └── bm25/
-                ├── manifest.json
-                └── t150/
-                    └── snapshot.bin
+            ├── mapping/
+            └── snapshots/
 ```
 
 ### File Formats
@@ -293,10 +303,13 @@ See [Storage Encryption](../security/encryption.md) for full documentation.
 ```json
 {
   "ledger_id": "mydb:main",
+  "name": "mydb",
+  "branch": "main",
   "commit_t": 150,
   "index_t": 145,
-  "commit_id": "bafybeig...commitT150",
-  "index_id": "bafybeig...indexRootT145"
+  "commit_head_id": "bafybeig...commitT150",
+  "index_head_id": "bafybeig...indexRootT145",
+  "retracted": false
 }
 ```
 
@@ -306,8 +319,12 @@ See [Storage Encryption](../security/encryption.md) for full documentation.
 - Cryptographic signatures
 
 **Indexes (Binary):**
-- SPOT, POST, OPST, PSOT trees
+- Root descriptors, branch manifests, leaf pages, and history sidecars
 - Optimized for query performance
+
+**Shared dictionaries (Binary):**
+- Cross-branch dictionary blobs under `{ledger}/@shared/dicts/`
+- May be referenced by more than one branch of the same ledger
 
 ### File System Requirements
 
@@ -328,19 +345,27 @@ See [Storage Encryption](../security/encryption.md) for full documentation.
 
 ```text
 s3://fluree-prod-data/
-├── commit/
-│   ├── abc123def456.commit
-│   └── def456abc789.commit
-├── index/
-│   ├── mydb-main-t100.idx
-│   └── mydb-main-t150.idx
+├── mydb/
+│   ├── main/
+│   │   ├── commit/
+│   │   ├── txn/
+│   │   ├── config/
+│   │   └── index/
+│   │       ├── roots/
+│   │       ├── objects/
+│   │       │   ├── branches/
+│   │       │   ├── leaves/
+│   │       │   └── history/
+│   │       ├── garbage/
+│   │       ├── stats/
+│   │       └── spatial/
+│   └── @shared/
+│       └── dicts/
 └── graph-sources/
     └── products-search/
         └── main/
-            └── bm25/
-                ├── manifest.json
-                └── t150/
-                    └── snapshot.bin
+            ├── mapping/
+            └── snapshots/
 ```
 
 ### DynamoDB Schema
@@ -375,7 +400,8 @@ Required IAM permissions:
   "Action": [
     "s3:GetObject",
     "s3:PutObject",
-    "s3:ListBucket"
+    "s3:ListBucket",
+    "s3:DeleteObject"
   ],
   "Resource": [
     "arn:aws:s3:::fluree-prod-data",
@@ -392,8 +418,10 @@ Required IAM permissions:
     "dynamodb:GetItem",
     "dynamodb:PutItem",
     "dynamodb:UpdateItem",
+    "dynamodb:DeleteItem",
     "dynamodb:Query",
-    "dynamodb:BatchGetItem"
+    "dynamodb:BatchGetItem",
+    "dynamodb:BatchWriteItem"
   ],
   "Resource": [
     "arn:aws:dynamodb:us-east-1:*:table/fluree-nameservice",

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -10,7 +10,10 @@
 //! available on read-only storage.
 
 use crate::{error::ApiError, tx::IndexingMode, Result};
-use fluree_db_core::{address_path::ledger_id_to_path_prefix, format_ledger_id, DEFAULT_BRANCH};
+use fluree_db_core::{
+    address_path::{ledger_id_to_path_prefix, shared_prefix_for_path},
+    format_ledger_id, DEFAULT_BRANCH,
+};
 use fluree_db_indexer::{clean_garbage, rebuild_index_from_commits, CleanGarbageConfig};
 use fluree_db_nameservice::NsRecord;
 use std::time::Duration;
@@ -237,6 +240,17 @@ impl crate::Fluree {
     /// This only stops the in-process background worker. External indexers
     /// (Lambda, etc.) **MUST** check `NsRecord.retracted` before indexing
     /// and before publishing to prevent recreating files after drop.
+    ///
+    /// # Branch safety
+    ///
+    /// `drop_ledger` operates on a single branch's `ledger_id` and does **not**
+    /// cascade to child branches. Hard-dropping a parent branch (e.g.
+    /// `mydb:main`) while child branches are still alive will delete
+    /// commit/index artifacts that those children may resolve through the
+    /// branched content store, breaking their reads. Drop child branches via
+    /// [`drop_branch`](Self::drop_branch) first, or accept the breakage. The
+    /// `@shared/dicts/` namespace is automatically preserved when sibling
+    /// branches are live; commit/index/config artifacts are not.
     pub async fn drop_ledger(&self, ledger_id: &str, mode: DropMode) -> Result<DropReport> {
         // 1. Normalize ledger_id (ensure branch suffix)
         let ledger_id = normalize_ledger_id(ledger_id);
@@ -269,7 +283,13 @@ impl crate::Fluree {
         // 4. Delete artifacts (Hard mode)
         // Run deletion even for NotFound/AlreadyRetracted - enables admin cleanup
         if matches!(mode, DropMode::Hard) {
-            let (count, warnings) = self.drop_artifacts(&ledger_id, record.as_ref()).await;
+            // Cross-branch `@shared` dicts may only be wiped when this is the
+            // last live branch of the ledger. Anything else risks breaking
+            // sibling branches that still resolve via the shared namespace.
+            let include_shared = self.is_last_live_branch(&ledger_id).await;
+            let (count, warnings) = self
+                .drop_artifacts(&ledger_id, record.as_ref(), include_shared)
+                .await;
             report.artifacts_deleted = count;
             report.warnings.extend(warnings);
         }
@@ -396,7 +416,11 @@ impl crate::Fluree {
             handle.wait_for_idle(ledger_id).await;
         }
 
-        let (count, warnings) = self.drop_artifacts(ledger_id, record).await;
+        // Branch path: never wipe `@shared` here. Sibling branches and any
+        // surviving parent may still reference shared dicts; deferring shared
+        // cleanup to a final ledger-level drop is safer than risking a live
+        // branch with missing blobs.
+        let (count, warnings) = self.drop_artifacts(ledger_id, record, false).await;
         report.artifacts_deleted += count;
         report.warnings.extend(warnings);
 
@@ -447,21 +471,53 @@ impl crate::Fluree {
         }
     }
 
+    /// Determine whether `ledger_id` is the only live (non-retracted) branch
+    /// of its ledger name.
+    ///
+    /// Used to gate cross-branch (`@shared/`) cleanup: only safe to wipe when
+    /// no sibling branches remain. Returns `false` on lookup failure so we
+    /// err toward leaving shared blobs in place rather than risking a live
+    /// branch with broken dict reads.
+    async fn is_last_live_branch(&self, ledger_id: &str) -> bool {
+        let (name, _branch) = match fluree_db_core::ledger_id::split_ledger_id(ledger_id) {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        match self.nameservice().list_branches(&name).await {
+            Ok(records) => records.iter().all(|r| r.ledger_id == ledger_id),
+            Err(e) => {
+                warn!(error = %e, "list_branches failed during drop; preserving @shared");
+                false
+            }
+        }
+    }
+
     /// Delete all storage artifacts for a ledger.
     ///
     /// Uses a two-path strategy:
-    /// - **Fast path**: `list_prefix` on the entire ledger root — catches all
-    ///   subdirectories (commit/, txn/, index/, config/, etc.). Works for
-    ///   file, S3, and memory backends.
+    /// - **Fast path**: list each known subprefix (`commit/`, `txn/`, `index/`,
+    ///   and optionally `@shared/dicts/`) under the ledger root and batch
+    ///   delete. Enumerating per-subprefix is required so that `TieredStorage`
+    ///   routes commit/txn listings to the commit tier and index listings to
+    ///   the index tier — a single ledger-root list misses the commit tier
+    ///   entirely in split commit/index deployments.
     /// - **Slow path**: If `list_prefix` fails (e.g., IPFS), walks the commit
     ///   chain + index tree to collect all CIDs, derives storage addresses, and
     ///   deletes each individually.
+    ///
+    /// `include_shared` controls whether `{ledger_name}/@shared/dicts/` (cross-
+    /// branch dict blobs) is also wiped. This must only be `true` when no other
+    /// non-retracted branches of this ledger remain, since dicts are shared
+    /// across branches. Leaving `@shared/` in place when other branches are
+    /// alive avoids breaking their dict reads, at the cost of orphan blobs
+    /// until a final ledger drop or explicit GC.
     ///
     /// Returns `(count_deleted, warnings)`.
     async fn drop_artifacts(
         &self,
         ledger_id: &str,
         record: Option<&fluree_db_nameservice::NsRecord>,
+        include_shared: bool,
     ) -> (usize, Vec<String>) {
         let mut warnings = Vec::new();
         let storage = match self.admin_storage() {
@@ -476,42 +532,96 @@ impl crate::Fluree {
         };
         let storage_method = storage.storage_method();
 
-        // Build the ledger root prefix: fluree:{method}://{ledger_path}/
-        let prefix = match ledger_id_to_path_prefix(ledger_id) {
+        // Build the per-branch path prefix (e.g. "mydb/main").
+        let branch_prefix = match ledger_id_to_path_prefix(ledger_id) {
             Ok(p) => p,
             Err(e) => {
                 warnings.push(format!("Invalid ledger ID '{ledger_id}': {e}"));
                 return (0, warnings);
             }
         };
-        let ledger_root = format!("fluree:{storage_method}://{prefix}/");
 
-        // Fast path: list everything under the ledger root and batch delete
-        match storage.list_prefix(&ledger_root).await {
-            Ok(mut files) => {
-                files.sort();
-                let mut count = 0;
-                for file in &files {
-                    if let Err(e) = storage.delete(file).await {
-                        warn!(file = %file, error = %e, "Failed to delete artifact");
-                        warnings.push(format!("Failed to delete {file}: {e}"));
-                    } else {
-                        count += 1;
+        // Enumerate explicit subprefixes. `TieredStorage` routes by substring
+        // (`/commit/`, `/txn/` → commit tier; otherwise → index tier), so we
+        // must hit each one separately. `index/` covers index roots, garbage,
+        // and all object subkinds (branches, leaves, dicts when per-branch);
+        // `config/` covers the LedgerConfig blob and the default-context blob,
+        // both stored as `ContentKind::LedgerConfig`.
+        let mut subprefixes = vec![
+            format!("fluree:{storage_method}://{branch_prefix}/commit/"),
+            format!("fluree:{storage_method}://{branch_prefix}/txn/"),
+            format!("fluree:{storage_method}://{branch_prefix}/index/"),
+            format!("fluree:{storage_method}://{branch_prefix}/config/"),
+        ];
+
+        if include_shared {
+            // Cross-branch dict blobs: {ledger}/@shared/dicts/. Caller is
+            // responsible for ensuring no other branches still need them.
+            let shared = shared_prefix_for_path(ledger_id);
+            subprefixes.push(format!("fluree:{storage_method}://{shared}/dicts/"));
+        }
+
+        let mut total = 0usize;
+        let mut any_listed = false;
+        let mut listing_errors: Vec<String> = Vec::new();
+
+        for sub in &subprefixes {
+            match storage.list_prefix(sub).await {
+                Ok(files) => {
+                    any_listed = true;
+                    let mut sorted = files;
+                    sorted.sort();
+                    for file in &sorted {
+                        if let Err(e) = storage.delete(file).await {
+                            warn!(file = %file, error = %e, "Failed to delete artifact");
+                            warnings.push(format!("Failed to delete {file}: {e}"));
+                        } else {
+                            total += 1;
+                        }
                     }
                 }
-                info!(count = count, "Fast-path artifact deletion complete");
-                (count, warnings)
-            }
-            Err(e) => {
-                // Slow path: walk CID chains (any backend without list_prefix)
-                info!(
-                    error = %e,
-                    "list_prefix unavailable, falling back to CID-walking drop"
-                );
-                self.drop_artifacts_by_cid_walk(ledger_id, record, &mut warnings)
-                    .await
+                Err(e) => {
+                    let msg = format!("list_prefix({sub}) failed: {e}");
+                    warn!(error = %e, prefix = %sub, "list_prefix failed during drop");
+                    listing_errors.push(msg);
+                }
             }
         }
+
+        // Two failure modes to handle distinctly:
+        //
+        // - No subprefix listed successfully: backend doesn't support
+        //   list_prefix at all (or every call errored). Fall back to the CID
+        //   walk so we still remove what we can address.
+        // - Some succeeded, some failed: we likely deleted a partial set of
+        //   artifacts. Run the CID walk as a cleanup pass — `release` is
+        //   idempotent on already-deleted CIDs — and record the listing
+        //   errors as warnings so callers see the partial-failure.
+        if !any_listed {
+            info!(
+                errors = ?listing_errors,
+                "list_prefix unavailable for all subprefixes, falling back to CID-walking drop"
+            );
+            return self
+                .drop_artifacts_by_cid_walk(ledger_id, record, &mut warnings)
+                .await;
+        }
+
+        if !listing_errors.is_empty() {
+            warn!(
+                errors = ?listing_errors,
+                "fast-path drop had partial listing failures; running CID walk to clean up"
+            );
+            warnings.extend(listing_errors);
+            let (extra, cid_warnings) = self
+                .drop_artifacts_by_cid_walk(ledger_id, record, &mut Vec::new())
+                .await;
+            total += extra;
+            warnings.extend(cid_warnings);
+        }
+
+        info!(count = total, "Fast-path artifact deletion complete");
+        (total, warnings)
     }
 
     /// Slow-path artifact deletion: walk commit + index chains to collect CIDs,

--- a/fluree-db-api/tests/it_storage_s3_testcontainers.rs
+++ b/fluree-db-api/tests/it_storage_s3_testcontainers.rs
@@ -372,3 +372,126 @@ async fn s3_testcontainers_indexing_test() {
         })
         .await;
 }
+
+/// End-to-end hard drop on S3 + DynamoDB.
+///
+/// Covers the three fixes that were needed for Hard drop to work on AWS:
+/// 1. `DynamoDbNameService::purge` deletes every row under the alias (not just
+///    flipping `meta.retracted = true`), so the alias can be re-initialized.
+/// 2. `S3Storage::list_prefix` parses the `fluree:s3://...` scheme like
+///    reads/writes/deletes, so the enumeration actually finds artifacts under
+///    the configured bucket prefix.
+/// 3. `drop_artifacts` enumerates per-subprefix (`commit/`, `txn/`, `index/`)
+///    so `TieredStorage` routes each list to the right tier.
+#[tokio::test]
+#[cfg(feature = "native")]
+async fn s3_testcontainers_hard_drop_clears_ledger() {
+    use fluree_db_api::{DropMode, DropStatus};
+
+    let (_lock, _container, endpoint) = start_localstack("s3,dynamodb").await;
+    let sdk_config = sdk_config_for_localstack(&endpoint).await;
+
+    let bucket = "fluree-drop-test";
+    let table = "fluree-drop-test-ns";
+    ensure_bucket(&sdk_config, bucket).await;
+    ensure_dynamodb_table(&sdk_config, table).await;
+
+    let storage = S3Storage::new(
+        &sdk_config,
+        S3Config {
+            bucket: bucket.to_string(),
+            prefix: Some("fluree-data".to_string()),
+            endpoint: None,
+            timeout_ms: Some(30_000),
+            max_retries: None,
+            retry_base_delay_ms: None,
+            retry_max_delay_ms: None,
+        },
+    )
+    .await
+    .expect("S3Storage::new");
+
+    let nameservice = DynamoDbNameService::new(
+        &sdk_config,
+        DynamoDbConfig {
+            table_name: table.to_string(),
+            region: None,
+            endpoint: None,
+            timeout_ms: Some(30_000),
+        },
+    )
+    .await
+    .expect("DynamoDbNameService::new");
+
+    let fluree = build_fluree(storage.clone(), nameservice.clone());
+
+    let ledger_id = "drop-test:main";
+    let ledger0 = fluree
+        .create_ledger(ledger_id)
+        .await
+        .expect("create ledger");
+
+    let tx = json!({
+        "@context": [support::default_context(), {"ex": "http://example.org/ns/"}],
+        "insert": (0..10).map(|i| json!({
+            "@id": format!("ex:person{}", i),
+            "@type": "ex:Person",
+            "ex:name": format!("Person {}", i)
+        })).collect::<Vec<_>>()
+    });
+    let _ledger1 = fluree.update(ledger0, &tx).await.expect("update").ledger;
+
+    // Sanity: we wrote commit + meta artifacts to the bucket.
+    let keys_before = list_object_keys(&sdk_config, bucket).await;
+    assert!(
+        keys_before.iter().any(|k| k.contains("/commit/")),
+        "expected commit artifacts before drop: {keys_before:?}"
+    );
+
+    // Hard drop.
+    let report = fluree
+        .drop_ledger(ledger_id, DropMode::Hard)
+        .await
+        .expect("drop_ledger");
+    assert_eq!(report.status, DropStatus::Dropped);
+    assert!(
+        report.artifacts_deleted > 0,
+        "expected hard drop to remove artifacts, got 0 with warnings: {:?}",
+        report.warnings
+    );
+
+    // Nameservice purged: lookup returns None and we can re-init the alias.
+    let after = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("lookup after drop");
+    assert!(
+        after.is_none(),
+        "hard drop must purge the NS record entirely, got: {after:?}"
+    );
+
+    // Bucket cleared of this ledger's branch artifacts. (No assertion on the
+    // unrelated bucket prefix itself; only the per-ledger commit/txn/index
+    // subkeys should be gone.)
+    let keys_after = list_object_keys(&sdk_config, bucket).await;
+    let stragglers: Vec<_> = keys_after
+        .iter()
+        .filter(|k| {
+            k.contains("/drop-test/main/commit/")
+                || k.contains("/drop-test/main/txn/")
+                || k.contains("/drop-test/main/index/")
+        })
+        .cloned()
+        .collect();
+    assert!(
+        stragglers.is_empty(),
+        "expected no branch-scoped artifacts after hard drop, found: {stragglers:?}"
+    );
+
+    // Re-initialization works because purge removed every row under the alias.
+    let _reinit = fluree
+        .create_ledger(ledger_id)
+        .await
+        .expect("re-create ledger after hard drop");
+}

--- a/fluree-db-api/tests/it_storage_s3_testcontainers.rs
+++ b/fluree-db-api/tests/it_storage_s3_testcontainers.rs
@@ -375,14 +375,15 @@ async fn s3_testcontainers_indexing_test() {
 
 /// End-to-end hard drop on S3 + DynamoDB.
 ///
-/// Covers the three fixes that were needed for Hard drop to work on AWS:
+/// Covers the fixes that were needed for Hard drop to work on AWS:
 /// 1. `DynamoDbNameService::purge` deletes every row under the alias (not just
 ///    flipping `meta.retracted = true`), so the alias can be re-initialized.
 /// 2. `S3Storage::list_prefix` parses the `fluree:s3://...` scheme like
 ///    reads/writes/deletes, so the enumeration actually finds artifacts under
 ///    the configured bucket prefix.
-/// 3. `drop_artifacts` enumerates per-subprefix (`commit/`, `txn/`, `index/`)
-///    so `TieredStorage` routes each list to the right tier.
+/// 3. `drop_artifacts` enumerates per-subprefix (`commit/`, `txn/`, `index/`,
+///    `config/`, and optionally `@shared/dicts/`) so `TieredStorage` routes
+///    each list to the right tier and no artifact class is missed.
 #[tokio::test]
 #[cfg(feature = "native")]
 async fn s3_testcontainers_hard_drop_clears_ledger() {
@@ -441,11 +442,28 @@ async fn s3_testcontainers_hard_drop_clears_ledger() {
     });
     let _ledger1 = fluree.update(ledger0, &tx).await.expect("update").ledger;
 
-    // Sanity: we wrote commit + meta artifacts to the bucket.
+    // Write a default context so the bucket also has `config/` artifacts
+    // (both `ConfigPayload` and `default_context` blobs are stored under
+    // `ContentKind::LedgerConfig` → `{ledger}/{branch}/config/`).
+    fluree
+        .set_default_context(
+            ledger_id,
+            &json!({"ex": "http://example.org/ns/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}),
+        )
+        .await
+        .expect("set_default_context");
+
+    // Sanity: commits and a config blob landed in the bucket.
     let keys_before = list_object_keys(&sdk_config, bucket).await;
     assert!(
         keys_before.iter().any(|k| k.contains("/commit/")),
         "expected commit artifacts before drop: {keys_before:?}"
+    );
+    assert!(
+        keys_before
+            .iter()
+            .any(|k| k.contains("/drop-test/main/config/")),
+        "expected a config artifact before drop: {keys_before:?}"
     );
 
     // Hard drop.
@@ -471,9 +489,9 @@ async fn s3_testcontainers_hard_drop_clears_ledger() {
         "hard drop must purge the NS record entirely, got: {after:?}"
     );
 
-    // Bucket cleared of this ledger's branch artifacts. (No assertion on the
-    // unrelated bucket prefix itself; only the per-ledger commit/txn/index
-    // subkeys should be gone.)
+    // Bucket cleared of every per-ledger artifact class we enumerate:
+    // commit/, txn/, index/, config/, and (since this is the only branch)
+    // @shared/dicts/. We don't assert on the bucket prefix itself.
     let keys_after = list_object_keys(&sdk_config, bucket).await;
     let stragglers: Vec<_> = keys_after
         .iter()
@@ -481,12 +499,14 @@ async fn s3_testcontainers_hard_drop_clears_ledger() {
             k.contains("/drop-test/main/commit/")
                 || k.contains("/drop-test/main/txn/")
                 || k.contains("/drop-test/main/index/")
+                || k.contains("/drop-test/main/config/")
+                || k.contains("/drop-test/@shared/dicts/")
         })
         .cloned()
         .collect();
     assert!(
         stragglers.is_empty(),
-        "expected no branch-scoped artifacts after hard drop, found: {stragglers:?}"
+        "expected no per-ledger artifacts after hard drop, found: {stragglers:?}"
     );
 
     // Re-initialization works because purge removed every row under the alias.

--- a/fluree-db-storage-aws/src/dynamodb/mod.rs
+++ b/fluree-db-storage-aws/src/dynamodb/mod.rs
@@ -705,81 +705,12 @@ impl NameService for DynamoDbNameService {
             .cloned()
             .unwrap_or_default();
 
-        // Conditionally delete the meta item first — this is the linearization
-        // point that prevents a double-drop race. If two callers race, only one
-        // wins the conditional delete; the other gets ConditionalCheckFailed and
-        // we return NotFound, avoiding a double parent-count decrement.
-        match self
-            .client
-            .delete_item()
-            .table_name(&self.table_name)
-            .key(ATTR_PK, AttributeValue::S(pk.clone()))
-            .key(ATTR_SK, AttributeValue::S(SK_META.to_string()))
-            .condition_expression("attribute_exists(#pk)")
-            .expression_attribute_names("#pk", ATTR_PK)
-            .send()
-            .await
-        {
-            Ok(_) => {}
-            Err(aws_sdk_dynamodb::error::SdkError::ServiceError(se))
-                if matches!(
-                    se.err(),
-                    aws_sdk_dynamodb::operation::delete_item::DeleteItemError::ConditionalCheckFailedException(_)
-                ) =>
-            {
-                return Err(NameServiceError::not_found(ledger_id));
-            }
-            Err(e) => {
-                return Err(NameServiceError::storage(format!(
-                    "DynamoDB conditional delete failed: {e}"
-                )));
-            }
-        }
-
-        // Delete remaining (non-meta) items via BatchWriteItem
-        let delete_requests: Vec<_> = items
-            .iter()
-            .filter_map(|item| {
-                let sk_val = item.get(ATTR_SK)?.as_s().ok()?;
-                if sk_val == SK_META {
-                    return None; // already deleted above
-                }
-                Some(
-                    aws_sdk_dynamodb::types::WriteRequest::builder()
-                        .delete_request(
-                            aws_sdk_dynamodb::types::DeleteRequest::builder()
-                                .key(ATTR_PK, AttributeValue::S(pk.clone()))
-                                .key(ATTR_SK, AttributeValue::S(sk_val.to_string()))
-                                .build()
-                                .expect("delete request keys set"),
-                        )
-                        .build(),
-                )
-            })
-            .collect();
-
-        let mut remaining: std::collections::HashMap<String, Vec<_>> =
-            std::collections::HashMap::new();
-        remaining.insert(self.table_name.clone(), delete_requests);
-
-        while !remaining.is_empty() {
-            // DynamoDB BatchWriteItem accepts at most 25 items total per call.
-            // We already chunked into ≤25-item batches per table, but after
-            // unprocessed retries the map may have items across tables.
-            let mut builder = self.client.batch_write_item();
-            for (table, items) in &remaining {
-                builder = builder.request_items(table, items.clone());
-            }
-
-            let result = builder.send().await.map_err(|e| {
-                NameServiceError::storage(format!("DynamoDB batch delete failed: {e}"))
-            })?;
-
-            remaining = result.unprocessed_items().cloned().unwrap_or_default();
-
-            if !remaining.is_empty() {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
+        // Atomic linearization point: conditional delete of meta, then sweep
+        // every remaining row under this pk. If meta is already gone, another
+        // caller already won — surface as NotFound here so we don't decrement
+        // the parent's branch count twice.
+        if !self.delete_all_rows_for_pk(&pk, &items).await? {
+            return Err(NameServiceError::not_found(ledger_id));
         }
 
         // Decrement parent's child count if this branch had a parent
@@ -1063,12 +994,118 @@ impl Publisher for DynamoDbNameService {
         Ok(())
     }
 
+    async fn purge(&self, ledger_id: &str) -> std::result::Result<(), NameServiceError> {
+        // Hard drop: delete every row under this pk (meta/head/index/status/
+        // config, plus any other ledger-level rows). Idempotent — if the
+        // record is already gone we return Ok so repeated drops are safe.
+        let pk = Self::normalize(ledger_id);
+        let items = self.query_all_items(&pk).await?;
+        let _ = self.delete_all_rows_for_pk(&pk, &items).await?;
+        Ok(())
+    }
+
     fn publishing_ledger_id(&self, ledger_id: &str) -> Option<String> {
         Some(Self::normalize(ledger_id))
     }
 }
 
 impl DynamoDbNameService {
+    /// Conditionally delete the meta row and sweep every remaining row under `pk`.
+    ///
+    /// Always attempts to sweep non-meta rows, even when the conditional meta
+    /// delete fails (meta already gone). That handles the partial-failure
+    /// replay case: a prior caller could have deleted meta and crashed before
+    /// sweeping head/index/status/config; the next purge must finish the job.
+    ///
+    /// Returns `Ok(true)` if this caller won the conditional delete on meta
+    /// (the linearization point — used by `drop_branch` to gate its single
+    /// parent-count decrement). Returns `Ok(false)` if meta was already gone.
+    /// In both cases the remaining rows are swept.
+    async fn delete_all_rows_for_pk(
+        &self,
+        pk: &str,
+        items: &[Item],
+    ) -> std::result::Result<bool, NameServiceError> {
+        let meta_was_present = match self
+            .client
+            .delete_item()
+            .table_name(&self.table_name)
+            .key(ATTR_PK, AttributeValue::S(pk.to_string()))
+            .key(ATTR_SK, AttributeValue::S(SK_META.to_string()))
+            .condition_expression("attribute_exists(#pk)")
+            .expression_attribute_names("#pk", ATTR_PK)
+            .send()
+            .await
+        {
+            Ok(_) => true,
+            Err(aws_sdk_dynamodb::error::SdkError::ServiceError(se))
+                if matches!(
+                    se.err(),
+                    aws_sdk_dynamodb::operation::delete_item::DeleteItemError::ConditionalCheckFailedException(_)
+                ) =>
+            {
+                false
+            }
+            Err(e) => {
+                return Err(NameServiceError::storage(format!(
+                    "DynamoDB conditional delete failed: {e}"
+                )));
+            }
+        };
+
+        // Sweep remaining (non-meta) items via BatchWriteItem. DynamoDB
+        // BatchWriteItem accepts at most 25 items per call; chunk accordingly.
+        // Runs unconditionally so a half-completed purge is finished on the
+        // next call.
+        let mut delete_requests: Vec<aws_sdk_dynamodb::types::WriteRequest> = items
+            .iter()
+            .filter_map(|item| {
+                let sk_val = item.get(ATTR_SK)?.as_s().ok()?;
+                if sk_val == SK_META {
+                    return None;
+                }
+                Some(
+                    aws_sdk_dynamodb::types::WriteRequest::builder()
+                        .delete_request(
+                            aws_sdk_dynamodb::types::DeleteRequest::builder()
+                                .key(ATTR_PK, AttributeValue::S(pk.to_string()))
+                                .key(ATTR_SK, AttributeValue::S(sk_val.to_string()))
+                                .build()
+                                .expect("delete request keys set"),
+                        )
+                        .build(),
+                )
+            })
+            .collect();
+
+        while !delete_requests.is_empty() {
+            let chunk_size = delete_requests.len().min(25);
+            let chunk: Vec<_> = delete_requests.drain(..chunk_size).collect();
+
+            let mut remaining: std::collections::HashMap<String, Vec<_>> =
+                std::collections::HashMap::new();
+            remaining.insert(self.table_name.clone(), chunk);
+
+            while !remaining.is_empty() {
+                let mut builder = self.client.batch_write_item();
+                for (table, batch) in &remaining {
+                    builder = builder.request_items(table, batch.clone());
+                }
+
+                let result = builder.send().await.map_err(|e| {
+                    NameServiceError::storage(format!("DynamoDB batch delete failed: {e}"))
+                })?;
+
+                remaining = result.unprocessed_items().cloned().unwrap_or_default();
+                if !remaining.is_empty() {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+
+        Ok(meta_was_present)
+    }
+
     /// Shared helper for publish_index and publish_index_allow_equal.
     ///
     /// First attempts the update with only the monotonicity `condition`

--- a/fluree-db-storage-aws/src/s3/mod.rs
+++ b/fluree-db-storage-aws/src/s3/mod.rs
@@ -383,10 +383,8 @@ impl StorageRead for S3Storage {
         let mut objects = Vec::new();
         let mut continuation_token = None;
 
-        let full_prefix = match &self.prefix {
-            Some(p) => format!("{}/{}", p.trim_end_matches('/'), prefix),
-            None => prefix.to_string(),
-        };
+        let full_prefix = build_list_prefix(prefix, self.prefix.as_deref())
+            .map_err(|e| CoreError::io(format!("Invalid list prefix: {e}")))?;
 
         loop {
             let mut request = self
@@ -516,11 +514,8 @@ impl StorageList for S3Storage {
         let mut addresses = Vec::new();
         let mut continuation_token = None;
 
-        // Build the full prefix including any configured prefix
-        let full_prefix = match &self.prefix {
-            Some(p) => format!("{}/{}", p.trim_end_matches('/'), prefix),
-            None => prefix.to_string(),
-        };
+        let full_prefix = build_list_prefix(prefix, self.prefix.as_deref())
+            .map_err(|e| StorageExtError::io(format!("Invalid list prefix: {e}")))?;
 
         loop {
             let mut request = self
@@ -559,11 +554,8 @@ impl StorageList for S3Storage {
         continuation_token: Option<String>,
         max_keys: usize,
     ) -> StorageExtResult<NsListResult> {
-        // Build the full prefix including any configured prefix
-        let full_prefix = match &self.prefix {
-            Some(p) => format!("{}/{}", p.trim_end_matches('/'), prefix),
-            None => prefix.to_string(),
-        };
+        let full_prefix = build_list_prefix(prefix, self.prefix.as_deref())
+            .map_err(|e| StorageExtError::io(format!("Invalid list prefix: {e}")))?;
 
         let mut request = self
             .client
@@ -741,6 +733,40 @@ impl StorageCas for S3Storage {
 /// Result of a list operation (re-export for convenience)
 pub type ListResult = NsListResult;
 
+/// Build the full S3 key prefix for a list operation.
+///
+/// Mirrors the address parsing used by reads/writes/deletes so callers can
+/// pass a fluree address (`fluree:s3://ledger/main/`) or a raw path
+/// (`ledger/main/`) and have the configured bucket prefix correctly prepended.
+/// An empty `prefix` lists everything under the bucket prefix (or the whole
+/// bucket if no prefix is configured).
+fn build_list_prefix(prefix: &str, bucket_prefix: Option<&str>) -> Result<String> {
+    let has_trailing_slash = prefix.ends_with('/');
+    let path = if prefix.is_empty() {
+        ""
+    } else {
+        address::parse_fluree_address(prefix)?
+    };
+
+    let with_trailing = if has_trailing_slash && !path.ends_with('/') && !path.is_empty() {
+        format!("{path}/")
+    } else {
+        path.to_string()
+    };
+
+    Ok(match bucket_prefix {
+        Some(bp) => {
+            let bp = bp.trim_end_matches('/');
+            if with_trailing.is_empty() {
+                format!("{bp}/")
+            } else {
+                format!("{bp}/{with_trailing}")
+            }
+        }
+        None => with_trailing,
+    })
+}
+
 // Error mapping helpers
 
 /// Map an SDK error to CoreError, properly handling 404 as NotFound
@@ -856,5 +882,59 @@ mod tests {
         assert!(config.prefix.is_none());
         assert!(config.endpoint.is_none());
         assert!(config.timeout_ms.is_none());
+    }
+
+    #[test]
+    fn test_build_list_prefix_strips_fluree_scheme() {
+        assert_eq!(
+            build_list_prefix("fluree:s3://ledger/main/", Some("fluree-data")).unwrap(),
+            "fluree-data/ledger/main/"
+        );
+    }
+
+    #[test]
+    fn test_build_list_prefix_no_bucket_prefix() {
+        assert_eq!(
+            build_list_prefix("fluree:s3://ledger/main/commit/", None).unwrap(),
+            "ledger/main/commit/"
+        );
+    }
+
+    #[test]
+    fn test_build_list_prefix_raw_path() {
+        // Callers that already stripped the scheme should still work.
+        assert_eq!(
+            build_list_prefix("ledger/main/commit/", Some("fluree-data")).unwrap(),
+            "fluree-data/ledger/main/commit/"
+        );
+    }
+
+    #[test]
+    fn test_build_list_prefix_preserves_trailing_slash() {
+        assert_eq!(
+            build_list_prefix("fluree:s3://ledger/main", Some("fluree-data")).unwrap(),
+            "fluree-data/ledger/main"
+        );
+        assert_eq!(
+            build_list_prefix("fluree:s3://ledger/main/", Some("fluree-data")).unwrap(),
+            "fluree-data/ledger/main/"
+        );
+    }
+
+    #[test]
+    fn test_build_list_prefix_empty_lists_bucket_root() {
+        assert_eq!(
+            build_list_prefix("", Some("fluree-data")).unwrap(),
+            "fluree-data/"
+        );
+        assert_eq!(build_list_prefix("", None).unwrap(), "");
+    }
+
+    #[test]
+    fn test_build_list_prefix_trims_bucket_prefix_trailing_slash() {
+        assert_eq!(
+            build_list_prefix("fluree:s3://ledger/main/", Some("fluree-data/")).unwrap(),
+            "fluree-data/ledger/main/"
+        );
     }
 }


### PR DESCRIPTION
Hard-dropping a ledger on the AWS stack (S3 storage + DynamoDB nameservice) was silently behaving like a soft drop: the alias remained unreusable in DynamoDB and 0 artifacts were deleted in S3. This PR fixes four cooperating bugs so `drop_ledger(.., DropMode::Hard)` actually clears the ledger end-to-end.

## Bugs fixed

### 1. `DynamoDbNameService::purge` was missing — fell back to `retract`

`Publisher::purge` has a default impl that delegates to `retract()`, which only flips `meta.retracted = true`. `DynamoDbNameService` never overrode it, so `head` / `index` / `config` / `status` rows were left behind and `publish_ledger_init` (which uses `attribute_not_exists(pk)` per row) couldn't recreate the alias.

**Fix:** Override `purge()` to delete every row under `pk`. Factored a `delete_all_rows_for_pk` helper that's also reused by `drop_branch`. The helper always sweeps non-meta rows regardless of the conditional-meta-delete outcome, so a purge that crashed mid-sweep is recovered on the next call.

### 2. `S3Storage::list_prefix*` didn't parse fluree addresses

Reads, writes, and deletes route through `address_to_key` (which strips `fluree:s3://`). The list APIs didn't, so a caller passing `fluree:s3://ledger/main/` ended up querying S3 with `fluree-data/fluree:s3://ledger/main/` — a literal substring that never matches real keys. Result: list returned 0 → fast-path drop deleted nothing.

**Fix:** New `build_list_prefix` helper that runs the same `parse_fluree_address` path. Applied to all four list entry points (`StorageRead::list_prefix`, `StorageList::list_prefix`, `list_prefix_paginated`, `list_prefix_with_metadata`). Six unit tests covering scheme stripping, trailing-slash preservation, empty input, and bucket-prefix trimming.

### 3. `TieredStorage` routing missed entire tiers on a ledger-root list

`TieredStorage::list_prefix` routes by substring: `/commit/` or `/txn/` → commit tier; everything else → index tier. A ledger-root prefix like `fluree:s3://ledger/main/` contains neither, so a single root-level list misses the whole commit bucket in split commit/index deployments. The original `drop_artifacts` also missed `{prefix}/config/` (where `ContentKind::LedgerConfig` blobs — config + default-context — are written).

**Fix:** `drop_artifacts` now enumerates per-subprefix: `commit/`, `txn/`, `index/`, `config/`, and conditionally `{ledger}/@shared/dicts/`. Each list call routes to the correct tier.

### 4. Partial list failures were silently treated as success

The original "if any subprefix listed OK, declare success" branch could purge the nameservice while leaving an entire artifact class behind if one tier returned an error.

**Fix:** Failures are collected as warnings on the `DropReport`. When any subprefix errors, a CID-walk cleanup pass runs after the fast path (`release` is idempotent on already-deleted CIDs). The nameservice is only purged once `drop_artifacts` has had its best shot.

## Branch safety

- Cross-branch `@shared/dicts/` is only wiped when `is_last_live_branch` returns true (uses `NameService::list_branches` to confirm no sibling branches remain). Branch-scoped `drop_branch` / `purge_branch` always pass `false`.
- `drop_ledger`'s doc-comment now calls out that hard-dropping a parent branch while child branches are still alive will delete commit/index artifacts the children may resolve through the branched content store. Drop child branches first.


