### PR TITLE
feat: drop_ledger drops the whole ledger; root-branch check is struct…

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1203,7 +1203,8 @@ curl -X POST http://localhost:8090/v1/fluree/create \
 
 ### POST /drop
 
-Drop a ledger or graph source.
+Drop a whole ledger (every branch under the supplied name) or, as a
+fallback, a graph source with the same name.
 
 **URL:**
 ```
@@ -1216,84 +1217,91 @@ POST /drop
 
 ```json
 {
-  "ledger": "mydb:main",
+  "ledger": "mydb",
   "hard": false
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `ledger` | string | Yes | Ledger ID (e.g., "mydb" or "mydb:main") |
-| `hard` | boolean | No | If `true`, delete managed storage artifacts and purge the nameservice record where the backend supports purge. Default: `false` (soft drop) |
+| `ledger` | string | Yes | Ledger name (e.g., `"mydb"`). The branch-qualified form `"mydb:main"` is accepted for backwards compatibility but a warning is attached. Non-default branch suffixes like `"mydb:dev"` are **rejected** — use the [`POST /drop-branch`](#post-drop-branch) endpoint (or call `drop_branch` in the Rust API) to drop a single branch. |
+| `hard` | boolean | No | If `true`, delete managed storage artifacts and purge the nameservice records. Default: `false` (soft drop). |
+
+**Scope:**
+
+`/drop` operates on the **whole ledger** — every branch under the ledger name, including any retracted-but-not-purged branches. Branches are dropped leaf-first so that if the operation aborts mid-way the surviving state stays consistent (orphan parents, never dangling children). The cross-branch `@shared/dicts/` namespace is cleaned up at the very end.
 
 **Drop Modes:**
 
-- **Soft drop** (`hard: false`, default): Marks the ledger as retracted in the nameservice and preserves storage artifacts. The alias remains reserved; normal create/load paths treat the ledger as unavailable.
-- **Hard drop** (`hard: true`): Deletes managed storage artifacts, then purges the nameservice record so the alias can be reused on backends with purge support. **This is irreversible for deleted artifacts.**
+- **Soft drop** (`hard: false`, default): Marks every branch as retracted in the nameservice and preserves storage artifacts. Aliases remain reserved; normal create/load paths treat the ledger as unavailable.
+- **Hard drop** (`hard: true`): Deletes managed storage artifacts for every branch and purges the nameservice records so the name can be reused. **This is irreversible for deleted artifacts.**
 
-If no ledger is found, the server tries the same name as a graph source on branch `main`. Graph source hard-drop cleanup is best effort and may be implementation-specific; graph-source fallback responses currently omit `files_deleted`.
+If no ledger is found by name, the server tries the same name as a graph source on branch `main`. Graph source hard-drop cleanup is best effort; graph-source fallback responses omit `branches_dropped` and `files_deleted`.
 
 **Response:**
 
 ```json
 {
-  "ledger_id": "mydb:main",
+  "ledger_id": "mydb",
   "status": "dropped",
-  "files_deleted": 23
+  "files_deleted": 73,
+  "branches_dropped": ["mydb:feature-x", "mydb:dev", "mydb:main"]
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `ledger_id` | string | Normalized ledger ID, or graph source ID if the graph-source fallback handled the request |
-| `status` | string | One of: `"dropped"`, `"already_retracted"`, `"not_found"` |
-| `files_deleted` | integer | Number of managed storage artifacts deleted; omitted when zero |
+| `ledger_id` | string | Ledger name (or graph source ID if the graph-source fallback handled the request) |
+| `status` | string | Aggregate status across branches. One of: `"dropped"`, `"already_retracted"`, `"not_found"` |
+| `files_deleted` | integer | Number of managed storage artifacts deleted (sum across branches + `@shared/dicts/` cleanup); omitted when zero |
+| `branches_dropped` | string[] | Per-branch `ledger_id`s that were dropped, in leaf-first order; omitted when empty |
 | `warnings` | string[] | Non-fatal cleanup warnings; omitted when empty |
 
 **Status Codes:**
 - `200 OK` - Drop successful (or already dropped/not found)
-- `400 Bad Request` - Invalid request body
+- `400 Bad Request` - Invalid request body, or a non-default branch suffix was supplied
 - `401 Unauthorized` - Bearer token required (when admin auth enabled)
-- `500 Internal Server Error` - Server error
+- `500 Internal Server Error` - Branch enumeration failed, or another unrecoverable error
 
 **Drop Sequence:**
 
-1. Normalizes the ledger ID (ensures branch suffix like `:main`)
-2. Cancels any pending background indexing
-3. Waits for in-progress indexing to complete
-4. In hard mode: deletes managed storage artifacts (commits, txns, indexes, config/context blobs, and related content)
-5. In soft mode: retracts from nameservice; in hard mode: purges the nameservice record where supported
-6. Disconnects from ledger cache
+1. Parses input. `"mydb"` is the canonical form; `"mydb:main"` is accepted with a warning; anything else (`"mydb:dev"`, etc.) returns a `400`.
+2. Enumerates every NsRecord under the ledger name (including retracted ones).
+3. Sorts branches leaf-first via the `source_branch` parent pointers.
+4. Cancels and waits for pending background indexing on each branch.
+5. For each branch (leaf-first): deletes managed storage artifacts (hard mode) and retracts (soft) or removes the NS record (hard). Hard mode uses the parent-aware drop path so child counts on surviving parents stay accurate even under partial failure.
+6. Hard mode only: wipes the cross-branch `{ledger_name}/@shared/dicts/` namespace.
+7. Disconnects every branch from the ledger cache.
 
 **Idempotency:**
 
 Safe to call multiple times:
-- Returns `"already_retracted"` if the ledger was previously dropped
-- Hard mode still attempts artifact deletion even for already-retracted or not-found ledgers (useful for cleanup)
+- Returns `"already_retracted"` when every branch was already retracted (hard mode still proceeds with cleanup for these).
+- Returns `"not_found"` without touching storage when no nameservice record exists for the ledger name. Truly orphaned artifacts with no nameservice pointer are **not** swept by `/drop`; that's a separate admin concern.
 
 **Examples:**
 
 ```bash
-# Soft drop (retract only, preserve storage artifacts)
+# Soft drop the whole "mydb" ledger
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
-  -d '{"ledger": "mydb:main"}'
+  -d '{"ledger": "mydb"}'
 
-# Hard drop (delete managed storage artifacts - IRREVERSIBLE)
+# Hard drop (delete every branch's artifacts + @shared/dicts - IRREVERSIBLE)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
-  -d '{"ledger": "mydb:main", "hard": true}'
+  -d '{"ledger": "mydb", "hard": true}'
 
 # Drop with auth token (when admin auth enabled)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer eyJ..." \
-  -d '{"ledger": "mydb:main", "hard": true}'
+  -d '{"ledger": "mydb", "hard": true}'
 
-# Drop with short ledger ID (auto-resolves to :main)
+# Backwards-compatible form (accepted with a warning; prefer the bare name)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
-  -d '{"ledger": "mydb"}'
+  -d '{"ledger": "mydb:main"}'
 ```
 
 ### GET /context/{ledger...}

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1224,7 +1224,7 @@ POST /drop
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `ledger` | string | Yes | Ledger name (e.g., `"mydb"`). The branch-qualified form `"mydb:main"` is accepted for backwards compatibility but a warning is attached. Non-default branch suffixes like `"mydb:dev"` are **rejected** — use the [`POST /drop-branch`](#post-drop-branch) endpoint (or call `drop_branch` in the Rust API) to drop a single branch. |
+| `ledger` | string | Yes | Ledger name (e.g., `"mydb"`). Any branch-qualified form (including `"mydb:main"`) is **rejected** with a `400` — use the [`POST /drop-branch`](#post-drop-branch) endpoint (or call `drop_branch` in the Rust API) to drop a single branch. |
 | `hard` | boolean | No | If `true`, delete managed storage artifacts and purge the nameservice records. Default: `false` (soft drop). |
 
 **Scope:**
@@ -1259,13 +1259,13 @@ If no ledger is found by name, the server tries the same name as a graph source 
 
 **Status Codes:**
 - `200 OK` - Drop successful (or already dropped/not found)
-- `400 Bad Request` - Invalid request body, or a non-default branch suffix was supplied
+- `400 Bad Request` - Invalid request body, or any branch-qualified ledger id was supplied
 - `401 Unauthorized` - Bearer token required (when admin auth enabled)
 - `500 Internal Server Error` - Branch enumeration failed, or another unrecoverable error
 
 **Drop Sequence:**
 
-1. Parses input. `"mydb"` is the canonical form; `"mydb:main"` is accepted with a warning; anything else (`"mydb:dev"`, etc.) returns a `400`.
+1. Parses input. `"mydb"` is the canonical form; any branch-qualified id (`"mydb:main"`, `"mydb:dev"`, …) returns a `400`.
 2. Enumerates every NsRecord under the ledger name (including retracted ones).
 3. Sorts branches leaf-first via the `source_branch` parent pointers.
 4. Cancels and waits for pending background indexing on each branch.

--- a/docs/cli/drop.md
+++ b/docs/cli/drop.md
@@ -1,6 +1,6 @@
 # fluree drop
 
-Hard-drop a ledger or graph source.
+Hard-drop an entire ledger (every branch under the name) or a graph source.
 
 ## Usage
 
@@ -12,7 +12,7 @@ fluree drop <NAME> --force
 
 | Argument | Description |
 |----------|-------------|
-| `<NAME>` | Ledger or graph source name to drop |
+| `<NAME>` | Ledger name (bare, e.g. `mydb`) or graph source name. Branch-qualified ledger ids like `mydb:main` are accepted with a warning; non-default suffixes like `mydb:dev` are rejected — use `fluree branch drop dev --ledger mydb` to drop a single branch. |
 
 ## Options
 
@@ -22,21 +22,21 @@ fluree drop <NAME> --force
 
 ## Description
 
-Deletes a ledger using the same hard-drop mode as `POST /drop` with `"hard": true`. For managed storage backends, Fluree deletes storage artifacts and removes the nameservice record where the backend supports purge, allowing the alias to be reused. Deleted artifacts are irreversible.
+Hard-drops a **whole ledger** — every branch under the name, including any retracted-but-not-purged branches, plus the cross-branch `@shared/dicts/` namespace. Branches are dropped leaf-first so partial failure leaves orphan parents rather than dangling children. Equivalent to `POST /drop` with `"hard": true`. Deleted artifacts are irreversible.
 
-The command first tries to drop the name as a ledger. If no ledger is found, it tries to drop it as a graph source. This means `fluree drop` works uniformly for both ledgers and graph sources like Iceberg mappings.
+The command first tries to drop the name as a ledger. If no nameservice record exists for the name, it tries to drop it as a graph source. This means `fluree drop` works uniformly for both ledgers and graph sources like Iceberg mappings.
 
-The `--force` flag is required to prevent accidental deletion. There is no CLI soft-drop flag; use the HTTP or Rust API if you need to retract a ledger while preserving artifacts.
+The `--force` flag is required to prevent accidental deletion. There is no CLI soft-drop flag; use the HTTP or Rust API if you need to retract a ledger while preserving artifacts. To remove a single branch (not the whole ledger), use `fluree branch drop`.
 
 Graph source cleanup is implementation-specific. The command retracts the graph source record and performs any available hard-drop cleanup for that graph source type; warnings are printed when cleanup is partial.
 
 ## Examples
 
 ```bash
-# Delete a ledger
+# Drop the whole "oldledger" ledger (all branches + @shared/dicts/)
 fluree drop oldledger --force
 
-# Delete a graph source (Iceberg mapping)
+# Drop a graph source (Iceberg mapping)
 fluree drop warehouse-orders --force
 ```
 
@@ -49,7 +49,7 @@ Dropped ledger 'oldledger'
 
 Ledger with artifact cleanup:
 ```
-Dropped ledger 'oldledger' (deleted 23 artifacts)
+Dropped ledger 'oldledger' (deleted 73 artifacts across 3 branches)
 ```
 
 Graph source:
@@ -62,6 +62,13 @@ Dropped graph source 'warehouse-orders:main'
 Without `--force`:
 ```
 error: use --force to confirm deletion of 'oldledger'
+```
+
+Branch-qualified input with a non-default suffix:
+```
+error: drop_ledger drops the whole ledger and does not accept a non-default
+       branch suffix 'dev'. Use drop_branch("mydb", "dev") to drop a single
+       branch, or pass "mydb" to drop the whole ledger.
 ```
 
 ## See Also

--- a/docs/cli/drop.md
+++ b/docs/cli/drop.md
@@ -12,7 +12,7 @@ fluree drop <NAME> --force
 
 | Argument | Description |
 |----------|-------------|
-| `<NAME>` | Ledger name (bare, e.g. `mydb`) or graph source name. Branch-qualified ledger ids like `mydb:main` are accepted with a warning; non-default suffixes like `mydb:dev` are rejected — use `fluree branch drop dev --ledger mydb` to drop a single branch. |
+| `<NAME>` | Ledger name (bare, e.g. `mydb`) or graph source name. Branch-qualified ledger ids (including `mydb:main`) are rejected — use `fluree branch drop <branch> --ledger mydb` to drop a single branch. |
 
 ## Options
 

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -599,7 +599,7 @@ ledger-level `POST /drop` endpoint.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `ledger` | string | Yes | Ledger name without branch suffix. |
-| `branch` | string | Yes | Branch to drop. Cannot be `"main"`. |
+| `branch` | string | Yes | Branch to drop. Cannot be the **root** branch (any branch with `source_branch.is_none()`). `"main"` carries no special meaning — it's the default and so the root on most ledgers, but a ledger created with a different initial branch will refuse that branch instead, and a non-root branch named `"main"` is droppable. Use `POST /drop` to remove the whole ledger including its root. |
 
 ### Auth
 
@@ -610,7 +610,8 @@ Admin-protected (same bracket as `/branch`, `/rebase`, `/merge`,
 
 The reference server's `Fluree::drop_branch`:
 
-1. Refuses to drop `"main"` with `400`.
+1. Refuses the **root** branch with `400` (structural check on
+   `source_branch.is_none()`, not a name comparison).
 2. If the branch is **retracted** already → returns status `already_retracted`.
 3. If the branch has children (`branches > 0`) → **soft-retracts** it (preserves
    storage so children can still resolve), returns `deferred: true`.
@@ -648,7 +649,7 @@ The CLI's `print_branch_dropped` reads `ledger_id`, `deferred`,
 
 | Status | When |
 |--------|------|
-| `400` | Attempting to drop `"main"`; malformed JSON body. |
+| `400` | Attempting to drop the root branch (`source_branch.is_none()`); malformed JSON body. |
 | `401` / `403` | Admin token required and absent/invalid. |
 | `404` | Branch not found (the underlying lookup miss surfaces as `ApiError::NotFound` → 404). |
 | `5xx` | Storage / nameservice errors during purge. |
@@ -680,7 +681,7 @@ Content-Type: application/json
 | Field | Type | Required | Server default | Description |
 |-------|------|----------|----------------|-------------|
 | `ledger` | string | Yes | — | Ledger name without branch suffix. |
-| `branch` | string | Yes | — | Branch to rebase. Cannot be `"main"`. |
+| `branch` | string | Yes | — | Branch to rebase. Cannot be the **root** branch (`source_branch.is_none()`) — it has no parent to rebase onto. The check is structural, not name-based. |
 | `strategy` | string | No | `"take-both"` | One of `take-both`, `abort`, `take-source`, `take-branch`, `skip`. Parsed by `ConflictStrategy::from_str_name`; unknown values respond `400`. |
 
 ### Auth
@@ -739,7 +740,7 @@ The CLI's `print_rebase_result` reads `fast_forward`, `branch`, `source_head_t`,
 
 | Status | When |
 |--------|------|
-| `400` | Rebasing `"main"` (`InvalidBranch`); branch has no `source_branch` (root branch); unknown / unsupported strategy; malformed JSON body. |
+| `400` | Rebasing the root branch (no `source_branch` — surfaced as `InvalidBranch`); unknown / unsupported strategy; malformed JSON body. |
 | `401` / `403` | Admin token required and absent/invalid. |
 | `404` | Branch or its source not found. |
 | `409` | `BranchConflict` — currently raised when `strategy=abort` and any commit conflicts with the source delta. |

--- a/docs/concepts/ledgers-and-nameservice.md
+++ b/docs/concepts/ledgers-and-nameservice.md
@@ -519,7 +519,13 @@ fluree branch list --ledger mydb
 
 #### Dropping a Branch
 
-Branches can be deleted with `drop_branch`. The `main` branch cannot be dropped.
+Branches can be deleted with `drop_branch`. The **root** branch — any branch
+whose `source_branch.is_none()` on its `NsRecord` — cannot be dropped via
+`drop_branch`; use [`drop_ledger`](#dropping-a-whole-ledger) to remove the
+entire ledger including its root. `"main"` is the default branch name and so
+is the root on most ledgers, but the refusal is structural: a ledger created
+as `mydb:trunk` has `trunk` as its root, and `drop_branch("mydb", "trunk")`
+will be refused. Conversely, a non-root branch named `"main"` is droppable.
 
 Branches use **reference counting** (`branches` field on `NsRecord`) to track child branches. This enables safe deletion:
 

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -730,7 +730,9 @@ async fn main() -> Result<()> {
 
 #### Dropping Ledgers
 
-Use `drop_ledger` to retract a ledger or to permanently remove its managed storage artifacts:
+`drop_ledger` operates on the **whole ledger** — every branch under a ledger
+name, including retracted-but-not-purged branches and the cross-branch
+`@shared/dicts/` namespace. Use `drop_branch` to remove a single branch.
 
 ```rust
 use fluree_db_api::{FlureeBuilder, DropMode, DropStatus, Result};
@@ -739,59 +741,89 @@ use fluree_db_api::{FlureeBuilder, DropMode, DropStatus, Result};
 async fn main() -> Result<()> {
     let fluree = FlureeBuilder::file("./data").build()?;
 
-    // Soft drop: retract from nameservice, preserve storage artifacts
-    let report = fluree.drop_ledger("mydb:main", DropMode::Soft).await?;
+    // Soft drop: retract every branch in the nameservice, preserve artifacts
+    let report = fluree.drop_ledger("mydb", DropMode::Soft).await?;
     match report.status {
         DropStatus::Dropped => println!("Ledger dropped"),
         DropStatus::AlreadyRetracted => println!("Already dropped"),
         DropStatus::NotFound => println!("Ledger not found"),
     }
 
-    // Hard drop: delete managed storage artifacts (IRREVERSIBLE)
-    let report = fluree.drop_ledger("mydb:main", DropMode::Hard).await?;
-    println!("Deleted {} storage artifacts", report.artifacts_deleted);
+    // Hard drop: delete artifacts for every branch + @shared/dicts (IRREVERSIBLE)
+    let report = fluree.drop_ledger("mydb", DropMode::Hard).await?;
+    println!(
+        "Dropped {} branches; deleted {} storage artifacts",
+        report.branch_reports.len(),
+        report.artifacts_deleted
+    );
+    for br in &report.branch_reports {
+        println!("  - {} ({:?})", br.ledger_id, br.status);
+    }
 
     Ok(())
 }
 ```
 
+**Accepted inputs:**
+
+| Input | Behavior |
+|-------|----------|
+| `"mydb"` | Whole-ledger drop (canonical form). |
+| `"mydb:main"` | Accepted for backwards compatibility; a warning is attached to the report. |
+| `"mydb:dev"` (any non-default branch suffix) | **Rejected** with a `400`/`ApiError::Http`. Use `drop_branch("mydb", "dev")` instead. |
+
 **Drop Modes:**
 
 | Mode | Behavior | Reversible |
 |------|----------|------------|
-| `DropMode::Soft` (default) | Marks the ledger retracted in the nameservice; artifacts remain and the alias stays reserved | Partially; requires administrative recovery |
-| `DropMode::Hard` | Deletes managed storage artifacts and purges the nameservice record where supported | **No** for deleted artifacts |
+| `DropMode::Soft` (default) | Marks every branch retracted in the nameservice; artifacts remain | Partially; requires administrative recovery |
+| `DropMode::Hard` | Deletes managed storage artifacts for every branch, wipes `@shared/dicts/`, and purges nameservice records so the name can be reused | **No** for deleted artifacts |
 
 **Drop Sequence:**
 
-1. Normalizes the ledger ID (ensures `:main` suffix)
-2. Cancels any pending background indexing
-3. Waits for in-progress indexing to complete
-4. In hard mode: deletes managed storage artifacts (commits, txns, indexes, config/context blobs, and related content)
-5. In soft mode: retracts from nameservice; in hard mode: purges the nameservice record where supported
-6. Disconnects from ledger cache (if caching enabled)
+1. Parses input (rejects non-default branch suffixes).
+2. Snapshots every NsRecord under the ledger name via `all_records` (so retracted branches are included). Enumeration failures propagate as `Err`.
+3. Sorts branches leaf-first via `source_branch` parent pointers — partial failures leave orphan parents, never dangling children.
+4. Cancels and waits for pending background indexing on each branch.
+5. For each branch: deletes per-branch artifacts (commit/txn/index/config) in hard mode; retracts (soft) or drops the NS record (hard) using the parent-aware path so surviving parents have accurate child counts.
+6. Hard mode: wipes `{ledger_name}/@shared/dicts/` after every branch is gone.
+7. Disconnects each branch from the ledger cache.
 
-**When to use `drop_ledger`:**
+**Report shape:**
 
-- **Cleanup**: Remove test ledgers or unused data
-- **Data lifecycle**: Permanently delete ledgers that are no longer needed
-- **Admin operations**: Clean up after migrations or failures
+`DropReport.ledger_id` is the bare ledger name. `artifacts_deleted` and
+`warnings` aggregate across branches plus the shared cleanup;
+`branch_reports: Vec<BranchDropReport>` carries per-branch detail in
+leaf-first order — useful for surfacing partial failures.
+
+**`drop_branch` for single branches:**
+
+```rust
+let report = fluree.drop_branch("mydb", "dev").await?;
+```
+
+`drop_branch` refuses the **root** branch (any branch whose
+`source_branch.is_none()`). `"main"` carries no special meaning; a ledger
+created with a different initial branch (e.g. `mydb:trunk`) has that
+branch as its root and is the one that `drop_branch` will refuse.
 
 **Idempotency:**
 
 Safe to call multiple times:
-- Returns `DropStatus::AlreadyRetracted` if previously dropped
-- Hard mode still attempts deletion for `NotFound`/`AlreadyRetracted` (useful for admin cleanup)
+- Returns `DropStatus::AlreadyRetracted` when every branch was already retracted (hard mode still runs cleanup for these).
+- Returns `DropStatus::NotFound` without touching storage when no NsRecord exists for the ledger name. Orphaned storage with no nameservice pointer is not swept by `drop_ledger`; that's a separate admin concern.
+- On a real per-branch nameservice failure, returns `ApiError::Drop` without touching parents or `@shared/dicts/`. Each step is idempotent under partial progress, so retry is safe.
 
 **Warnings:**
 
-The `DropReport` includes a `warnings` field for any non-fatal errors encountered during the operation (e.g., failed to delete a specific file). Always check this for hard drops:
-
 ```rust
-let report = fluree.drop_ledger("mydb:main", DropMode::Hard).await?;
-if !report.warnings.is_empty() {
-    for warning in &report.warnings {
-        eprintln!("Warning: {}", warning);
+let report = fluree.drop_ledger("mydb", DropMode::Hard).await?;
+for warning in &report.warnings {
+    eprintln!("Warning: {warning}");
+}
+for br in &report.branch_reports {
+    for warning in &br.warnings {
+        eprintln!("  {}: {warning}", br.ledger_id);
     }
 }
 ```

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -769,8 +769,7 @@ async fn main() -> Result<()> {
 | Input | Behavior |
 |-------|----------|
 | `"mydb"` | Whole-ledger drop (canonical form). |
-| `"mydb:main"` | Accepted for backwards compatibility; a warning is attached to the report. |
-| `"mydb:dev"` (any non-default branch suffix) | **Rejected** with a `400`/`ApiError::Http`. Use `drop_branch("mydb", "dev")` instead. |
+| `"mydb:<branch>"` (including `"mydb:main"`) | **Rejected** with a `400`/`ApiError::Http`. Use `drop_branch("mydb", "<branch>")` to drop a single branch. |
 
 **Drop Modes:**
 

--- a/docs/operations/admin-and-health.md
+++ b/docs/operations/admin-and-health.md
@@ -236,44 +236,51 @@ See [Admin Authentication](../api/endpoints.md#admin-authentication) for details
 
 ### POST /v1/fluree/drop
 
-Drop a ledger or graph source:
+Drop an **entire ledger** (every branch under the name, plus `@shared/dicts/` in hard mode) or, as a fallback, a graph source with the same name:
 
 ```bash
-# Soft drop (retract from nameservice, preserve storage artifacts)
+# Soft drop the whole "mydb" ledger (retract every branch)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
-  -d '{"ledger": "mydb:main"}'
+  -d '{"ledger": "mydb"}'
 
-# Hard drop (delete managed storage artifacts - IRREVERSIBLE)
+# Hard drop (delete every branch's artifacts + @shared/dicts - IRREVERSIBLE)
 curl -X POST http://localhost:8090/v1/fluree/drop \
   -H "Content-Type: application/json" \
-  -d '{"ledger": "mydb:main", "hard": true}'
+  -d '{"ledger": "mydb", "hard": true}'
 ```
+
+`ledger` accepts the bare ledger name. The branch-qualified form
+`"mydb:main"` is accepted for backwards compatibility with a warning;
+non-default branch suffixes like `"mydb:dev"` are **rejected** — use
+[`POST /drop-branch`](../api/endpoints.md#post-drop-branch) to drop a
+single branch.
 
 **Response:**
 ```json
 {
-  "ledger_id": "mydb:main",
+  "ledger_id": "mydb",
   "status": "dropped",
-  "files_deleted": 23
+  "files_deleted": 73,
+  "branches_dropped": ["mydb:feature-x", "mydb:dev", "mydb:main"]
 }
 ```
 
 | Status | Description |
 |--------|-------------|
-| `dropped` | Successfully dropped |
-| `already_retracted` | Was previously dropped |
-| `not_found` | Ledger doesn't exist |
+| `dropped` | Successfully dropped (aggregate across branches) |
+| `already_retracted` | Every branch was previously retracted |
+| `not_found` | No nameservice record exists for the name |
 
 **Authentication:** When `--admin-auth-mode=required`, requires Bearer token from a trusted issuer.
 
 **Drop Modes:**
-- **Soft** (default): Marks the ledger retracted in the nameservice; artifacts remain and the alias stays reserved.
-- **Hard**: Deletes managed storage artifacts and purges the nameservice record where supported, allowing alias reuse. Deleted artifacts are irreversible.
+- **Soft** (default): Marks every branch retracted in the nameservice; artifacts remain and aliases stay reserved.
+- **Hard**: Deletes per-branch storage artifacts and `@shared/dicts/`, then purges the nameservice records so the ledger name can be reused. Branches are dropped leaf-first; on a per-branch nameservice failure the operation aborts with `500` before touching parents or shared cleanup (retry is safe — each step is idempotent).
 
-If no ledger is found, the endpoint tries the same name as a graph source on branch `main`.
+If no nameservice record is found for the name, the endpoint tries the same name as a graph source on branch `main`. Truly orphaned storage with no nameservice pointer is **not** swept by `/drop`.
 
-See [Dropping Ledgers](../getting-started/rust-api.md#dropping-ledgers) for more details.
+See [Dropping Ledgers](../getting-started/rust-api.md#dropping-ledgers) and [`POST /drop`](../api/endpoints.md#post-drop) for the full reference.
 
 ## API Specification
 

--- a/docs/operations/admin-and-health.md
+++ b/docs/operations/admin-and-health.md
@@ -250,9 +250,8 @@ curl -X POST http://localhost:8090/v1/fluree/drop \
   -d '{"ledger": "mydb", "hard": true}'
 ```
 
-`ledger` accepts the bare ledger name. The branch-qualified form
-`"mydb:main"` is accepted for backwards compatibility with a warning;
-non-default branch suffixes like `"mydb:dev"` are **rejected** — use
+`ledger` accepts the bare ledger name. Any branch-qualified form
+(including `"mydb:main"`) is **rejected** — use
 [`POST /drop-branch`](../api/endpoints.md#post-drop-branch) to drop a
 single branch.
 

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -61,19 +61,34 @@ pub enum DropStatus {
 // Drop Report Types
 // =============================================================================
 
-/// Report of what was deleted/retracted for a ledger
+/// Report of what was deleted/retracted for a ledger.
+///
+/// `drop_ledger` operates on the **whole ledger** (every branch under a
+/// ledger name). `artifacts_deleted` is the sum across all branches plus
+/// the cross-branch `@shared/dicts/` cleanup; `branch_reports` carries the
+/// per-branch detail so partial failures can be inspected.
 #[derive(Debug, Clone, Default)]
 pub struct DropReport {
-    /// The normalized ledger ID that was dropped
+    /// The ledger name that was dropped (e.g. `"mydb"`, without `:branch`).
     pub ledger_id: String,
-    /// Status based on nameservice state at lookup time
+    /// Aggregate status across branches:
+    /// - `Dropped` if at least one branch was dropped or already retracted
+    /// - `AlreadyRetracted` if every branch was already retracted
+    /// - `NotFound` if no branches exist (or never existed)
     pub status: DropStatus,
-    /// Number of storage artifacts deleted (Hard mode only).
+    /// Number of storage artifacts deleted (Hard mode only), summed across
+    /// every branch + the `@shared/dicts/` namespace.
     ///
     /// Includes commits, transactions, index roots, leaves, branches, dicts,
     /// garbage records, config, and context blobs.
     pub artifacts_deleted: usize,
-    /// Any non-fatal errors or warnings encountered during the operation
+    /// Per-branch reports. One entry per branch we attempted to drop, in
+    /// leaf-first order. Empty when the ledger had no branches.
+    pub branch_reports: Vec<BranchDropReport>,
+    /// Any non-fatal errors or warnings encountered during the operation.
+    /// Branch-scoped warnings are also surfaced inside `branch_reports`;
+    /// top-level warnings cover whole-ledger steps (shared cleanup,
+    /// branch enumeration, etc.).
     pub warnings: Vec<String>,
 }
 
@@ -203,145 +218,331 @@ fn normalize_ledger_id(ledger_id: &str) -> String {
     fluree_db_core::normalize_ledger_id(ledger_id).unwrap_or_else(|_| ledger_id.to_string())
 }
 
+/// Parse a `drop_ledger` input.
+///
+/// Accepted forms:
+/// - `"mydb"`: whole-ledger drop. Returns `("mydb", None)`.
+/// - `"mydb:main"`: whole-ledger drop, but a warning is returned to nudge
+///   callers away from the branch-qualified form. Returns
+///   `("mydb", Some(warning))`.
+/// - `"mydb:dev"` (or any non-default branch suffix): rejected with
+///   `ApiError::Http(400)` — likely a caller that meant `drop_branch`.
+fn parse_whole_ledger_input(input: &str) -> Result<(String, Option<String>)> {
+    use fluree_db_core::ledger_id::split_ledger_id;
+    use fluree_db_core::DEFAULT_BRANCH;
+
+    let bad_input = |msg: String| ApiError::Http {
+        status: 400,
+        message: msg,
+    };
+
+    if !input.contains(':') {
+        let (name, _) = split_ledger_id(input)
+            .map_err(|e| bad_input(format!("Invalid ledger name '{input}': {e}")))?;
+        return Ok((name, None));
+    }
+
+    let (name, branch) = split_ledger_id(input)
+        .map_err(|e| bad_input(format!("Invalid ledger id '{input}': {e}")))?;
+
+    if branch == DEFAULT_BRANCH {
+        let warning = format!(
+            "drop_ledger received branch-qualified id '{input}'; treating as whole-ledger drop of '{name}'. \
+             Pass the bare ledger name to silence this warning, or use drop_branch to drop a single branch."
+        );
+        return Ok((name, Some(warning)));
+    }
+
+    Err(bad_input(format!(
+        "drop_ledger drops the whole ledger and does not accept a non-default branch suffix '{branch}'. \
+         Use drop_branch(\"{name}\", \"{branch}\") to drop a single branch, or pass \"{name}\" to drop the whole ledger."
+    )))
+}
+
+/// Sort branches so children come before their parents (leaf-first).
+///
+/// Used by `drop_ledger` so that if the operation aborts mid-way the
+/// surviving state is consistent: a parent may end up orphaned of
+/// children, but a child never points at a missing parent. Branches
+/// whose `source_branch` doesn't resolve to a record in `records`
+/// (orphan branches, broken pointers) are placed after their named
+/// peers — they'll be dropped after siblings, before genuine roots.
+fn sort_leaf_first(records: &mut [NsRecord]) {
+    use std::collections::{HashMap, HashSet};
+
+    // Map branch name → index. Then count descendants under each name.
+    let by_branch: HashMap<String, usize> = records
+        .iter()
+        .enumerate()
+        .map(|(i, r)| (r.branch.clone(), i))
+        .collect();
+
+    // For each record, count how many other records are descended from it
+    // (so true leaves get 0; the root gets the largest count).
+    let mut descendants: HashMap<usize, usize> = HashMap::new();
+    for (i, r) in records.iter().enumerate() {
+        let mut walker = r.source_branch.clone();
+        let mut seen: HashSet<String> = HashSet::new();
+        seen.insert(r.branch.clone());
+        while let Some(parent) = walker {
+            if !seen.insert(parent.clone()) {
+                break; // cycle guard
+            }
+            if let Some(&pi) = by_branch.get(&parent) {
+                *descendants.entry(pi).or_insert(0) += 1;
+                walker = records[pi].source_branch.clone();
+            } else {
+                break;
+            }
+        }
+        descendants.entry(i).or_insert(0);
+    }
+
+    records.sort_by(|a, b| {
+        let ai = by_branch[&a.branch];
+        let bi = by_branch[&b.branch];
+        descendants[&ai]
+            .cmp(&descendants[&bi])
+            .then_with(|| a.branch.cmp(&b.branch))
+    });
+}
+
 // =============================================================================
 // Fluree Drop Implementation
 // =============================================================================
 
 impl crate::Fluree {
-    /// Drop a ledger
-    ///
-    /// This operation:
-    /// 1. Normalizes the ledger ID (ensures branch suffix like `:main`)
-    /// 2. Cancels any pending background indexing
-    /// 3. Waits for in-progress indexing to complete
-    /// 4. In Hard mode: deletes all storage artifacts (commits + indexes)
-    /// 5. Retracts from nameservice
-    /// 6. Disconnects from ledger cache (if caching enabled)
+    /// Drop an entire ledger — every branch under the supplied name, plus
+    /// the cross-branch `@shared/dicts/` namespace in hard mode.
     ///
     /// # Arguments
     ///
-    /// * `ledger_id` - Ledger ID (e.g., "mydb" or "mydb:main")
-    /// * `mode` - `Soft` (retract only) or `Hard` (retract + delete files)
+    /// * `ledger_id` - Ledger name. See **Input forms** below for accepted shapes.
+    /// * `mode` - `Soft` (retract only) or `Hard` (retract + delete artifacts).
+    ///
+    /// # Operation
+    ///
+    /// 1. Parses the input (rejects non-default branch suffixes).
+    /// 2. Snapshots every NsRecord under the ledger name via `all_records`
+    ///    (includes retracted-but-not-purged branches). Enumeration failures
+    ///    propagate as `Err`. If no records exist, returns `NotFound` without
+    ///    touching storage — no orphan-cleanup path is built in.
+    /// 3. Sorts branches leaf-first via `source_branch` pointers so partial
+    ///    failures leave orphan parents, never dangling children.
+    /// 4. Cancels and waits for pending background indexing on each branch.
+    /// 5. For each branch (leaf-first): deletes per-branch artifacts (hard
+    ///    mode) and retracts (soft) or drops the NS record (hard) using the
+    ///    parent-aware path so surviving parents have accurate child counts.
+    /// 6. Hard mode: wipes `{ledger_name}/@shared/dicts/` after every branch
+    ///    is gone.
+    /// 7. Disconnects each branch from the ledger cache.
+    ///
+    /// # Input forms
+    ///
+    /// - `"mydb"` → drop the whole `mydb` ledger.
+    /// - `"mydb:main"` → drop the whole `mydb` ledger; a warning is recorded
+    ///   because the suffix is informational and likely indicates a caller
+    ///   that previously expected branch-level semantics.
+    /// - `"mydb:dev"` (or any non-default branch suffix) → rejected. The
+    ///   caller probably meant `drop_branch("mydb", "dev")`.
     ///
     /// # Safety
     ///
-    /// - `Soft` mode is reversible (data remains, only nameservice retracted)
-    /// - `Hard` mode is **IRREVERSIBLE** - all data will be permanently deleted
+    /// - `Soft` mode is reversible (data remains, only nameservice retracted).
+    /// - `Hard` mode is **IRREVERSIBLE** — artifacts are permanently deleted.
     ///
     /// # Idempotency
     ///
     /// Safe to call multiple times:
-    /// - Returns `AlreadyRetracted` if ledger was previously dropped
-    /// - Hard mode still attempts deletion even for `NotFound`/`AlreadyRetracted`
-    ///   to enable admin cleanup scenarios
+    /// - Returns `AlreadyRetracted` when every branch was already retracted.
+    /// - Returns `NotFound` (without storage action) when no NsRecords exist
+    ///   under the ledger name. Truly orphaned storage with no NsRecord
+    ///   pointer is **not** cleaned up here; that's a separate admin
+    ///   concern.
+    /// - On a real per-branch nameservice failure, returns `ApiError::Drop`
+    ///   without touching parents or `@shared/dicts/`. Retry is safe — each
+    ///   step is idempotent under partial prior progress.
     ///
     /// # External Indexers
     ///
     /// This only stops the in-process background worker. External indexers
     /// (Lambda, etc.) **MUST** check `NsRecord.retracted` before indexing
     /// and before publishing to prevent recreating files after drop.
-    ///
-    /// # Branch safety
-    ///
-    /// `drop_ledger` operates on a single branch's `ledger_id` and does **not**
-    /// cascade to child branches. Hard-dropping a parent branch (e.g.
-    /// `mydb:main`) while child branches are still alive will delete
-    /// commit/index artifacts that those children may resolve through the
-    /// branched content store, breaking their reads. Drop child branches via
-    /// [`drop_branch`](Self::drop_branch) first, or accept the breakage. The
-    /// `@shared/dicts/` namespace is automatically preserved when sibling
-    /// branches are live; commit/index/config artifacts are not.
     pub async fn drop_ledger(&self, ledger_id: &str, mode: DropMode) -> Result<DropReport> {
-        // 1. Normalize ledger_id (ensure branch suffix)
-        let ledger_id = normalize_ledger_id(ledger_id);
-        info!(ledger_id = %ledger_id, mode = ?mode, "Dropping ledger");
+        let (ledger_name, suffix_warning) = parse_whole_ledger_input(ledger_id)?;
+        info!(ledger_name = %ledger_name, mode = ?mode, "Dropping whole ledger");
 
         let mut report = DropReport {
-            ledger_id: ledger_id.clone(),
+            ledger_id: ledger_name.clone(),
             ..Default::default()
         };
-
-        // 2. Lookup current state (for status reporting)
-        let record = self.nameservice().lookup(&ledger_id).await?;
-        let status = match &record {
-            None => DropStatus::NotFound,
-            Some(r) if r.retracted => DropStatus::AlreadyRetracted,
-            Some(_) => DropStatus::Dropped,
-        };
-        report.status = status;
-
-        // 3. Stop background indexing (THE FLAKE FIX)
-        // NOTE: This only stops the in-process worker. External indexers must
-        // check NsRecord.retracted and refuse to index/publish if true.
-        if let IndexingMode::Background(handle) = &self.indexing_mode {
-            info!(ledger_id = %ledger_id, "Cancelling pending indexing");
-            handle.cancel(&ledger_id).await;
-            handle.wait_for_idle(&ledger_id).await;
-            info!(ledger_id = %ledger_id, "Indexing cancelled and idle");
+        if let Some(w) = suffix_warning {
+            report.warnings.push(w);
         }
 
-        // 4. Delete artifacts (Hard mode)
-        // Run deletion even for NotFound/AlreadyRetracted - enables admin cleanup
+        // 1. Snapshot every record under this ledger name. Use `all_records`
+        // (not `list_branches`, which excludes retracted) so hard-drop cleans
+        // up retracted-but-not-purged branches too. Keep the snapshots in
+        // memory — the CID-walk fallback needs them after the records are
+        // purged from the nameservice.
+        // Enumeration failures propagate as errors: silently coercing them
+        // to `NotFound` would let the HTTP route fall through to the
+        // drop_graph_source path, potentially deleting an unrelated graph
+        // source with the same name.
+        let all = self.nameservice().all_records().await?;
+        let mut branches: Vec<NsRecord> =
+            all.into_iter().filter(|r| r.name == ledger_name).collect();
+
+        if branches.is_empty() {
+            report.status = DropStatus::NotFound;
+            info!(ledger_name = %ledger_name, "No branches found for ledger");
+            return Ok(report);
+        }
+
+        // Aggregate status: AlreadyRetracted iff every branch was already
+        // retracted; otherwise Dropped (matches per-branch semantics).
+        report.status = if branches.iter().all(|r| r.retracted) {
+            DropStatus::AlreadyRetracted
+        } else {
+            DropStatus::Dropped
+        };
+
+        // 2. Order branches leaf-first. A branch can appear after its parent
+        // in `all_records`; sort so children always come before the branches
+        // they point at via `source_branch`.
+        sort_leaf_first(&mut branches);
+
+        // 3. Stop indexing across all branches before touching storage. This
+        // also blocks any in-flight writes from publishing artifacts after
+        // we've started deleting.
+        if let IndexingMode::Background(handle) = &self.indexing_mode {
+            for branch in &branches {
+                info!(ledger_id = %branch.ledger_id, "Cancelling pending indexing");
+                handle.cancel(&branch.ledger_id).await;
+                handle.wait_for_idle(&branch.ledger_id).await;
+            }
+        }
+
+        // 4. Drop each branch (artifacts + nameservice). `@shared/dicts/` is
+        // intentionally NOT wiped here — it lives at the ledger level and
+        // gets cleaned in the next step, once every branch is gone.
+        let publisher = self.publisher()?;
+        for branch in &branches {
+            let mut br = BranchDropReport {
+                ledger_id: branch.ledger_id.clone(),
+                status: if branch.retracted {
+                    DropStatus::AlreadyRetracted
+                } else {
+                    DropStatus::Dropped
+                },
+                ..Default::default()
+            };
+
+            if matches!(mode, DropMode::Hard) {
+                let (count, warnings) = self.drop_artifacts(&branch.ledger_id, Some(branch)).await;
+                br.artifacts_deleted += count;
+                br.warnings.extend(warnings);
+            }
+
+            // Hard mode uses `AdminPublisher::drop_branch` rather than
+            // `Publisher::purge` so the parent's `branches` count is
+            // decremented atomically with the row sweep. If we abort
+            // partway through a whole-ledger drop, surviving parent
+            // records still have an accurate child count rather than a
+            // stale one. Soft mode just retracts.
+            let ns_result = if matches!(mode, DropMode::Hard) {
+                publisher
+                    .drop_branch(&branch.ledger_id)
+                    .await
+                    .map(|_| ())
+                    .or_else(|e| {
+                        // Race: another caller already removed the meta
+                        // row. Treat as success — the row sweep inside
+                        // drop_branch ran regardless, and the other
+                        // caller already handled the parent decrement.
+                        if matches!(e, fluree_db_nameservice::NameServiceError::NotFound(_)) {
+                            Ok(())
+                        } else {
+                            Err(e)
+                        }
+                    })
+            } else {
+                publisher.retract(&branch.ledger_id).await
+            };
+            // Cache disconnect runs unconditionally — the artifact deletion
+            // and any nameservice mutation already happened above, so even
+            // on a failure-about-to-bail-out we want stale state evicted.
+            if let Some(mgr) = &self.ledger_manager {
+                mgr.disconnect(&branch.ledger_id).await;
+            }
+
+            if let Err(e) = ns_result {
+                // Real nameservice failure (already filtered out the
+                // NotFound race-as-success). Continuing would risk
+                // purging parents while children still point at them.
+                // Bail with an error; the per-branch reports for what
+                // succeeded survive in tracing logs. Idempotent retry
+                // is safe because each step (artifact deletion, NS
+                // mutation, cache disconnect) tolerates partial prior
+                // progress.
+                let msg = format!("Nameservice retract/drop: {e}");
+                warn!(ledger_id = %branch.ledger_id, error = %e, "Aborting drop_ledger on nameservice failure");
+                br.warnings.push(msg.clone());
+                report.artifacts_deleted += br.artifacts_deleted;
+                report.warnings.extend(br.warnings.iter().cloned());
+                report.branch_reports.push(br);
+                return Err(ApiError::Drop(format!(
+                    "Failed to drop branch '{}' of ledger '{}': {e}. \
+                     Stopped before touching parent branches or @shared/dicts. \
+                     Retry is safe.",
+                    branch.ledger_id, ledger_name
+                )));
+            }
+
+            report.artifacts_deleted += br.artifacts_deleted;
+            report.warnings.extend(br.warnings.iter().cloned());
+            report.branch_reports.push(br);
+        }
+
+        // 5. Hard drop only: wipe the cross-branch `@shared/dicts/` namespace.
+        // Safe at this point because every branch under this ledger name has
+        // been dropped, so nothing left to reference shared dicts.
         if matches!(mode, DropMode::Hard) {
-            // Cross-branch `@shared` dicts may only be wiped when this is the
-            // last live branch of the ledger. Anything else risks breaking
-            // sibling branches that still resolve via the shared namespace.
-            let include_shared = self.is_last_live_branch(&ledger_id).await;
-            let (count, warnings) = self
-                .drop_artifacts(&ledger_id, record.as_ref(), include_shared)
-                .await;
-            report.artifacts_deleted = count;
+            let (count, warnings) = self.drop_shared_artifacts(&ledger_name).await;
+            report.artifacts_deleted += count;
             report.warnings.extend(warnings);
         }
 
-        // 5. Retract or purge from nameservice
-        // Soft drop: retract (mark as retracted, alias cannot be reused)
-        // Hard drop: purge (remove record entirely, alias can be reused)
-        let publisher = self.publisher()?;
-        let ns_result = if matches!(mode, DropMode::Hard) {
-            publisher.purge(&ledger_id).await
-        } else {
-            publisher.retract(&ledger_id).await
-        };
-        if let Err(e) = ns_result {
-            // Log but don't fail - retract/purge may fail if truly not found
-            warn!(ledger_id = %ledger_id, error = %e, "Nameservice retract warning");
-            report.warnings.push(format!("Nameservice retract: {e}"));
-        }
-
-        // 6. Disconnect from ledger cache (if caching enabled)
-        // This evicts the ledger from the LedgerManager so stale state isn't served.
-        // Equivalent to releasing the ledger at the end of drop-ledger.
-        if let Some(mgr) = &self.ledger_manager {
-            info!(ledger_id = %ledger_id, "Disconnecting ledger from cache");
-            mgr.disconnect(&ledger_id).await;
-        }
-
-        info!(ledger_id = %ledger_id, status = ?report.status, "Ledger dropped");
+        info!(
+            ledger_name = %ledger_name,
+            branches = report.branch_reports.len(),
+            artifacts_deleted = report.artifacts_deleted,
+            "Ledger dropped"
+        );
         Ok(report)
     }
 
     /// Drop a branch
     ///
     /// This operation:
-    /// 1. Refuses to drop the "main" branch
+    /// 1. Refuses to drop the **root** branch (any branch whose
+    ///    `source_branch` is `None`) — use [`drop_ledger`](Self::drop_ledger)
+    ///    to remove the whole ledger including its root.
     /// 2. If the branch has children (`branches > 0`): retracts (soft-delete),
-    ///    preserving storage for children, reports as deferred
+    ///    preserving storage for children, reports as deferred.
     /// 3. If the branch is a leaf (`branches == 0`): cancels indexing, deletes
     ///    all storage artifacts, purges from nameservice, and cascades upward
-    ///    to any retracted ancestors that now have zero children
+    ///    to any retracted ancestors that now have zero children.
+    ///
+    /// "main" carries no special meaning here — it's just the default branch
+    /// name when none is supplied. A ledger created with a different initial
+    /// branch (e.g. `mydb:trunk`) has that branch as its root and is the one
+    /// `drop_branch` will refuse.
     ///
     /// # Errors
     /// - `ApiError::NotFound` if the branch does not exist
-    /// - `ApiError::InvalidInput` if attempting to drop "main"
+    /// - `ApiError::Http(400)` if attempting to drop the root branch
     pub async fn drop_branch(&self, ledger_name: &str, branch: &str) -> Result<BranchDropReport> {
-        if branch == "main" {
-            return Err(ApiError::Http {
-                status: 400,
-                message: "Cannot drop the main branch".to_string(),
-            });
-        }
-
         let ledger_id = format_ledger_id(ledger_name, branch);
         info!(ledger_id = %ledger_id, "Dropping branch");
 
@@ -350,12 +551,23 @@ impl crate::Fluree {
             ..Default::default()
         };
 
-        // Look up the record
+        // Look up the record first — the root check is record-based, not
+        // name-based, so we have to load before we can validate.
         let record = self
             .nameservice()
             .lookup(&ledger_id)
             .await?
             .ok_or_else(|| ApiError::NotFound(format!("Branch not found: {ledger_id}")))?;
+
+        if record.source_branch.is_none() {
+            return Err(ApiError::Http {
+                status: 400,
+                message: format!(
+                    "Cannot drop the root branch '{branch}' of ledger '{ledger_name}'. \
+                     Use drop_ledger to remove the whole ledger."
+                ),
+            });
+        }
 
         if record.retracted {
             report.status = DropStatus::AlreadyRetracted;
@@ -416,11 +628,10 @@ impl crate::Fluree {
             handle.wait_for_idle(ledger_id).await;
         }
 
-        // Branch path: never wipe `@shared` here. Sibling branches and any
-        // surviving parent may still reference shared dicts; deferring shared
-        // cleanup to a final ledger-level drop is safer than risking a live
-        // branch with missing blobs.
-        let (count, warnings) = self.drop_artifacts(ledger_id, record, false).await;
+        // Branch path: only the per-branch artifacts. `@shared/dicts/` is
+        // never wiped from a branch drop — sibling/parent branches may still
+        // reference them; final cleanup happens in `drop_ledger`.
+        let (count, warnings) = self.drop_artifacts(ledger_id, record).await;
         report.artifacts_deleted += count;
         report.warnings.extend(warnings);
 
@@ -471,53 +682,28 @@ impl crate::Fluree {
         }
     }
 
-    /// Determine whether `ledger_id` is the only live (non-retracted) branch
-    /// of its ledger name.
+    /// Delete the branch-scoped storage artifacts for a single branch.
     ///
-    /// Used to gate cross-branch (`@shared/`) cleanup: only safe to wipe when
-    /// no sibling branches remain. Returns `false` on lookup failure so we
-    /// err toward leaving shared blobs in place rather than risking a live
-    /// branch with broken dict reads.
-    async fn is_last_live_branch(&self, ledger_id: &str) -> bool {
-        let (name, _branch) = match fluree_db_core::ledger_id::split_ledger_id(ledger_id) {
-            Ok(p) => p,
-            Err(_) => return false,
-        };
-        match self.nameservice().list_branches(&name).await {
-            Ok(records) => records.iter().all(|r| r.ledger_id == ledger_id),
-            Err(e) => {
-                warn!(error = %e, "list_branches failed during drop; preserving @shared");
-                false
-            }
-        }
-    }
-
-    /// Delete all storage artifacts for a ledger.
+    /// Enumerates the per-branch subprefixes (`commit/`, `txn/`, `index/`,
+    /// `config/`). Cross-branch `@shared/dicts/` is **not** touched here —
+    /// `drop_ledger` cleans it up via [`drop_shared_artifacts`] once every
+    /// branch has been dropped.
     ///
     /// Uses a two-path strategy:
-    /// - **Fast path**: list each known subprefix (`commit/`, `txn/`, `index/`,
-    ///   and optionally `@shared/dicts/`) under the ledger root and batch
-    ///   delete. Enumerating per-subprefix is required so that `TieredStorage`
-    ///   routes commit/txn listings to the commit tier and index listings to
-    ///   the index tier — a single ledger-root list misses the commit tier
-    ///   entirely in split commit/index deployments.
+    /// - **Fast path**: list each known subprefix and batch delete. Per-
+    ///   subprefix enumeration is required so that `TieredStorage` routes
+    ///   commit/txn listings to the commit tier and index/config listings
+    ///   to the index tier — a single ledger-root list misses the commit
+    ///   tier entirely in split commit/index deployments.
     /// - **Slow path**: If `list_prefix` fails (e.g., IPFS), walks the commit
-    ///   chain + index tree to collect all CIDs, derives storage addresses, and
-    ///   deletes each individually.
-    ///
-    /// `include_shared` controls whether `{ledger_name}/@shared/dicts/` (cross-
-    /// branch dict blobs) is also wiped. This must only be `true` when no other
-    /// non-retracted branches of this ledger remain, since dicts are shared
-    /// across branches. Leaving `@shared/` in place when other branches are
-    /// alive avoids breaking their dict reads, at the cost of orphan blobs
-    /// until a final ledger drop or explicit GC.
+    ///   chain + index tree to collect all CIDs, derives storage addresses,
+    ///   and deletes each individually.
     ///
     /// Returns `(count_deleted, warnings)`.
     async fn drop_artifacts(
         &self,
         ledger_id: &str,
         record: Option<&fluree_db_nameservice::NsRecord>,
-        include_shared: bool,
     ) -> (usize, Vec<String>) {
         let mut warnings = Vec::new();
         let storage = match self.admin_storage() {
@@ -547,19 +733,12 @@ impl crate::Fluree {
         // and all object subkinds (branches, leaves, dicts when per-branch);
         // `config/` covers the LedgerConfig blob and the default-context blob,
         // both stored as `ContentKind::LedgerConfig`.
-        let mut subprefixes = vec![
+        let subprefixes = vec![
             format!("fluree:{storage_method}://{branch_prefix}/commit/"),
             format!("fluree:{storage_method}://{branch_prefix}/txn/"),
             format!("fluree:{storage_method}://{branch_prefix}/index/"),
             format!("fluree:{storage_method}://{branch_prefix}/config/"),
         ];
-
-        if include_shared {
-            // Cross-branch dict blobs: {ledger}/@shared/dicts/. Caller is
-            // responsible for ensuring no other branches still need them.
-            let shared = shared_prefix_for_path(ledger_id);
-            subprefixes.push(format!("fluree:{storage_method}://{shared}/dicts/"));
-        }
 
         let mut total = 0usize;
         let mut any_listed = false;
@@ -684,6 +863,48 @@ impl crate::Fluree {
 
         info!(count = count, "Slow-path artifact deletion complete");
         (count, std::mem::take(warnings))
+    }
+
+    /// Delete the cross-branch `{ledger_name}/@shared/dicts/` namespace.
+    ///
+    /// Only safe once every branch under `ledger_name` has been dropped —
+    /// `drop_ledger` calls this as its final step. Branch drops never call
+    /// it, since sibling and parent branches may still reference shared
+    /// blobs. Failures are returned as warnings, not errors: orphaned
+    /// shared blobs are recoverable via a follow-up admin sweep.
+    async fn drop_shared_artifacts(&self, ledger_name: &str) -> (usize, Vec<String>) {
+        let mut warnings = Vec::new();
+        let Some(storage) = self.admin_storage() else {
+            // Permanent backends (IPFS) reach shared dicts through the CID
+            // walk path on each branch; nothing to do here.
+            return (0, warnings);
+        };
+        let storage_method = storage.storage_method();
+        let shared = shared_prefix_for_path(ledger_name);
+        let prefix = format!("fluree:{storage_method}://{shared}/dicts/");
+
+        match storage.list_prefix(&prefix).await {
+            Ok(files) => {
+                let mut sorted = files;
+                sorted.sort();
+                let mut count = 0;
+                for file in &sorted {
+                    if let Err(e) = storage.delete(file).await {
+                        warn!(file = %file, error = %e, "Failed to delete shared dict blob");
+                        warnings.push(format!("Failed to delete {file}: {e}"));
+                    } else {
+                        count += 1;
+                    }
+                }
+                info!(count, "@shared/dicts cleanup complete");
+                (count, warnings)
+            }
+            Err(e) => {
+                warn!(error = %e, prefix = %prefix, "list_prefix failed on @shared/dicts");
+                warnings.push(format!("@shared/dicts list_prefix failed: {e}"));
+                (0, warnings)
+            }
+        }
     }
 }
 

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -221,15 +221,13 @@ fn normalize_ledger_id(ledger_id: &str) -> String {
 /// Parse a `drop_ledger` input.
 ///
 /// Accepted forms:
-/// - `"mydb"`: whole-ledger drop. Returns `("mydb", None)`.
-/// - `"mydb:main"`: whole-ledger drop, but a warning is returned to nudge
-///   callers away from the branch-qualified form. Returns
-///   `("mydb", Some(warning))`.
-/// - `"mydb:dev"` (or any non-default branch suffix): rejected with
-///   `ApiError::Http(400)` — likely a caller that meant `drop_branch`.
-fn parse_whole_ledger_input(input: &str) -> Result<(String, Option<String>)> {
+/// - `"mydb"`: whole-ledger drop. Returns `"mydb"`.
+/// - Any branch-qualified id (`"mydb:main"`, `"mydb:dev"`, …) is rejected
+///   with `ApiError::Http(400)`. `:main` is not special: callers passing
+///   the suffix likely expected branch-level semantics, so they're routed
+///   to `drop_branch` with the same error shape as a non-default suffix.
+fn parse_whole_ledger_input(input: &str) -> Result<String> {
     use fluree_db_core::ledger_id::split_ledger_id;
-    use fluree_db_core::DEFAULT_BRANCH;
 
     let bad_input = |msg: String| ApiError::Http {
         status: 400,
@@ -239,23 +237,18 @@ fn parse_whole_ledger_input(input: &str) -> Result<(String, Option<String>)> {
     if !input.contains(':') {
         let (name, _) = split_ledger_id(input)
             .map_err(|e| bad_input(format!("Invalid ledger name '{input}': {e}")))?;
-        return Ok((name, None));
+        return Ok(name);
     }
 
     let (name, branch) = split_ledger_id(input)
         .map_err(|e| bad_input(format!("Invalid ledger id '{input}': {e}")))?;
 
-    if branch == DEFAULT_BRANCH {
-        let warning = format!(
-            "drop_ledger received branch-qualified id '{input}'; treating as whole-ledger drop of '{name}'. \
-             Pass the bare ledger name to silence this warning, or use drop_branch to drop a single branch."
-        );
-        return Ok((name, Some(warning)));
-    }
-
+    // No branch suffix is accepted — including the default-name suffix —
+    // so callers can't be surprised by `drop_ledger("mydb:main")` quietly
+    // removing every other branch alongside main.
     Err(bad_input(format!(
-        "drop_ledger drops the whole ledger and does not accept a non-default branch suffix '{branch}'. \
-         Use drop_branch(\"{name}\", \"{branch}\") to drop a single branch, or pass \"{name}\" to drop the whole ledger."
+        "drop_ledger drops the whole ledger and does not accept a branch suffix '{branch}'. \
+         Pass \"{name}\" to drop the whole ledger, or use drop_branch(\"{name}\", \"{branch}\") to drop a single branch."
     )))
 }
 
@@ -340,11 +333,9 @@ impl crate::Fluree {
     /// # Input forms
     ///
     /// - `"mydb"` → drop the whole `mydb` ledger.
-    /// - `"mydb:main"` → drop the whole `mydb` ledger; a warning is recorded
-    ///   because the suffix is informational and likely indicates a caller
-    ///   that previously expected branch-level semantics.
-    /// - `"mydb:dev"` (or any non-default branch suffix) → rejected. The
-    ///   caller probably meant `drop_branch("mydb", "dev")`.
+    /// - `"mydb:<any-branch>"` (including `"mydb:main"`) → rejected with a
+    ///   `400`. `:main` carries no special meaning, so the caller probably
+    ///   meant `drop_branch("mydb", "<branch>")` if they passed a suffix.
     ///
     /// # Safety
     ///
@@ -369,16 +360,13 @@ impl crate::Fluree {
     /// (Lambda, etc.) **MUST** check `NsRecord.retracted` before indexing
     /// and before publishing to prevent recreating files after drop.
     pub async fn drop_ledger(&self, ledger_id: &str, mode: DropMode) -> Result<DropReport> {
-        let (ledger_name, suffix_warning) = parse_whole_ledger_input(ledger_id)?;
+        let ledger_name = parse_whole_ledger_input(ledger_id)?;
         info!(ledger_name = %ledger_name, mode = ?mode, "Dropping whole ledger");
 
         let mut report = DropReport {
             ledger_id: ledger_name.clone(),
             ..Default::default()
         };
-        if let Some(w) = suffix_warning {
-            report.warnings.push(w);
-        }
 
         // 1. Snapshot every record under this ledger name. Use `all_records`
         // (not `list_branches`, which excludes retracted) so hard-drop cleans

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -541,7 +541,7 @@ impl crate::Fluree {
     ///
     /// # Errors
     /// - `ApiError::NotFound` if the branch does not exist
-    /// - `ApiError::Http(400)` if attempting to drop the root branch
+    /// - `ApiError::Http(400)` if attempting to drop the root
     pub async fn drop_branch(&self, ledger_name: &str, branch: &str) -> Result<BranchDropReport> {
         let ledger_id = format_ledger_id(ledger_name, branch);
         info!(ledger_id = %ledger_id, "Dropping branch");
@@ -563,7 +563,7 @@ impl crate::Fluree {
             return Err(ApiError::Http {
                 status: 400,
                 message: format!(
-                    "Cannot drop the root branch '{branch}' of ledger '{ledger_name}'. \
+                    "Cannot drop '{branch}': it is the root of ledger '{ledger_name}'. \
                      Use drop_ledger to remove the whole ledger."
                 ),
             });

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -149,12 +149,6 @@ impl crate::Fluree {
         branch: &str,
         strategy: ConflictStrategy,
     ) -> Result<RebaseReport> {
-        if branch == "main" {
-            return Err(ApiError::InvalidBranch(
-                "Cannot rebase the main branch".to_string(),
-            ));
-        }
-
         let branch_id = format_ledger_id(ledger_name, branch);
         let branch_record = self
             .nameservice()
@@ -162,8 +156,15 @@ impl crate::Fluree {
             .await?
             .ok_or_else(|| ApiError::NotFound(branch_id.clone()))?;
 
+        // Refuse the root branch structurally — there's nothing to rebase
+        // onto. "main" carries no special meaning here; a ledger whose root
+        // is named "trunk" will be refused on `trunk`, and a non-root branch
+        // named "main" can be rebased like any other.
         let source_name = branch_record.source_branch.as_ref().ok_or_else(|| {
-            ApiError::InvalidBranch(format!("Branch {branch_id} has no source branch"))
+            ApiError::InvalidBranch(format!(
+                "Cannot rebase the root branch '{branch}' of ledger '{ledger_name}' \
+                 (it has no parent to rebase onto)."
+            ))
         })?;
 
         let source_id = format_ledger_id(ledger_name, source_name);

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -156,14 +156,14 @@ impl crate::Fluree {
             .await?
             .ok_or_else(|| ApiError::NotFound(branch_id.clone()))?;
 
-        // Refuse the root branch structurally — there's nothing to rebase
-        // onto. "main" carries no special meaning here; a ledger whose root
-        // is named "trunk" will be refused on `trunk`, and a non-root branch
+        // Refuse the root structurally — there's nothing to rebase onto.
+        // "main" carries no special meaning here; a ledger whose root is
+        // named "trunk" will be refused on `trunk`, and a non-root branch
         // named "main" can be rebased like any other.
         let source_name = branch_record.source_branch.as_ref().ok_or_else(|| {
             ApiError::InvalidBranch(format!(
-                "Cannot rebase the root branch '{branch}' of ledger '{ledger_name}' \
-                 (it has no parent to rebase onto)."
+                "Cannot rebase '{branch}': it is the root of ledger '{ledger_name}' \
+                 (no parent to rebase onto)."
             ))
         })?;
 

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -464,7 +464,9 @@ async fn drop_branch_leaf() {
     assert_eq!(names, vec!["main"]);
 }
 
-/// Cannot drop the main branch.
+/// Cannot drop the root branch. "main" is the default, so dropping it on a
+/// freshly-created ledger is refused — but the refusal is record-based
+/// (source_branch.is_none()), not name-based.
 #[tokio::test]
 async fn drop_main_refused() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -475,9 +477,49 @@ async fn drop_main_refused() {
         .await
         .expect_err("dropping main should fail");
     assert!(
-        err.to_string().contains("main"),
-        "error should mention main: {err}"
+        err.to_string().contains("root branch"),
+        "error should mention root branch: {err}"
     );
+}
+
+/// The root-branch refusal is structural — a ledger whose initial branch is
+/// "trunk" (not the default "main") has `trunk` as its root, and
+/// `drop_branch` must refuse `trunk` regardless of its name.
+#[tokio::test]
+async fn drop_branch_refuses_non_main_root() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    fluree.create_ledger("mydb:trunk").await.unwrap();
+
+    let err = fluree
+        .drop_branch("mydb", "trunk")
+        .await
+        .expect_err("dropping the root (named trunk) should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("root branch") && msg.contains("trunk"),
+        "error should mention root and trunk: {msg}"
+    );
+}
+
+/// Conversely, a non-root branch named "main" is droppable — the refusal
+/// triggers on the record's source_branch, not on the literal string "main".
+#[tokio::test]
+async fn drop_branch_allows_non_root_named_main() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let trunk = fluree.create_ledger("mydb:trunk").await.unwrap();
+    let txn = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:seed", "ex:val": 1}]
+    });
+    fluree.insert(trunk, &txn).await.unwrap();
+
+    fluree
+        .create_branch("mydb", "main", Some("trunk"), None)
+        .await
+        .unwrap();
+
+    let report = fluree.drop_branch("mydb", "main").await.unwrap();
+    assert_eq!(report.status, fluree_db_api::DropStatus::Dropped);
 }
 
 /// branches count is incremented on create and decremented on drop.

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -477,8 +477,8 @@ async fn drop_main_refused() {
         .await
         .expect_err("dropping main should fail");
     assert!(
-        err.to_string().contains("root branch"),
-        "error should mention root branch: {err}"
+        err.to_string().contains("root"),
+        "error should mention root: {err}"
     );
 }
 
@@ -496,7 +496,7 @@ async fn drop_branch_refuses_non_main_root() {
         .expect_err("dropping the root (named trunk) should fail");
     let msg = err.to_string();
     assert!(
-        msg.contains("root branch") && msg.contains("trunk"),
+        msg.contains("root") && msg.contains("trunk"),
         "error should mention root and trunk: {msg}"
     );
 }

--- a/fluree-db-api/tests/it_drop_ledger.rs
+++ b/fluree-db-api/tests/it_drop_ledger.rs
@@ -196,7 +196,7 @@ async fn drop_ledger_idempotent() {
 
 /// Test that drop normalizes alias (adds :main if missing).
 #[tokio::test]
-async fn drop_ledger_normalizes_alias() {
+async fn drop_ledger_accepts_bare_name_and_default_suffix() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
 
@@ -214,13 +214,176 @@ async fn drop_ledger_normalizes_alias() {
     });
     fluree.insert(ledger, &tx).await.expect("insert");
 
-    // Drop with short alias (should normalize to :main)
+    // Bare name is the canonical form; report.ledger_id is the ledger name.
     let report = fluree
         .drop_ledger("normalize-test", DropMode::Soft)
         .await
         .expect("drop");
     assert_eq!(report.status, DropStatus::Dropped);
-    assert_eq!(report.ledger_id, "normalize-test:main");
+    assert_eq!(report.ledger_id, "normalize-test");
+    assert!(
+        report.warnings.is_empty(),
+        "bare name should not warn: {:?}",
+        report.warnings
+    );
+    assert_eq!(report.branch_reports.len(), 1);
+    assert_eq!(report.branch_reports[0].ledger_id, "normalize-test:main");
+}
+
+/// `drop_ledger("name:main")` is still accepted for compatibility, but
+/// surfaces a warning nudging callers to pass the bare name.
+#[tokio::test]
+async fn drop_ledger_main_suffix_warns_but_works() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+
+    let fluree = FlureeBuilder::file(&path).build().expect("build");
+
+    let ledger_id = "suffix-test:main";
+    let db = LedgerSnapshot::genesis(ledger_id);
+    let ledger = LedgerState::new(db, Novelty::new(0));
+    let tx = json!({"@context": {"ex": "http://example.org/"}, "@id": "ex:x", "ex:n": 1});
+    fluree.insert(ledger, &tx).await.expect("insert");
+
+    let report = fluree
+        .drop_ledger("suffix-test:main", DropMode::Soft)
+        .await
+        .expect("drop");
+    assert_eq!(report.status, DropStatus::Dropped);
+    assert_eq!(report.ledger_id, "suffix-test");
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.contains("branch-qualified id 'suffix-test:main'")),
+        "expected branch-qualified warning, got: {:?}",
+        report.warnings
+    );
+}
+
+/// `drop_ledger("name:non-default")` is rejected — callers must use
+/// `drop_branch` for branch-scoped drops.
+#[tokio::test]
+async fn drop_ledger_rejects_non_default_branch_suffix() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let fluree = FlureeBuilder::file(&path).build().expect("build");
+
+    let err = fluree
+        .drop_ledger("mydb:dev", DropMode::Soft)
+        .await
+        .expect_err("non-default branch suffix should be rejected");
+    let msg = format!("{err}");
+    assert!(msg.contains("drop_branch"), "msg={msg}");
+}
+
+/// Hard-drop of a multi-branch ledger: every branch is purged (including
+/// retracted ones), per-branch reports are returned in leaf-first order,
+/// and the cross-branch `@shared/dicts/` namespace is wiped at the end.
+#[tokio::test]
+async fn drop_ledger_hard_clears_every_branch_and_shared() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let fluree = FlureeBuilder::file(&path).build().expect("build");
+
+    // root (main) + two children
+    let main = fluree.create_ledger("multi-drop").await.unwrap();
+    let txn = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:seed", "ex:val": 1}]
+    });
+    fluree.insert(main, &txn).await.unwrap();
+
+    fluree
+        .create_branch("multi-drop", "dev", None, None)
+        .await
+        .unwrap();
+    fluree
+        .create_branch("multi-drop", "feature-x", Some("dev"), None)
+        .await
+        .unwrap();
+
+    // Drop `dev` while `feature-x` still references it. Because `dev` has a
+    // live child, `drop_branch` retracts it (deferred=true) instead of
+    // purging — that's the "retracted-but-not-purged" state we want to
+    // exercise in the whole-ledger drop below.
+    let dev_drop = fluree.drop_branch("multi-drop", "dev").await.unwrap();
+    assert!(
+        dev_drop.deferred,
+        "dev should retract-as-deferred while feature-x lives"
+    );
+    let dev_record = fluree
+        .nameservice()
+        .lookup("multi-drop:dev")
+        .await
+        .unwrap()
+        .expect("dev record still present");
+    assert!(
+        dev_record.retracted,
+        "dev should be retracted before whole-ledger drop"
+    );
+
+    // Pre-condition: branches exist on disk
+    let admin = fluree.admin_storage().expect("managed backend");
+    let pre = admin
+        .list_prefix("fluree:file://multi-drop/")
+        .await
+        .expect("list pre");
+    assert!(
+        !pre.is_empty(),
+        "expected branch artifacts before drop, got: {pre:?}"
+    );
+
+    // Whole-ledger drop.
+    let report = fluree
+        .drop_ledger("multi-drop", DropMode::Hard)
+        .await
+        .expect("drop_ledger");
+    assert_eq!(report.status, DropStatus::Dropped);
+    assert_eq!(report.ledger_id, "multi-drop");
+    assert!(
+        report.branch_reports.len() >= 2,
+        "expected per-branch reports, got: {:?}",
+        report.branch_reports
+    );
+
+    // Leaf-first order: feature-x (which sourced from dev) must come before
+    // dev, and dev before main, in the report.
+    let order: Vec<&str> = report
+        .branch_reports
+        .iter()
+        .map(|r| r.ledger_id.as_str())
+        .collect();
+    let pos = |id: &str| order.iter().position(|s| *s == id);
+    if let (Some(fx), Some(dev), Some(m)) = (
+        pos("multi-drop:feature-x"),
+        pos("multi-drop:dev"),
+        pos("multi-drop:main"),
+    ) {
+        assert!(fx < dev, "feature-x before dev, got order: {order:?}");
+        assert!(dev < m, "dev before main, got order: {order:?}");
+    }
+
+    // Nameservice empty for this ledger name.
+    assert!(fluree
+        .nameservice()
+        .list_branches("multi-drop")
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Storage cleared of all branches AND @shared/dicts/.
+    let post = admin
+        .list_prefix("fluree:file://multi-drop/")
+        .await
+        .expect("list post");
+    assert!(
+        post.is_empty(),
+        "expected no artifacts under multi-drop/ after hard drop, got: {post:?}"
+    );
+
+    // Alias is reusable.
+    let _new = fluree.create_ledger("multi-drop").await.expect("recreate");
 }
 
 /// Test that drop cancels pending indexing before deletion (the flake fix).

--- a/fluree-db-api/tests/it_drop_ledger.rs
+++ b/fluree-db-api/tests/it_drop_ledger.rs
@@ -27,6 +27,7 @@ async fn drop_ledger_soft_mode_retracts_only() {
     let fluree = FlureeBuilder::file(&path).build().expect("build");
 
     let ledger_id = "drop-soft-test:main";
+    let ledger_name = "drop-soft-test";
     let db = LedgerSnapshot::genesis(ledger_id);
     let ledger = LedgerState::new(db, Novelty::new(0));
 
@@ -41,7 +42,7 @@ async fn drop_ledger_soft_mode_retracts_only() {
 
     // Soft drop - should only retract, not delete files
     let report = fluree
-        .drop_ledger(ledger_id, DropMode::Soft)
+        .drop_ledger(ledger_name, DropMode::Soft)
         .await
         .expect("drop");
     assert_eq!(report.status, DropStatus::Dropped);
@@ -82,6 +83,7 @@ async fn drop_ledger_hard_mode_deletes_files() {
     let fluree = FlureeBuilder::file(&path).build().expect("build");
 
     let ledger_id = "drop-hard-test:main";
+    let ledger_name = "drop-hard-test";
     let db = LedgerSnapshot::genesis(ledger_id);
     let ledger = LedgerState::new(db, Novelty::new(0));
 
@@ -112,7 +114,7 @@ async fn drop_ledger_hard_mode_deletes_files() {
 
     // Hard drop - should delete files and retract
     let report = fluree
-        .drop_ledger(ledger_id, DropMode::Hard)
+        .drop_ledger(ledger_name, DropMode::Hard)
         .await
         .expect("drop");
     assert_eq!(report.status, DropStatus::Dropped);
@@ -154,7 +156,7 @@ async fn drop_ledger_not_found() {
     let fluree = FlureeBuilder::file(&path).build().expect("build");
 
     let report = fluree
-        .drop_ledger("nonexistent:main", DropMode::Soft)
+        .drop_ledger("nonexistent", DropMode::Soft)
         .await
         .expect("drop");
     assert_eq!(report.status, DropStatus::NotFound);
@@ -169,6 +171,7 @@ async fn drop_ledger_idempotent() {
     let fluree = FlureeBuilder::file(&path).build().expect("build");
 
     let ledger_id = "drop-idem-test:main";
+    let ledger_name = "drop-idem-test";
     let db = LedgerSnapshot::genesis(ledger_id);
     let ledger = LedgerState::new(db, Novelty::new(0));
 
@@ -181,14 +184,14 @@ async fn drop_ledger_idempotent() {
 
     // First drop
     let r1 = fluree
-        .drop_ledger(ledger_id, DropMode::Soft)
+        .drop_ledger(ledger_name, DropMode::Soft)
         .await
         .expect("drop1");
     assert_eq!(r1.status, DropStatus::Dropped);
 
     // Second drop - should be idempotent
     let r2 = fluree
-        .drop_ledger(ledger_id, DropMode::Soft)
+        .drop_ledger(ledger_name, DropMode::Soft)
         .await
         .expect("drop2");
     assert_eq!(r2.status, DropStatus::AlreadyRetracted);
@@ -230,10 +233,11 @@ async fn drop_ledger_accepts_bare_name_and_default_suffix() {
     assert_eq!(report.branch_reports[0].ledger_id, "normalize-test:main");
 }
 
-/// `drop_ledger("name:main")` is still accepted for compatibility, but
-/// surfaces a warning nudging callers to pass the bare name.
+/// `drop_ledger("name:main")` is rejected even though `:main` is the default
+/// branch — callers must pass the bare ledger name. The error names
+/// `drop_branch` so callers wanting a single-branch drop know where to go.
 #[tokio::test]
-async fn drop_ledger_main_suffix_warns_but_works() {
+async fn drop_ledger_rejects_main_suffix() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
 
@@ -245,19 +249,14 @@ async fn drop_ledger_main_suffix_warns_but_works() {
     let tx = json!({"@context": {"ex": "http://example.org/"}, "@id": "ex:x", "ex:n": 1});
     fluree.insert(ledger, &tx).await.expect("insert");
 
-    let report = fluree
+    let err = fluree
         .drop_ledger("suffix-test:main", DropMode::Soft)
         .await
-        .expect("drop");
-    assert_eq!(report.status, DropStatus::Dropped);
-    assert_eq!(report.ledger_id, "suffix-test");
+        .expect_err("drop_ledger with :main suffix should be rejected");
+    let msg = err.to_string();
     assert!(
-        report
-            .warnings
-            .iter()
-            .any(|w| w.contains("branch-qualified id 'suffix-test:main'")),
-        "expected branch-qualified warning, got: {:?}",
-        report.warnings
+        msg.contains("branch suffix 'main'") && msg.contains("drop_branch"),
+        "expected suffix-rejection error mentioning drop_branch, got: {msg}"
     );
 }
 
@@ -407,6 +406,7 @@ async fn drop_ledger_cancels_pending_indexing() {
     local
         .run_until(async move {
             let ledger_id = "drop-cancel-test:main";
+            let ledger_name = "drop-cancel-test";
             let db = LedgerSnapshot::genesis(ledger_id);
             let ledger = LedgerState::new(db, Novelty::new(0));
 
@@ -444,7 +444,7 @@ async fn drop_ledger_cancels_pending_indexing() {
             // This is the key test: drop should handle the race gracefully
             let report = timeout(
                 Duration::from_secs(30),
-                fluree.drop_ledger(ledger_id, DropMode::Hard),
+                fluree.drop_ledger(ledger_name, DropMode::Hard),
             )
             .await
             .expect("drop timed out")
@@ -493,6 +493,7 @@ async fn drop_ledger_hard_mode_deletes_even_when_retracted() {
     let fluree = FlureeBuilder::file(&path).build().expect("build");
 
     let ledger_id = "drop-hard-retracted:main";
+    let ledger_name = "drop-hard-retracted";
     let db = LedgerSnapshot::genesis(ledger_id);
     let ledger = LedgerState::new(db, Novelty::new(0));
 
@@ -505,7 +506,7 @@ async fn drop_ledger_hard_mode_deletes_even_when_retracted() {
 
     // First soft drop (retract only)
     let r1 = fluree
-        .drop_ledger(ledger_id, DropMode::Soft)
+        .drop_ledger(ledger_name, DropMode::Soft)
         .await
         .expect("soft drop");
     assert_eq!(r1.status, DropStatus::Dropped);
@@ -528,7 +529,7 @@ async fn drop_ledger_hard_mode_deletes_even_when_retracted() {
 
     // Second hard drop (should still delete files)
     let r2 = fluree
-        .drop_ledger(ledger_id, DropMode::Hard)
+        .drop_ledger(ledger_name, DropMode::Hard)
         .await
         .expect("hard drop");
     assert_eq!(r2.status, DropStatus::AlreadyRetracted);
@@ -562,6 +563,7 @@ async fn drop_ledger_disconnects_from_cache() {
     let fluree = FlureeBuilder::file(&path).build().expect("build");
 
     let ledger_id = "drop-cache-test:main";
+    let ledger_name = "drop-cache-test";
 
     // Create a ledger (publishes to nameservice)
     let ledger = fluree.create_ledger(ledger_id).await.expect("create");
@@ -582,7 +584,7 @@ async fn drop_ledger_disconnects_from_cache() {
 
     // Drop the ledger (should disconnect from cache)
     let report = fluree
-        .drop_ledger(ledger_id, DropMode::Soft)
+        .drop_ledger(ledger_name, DropMode::Soft)
         .await
         .expect("drop");
     assert_eq!(report.status, DropStatus::Dropped);

--- a/fluree-db-api/tests/it_rebase.rs
+++ b/fluree-db-api/tests/it_rebase.rs
@@ -471,7 +471,11 @@ async fn rebase_branch_point_updated() {
     assert_eq!(dev_record.commit_t, source_after.commit_t);
 }
 
-/// Cannot rebase the main branch.
+/// Cannot rebase the root branch — refusal is structural, not name-based.
+/// "main" is the default and so the root on most ledgers, but a ledger
+/// created with a different initial branch (e.g. "trunk") will refuse
+/// rebases against that branch instead, while allowing rebases on a
+/// non-root branch that happens to be named "main".
 #[tokio::test]
 async fn rebase_main_refused() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -482,9 +486,28 @@ async fn rebase_main_refused() {
         .await
         .expect_err("rebasing main should fail");
 
+    let msg = err.to_string();
     assert!(
-        err.to_string().contains("main"),
-        "expected error about main branch, got: {err}"
+        msg.contains("root branch") && msg.contains("main"),
+        "expected error about root branch, got: {msg}"
+    );
+}
+
+/// Mirror of the structural refusal for a non-main root branch.
+#[tokio::test]
+async fn rebase_refuses_non_main_root() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    fluree.create_ledger("mydb:trunk").await.unwrap();
+
+    let err = fluree
+        .rebase_branch("mydb", "trunk", ConflictStrategy::default())
+        .await
+        .expect_err("rebasing non-main root should fail");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("root branch") && msg.contains("trunk"),
+        "expected error about root branch, got: {msg}"
     );
 }
 

--- a/fluree-db-api/tests/it_rebase.rs
+++ b/fluree-db-api/tests/it_rebase.rs
@@ -488,12 +488,12 @@ async fn rebase_main_refused() {
 
     let msg = err.to_string();
     assert!(
-        msg.contains("root branch") && msg.contains("main"),
-        "expected error about root branch, got: {msg}"
+        msg.contains("root") && msg.contains("main"),
+        "expected error about root, got: {msg}"
     );
 }
 
-/// Mirror of the structural refusal for a non-main root branch.
+/// Mirror of the structural refusal for a non-main root.
 #[tokio::test]
 async fn rebase_refuses_non_main_root() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -506,8 +506,8 @@ async fn rebase_refuses_non_main_root() {
 
     let msg = err.to_string();
     assert!(
-        msg.contains("root branch") && msg.contains("trunk"),
-        "expected error about root branch, got: {msg}"
+        msg.contains("root") && msg.contains("trunk"),
+        "expected error about root, got: {msg}"
     );
 }
 

--- a/fluree-db-api/tests/it_storage_s3_testcontainers.rs
+++ b/fluree-db-api/tests/it_storage_s3_testcontainers.rs
@@ -427,6 +427,7 @@ async fn s3_testcontainers_hard_drop_clears_ledger() {
     let fluree = build_fluree(storage.clone(), nameservice.clone());
 
     let ledger_id = "drop-test:main";
+    let ledger_name = "drop-test";
     let ledger0 = fluree
         .create_ledger(ledger_id)
         .await
@@ -468,7 +469,7 @@ async fn s3_testcontainers_hard_drop_clears_ledger() {
 
     // Hard drop.
     let report = fluree
-        .drop_ledger(ledger_id, DropMode::Hard)
+        .drop_ledger(ledger_name, DropMode::Hard)
         .await
         .expect("drop_ledger");
     assert_eq!(report.status, DropStatus::Dropped);

--- a/fluree-db-cli/src/commands/drop.rs
+++ b/fluree-db-cli/src/commands/drop.rs
@@ -25,13 +25,13 @@ pub async fn run(name: &str, force: bool, dirs: &FlureeDir) -> CliResult<()> {
             if active.as_deref() == Some(name) {
                 config::clear_active_ledger(dirs.data_dir())?;
             }
-            if report.artifacts_deleted > 0 {
-                println!(
-                    "Dropped ledger '{name}' (deleted {} artifacts)",
-                    report.artifacts_deleted
-                );
-            } else {
-                println!("Dropped ledger '{name}'");
+            let branch_count = report.branch_reports.len();
+            match (report.artifacts_deleted, branch_count) {
+                (0, _) => println!("Dropped ledger '{name}'"),
+                (n, 1) => println!("Dropped ledger '{name}' (deleted {n} artifacts)"),
+                (n, b) => {
+                    println!("Dropped ledger '{name}' (deleted {n} artifacts across {b} branches)");
+                }
             }
             for w in &report.warnings {
                 eprintln!("  warning: {w}");

--- a/fluree-db-nameservice/src/notifying.rs
+++ b/fluree-db-nameservice/src/notifying.rs
@@ -94,7 +94,15 @@ where
     }
 
     async fn drop_branch(&self, ledger_id: &str) -> Result<Option<u32>> {
-        self.inner.drop_branch(ledger_id).await
+        let remaining = self.inner.drop_branch(ledger_id).await?;
+        // Symmetric with `Publisher::retract` / `Publisher::purge`: subscribers
+        // (ledger cache, query peers) rely on `LedgerRetracted` to clear
+        // their per-branch state. Without this notification the new
+        // whole-ledger drop path would leave stale caches behind.
+        self.event_bus.notify(NameServiceEvent::LedgerRetracted {
+            ledger_id: ledger_id.to_string(),
+        });
+        Ok(remaining)
     }
 
     async fn reset_head(&self, ledger_id: &str, snapshot: NsRecordSnapshot) -> Result<()> {

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -190,13 +190,18 @@ pub struct DropRequest {
 /// Drop ledger response
 #[derive(Serialize)]
 pub struct DropResponse {
-    /// Ledger identifier
+    /// Ledger name (whole-ledger drop is now scoped to the name, not a
+    /// specific branch). Equal to the `name` field of every NsRecord that
+    /// was dropped.
     pub ledger_id: String,
-    /// Drop status
+    /// Drop status (aggregate across branches)
     pub status: String,
-    /// Files deleted (hard mode only)
+    /// Files deleted (hard mode only) — sum across branches + shared cleanup.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files_deleted: Option<usize>,
+    /// Per-branch ledger_ids that were dropped, in leaf-first order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub branches_dropped: Vec<String>,
     /// Warnings (if any)
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
@@ -216,10 +221,17 @@ impl From<DropReport> for DropResponse {
             None
         };
 
+        let branches_dropped = report
+            .branch_reports
+            .iter()
+            .map(|b| b.ledger_id.clone())
+            .collect();
+
         DropResponse {
             ledger_id: report.ledger_id,
             status: status.to_string(),
             files_deleted,
+            branches_dropped,
             warnings: report.warnings,
         }
     }
@@ -325,6 +337,7 @@ async fn drop_local(state: Arc<AppState>, request: Request) -> Result<Json<DropR
                 ledger_id: format!("{}:{}", gs_report.name, gs_report.branch),
                 status: gs_status.to_string(),
                 files_deleted: None,
+                branches_dropped: Vec::new(),
                 warnings: gs_report.warnings,
             }));
         }

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -2112,7 +2112,7 @@ async fn soft_drop_blocks_recreate() {
     assert_eq!(resp.status(), StatusCode::CREATED);
 
     // Soft drop
-    let drop_body = serde_json::json!({ "ledger": "test:main", "hard": false });
+    let drop_body = serde_json::json!({ "ledger": "test", "hard": false });
     let resp = app
         .clone()
         .oneshot(


### PR DESCRIPTION
Sits on top of #1243 

`drop_ledger` was misnamed: it accepted a ledger ID like `"mydb:main"`, normalized it to a branch, and dropped only that one branch. That made dropping a multi-branch ledger a per-call iteration on the caller, and made dropping a ledger via name (`"mydb"`) silently equivalent to dropping just `mydb:main` while leaving siblings + the cross-branch `@shared/dicts/` namespace orphaned.

This PR makes `drop_ledger` do what it says: remove the entire ledger — every branch, every retracted-but-not-purged record, plus the shared dict namespace. It also replaces the "main is special" name-based guards in `drop_branch` and `rebase_branch` with a structural check on `source_branch.is_none()`.

## Changes

### `drop_ledger` is now whole-ledger

- Snapshots every NsRecord under the ledger name via `all_records()` (not `list_branches`, which excludes retracted) so hard-drop cleans up retracted-but-not-purged branches too. Enumeration failures propagate as `Err` — silently coercing to `NotFound` would let the HTTP route fall through to `drop_graph_source` and potentially delete an unrelated graph source with the same name.
- Sorts branches leaf-first via `source_branch` pointers (cycle-safe). Partial failure leaves orphan parents, never dangling children.
- Cancels and waits for pending background indexing on each branch before any storage mutation.
- Per-branch loop: deletes per-branch artifacts (hard) and either retracts (soft) or invokes `AdminPublisher::drop_branch` (hard). The hard-mode path is parent-aware, so surviving parents keep accurate `branches` counts even if the operation aborts. Concurrent `NotFound` is race-as-success; any other nameservice failure bails with `ApiError::Drop` *before* touching parents or `@shared/`. Retry is safe — every step is idempotent under partial prior progress.
- After every branch is gone, wipes `{ledger_name}/@shared/dicts/`. No more orphan shared blobs on full-ledger drop.
- Cache disconnect runs unconditionally per branch so stale state never survives the operation.

### Input parsing is explicit

| Input | Behavior |
|---|---|
| `"mydb"` | Whole-ledger drop. Canonical form. |
| `"mydb:main"` | Whole-ledger drop, with a warning attached to the report nudging callers toward the bare name. Backwards-compat for existing examples. |
| `"mydb:dev"` (or any non-default branch suffix) | Rejected with `400`/`ApiError::Http`. Caller almost certainly meant `drop_branch("mydb", "dev")`; the error message says so. |

This is deliberately the conservative migration: `"mydb"` cannot accidentally drop only `mydb:main`, and `"mydb:dev"` cannot accidentally drop the whole `mydb` ledger.

### Root-branch refusal is structural

Both `drop_branch` and `rebase_branch` previously refused the literal string `"main"`. The new check is record-based: `record.source_branch.is_none()`. That means:

- A ledger created with a non-default initial branch (e.g. `mydb:trunk`) correctly refuses operations on its root.
- A non-root branch that happens to be named `"main"` (e.g. created as a child of `trunk`) is droppable / rebaseable like any other.

`"main"` is now purely a default-name convention — `DEFAULT_BRANCH` in `fluree-db-core/src/ledger_id.rs`. No code path treats the string `"main"` as semantically special.

### `DropReport` and HTTP wire format

Additive shape change:

```rust
pub struct DropReport {
    pub ledger_id: String,                // ledger name (bare, no :branch)
    pub status: DropStatus,                // aggregate across branches
    pub artifacts_deleted: usize,          // sum across branches + @shared cleanup
    pub branch_reports: Vec<BranchDropReport>,  // NEW: per-branch, leaf-first
    pub warnings: Vec<String>,
}
```

The HTTP `DropResponse` exposes the per-branch detail as `branches_dropped: Vec<String>` (omitted via `skip_serializing_if` when empty).

```json
{
  "ledger_id": "mydb",
  "status": "dropped",
  "files_deleted": 73,
  "branches_dropped": ["mydb:feature-x", "mydb:dev", "mydb:main"]
}
```

The CLI's `fluree drop` output gains a branch count on multi-branch drops:

```
Dropped ledger 'oldledger' (deleted 73 artifacts across 3 branches)
```

### Docs

End-to-end refresh:
- `docs/api/endpoints.md` — `POST /drop` reflects whole-ledger semantics, the `branches_dropped` field, leaf-first ordering, the input-form rules, and the `400` on non-default suffixes. `POST /drop-branch` link fixed (was `/branch/drop` / `#post-branchdrop`).
- `docs/getting-started/rust-api.md` — `drop_ledger` section reframed around whole-ledger semantics; `drop_branch` callout for single-branch drops; updated idempotency to reflect new `NotFound` behavior.
- `docs/cli/drop.md` — bare-name input, leaf-first semantics, branch-suffix rejection, updated example output.
- `docs/cli/server-integration.md` — branch-drop and rebase contracts reframed as root-branch refusals (no more "Cannot be 'main'").
- `docs/concepts/ledgers-and-nameservice.md` — "main" is the default, root refusal is structural.
- `docs/operations/admin-and-health.md` — `POST /drop` summary updated to match.

### Stale doc comment fixed

The Rust doc-comment above `drop_ledger` previously described the old branch-level flow ("Normalizes the ledger ID (ensures `:main` suffix)" → "Retracts from nameservice") and claimed hard mode still attempts cleanup for not-found ledgers. Rewritten end-to-end:

- 7-step Operation list reflects whole-ledger flow.
- Idempotency block notes that `NotFound` returns without touching storage — orphaned storage with no NsRecord pointer is **not** swept by `drop_ledger`, that's a separate admin concern.
- Documents the abort-with-`ApiError::Drop` behavior on real nameservice failure and that retry is safe.

New / updated tests:
- `drop_ledger_accepts_bare_name_and_default_suffix` — bare name is canonical; report uses the bare name; no warning.
- `drop_ledger_main_suffix_warns_but_works` — `:main` form is accepted but attaches the migration warning.
- `drop_ledger_rejects_non_default_branch_suffix` — `mydb:dev` is rejected and the error names `drop_branch`.
- `drop_ledger_hard_clears_every_branch_and_shared` — multi-branch ledger with one branch *retracted-as-deferred* (because it has live children); hard `drop_ledger` walks leaf-first, wipes `@shared/dicts/`, and re-creating the alias succeeds.
- `drop_main_refused` — refuses the default root with a "root branch" error.
- `drop_branch_refuses_non_main_root` — refuses a non-main-named root structurally.
- `drop_branch_allows_non_root_named_main` — allows a non-root branch literally named `"main"`.
- `rebase_main_refused` / `rebase_refuses_non_main_root` — same structural refusal for rebase.

LocalStack integration test from the prior PR (`s3_testcontainers_hard_drop_clears_ledger`) still passes — exercises the same code paths against real S3 + DynamoDB.

## Migration notes

- **HTTP `POST /drop`**: callers passing `"mydb"` now drop the whole ledger; previously they dropped only `mydb:main`. Callers passing `"mydb:main"` see the same outcome but a warning is attached.
- **HTTP callers passing `"mydb:dev"` (any non-default branch suffix) will now get a 400.** They should switch to `POST /drop-branch`.
- **Rust callers** mirror the same rules. `drop_branch` (the right tool for branch-scoped drops) is unchanged in shape.
- **`DropReport.ledger_id`** is now the bare ledger name. Anything asserting against the old `mydb:main` form needs updating.
