### PR TITLE
  fix: Complete incremental indexing on Standard S3

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -177,6 +177,7 @@
   - [Configuration](operations/configuration.md)
   - [Running with Docker](operations/docker.md)
   - [Storage modes (memory/file/AWS/IPFS)](operations/storage.md)
+  - [Serverless storage choices](operations/serverless-storage.md)
   - [IPFS storage](operations/ipfs-storage.md)
   - [DynamoDB nameservice](operations/dynamodb-guide.md)
   - [Query peers and replication](operations/query-peers.md)

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -202,7 +202,7 @@ Connection node:
 
 Storage node:
 - File: `filePath`, `AES256Key`
-- S3: `s3Bucket`, `s3Prefix`, `s3Endpoint`, `s3ReadTimeoutMs`, `s3WriteTimeoutMs`, `s3ListTimeoutMs`, `s3MaxRetries`, `s3RetryBaseDelayMs`, `s3RetryMaxDelayMs`
+- S3: `s3Bucket`, `s3Prefix`, `s3Endpoint`, `s3ReadTimeoutMs`, `s3WriteTimeoutMs`, `s3ListTimeoutMs`, `s3MaxRetries`, `s3RetryBaseDelayMs`, `s3RetryMaxDelayMs`, `s3MaxConcurrentRequests`
 
 Publisher node:
 - DynamoDB nameservice: `dynamodbTable`, `dynamodbRegion`, `dynamodbEndpoint`, `dynamodbTimeoutMs`

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -32,6 +32,14 @@ Storage backend options:
 - Storage selection criteria
 - Switching between storage modes
 
+### [Serverless Storage Choices](serverless-storage.md)
+
+Cloud/serverless storage placement guidance:
+- Standard S3 vs S3 Express One Zone for index storage
+- Why commits should normally remain on Standard S3
+- Expected transaction, query, and indexing latency ranges
+- Lambda disk cache and S3 concurrency tuning notes
+
 ### [IPFS Storage](ipfs-storage.md)
 
 IPFS-specific setup and configuration:

--- a/docs/operations/serverless-storage.md
+++ b/docs/operations/serverless-storage.md
@@ -1,0 +1,149 @@
+# Serverless Storage Choices
+
+This guide covers storage placement for cloud and serverless deployments, especially
+AWS Lambda-style architectures where commit writes, background indexing, and query
+execution may run in separate warm containers.
+
+## Short Recommendation
+
+Use **Standard S3 for commits**. Commits are the durable source of truth and should
+use the strongest redundancy profile available. Indexes are derived from commits
+and can be rebuilt, so index storage can be optimized separately.
+
+For indexes:
+
+- Choose **Standard S3** when cost, multi-AZ durability, and operational simplicity
+  matter more than the lowest cold-read/indexing latency.
+- Choose **S3 Express One Zone** when you need lower latency for cold queries,
+  sustained incremental indexing, or workloads that touch many small index blobs.
+- Keep a local disk artifact cache enabled for Lambda/query/indexer workers. It
+  is what makes hot query performance largely independent of the remote index
+  bucket.
+
+## Commit Storage
+
+Commit blobs are immutable and are the canonical history of the ledger. Indexes,
+statistics, and derived query structures can always be reconstructed from commits.
+
+For that reason, prefer Standard S3 for `commitStorage` even when using S3 Express
+One Zone for `indexStorage`:
+
+```json
+{
+  "@context": {
+    "@base": "https://ns.flur.ee/config/connection/",
+    "@vocab": "https://ns.flur.ee/system#"
+  },
+  "@graph": [
+    {
+      "@id": "commitStorage",
+      "@type": "Storage",
+      "s3Bucket": "fluree-commits",
+      "s3Prefix": "commits/"
+    },
+    {
+      "@id": "indexStorage",
+      "@type": "Storage",
+      "s3Bucket": "fluree-index--use1-az1--x-s3",
+      "s3Prefix": "indexes/"
+    },
+    {
+      "@id": "connection",
+      "@type": "Connection",
+      "commitStorage": { "@id": "commitStorage" },
+      "indexStorage": { "@id": "indexStorage" }
+    }
+  ]
+}
+```
+
+When using S3 Express One Zone, omit `s3Endpoint` and let the AWS SDK resolve the
+directory-bucket endpoint.
+
+## What To Expect
+
+Every database and query shape is different. The ranges below come from internal
+serverless benchmarks using identical Lambda binaries, one stack backed by
+Standard S3 for indexes and one backed by S3 Express One Zone for indexes. Dataset
+names and customer-specific identifiers are intentionally omitted.
+
+### Transactions
+
+Transactions showed no meaningful difference between Standard S3 and S3 Express
+for index storage.
+
+In the benchmark, transaction wall time was dominated by the synchronous commit
+path through the transactor and queueing layer, not by index storage. Across a
+medium staged JSON-LD workload, both backends landed in the same rough multi-second
+range per commit, with differences lost in normal Lambda and queue variance.
+
+### Queries
+
+Hot queries should show little to no difference. Once the relevant root, branch,
+leaf, dictionary, and sidecar artifacts are in local memory or the disk artifact
+cache, the remote bucket is no longer on the critical path.
+
+For cold or partially warm queries:
+
+- Simple lookups that touch only a small number of index blobs are usually close.
+  Expect roughly no measurable difference to about a 30% slowdown on Standard S3.
+- Queries that touch many index blobs can show a larger cold-cache gap, because
+  Standard S3 has higher per-object latency and the penalty compounds with the
+  number of small reads.
+- If background indexing falls behind, query latency can degrade for reasons
+  unrelated to S3 Express vs Standard S3. The query engine may need to account
+  for unindexed commits, and that work grows with the indexing gap.
+
+In one small synthetic workload, Standard S3 query medians were about 10-35%
+slower before cache effects dominated. In a medium staged workload with the
+indexer keeping up, Standard and Express query medians were effectively
+indistinguishable, with individual queries varying by normal runtime noise.
+
+### Indexing
+
+Indexing is the area where index bucket choice is most visible. Incremental
+indexing reads and writes many small content-addressed artifacts: roots, branch
+manifests, leaves, sidecars, dictionaries, sketches, and other derived blobs.
+S3 Express One Zone is optimized for this small-object, low-latency access pattern.
+
+In a medium staged workload of roughly 8.5 MB JSON-LD, about 10,000 subjects, and
+five commits, Standard S3 indexing was consistently slower but completed cleanly:
+
+| Index Event | Express Indexing | Standard S3 Indexing | Standard / Express |
+|-------------|------------------|----------------------|--------------------|
+| Initial build | ~0.5 s | ~1.2 s | ~2.5x |
+| Incremental updates | ~0.7-1.1 s | ~1.5-1.9 s | ~1.7-2.5x |
+
+Treat these as ballpark ranges, not guarantees. Larger ledgers, wider class and
+property statistics, more named graphs, and colder caches can increase the gap.
+On the other hand, hot repeated query traffic may see almost no difference.
+
+## Choosing An Index Backend
+
+Use Standard S3 for indexes when:
+
+- You want multi-AZ S3 durability for both commits and indexes.
+- You are cost-sensitive or want to avoid the S3 Express per-bucket cost floor.
+- Your workload is mostly hot queries, modest indexing volume, or can tolerate
+  indexing taking roughly twice as long.
+
+Use S3 Express One Zone for indexes when:
+
+- Cold query latency matters.
+- Incremental indexing throughput is important.
+- Queries touch many index segments before the local cache is warm.
+- You can tolerate the single-AZ durability profile because indexes are
+  reproducible from commits.
+
+## Tuning Notes
+
+- Size Lambda `/tmp` large enough for the disk artifact cache. The cache softens
+  both query and indexing latency by avoiding repeated remote reads of immutable
+  artifacts.
+- Use `s3MaxConcurrentRequests` to cap per-process S3 SDK concurrency if a
+  deployment shows signs of retry storms or HTTP-layer stalls.
+- Use the indexer worker's own processing time logs for indexing measurements.
+  Client-side polling includes nameservice propagation and scheduling delays.
+- Watch `index_t` vs `commit_t`. If `index_t` lags behind `commit_t`, query
+  latency may reflect catch-up work rather than the raw performance of the
+  selected index bucket.

--- a/docs/operations/storage.md
+++ b/docs/operations/storage.md
@@ -88,6 +88,12 @@ Distributed storage using S3 and DynamoDB:
 - Usage costs
 - More complex setup
 
+For cloud and serverless deployments, commit and index storage can be split.
+Prefer Standard S3 for commits because commits are the durable source of truth.
+Indexes are reproducible from commits, so they can use either Standard S3 or S3
+Express One Zone depending on latency and cost requirements. See
+[Serverless Storage Choices](serverless-storage.md) for benchmark-backed guidance.
+
 ### IPFS Storage
 
 Decentralized content-addressed storage via a local Kubo node:

--- a/docs/reference/connection-config-jsonld.md
+++ b/docs/reference/connection-config-jsonld.md
@@ -148,6 +148,8 @@ Supported fields (parsed and **applied** by Rust):
   - Rust applies a single **operation timeout** of `max(read, write, list)`
 - `s3MaxRetries`, `s3RetryBaseDelayMs`, `s3RetryMaxDelayMs`
   - Rust maps `s3MaxRetries` to AWS SDK `max_attempts = max_retries + 1`
+- `s3MaxConcurrentRequests`
+  - Optional per-storage-instance cap on concurrent S3 SDK operations
 
 #### Standard S3 (AWS)
 
@@ -195,6 +197,10 @@ Guidance:
 - **Standard S3 in AWS**: omit `s3Endpoint` (let the SDK pick defaults)
 - **Express One Zone**: omit `s3Endpoint`
 - **LocalStack/MinIO/custom**: set `s3Endpoint`
+
+For serverless index-storage tradeoffs, including Standard S3 vs S3 Express One
+Zone benchmark ranges, see
+[Serverless Storage Choices](../operations/serverless-storage.md).
 
 #### addressIdentifier
 

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -1182,25 +1182,36 @@ impl crate::Fluree {
             "Reindex completed"
         );
 
-        // 6. Spawn async garbage collection (non-blocking)
-        let gc_store = self.content_store(&ledger_id);
-        let gc_root_id = index_result.root_id.clone();
-        let gc_config = CleanGarbageConfig {
-            max_old_indexes: Some(gc_max_old_indexes),
-            min_time_garbage_mins: Some(gc_min_time_mins),
-            ..Default::default()
-        };
-        tokio::spawn(async move {
-            if let Err(e) = clean_garbage(gc_store.as_ref(), &gc_root_id, gc_config).await {
-                tracing::warn!(
-                    error = %e,
-                    root_id = %gc_root_id,
-                    "Background garbage collection failed (non-fatal)"
-                );
-            } else {
-                tracing::debug!(root_id = %gc_root_id, "Background garbage collection completed");
-            }
-        });
+        // 6. Spawn async garbage collection (non-blocking) only after enough
+        // published index versions can exist to exceed retention.
+        let gc_keep_count = 1_i64 + i64::from(gc_max_old_indexes);
+        if index_result.index_t <= gc_keep_count {
+            tracing::debug!(
+                root_id = %index_result.root_id,
+                index_t = index_result.index_t,
+                gc_keep_count,
+                "Skipping background garbage collection; index chain cannot exceed retention yet"
+            );
+        } else {
+            let gc_store = self.content_store(&ledger_id);
+            let gc_root_id = index_result.root_id.clone();
+            let gc_config = CleanGarbageConfig {
+                max_old_indexes: Some(gc_max_old_indexes),
+                min_time_garbage_mins: Some(gc_min_time_mins),
+                ..Default::default()
+            };
+            tokio::spawn(async move {
+                if let Err(e) = clean_garbage(gc_store.as_ref(), &gc_root_id, gc_config).await {
+                    tracing::warn!(
+                        error = %e,
+                        root_id = %gc_root_id,
+                        "Background garbage collection failed (non-fatal)"
+                    );
+                } else {
+                    tracing::debug!(root_id = %gc_root_id, "Background garbage collection completed");
+                }
+            });
+        }
 
         Ok(ReindexResult {
             ledger_id,

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -1188,6 +1188,7 @@ impl crate::Fluree {
         let gc_config = CleanGarbageConfig {
             max_old_indexes: Some(gc_max_old_indexes),
             min_time_garbage_mins: Some(gc_min_time_mins),
+            ..Default::default()
         };
         tokio::spawn(async move {
             if let Err(e) = clean_garbage(gc_store.as_ref(), &gc_root_id, gc_config).await {

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1059,6 +1059,7 @@ async fn build_s3_storage_from_config(
         max_retries: s3_config.max_retries.map(|n| n as u32),
         retry_base_delay_ms: s3_config.retry_base_delay_ms,
         retry_max_delay_ms: s3_config.retry_max_delay_ms,
+        max_concurrent_requests: s3_config.max_concurrent_requests,
     };
 
     let storage = S3Storage::new(sdk_config, raw_config)
@@ -1371,6 +1372,7 @@ impl FlureeBuilder {
             max_retries: None,
             retry_base_delay_ms: None,
             retry_max_delay_ms: None,
+            max_concurrent_requests: None,
             address_identifier: None,
         };
 
@@ -1467,6 +1469,15 @@ impl FlureeBuilder {
     pub fn s3_retry_max_delay_ms(mut self, ms: u64) -> Self {
         if let StorageType::S3(s3) = &mut self.config.index_storage.storage_type {
             s3.retry_max_delay_ms = Some(ms);
+        }
+        self
+    }
+
+    /// Set the maximum concurrent S3 SDK requests per storage instance.
+    #[cfg(feature = "aws")]
+    pub fn s3_max_concurrent_requests(mut self, n: usize) -> Self {
+        if let StorageType::S3(s3) = &mut self.config.index_storage.storage_type {
+            s3.max_concurrent_requests = Some(n.max(1));
         }
         self
     }
@@ -2055,6 +2066,7 @@ impl FlureeBuilder {
                 max_retries: s3_cfg.max_retries.map(|n| n as u32),
                 retry_base_delay_ms: s3_cfg.retry_base_delay_ms,
                 retry_max_delay_ms: s3_cfg.retry_max_delay_ms,
+                max_concurrent_requests: s3_cfg.max_concurrent_requests,
             },
         )
         .await
@@ -2131,6 +2143,7 @@ impl FlureeBuilder {
                 max_retries: s3_cfg.max_retries.map(|n| n as u32),
                 retry_base_delay_ms: s3_cfg.retry_base_delay_ms,
                 retry_max_delay_ms: s3_cfg.retry_max_delay_ms,
+                max_concurrent_requests: s3_cfg.max_concurrent_requests,
             },
         )
         .await

--- a/fluree-db-api/tests/it_storage_s3_testcontainers.rs
+++ b/fluree-db-api/tests/it_storage_s3_testcontainers.rs
@@ -179,6 +179,7 @@ async fn s3_testcontainers_basic_test() {
             max_retries: None,
             retry_base_delay_ms: None,
             retry_max_delay_ms: None,
+            max_concurrent_requests: None,
         },
     )
     .await
@@ -274,6 +275,7 @@ async fn s3_testcontainers_indexing_test() {
             max_retries: None,
             retry_base_delay_ms: None,
             retry_max_delay_ms: None,
+            max_concurrent_requests: None,
         },
     )
     .await
@@ -407,6 +409,7 @@ async fn s3_testcontainers_hard_drop_clears_ledger() {
             max_retries: None,
             retry_base_delay_ms: None,
             retry_max_delay_ms: None,
+            max_concurrent_requests: None,
         },
     )
     .await

--- a/fluree-db-binary-index/src/read/artifact_cache.rs
+++ b/fluree-db-binary-index/src/read/artifact_cache.rs
@@ -143,7 +143,7 @@ impl DiskArtifactCache {
                     0
                 }
                 Ok(bytes) => {
-                    tracing::debug!(
+                    tracing::trace!(
                         cache_dir = %root.display(),
                         budget_bytes = bytes,
                         "using FLUREE_DISK_CACHE_BUDGET_BYTES override"

--- a/fluree-db-connection/src/config.rs
+++ b/fluree-db-connection/src/config.rs
@@ -57,6 +57,7 @@ pub struct S3StorageConfig {
     pub max_retries: Option<u64>,
     pub retry_base_delay_ms: Option<u64>,
     pub retry_max_delay_ms: Option<u64>,
+    pub max_concurrent_requests: Option<usize>,
     /// Optional address identifier
     pub address_identifier: Option<Arc<str>>,
 }
@@ -399,6 +400,12 @@ fn parse_storage_node(graph: &ConfigGraph, node: &JsonValue) -> Result<StorageCo
             max_retries: resolve_u64(graph, node, vocab::FIELD_S3_MAX_RETRIES),
             retry_base_delay_ms: resolve_u64(graph, node, vocab::FIELD_S3_RETRY_BASE_DELAY_MS),
             retry_max_delay_ms: resolve_u64(graph, node, vocab::FIELD_S3_RETRY_MAX_DELAY_MS),
+            max_concurrent_requests: resolve_u64(
+                graph,
+                node,
+                vocab::FIELD_S3_MAX_CONCURRENT_REQUESTS,
+            )
+            .map(|n| n as usize),
             address_identifier: address_identifier.clone(),
         };
 

--- a/fluree-db-connection/src/registry.rs
+++ b/fluree-db-connection/src/registry.rs
@@ -103,6 +103,7 @@ impl StorageRegistry {
             max_retries: s3_config.max_retries.map(|n| n as u32),
             retry_base_delay_ms: s3_config.retry_base_delay_ms,
             retry_max_delay_ms: s3_config.retry_max_delay_ms,
+            max_concurrent_requests: s3_config.max_concurrent_requests,
         };
 
         let storage = S3Storage::new(sdk_config, raw_config)

--- a/fluree-db-connection/src/vocab.rs
+++ b/fluree-db-connection/src/vocab.rs
@@ -58,6 +58,10 @@ pub const FIELD_S3_RETRY_BASE_DELAY_MS: &str = "https://ns.flur.ee/system#s3Retr
 /// S3 retry max delay (ms)
 pub const FIELD_S3_RETRY_MAX_DELAY_MS: &str = "https://ns.flur.ee/system#s3RetryMaxDelayMs";
 
+/// Maximum concurrent S3 SDK requests per storage instance.
+pub const FIELD_S3_MAX_CONCURRENT_REQUESTS: &str =
+    "https://ns.flur.ee/system#s3MaxConcurrentRequests";
+
 /// Optional address identifier for a storage backend
 ///
 /// Used in legacy configs to embed a storage identifier into Fluree addresses, e.g.

--- a/fluree-db-connection/tests/aws_config_test.rs
+++ b/fluree-db-connection/tests/aws_config_test.rs
@@ -313,7 +313,8 @@ fn test_full_aws_config() {
                 "@type": "Storage",
                 "s3Bucket": "fluree-indexes",
                 "s3Prefix": "prod/indexes",
-                "s3ReadTimeoutMs": 5000
+                "s3ReadTimeoutMs": 5000,
+                "s3MaxConcurrentRequests": 16
             },
             {
                 "@id": "s3CommitStorage",
@@ -353,6 +354,7 @@ fn test_full_aws_config() {
             assert_eq!(&*s3_config.bucket, "fluree-indexes");
             assert_eq!(s3_config.prefix.as_deref(), Some("prod/indexes"));
             assert_eq!(s3_config.read_timeout_ms, Some(5000));
+            assert_eq!(s3_config.max_concurrent_requests, Some(16));
         }
         _ => panic!("Expected S3 index storage"),
     }

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2267,26 +2267,13 @@ pub async fn incremental_index(
                 let total_class_entries = entries_by_key.len();
                 let mut visited_class_entries = 0usize;
                 let mut last_property_merge_log = Instant::now();
+                let mut next_merged_class_progress = 500usize;
                 for (&(g_id, class_sid64), entry) in &mut entries_by_key {
                     visited_class_entries += 1;
                     if let Some(props) = class_properties.get(&(g_id, class_sid64)) {
                         let class_merge_started = Instant::now();
                         let existing_property_count = entry.properties.len();
                         let novelty_property_count = props.len();
-                        if merged_class_entries < 10
-                            || existing_property_count >= 100
-                            || novelty_property_count >= 100
-                        {
-                            tracing::debug!(
-                                g_id,
-                                class_sid64,
-                                existing_property_count,
-                                novelty_property_count,
-                                visited_class_entries,
-                                total_entries = total_class_entries,
-                                "Phase 3b: class property attribution entry starting"
-                            );
-                        }
                         let class_dts = class_prop_dts.get(&(g_id, class_sid64));
                         let class_refs = ref_edges.get(&(g_id, class_sid64));
                         let class_langs = class_prop_lang_deltas.get(&(g_id, class_sid64));
@@ -2333,50 +2320,10 @@ pub async fn incremental_index(
                             .collect();
 
                         let total_class_properties = prop_set.len();
-                        let base_ref_class_count: usize =
-                            entry.properties.iter().map(|pu| pu.ref_classes.len()).sum();
-                        if merged_class_entries < 10
-                            || total_class_properties >= 100
-                            || base_ref_class_count >= 100
-                        {
-                            tracing::debug!(
-                                g_id,
-                                class_sid64,
-                                existing_property_count,
-                                novelty_property_count,
-                                total_class_properties,
-                                base_ref_class_count,
-                                visited_class_entries,
-                                total_entries = total_class_entries,
-                                "Phase 3b: merging class property attribution entry"
-                            );
-                        }
-
                         let mut merged_properties = Vec::with_capacity(total_class_properties);
                         let mut merged_property_count = 0usize;
                         let mut last_class_property_log = Instant::now();
                         for &cp_id in &prop_set {
-                            if merged_property_count < 3
-                                || last_class_property_log.elapsed()
-                                    >= std::time::Duration::from_secs(5)
-                            {
-                                tracing::debug!(
-                                    g_id,
-                                    class_sid64,
-                                    cp_id,
-                                    merged_property_count,
-                                    total_class_properties,
-                                    has_base_property = base_prop_by_pid.contains_key(&cp_id),
-                                    has_datatype_delta =
-                                        class_dts.is_some_and(|m| m.contains_key(&cp_id)),
-                                    has_lang_delta =
-                                        class_langs.is_some_and(|m| m.contains_key(&cp_id)),
-                                    ref_delta_count = class_refs
-                                        .and_then(|m| m.get(&cp_id))
-                                        .map_or(0, std::collections::HashMap::len),
-                                    "Phase 3b: class property attribution property starting"
-                                );
-                            }
                             let iri = novelty.shared.predicates.resolve(cp_id).unwrap_or("");
                             let p_sid = match trie.longest_match(iri) {
                                 Some((code, plen)) => fluree_db_core::Sid::new(code, &iri[plen..]),
@@ -2441,17 +2388,6 @@ pub async fn incremental_index(
                             }
                             if let Some(ref_delta) = class_refs.and_then(|m| m.get(&cp_id)) {
                                 let ref_delta_count = ref_delta.len();
-                                if ref_delta_count >= 25 || merged_class_entries < 10 {
-                                    tracing::debug!(
-                                        g_id,
-                                        class_sid64,
-                                        cp_id,
-                                        ref_delta_count,
-                                        merged_property_count,
-                                        total_class_properties,
-                                        "Phase 3b: merging novelty ref-class deltas"
-                                    );
-                                }
                                 let mut merged_ref_delta_count = 0usize;
                                 let mut last_ref_delta_log = Instant::now();
                                 for (&target, &cnt) in ref_delta {
@@ -2560,7 +2496,7 @@ pub async fn incremental_index(
                             &new_subject_suffix,
                         );
                     }
-                    if merged_class_entries > 0 && merged_class_entries.is_multiple_of(500) {
+                    if merged_class_entries >= next_merged_class_progress {
                         tracing::debug!(
                             merged_class_entries,
                             total_entries = total_class_entries,
@@ -2573,6 +2509,7 @@ pub async fn incremental_index(
                             "Phase 3b: property attribution merge progress"
                         );
                         last_property_merge_log = Instant::now();
+                        next_merged_class_progress = next_merged_class_progress.saturating_add(500);
                     } else if last_property_merge_log.elapsed() >= std::time::Duration::from_secs(5)
                     {
                         tracing::debug!(

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2233,6 +2233,24 @@ pub async fn incremental_index(
                     "Phase 3b: applied class count deltas"
                 );
 
+                let mut class_sid_cache: std::collections::HashMap<u64, fluree_db_core::Sid> =
+                    entries_by_key
+                        .iter()
+                        .filter_map(|(&(_, class_sid64), entry)| {
+                            if entry.class_sid.name.is_empty()
+                                && entry.class_sid.namespace_code == 0
+                            {
+                                None
+                            } else {
+                                Some((class_sid64, entry.class_sid.clone()))
+                            }
+                        })
+                        .collect();
+                tracing::debug!(
+                    cached_class_sids = class_sid_cache.len(),
+                    "Phase 3b: cached class Sid values for property attribution merge"
+                );
+
                 // Build property attribution for each class entry.
                 let property_merge_started = Instant::now();
                 tracing::debug!(
@@ -2338,6 +2356,27 @@ pub async fn incremental_index(
                         let mut merged_property_count = 0usize;
                         let mut last_class_property_log = Instant::now();
                         for &cp_id in &prop_set {
+                            if merged_property_count < 3
+                                || last_class_property_log.elapsed()
+                                    >= std::time::Duration::from_secs(5)
+                            {
+                                tracing::debug!(
+                                    g_id,
+                                    class_sid64,
+                                    cp_id,
+                                    merged_property_count,
+                                    total_class_properties,
+                                    has_base_property = base_prop_by_pid.contains_key(&cp_id),
+                                    has_datatype_delta =
+                                        class_dts.is_some_and(|m| m.contains_key(&cp_id)),
+                                    has_lang_delta =
+                                        class_langs.is_some_and(|m| m.contains_key(&cp_id)),
+                                    ref_delta_count = class_refs
+                                        .and_then(|m| m.get(&cp_id))
+                                        .map_or(0, std::collections::HashMap::len),
+                                    "Phase 3b: class property attribution property starting"
+                                );
+                            }
                             let iri = novelty.shared.predicates.resolve(cp_id).unwrap_or("");
                             let p_sid = match trie.longest_match(iri) {
                                 Some((code, plen)) => fluree_db_core::Sid::new(code, &iri[plen..]),
@@ -2401,15 +2440,65 @@ pub async fn incremental_index(
                                 }
                             }
                             if let Some(ref_delta) = class_refs.and_then(|m| m.get(&cp_id)) {
+                                let ref_delta_count = ref_delta.len();
+                                if ref_delta_count >= 25 || merged_class_entries < 10 {
+                                    tracing::debug!(
+                                        g_id,
+                                        class_sid64,
+                                        cp_id,
+                                        ref_delta_count,
+                                        merged_property_count,
+                                        total_class_properties,
+                                        "Phase 3b: merging novelty ref-class deltas"
+                                    );
+                                }
+                                let mut merged_ref_delta_count = 0usize;
+                                let mut last_ref_delta_log = Instant::now();
                                 for (&target, &cnt) in ref_delta {
                                     ref_class_sid_lookups.fetch_add(1, Ordering::Relaxed);
-                                    let cs = resolve_class_sid(
-                                        target,
-                                        store_opt.as_deref(),
-                                        &new_subject_suffix,
-                                    );
-                                    ref_class_sid_hits.fetch_add(1, Ordering::Relaxed);
+                                    let cs = if let Some(cs) = class_sid_cache.get(&target) {
+                                        ref_class_sid_hits.fetch_add(1, Ordering::Relaxed);
+                                        cs.clone()
+                                    } else {
+                                        let sid =
+                                            fluree_db_core::subject_id::SubjectId::from_u64(target);
+                                        let cs = if let Some(suffix) =
+                                            new_subject_suffix.get(&(sid.ns_code(), sid.local_id()))
+                                        {
+                                            resolve_class_sid_novelty_hits
+                                                .fetch_add(1, Ordering::Relaxed);
+                                            fluree_db_core::Sid::new(sid.ns_code(), suffix.as_str())
+                                        } else {
+                                            resolve_class_sid_fallbacks
+                                                .fetch_add(1, Ordering::Relaxed);
+                                            fluree_db_core::Sid::new(
+                                                sid.ns_code(),
+                                                sid.local_id().to_string(),
+                                            )
+                                        };
+                                        class_sid_cache.insert(target, cs.clone());
+                                        cs
+                                    };
                                     *merged_refs.entry(cs).or_insert(0) += cnt;
+                                    merged_ref_delta_count += 1;
+                                    if last_ref_delta_log.elapsed()
+                                        >= std::time::Duration::from_secs(5)
+                                    {
+                                        tracing::debug!(
+                                            g_id,
+                                            class_sid64,
+                                            cp_id,
+                                            merged_ref_delta_count,
+                                            ref_delta_count,
+                                            class_sid_cache_size = class_sid_cache.len(),
+                                            elapsed_ms =
+                                                class_merge_started.elapsed().as_millis() as u64,
+                                            phase_elapsed_ms =
+                                                phase3b_started.elapsed().as_millis() as u64,
+                                            "Phase 3b: novelty ref-class deltas still merging"
+                                        );
+                                        last_ref_delta_log = Instant::now();
+                                    }
                                 }
                             }
                             let ref_classes: Vec<is::ClassRefCount> = merged_refs

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -16,7 +16,7 @@
 //! 4. **Dict updates**: Update reverse trees + forward packs for new subjects/strings
 //! 5. **Root assembly**: `IncrementalRootBuilder` → encode → CAS write → publish
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -46,6 +46,102 @@ fn artifact_cache_dir(config: &IndexerConfig) -> std::path::PathBuf {
         .unwrap_or_else(|| std::env::temp_dir().join("fluree_binary_cache"))
 }
 
+#[derive(Default)]
+struct Phase2FetchStats {
+    leaf_fetches: AtomicU64,
+    leaf_cache_hits: AtomicU64,
+    leaf_cache_misses: AtomicU64,
+    leaf_bytes: AtomicU64,
+    leaf_fetch_ms: AtomicU64,
+    sidecar_fetches: AtomicU64,
+    sidecar_cache_hits: AtomicU64,
+    sidecar_cache_misses: AtomicU64,
+    sidecar_absent: AtomicU64,
+    sidecar_bytes: AtomicU64,
+    sidecar_fetch_ms: AtomicU64,
+}
+
+#[derive(Debug, Default, Clone)]
+struct Phase2FetchStatsSnapshot {
+    leaf_fetches: u64,
+    leaf_cache_hits: u64,
+    leaf_cache_misses: u64,
+    leaf_bytes: u64,
+    leaf_fetch_ms: u64,
+    sidecar_fetches: u64,
+    sidecar_cache_hits: u64,
+    sidecar_cache_misses: u64,
+    sidecar_absent: u64,
+    sidecar_bytes: u64,
+    sidecar_fetch_ms: u64,
+}
+
+impl Phase2FetchStats {
+    fn snapshot(&self) -> Phase2FetchStatsSnapshot {
+        Phase2FetchStatsSnapshot {
+            leaf_fetches: self.leaf_fetches.load(Ordering::Relaxed),
+            leaf_cache_hits: self.leaf_cache_hits.load(Ordering::Relaxed),
+            leaf_cache_misses: self.leaf_cache_misses.load(Ordering::Relaxed),
+            leaf_bytes: self.leaf_bytes.load(Ordering::Relaxed),
+            leaf_fetch_ms: self.leaf_fetch_ms.load(Ordering::Relaxed),
+            sidecar_fetches: self.sidecar_fetches.load(Ordering::Relaxed),
+            sidecar_cache_hits: self.sidecar_cache_hits.load(Ordering::Relaxed),
+            sidecar_cache_misses: self.sidecar_cache_misses.load(Ordering::Relaxed),
+            sidecar_absent: self.sidecar_absent.load(Ordering::Relaxed),
+            sidecar_bytes: self.sidecar_bytes.load(Ordering::Relaxed),
+            sidecar_fetch_ms: self.sidecar_fetch_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+fn cache_artifact_bytes(
+    cache_dir: &std::path::Path,
+    cid: &ContentId,
+    bytes: &[u8],
+    artifact_kind: &'static str,
+) {
+    fluree_db_binary_index::read::artifact_cache::best_effort_cache_bytes_to_path(
+        cache_dir,
+        &cache_dir.join(cid.to_string()),
+        bytes,
+    );
+    tracing::trace!(
+        %cid,
+        artifact_kind,
+        bytes = bytes.len(),
+        cache_dir = %cache_dir.display(),
+        "V6 incremental: seeded artifact cache"
+    );
+}
+
+async fn fetch_cached_index_bytes(
+    content_store: &dyn ContentStore,
+    cid: &ContentId,
+    cache_dir: &std::path::Path,
+    context: impl Into<String>,
+) -> Result<Vec<u8>> {
+    let context = context.into();
+    fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
+        content_store,
+        cid,
+        cache_dir,
+    )
+    .await
+    .map_err(|e| IndexerError::StorageRead(format!("{context}: {e}")))
+}
+
+async fn upload_dict_blob_cached(
+    content_store: &dyn ContentStore,
+    dict: fluree_db_core::DictKind,
+    bytes: &[u8],
+    msg: &'static str,
+    cache_dir: &std::path::Path,
+) -> Result<ContentId> {
+    let cid = super::upload::upload_dict_blob(content_store, dict, bytes, msg).await?;
+    cache_artifact_bytes(cache_dir, &cid, bytes, "dict_blob");
+    Ok(cid)
+}
+
 /// Run `update_branch` on a blocking thread.
 ///
 /// Uses `spawn_blocking` instead of `block_in_place` so this works on both
@@ -58,53 +154,136 @@ async fn run_update_branch(
     branch_config: BranchUpdateConfig,
     content_store: Arc<dyn fluree_db_core::storage::ContentStore>,
     cache_dir: std::path::PathBuf,
-) -> std::result::Result<BranchUpdateResult, IndexerError> {
+) -> std::result::Result<(BranchUpdateResult, Phase2FetchStatsSnapshot), IndexerError> {
     let handle = tokio::runtime::Handle::current();
     let parent_span = tracing::Span::current();
-    tokio::task::spawn_blocking(move || {
+    let stats = Arc::new(Phase2FetchStats::default());
+    let task_stats = Arc::clone(&stats);
+    let result = tokio::task::spawn_blocking(move || {
         let _guard = parent_span.enter();
         let cs = content_store.clone();
         let cs2 = content_store;
         let cache_dir2 = cache_dir.clone();
+        let leaf_stats = Arc::clone(&task_stats);
+        let sidecar_stats = Arc::clone(&task_stats);
         update_branch(
             &branch_bytes,
             &sorted_records,
             &sorted_ops,
             &branch_config,
             &|cid| {
-                handle.block_on(async {
+                let cached_before = cache_dir.join(cid.to_string()).exists();
+                let fetch_started = Instant::now();
+                let result = handle.block_on(async {
                     fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
                         cs.as_ref(),
                         cid,
                         &cache_dir,
                     )
                     .await
-                })
+                });
+                let elapsed_ms = fetch_started.elapsed().as_millis() as u64;
+                leaf_stats.leaf_fetches.fetch_add(1, Ordering::Relaxed);
+                leaf_stats
+                    .leaf_fetch_ms
+                    .fetch_add(elapsed_ms, Ordering::Relaxed);
+                match &result {
+                    Ok(bytes) => {
+                        leaf_stats
+                            .leaf_bytes
+                            .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                        if cached_before {
+                            leaf_stats.leaf_cache_hits.fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            leaf_stats.leaf_cache_misses.fetch_add(1, Ordering::Relaxed);
+                        }
+                        tracing::trace!(
+                            %cid,
+                            cached_before,
+                            bytes = bytes.len(),
+                            elapsed_ms,
+                            "V6 Phase 2 leaf fetch"
+                        );
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            %cid,
+                            cached_before,
+                            elapsed_ms,
+                            error = %err,
+                            "V6 Phase 2 leaf fetch failed"
+                        );
+                    }
+                }
+                result
             },
             &|cid| {
-                handle
-                    .block_on(async {
-                        fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
-                            cs2.as_ref(),
-                            cid,
-                            &cache_dir2,
-                        )
-                        .await
-                    })
-                    .map(Some)
-                    .or_else(|e| match e.kind() {
-                        std::io::ErrorKind::NotFound => {
-                            tracing::debug!("sidecar not found (treating as absent): {e}");
-                            Ok(None)
+                let cached_before = cache_dir2.join(cid.to_string()).exists();
+                let fetch_started = Instant::now();
+                let result = handle.block_on(async {
+                    fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
+                        cs2.as_ref(),
+                        cid,
+                        &cache_dir2,
+                    )
+                    .await
+                });
+                let elapsed_ms = fetch_started.elapsed().as_millis() as u64;
+                sidecar_stats
+                    .sidecar_fetches
+                    .fetch_add(1, Ordering::Relaxed);
+                sidecar_stats
+                    .sidecar_fetch_ms
+                    .fetch_add(elapsed_ms, Ordering::Relaxed);
+                match &result {
+                    Ok(bytes) => {
+                        sidecar_stats
+                            .sidecar_bytes
+                            .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                        if cached_before {
+                            sidecar_stats
+                                .sidecar_cache_hits
+                                .fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            sidecar_stats
+                                .sidecar_cache_misses
+                                .fetch_add(1, Ordering::Relaxed);
                         }
-                        _ => Err(e),
-                    })
+                        tracing::trace!(
+                            %cid,
+                            cached_before,
+                            bytes = bytes.len(),
+                            elapsed_ms,
+                            "V6 Phase 2 sidecar fetch"
+                        );
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        sidecar_stats.sidecar_absent.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            %cid,
+                            cached_before,
+                            elapsed_ms,
+                            error = %err,
+                            "V6 Phase 2 sidecar fetch failed"
+                        );
+                    }
+                }
+                result.map(Some).or_else(|e| match e.kind() {
+                    std::io::ErrorKind::NotFound => {
+                        tracing::debug!("sidecar not found (treating as absent): {e}");
+                        Ok(None)
+                    }
+                    _ => Err(e),
+                })
             },
         )
     })
     .await
     .map_err(|e| IndexerError::StorageWrite(format!("branch update task panicked: {e}")))?
-    .map_err(|e| IndexerError::StorageWrite(e.to_string()))
+    .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+    Ok((result, stats.snapshot()))
 }
 
 enum Phase2TaskKind {
@@ -136,6 +315,7 @@ struct Phase2TaskOutput {
     replaced_leaf_cids: Vec<ContentId>,
     replaced_sidecar_cids: Vec<ContentId>,
     new_leaf_count: usize,
+    fetch_stats: Phase2FetchStatsSnapshot,
 }
 
 async fn execute_phase2_task(
@@ -169,16 +349,16 @@ async fn execute_phase2_task(
         Phase2TaskKind::DefaultExisting { leaves } => {
             let branch_bytes =
                 fluree_db_binary_index::format::branch::build_branch_bytes(order, g_id, &leaves);
-            let result = run_update_branch(
+            let (result, fetch_stats) = run_update_branch(
                 branch_bytes,
                 sorted_records,
                 sorted_ops,
                 branch_config,
                 Arc::clone(&content_store),
-                cache_dir,
+                cache_dir.clone(),
             )
             .await?;
-            upload_leaf_blobs(content_store.as_ref(), &result).await?;
+            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
             Phase2TaskOutput {
                 seq,
                 g_id,
@@ -189,12 +369,13 @@ async fn execute_phase2_task(
                 replaced_leaf_cids: result.replaced_leaf_cids,
                 replaced_sidecar_cids: result.replaced_sidecar_cids,
                 new_leaf_count: result.new_leaf_blobs.len(),
+                fetch_stats,
             }
         }
         Phase2TaskKind::DefaultFresh => {
             let result =
                 build_fresh_default_graph_v3(&sorted_records, &sorted_ops, order, g_id, config)?;
-            upload_leaf_blobs(content_store.as_ref(), &result).await?;
+            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
             Phase2TaskOutput {
                 seq,
                 g_id,
@@ -205,62 +386,72 @@ async fn execute_phase2_task(
                 replaced_leaf_cids: Vec::new(),
                 replaced_sidecar_cids: Vec::new(),
                 new_leaf_count: result.new_leaf_blobs.len(),
+                fetch_stats: Phase2FetchStatsSnapshot::default(),
             }
         }
         Phase2TaskKind::NamedExisting { branch_cid } => {
-            let branch_bytes =
-                fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
-                    content_store.as_ref(),
-                    &branch_cid,
-                    &cache_dir,
-                )
-                .await
-                .map_err(|e| {
-                    IndexerError::StorageRead(format!("fetch V3 branch g_id={g_id} {order:?}: {e}"))
-                })?;
-            let result = run_update_branch(
+            let branch_bytes = fetch_cached_index_bytes(
+                content_store.as_ref(),
+                &branch_cid,
+                &cache_dir,
+                format!("fetch V3 branch g_id={g_id} {order:?}"),
+            )
+            .await?;
+            let (result, fetch_stats) = run_update_branch(
                 branch_bytes,
                 sorted_records,
                 sorted_ops,
                 branch_config,
                 Arc::clone(&content_store),
-                cache_dir,
+                cache_dir.clone(),
             )
             .await?;
-            upload_leaf_blobs(content_store.as_ref(), &result).await?;
-            content_store
+            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
+            let branch_cid = content_store
                 .put(ContentKind::IndexBranch, &result.branch_bytes)
                 .await
                 .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+            debug_assert!(branch_cid == result.branch_cid);
+            cache_artifact_bytes(
+                &cache_dir,
+                &branch_cid,
+                &result.branch_bytes,
+                "index_branch",
+            );
             Phase2TaskOutput {
                 seq,
                 g_id,
                 order,
-                update: Phase2TaskUpdate::Named {
-                    branch_cid: result.branch_cid,
-                },
+                update: Phase2TaskUpdate::Named { branch_cid },
                 replaced_leaf_cids: result.replaced_leaf_cids,
                 replaced_sidecar_cids: result.replaced_sidecar_cids,
                 new_leaf_count: result.new_leaf_blobs.len(),
+                fetch_stats,
             }
         }
         Phase2TaskKind::NamedFresh => {
             let result = build_fresh_named_graph_v3(&sorted_records, order, g_id, config)?;
-            upload_leaf_blobs(content_store.as_ref(), &result).await?;
-            content_store
+            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
+            let branch_cid = content_store
                 .put(ContentKind::IndexBranch, &result.branch_bytes)
                 .await
                 .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+            debug_assert!(branch_cid == result.branch_cid);
+            cache_artifact_bytes(
+                &cache_dir,
+                &branch_cid,
+                &result.branch_bytes,
+                "index_branch",
+            );
             Phase2TaskOutput {
                 seq,
                 g_id,
                 order,
-                update: Phase2TaskUpdate::Named {
-                    branch_cid: result.branch_cid,
-                },
+                update: Phase2TaskUpdate::Named { branch_cid },
                 replaced_leaf_cids: Vec::new(),
                 replaced_sidecar_cids: Vec::new(),
                 new_leaf_count: result.new_leaf_blobs.len(),
+                fetch_stats: Phase2FetchStatsSnapshot::default(),
             }
         }
     };
@@ -270,6 +461,17 @@ async fn execute_phase2_task(
         g_id,
         ?order,
         new_leaf_count = output.new_leaf_count,
+        leaf_fetches = output.fetch_stats.leaf_fetches,
+        leaf_cache_hits = output.fetch_stats.leaf_cache_hits,
+        leaf_cache_misses = output.fetch_stats.leaf_cache_misses,
+        leaf_bytes = output.fetch_stats.leaf_bytes,
+        leaf_fetch_ms = output.fetch_stats.leaf_fetch_ms,
+        sidecar_fetches = output.fetch_stats.sidecar_fetches,
+        sidecar_cache_hits = output.fetch_stats.sidecar_cache_hits,
+        sidecar_cache_misses = output.fetch_stats.sidecar_cache_misses,
+        sidecar_absent = output.fetch_stats.sidecar_absent,
+        sidecar_bytes = output.fetch_stats.sidecar_bytes,
+        sidecar_fetch_ms = output.fetch_stats.sidecar_fetch_ms,
         elapsed_ms = started.elapsed().as_millis() as u64,
         "V6 Phase 2 task complete"
     );
@@ -436,8 +638,20 @@ pub async fn incremental_index(
         phase2_results.into_iter().collect::<Result<Vec<_>>>()?;
     phase2_outputs.sort_unstable_by_key(|output| output.seq);
 
+    let mut phase2_fetch_totals = Phase2FetchStatsSnapshot::default();
     for output in phase2_outputs {
         total_new_leaves += output.new_leaf_count;
+        phase2_fetch_totals.leaf_fetches += output.fetch_stats.leaf_fetches;
+        phase2_fetch_totals.leaf_cache_hits += output.fetch_stats.leaf_cache_hits;
+        phase2_fetch_totals.leaf_cache_misses += output.fetch_stats.leaf_cache_misses;
+        phase2_fetch_totals.leaf_bytes += output.fetch_stats.leaf_bytes;
+        phase2_fetch_totals.leaf_fetch_ms += output.fetch_stats.leaf_fetch_ms;
+        phase2_fetch_totals.sidecar_fetches += output.fetch_stats.sidecar_fetches;
+        phase2_fetch_totals.sidecar_cache_hits += output.fetch_stats.sidecar_cache_hits;
+        phase2_fetch_totals.sidecar_cache_misses += output.fetch_stats.sidecar_cache_misses;
+        phase2_fetch_totals.sidecar_absent += output.fetch_stats.sidecar_absent;
+        phase2_fetch_totals.sidecar_bytes += output.fetch_stats.sidecar_bytes;
+        phase2_fetch_totals.sidecar_fetch_ms += output.fetch_stats.sidecar_fetch_ms;
         match output.update {
             Phase2TaskUpdate::Default { leaf_entries } => {
                 root_builder.set_default_graph_order(output.order, leaf_entries);
@@ -454,6 +668,17 @@ pub async fn incremental_index(
         new_leaves = total_new_leaves,
         graphs = by_graph.len(),
         concurrency,
+        leaf_fetches = phase2_fetch_totals.leaf_fetches,
+        leaf_cache_hits = phase2_fetch_totals.leaf_cache_hits,
+        leaf_cache_misses = phase2_fetch_totals.leaf_cache_misses,
+        leaf_bytes = phase2_fetch_totals.leaf_bytes,
+        leaf_fetch_ms = phase2_fetch_totals.leaf_fetch_ms,
+        sidecar_fetches = phase2_fetch_totals.sidecar_fetches,
+        sidecar_cache_hits = phase2_fetch_totals.sidecar_cache_hits,
+        sidecar_cache_misses = phase2_fetch_totals.sidecar_cache_misses,
+        sidecar_absent = phase2_fetch_totals.sidecar_absent,
+        sidecar_bytes = phase2_fetch_totals.sidecar_bytes,
+        sidecar_fetch_ms = phase2_fetch_totals.sidecar_fetch_ms,
         "V6 Phase 2 complete: branch updates"
     );
 
@@ -744,11 +969,12 @@ pub async fn incremental_index(
                             IndexerError::StorageWrite(format!("numbig arena serialize: {e}"))
                         })?;
                     let dict_kind = fluree_db_core::DictKind::NumBig { p_id };
-                    let cid = super::upload::upload_dict_blob(
+                    let cid = upload_dict_blob_cached(
                         content_store.as_ref(),
                         dict_kind,
                         &bytes,
                         "incremental V6 numbig arena uploaded",
+                        &cache_dir,
                     )
                     .await?;
 
@@ -799,12 +1025,13 @@ pub async fn incremental_index(
                         // Extending an existing vector arena.
                         let existing = &ga.vectors[pos];
 
-                        let old_manifest_bytes =
-                            content_store.get(&existing.manifest).await.map_err(|e| {
-                                IndexerError::StorageRead(format!(
-                                    "read existing vector manifest: {e}"
-                                ))
-                            })?;
+                        let old_manifest_bytes = fetch_cached_index_bytes(
+                            content_store.as_ref(),
+                            &existing.manifest,
+                            &cache_dir,
+                            "read existing vector manifest",
+                        )
+                        .await?;
                         let old_manifest =
                             fluree_db_binary_index::arena::vector::read_vector_manifest(
                                 &old_manifest_bytes,
@@ -875,12 +1102,13 @@ pub async fn incremental_index(
                                 if take > 0 {
                                     let last_idx = combined_shard_infos.len() - 1;
                                     let old_last_cid = combined_shards[last_idx].clone();
-                                    let old_last_bytes =
-                                        content_store.get(&old_last_cid).await.map_err(|e| {
-                                            IndexerError::StorageRead(format!(
-                                                "read vector last shard: {e}"
-                                            ))
-                                        })?;
+                                    let old_last_bytes = fetch_cached_index_bytes(
+                                        content_store.as_ref(),
+                                        &old_last_cid,
+                                        &cache_dir,
+                                        "read vector last shard",
+                                    )
+                                    .await?;
                                     let old_last_shard =
                                         fluree_db_binary_index::arena::vector::read_vector_shard_from_bytes(
                                             &old_last_bytes,
@@ -909,11 +1137,12 @@ pub async fn incremental_index(
                                         })?;
 
                                     let dict_kind = fluree_db_core::DictKind::VectorShard { p_id };
-                                    let new_last_cid = super::upload::upload_dict_blob(
+                                    let new_last_cid = upload_dict_blob_cached(
                                         content_store.as_ref(),
                                         dict_kind,
                                         &shard_bytes,
                                         "incremental V6 vector last shard replaced",
+                                        &cache_dir,
                                     )
                                     .await?;
 
@@ -939,11 +1168,12 @@ pub async fn incremental_index(
 
                         for (shard_bytes, mut shard_info) in shard_results {
                             let dict_kind = fluree_db_core::DictKind::VectorShard { p_id };
-                            let shard_cid = super::upload::upload_dict_blob(
+                            let shard_cid = upload_dict_blob_cached(
                                 content_store.as_ref(),
                                 dict_kind,
                                 &shard_bytes,
                                 "incremental V6 vector shard uploaded",
+                                &cache_dir,
                             )
                             .await?;
                             shard_info.cas = shard_cid.to_string();
@@ -973,11 +1203,12 @@ pub async fn incremental_index(
                             })?;
 
                         let dict_kind = fluree_db_core::DictKind::VectorManifest { p_id };
-                        let manifest_cid = super::upload::upload_dict_blob(
+                        let manifest_cid = upload_dict_blob_cached(
                             content_store.as_ref(),
                             dict_kind,
                             &manifest_json,
                             "incremental V6 vector manifest uploaded",
+                            &cache_dir,
                         )
                         .await?;
 
@@ -1002,11 +1233,12 @@ pub async fn incremental_index(
 
                         for (shard_bytes, mut shard_info) in shard_results {
                             let dict_kind = fluree_db_core::DictKind::VectorShard { p_id };
-                            let shard_cid = super::upload::upload_dict_blob(
+                            let shard_cid = upload_dict_blob_cached(
                                 content_store.as_ref(),
                                 dict_kind,
                                 &shard_bytes,
                                 "incremental V6 vector shard uploaded",
+                                &cache_dir,
                             )
                             .await?;
                             shard_info.cas = shard_cid.to_string();
@@ -1029,11 +1261,12 @@ pub async fn incremental_index(
                         })?;
 
                         let dict_kind = fluree_db_core::DictKind::VectorManifest { p_id };
-                        let manifest_cid = super::upload::upload_dict_blob(
+                        let manifest_cid = upload_dict_blob_cached(
                             content_store.as_ref(),
                             dict_kind,
                             &manifest_json,
                             "incremental V6 vector manifest uploaded",
+                            &cache_dir,
                         )
                         .await?;
 
@@ -1117,12 +1350,16 @@ pub async fn incremental_index(
                     // back to a full rebuild on incremental failure, which is
                     // the correct recovery for a bad prior-arena blob.
                     let prior_arena = if let Some(ft_ref) = existing_ref {
-                        let blob = content_store.get(&ft_ref.arena_cid).await.map_err(|e| {
-                            IndexerError::StorageRead(format!(
-                                "fulltext incremental: prior arena fetch for (g_id={g_id}, p_id={p_id}, lang_id={lang_id}) cid={}: {e}",
+                        let blob = fetch_cached_index_bytes(
+                            content_store.as_ref(),
+                            &ft_ref.arena_cid,
+                            &cache_dir,
+                            format!(
+                                "fulltext incremental: prior arena fetch for (g_id={g_id}, p_id={p_id}, lang_id={lang_id}) cid={}",
                                 ft_ref.arena_cid
-                            ))
-                        })?;
+                            ),
+                        )
+                        .await?;
                         fluree_db_binary_index::arena::fulltext::FulltextArena::decode(&blob)
                             .map_err(|e| {
                                 IndexerError::Other(format!(
@@ -1163,6 +1400,7 @@ pub async fn incremental_index(
                         .map_err(|e| {
                             IndexerError::StorageWrite(format!("fulltext CAS write: {e}"))
                         })?;
+                    cache_artifact_bytes(&cache_dir, &arena_cid, &blob, "fulltext_arena");
 
                     let new_ref = FulltextArenaRef {
                         p_id,
@@ -1249,12 +1487,13 @@ pub async fn incremental_index(
 
                     if let Some(sp_ref) = existing_ref {
                         // Load the SpatialIndexRoot + snapshot from CAS.
-                        let root_bytes =
-                            content_store.get(&sp_ref.root_cid).await.map_err(|e| {
-                                IndexerError::StorageRead(format!(
-                                    "spatial root load for g{g_id}:p{p_id}: {e}"
-                                ))
-                            })?;
+                        let root_bytes = fetch_cached_index_bytes(
+                            content_store.as_ref(),
+                            &sp_ref.root_cid,
+                            &cache_dir,
+                            format!("spatial root load for g{g_id}:p{p_id}"),
+                        )
+                        .await?;
                         let spatial_root: fluree_db_spatial::SpatialIndexRoot =
                             serde_json::from_slice(&root_bytes).map_err(|e| {
                                 IndexerError::StorageRead(format!(
@@ -1266,15 +1505,23 @@ pub async fn incremental_index(
                         let mut blob_cache: std::collections::HashMap<String, Vec<u8>> =
                             std::collections::HashMap::new();
                         for cid in [&sp_ref.manifest, &sp_ref.arena] {
-                            let bytes = content_store.get(cid).await.map_err(|e| {
-                                IndexerError::StorageRead(format!("spatial blob fetch: {e}"))
-                            })?;
+                            let bytes = fetch_cached_index_bytes(
+                                content_store.as_ref(),
+                                cid,
+                                &cache_dir,
+                                "spatial blob fetch",
+                            )
+                            .await?;
                             blob_cache.insert(cid.digest_hex(), bytes);
                         }
                         for leaflet_cid in &sp_ref.leaflets {
-                            let bytes = content_store.get(leaflet_cid).await.map_err(|e| {
-                                IndexerError::StorageRead(format!("spatial leaflet fetch: {e}"))
-                            })?;
+                            let bytes = fetch_cached_index_bytes(
+                                content_store.as_ref(),
+                                leaflet_cid,
+                                &cache_dir,
+                                "spatial leaflet fetch",
+                            )
+                            .await?;
                             blob_cache.insert(leaflet_cid.digest_hex(), bytes);
                         }
 
@@ -1348,10 +1595,11 @@ pub async fn incremental_index(
                         .map_err(|e| IndexerError::Other(format!("spatial CAS build: {e}")))?;
 
                     for (_hash, blob_bytes) in &pending_blobs {
-                        content_store
+                        let cid = content_store
                             .put(ContentKind::SpatialIndex, blob_bytes)
                             .await
                             .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+                        cache_artifact_bytes(&cache_dir, &cid, blob_bytes, "spatial_blob");
                     }
 
                     // Build CIDs.
@@ -1362,6 +1610,7 @@ pub async fn incremental_index(
                         .put(ContentKind::SpatialIndex, &root_json)
                         .await
                         .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+                    cache_artifact_bytes(&cache_dir, &root_cid, &root_json, "spatial_root");
                     let manifest_cid =
                         ContentId::from_hex_digest(spatial_codec, &write_result.manifest_address)
                             .ok_or_else(|| {
@@ -1532,6 +1781,7 @@ pub async fn incremental_index(
                     .put(ContentKind::StatsSketch, &sketch_bytes)
                     .await
                     .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+                cache_artifact_bytes(&cache_dir, &cid, &sketch_bytes, "stats_sketch");
                 tracing::debug!(
                     %cid,
                     bytes = sketch_bytes.len(),
@@ -2362,6 +2612,7 @@ pub async fn incremental_index(
             .put(ContentKind::IndexRoot, &root_bytes)
             .await
             .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+        cache_artifact_bytes(&cache_dir, &root_id, &root_bytes, "index_root");
 
         tracing::debug!(
             %root_id,
@@ -2398,6 +2649,7 @@ pub async fn incremental_index(
             .put(ContentKind::IndexRoot, &root_bytes)
             .await
             .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+        cache_artifact_bytes(&cache_dir, &root_id, &root_bytes, "index_root");
 
         tracing::debug!(
             %root_id,
@@ -2430,20 +2682,41 @@ pub async fn incremental_index(
 async fn upload_leaf_blobs(
     content_store: &dyn ContentStore,
     result: &BranchUpdateResult,
+    cache_dir: &std::path::Path,
 ) -> Result<()> {
+    let mut leaf_bytes = 0u64;
+    let mut sidecar_bytes = 0u64;
+    let mut sidecar_count = 0u64;
     for blob in &result.new_leaf_blobs {
-        content_store
+        let leaf_cid = content_store
             .put(ContentKind::IndexLeaf, &blob.info.leaf_bytes)
             .await
             .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+        debug_assert!(leaf_cid == blob.info.leaf_cid);
+        cache_artifact_bytes(cache_dir, &leaf_cid, &blob.info.leaf_bytes, "index_leaf");
+        leaf_bytes += blob.info.leaf_bytes.len() as u64;
 
         if let Some(ref sc_bytes) = blob.info.sidecar_bytes {
-            content_store
+            let sidecar_cid = content_store
                 .put(ContentKind::HistorySidecar, sc_bytes)
                 .await
                 .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+            if let Some(expected) = &blob.info.sidecar_cid {
+                debug_assert!(&sidecar_cid == expected);
+            }
+            cache_artifact_bytes(cache_dir, &sidecar_cid, sc_bytes, "history_sidecar");
+            sidecar_bytes += sc_bytes.len() as u64;
+            sidecar_count += 1;
         }
     }
+    tracing::debug!(
+        leaves = result.new_leaf_blobs.len(),
+        leaf_bytes,
+        sidecars = sidecar_count,
+        sidecar_bytes,
+        cache_dir = %cache_dir.display(),
+        "V6 Phase 2 upload complete; seeded artifact cache"
+    );
     Ok(())
 }
 

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2255,6 +2255,20 @@ pub async fn incremental_index(
                         let class_merge_started = Instant::now();
                         let existing_property_count = entry.properties.len();
                         let novelty_property_count = props.len();
+                        if merged_class_entries < 10
+                            || existing_property_count >= 100
+                            || novelty_property_count >= 100
+                        {
+                            tracing::debug!(
+                                g_id,
+                                class_sid64,
+                                existing_property_count,
+                                novelty_property_count,
+                                visited_class_entries,
+                                total_entries = total_class_entries,
+                                "Phase 3b: class property attribution entry starting"
+                            );
+                        }
                         let class_dts = class_prop_dts.get(&(g_id, class_sid64));
                         let class_refs = ref_edges.get(&(g_id, class_sid64));
                         let class_langs = class_prop_lang_deltas.get(&(g_id, class_sid64));
@@ -2300,114 +2314,139 @@ pub async fn incremental_index(
                             })
                             .collect();
 
-                        entry.properties = prop_set
-                            .iter()
-                            .map(|&cp_id| {
-                                let iri = novelty.shared.predicates.resolve(cp_id).unwrap_or("");
-                                let p_sid = match trie.longest_match(iri) {
-                                    Some((code, plen)) => {
-                                        fluree_db_core::Sid::new(code, &iri[plen..])
-                                    }
-                                    None => fluree_db_core::Sid::new(0, iri),
-                                };
-                                let base_pu = base_prop_by_pid.get(&cp_id).copied();
+                        let total_class_properties = prop_set.len();
+                        let base_ref_class_count: usize =
+                            entry.properties.iter().map(|pu| pu.ref_classes.len()).sum();
+                        if merged_class_entries < 10
+                            || total_class_properties >= 100
+                            || base_ref_class_count >= 100
+                        {
+                            tracing::debug!(
+                                g_id,
+                                class_sid64,
+                                existing_property_count,
+                                novelty_property_count,
+                                total_class_properties,
+                                base_ref_class_count,
+                                visited_class_entries,
+                                total_entries = total_class_entries,
+                                "Phase 3b: merging class property attribution entry"
+                            );
+                        }
 
-                                // Merge base + novelty datatypes.
-                                let mut merged_dts: std::collections::HashMap<u8, i64> =
-                                    std::collections::HashMap::new();
-                                if let Some(bpu) = base_pu {
-                                    for &(dt, cnt) in &bpu.datatypes {
-                                        *merged_dts.entry(dt).or_insert(0) += cnt as i64;
-                                    }
-                                }
-                                if let Some(dt_delta) = class_dts.and_then(|m| m.get(&cp_id)) {
-                                    for (&dt, &cnt) in dt_delta {
-                                        *merged_dts.entry(dt).or_insert(0) += cnt;
-                                    }
-                                }
-                                let datatypes: Vec<(u8, u64)> = merged_dts
-                                    .into_iter()
-                                    .filter(|(_, v)| *v > 0)
-                                    .map(|(dt, v)| (dt, v as u64))
-                                    .collect();
+                        let mut merged_properties = Vec::with_capacity(total_class_properties);
+                        let mut merged_property_count = 0usize;
+                        let mut last_class_property_log = Instant::now();
+                        for &cp_id in &prop_set {
+                            let iri = novelty.shared.predicates.resolve(cp_id).unwrap_or("");
+                            let p_sid = match trie.longest_match(iri) {
+                                Some((code, plen)) => fluree_db_core::Sid::new(code, &iri[plen..]),
+                                None => fluree_db_core::Sid::new(0, iri),
+                            };
+                            let base_pu = base_prop_by_pid.get(&cp_id).copied();
 
-                                // Merge base + novelty langs.
-                                let mut merged_langs: std::collections::HashMap<String, i64> =
-                                    std::collections::HashMap::new();
-                                if let Some(bpu) = base_pu {
-                                    for (tag, cnt) in &bpu.langs {
-                                        *merged_langs.entry(tag.clone()).or_insert(0) +=
-                                            *cnt as i64;
-                                    }
+                            // Merge base + novelty datatypes.
+                            let mut merged_dts: std::collections::HashMap<u8, i64> =
+                                std::collections::HashMap::new();
+                            if let Some(bpu) = base_pu {
+                                for &(dt, cnt) in &bpu.datatypes {
+                                    *merged_dts.entry(dt).or_insert(0) += cnt as i64;
                                 }
-                                if let Some(lang_delta) = class_langs.and_then(|m| m.get(&cp_id)) {
-                                    for (&lid, &cnt) in lang_delta {
-                                        let tag = lang_id_to_tag
-                                            .get(&lid)
-                                            .cloned()
-                                            .unwrap_or_else(|| format!("lang:{lid}"));
-                                        *merged_langs.entry(tag).or_insert(0) += cnt;
-                                    }
+                            }
+                            if let Some(dt_delta) = class_dts.and_then(|m| m.get(&cp_id)) {
+                                for (&dt, &cnt) in dt_delta {
+                                    *merged_dts.entry(dt).or_insert(0) += cnt;
                                 }
-                                let langs: Vec<(String, u64)> = merged_langs
-                                    .into_iter()
-                                    .filter(|(_, v)| *v > 0)
-                                    .map(|(tag, v)| (tag, v as u64))
-                                    .collect();
+                            }
+                            let datatypes: Vec<(u8, u64)> = merged_dts
+                                .into_iter()
+                                .filter(|(_, v)| *v > 0)
+                                .map(|(dt, v)| (dt, v as u64))
+                                .collect();
 
-                                // Merge base + novelty ref_classes.
-                                let mut merged_refs: std::collections::HashMap<u64, i64> =
-                                    std::collections::HashMap::new();
-                                if let Some(bpu) = base_pu {
-                                    for rc in &bpu.ref_classes {
-                                        ref_class_sid_lookups.fetch_add(1, Ordering::Relaxed);
-                                        let rc_sid64 = store_opt
-                                            .as_ref()
-                                            .and_then(|s| {
-                                                s.find_subject_id_by_parts(
-                                                    rc.class_sid.namespace_code,
-                                                    &rc.class_sid.name,
-                                                )
-                                                .ok()
-                                                .flatten()
-                                            })
-                                            .unwrap_or(0);
-                                        if rc_sid64 != 0 {
-                                            ref_class_sid_hits.fetch_add(1, Ordering::Relaxed);
-                                            *merged_refs.entry(rc_sid64).or_insert(0) +=
-                                                rc.count as i64;
-                                        }
-                                    }
+                            // Merge base + novelty langs.
+                            let mut merged_langs: std::collections::HashMap<String, i64> =
+                                std::collections::HashMap::new();
+                            if let Some(bpu) = base_pu {
+                                for (tag, cnt) in &bpu.langs {
+                                    *merged_langs.entry(tag.clone()).or_insert(0) += *cnt as i64;
                                 }
-                                if let Some(ref_delta) = class_refs.and_then(|m| m.get(&cp_id)) {
-                                    for (&target, &cnt) in ref_delta {
-                                        *merged_refs.entry(target).or_insert(0) += cnt;
-                                    }
+                            }
+                            if let Some(lang_delta) = class_langs.and_then(|m| m.get(&cp_id)) {
+                                for (&lid, &cnt) in lang_delta {
+                                    let tag = lang_id_to_tag
+                                        .get(&lid)
+                                        .cloned()
+                                        .unwrap_or_else(|| format!("lang:{lid}"));
+                                    *merged_langs.entry(tag).or_insert(0) += cnt;
                                 }
-                                let ref_classes: Vec<is::ClassRefCount> = merged_refs
-                                    .into_iter()
-                                    .filter(|(_, v)| *v > 0)
-                                    .map(|(target_sid64, cnt)| {
-                                        let cs = resolve_class_sid(
-                                            target_sid64,
-                                            store_opt.as_deref(),
-                                            &new_subject_suffix,
-                                        );
-                                        is::ClassRefCount {
-                                            class_sid: cs,
-                                            count: cnt as u64,
-                                        }
-                                    })
-                                    .collect();
+                            }
+                            let langs: Vec<(String, u64)> = merged_langs
+                                .into_iter()
+                                .filter(|(_, v)| *v > 0)
+                                .map(|(tag, v)| (tag, v as u64))
+                                .collect();
 
-                                is::ClassPropertyUsage {
-                                    property_sid: p_sid,
-                                    datatypes,
-                                    langs,
-                                    ref_classes,
+                            // Merge by Sid directly. The old path converted every
+                            // base ref-class Sid back through the reverse dictionary,
+                            // which can demand-load dictionary leaves during Phase 3b.
+                            let mut merged_refs: std::collections::HashMap<
+                                fluree_db_core::Sid,
+                                i64,
+                            > = std::collections::HashMap::new();
+                            if let Some(bpu) = base_pu {
+                                for rc in &bpu.ref_classes {
+                                    *merged_refs.entry(rc.class_sid.clone()).or_insert(0) +=
+                                        rc.count as i64;
                                 }
-                            })
-                            .collect();
+                            }
+                            if let Some(ref_delta) = class_refs.and_then(|m| m.get(&cp_id)) {
+                                for (&target, &cnt) in ref_delta {
+                                    ref_class_sid_lookups.fetch_add(1, Ordering::Relaxed);
+                                    let cs = resolve_class_sid(
+                                        target,
+                                        store_opt.as_deref(),
+                                        &new_subject_suffix,
+                                    );
+                                    ref_class_sid_hits.fetch_add(1, Ordering::Relaxed);
+                                    *merged_refs.entry(cs).or_insert(0) += cnt;
+                                }
+                            }
+                            let ref_classes: Vec<is::ClassRefCount> = merged_refs
+                                .into_iter()
+                                .filter(|(_, v)| *v > 0)
+                                .map(|(class_sid, cnt)| is::ClassRefCount {
+                                    class_sid,
+                                    count: cnt as u64,
+                                })
+                                .collect();
+
+                            merged_properties.push(is::ClassPropertyUsage {
+                                property_sid: p_sid,
+                                datatypes,
+                                langs,
+                                ref_classes,
+                            });
+                            merged_property_count += 1;
+
+                            if last_class_property_log.elapsed()
+                                >= std::time::Duration::from_secs(5)
+                            {
+                                tracing::debug!(
+                                    g_id,
+                                    class_sid64,
+                                    merged_property_count,
+                                    total_class_properties,
+                                    ref_class_sid_lookups =
+                                        ref_class_sid_lookups.load(Ordering::Relaxed),
+                                    elapsed_ms = class_merge_started.elapsed().as_millis() as u64,
+                                    phase_elapsed_ms = phase3b_started.elapsed().as_millis() as u64,
+                                    "Phase 3b: class property attribution entry still merging"
+                                );
+                                last_class_property_log = Instant::now();
+                            }
+                        }
+                        entry.properties = merged_properties;
                         merged_class_entries += 1;
                         let class_merge_ms = class_merge_started.elapsed().as_millis() as u64;
                         if class_merge_ms >= 1_000 {

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -1714,11 +1714,21 @@ pub async fn incremental_index(
 
         // Load prior sketches from the base root's sketch_ref (if present).
         let prior_properties = if let Some(ref cid) = base_root.sketch_ref {
-            match stats::load_sketch_blob(content_store.as_ref(), cid).await {
-                Ok(Some(blob)) => match blob.into_properties() {
+            match fetch_cached_index_bytes(
+                content_store.as_ref(),
+                cid,
+                &cache_dir,
+                format!("sketch blob {cid}"),
+            )
+            .await
+            {
+                Ok(bytes) => match stats::HllSketchBlob::from_json_bytes(&bytes)
+                    .and_then(stats::HllSketchBlob::into_properties)
+                {
                     Ok(props) => {
                         tracing::debug!(
                             entries = props.len(),
+                            bytes = bytes.len(),
                             "loaded prior HLL sketches for incremental refresh"
                         );
                         props
@@ -1728,7 +1738,7 @@ pub async fn incremental_index(
                         std::collections::HashMap::new()
                     }
                 },
-                Ok(None) => {
+                Err(IndexerError::StorageRead(e)) if e.contains("not found") => {
                     tracing::debug!(
                         "sketch blob CID present but content not found, starting fresh"
                     );
@@ -2225,12 +2235,26 @@ pub async fn incremental_index(
 
                 // Build property attribution for each class entry.
                 let property_merge_started = Instant::now();
+                tracing::debug!(
+                    total_entries = entries_by_key.len(),
+                    classes_with_properties = class_properties.len(),
+                    class_prop_dts = class_prop_dts.len(),
+                    class_prop_lang_deltas = class_prop_lang_deltas.len(),
+                    classes_with_ref_edges = ref_edges.len(),
+                    "Phase 3b: property attribution merge starting"
+                );
                 let ref_class_sid_lookups = AtomicUsize::new(0usize);
                 let ref_class_sid_hits = AtomicUsize::new(0usize);
                 let mut merged_class_entries = 0usize;
                 let total_class_entries = entries_by_key.len();
+                let mut visited_class_entries = 0usize;
+                let mut last_property_merge_log = Instant::now();
                 for (&(g_id, class_sid64), entry) in &mut entries_by_key {
+                    visited_class_entries += 1;
                     if let Some(props) = class_properties.get(&(g_id, class_sid64)) {
+                        let class_merge_started = Instant::now();
+                        let existing_property_count = entry.properties.len();
+                        let novelty_property_count = props.len();
                         let class_dts = class_prop_dts.get(&(g_id, class_sid64));
                         let class_refs = ref_edges.get(&(g_id, class_sid64));
                         let class_langs = class_prop_lang_deltas.get(&(g_id, class_sid64));
@@ -2385,6 +2409,20 @@ pub async fn incremental_index(
                             })
                             .collect();
                         merged_class_entries += 1;
+                        let class_merge_ms = class_merge_started.elapsed().as_millis() as u64;
+                        if class_merge_ms >= 1_000 {
+                            tracing::debug!(
+                                g_id,
+                                class_sid64,
+                                existing_property_count,
+                                novelty_property_count,
+                                merged_properties = entry.properties.len(),
+                                class_merge_ms,
+                                visited_class_entries,
+                                total_entries = total_class_entries,
+                                "Phase 3b: slow class property attribution merge"
+                            );
+                        }
                     }
                     // Resolve class SID if still placeholder.
                     if entry.class_sid.name.is_empty() && entry.class_sid.namespace_code == 0 {
@@ -2406,6 +2444,22 @@ pub async fn incremental_index(
                             elapsed_ms = property_merge_started.elapsed().as_millis() as u64,
                             "Phase 3b: property attribution merge progress"
                         );
+                        last_property_merge_log = Instant::now();
+                    } else if last_property_merge_log.elapsed() >= std::time::Duration::from_secs(5)
+                    {
+                        tracing::debug!(
+                            visited_class_entries,
+                            merged_class_entries,
+                            total_entries = total_class_entries,
+                            ref_class_sid_lookups = ref_class_sid_lookups.load(Ordering::Relaxed),
+                            ref_class_sid_hits = ref_class_sid_hits.load(Ordering::Relaxed),
+                            resolve_class_sid_calls =
+                                resolve_class_sid_calls.load(Ordering::Relaxed),
+                            phase_elapsed_ms = phase3b_started.elapsed().as_millis() as u64,
+                            elapsed_ms = property_merge_started.elapsed().as_millis() as u64,
+                            "Phase 3b: property attribution merge still running"
+                        );
+                        last_property_merge_log = Instant::now();
                     }
                 }
                 tracing::debug!(
@@ -2473,6 +2527,7 @@ pub async fn incremental_index(
         use crate::stats::SchemaExtractor;
         use fluree_db_core::o_type::OType;
         use fluree_db_core::{Flake, FlakeValue, Sid};
+        let phase3c_started = Instant::now();
 
         let rdfs_subclass_iri = format!("{}subClassOf", fluree_vocab::rdfs::NS);
         let rdfs_subprop_iri = format!("{}subPropertyOf", fluree_vocab::rdfs::NS);
@@ -2487,6 +2542,12 @@ pub async fn incremental_index(
         });
 
         if has_schema_records {
+            tracing::debug!(
+                subclass_p_id,
+                subprop_p_id,
+                novelty_records = novelty.records.len(),
+                "Phase 3c: incremental V6 schema refresh starting"
+            );
             match fluree_db_binary_index::read::binary_index_store::BinaryIndexStore::load_from_root_v6(
                 content_store.clone(),
                 base_root,
@@ -2558,7 +2619,10 @@ pub async fn incremental_index(
 
                     let updated_schema = extractor.finalize(novelty.max_t);
                     root_builder.set_schema(updated_schema);
-                    tracing::debug!("Phase 3c: incremental V6 schema refreshed");
+                    tracing::debug!(
+                        elapsed_ms = phase3c_started.elapsed().as_millis() as u64,
+                        "Phase 3c: incremental V6 schema refreshed"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -2568,16 +2632,33 @@ pub async fn incremental_index(
                     );
                 }
             }
+        } else {
+            tracing::debug!(
+                elapsed_ms = phase3c_started.elapsed().as_millis() as u64,
+                "Phase 3c: no schema records in novelty; carrying forward base schema"
+            );
         }
     }
 
     // ---- Phase 4: Root assembly ----
+    let phase4_started = Instant::now();
+    tracing::debug!(
+        base_index_t = base_root.index_t,
+        new_index_t = novelty.max_t,
+        total_new_leaves,
+        "Phase 4: incremental root assembly starting"
+    );
     root_builder.set_prev_index(Some(BinaryPrevIndexRef {
         t: base_root.index_t,
         id: base_root_id.clone(),
     }));
 
     let (new_root, replaced_cids) = root_builder.build();
+    tracing::debug!(
+        replaced_cids = replaced_cids.len(),
+        elapsed_ms = phase4_started.elapsed().as_millis() as u64,
+        "Phase 4: root builder finalized"
+    );
 
     // Write garbage manifest.
     if !replaced_cids.is_empty() {
@@ -2585,6 +2666,12 @@ pub async fn incremental_index(
             .iter()
             .map(std::string::ToString::to_string)
             .collect();
+        let garbage_write_started = Instant::now();
+        tracing::debug!(
+            replaced_cids = garbage_strings.len(),
+            index_t = new_root.index_t,
+            "Phase 4: writing garbage record"
+        );
         let garbage_cid = gc::write_garbage_record(
             content_store.as_ref(),
             ledger_id,
@@ -2593,6 +2680,11 @@ pub async fn incremental_index(
         )
         .await
         .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+        tracing::debug!(
+            %garbage_cid,
+            elapsed_ms = garbage_write_started.elapsed().as_millis() as u64,
+            "Phase 4: garbage record written"
+        );
 
         // Set garbage on the root before encoding.
         let mut final_root = new_root;
@@ -2607,7 +2699,19 @@ pub async fn incremental_index(
             final_root.index_t,
         )?;
 
+        let root_encode_started = Instant::now();
         let root_bytes = final_root.encode();
+        tracing::debug!(
+            bytes = root_bytes.len(),
+            elapsed_ms = root_encode_started.elapsed().as_millis() as u64,
+            "Phase 4: encoded incremental index root"
+        );
+        let root_write_started = Instant::now();
+        tracing::debug!(
+            bytes = root_bytes.len(),
+            index_t = final_root.index_t,
+            "Phase 4: writing incremental index root"
+        );
         let root_id = content_store
             .put(ContentKind::IndexRoot, &root_bytes)
             .await
@@ -2619,6 +2723,8 @@ pub async fn incremental_index(
             index_t = final_root.index_t,
             replaced = replaced_cids.len(),
             new_leaves = total_new_leaves,
+            root_write_ms = root_write_started.elapsed().as_millis() as u64,
+            phase4_elapsed_ms = phase4_started.elapsed().as_millis() as u64,
             "V6 incremental index root published"
         );
 
@@ -2644,7 +2750,19 @@ pub async fn incremental_index(
             &novelty.shared.ns_prefixes,
             final_root.index_t,
         )?;
+        let root_encode_started = Instant::now();
         let root_bytes = final_root.encode();
+        tracing::debug!(
+            bytes = root_bytes.len(),
+            elapsed_ms = root_encode_started.elapsed().as_millis() as u64,
+            "Phase 4: encoded incremental index root"
+        );
+        let root_write_started = Instant::now();
+        tracing::debug!(
+            bytes = root_bytes.len(),
+            index_t = final_root.index_t,
+            "Phase 4: writing incremental index root"
+        );
         let root_id = content_store
             .put(ContentKind::IndexRoot, &root_bytes)
             .await
@@ -2655,6 +2773,8 @@ pub async fn incremental_index(
             %root_id,
             index_t = final_root.index_t,
             new_leaves = total_new_leaves,
+            root_write_ms = root_write_started.elapsed().as_millis() as u64,
+            phase4_elapsed_ms = phase4_started.elapsed().as_millis() as u64,
             "V6 incremental index root published (no garbage)"
         );
 

--- a/fluree-db-indexer/src/gc/collector.rs
+++ b/fluree-db-indexer/src/gc/collector.rs
@@ -19,6 +19,7 @@ use crate::error::Result;
 use fluree_db_binary_index::IndexRoot;
 use fluree_db_core::storage::ContentStore;
 use fluree_db_core::ContentId;
+use std::path::Path;
 
 /// Entry in the prev-index chain.
 pub(crate) struct IndexChainEntry {
@@ -88,9 +89,23 @@ pub async fn clean_garbage(
         .unwrap_or(DEFAULT_MIN_TIME_GARBAGE_MINS);
     let min_age_ms = min_age_mins as i64 * 60 * 1000;
     let now_ms = current_timestamp_ms();
+    let started = std::time::Instant::now();
 
     // 1. Walk prev_index chain to collect all index versions (tolerant of missing roots)
-    let index_chain = walk_prev_index_chain_cs(store, current_root_id).await?;
+    let index_chain = walk_prev_index_chain_cs_cached(
+        store,
+        current_root_id,
+        config.artifact_cache_dir.as_deref(),
+    )
+    .await?;
+    tracing::debug!(
+        root_id = %current_root_id,
+        chain_len = index_chain.len(),
+        max_old_indexes,
+        min_age_mins,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "GC prev-index chain walk complete"
+    );
 
     // Retention: keep current + max_old_indexes
     // With max_old_indexes=5, keep_count=6 (indices 0..5)
@@ -141,27 +156,30 @@ pub async fn clean_garbage(
         };
 
         // Load the garbage record by CID
-        let record = match store.get(garbage_id).await {
-            Ok(bytes) => match parse_garbage_record(&bytes) {
-                Ok(r) => r,
+        let record =
+            match get_cached_or_remote(store, garbage_id, config.artifact_cache_dir.as_deref())
+                .await
+            {
+                Ok(bytes) => match parse_garbage_record(&bytes) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::debug!(
+                            t = manifest_entry.t,
+                            error = %e,
+                            "Failed to parse garbage record, stopping GC"
+                        );
+                        break;
+                    }
+                },
                 Err(e) => {
                     tracing::debug!(
                         t = manifest_entry.t,
                         error = %e,
-                        "Failed to parse garbage record, stopping GC"
+                        "Failed to load garbage record (may already be released), stopping GC"
                     );
                     break;
                 }
-            },
-            Err(e) => {
-                tracing::debug!(
-                    t = manifest_entry.t,
-                    error = %e,
-                    "Failed to load garbage record (may already be released), stopping GC"
-                );
-                break;
-            }
-        };
+            };
 
         // Check age: if created_at_ms is 0 (old format) or too recent, stop.
         // Newer manifests will be even more recent, so break is correct.
@@ -176,6 +194,13 @@ pub async fn clean_garbage(
         }
 
         // Release the garbage nodes (CID strings parsed back to ContentId).
+        let release_started = std::time::Instant::now();
+        tracing::debug!(
+            t = manifest_entry.t,
+            garbage_id = %garbage_id,
+            items = record.garbage.len(),
+            "GC releasing garbage record items"
+        );
         for item in &record.garbage {
             match item.parse::<ContentId>() {
                 Ok(cid) => {
@@ -198,6 +223,13 @@ pub async fn clean_garbage(
                 }
             }
         }
+        tracing::debug!(
+            t = manifest_entry.t,
+            garbage_id = %garbage_id,
+            deleted_count,
+            elapsed_ms = release_started.elapsed().as_millis() as u64,
+            "GC garbage record item release pass complete"
+        );
 
         // Release entry_to_delete's own garbage manifest
         if let Some(ref old_garbage_id) = entry_to_delete.garbage_id {
@@ -248,15 +280,41 @@ pub(crate) async fn walk_prev_index_chain_cs(
     store: &dyn ContentStore,
     current_root_id: &ContentId,
 ) -> Result<Vec<IndexChainEntry>> {
+    walk_prev_index_chain_cs_cached(store, current_root_id, None).await
+}
+
+async fn get_cached_or_remote(
+    store: &dyn ContentStore,
+    id: &ContentId,
+    cache_dir: Option<&Path>,
+) -> Result<Vec<u8>> {
+    match cache_dir {
+        Some(cache_dir) => Ok(
+            fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
+                store, id, cache_dir,
+            )
+            .await
+            .map_err(|e| crate::error::IndexerError::StorageRead(e.to_string()))?,
+        ),
+        None => Ok(store.get(id).await?),
+    }
+}
+
+pub(crate) async fn walk_prev_index_chain_cs_cached(
+    store: &dyn ContentStore,
+    current_root_id: &ContentId,
+    cache_dir: Option<&Path>,
+) -> Result<Vec<IndexChainEntry>> {
     let mut chain = Vec::new();
     let mut current_id = current_root_id.clone();
 
     loop {
-        let bytes = match store.get(&current_id).await {
+        let read_started = std::time::Instant::now();
+        let bytes = match get_cached_or_remote(store, &current_id, cache_dir).await {
             Ok(b) => b,
             Err(e) => {
                 if chain.is_empty() {
-                    return Err(e.into());
+                    return Err(e);
                 }
                 tracing::debug!(
                     root_id = %current_id,
@@ -265,6 +323,13 @@ pub(crate) async fn walk_prev_index_chain_cs(
                 break;
             }
         };
+        tracing::trace!(
+            root_id = %current_id,
+            bytes = bytes.len(),
+            elapsed_ms = read_started.elapsed().as_millis() as u64,
+            from_cache_enabled = cache_dir.is_some(),
+            "GC loaded prev-index root"
+        );
 
         let (t, prev_index_id, garbage_id, root) = parse_chain_fields(&bytes)?;
 
@@ -415,6 +480,7 @@ mod tests {
         let config = CleanGarbageConfig {
             max_old_indexes: Some(5),
             min_time_garbage_mins: Some(0),
+            ..Default::default()
         };
         let result = clean_garbage(&store, &root_cid, config).await.unwrap();
         assert_eq!(result.indexes_cleaned, 0);
@@ -558,6 +624,7 @@ mod tests {
         let config = CleanGarbageConfig {
             max_old_indexes: Some(1),
             min_time_garbage_mins: Some(30),
+            ..Default::default()
         };
 
         let store = test_store(&storage);
@@ -627,6 +694,7 @@ mod tests {
         let config = CleanGarbageConfig {
             max_old_indexes: Some(1),
             min_time_garbage_mins: Some(30),
+            ..Default::default()
         };
 
         let store = test_store(&storage);
@@ -690,6 +758,7 @@ mod tests {
         let config = CleanGarbageConfig {
             max_old_indexes: Some(1),
             min_time_garbage_mins: Some(30),
+            ..Default::default()
         };
 
         let store = test_store(&storage);
@@ -802,6 +871,7 @@ mod tests {
         let config = CleanGarbageConfig {
             max_old_indexes: Some(1),
             min_time_garbage_mins: Some(30),
+            ..Default::default()
         };
 
         let store = test_store(&storage);
@@ -938,6 +1008,7 @@ mod tests {
         let config = CleanGarbageConfig {
             max_old_indexes: Some(0),
             min_time_garbage_mins: Some(30),
+            ..Default::default()
         };
         let result = clean_garbage(&store, &new_root_cid, config).await.unwrap();
 

--- a/fluree-db-indexer/src/gc/mod.rs
+++ b/fluree-db-indexer/src/gc/mod.rs
@@ -40,6 +40,7 @@ pub use record::GarbageRecord;
 
 use crate::error::Result;
 use fluree_db_core::{ContentId, ContentKind, ContentStore};
+use std::path::PathBuf;
 
 /// Default maximum number of old indexes to retain
 pub const DEFAULT_MAX_OLD_INDEXES: u32 = 5;
@@ -58,6 +59,8 @@ pub struct CleanGarbageConfig {
     ///
     /// Garbage records must be at least this old before their nodes can be deleted.
     pub min_time_garbage_mins: Option<u32>,
+    /// Optional disk artifact cache for root and garbage-record reads.
+    pub artifact_cache_dir: Option<PathBuf>,
 }
 
 /// Result of garbage collection

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -1047,6 +1047,15 @@ impl BackgroundIndexerWorker {
                     let gc_config = crate::gc::CleanGarbageConfig {
                         max_old_indexes: Some(self.config.gc_max_old_indexes),
                         min_time_garbage_mins: Some(self.config.gc_min_time_mins),
+                        artifact_cache_dir: Some(
+                            self.config
+                                .data_dir
+                                .as_ref()
+                                .map(|d| d.join("binary_artifact_cache"))
+                                .unwrap_or_else(|| {
+                                    std::env::temp_dir().join("fluree_binary_cache")
+                                }),
+                        ),
                     };
                     tokio::spawn(async move {
                         if let Err(e) =

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -1041,36 +1041,48 @@ impl BackgroundIndexerWorker {
                             "Successfully indexed ledger"
                         );
 
-                    // Spawn garbage collection (fire-and-forget, non-fatal).
-                    let gc_store = self.backend.content_store(&index_result.ledger_id);
-                    let gc_root_id = index_result.root_id.clone();
-                    let gc_config = crate::gc::CleanGarbageConfig {
-                        max_old_indexes: Some(self.config.gc_max_old_indexes),
-                        min_time_garbage_mins: Some(self.config.gc_min_time_mins),
-                        artifact_cache_dir: Some(
-                            self.config
-                                .data_dir
-                                .as_ref()
-                                .map(|d| d.join("binary_artifact_cache"))
-                                .unwrap_or_else(|| {
-                                    std::env::temp_dir().join("fluree_binary_cache")
-                                }),
-                        ),
-                    };
-                    tokio::spawn(async move {
-                        if let Err(e) =
-                            crate::gc::clean_garbage(gc_store.as_ref(), &gc_root_id, gc_config)
-                                .await
-                        {
-                            warn!(
-                                error = %e,
-                                root_id = %gc_root_id,
-                                "Background GC failed (non-fatal)"
-                            );
-                        } else {
-                            debug!(root_id = %gc_root_id, "Background GC completed");
-                        }
-                    });
+                    // Spawn garbage collection only after enough published index
+                    // versions can exist to exceed retention. The collector still
+                    // checks the exact prev-index chain and age thresholds.
+                    let gc_keep_count = 1_i64 + i64::from(self.config.gc_max_old_indexes);
+                    if index_result.index_t <= gc_keep_count {
+                        debug!(
+                            root_id = %index_result.root_id,
+                            index_t = index_result.index_t,
+                            gc_keep_count,
+                            "Skipping background GC; index chain cannot exceed retention yet"
+                        );
+                    } else {
+                        let gc_store = self.backend.content_store(&index_result.ledger_id);
+                        let gc_root_id = index_result.root_id.clone();
+                        let gc_config = crate::gc::CleanGarbageConfig {
+                            max_old_indexes: Some(self.config.gc_max_old_indexes),
+                            min_time_garbage_mins: Some(self.config.gc_min_time_mins),
+                            artifact_cache_dir: Some(
+                                self.config
+                                    .data_dir
+                                    .as_ref()
+                                    .map(|d| d.join("binary_artifact_cache"))
+                                    .unwrap_or_else(|| {
+                                        std::env::temp_dir().join("fluree_binary_cache")
+                                    }),
+                            ),
+                        };
+                        tokio::spawn(async move {
+                            if let Err(e) =
+                                crate::gc::clean_garbage(gc_store.as_ref(), &gc_root_id, gc_config)
+                                    .await
+                            {
+                                warn!(
+                                    error = %e,
+                                    root_id = %gc_root_id,
+                                    "Background GC failed (non-fatal)"
+                                );
+                            } else {
+                                debug!(root_id = %gc_root_id, "Background GC completed");
+                            }
+                        });
+                    }
 
                     // Resolve waiters
                     let mut states = self.states.lock().await;

--- a/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
@@ -13,6 +13,7 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -28,6 +29,26 @@ use fluree_db_core::value_id::{ObjKey, ObjKind};
 use fluree_db_core::DatatypeDictId;
 
 use crate::run_index::resolve::resolver::{RebuildChunk, ResolverError, SharedResolverState};
+
+async fn fetch_cached_or_get(
+    cs: &dyn ContentStore,
+    cid: &ContentId,
+    cache_dir: Option<&Path>,
+    context: impl Into<String>,
+) -> Result<Vec<u8>, IncrementalResolveError> {
+    let context = context.into();
+    match cache_dir {
+        Some(cache_dir) => {
+            fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(cs, cid, cache_dir)
+                .await
+                .map_err(|e| IncrementalResolveError::RootLoad(format!("{context}: {e}")))
+        }
+        None => cs
+            .get(cid)
+            .await
+            .map_err(|e| IncrementalResolveError::RootLoad(format!("{context}: {e}"))),
+    }
+}
 
 // ============================================================================
 // Error type
@@ -166,12 +187,13 @@ pub async fn resolve_incremental_commits_v6(
     // 1. Load and decode IndexRoot.
     let (root_bytes, t_root_load_ms) = {
         let t0 = Instant::now();
-        let bytes = cs.get(&config.base_root_id).await.map_err(|e| {
-            IncrementalResolveError::RootLoad(format!(
-                "failed to load FIR6 root {}: {}",
-                config.base_root_id, e
-            ))
-        })?;
+        let bytes = fetch_cached_or_get(
+            cs.as_ref(),
+            &config.base_root_id,
+            config.artifact_cache_dir.as_deref(),
+            format!("failed to load FIR6 root {}", config.base_root_id),
+        )
+        .await?;
         (bytes, t0.elapsed().as_millis() as u64)
     };
 
@@ -259,12 +281,13 @@ pub async fn resolve_incremental_commits_v6(
             }
             let nb_map = shared.numbigs.entry(ga.g_id).or_default();
             for (p_id, cid) in &ga.numbig {
-                let bytes = cs.get(cid).await.map_err(|e| {
-                    IncrementalResolveError::RootLoad(format!(
-                        "numbig arena load for g_id={}, p_id={}: {}",
-                        ga.g_id, p_id, e
-                    ))
-                })?;
+                let bytes = fetch_cached_or_get(
+                    cs.as_ref(),
+                    cid,
+                    config.artifact_cache_dir.as_deref(),
+                    format!("numbig arena load for g_id={}, p_id={}", ga.g_id, p_id),
+                )
+                .await?;
                 let arena =
                     fluree_db_binary_index::arena::numbig::read_numbig_arena_from_bytes(&bytes)
                         .map_err(|e| {
@@ -283,12 +306,16 @@ pub async fn resolve_incremental_commits_v6(
         )> = Vec::new();
         for ga in &root.graph_arenas {
             for vref in &ga.vectors {
-                let manifest_bytes = cs.get(&vref.manifest).await.map_err(|e| {
-                    IncrementalResolveError::RootLoad(format!(
-                        "vector manifest load for g_id={}, p_id={}: {}",
-                        ga.g_id, vref.p_id, e
-                    ))
-                })?;
+                let manifest_bytes = fetch_cached_or_get(
+                    cs.as_ref(),
+                    &vref.manifest,
+                    config.artifact_cache_dir.as_deref(),
+                    format!(
+                        "vector manifest load for g_id={}, p_id={}",
+                        ga.g_id, vref.p_id
+                    ),
+                )
+                .await?;
                 let manifest =
                     fluree_db_binary_index::arena::vector::read_vector_manifest(&manifest_bytes)
                         .map_err(|e| {
@@ -319,6 +346,7 @@ pub async fn resolve_incremental_commits_v6(
             &config.head_commit_id,
             config.from_t,
             config.max_commit_bytes,
+            config.artifact_cache_dir.as_deref(),
         )
         .await?;
         (commits, t0.elapsed().as_millis() as u64)
@@ -359,12 +387,16 @@ pub async fn resolve_incremental_commits_v6(
                         "vector shard CID parse for g_id={g_id}, p_id={p_id}: {e}"
                     ))
                 })?;
-                let bytes = cs.get(&cid).await.map_err(|e| {
-                    IncrementalResolveError::RootLoad(format!(
-                        "vector shard load for g_id={g_id}, p_id={p_id}, cid={}: {e}",
+                let bytes = fetch_cached_or_get(
+                    cs.as_ref(),
+                    &cid,
+                    config.artifact_cache_dir.as_deref(),
+                    format!(
+                        "vector shard load for g_id={g_id}, p_id={p_id}, cid={}",
                         shard_info.cas
-                    ))
-                })?;
+                    ),
+                )
+                .await?;
                 let shard =
                     fluree_db_binary_index::arena::vector::read_vector_shard_from_bytes(&bytes)
                         .map_err(|e| {
@@ -834,6 +866,7 @@ async fn walk_commit_chain_since(
     head_id: &ContentId,
     from_t: i64,
     max_commit_bytes: Option<usize>,
+    cache_dir: Option<&Path>,
 ) -> Result<Vec<WalkedCommit>, IncrementalResolveError> {
     let walk_started = Instant::now();
 
@@ -863,9 +896,22 @@ async fn walk_commit_chain_since(
             }
         }
 
-        let bytes = cs.get(&cid).await.map_err(|e| {
-            IncrementalResolveError::CommitChain(format!("failed to load commit {cid}: {e}"))
-        })?;
+        let bytes = match cache_dir {
+            Some(cache_dir) => {
+                fluree_db_binary_index::read::artifact_cache::fetch_cached_bytes_cid(
+                    cs, &cid, cache_dir,
+                )
+                .await
+                .map_err(|e| {
+                    IncrementalResolveError::CommitChain(format!(
+                        "failed to load commit {cid}: {e}"
+                    ))
+                })?
+            }
+            None => cs.get(&cid).await.map_err(|e| {
+                IncrementalResolveError::CommitChain(format!("failed to load commit {cid}: {e}"))
+            })?,
+        };
         cumulative_bytes += bytes.len();
         commits.push(WalkedCommit { cid, t, bytes });
     }

--- a/fluree-db-storage-aws/src/lib.rs
+++ b/fluree-db-storage-aws/src/lib.rs
@@ -26,6 +26,7 @@
 //!     bucket: "my-bucket".to_string(),
 //!     prefix: Some("ledgers".to_string()),
 //!     timeout_ms: Some(30000),
+//!     ..Default::default()
 //! };
 //! let storage = S3Storage::new(&sdk_config, s3_config).await?;
 //!

--- a/fluree-db-storage-aws/src/s3/mod.rs
+++ b/fluree-db-storage-aws/src/s3/mod.rs
@@ -20,9 +20,10 @@
 //!
 //! ## Timeout Configuration
 //!
-//! The `timeout_ms` setting controls the total operation timeout, which **includes
-//! SDK retry time**. For Lambda environments, ensure this value accounts for your
-//! function's remaining execution time.
+//! The `timeout_ms` setting bounds each S3 request send and response-body
+//! collection. The SDK operation timeout applied to sends includes SDK retry
+//! time. For Lambda environments, ensure this value accounts for your function's
+//! remaining execution time.
 
 pub mod address;
 
@@ -40,7 +41,11 @@ use fluree_db_core::{
     StorageExtResult, StorageList, StorageRead, StorageWrite,
 };
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 32;
 
 /// S3 storage configuration
 #[derive(Debug, Clone, Default)]
@@ -59,6 +64,11 @@ pub struct S3Config {
     pub retry_base_delay_ms: Option<u64>,
     /// Max backoff for retries in milliseconds
     pub retry_max_delay_ms: Option<u64>,
+    /// Maximum concurrent S3 SDK operations per storage instance.
+    ///
+    /// This bounds in-flight reads/writes/deletes so retry storms cannot create
+    /// an unbounded queue inside the SDK HTTP layer.
+    pub max_concurrent_requests: Option<usize>,
 }
 
 /// S3-based storage backend
@@ -78,6 +88,9 @@ pub struct S3Storage {
     prefix: Option<String>,
     /// Per-request send timeout (from `S3Config::timeout_ms`, or default 35s)
     send_timeout: Duration,
+    /// Storage-level bulkhead for all S3 SDK operations from this instance.
+    request_semaphore: Arc<Semaphore>,
+    max_concurrent_requests: usize,
 }
 
 impl Debug for S3Storage {
@@ -86,6 +99,7 @@ impl Debug for S3Storage {
             .field("bucket", &self.bucket)
             .field("prefix", &self.prefix)
             .field("is_express", &Self::is_express_bucket(&self.bucket))
+            .field("max_concurrent_requests", &self.max_concurrent_requests)
             .finish()
     }
 }
@@ -109,6 +123,7 @@ impl S3Storage {
     ///     bucket: "my-bucket".to_string(),
     ///     prefix: Some("data".to_string()),
     ///     timeout_ms: Some(30000),
+    ///     ..Default::default()
     /// };
     /// let storage = S3Storage::new(&sdk_config, s3_config).await?;
     /// ```
@@ -161,12 +176,18 @@ impl S3Storage {
             .timeout_ms
             .map(Duration::from_millis)
             .unwrap_or(Duration::from_secs(35));
+        let max_concurrent_requests = config
+            .max_concurrent_requests
+            .unwrap_or(DEFAULT_MAX_CONCURRENT_REQUESTS)
+            .max(1);
 
         Ok(Self {
             client,
             bucket: config.bucket,
             prefix: config.prefix,
             send_timeout,
+            request_semaphore: Arc::new(Semaphore::new(max_concurrent_requests)),
+            max_concurrent_requests,
         })
     }
 
@@ -177,6 +198,8 @@ impl S3Storage {
             bucket,
             prefix,
             send_timeout: Duration::from_secs(35),
+            request_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_REQUESTS)),
+            max_concurrent_requests: DEFAULT_MAX_CONCURRENT_REQUESTS,
         }
     }
 
@@ -221,6 +244,24 @@ impl S3Storage {
         self.prefix.as_deref()
     }
 
+    async fn acquire_request_permit_core(
+        &self,
+    ) -> std::result::Result<OwnedSemaphorePermit, CoreError> {
+        self.request_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| CoreError::io("S3 request limiter closed"))
+    }
+
+    async fn acquire_request_permit_ext(&self) -> StorageExtResult<OwnedSemaphorePermit> {
+        self.request_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| StorageExtError::io("S3 request limiter closed"))
+    }
+
     /// Convert a Fluree address to an S3 key
     fn to_key(&self, address: &str) -> std::result::Result<String, CoreError> {
         address_to_key(address, self.prefix.as_deref())
@@ -241,6 +282,7 @@ impl StorageRead for S3Storage {
 
         let send_timeout = self.send_timeout;
         let key = self.to_key(address)?;
+        let permit = self.acquire_request_permit_core().await?;
         let total_started = Instant::now();
 
         let send_started = Instant::now();
@@ -280,13 +322,27 @@ impl StorageRead for S3Storage {
         }
 
         let body_collect_started = Instant::now();
-        let bytes = response
-            .body
-            .collect()
-            .await
-            .map_err(|e| CoreError::io(format!("Failed to read S3 body: {e}")))?
-            .into_bytes()
-            .to_vec();
+        let bytes = match tokio::time::timeout(send_timeout, response.body.collect()).await {
+            Ok(Ok(body)) => body.into_bytes().to_vec(),
+            Ok(Err(e)) => return Err(CoreError::io(format!("Failed to read S3 body: {e}"))),
+            Err(_) => {
+                let body_collect_elapsed_ms = body_collect_started.elapsed().as_millis() as u64;
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key = key.as_str(),
+                    address,
+                    body_collect_elapsed_ms,
+                    timeout_ms = send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 read_bytes: body collect timed out"
+                );
+                return Err(CoreError::io(format!(
+                    "S3 GetObject body timed out after {} ms for {}",
+                    send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
         let body_collect_elapsed_ms = body_collect_started.elapsed().as_millis() as u64;
         let total_elapsed_ms = total_started.elapsed().as_millis() as u64;
 
@@ -303,6 +359,7 @@ impl StorageRead for S3Storage {
             );
         }
 
+        drop(permit);
         Ok(bytes)
     }
 
@@ -311,44 +368,129 @@ impl StorageRead for S3Storage {
         address: &str,
         range: std::ops::Range<u64>,
     ) -> std::result::Result<Vec<u8>, CoreError> {
+        const SLOW_S3_RANGE_SEND_WARN_MS: u64 = 1_000;
+        const SLOW_S3_RANGE_BODY_WARN_MS: u64 = 5_000;
+
         if range.start >= range.end {
             return Ok(Vec::new());
         }
         let key = self.to_key(address)?;
         let range_header = format!("bytes={}-{}", range.start, range.end - 1);
+        let send_timeout = self.send_timeout;
+        let permit = self.acquire_request_permit_core().await?;
+        let total_started = Instant::now();
+        let send_started = Instant::now();
 
-        let response = self
+        let request = self
             .client
             .get_object()
             .bucket(&self.bucket)
             .key(&key)
-            .range(range_header)
-            .send()
-            .await
-            .map_err(|e| map_s3_error_core(e, &key))?;
+            .range(range_header.clone());
 
-        let bytes = response
-            .body
-            .collect()
-            .await
-            .map_err(|e| CoreError::io(format!("Failed to read S3 body: {e}")))?
-            .into_bytes()
-            .to_vec();
+        let response = match tokio::time::timeout(send_timeout, request.send()).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => return Err(map_s3_error_core(e, &key)),
+            Err(_) => {
+                let send_elapsed_ms = send_started.elapsed().as_millis() as u64;
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key = key.as_str(),
+                    address,
+                    range = range_header.as_str(),
+                    send_elapsed_ms,
+                    timeout_ms = send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 read_byte_range: get_object send timed out"
+                );
+                return Err(CoreError::io(format!(
+                    "S3 ranged GetObject timed out after {} ms for {}",
+                    send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
+        let send_elapsed_ms = send_started.elapsed().as_millis() as u64;
 
+        if send_elapsed_ms >= SLOW_S3_RANGE_SEND_WARN_MS {
+            tracing::debug!(
+                bucket = self.bucket.as_str(),
+                key = key.as_str(),
+                address,
+                range = range_header.as_str(),
+                send_elapsed_ms,
+                is_express = Self::is_express_bucket(&self.bucket),
+                "s3 read_byte_range: slow get_object send"
+            );
+        }
+
+        let body_started = Instant::now();
+        let bytes = match tokio::time::timeout(send_timeout, response.body.collect()).await {
+            Ok(Ok(body)) => body.into_bytes().to_vec(),
+            Ok(Err(e)) => return Err(CoreError::io(format!("Failed to read S3 body: {e}"))),
+            Err(_) => {
+                let body_elapsed_ms = body_started.elapsed().as_millis() as u64;
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key = key.as_str(),
+                    address,
+                    range = range_header.as_str(),
+                    body_elapsed_ms,
+                    timeout_ms = send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 read_byte_range: body collect timed out"
+                );
+                return Err(CoreError::io(format!(
+                    "S3 ranged GetObject body timed out after {} ms for {}",
+                    send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
+        let body_elapsed_ms = body_started.elapsed().as_millis() as u64;
+        if body_elapsed_ms >= SLOW_S3_RANGE_BODY_WARN_MS {
+            tracing::debug!(
+                bucket = self.bucket.as_str(),
+                key = key.as_str(),
+                address,
+                range = range_header.as_str(),
+                body_bytes = bytes.len(),
+                body_elapsed_ms,
+                total_elapsed_ms = total_started.elapsed().as_millis() as u64,
+                is_express = Self::is_express_bucket(&self.bucket),
+                "s3 read_byte_range: slow body collect"
+            );
+        }
+
+        drop(permit);
         Ok(bytes)
     }
 
     async fn exists(&self, address: &str) -> std::result::Result<bool, CoreError> {
         let key = self.to_key(address)?;
+        let permit = self.acquire_request_permit_core().await?;
 
-        match self
-            .client
-            .head_object()
-            .bucket(&self.bucket)
-            .key(&key)
-            .send()
-            .await
-        {
+        let request = self.client.head_object().bucket(&self.bucket).key(&key);
+
+        let result = match tokio::time::timeout(self.send_timeout, request.send()).await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key = key.as_str(),
+                    address,
+                    timeout_ms = self.send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 exists: head_object timed out"
+                );
+                return Err(CoreError::io(format!(
+                    "S3 HeadObject timed out after {} ms for {}",
+                    self.send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
+        let exists = match result {
             Ok(_) => Ok(true),
             Err(e) => {
                 // Pattern match on SdkError to avoid panic from into_service_error()
@@ -366,7 +508,9 @@ impl StorageRead for S3Storage {
                     _ => Err(map_s3_error_core(e, &key)),
                 }
             }
-        }
+        }?;
+        drop(permit);
+        Ok(exists)
     }
 
     async fn list_prefix(&self, prefix: &str) -> std::result::Result<Vec<String>, CoreError> {
@@ -397,10 +541,26 @@ impl StorageRead for S3Storage {
                 request = request.continuation_token(token);
             }
 
-            let response = request
-                .send()
-                .await
-                .map_err(|e| map_s3_error_core(e, &full_prefix))?;
+            let permit = self.acquire_request_permit_core().await?;
+            let response = match tokio::time::timeout(self.send_timeout, request.send()).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => return Err(map_s3_error_core(e, &full_prefix)),
+                Err(_) => {
+                    tracing::error!(
+                        bucket = self.bucket.as_str(),
+                        prefix = full_prefix.as_str(),
+                        timeout_ms = self.send_timeout.as_millis() as u64,
+                        is_express = Self::is_express_bucket(&self.bucket),
+                        "s3 list_prefix_with_metadata: list_objects_v2 timed out"
+                    );
+                    return Err(CoreError::io(format!(
+                        "S3 ListObjectsV2 timed out after {} ms for {}",
+                        self.send_timeout.as_millis(),
+                        full_prefix
+                    )));
+                }
+            };
+            drop(permit);
 
             for object in response.contents() {
                 if let Some(key) = object.key() {
@@ -425,17 +585,57 @@ impl StorageRead for S3Storage {
 #[async_trait]
 impl StorageWrite for S3Storage {
     async fn write_bytes(&self, address: &str, bytes: &[u8]) -> std::result::Result<(), CoreError> {
-        let key = self.to_key(address)?;
+        const SLOW_S3_PUT_WARN_MS: u64 = 1_000;
 
-        self.client
+        let key = self.to_key(address)?;
+        let send_timeout = self.send_timeout;
+        let permit = self.acquire_request_permit_core().await?;
+        let started = Instant::now();
+
+        let request = self
+            .client
             .put_object()
             .bucket(&self.bucket)
             .key(&key)
-            .body(ByteStream::from(bytes.to_vec()))
-            .send()
-            .await
-            .map_err(|e| map_s3_error_core(e, &key))?;
+            .body(ByteStream::from(bytes.to_vec()));
 
+        match tokio::time::timeout(send_timeout, request.send()).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => return Err(map_s3_error_core(e, &key)),
+            Err(_) => {
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key = key.as_str(),
+                    address,
+                    bytes = bytes.len(),
+                    elapsed_ms,
+                    timeout_ms = send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 write_bytes: put_object timed out"
+                );
+                return Err(CoreError::io(format!(
+                    "S3 PutObject timed out after {} ms for {}",
+                    send_timeout.as_millis(),
+                    key
+                )));
+            }
+        }
+
+        let elapsed_ms = started.elapsed().as_millis() as u64;
+        if elapsed_ms >= SLOW_S3_PUT_WARN_MS {
+            tracing::debug!(
+                bucket = self.bucket.as_str(),
+                key = key.as_str(),
+                address,
+                bytes = bytes.len(),
+                elapsed_ms,
+                is_express = Self::is_express_bucket(&self.bucket),
+                "s3 write_bytes: slow put_object"
+            );
+        }
+
+        drop(permit);
         Ok(())
     }
 
@@ -493,17 +693,51 @@ impl ContentAddressedWrite for S3Storage {
 #[async_trait]
 impl StorageDelete for S3Storage {
     async fn delete(&self, address: &str) -> StorageExtResult<()> {
+        const SLOW_S3_DELETE_WARN_MS: u64 = 1_000;
+
         let key = address_to_key(address, self.prefix.as_deref())
             .map_err(|e| StorageExtError::io(format!("Invalid address: {e}")))?;
+        let send_timeout = self.send_timeout;
+        let permit = self.acquire_request_permit_ext().await?;
+        let started = Instant::now();
 
-        self.client
-            .delete_object()
-            .bucket(&self.bucket)
-            .key(&key)
-            .send()
-            .await
-            .map_err(|e| map_s3_error_ext(e, &key))?;
+        let request = self.client.delete_object().bucket(&self.bucket).key(&key);
 
+        match tokio::time::timeout(send_timeout, request.send()).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => return Err(map_s3_error_ext(e, &key)),
+            Err(_) => {
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key = key.as_str(),
+                    address,
+                    elapsed_ms,
+                    timeout_ms = send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 delete: delete_object timed out"
+                );
+                return Err(StorageExtError::io(format!(
+                    "S3 DeleteObject timed out after {} ms for {}",
+                    send_timeout.as_millis(),
+                    key
+                )));
+            }
+        }
+
+        let elapsed_ms = started.elapsed().as_millis() as u64;
+        if elapsed_ms >= SLOW_S3_DELETE_WARN_MS {
+            tracing::debug!(
+                bucket = self.bucket.as_str(),
+                key = key.as_str(),
+                address,
+                elapsed_ms,
+                is_express = Self::is_express_bucket(&self.bucket),
+                "s3 delete: slow delete_object"
+            );
+        }
+
+        drop(permit);
         Ok(())
     }
 }
@@ -528,10 +762,26 @@ impl StorageList for S3Storage {
                 request = request.continuation_token(token);
             }
 
-            let response = request
-                .send()
-                .await
-                .map_err(|e| map_s3_error_ext(e, &full_prefix))?;
+            let permit = self.acquire_request_permit_ext().await?;
+            let response = match tokio::time::timeout(self.send_timeout, request.send()).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => return Err(map_s3_error_ext(e, &full_prefix)),
+                Err(_) => {
+                    tracing::error!(
+                        bucket = self.bucket.as_str(),
+                        prefix = full_prefix.as_str(),
+                        timeout_ms = self.send_timeout.as_millis() as u64,
+                        is_express = Self::is_express_bucket(&self.bucket),
+                        "s3 list_prefix: list_objects_v2 timed out"
+                    );
+                    return Err(StorageExtError::io(format!(
+                        "S3 ListObjectsV2 timed out after {} ms for {}",
+                        self.send_timeout.as_millis(),
+                        full_prefix
+                    )));
+                }
+            };
+            drop(permit);
 
             for object in response.contents() {
                 if let Some(key) = object.key() {
@@ -568,10 +818,26 @@ impl StorageList for S3Storage {
             request = request.continuation_token(token);
         }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| map_s3_error_ext(e, &full_prefix))?;
+        let permit = self.acquire_request_permit_ext().await?;
+        let response = match tokio::time::timeout(self.send_timeout, request.send()).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => return Err(map_s3_error_ext(e, &full_prefix)),
+            Err(_) => {
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    prefix = full_prefix.as_str(),
+                    timeout_ms = self.send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 list_prefix_paginated: list_objects_v2 timed out"
+                );
+                return Err(StorageExtError::io(format!(
+                    "S3 ListObjectsV2 timed out after {} ms for {}",
+                    self.send_timeout.as_millis(),
+                    full_prefix
+                )));
+            }
+        };
+        drop(permit);
 
         let addresses: Vec<String> = response
             .contents()
@@ -595,15 +861,34 @@ const MAX_S3_CAS_RETRIES: u32 = 5;
 impl S3Storage {
     /// S3 put with `If-None-Match: *` (create-if-absent).
     async fn put_if_absent(&self, key: &str, bytes: &[u8]) -> StorageExtResult<bool> {
-        let result = self
+        let permit = self.acquire_request_permit_ext().await?;
+        let request = self
             .client
             .put_object()
             .bucket(&self.bucket)
             .key(key)
             .body(ByteStream::from(bytes.to_vec()))
-            .if_none_match("*")
-            .send()
-            .await;
+            .if_none_match("*");
+
+        let result = match tokio::time::timeout(self.send_timeout, request.send()).await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key,
+                    bytes = bytes.len(),
+                    timeout_ms = self.send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 cas insert: put_object timed out"
+                );
+                return Err(StorageExtError::io(format!(
+                    "S3 conditional PutObject timed out after {} ms for {}",
+                    self.send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
+        drop(permit);
 
         match result {
             Ok(_) => Ok(true),
@@ -620,15 +905,34 @@ impl S3Storage {
             format!("\"{etag}\"")
         };
 
-        let result = self
+        let permit = self.acquire_request_permit_ext().await?;
+        let request = self
             .client
             .put_object()
             .bucket(&self.bucket)
             .key(key)
             .body(ByteStream::from(bytes.to_vec()))
-            .if_match(&etag_quoted)
-            .send()
-            .await;
+            .if_match(&etag_quoted);
+
+        let result = match tokio::time::timeout(self.send_timeout, request.send()).await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key,
+                    bytes = bytes.len(),
+                    timeout_ms = self.send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 cas update: put_object timed out"
+                );
+                return Err(StorageExtError::io(format!(
+                    "S3 conditional PutObject timed out after {} ms for {}",
+                    self.send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
+        drop(permit);
 
         match result {
             Ok(output) => {
@@ -644,25 +948,50 @@ impl S3Storage {
 
     /// S3 get with ETag extraction.
     async fn get_with_etag(&self, key: &str) -> StorageExtResult<(Vec<u8>, String)> {
-        let response = self
-            .client
-            .get_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .send()
-            .await
-            .map_err(|e| map_s3_error_ext(e, key))?;
+        let permit = self.acquire_request_permit_ext().await?;
+        let request = self.client.get_object().bucket(&self.bucket).key(key);
+
+        let response = match tokio::time::timeout(self.send_timeout, request.send()).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => return Err(map_s3_error_ext(e, key)),
+            Err(_) => {
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key,
+                    timeout_ms = self.send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 cas read: get_object timed out"
+                );
+                return Err(StorageExtError::io(format!(
+                    "S3 CAS GetObject timed out after {} ms for {}",
+                    self.send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
 
         let etag = response.e_tag().map(normalize_etag).unwrap_or_default();
 
-        let bytes = response
-            .body
-            .collect()
-            .await
-            .map_err(|e| StorageExtError::io(format!("Failed to read S3 body: {e}")))?
-            .into_bytes()
-            .to_vec();
+        let bytes = match tokio::time::timeout(self.send_timeout, response.body.collect()).await {
+            Ok(Ok(body)) => body.into_bytes().to_vec(),
+            Ok(Err(e)) => return Err(StorageExtError::io(format!("Failed to read S3 body: {e}"))),
+            Err(_) => {
+                tracing::error!(
+                    bucket = self.bucket.as_str(),
+                    key,
+                    timeout_ms = self.send_timeout.as_millis() as u64,
+                    is_express = Self::is_express_bucket(&self.bucket),
+                    "s3 cas read: body collect timed out"
+                );
+                return Err(StorageExtError::io(format!(
+                    "S3 CAS GetObject body timed out after {} ms for {}",
+                    self.send_timeout.as_millis(),
+                    key
+                )));
+            }
+        };
 
+        drop(permit);
         Ok((bytes, etag))
     }
 }


### PR DESCRIPTION

  - Fixes a **Phase 3b incremental indexing hang** on Standard S3 where, after a successful initial full-build, the indexer would deterministically stall on the *first* per-class property-attribution merge entry and never progress past the first indexed `t`. Under pre-fix builds, the indexer Lambda burned its full 15 min execution budget and fell back to a  backpressure-triggered full rebuild on every subsequent commit.
  - Keeps incremental class/property stats merging **storage-free** by removing `BinaryIndexStore` lookups from the per-property ref-class merge loop — the hot path that was triggering on-demand dictionary/index artifact loads on Standard S3.
  - Adds operations guidance comparing **Standard S3 vs S3 Express One Zone** for index storage in serverless/Lambda deployments, including benchmark-backed transaction, query, and indexing  latency expectations.
  -  The fix improves S3 Express one indexing speed as well, this is not just a S3 standard fix. Stats show 30%+ improvement at the 10MB ledger range and speedup is proportional to ledger size, GB+ ledgers should be very meaningful improvements.
  
  ## Details

  ### Root cause

  Hidden store-backed class `Sid` resolution inside incremental stats merging. The per-property ref-class merge loop was reaching into `BinaryIndexStore` to resolve class IDs, which could demand-load dictionary and index artifacts mid-loop. On S3 Express that cost was masked by ~1–5 ms per-object latency; on Standard S3, with ~50–200 ms per-object latency and many small reads per merge entry, the loop effectively never made forward progress on larger ledgers.

 The fix moves all required resolution out of the inner merge loop so the per-property attribution merge is fully in-memory.
  
  ### Before / after on a medium staged workload
  
  Workload: ~8.5 MB JSON-LD, ~10K subjects, 5 commits (~1.5 MB chunk each). Indexer wall time measured from the indexer Lambda's own `processing_time_ms` (CloudWatch), not client-side polling. Identical compiled Lambdas on both stacks; only the index bucket type differs.

  #### Pre-fix indexing on Standard S3

  | Chunk | Express | Standard | Ratio | Notes |
  |------|---------|----------|------|-------|
  | 1 (full rebuild) | 561 ms | 1,383 ms | 2.5× | initial build — fine |
  | 2 (first incremental) | 755 ms | **31,971 ms** | **42×** | falls off a cliff |
  | 3 | 912 ms | **TIMEOUT (> 10 min)** | — | never completes |
  | 4 | 1,497 ms | **TIMEOUT** | — | — |

  #### Post-fix indexing on Standard S3
  
  | Chunk | Express | Standard | Standard / Express |
  |------|---------|----------|--------------------|
  | 1 (full rebuild) | 482 ms | 1,197 ms | 2.5× |
  | 2 (first incremental) | 706 ms | 1,768 ms | 2.5× |
  | 3 | 878 ms | 1,472 ms | 1.7× |
  | 4 | 969 ms | 1,629 ms | 1.7× |
  | 5 | 1,064 ms | 1,901 ms | 1.8× |

  **Standard S3 indexing is now a clean ~1.7–2.5× slower than Express across all chunks, with no degradation over time** (where pre-fix it was unusable past the first incremental).

  ### Transactions

  No meaningful difference between backends. Transaction wall time on both stacks lands in a ~4–7 s/commit range, dominated by the synchronous commit path through the transactor / SQS FIFO queue — index storage isn't on that critical path.

  ### Queries

  **With a caught-up indexer**, hot/warm query latency on Standard S3 is statistically indistinguishable from Express. Server-side median across 5 iterations after warmup, sampled after each  of the 5 chunks:

  | | Express median range | Standard median range |
  |---|----------------------|-----------------------|
  | Single-subject lookup | 152–171 ms | 157–176 ms |
  | Group aggregate | 178–247 ms | 171–228 ms |
  | Multi-hop join + filter | 144–184 ms | 144–174 ms |

  Standard is occasionally faster, sometimes slower — all within normal runtime noise. The 8 GB Lambda `/tmp` disk artifact cache absorbs per-request S3 latency once warm.
  
  **Cold/simple query latency on Standard** generally ranges from no measurable difference up to ~30% slower. On a tiny synthetic dataset (10 iters after warmup), Standard medians were 11–33% slower than Express — the penalty scales with the number of index segments touched per query.

  indexing gap. Pre-fix on Standard, a multi-hop join median climbed from 160 ms → 578 ms (3.6×) across 4 chunks as the indexer fell further behind. Post-fix, with the indexer keeping up, the same query stays flat at 144–174 ms across all 5 chunks.

  ### When S3 Express One Zone still matters
  
  For larger ledgers and sustained indexing throughput, **S3 Express One Zone remains a meaningful optimization** — observed indexing speedups of `30%+` versus Standard S3, and the gap is expected to widen with:

  - larger working sets (more cache-miss reads per commit)
  - wider class/property statistics (more attribution merge entries)
  - many small index blobs touched per query before the local disk cache is warm

  For workloads that are mostly hot queries, modest indexing volume, or cost-sensitive — Standard S3 is a viable index backend.
 
  ## Docs

  - New: [`docs/operations/serverless-storage.md`](docs/operations/serverless-storage.md) — Standard S3 vs S3 Express One Zone guidance, expected ranges, tuning notes.
  - Updated: `docs/operations/storage.md`, `docs/operations/README.md`, `docs/reference/connection-config-jsonld.md`, `docs/getting-started/rust-api.md`, `docs/SUMMARY.md` (cross-links + new
  `s3MaxConcurrentRequests` field).
