### PR TITLE
Feature/x ledger policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "futures",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -76,6 +76,7 @@
   - [Index format](design/index-format.md)
   - [Namespace allocation and fallback modes](design/namespace-allocation.md)
   - [Ontology imports (`f:schemaSource` + `owl:imports`)](design/ontology-imports.md)
+  - [Cross-ledger model enforcement](design/cross-ledger-model-enforcement.md)
   - [Storage traits](design/storage-traits.md)
 
 - [HTTP API (fluree-db-server)](api/README.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -124,6 +124,7 @@
   - [Policy in queries](security/policy-in-queries.md)
   - [Policy in transactions](security/policy-in-transactions.md)
   - [Programmatic policy API (Rust)](security/programmatic-policy.md)
+  - [Cross-ledger policy](security/cross-ledger-policy.md)
 
 - [Indexing and search](indexing-and-search/README.md)
   - [Background indexing](indexing-and-search/background-indexing.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -124,7 +124,7 @@
   - [Policy in queries](security/policy-in-queries.md)
   - [Policy in transactions](security/policy-in-transactions.md)
   - [Programmatic policy API (Rust)](security/programmatic-policy.md)
-  - [Cross-ledger policy, constraints, and schema](security/cross-ledger-policy.md)
+  - [Cross-ledger governance](security/cross-ledger-policy.md)
 
 - [Indexing and search](indexing-and-search/README.md)
   - [Background indexing](indexing-and-search/background-indexing.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -124,7 +124,7 @@
   - [Policy in queries](security/policy-in-queries.md)
   - [Policy in transactions](security/policy-in-transactions.md)
   - [Programmatic policy API (Rust)](security/programmatic-policy.md)
-  - [Cross-ledger policy and constraints](security/cross-ledger-policy.md)
+  - [Cross-ledger policy, constraints, and schema](security/cross-ledger-policy.md)
 
 - [Indexing and search](indexing-and-search/README.md)
   - [Background indexing](indexing-and-search/background-indexing.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -124,7 +124,7 @@
   - [Policy in queries](security/policy-in-queries.md)
   - [Policy in transactions](security/policy-in-transactions.md)
   - [Programmatic policy API (Rust)](security/programmatic-policy.md)
-  - [Cross-ledger policy](security/cross-ledger-policy.md)
+  - [Cross-ledger policy and constraints](security/cross-ledger-policy.md)
 
 - [Indexing and search](indexing-and-search/README.md)
   - [Background indexing](indexing-and-search/background-indexing.md)

--- a/docs/concepts/policy-enforcement.md
+++ b/docs/concepts/policy-enforcement.md
@@ -144,5 +144,6 @@ For deeper architectural detail see [Policy model and inputs](../security/policy
 - [Policy in queries](../security/policy-in-queries.md) — query-time behavior
 - [Policy in transactions](../security/policy-in-transactions.md) — transaction-time behavior
 - [Programmatic policy API (Rust)](../security/programmatic-policy.md) — building policy contexts in code
+- [Cross-ledger policy](../security/cross-ledger-policy.md) — govern many data ledgers from one model ledger
 - [Authentication](../security/authentication.md) — identity, JWTs, and bearer tokens
 - [Configuration](../operations/configuration.md) — server-side policy defaults (`data_auth_default_policy_class`, etc.)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -36,6 +36,10 @@ How Fluree assigns `ns_code` values for IRIs (prefix trie matching, fallback spl
 
 How the reasoner consumes schema from a named `f:schemaSource` graph and transitively resolves `owl:imports`: resolution order, the `SchemaBundleOverlay` projection, schema-triple whitelist, and caching.
 
+### [Cross-ledger model enforcement](cross-ledger-model-enforcement.md)
+
+How a single **model ledger** can hold the ontology, SHACL shapes, policy rules, datalog rules, and uniqueness constraints that govern many **data ledgers** that reference it via `f:GraphRef` (`f:ledger`, `f:atT`). Specifies the shared resolver contract, term-space translation, policy IR identity split, failure variants, caching, and phasing.
+
 ### [Storage Traits](storage-traits.md)
 
 Storage trait architecture: `StorageRead`, `StorageWrite`, `ContentAddressedWrite`, `Storage`, and `NameService` trait design with guidance for implementing new backends.

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -455,6 +455,12 @@ mode can be added without rewriting the failure taxonomy.
   policy IR carries definitional/contextual term references
   separately so the model ledger contributes rules while the
   data ledger contributes identity binding.
+- `f:constraintsSource` cross-ledger via the same shared
+  resolver. M's `f:enforceUnique true` annotations on
+  properties apply to D's transactions; a tx that would
+  create a duplicate value on one of those properties is
+  rejected with `TransactError::UniqueConstraintViolation`
+  even though the annotation never lives on D.
 - Per-request memo + per-instance governance cache, both keyed
   on `(ArtifactKind, canonical_model_ledger_id, graph_iri,
   resolved_t)`.
@@ -463,8 +469,8 @@ mode can be added without rewriting the failure taxonomy.
 - Reserved-feature rejection: `f:atT`, `f:trustPolicy`, and
   `f:rollbackGuard` are surfaced as `UnsupportedFeature` rather
   than silently ignored.
-- Identity-mode + cross-ledger combination fails closed with a
-  config error — the design's "M contributes rules, D
+- Identity-mode + cross-ledger policy combination fails closed
+  with a config error — the design's "M contributes rules, D
   contributes identity" boundary is enforced at the request
   surface.
 
@@ -481,7 +487,6 @@ materializers aren't implemented. Each lands as a new
   routing for `f:rulesSource` is also still pending; the
   cross-ledger path will route through the shared resolver
   once same-ledger lands.
-- `f:constraintsSource` cross-ledger (uniqueness annotations).
 - `f:atT` temporal pinning (currently rejected as
   `UnsupportedFeature`).
 - `f:trustPolicy` and `f:rollbackGuard` (rejected as

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -81,13 +81,19 @@ pub(crate) struct ResolveCtx<'a, S, N> {
     /// subsequent unpinned reference to that model in the same request
     /// reuses it.
     pub resolved_ts: &'a mut HashMap<String, i64>,
-    /// Active resolution stack — the chain of `(ledger, graph,
-    /// resolved_t)` tuples currently being resolved. Used only for cycle
-    /// detection; an entry is pushed before recursion and popped after.
-    pub active: &'a mut Vec<(String, String, i64)>,
+    /// Active resolution stack — the chain of `(kind, ledger, graph,
+    /// resolved_t)` tuples currently being resolved. Used only for
+    /// cycle detection; an entry is pushed before recursion and
+    /// popped after. `ArtifactKind` is part of the key so a
+    /// `PolicyRules` resolve of `(M, graph, t)` doesn't make a
+    /// `Shapes` resolve of the same `(M, graph, t)` look like a
+    /// cycle (or vice versa).
+    pub active: &'a mut Vec<(ArtifactKind, String, String, i64)>,
     /// Per-request memo of fully-resolved artifacts. Hits short-circuit
     /// without storage round-trip and without entering the cycle stack.
-    pub memo: &'a mut HashMap<(String, String, i64), Arc<ResolvedGraph>>,
+    /// Same `ArtifactKind`-extended key as `active` so different
+    /// artifact kinds can't return each other's memo entries.
+    pub memo: &'a mut HashMap<(ArtifactKind, String, String, i64), Arc<ResolvedGraph>>,
 }
 ```
 
@@ -126,7 +132,7 @@ The helper performs, in order:
    `ctx.memo` and the global cache.
 7. **Caching.** On cache hit the materialized artifact is returned
    directly. On miss the artifact is inserted under the key
-   `(canonical_model_ledger_id, graph_iri, resolved_t)`.
+   `(ArtifactKind, canonical_model_ledger_id, graph_iri, resolved_t)`.
 
 A `ResolvedGraph` is term-neutral and t-fixed:
 
@@ -290,10 +296,12 @@ opaque-blob variant to the binary-index cache (the artifact is
 serialized to bytes at the cache boundary), and is deferred until
 the artifact representation stabilizes.
 
-The key is `(canonical_model_ledger_id, graph_iri, resolved_t)`. New
-commits to M produce new keys without explicit invalidation;
-unreferenced entries age out under the cache's eviction policy.
-There is no "watermark-on-write" channel.
+The key is `(ArtifactKind, canonical_model_ledger_id, graph_iri,
+resolved_t)`. `ArtifactKind` is part of the key so a memoized
+`PolicyRules` entry never short-circuits a `Shapes` lookup of the
+same `(M, graph, t)`. New commits to M produce new keys without
+explicit invalidation; unreferenced entries age out under the
+cache's eviction policy. There is no "watermark-on-write" channel.
 
 The cache value is the term-neutral `ResolvedGraph` (IRIs, not Sids).
 Per-data-ledger interning is not part of the cache key — the cache

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -226,6 +226,32 @@ request context. The model ledger contributes rules and definitions;
 it never contributes identity, authentication keys, or session
 state. This keeps trust one-directional.
 
+### Identity-mode resolution under cross-ledger policy
+
+The same-ledger materializer in `policy_builder.rs` supports three
+modes, in priority order: identity (request identity → policies via
+that identity's `f:policyClass`), policy_class (configured class IRIs
+→ all policies of that class), and policy (inline JSON-LD).
+
+Cross-ledger does **not** generalize "identity mode" by querying
+M for `<identity> f:policyClass ?class`. The identity binding lives
+in D and the request context; querying M for identity records would
+either return empty (M has no entry for D's user) or — worse — match a
+model-ledger identity that happens to share an IRI with D's user. The
+resulting policy attribution is silently wrong.
+
+Concretely, cross-ledger policy resolution always uses
+**policy_class mode**: the data ledger's effective policy classes
+(from `opts.policyClass` or D's config) are looked up in M to load
+the corresponding policy rules. The request identity is bound to
+`?$identity` at evaluation time against D and the request context,
+exactly as in the same-ledger flow.
+
+If the data ledger's effective config does not specify
+`f:policyClass`, cross-ledger policy enforcement loads no rules
+from M (Allow/Deny depend on `f:defaultAllow`). Inline `opts.policy`
+JSON-LD continues to merge against D, never against M.
+
 ## Resolution time and `f:atT`
 
 | Case                       | Behavior |
@@ -244,20 +270,29 @@ datasets" property hold within a single request boundary.
 
 ## Caching
 
-Resolved artifacts are cached in the existing global `LeafletCache`
-(TinyLFU, byte budget `FLUREE_LEAFLET_CACHE_BYTES`). Reasons:
+Resolved artifacts are cached at the **API layer** (in
+`fluree-db-api`), not in `fluree-db-binary-index::LeafletCache`. The
+binary-index crate sits below `fluree-db-api`, `fluree-db-policy`,
+and the cross-ledger module; making it depend upward on typed
+governance-artifact representations would be a layering inversion.
 
-- One memory pool, one tuning knob.
-- Same eviction discipline as decoded leaflets.
-- Naturally bounded by the existing 8 GiB default.
+For Phase 1a the implementation is a Moka cache bounded by entry
+count, scoped to a `Fluree` instance. Single memory-pool unification
+with `LeafletCache` is a follow-up that requires adding an
+opaque-blob variant to the binary-index cache (the artifact is
+serialized to bytes at the cache boundary), and is deferred until
+the artifact representation stabilizes.
 
 The key is `(canonical_model_ledger_id, graph_iri, resolved_t)`. New
 commits to M produce new keys without explicit invalidation;
-unreferenced entries age out under TinyLFU. There is no
-"watermark-on-write" channel.
+unreferenced entries age out under the cache's eviction policy.
+There is no "watermark-on-write" channel.
 
 The cache value is the term-neutral `ResolvedGraph` (IRIs, not Sids).
-Per-data-ledger interning is not part of the cache key.
+Per-data-ledger interning is not part of the cache key — the cache
+is shareable across every data ledger that references the same
+`(model, graph, t)`, which is what makes "model edit propagates
+atomically to all governed datasets" cheap.
 
 ## Failure variants
 

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -1,29 +1,34 @@
 # Cross-ledger model enforcement
 
-Fluree's `f:GraphRef` shape was designed to point at "the graph that
-holds my policy / shapes / schema / rules / constraints." Today that
-pointer is constrained to the *current* ledger. This document
-specifies the contract for making the pointer cross-ledger so that a
-single **model ledger** — holding the ontology, SHACL shapes, policy
-rule set, datalog rules, and uniqueness constraints — can be
-referenced by many **data ledgers** that it governs.
+Fluree's `f:GraphRef` shape lets a data ledger reference a graph
+containing policy / shapes / schema / rules / constraints. Without
+cross-ledger references, every data ledger has to carry its own
+copy of those governance artifacts. This document explains the
+contracts that make `f:GraphRef` work cross-ledger so a single
+**model ledger** — holding the ontology, SHACL shapes, policy rule
+set, datalog rules, and uniqueness constraints — can be referenced
+by many **data ledgers** it governs.
 
-Status: design — implementation lands incrementally per the phasing
-in the last section.
+For the user-facing how-to (TriG examples, configuration steps),
+see [Cross-ledger policy](../security/cross-ledger-policy.md). This
+document explains the design decisions behind that mechanism: why
+the resolver returns term-neutral artifacts, why the cache is
+keyed the way it is, what the identity contract is, and how
+failures are surfaced.
 
 Topics:
 
-- Glossary and the basic shape of cross-ledger enforcement.
+- Glossary and what "cross-ledger" means at the contract level.
 - The resolver contract: a single `resolve_graph_ref` helper shared
-  by all five subsystems, returning term-neutral artifacts.
+  by every subsystem, returning term-neutral artifacts.
 - Term-space translation — why model-ledger Sids/GraphIds/t values
   cannot leak into data-ledger execution.
-- Resolution time, `f:atT` pinning, caching, and failure variants.
+- Resolution time, caching, and failure variants.
 - Policy IR identity split — definitional vs contextual term
   binding.
 - Trust model, reserved-graph guards, cycle detection, drop
   interaction.
-- Phasing and scope.
+- Scope: what the resolver covers today and what's deferred.
 
 Related docs:
 
@@ -58,42 +63,46 @@ This is read-only: cross-ledger writes are out of scope.
 
 ## The resolver contract
 
-All five subsystems — policy, shapes, schema, datalog rules,
-constraints — share a single helper:
+Every subsystem that needs to read a cross-ledger graph goes
+through the same helper:
 
 ```rust
-pub(crate) async fn resolve_graph_ref<S, N>(
-    graph_ref: &GraphRef,
-    ctx: &ResolveCtx<'_, S, N>,
-) -> Result<ResolvedGraph, CrossLedgerError>;
+pub async fn resolve_graph_ref(
+    graph_ref: &GraphSourceRef,
+    kind: ArtifactKind,
+    ctx: &mut ResolveCtx<'_>,
+) -> Result<Arc<ResolvedGraph>, CrossLedgerError>;
 ```
 
-where `ResolveCtx` carries everything the resolver needs without each
-subsystem rebuilding the surrounding state:
+where `ResolveCtx` carries everything the resolver needs without
+each subsystem rebuilding the surrounding state:
 
 ```rust
-pub(crate) struct ResolveCtx<'a, S, N> {
-    pub data_ledger_id: &'a str,                    // canonical id of D
-    pub fluree: &'a Fluree<S, N>,                    // nameservice lookup of M
-    /// Governance-context capture: lazily-populated map from canonical
-    /// model ledger id → `resolved_t` for this request. First
-    /// cross-ledger resolve to a given model populates the entry; every
-    /// subsequent unpinned reference to that model in the same request
-    /// reuses it.
-    pub resolved_ts: &'a mut HashMap<String, i64>,
-    /// Active resolution stack — the chain of `(kind, ledger, graph,
-    /// resolved_t)` tuples currently being resolved. Used only for
-    /// cycle detection; an entry is pushed before recursion and
-    /// popped after. `ArtifactKind` is part of the key so a
-    /// `PolicyRules` resolve of `(M, graph, t)` doesn't make a
-    /// `Shapes` resolve of the same `(M, graph, t)` look like a
-    /// cycle (or vice versa).
-    pub active: &'a mut Vec<(ArtifactKind, String, String, i64)>,
-    /// Per-request memo of fully-resolved artifacts. Hits short-circuit
-    /// without storage round-trip and without entering the cycle stack.
-    /// Same `ArtifactKind`-extended key as `active` so different
-    /// artifact kinds can't return each other's memo entries.
-    pub memo: &'a mut HashMap<(ArtifactKind, String, String, i64), Arc<ResolvedGraph>>,
+pub struct ResolveCtx<'a> {
+    /// Canonical data-ledger id D.
+    pub data_ledger_id: &'a str,
+    /// The Fluree instance hosting D and (per the same-instance
+    /// constraint) the referenced model ledger.
+    pub fluree: &'a Fluree,
+    /// Governance-context capture: lazily-populated map from
+    /// canonical model ledger id → `resolved_t` for this request.
+    /// The first reference to a given model populates the entry;
+    /// every subsequent reference in the same request reuses it.
+    pub resolved_ts: HashMap<String, i64>,
+    /// Active resolution stack — the chain of `(kind, ledger,
+    /// graph, resolved_t)` tuples currently being resolved. Used
+    /// only for cycle detection; an entry is pushed before
+    /// recursion and popped after. `ArtifactKind` is part of the
+    /// key so a `PolicyRules` resolve of `(M, graph, t)` doesn't
+    /// make a `Shapes` resolve of the same `(M, graph, t)` look
+    /// like a cycle (or vice versa).
+    pub active: Vec<(ArtifactKind, String, String, i64)>,
+    /// Per-request memo of fully-resolved artifacts. Hits short-
+    /// circuit without storage round-trip and without entering the
+    /// cycle stack. Same `ArtifactKind`-extended key as `active`
+    /// so different artifact kinds can't return each other's
+    /// entries.
+    pub memo: HashMap<(ArtifactKind, String, String, i64), Arc<ResolvedGraph>>,
 }
 ```
 
@@ -138,29 +147,28 @@ A `ResolvedGraph` is term-neutral and t-fixed:
 
 ```rust
 pub struct ResolvedGraph {
-    pub model_ledger_id: String,    // canonical
+    pub model_ledger_id: String,       // canonical
     pub graph_iri: String,
     pub resolved_t: i64,
-    pub artifact: GovernanceArtifact, // tagged union per subsystem
-    pub fingerprint: ContentId,      // for downstream cache keys
+    pub artifact: GovernanceArtifact,  // tagged union per subsystem
 }
 ```
 
-The `GovernanceArtifact` variants are:
+`GovernanceArtifact` is a tagged union with one variant per
+subsystem. Only `PolicyRules` is implemented today; the rest are
+named in [Scope](#scope) and land as new variants when their
+materializers do.
 
 ```rust
 pub enum GovernanceArtifact {
-    PolicyRules(PolicyRuleSet),       // canonical IR, IRI-form
-    Shapes(ShapeSet),                 // SHACL shapes in IRI-form
-    SchemaClosure(SchemaBundleIR),    // ontology in IRI-form
-    DatalogRules(DatalogRuleSet),     // rules in IRI-form
-    Constraints(ConstraintSet),       // f:enforceUnique annotations
+    PolicyRules(PolicyArtifactWire),   // IRI-form policy rules
 }
 ```
 
 Each variant is **term-neutral**: every subject, predicate, object,
 class, and datatype reference is stored as an IRI (or canonical
-literal), never as a model-ledger Sid or GraphId.
+literal), never as a model-ledger Sid or GraphId. The data-ledger
+consumer re-interns IRIs against its own dictionary at use time.
 
 ## Term-space translation
 
@@ -289,12 +297,14 @@ binary-index crate sits below `fluree-db-api`, `fluree-db-policy`,
 and the cross-ledger module; making it depend upward on typed
 governance-artifact representations would be a layering inversion.
 
-For Phase 1a the implementation is a Moka cache bounded by entry
-count, scoped to a `Fluree` instance. Single memory-pool unification
-with `LeafletCache` is a follow-up that requires adding an
-opaque-blob variant to the binary-index cache (the artifact is
-serialized to bytes at the cache boundary), and is deferred until
-the artifact representation stabilizes.
+The implementation is a Moka TinyLFU cache bounded by entry count
+(see `cross_ledger::GovernanceCache`), scoped to a `Fluree`
+instance. Single memory-pool unification with `LeafletCache` would
+require adding an opaque-blob variant to the binary-index cache
+(serializing the artifact to bytes at the cache boundary) and is
+deliberately deferred until the artifact representation
+stabilizes — keeping the two caches separate while artifact shapes
+are still evolving prevents premature coupling.
 
 The key is `(ArtifactKind, canonical_model_ledger_id, graph_iri,
 resolved_t)`. `ArtifactKind` is part of the key so a memoized
@@ -337,15 +347,25 @@ pub enum CrossLedgerError {
     /// the model dictionary lost, malformed rule, etc.).
     TranslationFailed { ledger_id: String, graph_iri: String, detail: String },
 
-    /// `f:trustPolicy` failed verification, or `f:rollbackGuard`
-    /// would be violated. (Phase 4.)
+    /// `f:trustPolicy` verification failed (reserved for when
+    /// trust-policy enforcement is implemented; see Scope).
     TrustCheckFailed { ledger_id: String, detail: String },
+
+    /// `f:atT`, `f:trustPolicy`, or `f:rollbackGuard` was set on
+    /// a `GraphSourceRef`. Those fields are parsed by the config
+    /// layer but their semantics are not yet implemented (see
+    /// Scope); the request fails closed rather than silently
+    /// ignoring the field.
+    UnsupportedFeature { feature: &'static str, phase: &'static str, ledger_id: String },
 
     /// `f:ledger` targets a ledger on a different instance.
     CrossInstanceUnsupported { ledger_id: String },
 
-    /// Cycle detected through `(ledger, graph, resolved_t)` chain.
-    CycleDetected { chain: Vec<(String, String, i64)> },
+    /// Cycle detected through the `(kind, ledger, graph, resolved_t)`
+    /// chain.
+    CycleDetected {
+        chain: Vec<(ArtifactKind, String, String, i64)>,
+    },
 }
 ```
 
@@ -357,15 +377,12 @@ fallback to "no policy" or "no shapes."
 A data ledger D's `#config` declaring `f:ledger <M>` is itself the
 capability assertion. Writing to D's `#config` already requires
 policy authority on D, so "whoever can write D's `#config` asserts
-that M is a trusted governance source for D."
+that M is a trusted governance source for D" is the binding
+decision; no separate consent is required from M.
 
-For v1, no consent is required from M. Phase 4 introduces
-`f:trustPolicy` and `f:rollbackGuard` for ledgers that need
-stronger guarantees (commit signer allowlist, hash pin, maximum
-staleness window).
-
-Cross-instance federation requires a different trust model (auth,
-transport, signing) and is out of scope.
+Cross-instance federation would require a different trust model
+(auth, transport, signing for ledgers hosted on different
+nameservices) and is out of scope. See [Scope](#scope).
 
 ## Reserved-graph guard
 
@@ -403,78 +420,88 @@ active-vs-completed distinction surfaced explicitly.
 
 ## Drop interaction
 
-V1: if a data ledger D references model ledger M and M is dropped,
+If a data ledger D references model ledger M and M is dropped,
 the next request against D that needs governance from M fails
 closed with `ModelLedgerMissing`. There is no reverse-reference
-index and no rejection of M's drop based on outstanding references.
+index and no rejection of M's drop based on outstanding
+references.
 
-This is the smallest contract that's safe; introducing reverse
-indexes requires nameservice schema work and is deferred. Operators
-who need stronger guarantees can publish a `f:trustPolicy` (Phase 4)
-or coordinate drops at the application layer.
+This is the smallest contract that's safe — operators get a clear
+failure on the next governed request rather than a silent shift in
+enforcement. Introducing reverse indexes would require nameservice
+schema work and is out of scope (see [Scope](#scope)). Operators
+who need stronger guarantees coordinate drops at the application
+layer for now.
 
-## Same-instance constraint (v1)
+## Same-instance constraint
 
 Both D and M must:
 
 - Belong to the same nameservice instance.
 - Live within the same storage namespace.
 
-Same-instance failures surface as `CrossInstanceUnsupported` before
-any storage round-trip.
+A reference that targets a ledger on a different instance surfaces
+as `CrossInstanceUnsupported` before any storage round-trip. This
+boundary is enforced implicitly by the nameservice lookup — a
+ledger not present in this instance's nameservice can't be
+canonicalized — and the variant exists so a future cross-instance
+mode can be added without rewriting the failure taxonomy.
 
-## Phasing
+## Scope
 
-| Phase | Scope | Status |
-|-------|-------|--------|
-| 0     | Same-ledger fail-closed across the five subsystems (policy, shapes, schema, constraints, rules). | Policy, shapes, schema, constraints: done. Rules: pending (deferred behind this design). |
-| 1a    | `f:policySource` cross-ledger via `resolve_graph_ref`. Policy IR identity split lands as part of this. | After this doc. |
-| 1b    | `f:schemaSource` + `f:ontologyImportMap` cross-ledger; transitive imports across ≥2 model ledgers. | After 1a. |
-| 2     | `f:shapesSource`, `f:rulesSource`, `f:constraintsSource` cross-ledger via the same resolver. | After 1a/1b. |
-| 3     | `f:atT` temporal pinning. | After 2. |
-| 4     | `f:trustPolicy`, `f:rollbackGuard`. Separate RFE. | Out of scope here. |
+### Implemented
 
-## Test plan (per phase)
+- `f:policySource` cross-ledger via `resolve_graph_ref`. The
+  policy IR carries definitional/contextual term references
+  separately so the model ledger contributes rules while the
+  data ledger contributes identity binding.
+- Per-request memo + per-instance governance cache, both keyed
+  on `(ArtifactKind, canonical_model_ledger_id, graph_iri,
+  resolved_t)`.
+- Reserved-graph guard (rejects `#config` / `#txn-meta` on M
+  before any storage round-trip).
+- Reserved-feature rejection: `f:atT`, `f:trustPolicy`, and
+  `f:rollbackGuard` are surfaced as `UnsupportedFeature` rather
+  than silently ignored.
+- Identity-mode + cross-ledger combination fails closed with a
+  config error — the design's "M contributes rules, D
+  contributes identity" boundary is enforced at the request
+  surface.
 
-Acceptance tests live next to the subsystems they exercise:
+### Reserved
 
-- `it_policy_cross_ledger.rs` — D references policy in M; query
-  against D enforces M's policies; inline `opts.policy` still
-  merges; fail-closed when M is unreachable.
-- `it_schema_cross_ledger.rs` — extension of
-  `it_reasoning_imports.rs` across a ledger boundary; transitive
-  imports across two model ledgers; cycle detection.
-- `it_shapes_cross_ledger.rs` — tx against D validates against
-  shapes in M.
-- `it_at_t_pinning.rs` — `f:atT N` pins; commits after N don't
-  affect the governed query.
-- `it_fail_closed.rs` — every failure variant rejects the request.
+The following subsystems share the resolver's contract but their
+materializers aren't implemented. Each lands as a new
+`GovernanceArtifact` variant + per-subsystem materializer:
 
-Two cross-cutting tests are mandatory regardless of phase:
+- `f:schemaSource` + `f:ontologyImportMap` cross-ledger
+  (transitive ontology imports across multiple model ledgers).
+- `f:shapesSource` cross-ledger (SHACL shapes).
+- `f:rulesSource` cross-ledger (datalog rules). The same-ledger
+  routing for `f:rulesSource` is also still pending; the
+  cross-ledger path will route through the shared resolver
+  once same-ledger lands.
+- `f:constraintsSource` cross-ledger (uniqueness annotations).
+- `f:atT` temporal pinning (currently rejected as
+  `UnsupportedFeature`).
+- `f:trustPolicy` and `f:rollbackGuard` (rejected as
+  `UnsupportedFeature` for the same reason).
 
-- **Distinct namespace codes.** M and D both interned the same
-  class IRI under different `ns_code` values; the resolved artifact
-  re-interns correctly against D and policy/shapes fire as
-  expected. This is the canary for term-space translation.
-- **Single-resolution-t.** Within one request, every subsystem
-  receives the same `resolved_t` for M, even when admission and
-  enforcement happen tens of milliseconds apart and M advanced in
-  between.
+### Out of scope
 
-Tests must drive through `Fluree::db()` (not
-`GraphDb::from_ledger_state`) so the config-graph path is exercised.
-
-## Out of scope
-
-- **Cross-instance federation.** Different nameservices, transport,
-  cross-org auth/signing. Separate RFE.
-- **`f:trustPolicy` / `f:rollbackGuard` implementations.** Phase 4.
+- **Cross-instance federation.** Different nameservices,
+  transport, cross-org auth/signing.
 - **Auto-resolution by IRI namespace.** "Which model governs
   `schema:*`?" — application-layer concern.
 - **Writing back to a model ledger from a governed ledger's
-  request.** Read-only references only.
-- **Reverse-reference indexes for safe drop.** V1 allows M to be
-  dropped; D fails closed on next request.
+  request.** Cross-ledger references are read-only.
+- **Reverse-reference indexes for safe drop.** A drop on M
+  surfaces on the next governed request against D, not at
+  drop time.
+- **Subclass entailment in policy_class filtering.** The
+  filter is exact-IRI; D must name the same class IRI M
+  declared. Mirrors same-ledger `load_policies_by_class`
+  semantics.
 
 ## Error type and HTTP mapping
 

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -73,10 +73,21 @@ subsystem rebuilding the surrounding state:
 
 ```rust
 pub(crate) struct ResolveCtx<'a, S, N> {
-    pub data_ledger_id: &'a str,        // canonical id of D
-    pub fluree: &'a Fluree<S, N>,        // for nameservice lookup of M
-    pub admit_time: Instant,             // request admission timestamp
-    pub seen: &'a mut Vec<(String, String, i64)>, // cycle detection
+    pub data_ledger_id: &'a str,                    // canonical id of D
+    pub fluree: &'a Fluree<S, N>,                    // nameservice lookup of M
+    /// Governance-context capture: lazily-populated map from canonical
+    /// model ledger id → `resolved_t` for this request. First
+    /// cross-ledger resolve to a given model populates the entry; every
+    /// subsequent unpinned reference to that model in the same request
+    /// reuses it.
+    pub resolved_ts: &'a mut HashMap<String, i64>,
+    /// Active resolution stack — the chain of `(ledger, graph,
+    /// resolved_t)` tuples currently being resolved. Used only for cycle
+    /// detection; an entry is pushed before recursion and popped after.
+    pub active: &'a mut Vec<(String, String, i64)>,
+    /// Per-request memo of fully-resolved artifacts. Hits short-circuit
+    /// without storage round-trip and without entering the cycle stack.
+    pub memo: &'a mut HashMap<(String, String, i64), Arc<ResolvedGraph>>,
 }
 ```
 
@@ -92,17 +103,27 @@ The helper performs, in order:
 3. **Reserved-graph guard.** Selectors that would resolve to
    `#config` or `#txn-meta` on M are rejected *before* any storage
    round-trip.
-4. **Resolved-t selection.** If `f:atT` is set, use it; otherwise
-   use M's latest committed `t` at `ctx.admit_time`. The chosen
-   value is **captured once per request** and reused across every
-   subsystem call within the same request — policy and shapes can
-   never disagree about which version of M they're enforcing.
-5. **Cycle check.** The tuple `(canonical_model_ledger_id,
-   graph_iri, resolved_t)` is checked against `ctx.seen`. Two
-   different `atT` pins of the same `(ledger, graph)` are not a
-   cycle; the same triple is.
+4. **Governance-context capture (`resolved_t`).** If `f:atT N` is set,
+   `resolved_t = N`. Otherwise, look up `ctx.resolved_ts[model_id]`;
+   on miss, read M's current head `t` and store it. The capture is
+   **lazy and per request**: the head is consulted only on the first
+   unpinned reference to a given model, and every later unpinned
+   reference in the same request reuses the same `resolved_t` so
+   policy and shapes can never disagree about which version of M
+   they're enforcing.
+5. **Memo / cycle check.** Form the tuple `(canonical_model_ledger_id,
+   graph_iri, resolved_t)`. If it appears in `ctx.memo`, return the
+   memoized artifact (this is the cross-subsystem de-dup path —
+   `policySource` and `shapesSource` pointing at the same model graph
+   resolve once). Otherwise check it against `ctx.active` (the
+   resolution stack); presence there means a true cycle and is an
+   error. Two different `atT` pins of the same `(ledger, graph)` are
+   not a cycle; the same triple is. Push the tuple onto `active`
+   before recursing into transitive imports.
 6. **Translation and materialization.** The graph at `resolved_t` is
    read and projected into term-neutral form (see next section).
+   Pop the tuple from `active` and insert the resolved artifact into
+   `ctx.memo` and the global cache.
 7. **Caching.** On cache hit the materialized artifact is returned
    directly. On miss the artifact is inserted under the key
    `(canonical_model_ledger_id, graph_iri, resolved_t)`.
@@ -209,14 +230,17 @@ state. This keeps trust one-directional.
 
 | Case                       | Behavior |
 |----------------------------|----------|
-| No `f:atT`                 | `resolved_t` = M's latest committed `t` at request admission. Captured once. |
-| `f:atT N`                  | `resolved_t = N`. M time-travels to that point. |
+| No `f:atT`                 | On first unpinned reference to M in this request, read M's current head `t` and cache it in `ctx.resolved_ts[model_id]`. Subsequent unpinned references to the same M reuse it. |
+| `f:atT N`                  | `resolved_t = N`. Per-resolve, not stored in `resolved_ts`. M time-travels to that point. |
 | `f:atT N`, N pruned        | Fail closed (see [Failure variants](#failure-variants)). No fallback to nearest-available. |
-| Mid-request M advancement  | Not reflected in the current request. The next request re-admits at the new head. |
+| Mid-request M advancement  | Not reflected in the current request. The next request re-captures on its first reference. |
 
-`resolved_t` is captured **once per request** in `ResolveCtx`, not
-per subsystem call. Without this, policy and shapes could enforce
-against different versions of M for the same request.
+Capture is **lazy and per request**: a request that never needs M
+never pays for M's head lookup. Once captured, `resolved_t` is
+stable across every subsystem in that request — policy and shapes
+can never disagree about which version of M they're enforcing. This
+is what makes the "model edit propagates atomically to all governed
+datasets" property hold within a single request boundary.
 
 ## Caching
 
@@ -305,13 +329,27 @@ M could leak commit metadata to D's request handler.
 
 ## Cycle detection
 
-The resolver maintains a `seen: Vec<(canonical_ledger_id, graph_iri,
-resolved_t)>` chain in `ResolveCtx`. Detection runs on the resolved
-tuple. Two distinct `atT` pins of the same `(ledger, graph)` are not
-a cycle. Two distinct graphs on the same ledger are not a cycle.
+Two structures, distinct purposes:
 
-This is the same BFS+dedupe pattern the existing same-ledger
-`owl:imports` resolver uses, generalized to a 3-tuple.
+- `ctx.active` is the **active resolution stack** — push the
+  `(canonical_ledger_id, graph_iri, resolved_t)` tuple before
+  recursing into a transitive import, pop on return. A tuple is a
+  cycle only if it is encountered while *already on the stack*.
+- `ctx.memo` is the **per-request completed map**. Once a tuple
+  resolves successfully, it lands here. Subsequent references to
+  the same tuple — from any subsystem in the same request — short-
+  circuit on the memo, never enter `active`, and never trip cycle
+  detection.
+
+So if `policySource` and `shapesSource` both reference the same
+`(ledger, graph, t)`, the second resolve is a memo hit, not a
+cycle. Two different `atT` pins of the same `(ledger, graph)` are
+not a cycle. Two different graphs on the same ledger are not a
+cycle. Only re-entering an in-flight tuple is.
+
+This generalizes the BFS+dedupe pattern the existing same-ledger
+`owl:imports` resolver uses to a 3-tuple, with the
+active-vs-completed distinction surfaced explicitly.
 
 ## Drop interaction
 
@@ -388,19 +426,33 @@ Tests must drive through `Fluree::db()` (not
 - **Reverse-reference indexes for safe drop.** V1 allows M to be
   dropped; D fails closed on next request.
 
-## Open questions for review
+## Error type and HTTP mapping
 
-- Should `resolved_t` capture happen at request admission or at
-  first cross-ledger resolution within the request? Spec currently
-  says admission; admission is simpler and avoids a per-resolver
-  inconsistency window, at the cost of materializing M's head even
-  when no subsystem ends up consulting M.
-- Should the `seen` chain be per-request or per-resolver-instance?
-  Per-request prevents a malicious config from making the same
-  resolver loop indefinitely across different subsystems; spec
-  defaults to per-request.
-- Should `CrossLedgerError` surface to the HTTP status as 502
-  (upstream-style) or 500? Argument for 502: operator distinction
-  between "your data ledger is broken" and "the model ledger this
-  data ledger depends on is broken." Not load-bearing on the
-  internal contract.
+`CrossLedgerError` surfaces through the API crate as a dedicated
+variant:
+
+```rust
+pub enum ApiError {
+    // ...
+    /// Cross-ledger governance resolution failed. The wrapped
+    /// variant carries the specific failure (missing ledger, graph
+    /// missing at t, retention pruned, etc.) for audit and
+    /// operator diagnostics.
+    #[error("Cross-ledger error: {0}")]
+    CrossLedger(#[from] CrossLedgerError),
+}
+```
+
+It is **not** collapsed into `ApiError::Http { status: 502, .. }` —
+preserving the structured variant is what makes "the model ledger
+this data ledger depends on is broken" distinguishable from "your
+data ledger is broken" in logs and audit trails.
+
+HTTP status mapping: **502 Bad Gateway** is the default. A model
+ledger dependency that cannot be resolved or used is conceptually
+an upstream-dependency failure, not an internal panic. 424 Failed
+Dependency is semantically closer but less commonly handled by
+client tooling; 502 is the pragmatic choice. The server layer reads
+the variant for the response body so callers can branch on the
+specific failure even when the status is generic.
+

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -248,9 +248,16 @@ the corresponding policy rules. The request identity is bound to
 exactly as in the same-ledger flow.
 
 If the data ledger's effective config does not specify
-`f:policyClass`, cross-ledger policy enforcement loads no rules
-from M (Allow/Deny depend on `f:defaultAllow`). Inline `opts.policy`
-JSON-LD continues to merge against D, never against M.
+`f:policyClass`, the filter defaults to `{f:AccessPolicy}` — the
+canonical policy class IRI. Cross-ledger enforcement then pulls
+in every rule in M's policy graph that's typed as
+`f:AccessPolicy` directly. Custom-typed rules (e.g.,
+`ex:OrgPolicy`) require an explicit `f:policyClass` entry in D's
+config to be enforced. This default is intentionally a small
+allowlist rather than "every structural rule from M": operators
+opt into custom-class enforcement by naming it, never by
+omission. Inline `opts.policy` JSON-LD continues to merge against
+D, never against M.
 
 ## Resolution time and `f:atT`
 

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -461,6 +461,14 @@ mode can be added without rewriting the failure taxonomy.
   create a duplicate value on one of those properties is
   rejected with `TransactError::UniqueConstraintViolation`
   even though the annotation never lives on D.
+- `f:schemaSource` cross-ledger via the same shared resolver.
+  The whitelisted schema axiom triples in M's ontology graph
+  (rdfs:subClassOf, rdfs:subPropertyOf, rdfs:domain, rdfs:range,
+  owl:equivalentClass / equivalentProperty / inverseOf / sameAs /
+  imports, and rdf:type for the schema-class set) are projected
+  into a `SchemaBundleFlakes` against D's snapshot and feed D's
+  reasoner. Single-graph only today; transitive `owl:imports`
+  recursion across multiple model ledgers is reserved.
 - Per-request memo + per-instance governance cache, both keyed
   on `(ArtifactKind, canonical_model_ledger_id, graph_iri,
   resolved_t)`.
@@ -480,8 +488,15 @@ The following subsystems share the resolver's contract but their
 materializers aren't implemented. Each lands as a new
 `GovernanceArtifact` variant + per-subsystem materializer:
 
-- `f:schemaSource` + `f:ontologyImportMap` cross-ledger
-  (transitive ontology imports across multiple model ledgers).
+- Transitive `owl:imports` recursion across multiple model
+  ledgers (Phase 1b's full scope). The single-graph schema
+  materialization above already projects M's `owl:imports`
+  triples into the wire so a future reader can see what M
+  declared — the recursion through `resolve_graph_ref`
+  (which would exercise `ResolveCtx.active` for cycle detection
+  across ledgers) lands separately.
+- `f:ontologyImportMap` cross-ledger (mapping table entries
+  whose `f:graphRef` targets another model ledger).
 - `f:shapesSource` cross-ledger (SHACL shapes).
 - `f:rulesSource` cross-ledger (datalog rules). The same-ledger
   routing for `f:rulesSource` is also still pending; the

--- a/docs/design/cross-ledger-model-enforcement.md
+++ b/docs/design/cross-ledger-model-enforcement.md
@@ -1,0 +1,406 @@
+# Cross-ledger model enforcement
+
+Fluree's `f:GraphRef` shape was designed to point at "the graph that
+holds my policy / shapes / schema / rules / constraints." Today that
+pointer is constrained to the *current* ledger. This document
+specifies the contract for making the pointer cross-ledger so that a
+single **model ledger** — holding the ontology, SHACL shapes, policy
+rule set, datalog rules, and uniqueness constraints — can be
+referenced by many **data ledgers** that it governs.
+
+Status: design — implementation lands incrementally per the phasing
+in the last section.
+
+Topics:
+
+- Glossary and the basic shape of cross-ledger enforcement.
+- The resolver contract: a single `resolve_graph_ref` helper shared
+  by all five subsystems, returning term-neutral artifacts.
+- Term-space translation — why model-ledger Sids/GraphIds/t values
+  cannot leak into data-ledger execution.
+- Resolution time, `f:atT` pinning, caching, and failure variants.
+- Policy IR identity split — definitional vs contextual term
+  binding.
+- Trust model, reserved-graph guards, cycle detection, drop
+  interaction.
+- Phasing and scope.
+
+Related docs:
+
+- [Ontology imports](ontology-imports.md) — the same-ledger
+  schema-source mechanism this generalizes.
+- [Policy enforcement](../concepts/policy-enforcement.md) — the
+  enforcement model the model ledger contributes rules to.
+- [Configuration / setting groups](../ledger-config/setting-groups.md)
+  — the `f:GraphRef` shape and where it appears.
+
+## Glossary
+
+| Term                        | Meaning |
+|-----------------------------|---------|
+| **Data ledger** (D)         | The ledger holding application data and serving the request. |
+| **Model ledger** (M)        | A ledger referenced by D's `#config` to provide governance artifacts (policy / shapes / schema / rules / constraints). |
+| **Governance artifact**     | The materialized output of resolving a `f:GraphRef` for one subsystem: a policy rule set, a shape set, a schema closure, a datalog rule set, or a constraint set. |
+| **Resolved t** (`resolved_t`) | The transaction time of M at which the artifact is materialized for this request. |
+| **Canonical ledger id**     | `NsRecord.ledger_id` from `nameservice.lookup()`, never a user-typed alias. |
+
+## What "cross-ledger" means at the contract level
+
+A data ledger D's `#config` declares a `f:GraphRef` whose `f:ledger`
+field names a model ledger M. When D is served a request, every
+configured `f:*Source` predicate that points at M is resolved to a
+governance artifact materialized from M and applied to the request
+against D. The data ledger's policy authority, identity, and term
+space remain the binding authority for the request; M contributes
+*rules*, not *identities*.
+
+This is read-only: cross-ledger writes are out of scope.
+
+## The resolver contract
+
+All five subsystems — policy, shapes, schema, datalog rules,
+constraints — share a single helper:
+
+```rust
+pub(crate) async fn resolve_graph_ref<S, N>(
+    graph_ref: &GraphRef,
+    ctx: &ResolveCtx<'_, S, N>,
+) -> Result<ResolvedGraph, CrossLedgerError>;
+```
+
+where `ResolveCtx` carries everything the resolver needs without each
+subsystem rebuilding the surrounding state:
+
+```rust
+pub(crate) struct ResolveCtx<'a, S, N> {
+    pub data_ledger_id: &'a str,        // canonical id of D
+    pub fluree: &'a Fluree<S, N>,        // for nameservice lookup of M
+    pub admit_time: Instant,             // request admission timestamp
+    pub seen: &'a mut Vec<(String, String, i64)>, // cycle detection
+}
+```
+
+The helper performs, in order:
+
+1. **Same-instance check.** M must live on the same nameservice and
+   storage namespace as D. Cross-instance federation is out of
+   scope (see below).
+2. **Canonical id resolution.** `f:ledger` is run through
+   `nameservice.lookup()`; the returned `NsRecord.ledger_id` is used
+   for every subsequent step, never the user-typed alias. (Same
+   discipline as the default-context content store.)
+3. **Reserved-graph guard.** Selectors that would resolve to
+   `#config` or `#txn-meta` on M are rejected *before* any storage
+   round-trip.
+4. **Resolved-t selection.** If `f:atT` is set, use it; otherwise
+   use M's latest committed `t` at `ctx.admit_time`. The chosen
+   value is **captured once per request** and reused across every
+   subsystem call within the same request — policy and shapes can
+   never disagree about which version of M they're enforcing.
+5. **Cycle check.** The tuple `(canonical_model_ledger_id,
+   graph_iri, resolved_t)` is checked against `ctx.seen`. Two
+   different `atT` pins of the same `(ledger, graph)` are not a
+   cycle; the same triple is.
+6. **Translation and materialization.** The graph at `resolved_t` is
+   read and projected into term-neutral form (see next section).
+7. **Caching.** On cache hit the materialized artifact is returned
+   directly. On miss the artifact is inserted under the key
+   `(canonical_model_ledger_id, graph_iri, resolved_t)`.
+
+A `ResolvedGraph` is term-neutral and t-fixed:
+
+```rust
+pub struct ResolvedGraph {
+    pub model_ledger_id: String,    // canonical
+    pub graph_iri: String,
+    pub resolved_t: i64,
+    pub artifact: GovernanceArtifact, // tagged union per subsystem
+    pub fingerprint: ContentId,      // for downstream cache keys
+}
+```
+
+The `GovernanceArtifact` variants are:
+
+```rust
+pub enum GovernanceArtifact {
+    PolicyRules(PolicyRuleSet),       // canonical IR, IRI-form
+    Shapes(ShapeSet),                 // SHACL shapes in IRI-form
+    SchemaClosure(SchemaBundleIR),    // ontology in IRI-form
+    DatalogRules(DatalogRuleSet),     // rules in IRI-form
+    Constraints(ConstraintSet),       // f:enforceUnique annotations
+}
+```
+
+Each variant is **term-neutral**: every subject, predicate, object,
+class, and datatype reference is stored as an IRI (or canonical
+literal), never as a model-ledger Sid or GraphId.
+
+## Term-space translation
+
+This is the load-bearing technical claim and the reason the resolver
+contract changes rather than just gaining a new `f:ledger` branch.
+
+Within a ledger, Fluree internally identifies subjects/predicates by
+`Sid(namespace_code, local_id)` and graphs by `GraphId(u16)`. Both
+are *ledger-local*. The IRI `<http://example.org/Person>` may be
+`Sid(ns=7, id=42)` in M and `Sid(ns=13, id=200)` in D. M's
+`GraphId(3)` and D's `GraphId(3)` have nothing to do with each
+other. M's `t=10` and D's `t=3` are not comparable.
+
+Today's same-ledger schema bundle (`build_schema_bundle_flakes` in
+`fluree-db-query/src/schema_bundle.rs`) returns raw flakes and
+relies on the data query's `to_t` for further filtering. That
+contract makes three implicit assumptions that all break
+cross-ledger:
+
+1. Sid namespace codes are shared between source and consumer.
+2. Graph ids are shared.
+3. The artifact's `t` is comparable to the consumer's `t`.
+
+The cross-ledger contract therefore returns a **term-space-neutral,
+model-t-fixed** artifact. Concretely:
+
+- All identifiers in the artifact are IRIs (interned at use site
+  against D's term space) or canonical literal values.
+- All time filtering against M is applied *at materialization time*
+  inside the resolver; the consumer never re-applies its own `to_t`
+  to the resolved artifact.
+- The data-ledger executor re-interns IRIs as needed against D's
+  dictionary. New IRIs that D has not seen are interned on demand
+  (the standard intern path); they do not need to pre-exist in D's
+  registry.
+
+The cache key is `(canonical_model_ledger_id, graph_iri,
+resolved_t)` — *not* parameterized by the data ledger's term space.
+This is the property that makes "model edit propagates atomically to
+all governed datasets" cheap: one cache entry per `(model, graph,
+t)` is reused across every data ledger that references it.
+
+Per-data-ledger interning is a derived view of the cached artifact,
+memoized at the use site only if profiling shows interning is a
+bottleneck.
+
+## Policy IR identity split
+
+Policy rules typically carry two kinds of term references that the
+existing IR conflates:
+
+| Reference kind | Examples                                      | Must bind in |
+|----------------|-----------------------------------------------|--------------|
+| Definitional  | Rule classes, predicate IRIs, target classes  | M (model ledger) |
+| Contextual    | Request identity, tested resource subjects    | D (data ledger) + request context |
+
+A naive "load rules from M, evaluate them as if D were M" build
+produces a worse-than-useless result: only model-ledger identities
+could ever satisfy the rules.
+
+The IR therefore distinguishes the two binding scopes explicitly.
+When the resolver returns a `PolicyRules` artifact, every term
+reference is tagged with its scope (`Definitional` resolves in M's
+term space at materialization time; `Contextual` is left as an IRI
+to bind at evaluation time against D).
+
+Authentication and identity flow only one way: from D and the
+request context. The model ledger contributes rules and definitions;
+it never contributes identity, authentication keys, or session
+state. This keeps trust one-directional.
+
+## Resolution time and `f:atT`
+
+| Case                       | Behavior |
+|----------------------------|----------|
+| No `f:atT`                 | `resolved_t` = M's latest committed `t` at request admission. Captured once. |
+| `f:atT N`                  | `resolved_t = N`. M time-travels to that point. |
+| `f:atT N`, N pruned        | Fail closed (see [Failure variants](#failure-variants)). No fallback to nearest-available. |
+| Mid-request M advancement  | Not reflected in the current request. The next request re-admits at the new head. |
+
+`resolved_t` is captured **once per request** in `ResolveCtx`, not
+per subsystem call. Without this, policy and shapes could enforce
+against different versions of M for the same request.
+
+## Caching
+
+Resolved artifacts are cached in the existing global `LeafletCache`
+(TinyLFU, byte budget `FLUREE_LEAFLET_CACHE_BYTES`). Reasons:
+
+- One memory pool, one tuning knob.
+- Same eviction discipline as decoded leaflets.
+- Naturally bounded by the existing 8 GiB default.
+
+The key is `(canonical_model_ledger_id, graph_iri, resolved_t)`. New
+commits to M produce new keys without explicit invalidation;
+unreferenced entries age out under TinyLFU. There is no
+"watermark-on-write" channel.
+
+The cache value is the term-neutral `ResolvedGraph` (IRIs, not Sids).
+Per-data-ledger interning is not part of the cache key.
+
+## Failure variants
+
+Cross-ledger failures must be distinguishable for audit; they MUST
+NOT collapse into a single generic import error.
+
+```rust
+pub enum CrossLedgerError {
+    /// `f:ledger` names a ledger that does not exist or has been
+    /// dropped on this instance.
+    ModelLedgerMissing { ledger_id: String },
+
+    /// `f:ledger` resolves but the named graph IRI has no entry in
+    /// the model ledger's graph registry at `resolved_t`.
+    GraphMissingAtT { ledger_id: String, graph_iri: String, resolved_t: i64 },
+
+    /// `f:atT N` was requested but M no longer retains state at N
+    /// (index pruning, history retention).
+    TAtUnavailable { ledger_id: String, requested_t: i64, oldest_available_t: i64 },
+
+    /// The selector targets `#config` or `#txn-meta` on the model
+    /// ledger.
+    ReservedGraphSelected { graph_iri: String },
+
+    /// The resolver successfully read the graph but could not
+    /// translate it to term-neutral form (missing IRI on a Sid that
+    /// the model dictionary lost, malformed rule, etc.).
+    TranslationFailed { ledger_id: String, graph_iri: String, detail: String },
+
+    /// `f:trustPolicy` failed verification, or `f:rollbackGuard`
+    /// would be violated. (Phase 4.)
+    TrustCheckFailed { ledger_id: String, detail: String },
+
+    /// `f:ledger` targets a ledger on a different instance.
+    CrossInstanceUnsupported { ledger_id: String },
+
+    /// Cycle detected through `(ledger, graph, resolved_t)` chain.
+    CycleDetected { chain: Vec<(String, String, i64)> },
+}
+```
+
+Every variant is fail-closed: the request fails. There is no silent
+fallback to "no policy" or "no shapes."
+
+## Trust model
+
+A data ledger D's `#config` declaring `f:ledger <M>` is itself the
+capability assertion. Writing to D's `#config` already requires
+policy authority on D, so "whoever can write D's `#config` asserts
+that M is a trusted governance source for D."
+
+For v1, no consent is required from M. Phase 4 introduces
+`f:trustPolicy` and `f:rollbackGuard` for ledgers that need
+stronger guarantees (commit signer allowlist, hash pin, maximum
+staleness window).
+
+Cross-instance federation requires a different trust model (auth,
+transport, signing) and is out of scope.
+
+## Reserved-graph guard
+
+The same-ledger version of this guard lives in
+`ontology_imports::resolve_local_graph_source`: selectors resolving
+to `g_id=1` (`#txn-meta`) or `g_id=2` (`#config`) are rejected.
+
+The cross-ledger version applies the same check by IRI *before* any
+storage round-trip on M. The motivation is doubled: `#txn-meta` on
+M could leak commit metadata to D's request handler.
+
+## Cycle detection
+
+The resolver maintains a `seen: Vec<(canonical_ledger_id, graph_iri,
+resolved_t)>` chain in `ResolveCtx`. Detection runs on the resolved
+tuple. Two distinct `atT` pins of the same `(ledger, graph)` are not
+a cycle. Two distinct graphs on the same ledger are not a cycle.
+
+This is the same BFS+dedupe pattern the existing same-ledger
+`owl:imports` resolver uses, generalized to a 3-tuple.
+
+## Drop interaction
+
+V1: if a data ledger D references model ledger M and M is dropped,
+the next request against D that needs governance from M fails
+closed with `ModelLedgerMissing`. There is no reverse-reference
+index and no rejection of M's drop based on outstanding references.
+
+This is the smallest contract that's safe; introducing reverse
+indexes requires nameservice schema work and is deferred. Operators
+who need stronger guarantees can publish a `f:trustPolicy` (Phase 4)
+or coordinate drops at the application layer.
+
+## Same-instance constraint (v1)
+
+Both D and M must:
+
+- Belong to the same nameservice instance.
+- Live within the same storage namespace.
+
+Same-instance failures surface as `CrossInstanceUnsupported` before
+any storage round-trip.
+
+## Phasing
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| 0     | Same-ledger fail-closed across the five subsystems (policy, shapes, schema, constraints, rules). | Policy, shapes, schema, constraints: done. Rules: pending (deferred behind this design). |
+| 1a    | `f:policySource` cross-ledger via `resolve_graph_ref`. Policy IR identity split lands as part of this. | After this doc. |
+| 1b    | `f:schemaSource` + `f:ontologyImportMap` cross-ledger; transitive imports across ≥2 model ledgers. | After 1a. |
+| 2     | `f:shapesSource`, `f:rulesSource`, `f:constraintsSource` cross-ledger via the same resolver. | After 1a/1b. |
+| 3     | `f:atT` temporal pinning. | After 2. |
+| 4     | `f:trustPolicy`, `f:rollbackGuard`. Separate RFE. | Out of scope here. |
+
+## Test plan (per phase)
+
+Acceptance tests live next to the subsystems they exercise:
+
+- `it_policy_cross_ledger.rs` — D references policy in M; query
+  against D enforces M's policies; inline `opts.policy` still
+  merges; fail-closed when M is unreachable.
+- `it_schema_cross_ledger.rs` — extension of
+  `it_reasoning_imports.rs` across a ledger boundary; transitive
+  imports across two model ledgers; cycle detection.
+- `it_shapes_cross_ledger.rs` — tx against D validates against
+  shapes in M.
+- `it_at_t_pinning.rs` — `f:atT N` pins; commits after N don't
+  affect the governed query.
+- `it_fail_closed.rs` — every failure variant rejects the request.
+
+Two cross-cutting tests are mandatory regardless of phase:
+
+- **Distinct namespace codes.** M and D both interned the same
+  class IRI under different `ns_code` values; the resolved artifact
+  re-interns correctly against D and policy/shapes fire as
+  expected. This is the canary for term-space translation.
+- **Single-resolution-t.** Within one request, every subsystem
+  receives the same `resolved_t` for M, even when admission and
+  enforcement happen tens of milliseconds apart and M advanced in
+  between.
+
+Tests must drive through `Fluree::db()` (not
+`GraphDb::from_ledger_state`) so the config-graph path is exercised.
+
+## Out of scope
+
+- **Cross-instance federation.** Different nameservices, transport,
+  cross-org auth/signing. Separate RFE.
+- **`f:trustPolicy` / `f:rollbackGuard` implementations.** Phase 4.
+- **Auto-resolution by IRI namespace.** "Which model governs
+  `schema:*`?" — application-layer concern.
+- **Writing back to a model ledger from a governed ledger's
+  request.** Read-only references only.
+- **Reverse-reference indexes for safe drop.** V1 allows M to be
+  dropped; D fails closed on next request.
+
+## Open questions for review
+
+- Should `resolved_t` capture happen at request admission or at
+  first cross-ledger resolution within the request? Spec currently
+  says admission; admission is simpler and avoids a per-resolver
+  inconsistency window, at the cost of materializing M's head even
+  when no subsystem ends up consulting M.
+- Should the `seen` chain be per-request or per-resolver-instance?
+  Per-request prevents a malicious config from making the same
+  resolver loop indefinitely across different subsystems; spec
+  defaults to per-request.
+- Should `CrossLedgerError` surface to the HTTP status as 502
+  (upstream-style) or 500? Argument for 502: operator distinction
+  between "your data ledger is broken" and "the model ledger this
+  data ledger depends on is broken." Not load-bearing on the
+  internal contract.

--- a/docs/guides/cookbook-shacl.md
+++ b/docs/guides/cookbook-shacl.md
@@ -339,6 +339,7 @@ Semantics:
 - `f:shapesSource` is **authoritative, not additive**: when set, shapes come exclusively from the configured graph. Shapes in the default graph are ignored.
 - `f:shapesSource` is **non-overridable** — it can only be set in the config graph, not via transaction/query-time options.
 - Use `f:graphSelector f:defaultGraph` to explicitly point at the default graph (same as omitting `f:shapesSource`).
+- `f:shapesSource` also supports **cross-ledger references** — set `f:ledger` on the inner `f:graphSource` to compile shapes from a different ledger at validation time. See [Cross-ledger governance — Cross-ledger SHACL shapes](../security/cross-ledger-policy.md#cross-ledger-shacl-shapes) for the end-to-end pattern.
 
 ## Inline shapes per transaction
 

--- a/docs/guides/cookbook-shacl.md
+++ b/docs/guides/cookbook-shacl.md
@@ -340,6 +340,67 @@ Semantics:
 - `f:shapesSource` is **non-overridable** — it can only be set in the config graph, not via transaction/query-time options.
 - Use `f:graphSelector f:defaultGraph` to explicitly point at the default graph (same as omitting `f:shapesSource`).
 
+## Inline shapes per transaction
+
+In addition to shapes stored in a ledger, a transaction can supply
+**inline shapes** via the `opts.shapes` field. The shapes are
+enforced only for that one transaction and never written into the
+ledger.
+
+```json
+{
+  "@context": {"ex": "http://example.org/ns/"},
+  "@id":   "ex:alice",
+  "@type": "ex:Person",
+  "opts": {
+    "shapes": {
+      "@context": {
+        "ex":  "http://example.org/ns/",
+        "sh":  "http://www.w3.org/ns/shacl#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+      },
+      "@graph": [
+        {
+          "@id":            "ex:PersonShape",
+          "@type":          "sh:NodeShape",
+          "sh:targetClass": {"@id": "ex:Person"},
+          "sh:property":    {"@id": "ex:pshape_name"}
+        },
+        {
+          "@id":         "ex:pshape_name",
+          "sh:path":     {"@id": "ex:name"},
+          "sh:minCount": 1,
+          "sh:datatype": {"@id": "xsd:string"}
+        }
+      ]
+    }
+  }
+}
+```
+
+Semantics:
+
+- **Additive, not replacing.** Inline shapes enforce *alongside*
+  any shapes from `f:shapesSource` (same-ledger or cross-ledger).
+  A subject must satisfy every shape from every source.
+- **Transient.** The shapes never appear in the ledger's data and
+  vanish after the transaction completes. The next transaction
+  without `opts.shapes` runs without them.
+- **Gated by config.** If `f:shaclEnabled false` (or no graph is
+  enabled), inline shapes do not bypass that posture — operator
+  config wins. To use inline shapes on a fresh ledger with no
+  config, the shapes-exist heuristic enables validation
+  automatically.
+- **No audit trail.** Because inline shapes don't persist, it
+  isn't possible to reconstruct "which shapes validated which
+  commit" from ledger history. If auditability matters, store
+  shapes in a `f:shapesSource` graph instead.
+
+Use cases that fit well: ad-hoc shape testing before committing
+to `f:shapesSource`, per-tenant validation layers in an
+application server, request-scoped governance that should not
+become part of permanent ledger state.
+
 ## Validation modes
 
 - **`f:ValidationReject`** (default): on any violation, the transaction fails with `ShaclViolation(report)`. The formatted report lists each violation's focus node, property path, and message.

--- a/docs/guides/cookbook-shacl.md
+++ b/docs/guides/cookbook-shacl.md
@@ -381,9 +381,13 @@ ledger.
 
 Semantics:
 
-- **Additive, not replacing.** Inline shapes enforce *alongside*
-  any shapes from `f:shapesSource` (same-ledger or cross-ledger).
-  A subject must satisfy every shape from every source.
+- **Additive with the configured source.** Inline shapes enforce
+  *alongside* whatever `f:shapesSource` resolves to. A subject
+  must satisfy every shape from both sources. Note that
+  `f:shapesSource` is itself singular — its `f:graphSource` is
+  either local (no `f:ledger`) or cross-ledger (with `f:ledger`),
+  not both at the same time. Inline shapes don't change that;
+  they layer on top of whichever variant is configured.
 - **Transient.** The shapes never appear in the ledger's data and
   vanish after the transaction completes. The next transaction
   without `opts.shapes` runs without them.

--- a/docs/ledger-config/README.md
+++ b/docs/ledger-config/README.md
@@ -223,3 +223,7 @@ No special CLI commands are needed — config is data, written and queried like 
 - [Setting groups](setting-groups.md) — All setting groups with fields and examples
 - [Override control](override-control.md) — Resolution precedence, identity gating, monotonicity
 - [Unique constraints](unique-constraints.md) — Enforcing property value uniqueness with `f:enforceUnique`
+
+## Related
+
+- [Cross-ledger policy](../security/cross-ledger-policy.md) — Configure one model ledger to govern many data ledgers via `f:policySource` with `f:ledger`. Builds on the `f:GraphRef` shape documented in [setting groups](setting-groups.md#policy-defaults).

--- a/docs/ledger-config/README.md
+++ b/docs/ledger-config/README.md
@@ -226,4 +226,4 @@ No special CLI commands are needed — config is data, written and queried like 
 
 ## Related
 
-- [Cross-ledger policy](../security/cross-ledger-policy.md) — Configure one model ledger to govern many data ledgers via `f:policySource` with `f:ledger`. Builds on the `f:GraphRef` shape documented in [setting groups](setting-groups.md#policy-defaults).
+- [Cross-ledger governance](../security/cross-ledger-policy.md) — Configure one model ledger to govern many data ledgers. Every `f:GraphRef`-shaped predicate (`f:policySource`, `f:constraintsSource`, `f:schemaSource`, `f:shapesSource`, `f:rulesSource`) accepts `f:ledger` to reference another ledger. Builds on the `f:GraphRef` shape documented in [setting groups](setting-groups.md#policy-defaults).

--- a/docs/ledger-config/setting-groups.md
+++ b/docs/ledger-config/setting-groups.md
@@ -40,7 +40,7 @@ When `f:policySource` is set, the policy loader scans the specified graph for po
 
 **Cross-ledger references are supported on `f:policySource`.** The graph source can name another ledger via `f:ledger`, so a single model ledger can hold policy rules that govern many data ledgers. See [Cross-ledger policy](../security/cross-ledger-policy.md) for the configuration pattern and the contract on `f:policyClass` filtering, baseline `f:AccessPolicy` semantics, and the failure modes.
 
-**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. The other `f:GraphRef`-shaped predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource`) remain same-ledger only — setting `f:ledger` on those produces an error.
+**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. Cross-ledger references are also supported on `f:constraintsSource` (see [Cross-ledger policy and constraints](../security/cross-ledger-policy.md#cross-ledger-uniqueness-constraints)). The remaining `f:GraphRef`-shaped predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`) remain same-ledger only — setting `f:ledger` on those produces an error.
 
 ### Example: policies in the default graph
 
@@ -363,7 +363,7 @@ A `f:GraphRef` has two levels: the outer node carries the type and optional trus
 | `f:trustPolicy` | `f:GraphRef` | object | How to verify the referenced graph (future) |
 | `f:rollbackGuard` | `f:GraphRef` | object | Freshness constraints (future) |
 | `f:graphSelector` | `f:graphSource` | IRI | Target graph: `f:defaultGraph`, `f:txnMetaGraph`, or a named graph IRI |
-| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource` (see [Cross-ledger policy](../security/cross-ledger-policy.md)); rejected on `f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource` until those subsystems route through the cross-ledger resolver. |
+| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource` and `f:constraintsSource` (see [Cross-ledger policy and constraints](../security/cross-ledger-policy.md)); rejected on `f:shapesSource`, `f:schemaSource`, `f:rulesSource` until those subsystems route through the cross-ledger resolver. |
 | `f:atT` | `f:graphSource` | integer | Pin to a specific transaction time (optional) |
 
 For the common case of referencing a graph within the same ledger, only `f:graphSelector` is needed inside `f:graphSource`:
@@ -384,4 +384,4 @@ f:policySource [
 ] .
 ```
 
-Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by `f:policySource` — see [Cross-ledger policy](../security/cross-ledger-policy.md) for the end-to-end pattern. The other source predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource`) accept the field in their parse layer but the cross-ledger materializers for those subsystems aren't implemented yet; setting `f:ledger` on them produces an explicit error rather than a silent fallback.
+Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by `f:policySource` and `f:constraintsSource` — see [Cross-ledger policy and constraints](../security/cross-ledger-policy.md) for end-to-end patterns. The other source predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`) accept the field in their parse layer but the cross-ledger materializers for those subsystems aren't implemented yet; setting `f:ledger` on them produces an explicit error rather than a silent fallback.

--- a/docs/ledger-config/setting-groups.md
+++ b/docs/ledger-config/setting-groups.md
@@ -40,7 +40,7 @@ When `f:policySource` is set, the policy loader scans the specified graph for po
 
 **Cross-ledger references are supported on `f:policySource`.** The graph source can name another ledger via `f:ledger`, so a single model ledger can hold policy rules that govern many data ledgers. See [Cross-ledger policy](../security/cross-ledger-policy.md) for the configuration pattern and the contract on `f:policyClass` filtering, baseline `f:AccessPolicy` semantics, and the failure modes.
 
-**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. Cross-ledger references are also supported on `f:constraintsSource` (see [Cross-ledger policy and constraints](../security/cross-ledger-policy.md#cross-ledger-uniqueness-constraints)). The remaining `f:GraphRef`-shaped predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`) remain same-ledger only — setting `f:ledger` on those produces an error.
+**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. Cross-ledger references are also supported on `f:constraintsSource` and `f:schemaSource` (single graph only — transitive `owl:imports` recursion across ledgers is not yet supported). See [Cross-ledger policy, constraints, and schema](../security/cross-ledger-policy.md). The remaining `f:GraphRef`-shaped predicates (`f:shapesSource`, `f:rulesSource`) remain same-ledger only — setting `f:ledger` on those produces an error.
 
 ### Example: policies in the default graph
 
@@ -363,7 +363,7 @@ A `f:GraphRef` has two levels: the outer node carries the type and optional trus
 | `f:trustPolicy` | `f:GraphRef` | object | How to verify the referenced graph (future) |
 | `f:rollbackGuard` | `f:GraphRef` | object | Freshness constraints (future) |
 | `f:graphSelector` | `f:graphSource` | IRI | Target graph: `f:defaultGraph`, `f:txnMetaGraph`, or a named graph IRI |
-| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource` and `f:constraintsSource` (see [Cross-ledger policy and constraints](../security/cross-ledger-policy.md)); rejected on `f:shapesSource`, `f:schemaSource`, `f:rulesSource` until those subsystems route through the cross-ledger resolver. |
+| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource`, `f:constraintsSource`, and `f:schemaSource` (single graph only; see [Cross-ledger policy, constraints, and schema](../security/cross-ledger-policy.md)); rejected on `f:shapesSource`, `f:rulesSource` until those subsystems route through the cross-ledger resolver. |
 | `f:atT` | `f:graphSource` | integer | Pin to a specific transaction time (optional) |
 
 For the common case of referencing a graph within the same ledger, only `f:graphSelector` is needed inside `f:graphSource`:
@@ -384,4 +384,4 @@ f:policySource [
 ] .
 ```
 
-Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by `f:policySource` and `f:constraintsSource` — see [Cross-ledger policy and constraints](../security/cross-ledger-policy.md) for end-to-end patterns. The other source predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`) accept the field in their parse layer but the cross-ledger materializers for those subsystems aren't implemented yet; setting `f:ledger` on them produces an explicit error rather than a silent fallback.
+Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by `f:policySource`, `f:constraintsSource`, and `f:schemaSource` (single graph only — transitive `owl:imports` recursion across ledgers is not yet supported on schema). See [Cross-ledger policy, constraints, and schema](../security/cross-ledger-policy.md) for end-to-end patterns. The remaining source predicates (`f:shapesSource`, `f:rulesSource`) accept the field in their parse layer but the cross-ledger materializers for those subsystems aren't implemented yet; setting `f:ledger` on them produces an explicit error rather than a silent fallback.

--- a/docs/ledger-config/setting-groups.md
+++ b/docs/ledger-config/setting-groups.md
@@ -38,7 +38,9 @@ Controls default policy enforcement behavior.
 
 When `f:policySource` is set, the policy loader scans the specified graph for policy rules instead of the default graph. This keeps policy rules separate from end-user data. If `f:policySource` is not set, policies are loaded from the default graph (backward compatible).
 
-**Current limitations**: `f:policySource` only supports same-ledger graphs. Cross-ledger references (`f:ledger`), temporal pinning (`f:atT`), trust policy, and rollback guard fields are parsed but will produce an error if configured.
+**Cross-ledger references are supported on `f:policySource`.** The graph source can name another ledger via `f:ledger`, so a single model ledger can hold policy rules that govern many data ledgers. See [Cross-ledger policy](../security/cross-ledger-policy.md) for the configuration pattern and the contract on `f:policyClass` filtering, baseline `f:AccessPolicy` semantics, and the failure modes.
+
+**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. The other `f:GraphRef`-shaped predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource`) remain same-ledger only — setting `f:ledger` on those produces an error.
 
 ### Example: policies in the default graph
 
@@ -361,7 +363,7 @@ A `f:GraphRef` has two levels: the outer node carries the type and optional trus
 | `f:trustPolicy` | `f:GraphRef` | object | How to verify the referenced graph (future) |
 | `f:rollbackGuard` | `f:GraphRef` | object | Freshness constraints (future) |
 | `f:graphSelector` | `f:graphSource` | IRI | Target graph: `f:defaultGraph`, `f:txnMetaGraph`, or a named graph IRI |
-| `f:ledger` | `f:graphSource` | IRI | Ledger identifier (for cross-ledger references; not yet supported for constraint sources) |
+| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource` (see [Cross-ledger policy](../security/cross-ledger-policy.md)); rejected on `f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource` until those subsystems route through the cross-ledger resolver. |
 | `f:atT` | `f:graphSource` | integer | Pin to a specific transaction time (optional) |
 
 For the common case of referencing a graph within the same ledger, only `f:graphSelector` is needed inside `f:graphSource`:
@@ -382,4 +384,4 @@ f:policySource [
 ] .
 ```
 
-Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is defined in the schema but not yet supported for constraint source resolution. Currently, only local graph references are resolved.
+Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by `f:policySource` — see [Cross-ledger policy](../security/cross-ledger-policy.md) for the end-to-end pattern. The other source predicates (`f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource`) accept the field in their parse layer but the cross-ledger materializers for those subsystems aren't implemented yet; setting `f:ledger` on them produces an explicit error rather than a silent fallback.

--- a/docs/ledger-config/setting-groups.md
+++ b/docs/ledger-config/setting-groups.md
@@ -40,7 +40,7 @@ When `f:policySource` is set, the policy loader scans the specified graph for po
 
 **Cross-ledger references are supported on `f:policySource`.** The graph source can name another ledger via `f:ledger`, so a single model ledger can hold policy rules that govern many data ledgers. See [Cross-ledger policy](../security/cross-ledger-policy.md) for the configuration pattern and the contract on `f:policyClass` filtering, baseline `f:AccessPolicy` semantics, and the failure modes.
 
-**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. Cross-ledger references are also supported on `f:constraintsSource` and `f:schemaSource` (single graph only — transitive `owl:imports` recursion across ledgers is not yet supported). See [Cross-ledger policy, constraints, and schema](../security/cross-ledger-policy.md). The remaining `f:GraphRef`-shaped predicates (`f:shapesSource`, `f:rulesSource`) remain same-ledger only — setting `f:ledger` on those produces an error.
+**Not yet honored on `f:policySource`** (parsed by the config layer but rejected at request time with a clear error): `f:atT` temporal pinning, `f:trustPolicy` verification, `f:rollbackGuard` freshness constraints. Cross-ledger references are also supported on `f:constraintsSource`, `f:schemaSource` (single graph only — transitive `owl:imports` recursion across ledgers is not yet supported), `f:shapesSource`, and `f:rulesSource`. See [Cross-ledger policy](../security/cross-ledger-policy.md) for the end-to-end configuration patterns and failure modes shared by all five subsystems.
 
 ### Example: policies in the default graph
 
@@ -363,7 +363,7 @@ A `f:GraphRef` has two levels: the outer node carries the type and optional trus
 | `f:trustPolicy` | `f:GraphRef` | object | How to verify the referenced graph (future) |
 | `f:rollbackGuard` | `f:GraphRef` | object | Freshness constraints (future) |
 | `f:graphSelector` | `f:graphSource` | IRI | Target graph: `f:defaultGraph`, `f:txnMetaGraph`, or a named graph IRI |
-| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource`, `f:constraintsSource`, and `f:schemaSource` (single graph only; see [Cross-ledger policy, constraints, and schema](../security/cross-ledger-policy.md)); rejected on `f:shapesSource`, `f:rulesSource` until those subsystems route through the cross-ledger resolver. |
+| `f:ledger` | `f:graphSource` | IRI | Ledger identifier. Supported on `f:policySource`, `f:constraintsSource`, `f:schemaSource` (single graph only), `f:shapesSource`, and `f:rulesSource`. See [Cross-ledger policy](../security/cross-ledger-policy.md) for the shared resolver contract and failure modes. |
 | `f:atT` | `f:graphSource` | integer | Pin to a specific transaction time (optional) |
 
 For the common case of referencing a graph within the same ledger, only `f:graphSelector` is needed inside `f:graphSource`:
@@ -384,4 +384,4 @@ f:policySource [
 ] .
 ```
 
-Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by `f:policySource`, `f:constraintsSource`, and `f:schemaSource` (single graph only — transitive `owl:imports` recursion across ledgers is not yet supported on schema). See [Cross-ledger policy, constraints, and schema](../security/cross-ledger-policy.md) for end-to-end patterns. The remaining source predicates (`f:shapesSource`, `f:rulesSource`) accept the field in their parse layer but the cross-ledger materializers for those subsystems aren't implemented yet; setting `f:ledger` on them produces an explicit error rather than a silent fallback.
+Cross-ledger `f:GraphRef` (using `f:ledger` to reference another ledger) is honored by all five governance source predicates: `f:policySource`, `f:constraintsSource`, `f:schemaSource` (single graph only — transitive `owl:imports` recursion across ledgers is not yet supported on schema), `f:shapesSource`, and `f:rulesSource`. See [Cross-ledger policy](../security/cross-ledger-policy.md) for end-to-end patterns.

--- a/docs/ledger-config/unique-constraints.md
+++ b/docs/ledger-config/unique-constraints.md
@@ -133,6 +133,50 @@ Upserts that change a value are handled correctly. When an upsert retracts the o
 
 Re-asserting the same `(subject, property, value)` triple that already exists is allowed. One subject still holds the value — no violation.
 
+## Inline `opts.uniqueProperties` per transaction
+
+In addition to constraints stored in the ledger, a transaction can
+supply **inline unique-property declarations** via the
+`opts.uniqueProperties` field. The properties are enforced only for
+that one transaction; the list itself never persists.
+
+```json
+{
+  "@context": {"ex": "http://example.org/ns/"},
+  "@id":      "ex:bob",
+  "ex:email": "alice@example.org",
+  "opts": {
+    "uniqueProperties": [
+      "http://example.org/ns/email"
+    ]
+  }
+}
+```
+
+Each entry must be a **full IRI** (not a compact prefix form). IRIs
+that the ledger's namespace map has never seen are dropped silently
+— no instance of the property exists, so the constraint cannot be
+violated either way; this matches the same-ledger contract.
+
+Semantics:
+
+- **Additive, not replacing.** Inline properties union with whatever
+  `f:constraintsSource` already resolves to (same-ledger or
+  cross-ledger). A property is enforced if either source declares it.
+- **Transient.** The list is never written into the ledger. The next
+  transaction without `opts.uniqueProperties` runs without it.
+- **No-config enforcement.** Inline properties drive enforcement
+  even on a ledger with no `f:transactDefaults` block — the inline
+  list is itself the configuration for this transaction.
+- **No audit trail.** Without persistence it's not reconstructable
+  which constraints validated which commit. If auditability matters,
+  declare the constraint in a `f:constraintsSource` graph instead.
+
+Use cases that fit well: per-tenant constraints layered on top of
+operator-set baselines; one-off bulk loads that need extra hygiene
+without polluting `#config`; testing a candidate constraint before
+committing the annotation.
+
 ## Error message
 
 When a uniqueness violation is detected, the transaction fails with an error like:

--- a/docs/ledger-config/unique-constraints.md
+++ b/docs/ledger-config/unique-constraints.md
@@ -77,6 +77,15 @@ f:transactDefaults [
 ] .
 ```
 
+### Cross-ledger constraint source
+
+`f:constraintsSource` also supports **cross-ledger references** —
+set `f:ledger` on the inner `f:graphSource` to load
+`f:enforceUnique` annotations from another ledger at transaction
+time. See
+[Cross-ledger governance — Cross-ledger constraints](../security/cross-ledger-policy.md#cross-ledger-uniqueness-constraints)
+for the end-to-end pattern and failure modes.
+
 ## What gets enforced
 
 Once enabled, any transaction that would result in **two or more distinct subjects** holding the same value for a unique property **within the same graph** is rejected.

--- a/docs/query/datalog-rules.md
+++ b/docs/query/datalog-rules.md
@@ -157,8 +157,15 @@ across all queries.
 See [Setting groups — datalogDefaults](../ledger-config/setting-groups.md) for
 full configuration options.
 
-When both stored and query-time rules are present, they are **merged** and
-execute together in the same fixpoint loop.
+`f:rulesSource` also supports cross-ledger references — set
+`f:ledger` on the inner `f:graphSource` to pull `f:rule` JSON
+bodies from another ledger at query time. See
+[Cross-ledger governance — Cross-ledger datalog rules](../security/cross-ledger-policy.md#cross-ledger-datalog-rules)
+for the end-to-end pattern and failure modes.
+
+When stored rules, cross-ledger rules, and query-time rules are
+present, they are all **merged** and execute together in the
+same fixpoint loop.
 
 ## Examples
 

--- a/docs/query/reasoning.md
+++ b/docs/query/reasoning.md
@@ -210,6 +210,53 @@ In SPARQL queries, reasoning is controlled via the Fluree-specific
 complementary mechanism for navigating transitive and inverse relationships
 directly in the query pattern — see [SPARQL](sparql.md) for details.
 
+## Inline ontology per query
+
+In addition to ontology axioms stored in the ledger (via
+`f:schemaSource`), a query can supply **inline ontology axioms**
+via the top-level `ontology` field. The axioms are used only for
+this query's reasoning pass and never persist.
+
+```json
+{
+  "@context": {"ex": "http://example.org/ns/"},
+  "select":    "?name",
+  "where":     {"@id": "?p", "@type": "ex:Person", "ex:name": "?name"},
+  "reasoning": "rdfs",
+  "ontology": {
+    "@context": {
+      "ex":   "http://example.org/ns/",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    },
+    "@id":             "ex:Employee",
+    "rdfs:subClassOf": {"@id": "ex:Person"}
+  }
+}
+```
+
+Semantics:
+
+- **Additive, not replacing.** Inline axioms layer on top of
+  whatever `f:schemaSource` configured for the ledger (same- or
+  cross-ledger). Both contribute to the bundle the reasoner sees.
+- **Transient.** Axioms never persist. The next query without
+  `ontology` runs against only the configured bundle.
+- **Reasoning mode still required.** Inline axioms don't enable
+  reasoning on their own — set `reasoning` (or rely on auto-RDFS
+  when a hierarchy exists) so the engine actually uses them.
+- **Namespace-scoped.** IRIs the snapshot already knows reuse
+  their codes; previously-unseen IRIs allocate request-scoped
+  codes that are discarded with the response — the on-disk
+  dictionary is untouched.
+- **No audit trail.** Without persistence, "which axioms drove
+  which result" can't be reconstructed from history. Store
+  long-lived ontologies in a graph and reference via
+  `f:schemaSource` if auditability matters.
+
+Use cases that fit well: testing a candidate ontology before
+committing it to the ledger, per-tenant axiom layers, exploratory
+analytics with hypothetical sub-class chains.
+
 ## Interaction with ledger configuration
 
 If `f:reasoningDefaults` is set in the ledger configuration graph (see

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -71,15 +71,16 @@ Using policies in Rust applications:
 - Transaction-side policy enforcement
 - Historical views with policy
 
-### [Cross-ledger policy](cross-ledger-policy.md)
+### [Cross-ledger policy and constraints](cross-ledger-policy.md)
 
-Govern many data ledgers from one model ledger via `f:policySource`
-with `f:ledger`:
+Govern many data ledgers from one model ledger via
+`f:policySource` and `f:constraintsSource` with `f:ledger`:
 - Two-ledger configuration pattern (model M, data D)
-- `f:policyClass` filtering with exact-IRI intersection
-- `f:AccessPolicy` baseline default
-- Engaging the policy path over HTTP
-- Failure modes (HTTP 502 + structured body)
+- Cross-ledger policy: `f:policyClass` filtering, `f:AccessPolicy`
+  baseline, engaging the policy path over HTTP
+- Cross-ledger uniqueness constraints: tx-time enforcement of
+  M's `f:enforceUnique` annotations on D's transactions
+- Failure modes and HTTP status mapping
 - Cache and update semantics
 
 ## Key Concepts

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -71,6 +71,17 @@ Using policies in Rust applications:
 - Transaction-side policy enforcement
 - Historical views with policy
 
+### [Cross-ledger policy](cross-ledger-policy.md)
+
+Govern many data ledgers from one model ledger via `f:policySource`
+with `f:ledger`:
+- Two-ledger configuration pattern (model M, data D)
+- `f:policyClass` filtering with exact-IRI intersection
+- `f:AccessPolicy` baseline default
+- Engaging the policy path over HTTP
+- Failure modes (HTTP 502 + structured body)
+- Cache and update semantics
+
 ## Key Concepts
 
 ### Data-Level Security

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -71,18 +71,25 @@ Using policies in Rust applications:
 - Transaction-side policy enforcement
 - Historical views with policy
 
-### [Cross-ledger policy, constraints, and schema](cross-ledger-policy.md)
+### [Cross-ledger governance](cross-ledger-policy.md)
 
-Govern many data ledgers from one model ledger via
-`f:policySource`, `f:constraintsSource`, and `f:schemaSource`
-with `f:ledger`:
+Govern many data ledgers from one model ledger via any of the
+five `f:GraphRef`-shaped predicates with `f:ledger`:
 - Two-ledger configuration pattern (model M, data D)
-- Cross-ledger policy: `f:policyClass` filtering, `f:AccessPolicy`
-  baseline, engaging the policy path over HTTP
-- Cross-ledger uniqueness constraints: tx-time enforcement of
-  M's `f:enforceUnique` annotations on D's transactions
-- Cross-ledger schema/ontology: M's RDFS/OWL axioms feed D's
-  reasoner (single graph, transitive `owl:imports` deferred)
+- Cross-ledger policy (`f:policySource`): `f:policyClass`
+  filtering, `f:AccessPolicy` baseline, engaging the policy
+  path over HTTP
+- Cross-ledger uniqueness constraints (`f:constraintsSource`):
+  tx-time enforcement of M's `f:enforceUnique` annotations on
+  D's transactions
+- Cross-ledger schema/ontology (`f:schemaSource`): M's RDFS/OWL
+  axioms feed D's reasoner (single graph, transitive
+  `owl:imports` deferred)
+- Cross-ledger SHACL shapes (`f:shapesSource`): M's shape
+  definitions compile against D's staged namespace at
+  validation time
+- Cross-ledger datalog rules (`f:rulesSource`): M's `f:rule`
+  JSON bodies feed D's query-time datalog evaluator
 - Failure modes and HTTP status mapping
 - Cache and update semantics
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -71,15 +71,18 @@ Using policies in Rust applications:
 - Transaction-side policy enforcement
 - Historical views with policy
 
-### [Cross-ledger policy and constraints](cross-ledger-policy.md)
+### [Cross-ledger policy, constraints, and schema](cross-ledger-policy.md)
 
 Govern many data ledgers from one model ledger via
-`f:policySource` and `f:constraintsSource` with `f:ledger`:
+`f:policySource`, `f:constraintsSource`, and `f:schemaSource`
+with `f:ledger`:
 - Two-ledger configuration pattern (model M, data D)
 - Cross-ledger policy: `f:policyClass` filtering, `f:AccessPolicy`
   baseline, engaging the policy path over HTTP
 - Cross-ledger uniqueness constraints: tx-time enforcement of
   M's `f:enforceUnique` annotations on D's transactions
+- Cross-ledger schema/ontology: M's RDFS/OWL axioms feed D's
+  reasoner (single graph, transitive `owl:imports` deferred)
 - Failure modes and HTTP status mapping
 - Cache and update semantics
 

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -1,22 +1,29 @@
-# Cross-ledger policy and constraints
+# Cross-ledger policy, constraints, and schema
 
 A single **model ledger** can hold governance artifacts —
-policy rules and uniqueness constraints — that govern many
-**data ledgers** that reference it. Update the model once and
-every governed data ledger sees the new rules / constraints on
-its next request, with no per-dataset duplication.
+policy rules, uniqueness constraints, and ontology/schema
+axioms — that govern many **data ledgers** that reference it.
+Update the model once and every governed data ledger sees the
+new rules / constraints / schema on its next request, with no
+per-dataset duplication.
 
-Two subsystems are wired today:
+Three subsystems are wired today:
 
 - **Cross-ledger policy** (`f:policySource` with `f:ledger`) —
   M's policy rule set is applied to queries against D.
 - **Cross-ledger constraints** (`f:constraintsSource` with
   `f:ledger`) — M's `f:enforceUnique` annotations are applied
   to transactions against D.
+- **Cross-ledger schema** (`f:schemaSource` with `f:ledger`) —
+  M's RDFS/OWL axioms (class hierarchy, property hierarchy,
+  domain/range, equivalences, owl:imports declarations) feed
+  D's reasoner. Single-graph only today; transitive
+  `owl:imports` recursion across multiple model ledgers is
+  reserved.
 
-Other subsystems (`f:schemaSource`, `f:shapesSource`,
-`f:rulesSource`) share the resolver's contract but their
-materializers are not yet implemented; see the design doc's
+The remaining subsystems (`f:shapesSource`, `f:rulesSource`)
+share the resolver's contract but their materializers are not
+yet implemented; see the design doc's
 [Scope](../design/cross-ledger-model-enforcement.md#scope)
 section.
 
@@ -234,6 +241,88 @@ A few specifics that differ from cross-ledger policy:
   `f:policyClass` filtering — every property M declares unique
   applies.
 
+## Cross-ledger schema / ontology
+
+Same two-ledger pattern, third subsystem. M holds an RDFS/OWL
+schema in a named graph (class hierarchy, property hierarchy,
+domain/range, equivalences); D references that graph in its
+`#config` under `f:reasoningDefaults.f:schemaSource`. When D's
+queries enable reasoning, M's axioms feed the reasoner exactly
+as if they lived on D.
+
+```trig
+# On model ledger M — ontology in a named graph
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://example.org/ns/> .
+
+GRAPH <http://example.org/ontology/core> {
+    ex:Animal  rdf:type        owl:Class .
+    ex:Dog     rdf:type        owl:Class ;
+               rdfs:subClassOf ex:Animal .
+
+    ex:knows   rdf:type           owl:ObjectProperty .
+    ex:friend  rdf:type           owl:ObjectProperty ;
+               rdfs:subPropertyOf ex:knows .
+}
+```
+
+```trig
+# On data ledger D — #config
+@prefix f:   <https://ns.flur.ee/db#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+GRAPH <urn:fluree:mydb:main#config> {
+    <urn:cfg:main> rdf:type f:LedgerConfig ;
+        f:reasoningDefaults <urn:cfg:reasoning> .
+
+    <urn:cfg:reasoning>
+        f:reasoningModes  ( "rdfs" "owl2-rl" ) ;
+        f:schemaSource    <urn:cfg:schema-ref> .
+
+    <urn:cfg:schema-ref> rdf:type f:GraphRef ;
+        f:graphSource <urn:cfg:schema-src> .
+
+    <urn:cfg:schema-src>
+        f:ledger        <org/ontology:main> ;
+        f:graphSelector <http://example.org/ontology/core> .
+}
+```
+
+With this config, a query against D for `?s rdf:type ex:Animal`
+returns every `ex:Dog` instance on D (subClassOf reasoning) —
+even though `ex:Dog rdfs:subClassOf ex:Animal` never appears on
+D itself.
+
+The materializer pulls a **whitelisted subset** of axioms from
+M's schema graph: the predicates `rdfs:subClassOf`,
+`rdfs:subPropertyOf`, `rdfs:domain`, `rdfs:range`,
+`owl:inverseOf`, `owl:equivalentClass`, `owl:equivalentProperty`,
+`owl:sameAs`, `owl:imports`, plus `rdf:type` declarations for
+the schema class set (`owl:Class`, `owl:ObjectProperty`,
+`owl:DatatypeProperty`, the property characteristic classes,
+`owl:Ontology`, `rdf:Property`). Instance data in the schema
+graph is filtered out; only axioms cross over.
+
+A few specifics that differ from cross-ledger policy:
+
+- Reasoning must be **enabled** for cross-ledger schema to take
+  effect. The data ledger's config can set
+  `f:reasoningModes` (e.g., `["rdfs"]` or `["owl2-rl"]`), or
+  the query can opt in via the `reasoning` option.
+- Failures during cross-ledger schema resolution surface as
+  `ApiError::OntologyImport` (with the underlying
+  `CrossLedgerError` displayed in the message) rather than
+  `ApiError::CrossLedger`. That preserves continuity with the
+  same-ledger ontology-imports error path.
+- Single graph only in this phase: `owl:imports` triples in
+  M's schema graph are carried through to the wire (so a
+  future reader can see them), but the resolver does NOT
+  transitively follow them across ledger boundaries yet. If M's
+  schema declares `owl:imports <X>` where X is on a different
+  model ledger M2, that import isn't resolved.
+
 ## Limitations
 
 The following behaviors are **not yet implemented** and fail
@@ -246,7 +335,8 @@ closed when configured:
 | `f:rollbackGuard` (freshness constraints)  | Request fails with `UnsupportedFeature`. |
 | `opts.identity` + cross-ledger `f:policySource` | Request fails with a config error. Identity-mode loads policies via the identity's `f:policyClass` triples, which would have to resolve in D (the identity isn't an M concept); combining the two modes ambiguously is rejected rather than silently choosing one. Use `opts.policy_class` with cross-ledger configs. |
 | `f:policySource` with `f:graphSelector` naming M's `#config` or `#txn-meta` | Request fails with `ReservedGraphSelected` before any storage read on M. |
-| `f:ledger` on `f:shapesSource`, `f:schemaSource`, `f:rulesSource` | Request fails — cross-ledger support is currently implemented for `f:policySource` and `f:constraintsSource` only. |
+| `f:ledger` on `f:shapesSource`, `f:rulesSource` | Request fails — cross-ledger support is currently implemented for `f:policySource`, `f:constraintsSource`, and `f:schemaSource` only. |
+| Transitive `owl:imports` across model ledgers (`f:schemaSource` recursion) | Not yet honored. Imports inside M's schema graph are projected but the resolver doesn't follow them across ledger boundaries. |
 
 The other reserved fields and source predicates may land in
 later releases; the resolver's contract is shared across all of

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -1,9 +1,24 @@
-# Cross-ledger policy
+# Cross-ledger policy and constraints
 
-Cross-ledger policy lets a single **model ledger** hold a policy
-rule set that governs many **data ledgers** that reference it.
-Update the model once and every governed data ledger sees the new
-rules on its next request — no per-dataset rule duplication.
+A single **model ledger** can hold governance artifacts —
+policy rules and uniqueness constraints — that govern many
+**data ledgers** that reference it. Update the model once and
+every governed data ledger sees the new rules / constraints on
+its next request, with no per-dataset duplication.
+
+Two subsystems are wired today:
+
+- **Cross-ledger policy** (`f:policySource` with `f:ledger`) —
+  M's policy rule set is applied to queries against D.
+- **Cross-ledger constraints** (`f:constraintsSource` with
+  `f:ledger`) — M's `f:enforceUnique` annotations are applied
+  to transactions against D.
+
+Other subsystems (`f:schemaSource`, `f:shapesSource`,
+`f:rulesSource`) share the resolver's contract but their
+materializers are not yet implemented; see the design doc's
+[Scope](../design/cross-ledger-model-enforcement.md#scope)
+section.
 
 This page covers how to configure cross-ledger policy. For the
 underlying design (resolver contract, term-space translation,
@@ -155,6 +170,70 @@ When using the in-process Rust API, calling
 policy path, even with empty opts. Programmatic users don't see
 this gating.
 
+## Cross-ledger uniqueness constraints
+
+Same two-ledger pattern, different subsystem. M holds an
+`f:enforceUnique true` annotation on a property; D references
+M's constraints graph in its `#config`. Every transaction
+against D that would create a duplicate value on that property
+is rejected.
+
+```trig
+# On model ledger M
+@prefix f:  <https://ns.flur.ee/db#> .
+@prefix ex: <http://example.org/ns/> .
+
+GRAPH <http://example.org/governance/constraints> {
+    ex:email f:enforceUnique true .
+}
+```
+
+```trig
+# On data ledger D — #config
+@prefix f:   <https://ns.flur.ee/db#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+GRAPH <urn:fluree:mydb:main#config> {
+    <urn:cfg:main> rdf:type f:LedgerConfig ;
+        f:transactDefaults <urn:cfg:transact> .
+
+    <urn:cfg:transact>
+        f:uniqueEnabled      true ;
+        f:constraintsSource  <urn:cfg:cref> .
+
+    <urn:cfg:cref> rdf:type f:GraphRef ;
+        f:graphSource <urn:cfg:csrc> .
+
+    <urn:cfg:csrc>
+        f:ledger        <org/governance:main> ;
+        f:graphSelector <http://example.org/governance/constraints> .
+}
+```
+
+After this config lands on D, the next transaction that creates
+a duplicate `ex:email` value is rejected with
+`TransactError::UniqueConstraintViolation`. The annotation
+itself never appears on D — D enforces it because its config
+points at M.
+
+A few specifics that differ from cross-ledger policy:
+
+- Constraints are enforced at **transaction time**, not query
+  time. No HTTP header gymnastics are needed to engage them —
+  the staging pipeline picks them up automatically whenever the
+  data ledger's config has `f:uniqueEnabled true` plus a
+  cross-ledger `f:constraintsSource`.
+- Failures during cross-ledger constraints resolution surface
+  as `TransactError::Parse` (mapped to HTTP **400 Bad Request**
+  at the API layer) rather than `ApiError::CrossLedger` (502).
+  That's a staging-pipeline quirk — the error message preserves
+  the underlying cross-ledger failure variant for diagnostics,
+  but the HTTP status differs from the query-side policy path.
+- The wire artifact for constraints is simpler than policy:
+  just a list of property IRIs. There's no equivalent of
+  `f:policyClass` filtering — every property M declares unique
+  applies.
+
 ## Limitations
 
 The following behaviors are **not yet implemented** and fail
@@ -167,7 +246,7 @@ closed when configured:
 | `f:rollbackGuard` (freshness constraints)  | Request fails with `UnsupportedFeature`. |
 | `opts.identity` + cross-ledger `f:policySource` | Request fails with a config error. Identity-mode loads policies via the identity's `f:policyClass` triples, which would have to resolve in D (the identity isn't an M concept); combining the two modes ambiguously is rejected rather than silently choosing one. Use `opts.policy_class` with cross-ledger configs. |
 | `f:policySource` with `f:graphSelector` naming M's `#config` or `#txn-meta` | Request fails with `ReservedGraphSelected` before any storage read on M. |
-| `f:ledger` on `f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource` | Request fails — cross-ledger support is currently only implemented for `f:policySource`. |
+| `f:ledger` on `f:shapesSource`, `f:schemaSource`, `f:rulesSource` | Request fails — cross-ledger support is currently implemented for `f:policySource` and `f:constraintsSource` only. |
 
 The other reserved fields and source predicates may land in
 later releases; the resolver's contract is shared across all of

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -1,13 +1,14 @@
-# Cross-ledger policy, constraints, and schema
+# Cross-ledger governance
 
 A single **model ledger** can hold governance artifacts —
-policy rules, uniqueness constraints, and ontology/schema
-axioms — that govern many **data ledgers** that reference it.
-Update the model once and every governed data ledger sees the
-new rules / constraints / schema on its next request, with no
-per-dataset duplication.
+policy rules, uniqueness constraints, ontology/schema axioms,
+SHACL shapes, and datalog rules — that govern many **data
+ledgers** that reference it. Update the model once and every
+governed data ledger sees the new artifacts on its next
+request, with no per-dataset duplication.
 
-Three subsystems are wired today:
+All five `f:GraphRef`-shaped governance predicates support
+cross-ledger references today:
 
 - **Cross-ledger policy** (`f:policySource` with `f:ledger`) —
   M's policy rule set is applied to queries against D.
@@ -20,15 +21,15 @@ Three subsystems are wired today:
   D's reasoner. Single-graph only today; transitive
   `owl:imports` recursion across multiple model ledgers is
   reserved.
+- **Cross-ledger SHACL shapes** (`f:shapesSource` with
+  `f:ledger`) — M's shape definitions are compiled against D's
+  staged namespace at validation time and rejected/accepted
+  transactions on D accordingly.
+- **Cross-ledger datalog rules** (`f:rulesSource` with
+  `f:ledger`) — M's `f:rule` JSON bodies feed D's query-time
+  datalog evaluator alongside any rules D stores locally.
 
-SHACL shapes (`f:shapesSource`) and datalog rules
-(`f:rulesSource`) now resolve through the same
-cross-ledger contract — shapes compile against the data ledger's
-staged namespace at validation time, rules feed the data ledger's
-existing query-time rule evaluator. See the matrix below for the
-full set of supported subsystems.
-
-This page covers how to configure cross-ledger policy. For the
+This page covers configuration for all five. For the
 underlying design (resolver contract, term-space translation,
 cache shape, failure taxonomy) see
 [Cross-ledger model enforcement](../design/cross-ledger-model-enforcement.md).
@@ -323,6 +324,122 @@ A few specifics that differ from cross-ledger policy:
   transitively follow them across ledger boundaries yet. If M's
   schema declares `owl:imports <X>` where X is on a different
   model ledger M2, that import isn't resolved.
+
+## Cross-ledger SHACL shapes
+
+Configure `f:shapesSource` on D's `#config` under
+`f:shaclDefaults`. When the source carries `f:ledger`, the
+resolver pulls M's shapes graph at transaction time, compiles
+the SHACL whitelist against D's *staged* namespace registry
+(post-stage, not pre-stage — so IRIs the in-flight transaction
+introduced are encodable), and feeds the resulting overlay to
+the same SHACL engine the same-ledger path uses.
+
+```trig
+# On model ledger M — shapes in a named graph
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix ex:   <http://example.org/ns/> .
+
+GRAPH <http://example.org/governance/shapes> {
+    ex:PersonShape a sh:NodeShape ;
+        sh:targetClass ex:Person ;
+        sh:property [
+            sh:path     ex:name ;
+            sh:minCount 1 ;
+            sh:datatype xsd:string
+        ] .
+}
+```
+
+```trig
+# On data ledger D — #config
+@prefix f:   <https://ns.flur.ee/db#> .
+
+GRAPH <urn:fluree:data:main#config> {
+    <urn:cfg:main>      a f:LedgerConfig ;
+                        f:shaclDefaults <urn:cfg:shacl> .
+    <urn:cfg:shacl>     f:shaclEnabled  true ;
+                        f:shapesSource  <urn:cfg:sref> .
+    <urn:cfg:sref>      a f:GraphRef ;
+                        f:graphSource   <urn:cfg:ssrc> .
+    <urn:cfg:ssrc>      f:ledger        <model:main> ;
+                        f:graphSelector <http://example.org/governance/shapes> .
+}
+```
+
+Specifics:
+
+- Shapes are **compiled against D's staged namespace registry**,
+  not its pre-stage snapshot. The in-flight transaction's
+  ns_registry sees the IRIs the transaction is introducing
+  (e.g., `ex:Person` declared by the same tx the shape is
+  validating), which the pre-stage snapshot doesn't.
+- IRIs the staged registry has never seen are dropped silently —
+  M-only IRIs can't apply to data D doesn't have, and
+  allocating a fresh namespace code for an M-only term would
+  introduce namespace churn into D for no benefit.
+- Inline `opts.shapes` layers **additively** on top of the
+  cross-ledger source: both shape sets enforce. See
+  [Cookbook: SHACL validation — Inline shapes per
+  transaction](../guides/cookbook-shacl.md#inline-shapes-per-transaction).
+
+## Cross-ledger datalog rules
+
+Configure `f:rulesSource` on D's `#config` under
+`f:datalogDefaults`. When the source carries `f:ledger`, the
+resolver pulls the `f:rule` JSON bodies from M's rules graph at
+query time and merges them into D's query-time datalog evaluator
+alongside any rules D stores locally and any rules supplied via
+the top-level `rules` query field.
+
+```trig
+# On model ledger M — rules in a named graph
+@prefix f:   <https://ns.flur.ee/db#> .
+@prefix ex:  <http://example.org/> .
+
+GRAPH <http://example.org/governance/rules> {
+    ex:grandparentRule f:rule """
+        {
+          \"@context\": {\"ex\": \"http://example.org/\"},
+          \"where\":   {\"@id\": \"?p\", \"ex:parent\": {\"ex:parent\": \"?g\"}},
+          \"insert\":  {\"@id\": \"?p\", \"ex:grandparent\": {\"@id\": \"?g\"}}
+        }
+    """^^rdf:JSON .
+}
+```
+
+```trig
+# On data ledger D — #config
+@prefix f:   <https://ns.flur.ee/db#> .
+
+GRAPH <urn:fluree:data:main#config> {
+    <urn:cfg:main>     a f:LedgerConfig ;
+                       f:datalogDefaults <urn:cfg:datalog> .
+    <urn:cfg:datalog>  f:datalogEnabled  true ;
+                       f:rulesSource     <urn:cfg:rref> .
+    <urn:cfg:rref>     a f:GraphRef ;
+                       f:graphSource     <urn:cfg:rsrc> .
+    <urn:cfg:rsrc>     f:ledger          <model:main> ;
+                       f:graphSelector   <http://example.org/governance/rules> .
+}
+```
+
+Specifics:
+
+- Rules are **inherently term-portable** — the JSON body is a
+  JSON-LD document whose IRIs resolve at parse time against
+  D's snapshot, the same way query-time rules from the top-level
+  `rules` field are handled. No term translation step on the
+  wire.
+- Engaging the rules still requires datalog reasoning on the
+  query: either `"reasoning": "datalog"` on the JSON-LD query
+  or `PRAGMA reasoning: datalog` on SPARQL.
+- **Fail-closed on malformed rules.** A bad JSON body in M's
+  rules graph errors the query rather than silently dropping
+  the rule (this differs from query-time `rules` where a single
+  bad entry only logs a warning — cross-ledger rules are
+  admin-authored, so silently weakening the configured
+  reasoning model is the worst failure mode).
 
 ## Limitations
 

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -21,11 +21,12 @@ Three subsystems are wired today:
   `owl:imports` recursion across multiple model ledgers is
   reserved.
 
-The remaining subsystems (`f:shapesSource`, `f:rulesSource`)
-share the resolver's contract but their materializers are not
-yet implemented; see the design doc's
-[Scope](../design/cross-ledger-model-enforcement.md#scope)
-section.
+SHACL shapes (`f:shapesSource`) and datalog rules
+(`f:rulesSource`) now resolve through the same
+cross-ledger contract — shapes compile against the data ledger's
+staged namespace at validation time, rules feed the data ledger's
+existing query-time rule evaluator. See the matrix below for the
+full set of supported subsystems.
 
 This page covers how to configure cross-ledger policy. For the
 underlying design (resolver contract, term-space translation,
@@ -335,7 +336,6 @@ closed when configured:
 | `f:rollbackGuard` (freshness constraints)  | Request fails with `UnsupportedFeature`. |
 | `opts.identity` + cross-ledger `f:policySource` | Request fails with a config error. Identity-mode loads policies via the identity's `f:policyClass` triples, which would have to resolve in D (the identity isn't an M concept); combining the two modes ambiguously is rejected rather than silently choosing one. Use `opts.policy_class` with cross-ledger configs. |
 | `f:policySource` with `f:graphSelector` naming M's `#config` or `#txn-meta` | Request fails with `ReservedGraphSelected` before any storage read on M. |
-| `f:ledger` on `f:shapesSource`, `f:rulesSource` | Request fails — cross-ledger support is currently implemented for `f:policySource`, `f:constraintsSource`, and `f:schemaSource` only. |
 | Transitive `owl:imports` across model ledgers (`f:schemaSource` recursion) | Not yet honored. Imports inside M's schema graph are projected but the resolver doesn't follow them across ledger boundaries. |
 
 The other reserved fields and source predicates may land in

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -1,0 +1,232 @@
+# Cross-ledger policy
+
+Cross-ledger policy lets a single **model ledger** hold a policy
+rule set that governs many **data ledgers** that reference it.
+Update the model once and every governed data ledger sees the new
+rules on its next request — no per-dataset rule duplication.
+
+This page covers how to configure cross-ledger policy. For the
+underlying design (resolver contract, term-space translation,
+cache shape, failure taxonomy) see
+[Cross-ledger model enforcement](../design/cross-ledger-model-enforcement.md).
+
+## When to use it
+
+Cross-ledger policy is the right tool when:
+
+- Multiple data ledgers share a common access-control model
+  (e.g., every customer dataset enforces the same baseline
+  policy on `Document` / `User` classes).
+- Policy authoring needs to be decoupled from data authoring
+  (a security team owns the model ledger; product teams own the
+  data ledgers).
+- Updates to policy rules must propagate atomically across all
+  governed datasets — no per-dataset re-sync window.
+
+If your policy lives entirely inside one ledger, stick with the
+local pattern in
+[Policy model and inputs](policy-model.md) — it's simpler.
+
+## The two-ledger pattern
+
+| Term            | Meaning |
+|-----------------|---------|
+| **Model ledger** (M) | The ledger holding the policy rule set. Identified by its canonical id (e.g., `org/governance:main`). |
+| **Data ledger** (D) | The application ledger holding the data being protected. References M in its `#config`. |
+
+Both ledgers must live on the same Fluree instance (same
+nameservice, same storage namespace). Cross-instance federation is
+out of scope.
+
+## Setting up the model ledger
+
+The model ledger holds policy resources just like a same-ledger
+configuration would — there is nothing special about them on M's
+side. The convention is to put them in a named graph so they
+don't mix with any data that happens to live on M:
+
+```trig
+@prefix f:    <https://ns.flur.ee/db#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ex:   <http://example.org/ns/> .
+
+GRAPH <http://example.org/governance/policies> {
+    ex:denyUsers
+        rdf:type    f:AccessPolicy ;
+        f:action    f:view ;
+        f:onClass   ex:User ;
+        f:allow     false .
+}
+```
+
+That graph IRI (`http://example.org/governance/policies` above) is
+what the data ledger's config will name. Any number of policies
+can live in the same graph; they're all loaded together on
+resolution.
+
+## Configuring the data ledger
+
+D's `#config` declares an `f:policySource` whose `f:graphSource`
+carries an explicit `f:ledger` field pointing at M:
+
+```trig
+@prefix f:   <https://ns.flur.ee/db#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+GRAPH <urn:fluree:mydb:main#config> {
+    <urn:cfg:main> rdf:type f:LedgerConfig ;
+        f:policyDefaults <urn:cfg:policy> .
+
+    <urn:cfg:policy>
+        f:defaultAllow false ;
+        f:policyClass  f:AccessPolicy ;
+        f:policySource <urn:cfg:policy-ref> .
+
+    <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+        f:graphSource <urn:cfg:policy-src> .
+
+    <urn:cfg:policy-src>
+        f:ledger        <org/governance:main> ;
+        f:graphSelector <http://example.org/governance/policies> .
+}
+```
+
+Three things to notice:
+
+1. **`f:ledger`** carries the canonical id of the model ledger
+   (`org/governance:main`). Use `nameservice.lookup()` if you
+   need to confirm the canonical form — aliases are resolved
+   into the canonical id before the resolver runs.
+2. **`f:graphSelector`** names the graph IRI within M that
+   holds the policies. It must match exactly what M used in
+   its `GRAPH <...>` block — there's no fuzzy matching.
+3. **`f:policyClass`** is what determines which rules from M
+   actually apply. See below.
+
+## How `f:policyClass` filtering works
+
+When D's request reaches the resolver, every rule materialized
+from M's policy graph is filtered against the data ledger's
+configured `f:policyClass` set by exact IRI intersection. A rule
+passes the filter if any of its `rdf:type` IRIs appears in D's
+`f:policyClass` list.
+
+| D's `f:policyClass`                  | Rules from M that apply |
+|--------------------------------------|--------------------------|
+| not set                              | Defaults to `{f:AccessPolicy}` — all `rdf:type f:AccessPolicy` rules apply. |
+| `f:AccessPolicy`                     | All `rdf:type f:AccessPolicy` rules apply. |
+| `ex:OrgPolicy`                       | Only rules typed `rdf:type ex:OrgPolicy`. |
+| `f:AccessPolicy`, `ex:OrgPolicy`     | Rules typed as either. |
+
+The match is **exact-IRI only**. There is no subclass entailment:
+declaring `ex:OrgPolicy rdfs:subClassOf f:AccessPolicy` doesn't
+make `ex:OrgPolicy`-typed rules match a config that asks for
+`f:AccessPolicy`. This mirrors the same-ledger
+`load_policies_by_class` behavior.
+
+The `{f:AccessPolicy}` default makes "set `f:policySource` and
+get baseline enforcement" the no-configuration path. Custom-typed
+rules are opt-in — operators name the class to enroll them.
+
+## Engaging policy enforcement
+
+There's a subtlety in how the server's JSON-LD query route
+chooses whether to invoke policy enforcement at all. Requests
+without an `fluree-policy-class`, `fluree-identity`, or inline
+`opts.policy` go through a no-policy fast path that bypasses the
+cross-ledger dispatch. A configured `f:policySource` in `#config`
+is **not** enough on its own to force enforcement at the HTTP
+layer today.
+
+To engage cross-ledger policy via HTTP, send a request with at
+least one of:
+
+- `fluree-policy-class: <iri>` — the policy class header (the
+  cleanest way to declare "use the configured policy"). Matching
+  the class in D's config (e.g., `f:AccessPolicy`) is the
+  natural choice.
+- `fluree-identity: <iri>` — an identity header. Identity-mode
+  has a different contract; see below.
+- `opts.policy` in the body — inline JSON-LD policy. This still
+  merges with cross-ledger rules.
+
+When using the in-process Rust API, calling
+`fluree.db_with_policy(ledger_id, &opts)` always engages the
+policy path, even with empty opts. Programmatic users don't see
+this gating.
+
+## Limitations
+
+The following behaviors are **not yet implemented** and fail
+closed when configured:
+
+| Configuration                              | Outcome |
+|--------------------------------------------|---------|
+| `f:atT` (temporal pinning of M)            | Request fails with `UnsupportedFeature { feature: "f:atT", phase: "Phase 3" }`. |
+| `f:trustPolicy` (commit-signer allowlist)  | Request fails with `UnsupportedFeature`. |
+| `f:rollbackGuard` (freshness constraints)  | Request fails with `UnsupportedFeature`. |
+| `opts.identity` + cross-ledger `f:policySource` | Request fails with a config error. Identity-mode loads policies via the identity's `f:policyClass` triples, which would have to resolve in D (the identity isn't an M concept); combining the two modes ambiguously is rejected rather than silently choosing one. Use `opts.policy_class` with cross-ledger configs. |
+| `f:policySource` with `f:graphSelector` naming M's `#config` or `#txn-meta` | Request fails with `ReservedGraphSelected` before any storage read on M. |
+| `f:ledger` on `f:shapesSource`, `f:schemaSource`, `f:rulesSource`, `f:constraintsSource` | Request fails — cross-ledger support is currently only implemented for `f:policySource`. |
+
+The other reserved fields and source predicates may land in
+later releases; the resolver's contract is shared across all of
+them. See [Cross-ledger model enforcement → Scope](../design/cross-ledger-model-enforcement.md#scope).
+
+## Failure modes
+
+When cross-ledger resolution fails, the request returns HTTP
+**502 Bad Gateway** with a structured JSON body naming the
+specific failure:
+
+```json
+{
+  "status": 502,
+  "@type": "err:system/CrossLedgerError",
+  "error": "model ledger 'org/governance:main' is not present on this instance"
+}
+```
+
+The specific failure modes operators see:
+
+| Variant                       | Trigger |
+|-------------------------------|---------|
+| `ModelLedgerMissing`          | The named model ledger isn't present or is retracted on this instance. |
+| `GraphMissingAtT`             | The model ledger exists but the named graph IRI isn't in its graph registry. |
+| `ReservedGraphSelected`       | The selector targets `#config` or `#txn-meta` on M. |
+| `TranslationFailed`           | The policy graph was read but couldn't be projected to the wire format (typically corruption or a dictionary loss in M). |
+| `UnsupportedFeature`          | A reserved field (`f:atT` / `f:trustPolicy` / `f:rollbackGuard`) was set. |
+| `CrossInstanceUnsupported`    | `f:ledger` names a ledger on a different instance. |
+| `CycleDetected`               | A model ledger graph transitively references itself. |
+
+The choice of 502 rather than 500 is deliberate: the data ledger
+isn't broken — its upstream governance dependency is — and
+operators distinguishing those two cases in their dashboards
+matters. The wrapped variant is preserved in the response body so
+clients can branch on the specific failure.
+
+## Behavior on model ledger updates
+
+There is no explicit invalidation channel. The cache key includes
+the model ledger's `resolved_t` (its commit head at the time of
+capture), so new commits to M produce new cache keys
+automatically. The next request after M advances captures the
+new head; older entries age out under the cache's LRU/TinyLFU
+policy.
+
+Within a single request, every cross-ledger reference to the
+same M reuses one `resolved_t` value. Policy and any future
+shapes / schema lookups on the same M can never disagree about
+which version they're enforcing for that request.
+
+If M is dropped while D references it, the next request against
+D that needs governance from M fails closed with
+`ModelLedgerMissing`. D isn't proactively notified — the
+failure surface is the next request.
+
+## Related
+
+- [Cross-ledger model enforcement](../design/cross-ledger-model-enforcement.md) — design rationale and the shared resolver contract.
+- [Policy model and inputs](policy-model.md) — policy structure (the rules themselves look the same in cross-ledger configs as in same-ledger ones).
+- [Setting groups](../ledger-config/setting-groups.md#policy-defaults) — `f:policySource` and the full `f:GraphRef` shape in the config schema.
+- [Programmatic policy API (Rust)](programmatic-policy.md) — how cross-ledger interacts with the in-process Rust API.

--- a/docs/security/policy-in-queries.md
+++ b/docs/security/policy-in-queries.md
@@ -271,6 +271,7 @@ This is the standard service-account pattern: register your CLI/app-server ident
 - [Policy model and inputs](policy-model.md) — node shape, combining algorithm, request-time options
 - [Policy enforcement (concepts)](../concepts/policy-enforcement.md) — model overview
 - [Policy in transactions](policy-in-transactions.md) — write-time enforcement
+- [Cross-ledger policy](cross-ledger-policy.md) — query-time engagement under cross-ledger `f:policySource`
 - [Cookbook: Access control policies](../guides/cookbook-policies.md) — worked patterns
 - [Programmatic policy API (Rust)](programmatic-policy.md) — building `PolicyContext` in code
 - [Query reference](../query/README.md) — SPARQL and JSON-LD syntax

--- a/docs/security/policy-in-transactions.md
+++ b/docs/security/policy-in-transactions.md
@@ -253,6 +253,7 @@ Unsigned bearer-authenticated transactions build a `PolicyContext` from the (pos
 - [Policy model and inputs](policy-model.md) — node shape, combining algorithm, request-time options
 - [Policy enforcement (concepts)](../concepts/policy-enforcement.md) — model overview
 - [Policy in queries](policy-in-queries.md) — read-time enforcement
+- [Cross-ledger policy](cross-ledger-policy.md) — transaction-time enforcement under cross-ledger `f:policySource`
 - [Cookbook: Access control policies](../guides/cookbook-policies.md) — worked patterns
 - [Programmatic policy API (Rust)](programmatic-policy.md) — building `PolicyContext` and using `transact_tracked_with_policy`
 - [Signed / credentialed transactions](../transactions/signed-transactions.md) — JWS / VC transaction wrapping

--- a/docs/security/policy-model.md
+++ b/docs/security/policy-model.md
@@ -230,6 +230,7 @@ History queries against the same shape produce a complete audit trail of policy 
 - [Policy in queries](policy-in-queries.md) — read-time enforcement details
 - [Policy in transactions](policy-in-transactions.md) — write-time enforcement details
 - [Programmatic policy API (Rust)](programmatic-policy.md) — `PolicyContext`, builder helpers, combining algorithm
+- [Cross-ledger policy](cross-ledger-policy.md) — one model ledger governs many data ledgers via `f:policySource` with `f:ledger`
 - [Authentication](authentication.md) — identities, JWTs, bearer-token verification
 - [Configuration](../operations/configuration.md) — server-side policy defaults (`data_auth_default_policy_class`, etc.)
 - [Vocabulary reference](../reference/vocabulary.md#policy-vocabulary) — predicate IRIs

--- a/docs/security/programmatic-policy.md
+++ b/docs/security/programmatic-policy.md
@@ -441,4 +441,5 @@ match graph.query(&fluree).jsonld(&query).execute().await {
 - [Policy Model](policy-model.md) - Policy structure and evaluation
 - [Policy in Queries](policy-in-queries.md) - Query-time enforcement
 - [Policy in Transactions](policy-in-transactions.md) - Transaction-time enforcement
+- [Cross-ledger policy](cross-ledger-policy.md) - Govern many data ledgers from one model ledger via `f:policySource` with `f:ledger`; `db_with_policy` dispatches automatically when the data ledger's `#config` is cross-ledger.
 - [Rust API](../getting-started/rust-api.md) - General Rust API usage

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -261,6 +261,10 @@ impl Fluree {
                         // re-validate same-ledger only.
                         cross_ledger_shapes: None,
                         staged_ns: None,
+                        // Inline shapes are an authoring-time
+                        // construct; commit replay carries no
+                        // `opts` payload.
+                        inline_shape_bundle: None,
                     },
                 )
                 .await

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -254,6 +254,13 @@ impl Fluree {
                         graph_delta: Some(&routing.graph_iris),
                         graph_sids: Some(&routing.graph_sids),
                         tracker: None,
+                        // Commit replay doesn't engage the
+                        // cross-ledger dispatch (the leader
+                        // already validated against M when the
+                        // commit was authored); followers
+                        // re-validate same-ledger only.
+                        cross_ledger_shapes: None,
+                        staged_ns: None,
                     },
                 )
                 .await

--- a/fluree-db-api/src/config_resolver.rs
+++ b/fluree-db-api/src/config_resolver.rs
@@ -397,6 +397,12 @@ pub struct EffectiveDatalogConfig {
     pub allow_query_time_rules: bool,
     /// Whether the query can override these settings.
     pub override_allowed: bool,
+    /// Pre-resolved `f:rulesSource` reference. When `Some`, the rule
+    /// extractor reads `f:rule` flakes from this `GraphSourceRef`
+    /// instead of the default graph. Cross-ledger (`f:ledger` set)
+    /// dispatches to the cross-ledger resolver at query time; pure
+    /// local references resolve to a graph id in the same ledger.
+    pub rules_source: Option<fluree_db_core::ledger_config::GraphSourceRef>,
 }
 
 /// Compute effective datalog settings from resolved config, respecting override control.
@@ -415,6 +421,7 @@ pub fn merge_datalog_opts(
         enabled: datalog.enabled.unwrap_or(true),
         allow_query_time_rules: datalog.allow_query_time_rules.unwrap_or(true),
         override_allowed,
+        rules_source: datalog.rules_source.clone(),
     })
 }
 

--- a/fluree-db-api/src/cross_ledger/cache.rs
+++ b/fluree-db-api/src/cross_ledger/cache.rs
@@ -1,0 +1,95 @@
+//! Per-instance governance artifact cache.
+//!
+//! Lives on the `Fluree` handle so resolved artifacts are shareable
+//! across requests and across every data ledger that references the
+//! same `(ArtifactKind, model_ledger_id, graph_iri, resolved_t)`.
+//! That is the property that makes "model edit propagates atomically
+//! to every governed dataset" cheap — one cache entry is reused by
+//! every D that points at the same M graph at the same M-t.
+//!
+//! Phase 1a uses a Moka TinyLFU cache bounded by entry count. Unifying
+//! with `fluree-db-binary-index::LeafletCache`'s byte budget is a
+//! follow-up: the binary-index crate sits below `fluree-db-api`,
+//! `fluree-db-policy`, and the cross-ledger module, so caching typed
+//! `ResolvedGraph` values there would be a layering inversion. The
+//! follow-up adds an opaque-blob variant to `LeafletCache`, serializes
+//! the artifact to bytes at this boundary, and re-uses the existing
+//! `FLUREE_LEAFLET_CACHE_BYTES` budget. Deferred until the artifact
+//! representation stabilizes.
+//!
+//! The cache is read- and write-only on the resolver hot path:
+//!
+//! - Resolver: per-request memo miss → cache lookup → cache miss
+//!   triggers materialization → write back into both per-request memo
+//!   and instance cache → return.
+//! - Cache invalidation is implicit: new commits to M produce new
+//!   `resolved_t` values and therefore new keys. Old entries age out
+//!   under TinyLFU eviction. There is no watermark-on-write channel.
+
+use super::types::{ResolutionKey, ResolvedGraph};
+use moka::sync::Cache;
+use std::sync::Arc;
+
+/// Default maximum number of cache entries.
+///
+/// Sized for governance artifacts, which are coarser than leaflets —
+/// a few thousand `(model, graph, t)` triples cover most realistic
+/// fleets. Phase 1a doesn't expose a tuning knob; if memory pressure
+/// becomes a concern the right fix is the byte-budget unification
+/// described in the module doc.
+const DEFAULT_MAX_ENTRIES: u64 = 4_096;
+
+/// Per-instance cache of resolved cross-ledger governance artifacts.
+///
+/// Thin wrapper around `moka::sync::Cache` so the cache type is named
+/// and discoverable. Cheap to clone via `Arc`.
+#[derive(Debug)]
+pub struct GovernanceCache {
+    inner: Cache<ResolutionKey, Arc<ResolvedGraph>>,
+}
+
+impl GovernanceCache {
+    /// Build a cache with the default capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MAX_ENTRIES)
+    }
+
+    /// Build a cache with a custom entry-count limit. Useful for tests
+    /// that want a small cache to exercise eviction, or for embedded
+    /// builds that want a tighter ceiling.
+    pub fn with_capacity(max_entries: u64) -> Self {
+        Self {
+            inner: Cache::builder().max_capacity(max_entries).build(),
+        }
+    }
+
+    /// Look up a resolved artifact. Returns `Some(Arc)` on hit; the
+    /// returned Arc is shared with the cache and any other live
+    /// references, so a cache hit is a cheap pointer clone.
+    pub fn get(&self, key: &ResolutionKey) -> Option<Arc<ResolvedGraph>> {
+        self.inner.get(key)
+    }
+
+    /// Insert a resolved artifact. Idempotent — if a value already
+    /// exists for the key (e.g., two concurrent requests both raced
+    /// to materialize the same (M, graph, t)) the existing entry
+    /// is replaced. The resolver constructs an `Arc::new` per
+    /// materialization, so concurrent racers don't share an Arc —
+    /// the second one's writeback wins, the first's Arc becomes
+    /// reachable only through any prior `get` clones.
+    pub fn insert(&self, key: ResolutionKey, value: Arc<ResolvedGraph>) {
+        self.inner.insert(key, value);
+    }
+
+    /// Approximate count of entries currently cached. Exposed for
+    /// tests and diagnostics — Moka's count is best-effort.
+    pub fn entry_count(&self) -> u64 {
+        self.inner.entry_count()
+    }
+}
+
+impl Default for GovernanceCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -36,7 +36,7 @@ pub(super) async fn materialize_constraints(
         })?;
 
     // 2. Resolve graph_iri → g_id in M's graph registry.
-    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri)?.ok_or_else(|| {
         CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -27,7 +27,7 @@ pub(super) async fn materialize_constraints(
 ) -> Result<ConstraintsArtifactWire, CrossLedgerError> {
     // 1. Open M at resolved_t.
     let m_db = fluree
-        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .load_graph_db_at_t(canonical_model_ledger_id, resolved_t)
         .await
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -1,0 +1,139 @@
+//! Cross-ledger constraints materialization.
+//!
+//! Reads a model ledger's constraints graph at `resolved_t` and
+//! projects every property carrying `f:enforceUnique true` into a
+//! term-neutral [`ConstraintsArtifactWire`]. The translator at the
+//! data ledger side encodes each IRI against D's namespace map to
+//! produce the property Sid set that the existing
+//! `enforce_unique_constraints` flow consumes.
+//!
+//! The artifact is the simplest of the cross-ledger materializers —
+//! a list of property IRIs, no per-rule body, no class targets, no
+//! values.
+
+use super::types::{ConstraintsArtifactWire, WireOrigin};
+use super::CrossLedgerError;
+use crate::Fluree;
+use fluree_db_core::{FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid};
+use fluree_vocab::config_iris;
+
+/// Materialize the constraints graph at `graph_iri` in model
+/// ledger `M` at `resolved_t` into a `ConstraintsArtifactWire`.
+pub(super) async fn materialize_constraints(
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+    resolved_t: i64,
+    fluree: &Fluree,
+) -> Result<ConstraintsArtifactWire, CrossLedgerError> {
+    // 1. Open M at resolved_t.
+    let m_db = fluree
+        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "failed to open model ledger snapshot at t={resolved_t}: {e}"
+            ),
+        })?;
+
+    // 2. Resolve graph_iri → g_id in M's graph registry.
+    let g_id = m_db
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(graph_iri)
+        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        })?;
+
+    // 3. Encode the system IRIs we need to scan against M. These
+    //    come from default namespaces pre-registered at genesis,
+    //    so failure here means M is corrupted.
+    let enforce_unique_sid = encode_system_iri(
+        &m_db.snapshot,
+        config_iris::ENFORCE_UNIQUE,
+        canonical_model_ledger_id,
+        graph_iri,
+    )?;
+    let xsd_boolean_sid = encode_system_iri(
+        &m_db.snapshot,
+        "http://www.w3.org/2001/XMLSchema#boolean",
+        canonical_model_ledger_id,
+        graph_iri,
+    )?;
+
+    // 4. Scan POST for ?prop f:enforceUnique true. The matching
+    //    subjects ARE the property IRIs we want.
+    let m_view = fluree_db_core::GraphDbRef::new(
+        &m_db.snapshot,
+        g_id,
+        m_db.overlay.as_ref(),
+        m_db.t,
+    );
+    let match_val = RangeMatch::predicate_object(
+        enforce_unique_sid,
+        FlakeValue::Boolean(true),
+    )
+    .with_datatype(xsd_boolean_sid);
+
+    let flakes = m_view
+        .range(IndexType::Post, RangeTest::Eq, match_val)
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "range scan for f:enforceUnique annotations failed: {e}"
+            ),
+        })?;
+
+    // 5. Decode each property Sid back to its IRI. A failure to
+    //    decode means M's namespace map is missing the entry —
+    //    structural corruption, not something a fail-open silent
+    //    drop should hide.
+    let mut property_iris = Vec::new();
+    for flake in flakes.into_iter().filter(|f| f.op) {
+        let iri = m_db.snapshot.decode_sid(&flake.s).ok_or_else(|| {
+            CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!(
+                    "could not decode property Sid {:?} declared \
+                     f:enforceUnique against model ledger's namespace map",
+                    flake.s
+                ),
+            }
+        })?;
+        property_iris.push(iri);
+    }
+
+    Ok(ConstraintsArtifactWire {
+        origin: WireOrigin {
+            model_ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        },
+        property_iris,
+    })
+}
+
+fn encode_system_iri(
+    snapshot: &LedgerSnapshot,
+    iri: &str,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<Sid, CrossLedgerError> {
+    snapshot
+        .encode_iri(iri)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "system IRI '{iri}' is not in the model ledger's namespace \
+                 map; this usually indicates the model ledger is corrupted \
+                 or did not initialize default namespaces"
+            ),
+        })
+}

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -19,6 +19,16 @@ use fluree_vocab::config_iris;
 
 /// Materialize the constraints graph at `graph_iri` in model
 /// ledger `M` at `resolved_t` into a `ConstraintsArtifactWire`.
+#[tracing::instrument(
+    name = "cross_ledger.constraints.materialize",
+    level = "debug",
+    skip(fluree),
+    fields(
+        model_ledger = canonical_model_ledger_id,
+        graph_iri = graph_iri,
+        resolved_t = resolved_t,
+    ),
+)]
 pub(super) async fn materialize_constraints(
     canonical_model_ledger_id: &str,
     graph_iri: &str,

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -36,15 +36,13 @@ pub(super) async fn materialize_constraints(
         })?;
 
     // 2. Resolve graph_iri → g_id in M's graph registry.
-    let g_id = m_db
-        .snapshot
-        .graph_registry
-        .graph_id_for_iri(graph_iri)
-        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+        CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             resolved_t,
-        })?;
+        }
+    })?;
 
     // 3. Encode the system IRIs we need to scan against M. These
     //    come from default namespaces pre-registered at genesis,

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -32,9 +32,7 @@ pub(super) async fn materialize_constraints(
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
-            detail: format!(
-                "failed to open model ledger snapshot at t={resolved_t}: {e}"
-            ),
+            detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
     // 2. Resolve graph_iri → g_id in M's graph registry.
@@ -66,17 +64,10 @@ pub(super) async fn materialize_constraints(
 
     // 4. Scan POST for ?prop f:enforceUnique true. The matching
     //    subjects ARE the property IRIs we want.
-    let m_view = fluree_db_core::GraphDbRef::new(
-        &m_db.snapshot,
-        g_id,
-        m_db.overlay.as_ref(),
-        m_db.t,
-    );
-    let match_val = RangeMatch::predicate_object(
-        enforce_unique_sid,
-        FlakeValue::Boolean(true),
-    )
-    .with_datatype(xsd_boolean_sid);
+    let m_view =
+        fluree_db_core::GraphDbRef::new(&m_db.snapshot, g_id, m_db.overlay.as_ref(), m_db.t);
+    let match_val = RangeMatch::predicate_object(enforce_unique_sid, FlakeValue::Boolean(true))
+        .with_datatype(xsd_boolean_sid);
 
     let flakes = m_view
         .range(IndexType::Post, RangeTest::Eq, match_val)
@@ -84,9 +75,7 @@ pub(super) async fn materialize_constraints(
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
-            detail: format!(
-                "range scan for f:enforceUnique annotations failed: {e}"
-            ),
+            detail: format!("range scan for f:enforceUnique annotations failed: {e}"),
         })?;
 
     // 5. Decode each property Sid back to its IRI. A failure to

--- a/fluree-db-api/src/cross_ledger/constraints_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/constraints_materializer.rs
@@ -12,9 +12,9 @@
 //! values.
 
 use super::types::{ConstraintsArtifactWire, WireOrigin};
-use super::CrossLedgerError;
+use super::{encode_system_iri, CrossLedgerError};
 use crate::Fluree;
-use fluree_db_core::{FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid};
+use fluree_db_core::{FlakeValue, IndexType, RangeMatch, RangeTest};
 use fluree_vocab::config_iris;
 
 /// Materialize the constraints graph at `graph_iri` in model
@@ -114,23 +114,4 @@ pub(super) async fn materialize_constraints(
         },
         property_iris,
     })
-}
-
-fn encode_system_iri(
-    snapshot: &LedgerSnapshot,
-    iri: &str,
-    canonical_model_ledger_id: &str,
-    graph_iri: &str,
-) -> Result<Sid, CrossLedgerError> {
-    snapshot
-        .encode_iri(iri)
-        .ok_or_else(|| CrossLedgerError::TranslationFailed {
-            ledger_id: canonical_model_ledger_id.to_string(),
-            graph_iri: graph_iri.to_string(),
-            detail: format!(
-                "system IRI '{iri}' is not in the model ledger's namespace \
-                 map; this usually indicates the model ledger is corrupted \
-                 or did not initialize default namespaces"
-            ),
-        })
 }

--- a/fluree-db-api/src/cross_ledger/error.rs
+++ b/fluree-db-api/src/cross_ledger/error.rs
@@ -120,20 +120,21 @@ pub enum CrossLedgerError {
         ledger_id: String,
     },
 
-    /// Cycle detected through the `(ledger, graph, resolved_t)` chain.
+    /// Cycle detected through the `(kind, ledger, graph, resolved_t)`
+    /// chain.
     #[error("cycle detected in cross-ledger resolution: {}", chain_display(chain))]
     CycleDetected {
         /// The active resolution stack at the point the cycle was
         /// detected, ordered from outermost to innermost.
-        chain: Vec<(String, String, i64)>,
+        chain: Vec<(super::ArtifactKind, String, String, i64)>,
     },
 }
 
 /// Render the resolution chain for diagnostic display.
-fn chain_display(chain: &[(String, String, i64)]) -> String {
+fn chain_display(chain: &[(super::ArtifactKind, String, String, i64)]) -> String {
     chain
         .iter()
-        .map(|(ledger, graph, t)| format!("{ledger}#{graph}@t={t}"))
+        .map(|(kind, ledger, graph, t)| format!("{kind}({ledger}#{graph}@t={t})"))
         .collect::<Vec<_>>()
         .join(" → ")
 }
@@ -143,17 +144,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cycle_display_renders_chain_in_order() {
+    fn cycle_display_renders_chain_in_order_with_artifact_kind() {
+        use super::super::ArtifactKind;
         let err = CrossLedgerError::CycleDetected {
             chain: vec![
-                ("a:main".into(), "http://ex.org/p".into(), 10),
-                ("b:main".into(), "http://ex.org/q".into(), 20),
-                ("a:main".into(), "http://ex.org/p".into(), 10),
+                (ArtifactKind::PolicyRules, "a:main".into(), "http://ex.org/p".into(), 10),
+                (ArtifactKind::PolicyRules, "b:main".into(), "http://ex.org/q".into(), 20),
+                (ArtifactKind::PolicyRules, "a:main".into(), "http://ex.org/p".into(), 10),
             ],
         };
         let msg = err.to_string();
-        assert!(msg.contains("a:main#http://ex.org/p@t=10"));
-        assert!(msg.contains("b:main#http://ex.org/q@t=20"));
+        assert!(msg.contains("PolicyRules(a:main#http://ex.org/p@t=10)"));
+        assert!(msg.contains("PolicyRules(b:main#http://ex.org/q@t=20)"));
         assert!(msg.contains(" → "));
     }
 

--- a/fluree-db-api/src/cross_ledger/error.rs
+++ b/fluree-db-api/src/cross_ledger/error.rs
@@ -91,6 +91,25 @@ pub enum CrossLedgerError {
         detail: String,
     },
 
+    /// A `GraphSourceRef` field is parsed but its implementation is
+    /// deferred to a later phase (`f:atT` → Phase 3, `f:trustPolicy` /
+    /// `f:rollbackGuard` → Phase 4). The request fails closed rather
+    /// than silently ignoring the field, so operators don't discover
+    /// after the fact that their configured constraint had no effect.
+    #[error(
+        "feature '{feature}' on a cross-ledger f:GraphRef is not yet implemented \
+         ({phase}); request fails closed rather than ignoring the field"
+    )]
+    UnsupportedFeature {
+        /// Field name (e.g., `f:atT`, `f:trustPolicy`, `f:rollbackGuard`).
+        feature: &'static str,
+        /// Phase tag for operator diagnostics.
+        phase: &'static str,
+        /// Canonical model ledger id (or the raw alias if canonicalization
+        /// didn't happen).
+        ledger_id: String,
+    },
+
     /// `f:ledger` targets a ledger on a different instance.
     ///
     /// Same-instance is the v1 contract; cross-instance federation
@@ -187,6 +206,11 @@ mod tests {
                 ledger_id: "remote:m:main".into(),
             },
             CrossLedgerError::CycleDetected { chain: vec![] },
+            CrossLedgerError::UnsupportedFeature {
+                feature: "f:atT",
+                phase: "Phase 3",
+                ledger_id: "m:main".into(),
+            },
         ];
 
         for v in variants {

--- a/fluree-db-api/src/cross_ledger/error.rs
+++ b/fluree-db-api/src/cross_ledger/error.rs
@@ -1,0 +1,223 @@
+//! Cross-ledger resolution errors.
+//!
+//! Every variant is fail-closed: the request fails. There is no
+//! silent fallback to "no policy" / "no shapes" / "no schema" when a
+//! model-ledger dependency cannot be resolved.
+//!
+//! See `docs/design/cross-ledger-model-enforcement.md` for the
+//! semantics behind each variant.
+
+use thiserror::Error;
+
+/// A cross-ledger governance resolution failed.
+///
+/// Variants are distinguishable for audit and operator diagnostics —
+/// callers MUST NOT collapse them into a single generic error. The
+/// HTTP layer maps the wrapping `ApiError::CrossLedger` to status 502
+/// uniformly, but preserves the variant in the response body so
+/// clients can branch on the specific failure.
+#[derive(Debug, Clone, Error)]
+pub enum CrossLedgerError {
+    /// `f:ledger` names a ledger that does not exist or has been
+    /// dropped on this instance.
+    #[error("model ledger '{ledger_id}' is not present on this instance")]
+    ModelLedgerMissing {
+        /// Canonical ledger id the request resolved to.
+        ledger_id: String,
+    },
+
+    /// `f:ledger` resolves but the named graph IRI has no entry in the
+    /// model ledger's graph registry at `resolved_t`.
+    #[error(
+        "graph '{graph_iri}' is not present in model ledger '{ledger_id}' at t={resolved_t}"
+    )]
+    GraphMissingAtT {
+        /// Canonical model ledger id.
+        ledger_id: String,
+        /// Graph IRI that failed to resolve.
+        graph_iri: String,
+        /// Model ledger `t` at which lookup was attempted.
+        resolved_t: i64,
+    },
+
+    /// `f:atT N` was requested but the model ledger no longer retains
+    /// state at `N` (index pruning, history retention).
+    #[error(
+        "model ledger '{ledger_id}' no longer retains state at t={requested_t} \
+         (oldest available is t={oldest_available_t})"
+    )]
+    TAtUnavailable {
+        /// Canonical model ledger id.
+        ledger_id: String,
+        /// The `t` the configuration pinned.
+        requested_t: i64,
+        /// The oldest `t` the model ledger can still serve.
+        oldest_available_t: i64,
+    },
+
+    /// The selector targets `#config` or `#txn-meta` on the model
+    /// ledger.
+    ///
+    /// Rejected before any storage round-trip — `#txn-meta` in
+    /// particular can leak commit metadata.
+    #[error("selector '{graph_iri}' resolves to a reserved system graph; refusing")]
+    ReservedGraphSelected {
+        /// The graph IRI as configured.
+        graph_iri: String,
+    },
+
+    /// The resolver successfully read the graph but could not translate
+    /// it to term-neutral form (malformed rule, missing IRI on a Sid
+    /// the model dictionary lost, etc.).
+    #[error(
+        "could not materialize graph '{graph_iri}' in model ledger '{ledger_id}': {detail}"
+    )]
+    TranslationFailed {
+        /// Canonical model ledger id.
+        ledger_id: String,
+        /// Graph IRI within the model ledger.
+        graph_iri: String,
+        /// Free-form detail; produced by the per-artifact projector.
+        detail: String,
+    },
+
+    /// `f:trustPolicy` failed verification, or `f:rollbackGuard` would
+    /// be violated. Phase 4.
+    #[error("trust check failed for model ledger '{ledger_id}': {detail}")]
+    TrustCheckFailed {
+        /// Canonical model ledger id.
+        ledger_id: String,
+        /// Which trust constraint was violated.
+        detail: String,
+    },
+
+    /// `f:ledger` targets a ledger on a different instance.
+    ///
+    /// Same-instance is the v1 contract; cross-instance federation
+    /// requires a different trust model and transport.
+    #[error("model ledger '{ledger_id}' is on a different instance; cross-instance is not supported")]
+    CrossInstanceUnsupported {
+        /// The user-supplied ledger reference that triggered this.
+        ledger_id: String,
+    },
+
+    /// Cycle detected through the `(ledger, graph, resolved_t)` chain.
+    #[error("cycle detected in cross-ledger resolution: {}", chain_display(chain))]
+    CycleDetected {
+        /// The active resolution stack at the point the cycle was
+        /// detected, ordered from outermost to innermost.
+        chain: Vec<(String, String, i64)>,
+    },
+}
+
+/// Render the resolution chain for diagnostic display.
+fn chain_display(chain: &[(String, String, i64)]) -> String {
+    chain
+        .iter()
+        .map(|(ledger, graph, t)| format!("{ledger}#{graph}@t={t}"))
+        .collect::<Vec<_>>()
+        .join(" → ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycle_display_renders_chain_in_order() {
+        let err = CrossLedgerError::CycleDetected {
+            chain: vec![
+                ("a:main".into(), "http://ex.org/p".into(), 10),
+                ("b:main".into(), "http://ex.org/q".into(), 20),
+                ("a:main".into(), "http://ex.org/p".into(), 10),
+            ],
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("a:main#http://ex.org/p@t=10"));
+        assert!(msg.contains("b:main#http://ex.org/q@t=20"));
+        assert!(msg.contains(" → "));
+    }
+
+    #[test]
+    fn graph_missing_message_includes_all_coordinates() {
+        let err = CrossLedgerError::GraphMissingAtT {
+            ledger_id: "model:main".into(),
+            graph_iri: "http://ex.org/policy".into(),
+            resolved_t: 42,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("model:main"));
+        assert!(msg.contains("http://ex.org/policy"));
+        assert!(msg.contains("t=42"));
+    }
+
+    #[test]
+    fn all_variants_lift_into_api_error_via_from_and_map_to_502() {
+        // Every CrossLedgerError variant must (a) convert into
+        // ApiError::CrossLedger via From, and (b) surface as HTTP 502.
+        // If a new variant is added without updating either path this
+        // test will fail to compile or fail at runtime.
+        let variants: Vec<CrossLedgerError> = vec![
+            CrossLedgerError::ModelLedgerMissing {
+                ledger_id: "m:main".into(),
+            },
+            CrossLedgerError::GraphMissingAtT {
+                ledger_id: "m:main".into(),
+                graph_iri: "http://ex.org/g".into(),
+                resolved_t: 7,
+            },
+            CrossLedgerError::TAtUnavailable {
+                ledger_id: "m:main".into(),
+                requested_t: 1,
+                oldest_available_t: 5,
+            },
+            CrossLedgerError::ReservedGraphSelected {
+                graph_iri: "urn:fluree:m:main#config".into(),
+            },
+            CrossLedgerError::TranslationFailed {
+                ledger_id: "m:main".into(),
+                graph_iri: "http://ex.org/g".into(),
+                detail: "malformed rule".into(),
+            },
+            CrossLedgerError::TrustCheckFailed {
+                ledger_id: "m:main".into(),
+                detail: "signer not in allowlist".into(),
+            },
+            CrossLedgerError::CrossInstanceUnsupported {
+                ledger_id: "remote:m:main".into(),
+            },
+            CrossLedgerError::CycleDetected { chain: vec![] },
+        ];
+
+        for v in variants {
+            let lifted: crate::error::ApiError = v.clone().into();
+            assert_eq!(
+                lifted.status_code(),
+                502,
+                "variant {v:?} must map to HTTP 502"
+            );
+            // Confirm we landed in the CrossLedger arm and preserved
+            // the variant rather than collapsing to a string.
+            match lifted {
+                crate::error::ApiError::CrossLedger(_) => {}
+                other => panic!("expected CrossLedger variant, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn cross_ledger_is_not_not_found() {
+        // ModelLedgerMissing names a ledger that doesn't exist on this
+        // instance — but the request itself isn't a "resource not
+        // found" failure (the resource the caller asked for is on
+        // *this* ledger; one of its governance dependencies is gone).
+        // Surfacing as 404 would mislead clients into retrying as if
+        // their target resource had been deleted. is_not_found() must
+        // stay false for cross-ledger variants.
+        let err: crate::error::ApiError = CrossLedgerError::ModelLedgerMissing {
+            ledger_id: "m:main".into(),
+        }
+        .into();
+        assert!(!err.is_not_found());
+    }
+}

--- a/fluree-db-api/src/cross_ledger/error.rs
+++ b/fluree-db-api/src/cross_ledger/error.rs
@@ -28,9 +28,7 @@ pub enum CrossLedgerError {
 
     /// `f:ledger` resolves but the named graph IRI has no entry in the
     /// model ledger's graph registry at `resolved_t`.
-    #[error(
-        "graph '{graph_iri}' is not present in model ledger '{ledger_id}' at t={resolved_t}"
-    )]
+    #[error("graph '{graph_iri}' is not present in model ledger '{ledger_id}' at t={resolved_t}")]
     GraphMissingAtT {
         /// Canonical model ledger id.
         ledger_id: String,
@@ -69,9 +67,7 @@ pub enum CrossLedgerError {
     /// The resolver successfully read the graph but could not translate
     /// it to term-neutral form (malformed rule, missing IRI on a Sid
     /// the model dictionary lost, etc.).
-    #[error(
-        "could not materialize graph '{graph_iri}' in model ledger '{ledger_id}': {detail}"
-    )]
+    #[error("could not materialize graph '{graph_iri}' in model ledger '{ledger_id}': {detail}")]
     TranslationFailed {
         /// Canonical model ledger id.
         ledger_id: String,
@@ -114,7 +110,9 @@ pub enum CrossLedgerError {
     ///
     /// Same-instance is the v1 contract; cross-instance federation
     /// requires a different trust model and transport.
-    #[error("model ledger '{ledger_id}' is on a different instance; cross-instance is not supported")]
+    #[error(
+        "model ledger '{ledger_id}' is on a different instance; cross-instance is not supported"
+    )]
     CrossInstanceUnsupported {
         /// The user-supplied ledger reference that triggered this.
         ledger_id: String,
@@ -148,9 +146,24 @@ mod tests {
         use super::super::ArtifactKind;
         let err = CrossLedgerError::CycleDetected {
             chain: vec![
-                (ArtifactKind::PolicyRules, "a:main".into(), "http://ex.org/p".into(), 10),
-                (ArtifactKind::PolicyRules, "b:main".into(), "http://ex.org/q".into(), 20),
-                (ArtifactKind::PolicyRules, "a:main".into(), "http://ex.org/p".into(), 10),
+                (
+                    ArtifactKind::PolicyRules,
+                    "a:main".into(),
+                    "http://ex.org/p".into(),
+                    10,
+                ),
+                (
+                    ArtifactKind::PolicyRules,
+                    "b:main".into(),
+                    "http://ex.org/q".into(),
+                    20,
+                ),
+                (
+                    ArtifactKind::PolicyRules,
+                    "a:main".into(),
+                    "http://ex.org/p".into(),
+                    10,
+                ),
             ],
         };
         let msg = err.to_string();

--- a/fluree-db-api/src/cross_ledger/error.rs
+++ b/fluree-db-api/src/cross_ledger/error.rs
@@ -40,6 +40,12 @@ pub enum CrossLedgerError {
 
     /// `f:atT N` was requested but the model ledger no longer retains
     /// state at `N` (index pruning, history retention).
+    ///
+    /// **Reserved for Phase 3** — `f:atT` is rejected upstream as
+    /// `UnsupportedFeature` until that phase lands, so this
+    /// variant is currently unreachable from the resolver. Kept in
+    /// the taxonomy so the surface stays stable when Phase 3
+    /// flips it on.
     #[error(
         "model ledger '{ledger_id}' no longer retains state at t={requested_t} \
          (oldest available is t={oldest_available_t})"

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -9,6 +9,7 @@
 //! `docs/design/cross-ledger-model-enforcement.md`.
 
 pub mod error;
+mod policy_materializer;
 mod resolver;
 mod types;
 

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -13,6 +13,7 @@ mod constraints_materializer;
 pub mod error;
 mod policy_materializer;
 mod resolver;
+mod schema_materializer;
 mod types;
 
 pub use cache::GovernanceCache;
@@ -20,5 +21,5 @@ pub use error::CrossLedgerError;
 pub use resolver::resolve_graph_ref;
 pub use types::{
     ArtifactKind, ConstraintsArtifactWire, GovernanceArtifact, ResolveCtx, ResolvedGraph,
-    WireOrigin,
+    SchemaArtifactWire, WireOrigin, WireTriple,
 };

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -8,11 +8,13 @@
 //! Contract and semantics: see
 //! `docs/design/cross-ledger-model-enforcement.md`.
 
+mod cache;
 pub mod error;
 mod policy_materializer;
 mod resolver;
 mod types;
 
+pub use cache::GovernanceCache;
 pub use error::CrossLedgerError;
 pub use resolver::resolve_graph_ref;
 pub use types::{ArtifactKind, GovernanceArtifact, ResolveCtx, ResolvedGraph};

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -26,18 +26,32 @@ pub use types::{
     RulesArtifactWire, SchemaArtifactWire, ShapesArtifactWire, WireObject, WireOrigin, WireTriple,
 };
 
-/// Resolve a `f:graphSelector` IRI against a model ledger snapshot,
-/// honoring `f:defaultGraph` as `g_id = 0`. Used by every
-/// materializer to translate the selector IRI carried on the wire
-/// into a concrete graph id. Returns `None` when the IRI is neither
-/// `f:defaultGraph` nor present in the snapshot's `graph_registry`;
-/// callers map `None` to [`CrossLedgerError::GraphMissingAtT`].
+/// Resolve a `f:graphSelector` IRI against a model ledger snapshot.
+///
+/// - `f:defaultGraph` → `Ok(Some(0))`.
+/// - `f:txnMetaGraph` → `Err(ReservedGraphSelected)`. The
+///   txn-meta graph carries commit-time provenance and is never a
+///   legitimate cross-ledger target; rejecting the sentinel here
+///   matches the per-canonical-ledger reserved-graph guard
+///   ([`crate::cross_ledger::types::reject_if_reserved_graph`])
+///   and surfaces the dedicated error variant instead of letting
+///   the request leak to a `GraphMissingAtT` after touching M.
+/// - Named graph IRI present in the snapshot's registry →
+///   `Ok(Some(g_id))`.
+/// - Otherwise → `Ok(None)`; callers map to
+///   [`CrossLedgerError::GraphMissingAtT`] with the full context
+///   (ledger id, resolved_t) that this helper doesn't carry.
 pub(crate) fn resolve_selector_g_id(
     snapshot: &fluree_db_core::LedgerSnapshot,
     graph_iri: &str,
-) -> Option<fluree_db_core::GraphId> {
+) -> Result<Option<fluree_db_core::GraphId>, CrossLedgerError> {
     if graph_iri == fluree_vocab::config_iris::DEFAULT_GRAPH {
-        return Some(0u16);
+        return Ok(Some(0u16));
     }
-    snapshot.graph_registry.graph_id_for_iri(graph_iri)
+    if graph_iri == fluree_vocab::config_iris::TXN_META_GRAPH {
+        return Err(CrossLedgerError::ReservedGraphSelected {
+            graph_iri: graph_iri.to_string(),
+        });
+    }
+    Ok(snapshot.graph_registry.graph_id_for_iri(graph_iri))
 }

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -25,3 +25,19 @@ pub use types::{
     ArtifactKind, ConstraintsArtifactWire, GovernanceArtifact, ResolveCtx, ResolvedGraph,
     RulesArtifactWire, SchemaArtifactWire, ShapesArtifactWire, WireObject, WireOrigin, WireTriple,
 };
+
+/// Resolve a `f:graphSelector` IRI against a model ledger snapshot,
+/// honoring `f:defaultGraph` as `g_id = 0`. Used by every
+/// materializer to translate the selector IRI carried on the wire
+/// into a concrete graph id. Returns `None` when the IRI is neither
+/// `f:defaultGraph` nor present in the snapshot's `graph_registry`;
+/// callers map `None` to [`CrossLedgerError::GraphMissingAtT`].
+pub(crate) fn resolve_selector_g_id(
+    snapshot: &fluree_db_core::LedgerSnapshot,
+    graph_iri: &str,
+) -> Option<fluree_db_core::GraphId> {
+    if graph_iri == fluree_vocab::config_iris::DEFAULT_GRAPH {
+        return Some(0u16);
+    }
+    snapshot.graph_registry.graph_id_for_iri(graph_iri)
+}

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -21,5 +21,5 @@ pub use error::CrossLedgerError;
 pub use resolver::resolve_graph_ref;
 pub use types::{
     ArtifactKind, ConstraintsArtifactWire, GovernanceArtifact, ResolveCtx, ResolvedGraph,
-    SchemaArtifactWire, WireOrigin, WireTriple,
+    SchemaArtifactWire, WireObject, WireOrigin, WireTriple,
 };

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -1,0 +1,13 @@
+//! Cross-ledger model enforcement.
+//!
+//! Resolution of `f:GraphRef` whose `f:ledger` targets a different
+//! ledger on the same instance: the model ledger holds governance
+//! artifacts (policy / shapes / schema / rules / constraints) that
+//! are applied to requests against the data ledger.
+//!
+//! Contract and semantics: see
+//! `docs/design/cross-ledger-model-enforcement.md`.
+
+pub mod error;
+
+pub use error::CrossLedgerError;

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -13,6 +13,7 @@ mod constraints_materializer;
 pub mod error;
 mod policy_materializer;
 mod resolver;
+mod rules_materializer;
 mod schema_materializer;
 mod shapes_materializer;
 mod types;
@@ -22,5 +23,5 @@ pub use error::CrossLedgerError;
 pub use resolver::resolve_graph_ref;
 pub use types::{
     ArtifactKind, ConstraintsArtifactWire, GovernanceArtifact, ResolveCtx, ResolvedGraph,
-    SchemaArtifactWire, ShapesArtifactWire, WireObject, WireOrigin, WireTriple,
+    RulesArtifactWire, SchemaArtifactWire, ShapesArtifactWire, WireObject, WireOrigin, WireTriple,
 };

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -9,5 +9,9 @@
 //! `docs/design/cross-ledger-model-enforcement.md`.
 
 pub mod error;
+mod resolver;
+mod types;
 
 pub use error::CrossLedgerError;
+pub use resolver::resolve_graph_ref;
+pub use types::{ArtifactKind, GovernanceArtifact, ResolveCtx, ResolvedGraph};

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -14,6 +14,7 @@ pub mod error;
 mod policy_materializer;
 mod resolver;
 mod schema_materializer;
+mod shapes_materializer;
 mod types;
 
 pub use cache::GovernanceCache;
@@ -21,5 +22,5 @@ pub use error::CrossLedgerError;
 pub use resolver::resolve_graph_ref;
 pub use types::{
     ArtifactKind, ConstraintsArtifactWire, GovernanceArtifact, ResolveCtx, ResolvedGraph,
-    SchemaArtifactWire, WireObject, WireOrigin, WireTriple,
+    SchemaArtifactWire, ShapesArtifactWire, WireObject, WireOrigin, WireTriple,
 };

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -9,6 +9,7 @@
 //! `docs/design/cross-ledger-model-enforcement.md`.
 
 mod cache;
+mod constraints_materializer;
 pub mod error;
 mod policy_materializer;
 mod resolver;
@@ -17,4 +18,7 @@ mod types;
 pub use cache::GovernanceCache;
 pub use error::CrossLedgerError;
 pub use resolver::resolve_graph_ref;
-pub use types::{ArtifactKind, GovernanceArtifact, ResolveCtx, ResolvedGraph};
+pub use types::{
+    ArtifactKind, ConstraintsArtifactWire, GovernanceArtifact, ResolveCtx, ResolvedGraph,
+    WireOrigin,
+};

--- a/fluree-db-api/src/cross_ledger/mod.rs
+++ b/fluree-db-api/src/cross_ledger/mod.rs
@@ -55,3 +55,30 @@ pub(crate) fn resolve_selector_g_id(
     }
     Ok(snapshot.graph_registry.graph_id_for_iri(graph_iri))
 }
+
+/// Encode a fixed system IRI (e.g. `rdf:type`, `f:allow`) against a
+/// model-ledger snapshot, returning a structured error if the IRI's
+/// namespace is not registered.
+///
+/// Uses `encode_iri_strict` so a missing well-known prefix surfaces as
+/// [`CrossLedgerError::TranslationFailed`] rather than silently
+/// falling back to an EMPTY-namespace Sid that would match nothing in
+/// M's flakes (silent governance downgrade).
+pub(crate) fn encode_system_iri(
+    snapshot: &fluree_db_core::LedgerSnapshot,
+    iri: &str,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<fluree_db_core::Sid, CrossLedgerError> {
+    snapshot
+        .encode_iri_strict(iri)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "system IRI '{iri}' is not in the model ledger's namespace map; \
+                 this usually indicates the model ledger is corrupted or did \
+                 not initialize default namespaces"
+            ),
+        })
+}

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -68,6 +68,16 @@ use std::collections::HashSet;
 
 /// Materialize the policy graph at `graph_iri` in model ledger `M` at
 /// `resolved_t` into a `PolicyArtifactWire`.
+#[tracing::instrument(
+    name = "cross_ledger.policy.materialize",
+    level = "debug",
+    skip(fluree),
+    fields(
+        model_ledger = canonical_model_ledger_id,
+        graph_iri = graph_iri,
+        resolved_t = resolved_t,
+    ),
+)]
 pub(super) async fn materialize_policy_rules(
     canonical_model_ledger_id: &str,
     graph_iri: &str,

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -86,7 +86,7 @@ pub(super) async fn materialize_policy_rules(
 
     // 2. Resolve graph_iri → g_id in M's graph registry (handling
     //    `f:defaultGraph` as g_id=0).
-    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri)?.ok_or_else(|| {
         CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -51,15 +51,14 @@ use crate::Fluree;
 use fluree_db_core::{FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid};
 use fluree_vocab::policy_iris;
 
-/// Canonical policy class IRI. Subjects typed exactly as this are
-/// included in the structural detection set even when they're missing
-/// `f:allow` and `f:query`, mirroring the same-ledger
-/// `load_policy_restriction` behavior that maps such "missing-effect"
-/// policies to `Deny` (fail-closed). Without this scan, a canonically-
-/// typed policy with no effect would be silently absent cross-ledger
-/// while still being enforced as Deny same-ledger — a divergence the
-/// design doc forbids.
-const ACCESS_POLICY_IRI: &str = "https://ns.flur.ee/db#AccessPolicy";
+// Canonical policy class IRI lives in `fluree_vocab::policy_iris::ACCESS_POLICY`.
+// Subjects typed exactly as this are included in the structural
+// detection set even when they're missing `f:allow` and `f:query`,
+// mirroring the same-ledger `load_policy_restriction` behavior
+// that maps such "missing-effect" policies to `Deny` (fail-closed).
+// Without this scan, a canonically-typed policy with no effect would
+// be silently absent cross-ledger while still being enforced as Deny
+// same-ledger — a divergence the design doc forbids.
 use fluree_db_policy::{
     PolicyArtifactWire, PolicyRestriction, PolicyValue, WireOrigin, WirePolicyValue,
     WireRestriction,
@@ -160,7 +159,7 @@ pub(super) async fn materialize_policy_rules(
     // canonical class is the only structural baseline; custom-typed
     // policies still need an explicit effect predicate to be picked
     // up cross-ledger. That's a documented Phase 1a limitation.
-    if let Some(access_policy_sid) = m_db.snapshot.encode_iri(ACCESS_POLICY_IRI) {
+    if let Some(access_policy_sid) = m_db.snapshot.encode_iri(policy_iris::ACCESS_POLICY) {
         let flakes = m_view
             .range(
                 IndexType::Post,

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -52,6 +52,16 @@ use fluree_db_core::{
     FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid,
 };
 use fluree_vocab::policy_iris;
+
+/// Canonical policy class IRI. Subjects typed exactly as this are
+/// included in the structural detection set even when they're missing
+/// `f:allow` and `f:query`, mirroring the same-ledger
+/// `load_policy_restriction` behavior that maps such "missing-effect"
+/// policies to `Deny` (fail-closed). Without this scan, a canonically-
+/// typed policy with no effect would be silently absent cross-ledger
+/// while still being enforced as Deny same-ledger — a divergence the
+/// design doc forbids.
+const ACCESS_POLICY_IRI: &str = "https://ns.flur.ee/db#AccessPolicy";
 use fluree_db_policy::{
     PolicyArtifactWire, PolicyRestriction, PolicyValue, WireOrigin, WirePolicyValue,
     WireRestriction,
@@ -108,7 +118,11 @@ pub(super) async fn materialize_policy_rules(
     );
 
     // 4. Structural detection — find every subject that has at least
-    //    one f:allow or f:query triple in this graph.
+    //    one f:allow or f:query triple OR is canonically typed as
+    //    f:AccessPolicy. The latter scan covers the case where a
+    //    canonically-typed policy is missing both effect predicates;
+    //    same-ledger load_policy_restriction maps that to Deny
+    //    (fail-closed), and the cross-ledger flow must agree.
     let mut policy_subjects: HashSet<Sid> = HashSet::new();
     for pred_sid in [allow_sid, query_sid] {
         let flakes = m_view
@@ -118,6 +132,32 @@ pub(super) async fn materialize_policy_rules(
                 ledger_id: canonical_model_ledger_id.to_string(),
                 graph_iri: graph_iri.to_string(),
                 detail: format!("range scan for policy-effect predicate failed: {e}"),
+            })?;
+        for flake in flakes.into_iter().filter(|f| f.op) {
+            policy_subjects.insert(flake.s);
+        }
+    }
+
+    // Union in subjects typed exactly as f:AccessPolicy. We don't
+    // attempt subclass entailment or scan for arbitrary types — the
+    // canonical class is the only structural baseline; custom-typed
+    // policies still need an explicit effect predicate to be picked
+    // up cross-ledger. That's a documented Phase 1a limitation.
+    if let Some(access_policy_sid) = m_db.snapshot.encode_iri(ACCESS_POLICY_IRI) {
+        let flakes = m_view
+            .range(
+                IndexType::Post,
+                RangeTest::Eq,
+                RangeMatch::predicate_object(
+                    rdf_type_sid.clone(),
+                    FlakeValue::Ref(access_policy_sid),
+                ),
+            )
+            .await
+            .map_err(|e| CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!("range scan for rdf:type f:AccessPolicy failed: {e}"),
             })?;
         for flake in flakes.into_iter().filter(|f| f.op) {
             policy_subjects.insert(flake.s);

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -76,7 +76,7 @@ pub(super) async fn materialize_policy_rules(
 ) -> Result<PolicyArtifactWire, CrossLedgerError> {
     // 1. Open M at resolved_t.
     let m_db = fluree
-        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .load_graph_db_at_t(canonical_model_ledger_id, resolved_t)
         .await
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -84,16 +84,15 @@ pub(super) async fn materialize_policy_rules(
             detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
-    // 2. Resolve graph_iri → g_id in M's graph registry.
-    let g_id = m_db
-        .snapshot
-        .graph_registry
-        .graph_id_for_iri(graph_iri)
-        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+    // 2. Resolve graph_iri → g_id in M's graph registry (handling
+    //    `f:defaultGraph` as g_id=0).
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+        CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             resolved_t,
-        })?;
+        }
+    })?;
 
     // 3. Encode the predicate IRIs we need to scan against M's
     //    namespace map. These come from default namespaces

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -48,9 +48,7 @@
 
 use super::CrossLedgerError;
 use crate::Fluree;
-use fluree_db_core::{
-    FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid,
-};
+use fluree_db_core::{FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid};
 use fluree_vocab::policy_iris;
 
 /// Canonical policy class IRI. Subjects typed exactly as this are
@@ -101,8 +99,18 @@ pub(super) async fn materialize_policy_rules(
     //    namespace map. These come from default namespaces
     //    (fluree, rdf) which are pre-registered at genesis, so a
     //    failure here means M is corrupt.
-    let allow_sid = encode_system_iri(&m_db.snapshot, policy_iris::ALLOW, canonical_model_ledger_id, graph_iri)?;
-    let query_sid = encode_system_iri(&m_db.snapshot, policy_iris::QUERY, canonical_model_ledger_id, graph_iri)?;
+    let allow_sid = encode_system_iri(
+        &m_db.snapshot,
+        policy_iris::ALLOW,
+        canonical_model_ledger_id,
+        graph_iri,
+    )?;
+    let query_sid = encode_system_iri(
+        &m_db.snapshot,
+        policy_iris::QUERY,
+        canonical_model_ledger_id,
+        graph_iri,
+    )?;
     let rdf_type_sid = encode_system_iri(
         &m_db.snapshot,
         rdf_type_iri(),
@@ -110,12 +118,8 @@ pub(super) async fn materialize_policy_rules(
         graph_iri,
     )?;
 
-    let m_view = fluree_db_core::GraphDbRef::new(
-        &m_db.snapshot,
-        g_id,
-        m_db.overlay.as_ref(),
-        m_db.t,
-    );
+    let m_view =
+        fluree_db_core::GraphDbRef::new(&m_db.snapshot, g_id, m_db.overlay.as_ref(), m_db.t);
 
     // 4. Structural detection — find every subject that has at least
     //    one f:allow or f:query triple OR is canonically typed as
@@ -126,7 +130,11 @@ pub(super) async fn materialize_policy_rules(
     let mut policy_subjects: HashSet<Sid> = HashSet::new();
     for pred_sid in [allow_sid, query_sid] {
         let flakes = m_view
-            .range(IndexType::Post, RangeTest::Eq, RangeMatch::predicate(pred_sid))
+            .range(
+                IndexType::Post,
+                RangeTest::Eq,
+                RangeMatch::predicate(pred_sid),
+            )
             .await
             .map_err(|e| CrossLedgerError::TranslationFailed {
                 ledger_id: canonical_model_ledger_id.to_string(),
@@ -273,15 +281,16 @@ async fn read_rdf_types(
         let FlakeValue::Ref(class_sid) = flake.o else {
             continue; // non-Ref rdf:type isn't valid; skip silently
         };
-        let iri = snapshot.decode_sid(&class_sid).ok_or_else(|| {
-            CrossLedgerError::TranslationFailed {
-                ledger_id: canonical_model_ledger_id.to_string(),
-                graph_iri: graph_iri.to_string(),
-                detail: format!(
-                    "could not decode rdf:type Sid {class_sid:?} on policy {subject:?}"
-                ),
-            }
-        })?;
+        let iri =
+            snapshot
+                .decode_sid(&class_sid)
+                .ok_or_else(|| CrossLedgerError::TranslationFailed {
+                    ledger_id: canonical_model_ledger_id.to_string(),
+                    graph_iri: graph_iri.to_string(),
+                    detail: format!(
+                        "could not decode rdf:type Sid {class_sid:?} on policy {subject:?}"
+                    ),
+                })?;
         out.push(iri);
     }
     Ok(out)
@@ -303,16 +312,17 @@ fn restriction_to_wire(
     let decode_set = |sids: &HashSet<Sid>, field: &str| -> Result<Vec<String>, CrossLedgerError> {
         let mut out = Vec::with_capacity(sids.len());
         for sid in sids {
-            let iri = snapshot.decode_sid(sid).ok_or_else(|| {
-                CrossLedgerError::TranslationFailed {
-                    ledger_id: canonical_model_ledger_id.to_string(),
-                    graph_iri: graph_iri.to_string(),
-                    detail: format!(
-                        "could not decode Sid {sid:?} on field '{field}' of policy {}",
-                        r.id,
-                    ),
-                }
-            })?;
+            let iri =
+                snapshot
+                    .decode_sid(sid)
+                    .ok_or_else(|| CrossLedgerError::TranslationFailed {
+                        ledger_id: canonical_model_ledger_id.to_string(),
+                        graph_iri: graph_iri.to_string(),
+                        detail: format!(
+                            "could not decode Sid {sid:?} on field '{field}' of policy {}",
+                            r.id,
+                        ),
+                    })?;
             out.push(iri);
         }
         Ok(out)

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -6,65 +6,67 @@
 //! layer's `build_policy_set_from_wire` against the data ledger's
 //! snapshot to produce a Sid-form `PolicySet` (slice 5).
 //!
-//! Phase 1a scope:
+//! ## Phase 1a scope
 //!
-//! - Loads only policies with `rdf:type f:AccessPolicy`. Subclass
-//!   entailment (`?p rdfs:subClassOf f:AccessPolicy`) is **not**
-//!   applied — policies in M must declare `f:AccessPolicy` directly.
-//!   The cache key stays free of policy-class context, which keeps a
-//!   single wire artifact shareable across every data ledger that
-//!   references the same model graph.
-//! - No `f:atT` pin — resolver passes M's current head `t`. Pinned
-//!   refs are accepted by the resolver but treated as the current
-//!   head for materialization; honoring pins lands in a later slice.
+//! **Structural detection of policy subjects.** A subject is treated
+//! as a policy if it has at least one `f:allow` or `f:query` triple
+//! in the configured graph. This is intentionally schema-agnostic —
+//! the rule's `rdf:type` is recorded on the wire as
+//! `WireRestriction.policy_types` and the translation step
+//! intersects those against the data ledger's configured
+//! `f:policyClass` set. This keeps the cross-ledger cache shareable
+//! across every data ledger that references the same model graph,
+//! regardless of policy-class configuration.
 //!
-//! Reuses the same-ledger `policy_builder::load_policies_by_class`
-//! against M's snapshot, then decodes the resulting Sid-form
-//! `PolicyRestriction` list into IRI-form `WireRestriction`s by
-//! routing every Sid through M's `decode_sid`.
+//! Exact IRI matching only. Subclass entailment
+//! (`rdfs:subClassOf` chains rooted at the configured policy class)
+//! is **not** applied — the data ledger's policy class IRI must
+//! appear verbatim in the rule subject's `rdf:type` list. This
+//! mirrors the same-ledger `load_policies_by_class` semantics, which
+//! also matches `rdf:type` directly without entailment.
+//!
+//! ## Failure handling
+//!
+//! - Snapshot construction fails → `TranslationFailed` (with the
+//!   underlying error in `detail`).
+//! - Graph IRI absent from M's registry → `GraphMissingAtT`.
+//! - System IRI (`f:allow`, `f:query`, `rdf:type`) absent from M's
+//!   namespace map → `TranslationFailed`. These IRIs come from
+//!   default namespaces pre-registered at genesis, so this only
+//!   surfaces on corrupted M.
+//! - The same-ledger `load_policy_restriction` returns `None` for a
+//!   subject (malformed — has the value predicate but the action /
+//!   target combination doesn't add up) → the subject is **skipped**
+//!   from the wire artifact, matching the existing same-ledger
+//!   behavior. The skip is silent because the same-ledger loader's
+//!   `None` return is itself an "ignore this subject" signal; if
+//!   that's wrong it's a same-ledger correctness bug, not something
+//!   cross-ledger should diverge on.
+//! - A Sid that doesn't decode against M's namespace map →
+//!   `TranslationFailed` (no silent drop; dropping a target would
+//!   produce a structurally weaker policy than authored).
 
 use super::CrossLedgerError;
 use crate::Fluree;
-use fluree_db_core::LedgerSnapshot;
+use fluree_db_core::{
+    FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid,
+};
+use fluree_vocab::policy_iris;
 use fluree_db_policy::{
     PolicyArtifactWire, PolicyRestriction, PolicyValue, WireOrigin, WirePolicyValue,
     WireRestriction,
 };
-
-/// IRI of the canonical policy class root.
-///
-/// Phase 1a scope: subclass entailment is not applied. Policies in
-/// the model ledger must declare `rdf:type f:AccessPolicy` directly.
-const ACCESS_POLICY_IRI: &str = "https://ns.flur.ee/db#AccessPolicy";
+use std::collections::HashSet;
 
 /// Materialize the policy graph at `graph_iri` in model ledger `M` at
 /// `resolved_t` into a `PolicyArtifactWire`.
-///
-/// Failure modes:
-///
-/// - The model ledger's snapshot cannot be opened at `resolved_t` —
-///   surfaces as [`CrossLedgerError::TranslationFailed`]. The
-///   resolver's nameservice lookup already covered the
-///   "ledger doesn't exist" case before reaching us; this is
-///   a snapshot-construction failure (storage error, etc.).
-/// - The graph IRI is not in `M`'s graph registry at `resolved_t` —
-///   [`CrossLedgerError::GraphMissingAtT`].
-/// - The same-ledger loader fails (system IRI encoding, query
-///   execution) — [`CrossLedgerError::TranslationFailed`] with the
-///   underlying error in `detail`.
-/// - A Sid in the loaded restrictions cannot be decoded back to an
-///   IRI against M's namespace map (dictionary loss / corruption) —
-///   [`CrossLedgerError::TranslationFailed`].
 pub(super) async fn materialize_policy_rules(
     canonical_model_ledger_id: &str,
     graph_iri: &str,
     resolved_t: i64,
     fluree: &Fluree,
 ) -> Result<PolicyArtifactWire, CrossLedgerError> {
-    // 1. Open M at resolved_t. The resolver already canonicalized the
-    //    ledger id via nameservice.lookup, so this should succeed
-    //    unless the snapshot itself can't be built (e.g., index
-    //    storage error).
+    // 1. Open M at resolved_t.
     let m_db = fluree
         .db_at_t(canonical_model_ledger_id, resolved_t)
         .await
@@ -85,32 +87,82 @@ pub(super) async fn materialize_policy_rules(
             resolved_t,
         })?;
 
-    // 3. Load all f:AccessPolicy-typed subjects in that graph via the
-    //    same-ledger loader, but applied to M's snapshot. The loader
-    //    handles the rdf:type scan, per-policy predicate fan-out, and
-    //    target-mode determination.
-    let restrictions = crate::policy_builder::load_policies_by_class(
+    // 3. Encode the predicate IRIs we need to scan against M's
+    //    namespace map. These come from default namespaces
+    //    (fluree, rdf) which are pre-registered at genesis, so a
+    //    failure here means M is corrupt.
+    let allow_sid = encode_system_iri(&m_db.snapshot, policy_iris::ALLOW, canonical_model_ledger_id, graph_iri)?;
+    let query_sid = encode_system_iri(&m_db.snapshot, policy_iris::QUERY, canonical_model_ledger_id, graph_iri)?;
+    let rdf_type_sid = encode_system_iri(
         &m_db.snapshot,
+        rdf_type_iri(),
+        canonical_model_ledger_id,
+        graph_iri,
+    )?;
+
+    let m_view = fluree_db_core::GraphDbRef::new(
+        &m_db.snapshot,
+        g_id,
         m_db.overlay.as_ref(),
         m_db.t,
-        &[ACCESS_POLICY_IRI.to_string()],
-        &[g_id],
-    )
-    .await
-    .map_err(|e| CrossLedgerError::TranslationFailed {
-        ledger_id: canonical_model_ledger_id.to_string(),
-        graph_iri: graph_iri.to_string(),
-        detail: format!("policy loader failed against model ledger: {e}"),
-    })?;
+    );
 
-    // 4. Decode each PolicyRestriction's Sids back to IRIs against M's
-    //    namespace map. The resulting WireRestrictions are term-neutral
-    //    — consumers re-intern them against their own data ledger's
-    //    dictionary in build_policy_set_from_wire.
-    let mut wire_restrictions = Vec::with_capacity(restrictions.len());
-    for r in &restrictions {
+    // 4. Structural detection — find every subject that has at least
+    //    one f:allow or f:query triple in this graph.
+    let mut policy_subjects: HashSet<Sid> = HashSet::new();
+    for pred_sid in [allow_sid, query_sid] {
+        let flakes = m_view
+            .range(IndexType::Post, RangeTest::Eq, RangeMatch::predicate(pred_sid))
+            .await
+            .map_err(|e| CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!("range scan for policy-effect predicate failed: {e}"),
+            })?;
+        for flake in flakes.into_iter().filter(|f| f.op) {
+            policy_subjects.insert(flake.s);
+        }
+    }
+
+    // 5. For each candidate policy subject, fan out via the same-
+    //    ledger loader (against M's snapshot) and read its rdf:type
+    //    set. Subjects the loader returns `None` for are silently
+    //    skipped — that's the existing local-side semantics for
+    //    malformed rules.
+    let policy_graphs = [g_id];
+    let mut wire_restrictions = Vec::with_capacity(policy_subjects.len());
+    for policy_sid in policy_subjects {
+        let restriction = crate::policy_builder::load_policy_restriction(
+            &m_db.snapshot,
+            m_db.overlay.as_ref(),
+            m_db.t,
+            &policy_sid,
+            &policy_graphs,
+        )
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("per-policy load failed for {policy_sid:?}: {e}"),
+        })?;
+
+        let Some(restriction) = restriction else {
+            continue; // malformed; matches same-ledger semantics
+        };
+
+        let policy_types = read_rdf_types(
+            &m_view,
+            &policy_sid,
+            &rdf_type_sid,
+            &m_db.snapshot,
+            canonical_model_ledger_id,
+            graph_iri,
+        )
+        .await?;
+
         wire_restrictions.push(restriction_to_wire(
-            r,
+            &restriction,
+            policy_types,
             &m_db.snapshot,
             canonical_model_ledger_id,
             graph_iri,
@@ -127,24 +179,88 @@ pub(super) async fn materialize_policy_rules(
     })
 }
 
-/// Decode a Sid-form `PolicyRestriction` (produced against M's
-/// snapshot) into an IRI-form `WireRestriction`.
+fn rdf_type_iri() -> &'static str {
+    // Avoid a dep cycle / extra const — the IRI is fixed by the W3C
+    // and pre-registered in every Fluree ledger via the RDF
+    // namespace code.
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+}
+
+fn encode_system_iri(
+    snapshot: &LedgerSnapshot,
+    iri: &str,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<Sid, CrossLedgerError> {
+    snapshot
+        .encode_iri(iri)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "system IRI '{iri}' is not in the model ledger's namespace map; \
+                 this usually indicates the model ledger is corrupted or did \
+                 not initialize default namespaces"
+            ),
+        })
+}
+
+/// Read every `rdf:type` value for `subject` in the policy graph and
+/// decode each to its IRI form.
+async fn read_rdf_types(
+    m_view: &fluree_db_core::GraphDbRef<'_>,
+    subject: &Sid,
+    rdf_type_sid: &Sid,
+    snapshot: &LedgerSnapshot,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<Vec<String>, CrossLedgerError> {
+    let flakes = m_view
+        .range(
+            IndexType::Spot,
+            RangeTest::Eq,
+            RangeMatch::subject_predicate(subject.clone(), rdf_type_sid.clone()),
+        )
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("rdf:type scan for {subject:?} failed: {e}"),
+        })?;
+
+    let mut out = Vec::new();
+    for flake in flakes.into_iter().filter(|f| f.op) {
+        let FlakeValue::Ref(class_sid) = flake.o else {
+            continue; // non-Ref rdf:type isn't valid; skip silently
+        };
+        let iri = snapshot.decode_sid(&class_sid).ok_or_else(|| {
+            CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!(
+                    "could not decode rdf:type Sid {class_sid:?} on policy {subject:?}"
+                ),
+            }
+        })?;
+        out.push(iri);
+    }
+    Ok(out)
+}
+
+/// Decode a Sid-form `PolicyRestriction` into an IRI-form
+/// `WireRestriction`, attaching the rule's `rdf:type` set.
 ///
-/// Every Sid that the same-ledger loader assembled must round-trip
-/// through `decode_sid`; failure to decode indicates a corrupt or
-/// truncated namespace map and is surfaced as `TranslationFailed`
-/// rather than silently dropping the target. Silent drop would
-/// produce a policy that's structurally weaker than what was
-/// authored — exactly the failure mode the design doc forbids.
+/// A Sid that doesn't round-trip through `decode_sid` surfaces as
+/// `TranslationFailed` rather than being silently dropped — silent
+/// drop would produce a policy structurally weaker than authored.
 fn restriction_to_wire(
     r: &PolicyRestriction,
+    policy_types: Vec<String>,
     snapshot: &LedgerSnapshot,
     canonical_model_ledger_id: &str,
     graph_iri: &str,
 ) -> Result<WireRestriction, CrossLedgerError> {
-    let decode_set = |sids: &std::collections::HashSet<fluree_db_core::Sid>,
-                      field: &str|
-     -> Result<Vec<String>, CrossLedgerError> {
+    let decode_set = |sids: &HashSet<Sid>, field: &str| -> Result<Vec<String>, CrossLedgerError> {
         let mut out = Vec::with_capacity(sids.len());
         for sid in sids {
             let iri = snapshot.decode_sid(sid).ok_or_else(|| {
@@ -152,8 +268,7 @@ fn restriction_to_wire(
                     ledger_id: canonical_model_ledger_id.to_string(),
                     graph_iri: graph_iri.to_string(),
                     detail: format!(
-                        "could not decode Sid {sid:?} on field '{field}' \
-                         of policy {} against model ledger's namespace map",
+                        "could not decode Sid {sid:?} on field '{field}' of policy {}",
                         r.id,
                     ),
                 }
@@ -174,6 +289,7 @@ fn restriction_to_wire(
 
     Ok(WireRestriction {
         id: r.id.clone(),
+        policy_types,
         target_mode: r.target_mode,
         targets,
         action: r.action,

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -1,0 +1,186 @@
+//! Cross-ledger PolicyRules materialization.
+//!
+//! Reads a model ledger's policy graph at `resolved_t` and projects it
+//! into a term-neutral [`PolicyArtifactWire`] keyed under the model
+//! ledger's canonical id. The wire artifact is consumed by the API
+//! layer's `build_policy_set_from_wire` against the data ledger's
+//! snapshot to produce a Sid-form `PolicySet` (slice 5).
+//!
+//! Phase 1a scope:
+//!
+//! - Loads only policies with `rdf:type f:AccessPolicy`. Subclass
+//!   entailment (`?p rdfs:subClassOf f:AccessPolicy`) is **not**
+//!   applied — policies in M must declare `f:AccessPolicy` directly.
+//!   The cache key stays free of policy-class context, which keeps a
+//!   single wire artifact shareable across every data ledger that
+//!   references the same model graph.
+//! - No `f:atT` pin — resolver passes M's current head `t`. Pinned
+//!   refs are accepted by the resolver but treated as the current
+//!   head for materialization; honoring pins lands in a later slice.
+//!
+//! Reuses the same-ledger `policy_builder::load_policies_by_class`
+//! against M's snapshot, then decodes the resulting Sid-form
+//! `PolicyRestriction` list into IRI-form `WireRestriction`s by
+//! routing every Sid through M's `decode_sid`.
+
+use super::CrossLedgerError;
+use crate::Fluree;
+use fluree_db_core::LedgerSnapshot;
+use fluree_db_policy::{
+    PolicyArtifactWire, PolicyRestriction, PolicyValue, WireOrigin, WirePolicyValue,
+    WireRestriction,
+};
+
+/// IRI of the canonical policy class root.
+///
+/// Phase 1a scope: subclass entailment is not applied. Policies in
+/// the model ledger must declare `rdf:type f:AccessPolicy` directly.
+const ACCESS_POLICY_IRI: &str = "https://ns.flur.ee/db#AccessPolicy";
+
+/// Materialize the policy graph at `graph_iri` in model ledger `M` at
+/// `resolved_t` into a `PolicyArtifactWire`.
+///
+/// Failure modes:
+///
+/// - The model ledger's snapshot cannot be opened at `resolved_t` —
+///   surfaces as [`CrossLedgerError::TranslationFailed`]. The
+///   resolver's nameservice lookup already covered the
+///   "ledger doesn't exist" case before reaching us; this is
+///   a snapshot-construction failure (storage error, etc.).
+/// - The graph IRI is not in `M`'s graph registry at `resolved_t` —
+///   [`CrossLedgerError::GraphMissingAtT`].
+/// - The same-ledger loader fails (system IRI encoding, query
+///   execution) — [`CrossLedgerError::TranslationFailed`] with the
+///   underlying error in `detail`.
+/// - A Sid in the loaded restrictions cannot be decoded back to an
+///   IRI against M's namespace map (dictionary loss / corruption) —
+///   [`CrossLedgerError::TranslationFailed`].
+pub(super) async fn materialize_policy_rules(
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+    resolved_t: i64,
+    fluree: &Fluree,
+) -> Result<PolicyArtifactWire, CrossLedgerError> {
+    // 1. Open M at resolved_t. The resolver already canonicalized the
+    //    ledger id via nameservice.lookup, so this should succeed
+    //    unless the snapshot itself can't be built (e.g., index
+    //    storage error).
+    let m_db = fluree
+        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
+        })?;
+
+    // 2. Resolve graph_iri → g_id in M's graph registry.
+    let g_id = m_db
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(graph_iri)
+        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        })?;
+
+    // 3. Load all f:AccessPolicy-typed subjects in that graph via the
+    //    same-ledger loader, but applied to M's snapshot. The loader
+    //    handles the rdf:type scan, per-policy predicate fan-out, and
+    //    target-mode determination.
+    let restrictions = crate::policy_builder::load_policies_by_class(
+        &m_db.snapshot,
+        m_db.overlay.as_ref(),
+        m_db.t,
+        &[ACCESS_POLICY_IRI.to_string()],
+        &[g_id],
+    )
+    .await
+    .map_err(|e| CrossLedgerError::TranslationFailed {
+        ledger_id: canonical_model_ledger_id.to_string(),
+        graph_iri: graph_iri.to_string(),
+        detail: format!("policy loader failed against model ledger: {e}"),
+    })?;
+
+    // 4. Decode each PolicyRestriction's Sids back to IRIs against M's
+    //    namespace map. The resulting WireRestrictions are term-neutral
+    //    — consumers re-intern them against their own data ledger's
+    //    dictionary in build_policy_set_from_wire.
+    let mut wire_restrictions = Vec::with_capacity(restrictions.len());
+    for r in &restrictions {
+        wire_restrictions.push(restriction_to_wire(
+            r,
+            &m_db.snapshot,
+            canonical_model_ledger_id,
+            graph_iri,
+        )?);
+    }
+
+    Ok(PolicyArtifactWire {
+        origin: WireOrigin {
+            model_ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        },
+        restrictions: wire_restrictions,
+    })
+}
+
+/// Decode a Sid-form `PolicyRestriction` (produced against M's
+/// snapshot) into an IRI-form `WireRestriction`.
+///
+/// Every Sid that the same-ledger loader assembled must round-trip
+/// through `decode_sid`; failure to decode indicates a corrupt or
+/// truncated namespace map and is surfaced as `TranslationFailed`
+/// rather than silently dropping the target. Silent drop would
+/// produce a policy that's structurally weaker than what was
+/// authored — exactly the failure mode the design doc forbids.
+fn restriction_to_wire(
+    r: &PolicyRestriction,
+    snapshot: &LedgerSnapshot,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<WireRestriction, CrossLedgerError> {
+    let decode_set = |sids: &std::collections::HashSet<fluree_db_core::Sid>,
+                      field: &str|
+     -> Result<Vec<String>, CrossLedgerError> {
+        let mut out = Vec::with_capacity(sids.len());
+        for sid in sids {
+            let iri = snapshot.decode_sid(sid).ok_or_else(|| {
+                CrossLedgerError::TranslationFailed {
+                    ledger_id: canonical_model_ledger_id.to_string(),
+                    graph_iri: graph_iri.to_string(),
+                    detail: format!(
+                        "could not decode Sid {sid:?} on field '{field}' \
+                         of policy {} against model ledger's namespace map",
+                        r.id,
+                    ),
+                }
+            })?;
+            out.push(iri);
+        }
+        Ok(out)
+    };
+
+    let targets = decode_set(&r.targets, "targets")?;
+    let for_classes = decode_set(&r.for_classes, "for_classes")?;
+
+    let value = match &r.value {
+        PolicyValue::Allow => WirePolicyValue::Allow,
+        PolicyValue::Deny => WirePolicyValue::Deny,
+        PolicyValue::Query(q) => WirePolicyValue::Query(q.json.clone()),
+    };
+
+    Ok(WireRestriction {
+        id: r.id.clone(),
+        target_mode: r.target_mode,
+        targets,
+        action: r.action,
+        value,
+        required: r.required,
+        message: r.message.clone(),
+        class_policy: r.class_policy,
+        for_classes,
+    })
+}

--- a/fluree-db-api/src/cross_ledger/policy_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/policy_materializer.rs
@@ -46,7 +46,7 @@
 //!   `TranslationFailed` (no silent drop; dropping a target would
 //!   produce a structurally weaker policy than authored).
 
-use super::CrossLedgerError;
+use super::{encode_system_iri, CrossLedgerError};
 use crate::Fluree;
 use fluree_db_core::{FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeTest, Sid};
 use fluree_vocab::policy_iris;
@@ -159,7 +159,7 @@ pub(super) async fn materialize_policy_rules(
     // canonical class is the only structural baseline; custom-typed
     // policies still need an explicit effect predicate to be picked
     // up cross-ledger. That's a documented Phase 1a limitation.
-    if let Some(access_policy_sid) = m_db.snapshot.encode_iri(policy_iris::ACCESS_POLICY) {
+    if let Some(access_policy_sid) = m_db.snapshot.encode_iri_strict(policy_iris::ACCESS_POLICY) {
         let flakes = m_view
             .range(
                 IndexType::Post,
@@ -240,25 +240,6 @@ fn rdf_type_iri() -> &'static str {
     // and pre-registered in every Fluree ledger via the RDF
     // namespace code.
     "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-}
-
-fn encode_system_iri(
-    snapshot: &LedgerSnapshot,
-    iri: &str,
-    canonical_model_ledger_id: &str,
-    graph_iri: &str,
-) -> Result<Sid, CrossLedgerError> {
-    snapshot
-        .encode_iri(iri)
-        .ok_or_else(|| CrossLedgerError::TranslationFailed {
-            ledger_id: canonical_model_ledger_id.to_string(),
-            graph_iri: graph_iri.to_string(),
-            detail: format!(
-                "system IRI '{iri}' is not in the model ledger's namespace map; \
-                 this usually indicates the model ledger is corrupted or did \
-                 not initialize default namespaces"
-            ),
-        })
 }
 
 /// Read every `rdf:type` value for `subject` in the policy graph and

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -140,19 +140,26 @@ pub async fn resolve_graph_ref(
         head_t
     };
 
-    let tuple = (canonical_ledger_id.clone(), graph_iri.to_string(), resolved_t);
+    let key: (ArtifactKind, String, String, i64) = (
+        kind,
+        canonical_ledger_id.clone(),
+        graph_iri.to_string(),
+        resolved_t,
+    );
 
     // (5) Memo hit — short-circuit cross-subsystem de-dup before
     // entering `active`, so two subsystems referencing the same
-    // (M, graph, t) never look like a cycle to each other.
-    if let Some(hit) = memo_hit(&ctx.memo, &tuple) {
+    // (kind, M, graph, t) never look like a cycle to each other.
+    // ArtifactKind is part of the key: a memoized PolicyRules entry
+    // never short-circuits a Shapes lookup for the same graph.
+    if let Some(hit) = memo_hit(&ctx.memo, &key) {
         return Ok(hit);
     }
 
     // (6) Cycle check.
-    check_cycle(&ctx.active, &tuple)?;
+    check_cycle(&ctx.active, &key)?;
 
-    ctx.active.push(tuple.clone());
+    ctx.active.push(key.clone());
 
     // Materialize. Slice 3 provides the dispatch shape; the actual
     // projector lands in slice 4.
@@ -172,7 +179,7 @@ pub async fn resolve_graph_ref(
 
     let resolved = materialize_result?;
     let arc = Arc::new(resolved);
-    ctx.memo.insert(tuple, arc.clone());
+    ctx.memo.insert(key, arc.clone());
     Ok(arc)
 }
 

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -262,6 +262,21 @@ async fn materialize(
                 artifact: GovernanceArtifact::SchemaClosure(wire),
             })
         }
+        ArtifactKind::Shapes => {
+            let wire = super::shapes_materializer::materialize_shapes(
+                canonical_ledger_id,
+                graph_iri,
+                resolved_t,
+                ctx.fluree,
+            )
+            .await?;
+            Ok(ResolvedGraph {
+                model_ledger_id: canonical_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                resolved_t,
+                artifact: GovernanceArtifact::Shapes(wire),
+            })
+        }
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -274,6 +274,21 @@ async fn materialize(
                 artifact: GovernanceArtifact::Shapes(wire),
             })
         }
+        ArtifactKind::Rules => {
+            let wire = super::rules_materializer::materialize_rules(
+                canonical_ledger_id,
+                graph_iri,
+                resolved_t,
+                ctx.fluree,
+            )
+            .await?;
+            Ok(ResolvedGraph {
+                model_ledger_id: canonical_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                resolved_t,
+                artifact: GovernanceArtifact::Rules(wire),
+            })
+        }
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -1,0 +1,284 @@
+//! Cross-ledger resolver entry point.
+//!
+//! The single helper shared by every subsystem (policy / shapes /
+//! schema / rules / constraints). Materialization is dispatched per
+//! [`ArtifactKind`]; only `PolicyRules` is implemented in Phase 1a
+//! (this slice provides the orchestration skeleton — the per-kind
+//! materializer is added in slice 4).
+//!
+//! See `docs/design/cross-ledger-model-enforcement.md`.
+
+use super::types::{
+    check_cycle, memo_hit, reject_if_reserved_graph, ArtifactKind, GovernanceArtifact,
+    ResolveCtx, ResolvedGraph,
+};
+use super::CrossLedgerError;
+use fluree_db_core::ledger_config::GraphSourceRef;
+use fluree_db_nameservice::NsRecord;
+use std::sync::Arc;
+
+/// Resolve a cross-ledger `GraphSourceRef` to a term-neutral artifact.
+///
+/// Performs, in order:
+///
+/// 1. Validate this is actually a cross-ledger ref (`f:ledger` set)
+///    and that unsupported Phase-4 fields (`f:trustPolicy`,
+///    `f:rollbackGuard`) are absent.
+/// 2. Canonicalize the model ledger id via the nameservice
+///    (`nameservice.lookup`); fail with `ModelLedgerMissing` if the
+///    ledger is absent or retracted on this instance.
+/// 3. Reject `#config` / `#txn-meta` selectors before any storage
+///    round-trip on M.
+/// 4. Capture `resolved_t` — `f:atT` pin if set, else lazy per-request
+///    head-t in `ctx.resolved_ts`.
+/// 5. Form the tuple `(canonical_model_ledger_id, graph_iri,
+///    resolved_t)` and check `ctx.memo`. On hit, return immediately.
+/// 6. Check `ctx.active` for cycles. On miss, push and call into the
+///    per-kind materializer.
+/// 7. On materializer success, pop `active`, insert into `memo`, and
+///    return.
+///
+/// Materialization itself is not implemented in this slice — the
+/// per-kind dispatch returns
+/// `CrossLedgerError::TranslationFailed { detail: "..." }` so call
+/// sites can be wired before the projector lands.
+pub async fn resolve_graph_ref(
+    graph_ref: &GraphSourceRef,
+    kind: ArtifactKind,
+    ctx: &mut ResolveCtx<'_>,
+) -> Result<Arc<ResolvedGraph>, CrossLedgerError> {
+    // (1) Phase-4 fields not yet supported. Surface a clear failure
+    // rather than silently ignoring them.
+    if graph_ref.trust_policy.is_some() {
+        return Err(CrossLedgerError::TrustCheckFailed {
+            ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
+            detail: "f:trustPolicy is not yet supported (Phase 4)".into(),
+        });
+    }
+    if graph_ref.rollback_guard.is_some() {
+        return Err(CrossLedgerError::TrustCheckFailed {
+            ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
+            detail: "f:rollbackGuard is not yet supported (Phase 4)".into(),
+        });
+    }
+
+    // Caller is expected to invoke this only for cross-ledger refs
+    // (graph_ref.ledger.is_some()). A same-ledger ref would be a
+    // bug at the call site, not a user-facing failure.
+    let raw_ledger_ref = graph_ref.ledger.as_deref().ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: String::new(),
+            graph_iri: graph_ref.graph_selector.clone().unwrap_or_default(),
+            detail: "resolve_graph_ref called without f:ledger; same-ledger refs \
+                    must use the local resolver"
+                .into(),
+        }
+    })?;
+
+    let graph_iri = graph_ref.graph_selector.as_deref().ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: raw_ledger_ref.to_string(),
+            graph_iri: String::new(),
+            detail: "cross-ledger references require an explicit f:graphSelector".into(),
+        }
+    })?;
+
+    // (2) Canonicalize via the nameservice. Same-instance is enforced
+    // implicitly: anything outside our nameservice can't be looked
+    // up. (Cross-instance federation would surface here as a separate
+    // resolver path; Phase next.)
+    let ns_record: NsRecord = match ctx.fluree.nameservice().lookup(raw_ledger_ref).await {
+        Ok(Some(record)) if !record.retracted => record,
+        Ok(Some(_retracted)) => {
+            return Err(CrossLedgerError::ModelLedgerMissing {
+                ledger_id: raw_ledger_ref.to_string(),
+            });
+        }
+        Ok(None) => {
+            return Err(CrossLedgerError::ModelLedgerMissing {
+                ledger_id: raw_ledger_ref.to_string(),
+            });
+        }
+        Err(e) => {
+            return Err(CrossLedgerError::TranslationFailed {
+                ledger_id: raw_ledger_ref.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!("nameservice lookup failed: {e}"),
+            });
+        }
+    };
+    let canonical_ledger_id = ns_record.ledger_id.clone();
+
+    // (3) Reserved-graph guard against the *canonical* id so an alias
+    // can't slip a #config selector through by typing it for a
+    // different alias spelling.
+    reject_if_reserved_graph(&canonical_ledger_id, graph_iri)?;
+
+    // (4) resolved_t: pinned f:atT or lazy per-request capture.
+    let resolved_t = if let Some(pinned) = graph_ref.at_t {
+        // Pinned values are NOT stored in resolved_ts; only unpinned
+        // captures are. This keeps the lazy-capture cache from being
+        // polluted by per-resolve pins.
+        pinned
+    } else if let Some(t) = ctx.resolved_ts.get(&canonical_ledger_id) {
+        *t
+    } else {
+        let head_t = ns_record.commit_t;
+        ctx.resolved_ts
+            .insert(canonical_ledger_id.clone(), head_t);
+        head_t
+    };
+
+    let tuple = (canonical_ledger_id.clone(), graph_iri.to_string(), resolved_t);
+
+    // (5) Memo hit — short-circuit cross-subsystem de-dup before
+    // entering `active`, so two subsystems referencing the same
+    // (M, graph, t) never look like a cycle to each other.
+    if let Some(hit) = memo_hit(&ctx.memo, &tuple) {
+        return Ok(hit);
+    }
+
+    // (6) Cycle check.
+    check_cycle(&ctx.active, &tuple)?;
+
+    ctx.active.push(tuple.clone());
+
+    // Materialize. Slice 3 provides the dispatch shape; the actual
+    // projector lands in slice 4.
+    let materialize_result = materialize(
+        kind,
+        &canonical_ledger_id,
+        graph_iri,
+        resolved_t,
+        ctx,
+    )
+    .await;
+
+    // Always pop active, even on error, so a failure deeper in the
+    // chain doesn't leave stale entries that trip cycle detection
+    // for unrelated subsequent calls.
+    ctx.active.pop();
+
+    let resolved = materialize_result?;
+    let arc = Arc::new(resolved);
+    ctx.memo.insert(tuple, arc.clone());
+    Ok(arc)
+}
+
+/// Dispatch per `ArtifactKind` to the subsystem-specific projector.
+///
+/// Slice 3 placeholder — every kind returns
+/// `TranslationFailed { detail: "not yet implemented" }`. Slice 4
+/// fills in `PolicyRules`; later phases add the rest.
+async fn materialize(
+    kind: ArtifactKind,
+    canonical_ledger_id: &str,
+    graph_iri: &str,
+    _resolved_t: i64,
+    _ctx: &mut ResolveCtx<'_>,
+) -> Result<ResolvedGraph, CrossLedgerError> {
+    let _ = canonical_ledger_id;
+    let _ = graph_iri;
+    let _ = kind;
+    Err(CrossLedgerError::TranslationFailed {
+        ledger_id: canonical_ledger_id.to_string(),
+        graph_iri: graph_iri.to_string(),
+        detail: format!("artifact materialization for {kind:?} not yet implemented"),
+    })
+}
+
+// The `GovernanceArtifact` enum currently has only the `PolicyRules`
+// variant; the suppression below keeps the materialization placeholder
+// honest about constructing one even while no caller does. It's
+// removed once slice 4 lands an actual producer.
+#[allow(dead_code)]
+fn _governance_artifact_construction_guard(wire: fluree_db_policy::PolicyArtifactWire) {
+    let _ = GovernanceArtifact::PolicyRules(wire);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cross_ledger::ResolveCtx;
+    use crate::FlureeBuilder;
+    use fluree_db_core::ledger_config::GraphSourceRef;
+
+    fn local_ref(graph: &str) -> GraphSourceRef {
+        GraphSourceRef {
+            ledger: None,
+            graph_selector: Some(graph.into()),
+            at_t: None,
+            trust_policy: None,
+            rollback_guard: None,
+        }
+    }
+
+    fn cross_ref(ledger: &str, graph: &str) -> GraphSourceRef {
+        GraphSourceRef {
+            ledger: Some(ledger.into()),
+            graph_selector: Some(graph.into()),
+            at_t: None,
+            trust_policy: None,
+            rollback_guard: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_ledger_field_is_a_call_site_bug() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let mut ctx = ResolveCtx::new("d:main", &fluree);
+
+        let err = resolve_graph_ref(
+            &local_ref("http://example.org/policy"),
+            ArtifactKind::PolicyRules,
+            &mut ctx,
+        )
+        .await
+        .unwrap_err();
+
+        match err {
+            CrossLedgerError::TranslationFailed { detail, .. } => {
+                assert!(detail.contains("same-ledger refs"));
+            }
+            other => panic!("expected TranslationFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_model_ledger_returns_model_ledger_missing() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let mut ctx = ResolveCtx::new("d:main", &fluree);
+
+        let err = resolve_graph_ref(
+            &cross_ref("nope:main", "http://example.org/policy"),
+            ArtifactKind::PolicyRules,
+            &mut ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, CrossLedgerError::ModelLedgerMissing { ref ledger_id } if ledger_id == "nope:main"),
+            "expected ModelLedgerMissing(nope:main), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn trust_policy_field_is_rejected_until_phase_4() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let mut ctx = ResolveCtx::new("d:main", &fluree);
+
+        let mut ref_with_trust = cross_ref("m:main", "http://example.org/policy");
+        ref_with_trust.trust_policy = Some(fluree_db_core::ledger_config::TrustPolicy {
+            trust_mode: fluree_db_core::ledger_config::TrustMode::Trusted,
+        });
+
+        let err = resolve_graph_ref(&ref_with_trust, ArtifactKind::PolicyRules, &mut ctx)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, CrossLedgerError::TrustCheckFailed { ref detail, .. } if detail.contains("Phase 4")),
+            "expected Phase-4 TrustCheckFailed, got {err:?}"
+        );
+    }
+}

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -10,8 +10,8 @@
 //! See `docs/design/cross-ledger-model-enforcement.md`.
 
 use super::types::{
-    check_cycle, memo_hit, reject_if_reserved_graph, ArtifactKind, GovernanceArtifact,
-    ResolveCtx, ResolvedGraph,
+    check_cycle, memo_hit, reject_if_reserved_graph, ArtifactKind, GovernanceArtifact, ResolveCtx,
+    ResolvedGraph,
 };
 use super::CrossLedgerError;
 use fluree_db_core::ledger_config::GraphSourceRef;
@@ -83,23 +83,27 @@ pub async fn resolve_graph_ref(
     // Caller is expected to invoke this only for cross-ledger refs
     // (graph_ref.ledger.is_some()). A same-ledger ref would be a
     // bug at the call site, not a user-facing failure.
-    let raw_ledger_ref = graph_ref.ledger.as_deref().ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
-            ledger_id: String::new(),
-            graph_iri: graph_ref.graph_selector.clone().unwrap_or_default(),
-            detail: "resolve_graph_ref called without f:ledger; same-ledger refs \
+    let raw_ledger_ref =
+        graph_ref
+            .ledger
+            .as_deref()
+            .ok_or_else(|| CrossLedgerError::TranslationFailed {
+                ledger_id: String::new(),
+                graph_iri: graph_ref.graph_selector.clone().unwrap_or_default(),
+                detail: "resolve_graph_ref called without f:ledger; same-ledger refs \
                     must use the local resolver"
-                .into(),
-        }
-    })?;
+                    .into(),
+            })?;
 
-    let graph_iri = graph_ref.graph_selector.as_deref().ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
-            ledger_id: raw_ledger_ref.to_string(),
-            graph_iri: String::new(),
-            detail: "cross-ledger references require an explicit f:graphSelector".into(),
-        }
-    })?;
+    let graph_iri =
+        graph_ref
+            .graph_selector
+            .as_deref()
+            .ok_or_else(|| CrossLedgerError::TranslationFailed {
+                ledger_id: raw_ledger_ref.to_string(),
+                graph_iri: String::new(),
+                detail: "cross-ledger references require an explicit f:graphSelector".into(),
+            })?;
 
     // (2) Canonicalize via the nameservice. Same-instance is enforced
     // implicitly: anything outside our nameservice can't be looked
@@ -142,8 +146,7 @@ pub async fn resolve_graph_ref(
         *t
     } else {
         let head_t = ns_record.commit_t;
-        ctx.resolved_ts
-            .insert(canonical_ledger_id.clone(), head_t);
+        ctx.resolved_ts.insert(canonical_ledger_id.clone(), head_t);
         head_t
     };
 
@@ -180,14 +183,8 @@ pub async fn resolve_graph_ref(
 
     // Materialize. Slice 3 provides the dispatch shape; the actual
     // projector lands in slice 4.
-    let materialize_result = materialize(
-        kind,
-        &canonical_ledger_id,
-        graph_iri,
-        resolved_t,
-        ctx,
-    )
-    .await;
+    let materialize_result =
+        materialize(kind, &canonical_ledger_id, graph_iri, resolved_t, ctx).await;
 
     // Always pop active, even on error, so a failure deeper in the
     // chain doesn't leave stale entries that trip cycle detection
@@ -364,9 +361,7 @@ mod tests {
             .await
             .unwrap_err();
         match err {
-            CrossLedgerError::UnsupportedFeature {
-                feature, phase, ..
-            } => {
+            CrossLedgerError::UnsupportedFeature { feature, phase, .. } => {
                 assert_eq!(feature, "f:atT");
                 assert_eq!(phase, "Phase 3");
             }
@@ -388,9 +383,7 @@ mod tests {
             .await
             .unwrap_err();
         match err {
-            CrossLedgerError::UnsupportedFeature {
-                feature, phase, ..
-            } => {
+            CrossLedgerError::UnsupportedFeature { feature, phase, .. } => {
                 assert_eq!(feature, "f:trustPolicy");
                 assert_eq!(phase, "Phase 4");
             }
@@ -404,17 +397,14 @@ mod tests {
         let mut ctx = ResolveCtx::new("d:main", &fluree);
 
         let mut ref_with_guard = cross_ref("m:main", "http://example.org/policy");
-        ref_with_guard.rollback_guard = Some(fluree_db_core::ledger_config::RollbackGuard {
-            min_t: Some(100),
-        });
+        ref_with_guard.rollback_guard =
+            Some(fluree_db_core::ledger_config::RollbackGuard { min_t: Some(100) });
 
         let err = resolve_graph_ref(&ref_with_guard, ArtifactKind::PolicyRules, &mut ctx)
             .await
             .unwrap_err();
         match err {
-            CrossLedgerError::UnsupportedFeature {
-                feature, phase, ..
-            } => {
+            CrossLedgerError::UnsupportedFeature { feature, phase, .. } => {
                 assert_eq!(feature, "f:rollbackGuard");
                 assert_eq!(phase, "Phase 4");
             }

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -3,8 +3,9 @@
 //! The single helper shared by every subsystem (policy / shapes /
 //! schema / rules / constraints). Materialization is dispatched per
 //! [`ArtifactKind`]; only `PolicyRules` is implemented in Phase 1a
-//! (this slice provides the orchestration skeleton — the per-kind
-//! materializer is added in slice 4).
+//! and dispatches into `policy_materializer`. Other kinds will return
+//! `CrossLedgerError::TranslationFailed` until their projector lands
+//! in a later phase.
 //!
 //! See `docs/design/cross-ledger-model-enforcement.md`.
 
@@ -21,27 +22,27 @@ use std::sync::Arc;
 ///
 /// Performs, in order:
 ///
-/// 1. Validate this is actually a cross-ledger ref (`f:ledger` set)
-///    and that unsupported Phase-4 fields (`f:trustPolicy`,
-///    `f:rollbackGuard`) are absent.
+/// 1. Reject Phase-3 and Phase-4 fields (`f:atT`, `f:trustPolicy`,
+///    `f:rollbackGuard`) with [`CrossLedgerError::UnsupportedFeature`];
+///    validate this is a cross-ledger ref (`f:ledger` and
+///    `f:graphSelector` both set).
 /// 2. Canonicalize the model ledger id via the nameservice
 ///    (`nameservice.lookup`); fail with `ModelLedgerMissing` if the
 ///    ledger is absent or retracted on this instance.
 /// 3. Reject `#config` / `#txn-meta` selectors before any storage
 ///    round-trip on M.
-/// 4. Capture `resolved_t` — `f:atT` pin if set, else lazy per-request
-///    head-t in `ctx.resolved_ts`.
-/// 5. Form the tuple `(canonical_model_ledger_id, graph_iri,
-///    resolved_t)` and check `ctx.memo`. On hit, return immediately.
-/// 6. Check `ctx.active` for cycles. On miss, push and call into the
-///    per-kind materializer.
+/// 4. Capture `resolved_t` lazily: read `ctx.resolved_ts[model_id]`
+///    on hit, else read M's head `commit_t` once and store. Pinned
+///    `f:atT` is rejected at step (1) until Phase 3.
+/// 5. Form the resolution key
+///    `(ArtifactKind, canonical_model_ledger_id, graph_iri,
+///    resolved_t)` and check `ctx.memo`. On hit, return immediately
+///    — cross-subsystem de-dup runs before cycle detection.
+/// 6. Check `ctx.active` for cycles. On miss, push and call into
+///    the per-kind materializer.
 /// 7. On materializer success, pop `active`, insert into `memo`, and
-///    return.
-///
-/// Materialization itself is not implemented in this slice — the
-/// per-kind dispatch returns
-/// `CrossLedgerError::TranslationFailed { detail: "..." }` so call
-/// sites can be wired before the projector lands.
+///    return. On failure, pop `active` so a deeper failure doesn't
+///    poison subsequent calls.
 pub async fn resolve_graph_ref(
     graph_ref: &GraphSourceRef,
     kind: ArtifactKind,

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -36,13 +36,19 @@ use std::sync::Arc;
 ///    `f:atT` is rejected at step (1) until Phase 3.
 /// 5. Form the resolution key
 ///    `(ArtifactKind, canonical_model_ledger_id, graph_iri,
-///    resolved_t)` and check `ctx.memo`. On hit, return immediately
-///    — cross-subsystem de-dup runs before cycle detection.
+///    resolved_t)` and check, in order: (a) `ctx.memo` (per-request
+///    de-dup); (b) `fluree.governance_cache()` (per-instance, shared
+///    across requests and across every data ledger that references
+///    the same (M, graph, t)). On hit at either layer, return —
+///    cross-subsystem de-dup runs before cycle detection, and a
+///    governance-cache hit is also folded into `ctx.memo` so later
+///    calls in the same request short-circuit at (a).
 /// 6. Check `ctx.active` for cycles. On miss, push and call into
 ///    the per-kind materializer.
-/// 7. On materializer success, pop `active`, insert into `memo`, and
-///    return. On failure, pop `active` so a deeper failure doesn't
-///    poison subsequent calls.
+/// 7. On materializer success, pop `active`, insert into both
+///    `ctx.memo` and `fluree.governance_cache()`, and return. On
+///    failure, pop `active` so a deeper failure doesn't poison
+///    subsequent calls.
 pub async fn resolve_graph_ref(
     graph_ref: &GraphSourceRef,
     kind: ArtifactKind,
@@ -148,12 +154,22 @@ pub async fn resolve_graph_ref(
         resolved_t,
     );
 
-    // (5) Memo hit — short-circuit cross-subsystem de-dup before
+    // (5a) Memo hit — short-circuit cross-subsystem de-dup before
     // entering `active`, so two subsystems referencing the same
     // (kind, M, graph, t) never look like a cycle to each other.
     // ArtifactKind is part of the key: a memoized PolicyRules entry
     // never short-circuits a Shapes lookup for the same graph.
     if let Some(hit) = memo_hit(&ctx.memo, &key) {
+        return Ok(hit);
+    }
+
+    // (5b) Per-instance governance cache hit — shareable across
+    // requests and across every data ledger on this instance that
+    // references the same (M, graph, t). Writeback below on miss.
+    // The per-request memo is populated alongside so subsequent
+    // resolutions in this same request short-circuit at (5a).
+    if let Some(hit) = ctx.fluree.governance_cache().get(&key) {
+        ctx.memo.insert(key.clone(), hit.clone());
         return Ok(hit);
     }
 
@@ -180,7 +196,12 @@ pub async fn resolve_graph_ref(
 
     let resolved = materialize_result?;
     let arc = Arc::new(resolved);
-    ctx.memo.insert(key, arc.clone());
+    // Write back to both the per-request memo and the per-instance
+    // cache. Subsequent calls in this same request hit the memo;
+    // subsequent calls in *other* requests on this instance hit
+    // the governance cache.
+    ctx.memo.insert(key.clone(), arc.clone());
+    ctx.fluree.governance_cache().insert(key, arc.clone());
     Ok(arc)
 }
 

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -247,6 +247,21 @@ async fn materialize(
                 artifact: GovernanceArtifact::Constraints(wire),
             })
         }
+        ArtifactKind::SchemaClosure => {
+            let wire = super::schema_materializer::materialize_schema(
+                canonical_ledger_id,
+                graph_iri,
+                resolved_t,
+                ctx.fluree,
+            )
+            .await?;
+            Ok(ResolvedGraph {
+                model_ledger_id: canonical_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                resolved_t,
+                artifact: GovernanceArtifact::SchemaClosure(wire),
+            })
+        }
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -232,6 +232,21 @@ async fn materialize(
                 artifact: GovernanceArtifact::PolicyRules(wire),
             })
         }
+        ArtifactKind::Constraints => {
+            let wire = super::constraints_materializer::materialize_constraints(
+                canonical_ledger_id,
+                graph_iri,
+                resolved_t,
+                ctx.fluree,
+            )
+            .await?;
+            Ok(ResolvedGraph {
+                model_ledger_id: canonical_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                resolved_t,
+                artifact: GovernanceArtifact::Constraints(wire),
+            })
+        }
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -47,18 +47,29 @@ pub async fn resolve_graph_ref(
     kind: ArtifactKind,
     ctx: &mut ResolveCtx<'_>,
 ) -> Result<Arc<ResolvedGraph>, CrossLedgerError> {
-    // (1) Phase-4 fields not yet supported. Surface a clear failure
-    // rather than silently ignoring them.
-    if graph_ref.trust_policy.is_some() {
-        return Err(CrossLedgerError::TrustCheckFailed {
+    // (1) Phase 3 / Phase 4 fields are parsed but not yet honored. Fail
+    // closed — partial behavior (e.g., accepting f:atT and opening M
+    // at that t with no retention check) would silently degrade the
+    // contract operators think they're getting.
+    if graph_ref.at_t.is_some() {
+        return Err(CrossLedgerError::UnsupportedFeature {
+            feature: "f:atT",
+            phase: "Phase 3",
             ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
-            detail: "f:trustPolicy is not yet supported (Phase 4)".into(),
+        });
+    }
+    if graph_ref.trust_policy.is_some() {
+        return Err(CrossLedgerError::UnsupportedFeature {
+            feature: "f:trustPolicy",
+            phase: "Phase 4",
+            ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
         });
     }
     if graph_ref.rollback_guard.is_some() {
-        return Err(CrossLedgerError::TrustCheckFailed {
+        return Err(CrossLedgerError::UnsupportedFeature {
+            feature: "f:rollbackGuard",
+            phase: "Phase 4",
             ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
-            detail: "f:rollbackGuard is not yet supported (Phase 4)".into(),
         });
     }
 
@@ -114,13 +125,13 @@ pub async fn resolve_graph_ref(
     // different alias spelling.
     reject_if_reserved_graph(&canonical_ledger_id, graph_iri)?;
 
-    // (4) resolved_t: pinned f:atT or lazy per-request capture.
-    let resolved_t = if let Some(pinned) = graph_ref.at_t {
-        // Pinned values are NOT stored in resolved_ts; only unpinned
-        // captures are. This keeps the lazy-capture cache from being
-        // polluted by per-resolve pins.
-        pinned
-    } else if let Some(t) = ctx.resolved_ts.get(&canonical_ledger_id) {
+    // (4) resolved_t: lazy per-request capture. f:atT pins are
+    // rejected at step (1) above (Phase 3, not yet implemented), so
+    // every cross-ledger reference resolves against M's current head
+    // for the duration of the request. Per-model entries are written
+    // once and reused; subsequent unpinned references to the same M
+    // in the same request hit the cache.
+    let resolved_t = if let Some(t) = ctx.resolved_ts.get(&canonical_ledger_id) {
         *t
     } else {
         let head_t = ns_record.commit_t;
@@ -263,6 +274,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn at_t_pin_is_rejected_until_phase_3() {
+        // f:atT is parsed by the config layer but Phase 3 hasn't
+        // landed the retention/pinning semantics yet. Accepting the
+        // pin and using it as the resolved_t would silently bypass
+        // the "no fallback to nearest-available" retention guard
+        // the design doc requires, so resolve_graph_ref must reject.
+        let fluree = FlureeBuilder::memory().build_memory();
+        let mut ctx = ResolveCtx::new("d:main", &fluree);
+
+        let mut pinned = cross_ref("m:main", "http://example.org/policy");
+        pinned.at_t = Some(5);
+
+        let err = resolve_graph_ref(&pinned, ArtifactKind::PolicyRules, &mut ctx)
+            .await
+            .unwrap_err();
+        match err {
+            CrossLedgerError::UnsupportedFeature {
+                feature, phase, ..
+            } => {
+                assert_eq!(feature, "f:atT");
+                assert_eq!(phase, "Phase 3");
+            }
+            other => panic!("expected UnsupportedFeature for f:atT, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn trust_policy_field_is_rejected_until_phase_4() {
         let fluree = FlureeBuilder::memory().build_memory();
         let mut ctx = ResolveCtx::new("d:main", &fluree);
@@ -275,9 +313,38 @@ mod tests {
         let err = resolve_graph_ref(&ref_with_trust, ArtifactKind::PolicyRules, &mut ctx)
             .await
             .unwrap_err();
-        assert!(
-            matches!(err, CrossLedgerError::TrustCheckFailed { ref detail, .. } if detail.contains("Phase 4")),
-            "expected Phase-4 TrustCheckFailed, got {err:?}"
-        );
+        match err {
+            CrossLedgerError::UnsupportedFeature {
+                feature, phase, ..
+            } => {
+                assert_eq!(feature, "f:trustPolicy");
+                assert_eq!(phase, "Phase 4");
+            }
+            other => panic!("expected UnsupportedFeature for f:trustPolicy, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rollback_guard_field_is_rejected_until_phase_4() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let mut ctx = ResolveCtx::new("d:main", &fluree);
+
+        let mut ref_with_guard = cross_ref("m:main", "http://example.org/policy");
+        ref_with_guard.rollback_guard = Some(fluree_db_core::ledger_config::RollbackGuard {
+            min_t: Some(100),
+        });
+
+        let err = resolve_graph_ref(&ref_with_guard, ArtifactKind::PolicyRules, &mut ctx)
+            .await
+            .unwrap_err();
+        match err {
+            CrossLedgerError::UnsupportedFeature {
+                feature, phase, ..
+            } => {
+                assert_eq!(feature, "f:rollbackGuard");
+                assert_eq!(phase, "Phase 4");
+            }
+            other => panic!("expected UnsupportedFeature for f:rollbackGuard, got {other:?}"),
+        }
     }
 }

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -167,33 +167,32 @@ pub async fn resolve_graph_ref(
 
 /// Dispatch per `ArtifactKind` to the subsystem-specific projector.
 ///
-/// Slice 3 placeholder — every kind returns
-/// `TranslationFailed { detail: "not yet implemented" }`. Slice 4
-/// fills in `PolicyRules`; later phases add the rest.
+/// Phase 1a implements `PolicyRules`; other kinds land in later
+/// phases per the design doc's phasing table.
 async fn materialize(
     kind: ArtifactKind,
     canonical_ledger_id: &str,
     graph_iri: &str,
-    _resolved_t: i64,
-    _ctx: &mut ResolveCtx<'_>,
+    resolved_t: i64,
+    ctx: &mut ResolveCtx<'_>,
 ) -> Result<ResolvedGraph, CrossLedgerError> {
-    let _ = canonical_ledger_id;
-    let _ = graph_iri;
-    let _ = kind;
-    Err(CrossLedgerError::TranslationFailed {
-        ledger_id: canonical_ledger_id.to_string(),
-        graph_iri: graph_iri.to_string(),
-        detail: format!("artifact materialization for {kind:?} not yet implemented"),
-    })
-}
-
-// The `GovernanceArtifact` enum currently has only the `PolicyRules`
-// variant; the suppression below keeps the materialization placeholder
-// honest about constructing one even while no caller does. It's
-// removed once slice 4 lands an actual producer.
-#[allow(dead_code)]
-fn _governance_artifact_construction_guard(wire: fluree_db_policy::PolicyArtifactWire) {
-    let _ = GovernanceArtifact::PolicyRules(wire);
+    match kind {
+        ArtifactKind::PolicyRules => {
+            let wire = super::policy_materializer::materialize_policy_rules(
+                canonical_ledger_id,
+                graph_iri,
+                resolved_t,
+                ctx.fluree,
+            )
+            .await?;
+            Ok(ResolvedGraph {
+                model_ledger_id: canonical_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                resolved_t,
+                artifact: GovernanceArtifact::PolicyRules(wire),
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/fluree-db-api/src/cross_ledger/resolver.rs
+++ b/fluree-db-api/src/cross_ledger/resolver.rs
@@ -54,35 +54,12 @@ pub async fn resolve_graph_ref(
     kind: ArtifactKind,
     ctx: &mut ResolveCtx<'_>,
 ) -> Result<Arc<ResolvedGraph>, CrossLedgerError> {
-    // (1) Phase 3 / Phase 4 fields are parsed but not yet honored. Fail
-    // closed — partial behavior (e.g., accepting f:atT and opening M
-    // at that t with no retention check) would silently degrade the
-    // contract operators think they're getting.
-    if graph_ref.at_t.is_some() {
-        return Err(CrossLedgerError::UnsupportedFeature {
-            feature: "f:atT",
-            phase: "Phase 3",
-            ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
-        });
-    }
-    if graph_ref.trust_policy.is_some() {
-        return Err(CrossLedgerError::UnsupportedFeature {
-            feature: "f:trustPolicy",
-            phase: "Phase 4",
-            ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
-        });
-    }
-    if graph_ref.rollback_guard.is_some() {
-        return Err(CrossLedgerError::UnsupportedFeature {
-            feature: "f:rollbackGuard",
-            phase: "Phase 4",
-            ledger_id: graph_ref.ledger.clone().unwrap_or_default(),
-        });
-    }
-
-    // Caller is expected to invoke this only for cross-ledger refs
-    // (graph_ref.ledger.is_some()). A same-ledger ref would be a
-    // bug at the call site, not a user-facing failure.
+    // (0) `resolve_graph_ref` is the cross-ledger dispatcher. A
+    // same-ledger ref hitting this path is a caller bug — fail with
+    // `TranslationFailed` carrying the offending selector so the
+    // error names the actual problem, rather than degrading into a
+    // downstream `UnsupportedFeature` error whose `ledger_id` would
+    // be empty.
     let raw_ledger_ref =
         graph_ref
             .ledger
@@ -94,6 +71,34 @@ pub async fn resolve_graph_ref(
                     must use the local resolver"
                     .into(),
             })?;
+
+    // (1) Phase 3 / Phase 4 fields are parsed but not yet honored. Fail
+    // closed — partial behavior (e.g., accepting f:atT and opening M
+    // at that t with no retention check) would silently degrade the
+    // contract operators think they're getting. `raw_ledger_ref` is
+    // now guaranteed Some, so the error messages carry a real ledger
+    // id.
+    if graph_ref.at_t.is_some() {
+        return Err(CrossLedgerError::UnsupportedFeature {
+            feature: "f:atT",
+            phase: "Phase 3",
+            ledger_id: raw_ledger_ref.to_string(),
+        });
+    }
+    if graph_ref.trust_policy.is_some() {
+        return Err(CrossLedgerError::UnsupportedFeature {
+            feature: "f:trustPolicy",
+            phase: "Phase 4",
+            ledger_id: raw_ledger_ref.to_string(),
+        });
+    }
+    if graph_ref.rollback_guard.is_some() {
+        return Err(CrossLedgerError::UnsupportedFeature {
+            feature: "f:rollbackGuard",
+            phase: "Phase 4",
+            ledger_id: raw_ledger_ref.to_string(),
+        });
+    }
 
     let graph_iri =
         graph_ref
@@ -197,6 +202,16 @@ pub async fn resolve_graph_ref(
     // cache. Subsequent calls in this same request hit the memo;
     // subsequent calls in *other* requests on this instance hit
     // the governance cache.
+    //
+    // Benign read/write race: two concurrent requests can both
+    // miss at (5b), each materialize independently, and each
+    // write its own `Arc`. The cache ends up holding whichever
+    // write completed last; the loser's `Arc` is dropped when
+    // its request finishes. Wire artifacts are pure functions of
+    // `(kind, model_ledger, graph, resolved_t)`, so the two
+    // materialized values are structurally identical — duplicate
+    // work, not duplicate semantics. Single-flight is a possible
+    // future optimization but not a correctness requirement.
     ctx.memo.insert(key.clone(), arc.clone());
     ctx.fluree.governance_cache().insert(key, arc.clone());
     Ok(arc)

--- a/fluree-db-api/src/cross_ledger/rules_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/rules_materializer.rs
@@ -35,7 +35,7 @@ pub(super) async fn materialize_rules(
             detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
-    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri)?.ok_or_else(|| {
         CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),

--- a/fluree-db-api/src/cross_ledger/rules_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/rules_materializer.rs
@@ -20,6 +20,16 @@ use crate::Fluree;
 use fluree_db_core::{FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest};
 use fluree_vocab::fluree::RULE;
 
+#[tracing::instrument(
+    name = "cross_ledger.rules.materialize",
+    level = "debug",
+    skip(fluree),
+    fields(
+        model_ledger = canonical_model_ledger_id,
+        graph_iri = graph_iri,
+        resolved_t = resolved_t,
+    ),
+)]
 pub(super) async fn materialize_rules(
     canonical_model_ledger_id: &str,
     graph_iri: &str,

--- a/fluree-db-api/src/cross_ledger/rules_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/rules_materializer.rs
@@ -1,0 +1,97 @@
+//! Cross-ledger datalog rules materialization.
+//!
+//! Reads M's rules graph at `resolved_t` and projects every
+//! `f:rule` flake whose object is `FlakeValue::Json` into the
+//! cross-ledger wire form. Unlike the schema / shapes / constraints
+//! paths, rules need no term-space translation: the JSON body
+//! references IRIs that
+//! [`fluree_db_query::datalog_rules::parse_query_time_rule`] resolves
+//! against the data ledger's snapshot at query time, the same way
+//! `opts.rules` are handled.
+//!
+//! Non-JSON values on `f:rule` are silently skipped — the local
+//! extractor (`fluree_db_query::datalog_rules::extract_datalog_rules`)
+//! does the same. A future variant could surface these as a warn
+//! when authors mistype the rule literal.
+
+use super::types::{RulesArtifactWire, WireOrigin};
+use super::CrossLedgerError;
+use crate::Fluree;
+use fluree_db_core::{FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest};
+use fluree_vocab::fluree::RULE;
+
+pub(super) async fn materialize_rules(
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+    resolved_t: i64,
+    fluree: &Fluree,
+) -> Result<RulesArtifactWire, CrossLedgerError> {
+    let m_db = fluree
+        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
+        })?;
+
+    let g_id = m_db
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(graph_iri)
+        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        })?;
+
+    // No `f:rule` predicate in M's namespace map → M never authored
+    // rules. Treat the same as an empty rule set so the caller's
+    // downstream merge is a no-op.
+    let Some(rule_pred_sid) = m_db.snapshot.encode_iri(RULE) else {
+        return Ok(RulesArtifactWire {
+            origin: WireOrigin {
+                model_ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                resolved_t,
+            },
+            rules: Vec::new(),
+        });
+    };
+
+    let opts = RangeOptions::default().with_to_t(m_db.t);
+    let flakes = fluree_db_core::range_with_overlay(
+        &m_db.snapshot,
+        g_id,
+        m_db.overlay.as_ref(),
+        IndexType::Psot,
+        RangeTest::Eq,
+        RangeMatch::predicate(rule_pred_sid),
+        opts,
+    )
+    .await
+    .map_err(|e| CrossLedgerError::TranslationFailed {
+        ledger_id: canonical_model_ledger_id.to_string(),
+        graph_iri: graph_iri.to_string(),
+        detail: format!("f:rule predicate scan failed: {e}"),
+    })?;
+
+    let mut rules: Vec<String> = Vec::new();
+    for f in flakes.into_iter().filter(|f| f.op) {
+        if let FlakeValue::Json(json_str) = &f.o {
+            rules.push(json_str.clone());
+        }
+        // Non-Json values are silently skipped, mirroring the
+        // same-ledger extractor's `if let FlakeValue::Json(...)`
+        // guard.
+    }
+
+    Ok(RulesArtifactWire {
+        origin: WireOrigin {
+            model_ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        },
+        rules,
+    })
+}

--- a/fluree-db-api/src/cross_ledger/rules_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/rules_materializer.rs
@@ -27,7 +27,7 @@ pub(super) async fn materialize_rules(
     fluree: &Fluree,
 ) -> Result<RulesArtifactWire, CrossLedgerError> {
     let m_db = fluree
-        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .load_graph_db_at_t(canonical_model_ledger_id, resolved_t)
         .await
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),

--- a/fluree-db-api/src/cross_ledger/rules_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/rules_materializer.rs
@@ -35,15 +35,13 @@ pub(super) async fn materialize_rules(
             detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
-    let g_id = m_db
-        .snapshot
-        .graph_registry
-        .graph_id_for_iri(graph_iri)
-        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+        CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             resolved_t,
-        })?;
+        }
+    })?;
 
     // No `f:rule` predicate in M's namespace map → M never authored
     // rules. Treat the same as an empty rule set so the caller's

--- a/fluree-db-api/src/cross_ledger/rules_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/rules_materializer.rs
@@ -56,7 +56,7 @@ pub(super) async fn materialize_rules(
     // No `f:rule` predicate in M's namespace map → M never authored
     // rules. Treat the same as an empty rule set so the caller's
     // downstream merge is a no-op.
-    let Some(rule_pred_sid) = m_db.snapshot.encode_iri(RULE) else {
+    let Some(rule_pred_sid) = m_db.snapshot.encode_iri_strict(RULE) else {
         return Ok(RulesArtifactWire {
             origin: WireOrigin {
                 model_ledger_id: canonical_model_ledger_id.to_string(),

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -42,16 +42,15 @@ pub(super) async fn materialize_schema(
             detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
-    // 2. Resolve graph_iri → g_id in M's graph registry.
-    let g_id = m_db
-        .snapshot
-        .graph_registry
-        .graph_id_for_iri(graph_iri)
-        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+    // 2. Resolve graph_iri → g_id in M's graph registry (handling
+    //    `f:defaultGraph` as g_id=0).
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+        CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             resolved_t,
-        })?;
+        }
+    })?;
 
     // 3. Encode the whitelist IRIs against M's namespace map. Same
     //    whitelist as fluree_db_query::schema_bundle::build_schema_bundle_flakes

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -1,0 +1,251 @@
+//! Cross-ledger schema/ontology materialization.
+//!
+//! Reads M's schema graph at `resolved_t` and projects the
+//! whitelisted ontology axiom triples (rdfs:subClassOf,
+//! owl:equivalentClass, owl:imports, rdf:type for owl:Class /
+//! owl:ObjectProperty / etc., and the rest of the schema-bundle
+//! whitelist) into a term-neutral [`SchemaArtifactWire`]. The
+//! translator on D encodes each IRI against D's snapshot and
+//! builds a `SchemaBundleFlakes` for the reasoner.
+//!
+//! Phase 1b-a scope: single graph only. The `owl:imports` triples
+//! are projected (so a future reader can see what imports M
+//! declared) but the resolver does NOT recursively walk them
+//! across ledgers. Transitive cross-ledger imports land in a
+//! follow-up.
+
+use super::types::{SchemaArtifactWire, WireOrigin, WireTriple};
+use super::CrossLedgerError;
+use crate::Fluree;
+use fluree_db_core::{
+    is_rdf_type, is_schema_class, is_schema_predicate, FlakeValue, IndexType, LedgerSnapshot,
+    RangeMatch, RangeOptions, RangeTest, Sid,
+};
+
+/// Materialize the schema graph at `graph_iri` in model ledger `M`
+/// at `resolved_t` into a `SchemaArtifactWire`.
+pub(super) async fn materialize_schema(
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+    resolved_t: i64,
+    fluree: &Fluree,
+) -> Result<SchemaArtifactWire, CrossLedgerError> {
+    use fluree_vocab::{owl, rdf, rdfs};
+
+    // 1. Open M at resolved_t.
+    let m_db = fluree
+        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "failed to open model ledger snapshot at t={resolved_t}: {e}"
+            ),
+        })?;
+
+    // 2. Resolve graph_iri → g_id in M's graph registry.
+    let g_id = m_db
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(graph_iri)
+        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        })?;
+
+    // 3. Encode the whitelist IRIs against M's namespace map. Same
+    //    whitelist as fluree_db_query::schema_bundle::build_schema_bundle_flakes
+    //    so cross-ledger and same-ledger see the same axiom subset.
+    //    IRIs M's namespace map has never seen are silently skipped
+    //    (they contribute nothing to the projection).
+    let schema_predicate_iris: &[&str] = &[
+        rdfs::SUB_CLASS_OF,
+        rdfs::SUB_PROPERTY_OF,
+        rdfs::DOMAIN,
+        rdfs::RANGE,
+        owl::INVERSE_OF,
+        owl::EQUIVALENT_CLASS,
+        owl::EQUIVALENT_PROPERTY,
+        owl::SAME_AS,
+        owl::IMPORTS,
+    ];
+    let schema_class_iris: &[&str] = &[
+        owl::CLASS,
+        owl::OBJECT_PROPERTY,
+        owl::DATATYPE_PROPERTY,
+        owl::SYMMETRIC_PROPERTY,
+        owl::TRANSITIVE_PROPERTY,
+        owl::FUNCTIONAL_PROPERTY,
+        owl::INVERSE_FUNCTIONAL_PROPERTY,
+        owl::ONTOLOGY,
+        rdf::PROPERTY,
+    ];
+
+    let schema_predicates: Vec<Sid> = schema_predicate_iris
+        .iter()
+        .filter_map(|iri| m_db.snapshot.encode_iri(iri))
+        .collect();
+    let schema_classes: Vec<Sid> = schema_class_iris
+        .iter()
+        .filter_map(|iri| m_db.snapshot.encode_iri(iri))
+        .collect();
+    let rdf_type_sid = m_db.snapshot.encode_iri(rdf::TYPE);
+
+    // 4. Build M's view at the requested graph + t.
+    let m_view = fluree_db_core::GraphDbRef::new(
+        &m_db.snapshot,
+        g_id,
+        m_db.overlay.as_ref(),
+        m_db.t,
+    );
+    let opts = RangeOptions::default().with_to_t(m_db.t);
+
+    // 5. Per-predicate PSOT scans for hierarchy / OWL axioms; per-
+    //    class OPST scans for declarations like `?p a owl:Class`.
+    //    For each matching flake, decode its s/p/o Sids to IRIs and
+    //    push a WireTriple. A Sid that fails to decode surfaces as
+    //    TranslationFailed — dropping the axiom would weaken the
+    //    schema observably.
+    let mut triples: Vec<WireTriple> = Vec::new();
+
+    for p_sid in &schema_predicates {
+        let flakes = fluree_db_core::range_with_overlay(
+            &m_db.snapshot,
+            g_id,
+            m_db.overlay.as_ref(),
+            IndexType::Psot,
+            RangeTest::Eq,
+            RangeMatch::predicate(p_sid.clone()),
+            opts.clone(),
+        )
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("schema predicate scan failed: {e}"),
+        })?;
+        for f in flakes.into_iter().filter(|f| f.op) {
+            if !is_schema_predicate(&f.p) {
+                continue; // defense in depth
+            }
+            push_ref_triple(
+                &mut triples,
+                &m_db.snapshot,
+                &f.s,
+                &f.p,
+                &f.o,
+                canonical_model_ledger_id,
+                graph_iri,
+            )?;
+        }
+    }
+
+    if let Some(ref rdf_type) = rdf_type_sid {
+        for cls in &schema_classes {
+            let flakes = fluree_db_core::range_with_overlay(
+                &m_db.snapshot,
+                g_id,
+                m_db.overlay.as_ref(),
+                IndexType::Opst,
+                RangeTest::Eq,
+                RangeMatch {
+                    p: Some(rdf_type.clone()),
+                    o: Some(FlakeValue::Ref(cls.clone())),
+                    ..Default::default()
+                },
+                opts.clone(),
+            )
+            .await
+            .map_err(|e| CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!("schema class rdf:type scan failed: {e}"),
+            })?;
+            for f in flakes.into_iter().filter(|f| f.op) {
+                if !is_rdf_type(&f.p) {
+                    continue;
+                }
+                let FlakeValue::Ref(ref obj) = f.o else { continue };
+                if !is_schema_class(obj) {
+                    continue;
+                }
+                push_ref_triple(
+                    &mut triples,
+                    &m_db.snapshot,
+                    &f.s,
+                    &f.p,
+                    &f.o,
+                    canonical_model_ledger_id,
+                    graph_iri,
+                )?;
+            }
+        }
+    }
+
+    let _ = m_view; // ensures the GraphDbRef binding is consumed; the
+                   // per-predicate scans hit range_with_overlay directly
+                   // for parity with build_schema_bundle_flakes.
+
+    Ok(SchemaArtifactWire {
+        origin: WireOrigin {
+            model_ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        },
+        triples,
+    })
+}
+
+/// Decode a (s, p, o-as-Ref) flake into a `WireTriple` of IRIs and
+/// append to `out`. Returns `TranslationFailed` if any of the three
+/// Sids can't be decoded — losing a schema axiom would weaken
+/// reasoning observably, so silent drop is wrong here even though
+/// it's accepted at the encode-side (unseen IRIs on M's namespace
+/// map are filtered earlier by `encode_iri` returning `None`).
+fn push_ref_triple(
+    out: &mut Vec<WireTriple>,
+    snapshot: &LedgerSnapshot,
+    s: &Sid,
+    p: &Sid,
+    o: &FlakeValue,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<(), CrossLedgerError> {
+    let FlakeValue::Ref(o_sid) = o else {
+        // Schema whitelist is Ref-valued in practice (rdfs:domain,
+        // rdfs:range, owl:equivalentClass, owl:imports, etc., all
+        // point at classes/properties/ontology resources). A
+        // literal-valued axiom in the whitelist is structurally
+        // unexpected and silently skipped for Phase 1b-a.
+        return Ok(());
+    };
+    let s_iri = snapshot.decode_sid(s).ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("could not decode schema subject Sid {s:?}"),
+        }
+    })?;
+    let p_iri = snapshot.decode_sid(p).ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("could not decode schema predicate Sid {p:?}"),
+        }
+    })?;
+    let o_iri = snapshot.decode_sid(o_sid).ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("could not decode schema object Sid {o_sid:?}"),
+        }
+    })?;
+    out.push(WireTriple {
+        s: s_iri,
+        p: p_iri,
+        o: o_iri,
+    });
+    Ok(())
+}

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -44,7 +44,7 @@ pub(super) async fn materialize_schema(
 
     // 2. Resolve graph_iri → g_id in M's graph registry (handling
     //    `f:defaultGraph` as g_id=0).
-    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri)?.ok_or_else(|| {
         CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -34,7 +34,7 @@ pub(super) async fn materialize_schema(
 
     // 1. Open M at resolved_t.
     let m_db = fluree
-        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .load_graph_db_at_t(canonical_model_ledger_id, resolved_t)
         .await
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -39,9 +39,7 @@ pub(super) async fn materialize_schema(
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
-            detail: format!(
-                "failed to open model ledger snapshot at t={resolved_t}: {e}"
-            ),
+            detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
     // 2. Resolve graph_iri → g_id in M's graph registry.
@@ -94,12 +92,8 @@ pub(super) async fn materialize_schema(
     let rdf_type_sid = m_db.snapshot.encode_iri(rdf::TYPE);
 
     // 4. Build M's view at the requested graph + t.
-    let m_view = fluree_db_core::GraphDbRef::new(
-        &m_db.snapshot,
-        g_id,
-        m_db.overlay.as_ref(),
-        m_db.t,
-    );
+    let m_view =
+        fluree_db_core::GraphDbRef::new(&m_db.snapshot, g_id, m_db.overlay.as_ref(), m_db.t);
     let opts = RangeOptions::default().with_to_t(m_db.t);
 
     // 5. Per-predicate PSOT scans for hierarchy / OWL axioms; per-
@@ -167,7 +161,9 @@ pub(super) async fn materialize_schema(
                 if !is_rdf_type(&f.p) {
                     continue;
                 }
-                let FlakeValue::Ref(ref obj) = f.o else { continue };
+                let FlakeValue::Ref(ref obj) = f.o else {
+                    continue;
+                };
                 if !is_schema_class(obj) {
                     continue;
                 }
@@ -185,8 +181,8 @@ pub(super) async fn materialize_schema(
     }
 
     let _ = m_view; // ensures the GraphDbRef binding is consumed; the
-                   // per-predicate scans hit range_with_overlay directly
-                   // for parity with build_schema_bundle_flakes.
+                    // per-predicate scans hit range_with_overlay directly
+                    // for parity with build_schema_bundle_flakes.
 
     Ok(SchemaArtifactWire {
         origin: WireOrigin {
@@ -221,27 +217,27 @@ fn push_ref_triple(
         // unexpected and silently skipped for Phase 1b-a.
         return Ok(());
     };
-    let s_iri = snapshot.decode_sid(s).ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
+    let s_iri = snapshot
+        .decode_sid(s)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             detail: format!("could not decode schema subject Sid {s:?}"),
-        }
-    })?;
-    let p_iri = snapshot.decode_sid(p).ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
+        })?;
+    let p_iri = snapshot
+        .decode_sid(p)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             detail: format!("could not decode schema predicate Sid {p:?}"),
-        }
-    })?;
-    let o_iri = snapshot.decode_sid(o_sid).ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
+        })?;
+    let o_iri = snapshot
+        .decode_sid(o_sid)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             detail: format!("could not decode schema object Sid {o_sid:?}"),
-        }
-    })?;
+        })?;
     out.push(WireTriple {
         s: s_iri,
         p: p_iri,

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -14,7 +14,7 @@
 //! across ledgers. Transitive cross-ledger imports land in a
 //! follow-up.
 
-use super::types::{SchemaArtifactWire, WireOrigin, WireTriple};
+use super::types::{SchemaArtifactWire, WireObject, WireOrigin, WireTriple};
 use super::CrossLedgerError;
 use crate::Fluree;
 use fluree_db_core::{
@@ -245,7 +245,7 @@ fn push_ref_triple(
     out.push(WireTriple {
         s: s_iri,
         p: p_iri,
-        o: o_iri,
+        o: WireObject::Ref(o_iri),
     });
     Ok(())
 }

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -24,6 +24,16 @@ use fluree_db_core::{
 
 /// Materialize the schema graph at `graph_iri` in model ledger `M`
 /// at `resolved_t` into a `SchemaArtifactWire`.
+#[tracing::instrument(
+    name = "cross_ledger.schema.materialize",
+    level = "debug",
+    skip(fluree),
+    fields(
+        model_ledger = canonical_model_ledger_id,
+        graph_iri = graph_iri,
+        resolved_t = resolved_t,
+    ),
+)]
 pub(super) async fn materialize_schema(
     canonical_model_ledger_id: &str,
     graph_iri: &str,

--- a/fluree-db-api/src/cross_ledger/schema_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/schema_materializer.rs
@@ -92,13 +92,13 @@ pub(super) async fn materialize_schema(
 
     let schema_predicates: Vec<Sid> = schema_predicate_iris
         .iter()
-        .filter_map(|iri| m_db.snapshot.encode_iri(iri))
+        .filter_map(|iri| m_db.snapshot.encode_iri_strict(iri))
         .collect();
     let schema_classes: Vec<Sid> = schema_class_iris
         .iter()
-        .filter_map(|iri| m_db.snapshot.encode_iri(iri))
+        .filter_map(|iri| m_db.snapshot.encode_iri_strict(iri))
         .collect();
-    let rdf_type_sid = m_db.snapshot.encode_iri(rdf::TYPE);
+    let rdf_type_sid = m_db.snapshot.encode_iri_strict(rdf::TYPE);
 
     // 4. Build M's view at the requested graph + t.
     let m_view =

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -186,7 +186,15 @@ fn push_triple(
             graph_iri: graph_iri.to_string(),
             detail: format!("could not decode shape predicate Sid {:?}", f.p),
         })?;
-    let o = encode_object(&f.o, &f.dt, snapshot, canonical_model_ledger_id, graph_iri)?;
+    let lang = f.m.as_ref().and_then(|m| m.lang.clone());
+    let o = encode_object(
+        &f.o,
+        &f.dt,
+        lang,
+        snapshot,
+        canonical_model_ledger_id,
+        graph_iri,
+    )?;
     out.push(WireTriple {
         s: s_iri,
         p: p_iri,
@@ -198,6 +206,7 @@ fn push_triple(
 fn encode_object(
     o: &FlakeValue,
     dt: &Sid,
+    lang: Option<String>,
     snapshot: &LedgerSnapshot,
     canonical_model_ledger_id: &str,
     graph_iri: &str,
@@ -213,28 +222,78 @@ fn encode_object(
                 })?;
         return Ok(WireObject::Ref(iri));
     }
-    let datatype_iri = snapshot
-        .decode_sid(dt)
-        .unwrap_or_else(|| "http://www.w3.org/2001/XMLSchema#string".to_string());
-    let value = flake_value_to_lexical(o);
+    // Fail-closed on datatype decode. M's snapshot owns the dt Sid
+    // it stored; if `decode_sid` returns None the snapshot is
+    // corrupt or the dt Sid is otherwise unresolvable — silently
+    // coercing every such literal to `xsd:string` would change
+    // the shape's `sh:datatype` semantics (a `sh:datatype
+    // xsd:integer` would collapse into a string-typed value that
+    // matches differently on D).
+    let datatype_iri =
+        snapshot
+            .decode_sid(dt)
+            .ok_or_else(|| CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!("could not decode shape literal datatype Sid {dt:?}"),
+            })?;
+    let value = flake_value_to_lexical(o, canonical_model_ledger_id, graph_iri)?;
     Ok(WireObject::Literal {
         value,
         datatype: datatype_iri,
-        lang: None,
+        lang,
     })
 }
 
-fn flake_value_to_lexical(o: &FlakeValue) -> String {
-    match o {
+/// Render a [`FlakeValue`] into its canonical xsd lexical form for
+/// the wire. Every variant has an explicit case so the wire can be
+/// round-tripped on D without fidelity loss. Variants without a
+/// canonical lexical form for SHACL purposes (`Vector`, `GeoPoint`)
+/// surface as `TranslationFailed` — `sh:hasValue` on a non-XSD
+/// custom Fluree datatype is out of scope for cross-ledger shapes
+/// and must be flagged rather than fall through to a
+/// `Debug`-formatted lossy string.
+fn flake_value_to_lexical(
+    o: &FlakeValue,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<String, CrossLedgerError> {
+    Ok(match o {
         FlakeValue::String(s) => s.clone(),
         FlakeValue::Boolean(b) => b.to_string(),
         FlakeValue::Long(n) => n.to_string(),
         FlakeValue::Double(f) => f.to_string(),
         FlakeValue::BigInt(b) => b.to_string(),
         FlakeValue::Decimal(d) => d.to_string(),
+        FlakeValue::DateTime(v) => v.to_string(),
+        FlakeValue::Date(v) => v.to_string(),
+        FlakeValue::Time(v) => v.to_string(),
+        FlakeValue::GYear(v) => v.to_string(),
+        FlakeValue::GYearMonth(v) => v.to_string(),
+        FlakeValue::GMonth(v) => v.to_string(),
+        FlakeValue::GDay(v) => v.to_string(),
+        FlakeValue::GMonthDay(v) => v.to_string(),
+        FlakeValue::YearMonthDuration(v) => v.to_string(),
+        FlakeValue::DayTimeDuration(v) => v.to_string(),
+        FlakeValue::Duration(v) => v.to_string(),
         FlakeValue::Json(s) => s.clone(),
         FlakeValue::Null => String::new(),
         FlakeValue::Ref(_) => unreachable!("Ref handled at encode_object"),
-        other => format!("{other:?}"),
-    }
+        FlakeValue::Vector(_) | FlakeValue::GeoPoint(_) => {
+            return Err(CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!(
+                    "shape literal uses a Fluree-specific datatype \
+                     (`{}`) that has no canonical xsd lexical form for \
+                     cross-ledger transport",
+                    match o {
+                        FlakeValue::Vector(_) => "Vector",
+                        FlakeValue::GeoPoint(_) => "GeoPoint",
+                        _ => unreachable!(),
+                    }
+                ),
+            });
+        }
+    })
 }

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -30,7 +30,7 @@ pub(super) async fn materialize_shapes(
     fluree: &Fluree,
 ) -> Result<ShapesArtifactWire, CrossLedgerError> {
     let m_db = fluree
-        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .load_graph_db_at_t(canonical_model_ledger_id, resolved_t)
         .await
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -38,15 +38,13 @@ pub(super) async fn materialize_shapes(
             detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
-    let g_id = m_db
-        .snapshot
-        .graph_registry
-        .graph_id_for_iri(graph_iri)
-        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+        CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             resolved_t,
-        })?;
+        }
+    })?;
 
     // SHACL whitelist — mirrors fluree_db_shacl::ShapeCompiler::compile_from_dbs
     let shacl_predicate_names: &[&str] = &[

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -1,0 +1,212 @@
+//! Cross-ledger SHACL shapes materialization.
+//!
+//! Reads M's shapes graph at `resolved_t` and projects the SHACL
+//! vocabulary triples (the same whitelist `ShapeCompiler` uses
+//! same-ledger) plus the `rdf:first` / `rdf:rest` internals used by
+//! `sh:in` / `sh:and` / `sh:or` / `sh:xone` list expansion. Object
+//! positions handle both `Ref` (sh:targetClass, sh:path, sh:class,
+//! sh:datatype, ...) and `Literal` (sh:minCount, sh:pattern,
+//! sh:message, ...) via [`WireObject`].
+//!
+//! The translation step on the data ledger side is in
+//! `ShapesArtifactWire::translate_to_schema_bundle_flakes` and
+//! must use the *staged* `NamespaceRegistry`, not D's pre-staging
+//! snapshot. See that method's docs for why.
+
+use super::types::{ShapesArtifactWire, WireObject, WireOrigin, WireTriple};
+use super::CrossLedgerError;
+use crate::Fluree;
+use fluree_db_core::{
+    FlakeValue, IndexType, LedgerSnapshot, RangeMatch, RangeOptions, RangeTest, Sid,
+};
+
+const SHACL: &str = "http://www.w3.org/ns/shacl#";
+const RDF: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+pub(super) async fn materialize_shapes(
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+    resolved_t: i64,
+    fluree: &Fluree,
+) -> Result<ShapesArtifactWire, CrossLedgerError> {
+    let m_db = fluree
+        .db_at_t(canonical_model_ledger_id, resolved_t)
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!(
+                "failed to open model ledger snapshot at t={resolved_t}: {e}"
+            ),
+        })?;
+
+    let g_id = m_db
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(graph_iri)
+        .ok_or_else(|| CrossLedgerError::GraphMissingAtT {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        })?;
+
+    // SHACL whitelist — mirrors fluree_db_shacl::ShapeCompiler::compile_from_dbs
+    let shacl_predicate_names: &[&str] = &[
+        "targetClass", "targetNode", "targetSubjectsOf", "targetObjectsOf",
+        "property", "path",
+        "minCount", "maxCount",
+        "datatype", "nodeKind", "class",
+        "minInclusive", "maxInclusive", "minExclusive", "maxExclusive",
+        "pattern", "flags", "minLength", "maxLength",
+        "hasValue", "in",
+        "equals", "disjoint", "lessThan", "lessThanOrEquals",
+        "closed", "ignoredProperties",
+        "uniqueLang", "languageIn",
+        "not", "and", "or", "xone",
+        "severity", "message", "name",
+    ];
+
+    let mut shacl_predicate_sids: Vec<Sid> = Vec::new();
+    for name in shacl_predicate_names {
+        if let Some(sid) = m_db.snapshot.encode_iri(&format!("{SHACL}{name}")) {
+            shacl_predicate_sids.push(sid);
+        }
+    }
+    let rdf_first_sid = m_db.snapshot.encode_iri(&format!("{RDF}first"));
+    let rdf_rest_sid = m_db.snapshot.encode_iri(&format!("{RDF}rest"));
+
+    let opts = RangeOptions::default().with_to_t(m_db.t);
+    let mut triples: Vec<WireTriple> = Vec::new();
+
+    for p_sid in &shacl_predicate_sids {
+        let flakes = fluree_db_core::range_with_overlay(
+            &m_db.snapshot,
+            g_id,
+            m_db.overlay.as_ref(),
+            IndexType::Psot,
+            RangeTest::Eq,
+            RangeMatch::predicate(p_sid.clone()),
+            opts.clone(),
+        )
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("SHACL predicate scan failed: {e}"),
+        })?;
+        for f in flakes.into_iter().filter(|f| f.op) {
+            push_triple(
+                &mut triples,
+                &m_db.snapshot,
+                &f,
+                canonical_model_ledger_id,
+                graph_iri,
+            )?;
+        }
+    }
+
+    for opt_sid in [rdf_first_sid, rdf_rest_sid].iter().filter_map(|s| s.as_ref()) {
+        let flakes = fluree_db_core::range_with_overlay(
+            &m_db.snapshot,
+            g_id,
+            m_db.overlay.as_ref(),
+            IndexType::Psot,
+            RangeTest::Eq,
+            RangeMatch::predicate(opt_sid.clone()),
+            opts.clone(),
+        )
+        .await
+        .map_err(|e| CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("rdf:first/rdf:rest scan failed: {e}"),
+        })?;
+        for f in flakes.into_iter().filter(|f| f.op) {
+            push_triple(
+                &mut triples,
+                &m_db.snapshot,
+                &f,
+                canonical_model_ledger_id,
+                graph_iri,
+            )?;
+        }
+    }
+
+    Ok(ShapesArtifactWire {
+        origin: WireOrigin {
+            model_ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            resolved_t,
+        },
+        triples,
+    })
+}
+
+fn push_triple(
+    out: &mut Vec<WireTriple>,
+    snapshot: &LedgerSnapshot,
+    f: &fluree_db_core::flake::Flake,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<(), CrossLedgerError> {
+    let s_iri = snapshot.decode_sid(&f.s).ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("could not decode shape subject Sid {:?}", f.s),
+        }
+    })?;
+    let p_iri = snapshot.decode_sid(&f.p).ok_or_else(|| {
+        CrossLedgerError::TranslationFailed {
+            ledger_id: canonical_model_ledger_id.to_string(),
+            graph_iri: graph_iri.to_string(),
+            detail: format!("could not decode shape predicate Sid {:?}", f.p),
+        }
+    })?;
+    let o = encode_object(&f.o, &f.dt, snapshot, canonical_model_ledger_id, graph_iri)?;
+    out.push(WireTriple { s: s_iri, p: p_iri, o });
+    Ok(())
+}
+
+fn encode_object(
+    o: &FlakeValue,
+    dt: &Sid,
+    snapshot: &LedgerSnapshot,
+    canonical_model_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<WireObject, CrossLedgerError> {
+    if let FlakeValue::Ref(o_sid) = o {
+        let iri = snapshot.decode_sid(o_sid).ok_or_else(|| {
+            CrossLedgerError::TranslationFailed {
+                ledger_id: canonical_model_ledger_id.to_string(),
+                graph_iri: graph_iri.to_string(),
+                detail: format!("could not decode shape object Sid {o_sid:?}"),
+            }
+        })?;
+        return Ok(WireObject::Ref(iri));
+    }
+    let datatype_iri = snapshot.decode_sid(dt).unwrap_or_else(|| {
+        "http://www.w3.org/2001/XMLSchema#string".to_string()
+    });
+    let value = flake_value_to_lexical(o);
+    Ok(WireObject::Literal {
+        value,
+        datatype: datatype_iri,
+        lang: None,
+    })
+}
+
+fn flake_value_to_lexical(o: &FlakeValue) -> String {
+    match o {
+        FlakeValue::String(s) => s.clone(),
+        FlakeValue::Boolean(b) => b.to_string(),
+        FlakeValue::Long(n) => n.to_string(),
+        FlakeValue::Double(f) => f.to_string(),
+        FlakeValue::BigInt(b) => b.to_string(),
+        FlakeValue::Decimal(d) => d.to_string(),
+        FlakeValue::Json(s) => s.clone(),
+        FlakeValue::Null => String::new(),
+        FlakeValue::Ref(_) => unreachable!("Ref handled at encode_object"),
+        other => format!("{other:?}"),
+    }
+}

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -35,9 +35,7 @@ pub(super) async fn materialize_shapes(
         .map_err(|e| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
-            detail: format!(
-                "failed to open model ledger snapshot at t={resolved_t}: {e}"
-            ),
+            detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
     let g_id = m_db
@@ -52,18 +50,42 @@ pub(super) async fn materialize_shapes(
 
     // SHACL whitelist — mirrors fluree_db_shacl::ShapeCompiler::compile_from_dbs
     let shacl_predicate_names: &[&str] = &[
-        "targetClass", "targetNode", "targetSubjectsOf", "targetObjectsOf",
-        "property", "path",
-        "minCount", "maxCount",
-        "datatype", "nodeKind", "class",
-        "minInclusive", "maxInclusive", "minExclusive", "maxExclusive",
-        "pattern", "flags", "minLength", "maxLength",
-        "hasValue", "in",
-        "equals", "disjoint", "lessThan", "lessThanOrEquals",
-        "closed", "ignoredProperties",
-        "uniqueLang", "languageIn",
-        "not", "and", "or", "xone",
-        "severity", "message", "name",
+        "targetClass",
+        "targetNode",
+        "targetSubjectsOf",
+        "targetObjectsOf",
+        "property",
+        "path",
+        "minCount",
+        "maxCount",
+        "datatype",
+        "nodeKind",
+        "class",
+        "minInclusive",
+        "maxInclusive",
+        "minExclusive",
+        "maxExclusive",
+        "pattern",
+        "flags",
+        "minLength",
+        "maxLength",
+        "hasValue",
+        "in",
+        "equals",
+        "disjoint",
+        "lessThan",
+        "lessThanOrEquals",
+        "closed",
+        "ignoredProperties",
+        "uniqueLang",
+        "languageIn",
+        "not",
+        "and",
+        "or",
+        "xone",
+        "severity",
+        "message",
+        "name",
     ];
 
     let mut shacl_predicate_sids: Vec<Sid> = Vec::new();
@@ -105,7 +127,10 @@ pub(super) async fn materialize_shapes(
         }
     }
 
-    for opt_sid in [rdf_first_sid, rdf_rest_sid].iter().filter_map(|s| s.as_ref()) {
+    for opt_sid in [rdf_first_sid, rdf_rest_sid]
+        .iter()
+        .filter_map(|s| s.as_ref())
+    {
         let flakes = fluree_db_core::range_with_overlay(
             &m_db.snapshot,
             g_id,
@@ -149,22 +174,26 @@ fn push_triple(
     canonical_model_ledger_id: &str,
     graph_iri: &str,
 ) -> Result<(), CrossLedgerError> {
-    let s_iri = snapshot.decode_sid(&f.s).ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
+    let s_iri = snapshot
+        .decode_sid(&f.s)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             detail: format!("could not decode shape subject Sid {:?}", f.s),
-        }
-    })?;
-    let p_iri = snapshot.decode_sid(&f.p).ok_or_else(|| {
-        CrossLedgerError::TranslationFailed {
+        })?;
+    let p_iri = snapshot
+        .decode_sid(&f.p)
+        .ok_or_else(|| CrossLedgerError::TranslationFailed {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),
             detail: format!("could not decode shape predicate Sid {:?}", f.p),
-        }
-    })?;
+        })?;
     let o = encode_object(&f.o, &f.dt, snapshot, canonical_model_ledger_id, graph_iri)?;
-    out.push(WireTriple { s: s_iri, p: p_iri, o });
+    out.push(WireTriple {
+        s: s_iri,
+        p: p_iri,
+        o,
+    });
     Ok(())
 }
 
@@ -176,18 +205,19 @@ fn encode_object(
     graph_iri: &str,
 ) -> Result<WireObject, CrossLedgerError> {
     if let FlakeValue::Ref(o_sid) = o {
-        let iri = snapshot.decode_sid(o_sid).ok_or_else(|| {
-            CrossLedgerError::TranslationFailed {
-                ledger_id: canonical_model_ledger_id.to_string(),
-                graph_iri: graph_iri.to_string(),
-                detail: format!("could not decode shape object Sid {o_sid:?}"),
-            }
-        })?;
+        let iri =
+            snapshot
+                .decode_sid(o_sid)
+                .ok_or_else(|| CrossLedgerError::TranslationFailed {
+                    ledger_id: canonical_model_ledger_id.to_string(),
+                    graph_iri: graph_iri.to_string(),
+                    detail: format!("could not decode shape object Sid {o_sid:?}"),
+                })?;
         return Ok(WireObject::Ref(iri));
     }
-    let datatype_iri = snapshot.decode_sid(dt).unwrap_or_else(|| {
-        "http://www.w3.org/2001/XMLSchema#string".to_string()
-    });
+    let datatype_iri = snapshot
+        .decode_sid(dt)
+        .unwrap_or_else(|| "http://www.w3.org/2001/XMLSchema#string".to_string());
     let value = flake_value_to_lexical(o);
     Ok(WireObject::Literal {
         value,

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -23,6 +23,16 @@ use fluree_db_core::{
 const SHACL: &str = "http://www.w3.org/ns/shacl#";
 const RDF: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 
+#[tracing::instrument(
+    name = "cross_ledger.shapes.materialize",
+    level = "debug",
+    skip(fluree),
+    fields(
+        model_ledger = canonical_model_ledger_id,
+        graph_iri = graph_iri,
+        resolved_t = resolved_t,
+    ),
+)]
 pub(super) async fn materialize_shapes(
     canonical_model_ledger_id: &str,
     graph_iri: &str,

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -38,7 +38,7 @@ pub(super) async fn materialize_shapes(
             detail: format!("failed to open model ledger snapshot at t={resolved_t}: {e}"),
         })?;
 
-    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri).ok_or_else(|| {
+    let g_id = super::resolve_selector_g_id(&m_db.snapshot, graph_iri)?.ok_or_else(|| {
         CrossLedgerError::GraphMissingAtT {
             ledger_id: canonical_model_ledger_id.to_string(),
             graph_iri: graph_iri.to_string(),

--- a/fluree-db-api/src/cross_ledger/shapes_materializer.rs
+++ b/fluree-db-api/src/cross_ledger/shapes_materializer.rs
@@ -98,12 +98,12 @@ pub(super) async fn materialize_shapes(
 
     let mut shacl_predicate_sids: Vec<Sid> = Vec::new();
     for name in shacl_predicate_names {
-        if let Some(sid) = m_db.snapshot.encode_iri(&format!("{SHACL}{name}")) {
+        if let Some(sid) = m_db.snapshot.encode_iri_strict(&format!("{SHACL}{name}")) {
             shacl_predicate_sids.push(sid);
         }
     }
-    let rdf_first_sid = m_db.snapshot.encode_iri(&format!("{RDF}first"));
-    let rdf_rest_sid = m_db.snapshot.encode_iri(&format!("{RDF}rest"));
+    let rdf_first_sid = m_db.snapshot.encode_iri_strict(&format!("{RDF}first"));
+    let rdf_rest_sid = m_db.snapshot.encode_iri_strict(&format!("{RDF}rest"));
 
     let opts = RangeOptions::default().with_to_t(m_db.t);
     let mut triples: Vec<WireTriple> = Vec::new();

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -25,7 +25,11 @@ pub enum ArtifactKind {
     /// `f:constraintsSource` → set of property IRIs declared
     /// `f:enforceUnique true` on the model ledger.
     Constraints,
-    // SchemaClosure  — reserved
+    /// `f:schemaSource` → schema/ontology axiom triples projected
+    /// from the model ledger's ontology graph. Single-graph only
+    /// in Phase 1b-a; transitive `owl:imports` recursion lands in
+    /// a follow-up.
+    SchemaClosure,
     // Shapes         — reserved
     // DatalogRules   — reserved
 }
@@ -35,6 +39,7 @@ impl std::fmt::Display for ArtifactKind {
         match self {
             ArtifactKind::PolicyRules => f.write_str("PolicyRules"),
             ArtifactKind::Constraints => f.write_str("Constraints"),
+            ArtifactKind::SchemaClosure => f.write_str("SchemaClosure"),
         }
     }
 }
@@ -79,7 +84,14 @@ pub enum GovernanceArtifact {
     /// Translate to D's Sid space via
     /// [`ConstraintsArtifactWire::translate_to_sids`].
     Constraints(ConstraintsArtifactWire),
-    // SchemaClosure(SchemaBundleWire) — reserved
+    /// Schema/ontology triples in IRI-form (whitelisted subset:
+    /// rdfs:subClassOf / subPropertyOf / domain / range,
+    /// owl:inverseOf / equivalentClass / equivalentProperty /
+    /// sameAs / imports, plus rdf:type for owl:Class /
+    /// owl:ObjectProperty / etc.). Translate to a
+    /// `fluree_db_query::SchemaBundleFlakes` via
+    /// [`SchemaArtifactWire::translate_to_schema_bundle_flakes`].
+    SchemaClosure(SchemaArtifactWire),
     // Shapes(ShapeSetWire)            — reserved
     // DatalogRules(DatalogRuleSetWire) — reserved
 }
@@ -117,6 +129,92 @@ impl ConstraintsArtifactWire {
             .iter()
             .filter_map(|iri| snapshot.encode_iri(iri))
             .collect()
+    }
+}
+
+/// Term-neutral wire form for a schema/ontology artifact.
+///
+/// Carries the whitelisted schema axiom triples (rdfs:subClassOf,
+/// owl:equivalentClass, owl:imports, rdf:type for owl:Class/etc.,
+/// plus the rest of the schema-bundle whitelist) in IRI form. The
+/// translator on D encodes each IRI against D's snapshot and builds
+/// a `SchemaBundleFlakes` from the result. IRIs that fail to encode
+/// drop their triples — same semantics as the same-ledger
+/// `build_schema_bundle_flakes` flow, where `encode_iri` returning
+/// `None` for an unseen IRI contributes nothing.
+///
+/// Phase 1b-a constraint: the materializer projects only Ref-valued
+/// objects (every predicate / class in the schema whitelist is
+/// Ref-valued in practice — owl:hasValue and similar literal-valued
+/// predicates aren't in the whitelist). Future literal handling
+/// lands if a use case requires it.
+#[derive(Debug, Clone)]
+pub struct SchemaArtifactWire {
+    /// Provenance for diagnostics and cache key derivation.
+    pub origin: WireOrigin,
+    /// Schema triples in the order they were read from M's graph.
+    /// Translation re-sorts into the four index orderings.
+    pub triples: Vec<WireTriple>,
+}
+
+/// IRI-form schema triple. All three positions are IRIs in the
+/// whitelisted projection.
+#[derive(Debug, Clone)]
+pub struct WireTriple {
+    pub s: String,
+    pub p: String,
+    pub o: String,
+}
+
+impl SchemaArtifactWire {
+    /// Translate to a Sid-form `SchemaBundleFlakes` against the
+    /// data ledger's snapshot.
+    ///
+    /// Each triple's IRIs are encoded via `snapshot.encode_iri`.
+    /// Failed encodings drop the triple — D has no data of those
+    /// IRIs so the missing axiom can't fire on instance data D
+    /// doesn't have, matching same-ledger semantics. The
+    /// downstream whitelist check in
+    /// `SchemaBundleFlakes::from_collected_schema_triples` is the
+    /// canonical filter; if a future cross-ledger producer emits
+    /// non-whitelist triples they'll drop there.
+    pub fn translate_to_schema_bundle_flakes(
+        &self,
+        snapshot: &fluree_db_core::LedgerSnapshot,
+    ) -> fluree_db_query::error::Result<std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>>
+    {
+        use fluree_db_core::flake::Flake;
+        use fluree_db_core::value::FlakeValue;
+        use fluree_db_core::Sid;
+
+        let mut collected: Vec<Flake> = Vec::with_capacity(self.triples.len());
+        for t in &self.triples {
+            let (Some(s_sid), Some(p_sid), Some(o_sid)) = (
+                snapshot.encode_iri(&t.s),
+                snapshot.encode_iri(&t.p),
+                snapshot.encode_iri(&t.o),
+            ) else {
+                continue;
+            };
+            collected.push(Flake {
+                g: None,
+                s: s_sid,
+                p: p_sid,
+                o: FlakeValue::Ref(o_sid),
+                // @id is the canonical datatype for Ref-valued
+                // objects. JSON_LD is a well-known namespace code
+                // pre-registered at genesis on every ledger, so this
+                // Sid construction is stable across ledgers.
+                dt: Sid::new(fluree_vocab::namespaces::JSON_LD, "id"),
+                t: 0,
+                op: true,
+                m: None,
+            });
+        }
+        fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(
+            collected,
+        )
+        .map(std::sync::Arc::new)
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -1,0 +1,257 @@
+//! Cross-ledger resolution types.
+//!
+//! See `docs/design/cross-ledger-model-enforcement.md` for the
+//! semantics of each type. The orchestration that uses these lives in
+//! `resolver.rs`; pure helpers below (reserved-graph guard, cycle
+//! check, memo lookup) are kept here and unit-tested in isolation.
+
+use super::CrossLedgerError;
+use crate::Fluree;
+use fluree_db_core::graph_registry::{config_graph_iri, txn_meta_graph_iri};
+use fluree_db_policy::PolicyArtifactWire;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Which subsystem's artifact is being resolved.
+///
+/// Only `PolicyRules` is implemented in Phase 1a; the remaining
+/// variants land in later phases per the design doc's phasing table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactKind {
+    /// `f:policySource` → policy rule set.
+    PolicyRules,
+    // SchemaClosure  — Phase 1b
+    // Shapes         — Phase 2
+    // DatalogRules   — Phase 2
+    // Constraints    — Phase 2
+}
+
+/// A successfully resolved, term-neutral governance artifact.
+///
+/// Cached at the API layer by `(model_ledger_id, graph_iri,
+/// resolved_t)`; per-data-ledger interning is a separate step.
+#[derive(Debug, Clone)]
+pub struct ResolvedGraph {
+    /// Canonical model ledger id this artifact came from.
+    pub model_ledger_id: String,
+    /// Graph IRI within the model ledger.
+    pub graph_iri: String,
+    /// Model ledger `t` at which the artifact was materialized.
+    pub resolved_t: i64,
+    /// The artifact itself, tagged by subsystem.
+    pub artifact: GovernanceArtifact,
+}
+
+/// Tagged union of governance artifacts.
+///
+/// The kind is named so a `ResolveCtx` memo (which is keyed only on
+/// `(ledger, graph, t)`) can carry mixed artifact types without
+/// dynamic dispatch and so callers can pattern-match to extract the
+/// shape they expect.
+#[derive(Debug, Clone)]
+pub enum GovernanceArtifact {
+    /// Policy rule set in IRI-form. Translate to `PolicySet` via
+    /// `fluree_db_policy::build_policy_set_from_wire`.
+    PolicyRules(PolicyArtifactWire),
+    // SchemaClosure(SchemaBundleWire) — Phase 1b
+    // Shapes(ShapeSetWire)            — Phase 2
+    // DatalogRules(DatalogRuleSetWire) — Phase 2
+    // Constraints(ConstraintSetWire)  — Phase 2
+}
+
+/// Per-request resolution context.
+///
+/// Born with the full lifetime / consistency model so the resolver
+/// API is correct from day one even before materialization lands:
+///
+/// - `resolved_ts` captures the lazy per-request head-t per
+///   canonical model ledger id (governance-context capture). Lookup
+///   on miss reads M's head once and stores it; later unpinned
+///   references to the same M reuse the same value so policy and
+///   shapes can never disagree about which version of M they're
+///   enforcing.
+///
+/// - `active` is the resolution stack used for cycle detection. Push
+///   before recursion, pop after. A tuple is a cycle only when it is
+///   encountered while *already on the stack*.
+///
+/// - `memo` is the per-request completed map. Subsequent references
+///   to the same `(ledger, graph, t)` tuple — from any subsystem —
+///   short-circuit on a memo hit. Memo hits never enter `active`,
+///   so cross-subsystem de-dup never trips cycle detection.
+pub struct ResolveCtx<'a> {
+    /// Canonical data-ledger id D.
+    pub data_ledger_id: &'a str,
+    /// The Fluree instance hosting D and (per the same-instance
+    /// constraint) the referenced model ledger.
+    pub fluree: &'a Fluree,
+    /// Lazy governance-context capture: canonical model ledger id →
+    /// `resolved_t` for unpinned references. Pinned `f:atT` does NOT
+    /// populate this map; pinned values are per-resolve.
+    pub resolved_ts: HashMap<String, i64>,
+    /// Active resolution stack (cycle detection).
+    pub active: Vec<(String, String, i64)>,
+    /// Per-request completed memo.
+    pub memo: HashMap<(String, String, i64), Arc<ResolvedGraph>>,
+}
+
+impl<'a> ResolveCtx<'a> {
+    /// Build a fresh resolution context for a request against D.
+    pub fn new(data_ledger_id: &'a str, fluree: &'a Fluree) -> Self {
+        Self {
+            data_ledger_id,
+            fluree,
+            resolved_ts: HashMap::new(),
+            active: Vec::new(),
+            memo: HashMap::new(),
+        }
+    }
+}
+
+/// Reject selectors that resolve to the model ledger's `#config` or
+/// `#txn-meta` graphs.
+///
+/// Applied *before* any storage round-trip on the model ledger —
+/// `#txn-meta` in particular can leak commit metadata, and `#config`
+/// is the recursive seed that defines what model M is. Neither is
+/// ever a legitimate target of a cross-ledger governance reference.
+///
+/// Pure on `(canonical_ledger_id, graph_iri)`; no I/O.
+pub(crate) fn reject_if_reserved_graph(
+    canonical_ledger_id: &str,
+    graph_iri: &str,
+) -> Result<(), CrossLedgerError> {
+    if graph_iri == config_graph_iri(canonical_ledger_id)
+        || graph_iri == txn_meta_graph_iri(canonical_ledger_id)
+    {
+        return Err(CrossLedgerError::ReservedGraphSelected {
+            graph_iri: graph_iri.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Memo lookup for the per-request completed map.
+///
+/// Memo hits short-circuit before `active` is consulted, so two
+/// subsystems referencing the same `(ledger, graph, t)` resolve once
+/// and never trip cycle detection.
+pub(crate) fn memo_hit(
+    memo: &HashMap<(String, String, i64), Arc<ResolvedGraph>>,
+    tuple: &(String, String, i64),
+) -> Option<Arc<ResolvedGraph>> {
+    memo.get(tuple).cloned()
+}
+
+/// Cycle check against the active resolution stack.
+///
+/// Returns the cycle as a chain (active stack + the offending tuple
+/// appended) when one is detected.
+pub(crate) fn check_cycle(
+    active: &[(String, String, i64)],
+    tuple: &(String, String, i64),
+) -> Result<(), CrossLedgerError> {
+    if active.iter().any(|t| t == tuple) {
+        let mut chain = active.to_vec();
+        chain.push(tuple.clone());
+        return Err(CrossLedgerError::CycleDetected { chain });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_graph_guard_blocks_config_and_txn_meta() {
+        let ledger = "model:main";
+        assert!(matches!(
+            reject_if_reserved_graph(ledger, "urn:fluree:model:main#config"),
+            Err(CrossLedgerError::ReservedGraphSelected { .. })
+        ));
+        assert!(matches!(
+            reject_if_reserved_graph(ledger, "urn:fluree:model:main#txn-meta"),
+            Err(CrossLedgerError::ReservedGraphSelected { .. })
+        ));
+    }
+
+    #[test]
+    fn reserved_graph_guard_allows_application_graphs() {
+        let ledger = "model:main";
+        // A user-named graph that happens to live on the model
+        // ledger is fine — we only block the system graphs.
+        assert!(reject_if_reserved_graph(ledger, "http://example.org/policy").is_ok());
+        // Even a config-shaped IRI for a *different* ledger is fine —
+        // it can't actually resolve to model:main's #config.
+        assert!(
+            reject_if_reserved_graph(ledger, "urn:fluree:other:main#config").is_ok(),
+            "config IRI for a different ledger should not match"
+        );
+    }
+
+    #[test]
+    fn cycle_check_passes_for_unique_tuples() {
+        let active = vec![
+            ("a:main".to_string(), "http://ex.org/p".to_string(), 10),
+            ("b:main".to_string(), "http://ex.org/q".to_string(), 20),
+        ];
+        let new_tuple = ("c:main".to_string(), "http://ex.org/r".to_string(), 30);
+        assert!(check_cycle(&active, &new_tuple).is_ok());
+    }
+
+    #[test]
+    fn cycle_check_fails_on_reentry_and_renders_full_chain() {
+        let cycle_tuple = ("a:main".to_string(), "http://ex.org/p".to_string(), 10);
+        let active = vec![
+            cycle_tuple.clone(),
+            ("b:main".to_string(), "http://ex.org/q".to_string(), 20),
+        ];
+        let err = check_cycle(&active, &cycle_tuple).unwrap_err();
+        match err {
+            CrossLedgerError::CycleDetected { chain } => {
+                // The chain should contain the original active stack
+                // (in order) plus the offending tuple appended.
+                assert_eq!(chain.len(), 3);
+                assert_eq!(chain[0], cycle_tuple);
+                assert_eq!(chain[2], cycle_tuple);
+            }
+            other => panic!("expected CycleDetected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cycle_check_treats_different_t_pins_of_same_graph_as_distinct() {
+        // Two f:atT pins of the same (ledger, graph) are NOT a cycle.
+        // The design doc is explicit on this.
+        let active = vec![("a:main".to_string(), "http://ex.org/p".to_string(), 10)];
+        let later_pin = ("a:main".to_string(), "http://ex.org/p".to_string(), 20);
+        assert!(check_cycle(&active, &later_pin).is_ok());
+    }
+
+    #[test]
+    fn memo_returns_cloned_arc_on_hit_and_none_on_miss() {
+        let mut memo = HashMap::new();
+        let tuple = ("a:main".to_string(), "http://ex.org/p".to_string(), 10);
+
+        let payload = Arc::new(ResolvedGraph {
+            model_ledger_id: tuple.0.clone(),
+            graph_iri: tuple.1.clone(),
+            resolved_t: tuple.2,
+            artifact: GovernanceArtifact::PolicyRules(PolicyArtifactWire {
+                origin: fluree_db_policy::WireOrigin {
+                    model_ledger_id: tuple.0.clone(),
+                    graph_iri: tuple.1.clone(),
+                    resolved_t: tuple.2,
+                },
+                restrictions: vec![],
+            }),
+        });
+
+        assert!(memo_hit(&memo, &tuple).is_none());
+        memo.insert(tuple.clone(), payload.clone());
+
+        let hit = memo_hit(&memo, &tuple).expect("hit after insert");
+        assert!(Arc::ptr_eq(&hit, &payload), "memo must return shared Arc");
+    }
+}

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -14,27 +14,27 @@ use std::sync::Arc;
 
 /// Which subsystem's artifact is being resolved.
 ///
-/// Only `PolicyRules` is implemented in Phase 1a; the remaining
-/// variants land in later phases per the design doc's phasing table.
-///
-/// `ArtifactKind` is part of the memo / cycle-detection key so that
-/// when a later phase adds a second variant (e.g., `Shapes`), a
+/// `ArtifactKind` is part of the memo / cycle-detection key so a
 /// memoized `PolicyRules` entry for the same `(ledger, graph, t)`
-/// can't be returned to a caller asking for `Shapes`.
+/// can't be returned to a caller asking for `Constraints` (or any
+/// future variant), and vice versa.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ArtifactKind {
     /// `f:policySource` → policy rule set.
     PolicyRules,
-    // SchemaClosure  — Phase 1b
-    // Shapes         — Phase 2
-    // DatalogRules   — Phase 2
-    // Constraints    — Phase 2
+    /// `f:constraintsSource` → set of property IRIs declared
+    /// `f:enforceUnique true` on the model ledger.
+    Constraints,
+    // SchemaClosure  — reserved
+    // Shapes         — reserved
+    // DatalogRules   — reserved
 }
 
 impl std::fmt::Display for ArtifactKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ArtifactKind::PolicyRules => f.write_str("PolicyRules"),
+            ArtifactKind::Constraints => f.write_str("Constraints"),
         }
     }
 }
@@ -75,10 +75,67 @@ pub enum GovernanceArtifact {
     /// Policy rule set in IRI-form. Translate to `PolicySet` via
     /// `fluree_db_policy::build_policy_set_from_wire`.
     PolicyRules(PolicyArtifactWire),
-    // SchemaClosure(SchemaBundleWire) — Phase 1b
-    // Shapes(ShapeSetWire)            — Phase 2
-    // DatalogRules(DatalogRuleSetWire) — Phase 2
-    // Constraints(ConstraintSetWire)  — Phase 2
+    /// `f:enforceUnique` property declarations in IRI-form.
+    /// Translate to D's Sid space via
+    /// [`ConstraintsArtifactWire::translate_to_sids`].
+    Constraints(ConstraintsArtifactWire),
+    // SchemaClosure(SchemaBundleWire) — reserved
+    // Shapes(ShapeSetWire)            — reserved
+    // DatalogRules(DatalogRuleSetWire) — reserved
+}
+
+/// Term-neutral wire form for a constraints artifact.
+///
+/// A constraints artifact is structurally simple: a list of
+/// property IRIs that the model ledger has annotated as
+/// `f:enforceUnique true`. The translator encodes each IRI
+/// against the data ledger's snapshot to produce the Sid set
+/// that the existing `enforce_unique_constraints` flow consumes.
+///
+/// IRIs that fail to resolve against D's snapshot are silently
+/// dropped — D has no data of those properties, so the constraint
+/// cannot be violated either way. The same semantics apply
+/// same-ledger via `encode_iri` returning `None` for unseen
+/// namespaces.
+#[derive(Debug, Clone)]
+pub struct ConstraintsArtifactWire {
+    /// Provenance for diagnostics and cache key derivation.
+    pub origin: WireOrigin,
+    /// Property IRIs declared `f:enforceUnique true` on the model
+    /// ledger's constraints graph.
+    pub property_iris: Vec<String>,
+}
+
+impl ConstraintsArtifactWire {
+    /// Translate the IRI list into property Sids against the
+    /// data ledger's snapshot. Unresolvable IRIs are dropped.
+    pub fn translate_to_sids(
+        &self,
+        snapshot: &fluree_db_core::LedgerSnapshot,
+    ) -> Vec<fluree_db_core::Sid> {
+        self.property_iris
+            .iter()
+            .filter_map(|iri| snapshot.encode_iri(iri))
+            .collect()
+    }
+}
+
+/// Provenance for a cross-ledger wire artifact.
+///
+/// Shared across `Constraints` and any future variant in this
+/// crate. `PolicyArtifactWire` carries its own `WireOrigin` from
+/// `fluree-db-policy` — identical shape, kept separate to avoid
+/// pulling fluree-db-api into the policy crate. A future
+/// unification would centralize these in `fluree-db-core`.
+#[derive(Debug, Clone)]
+pub struct WireOrigin {
+    /// Canonical model ledger id (`NsRecord.ledger_id`).
+    pub model_ledger_id: String,
+    /// Graph IRI within the model ledger whose triples produced
+    /// this artifact.
+    pub graph_iri: String,
+    /// Model ledger `t` at which the artifact was materialized.
+    pub resolved_t: i64,
 }
 
 /// Per-request resolution context.

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -442,26 +442,33 @@ pub struct RulesArtifactWire {
 impl RulesArtifactWire {
     /// Decode each rule body into a `serde_json::Value` ready for
     /// `execute_datalog_rules_with_query_rules`'s
-    /// `query_time_rules` slot. Malformed JSON entries are
-    /// skipped with a warning — a single bad rule should not
-    /// poison the entire ledger's reasoning pass.
-    pub fn parsed_rules(&self) -> Vec<serde_json::Value> {
+    /// `query_time_rules` slot.
+    ///
+    /// **Fail-closed**: a single malformed entry returns
+    /// [`super::CrossLedgerError::TranslationFailed`] rather than
+    /// silently dropping the rule. Cross-ledger governance is
+    /// administrator-authored — silently weakening the configured
+    /// reasoning model would be the worst possible behaviour. The
+    /// per-query path that maps `opts.rules` *does* tolerate
+    /// individual bad rules, but that's a self-service surface
+    /// where the author is the requester.
+    pub fn parsed_rules(&self) -> Result<Vec<serde_json::Value>, super::CrossLedgerError> {
         let mut out = Vec::with_capacity(self.rules.len());
         for (idx, raw) in self.rules.iter().enumerate() {
             match serde_json::from_str(raw) {
                 Ok(v) => out.push(v),
                 Err(e) => {
-                    tracing::warn!(
-                        rule_index = idx,
-                        error = %e,
-                        ledger = %self.origin.model_ledger_id,
-                        graph = %self.origin.graph_iri,
-                        "skipping malformed cross-ledger rule"
-                    );
+                    return Err(super::CrossLedgerError::TranslationFailed {
+                        ledger_id: self.origin.model_ledger_id.clone(),
+                        graph_iri: self.origin.graph_iri.clone(),
+                        detail: format!(
+                            "malformed cross-ledger rule at index {idx}: {e}"
+                        ),
+                    });
                 }
             }
         }
-        out
+        Ok(out)
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -232,8 +232,9 @@ impl SchemaArtifactWire {
     pub fn translate_to_schema_bundle_flakes(
         &self,
         snapshot: &fluree_db_core::LedgerSnapshot,
-    ) -> fluree_db_query::error::Result<std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>>
-    {
+    ) -> fluree_db_query::error::Result<
+        std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>,
+    > {
         use fluree_db_core::flake::Flake;
         use fluree_db_core::value::FlakeValue;
         use fluree_db_core::Sid;
@@ -244,7 +245,9 @@ impl SchemaArtifactWire {
             // object on a whitelisted predicate is silently skipped
             // (such triples can't survive the schema-bundle path
             // anyway — the reasoner expects Ref-valued schema axioms).
-            let WireObject::Ref(o_iri) = &t.o else { continue };
+            let WireObject::Ref(o_iri) = &t.o else {
+                continue;
+            };
             let (Some(s_sid), Some(p_sid), Some(o_sid)) = (
                 snapshot.encode_iri(&t.s),
                 snapshot.encode_iri(&t.p),
@@ -267,10 +270,8 @@ impl SchemaArtifactWire {
                 m: None,
             });
         }
-        fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(
-            collected,
-        )
-        .map(std::sync::Arc::new)
+        fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(collected)
+            .map(std::sync::Arc::new)
     }
 }
 
@@ -324,8 +325,9 @@ impl ShapesArtifactWire {
     pub fn translate_to_schema_bundle_flakes(
         &self,
         staged_ns: &fluree_db_transact::namespace::NamespaceRegistry,
-    ) -> fluree_db_query::error::Result<std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>>
-    {
+    ) -> fluree_db_query::error::Result<
+        std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>,
+    > {
         use fluree_db_core::flake::Flake;
         use fluree_db_core::Sid;
 
@@ -352,9 +354,9 @@ impl ShapesArtifactWire {
                     datatype,
                     lang: _,
                 } => {
-                    let dt_sid = staged_ns.lookup_sid_for_iri(datatype).unwrap_or_else(
-                        || Sid::new(fluree_vocab::namespaces::XSD, "string"),
-                    );
+                    let dt_sid = staged_ns
+                        .lookup_sid_for_iri(datatype)
+                        .unwrap_or_else(|| Sid::new(fluree_vocab::namespaces::XSD, "string"));
                     (literal_to_flake_value(value, datatype), dt_sid)
                 }
             };
@@ -369,10 +371,8 @@ impl ShapesArtifactWire {
                 m: None,
             });
         }
-        fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(
-            collected,
-        )
-        .map(std::sync::Arc::new)
+        fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(collected)
+            .map(std::sync::Arc::new)
     }
 }
 
@@ -390,8 +390,8 @@ fn literal_to_flake_value(value: &str, datatype: &str) -> fluree_db_core::FlakeV
             .map(FlakeValue::Boolean)
             .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
         "integer" | "long" | "int" | "short" | "byte" | "nonNegativeInteger"
-        | "positiveInteger" | "negativeInteger" | "nonPositiveInteger"
-        | "unsignedLong" | "unsignedInt" | "unsignedShort" | "unsignedByte" => value
+        | "positiveInteger" | "negativeInteger" | "nonPositiveInteger" | "unsignedLong"
+        | "unsignedInt" | "unsignedShort" | "unsignedByte" => value
             .parse::<i64>()
             .map(FlakeValue::Long)
             .unwrap_or_else(|_| FlakeValue::String(value.to_string())),

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -423,36 +423,42 @@ impl ShapesArtifactWire {
 
 /// Decode a wire literal into the matching `FlakeValue`.
 ///
-/// Returns `Err` when the lexical form fails to parse against the
-/// declared datatype (e.g., `"abc"^^xsd:integer`). The caller
-/// surfaces these as `TranslationFailed` — silently re-typing to
-/// `FlakeValue::String` would change shape semantics on D. Unknown
-/// (non-xsd) datatypes fall through to `String(value)` because the
-/// caller has *already* validated the datatype IRI is registered
-/// on D; an unknown but-registered datatype is the application's
-/// to interpret.
+/// Delegates to [`fluree_db_transact::value_convert::parse_xsd_lexical`]
+/// so cross-ledger SHACL literals parse with the **same parser the
+/// same-ledger import path uses** for every XSD-recognized datatype:
+/// integer family (with `i64 → BigInt` overflow), `xsd:decimal`
+/// (arbitrary-precision), `xsd:dateTime` / `xsd:date` / `xsd:time`,
+/// the `xsd:gYear*` family, `xsd:duration` / `dayTimeDuration` /
+/// `yearMonthDuration`, `xsd:double` / `xsd:float`, `xsd:boolean`,
+/// the string family, and `rdf:JSON`. SHACL range / `sh:hasValue`
+/// constraints against any of these now produce identical match
+/// behavior between same- and cross-ledger shape sources.
+///
+/// Returns `Err(detail)` when the lexical form is invalid against a
+/// recognized XSD datatype (e.g., `"abc"^^xsd:integer`). The caller
+/// surfaces this as `TranslationFailed` rather than silently
+/// re-typing the literal to `FlakeValue::String`, which would
+/// change shape semantics on D.
+///
+/// **Non-XSD datatypes deliberately fall through to
+/// `FlakeValue::String(value)`.** The translator's outer
+/// `translate_to_schema_bundle_flakes` has already validated that
+/// the datatype IRI is registered on D, so this is the
+/// application-defined custom-datatype case: Fluree has no
+/// `FlakeValue` variant for it, and the same-ledger import path
+/// stores the same lexical form as a `String` under the same
+/// datatype Sid. Cross-ledger must produce an identical flake
+/// shape so the SHACL engine matches identically. Failing closed
+/// here instead of mirroring same-ledger would *diverge* the two
+/// code paths and break the parity contract.
 fn literal_to_flake_value(
     value: &str,
     datatype: &str,
 ) -> Result<fluree_db_core::FlakeValue, String> {
     use fluree_db_core::FlakeValue;
-    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
-    let local = datatype.strip_prefix(XSD).unwrap_or("");
-    match local {
-        "boolean" => value.parse::<bool>().map(FlakeValue::Boolean).map_err(|e| {
-            format!("invalid xsd:boolean lexical `{value}` on cross-ledger shape: {e}")
-        }),
-        "integer" | "long" | "int" | "short" | "byte" | "nonNegativeInteger"
-        | "positiveInteger" | "negativeInteger" | "nonPositiveInteger" | "unsignedLong"
-        | "unsignedInt" | "unsignedShort" | "unsignedByte" => {
-            value.parse::<i64>().map(FlakeValue::Long).map_err(|e| {
-                format!("invalid xsd:{local} lexical `{value}` on cross-ledger shape: {e}")
-            })
-        }
-        "double" | "float" => value.parse::<f64>().map(FlakeValue::Double).map_err(|e| {
-            format!("invalid xsd:{local} lexical `{value}` on cross-ledger shape: {e}")
-        }),
-        _ => Ok(FlakeValue::String(value.to_string())),
+    match fluree_db_transact::value_convert::parse_xsd_lexical(value, datatype)? {
+        Some(fv) => Ok(fv),
+        None => Ok(FlakeValue::String(value.to_string())),
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -157,13 +157,53 @@ pub struct SchemaArtifactWire {
     pub triples: Vec<WireTriple>,
 }
 
-/// IRI-form schema triple. All three positions are IRIs in the
-/// whitelisted projection.
+/// IRI-form triple used by both `SchemaArtifactWire` and
+/// `ShapesArtifactWire`. Subject and predicate are always IRIs;
+/// the object can be either a Ref (IRI) or a literal value with
+/// its datatype IRI / language tag. Schema's whitelist is
+/// Ref-only in practice; SHACL's whitelist includes literal-valued
+/// predicates (`sh:minCount`, `sh:pattern`, `sh:message`, ...).
 #[derive(Debug, Clone)]
 pub struct WireTriple {
     pub s: String,
     pub p: String,
-    pub o: String,
+    pub o: WireObject,
+}
+
+/// IRI-form object value carried in a `WireTriple`.
+///
+/// `Ref(iri)` survives the round-trip as an `IRI → Sid` encode at
+/// the data ledger. `Literal { value, datatype, lang }` reconstructs
+/// the original `FlakeValue` against D by branching on `datatype`:
+/// xsd:integer → `Long`, xsd:boolean → `Boolean`, xsd:string → `String`,
+/// xsd:decimal → `Decimal`, xsd:dateTime → `DateTime`, etc. Unknown
+/// datatypes fall back to `FlakeValue::String(value)` rather than
+/// failing — the SHACL compiler will simply not match them on
+/// type-sensitive constraints, which is the same observable behavior
+/// as if the constraint weren't authored.
+#[derive(Debug, Clone)]
+pub enum WireObject {
+    /// IRI reference; encoded via `snapshot.encode_iri` at the data
+    /// ledger to produce a `FlakeValue::Ref(Sid)`.
+    Ref(String),
+    /// Literal value in its canonical lexical form, paired with the
+    /// datatype IRI and optional language tag. The datatype IRI is
+    /// the XSD/RDF IRI (e.g., `http://www.w3.org/2001/XMLSchema#integer`)
+    /// or `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString` for
+    /// language-tagged strings.
+    Literal {
+        value: String,
+        datatype: String,
+        lang: Option<String>,
+    },
+}
+
+impl WireObject {
+    /// Helper for callers that only emit Refs (e.g., schema's
+    /// whitelist projection). Equivalent to `WireObject::Ref(iri)`.
+    pub fn iri(iri: impl Into<String>) -> Self {
+        WireObject::Ref(iri.into())
+    }
 }
 
 impl SchemaArtifactWire {
@@ -189,10 +229,15 @@ impl SchemaArtifactWire {
 
         let mut collected: Vec<Flake> = Vec::with_capacity(self.triples.len());
         for t in &self.triples {
+            // Schema whitelist projects Refs only; any literal-valued
+            // object on a whitelisted predicate is silently skipped
+            // (such triples can't survive the schema-bundle path
+            // anyway — the reasoner expects Ref-valued schema axioms).
+            let WireObject::Ref(o_iri) = &t.o else { continue };
             let (Some(s_sid), Some(p_sid), Some(o_sid)) = (
                 snapshot.encode_iri(&t.s),
                 snapshot.encode_iri(&t.p),
-                snapshot.encode_iri(&t.o),
+                snapshot.encode_iri(o_iri),
             ) else {
                 continue;
             };

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -352,7 +352,7 @@ impl ShapesArtifactWire {
             ) else {
                 continue;
             };
-            let (o_value, dt_sid) = match &t.o {
+            let (o_value, dt_sid, meta) = match &t.o {
                 WireObject::Ref(o_iri) => {
                     let Some(o_sid) = staged_ns.lookup_sid_for_iri(o_iri) else {
                         continue;
@@ -360,17 +360,49 @@ impl ShapesArtifactWire {
                     (
                         fluree_db_core::FlakeValue::Ref(o_sid),
                         Sid::new(fluree_vocab::namespaces::JSON_LD, "id"),
+                        None,
                     )
                 }
                 WireObject::Literal {
                     value,
                     datatype,
-                    lang: _,
+                    lang,
                 } => {
-                    let dt_sid = staged_ns
-                        .lookup_sid_for_iri(datatype)
-                        .unwrap_or_else(|| Sid::new(fluree_vocab::namespaces::XSD, "string"));
-                    (literal_to_flake_value(value, datatype), dt_sid)
+                    // Language-tagged literals always carry
+                    // `rdf:langString` as their datatype Sid; the
+                    // tag itself lives on `FlakeMeta.lang`. The
+                    // wire's `datatype` IRI for these is
+                    // conventionally `rdf:langString` too, but we
+                    // bind the Sid from the constant — no lookup
+                    // needed, no D-side namespace mismatch
+                    // possible.
+                    if let Some(tag) = lang.as_ref() {
+                        (
+                            fluree_db_core::FlakeValue::String(value.clone()),
+                            Sid::new(fluree_vocab::namespaces::RDF, "langString"),
+                            Some(fluree_db_core::flake::FlakeMeta::with_lang(tag.as_str())),
+                        )
+                    } else {
+                        // Fail-closed on unknown datatype IRI. The
+                        // legacy fallback (re-type to xsd:string)
+                        // silently changed the shape's
+                        // `sh:datatype` semantics on D; the
+                        // legacy literal-parse fallback did the
+                        // same when "100"^^xsd:integer failed to
+                        // parse. Either is a real fidelity loss
+                        // — surface as TranslationFailed instead.
+                        let Some(dt_sid) = staged_ns.lookup_sid_for_iri(datatype) else {
+                            return Err(fluree_db_query::error::QueryError::Internal(format!(
+                                "cross-ledger shape literal datatype {datatype} \
+                                     is not registered on the data ledger; \
+                                     register the datatype IRI on D before \
+                                     referencing it from M's shapes"
+                            )));
+                        };
+                        let parsed = literal_to_flake_value(value, datatype)
+                            .map_err(fluree_db_query::error::QueryError::Internal)?;
+                        (parsed, dt_sid, None)
+                    }
                 }
             };
             collected.push(Flake {
@@ -381,7 +413,7 @@ impl ShapesArtifactWire {
                 dt: dt_sid,
                 t: 0,
                 op: true,
-                m: None,
+                m: meta,
             });
         }
         fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(collected)
@@ -389,30 +421,38 @@ impl ShapesArtifactWire {
     }
 }
 
-/// Decode a wire literal into the matching `FlakeValue`. Falls back
-/// to `String(value)` on parse failure or unknown datatype — the
-/// SHACL compiler will simply not match the value on type-sensitive
-/// constraints, same as if the constraint weren't authored.
-fn literal_to_flake_value(value: &str, datatype: &str) -> fluree_db_core::FlakeValue {
+/// Decode a wire literal into the matching `FlakeValue`.
+///
+/// Returns `Err` when the lexical form fails to parse against the
+/// declared datatype (e.g., `"abc"^^xsd:integer`). The caller
+/// surfaces these as `TranslationFailed` — silently re-typing to
+/// `FlakeValue::String` would change shape semantics on D. Unknown
+/// (non-xsd) datatypes fall through to `String(value)` because the
+/// caller has *already* validated the datatype IRI is registered
+/// on D; an unknown but-registered datatype is the application's
+/// to interpret.
+fn literal_to_flake_value(
+    value: &str,
+    datatype: &str,
+) -> Result<fluree_db_core::FlakeValue, String> {
     use fluree_db_core::FlakeValue;
     const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
     let local = datatype.strip_prefix(XSD).unwrap_or("");
     match local {
-        "boolean" => value
-            .parse::<bool>()
-            .map(FlakeValue::Boolean)
-            .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
+        "boolean" => value.parse::<bool>().map(FlakeValue::Boolean).map_err(|e| {
+            format!("invalid xsd:boolean lexical `{value}` on cross-ledger shape: {e}")
+        }),
         "integer" | "long" | "int" | "short" | "byte" | "nonNegativeInteger"
         | "positiveInteger" | "negativeInteger" | "nonPositiveInteger" | "unsignedLong"
-        | "unsignedInt" | "unsignedShort" | "unsignedByte" => value
-            .parse::<i64>()
-            .map(FlakeValue::Long)
-            .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
-        "double" | "float" => value
-            .parse::<f64>()
-            .map(FlakeValue::Double)
-            .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
-        _ => FlakeValue::String(value.to_string()),
+        | "unsignedInt" | "unsignedShort" | "unsignedByte" => {
+            value.parse::<i64>().map(FlakeValue::Long).map_err(|e| {
+                format!("invalid xsd:{local} lexical `{value}` on cross-ledger shape: {e}")
+            })
+        }
+        "double" | "float" => value.parse::<f64>().map(FlakeValue::Double).map_err(|e| {
+            format!("invalid xsd:{local} lexical `{value}` on cross-ledger shape: {e}")
+        }),
+        _ => Ok(FlakeValue::String(value.to_string())),
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -35,7 +35,12 @@ pub enum ArtifactKind {
     /// from the model ledger's shapes graph. Carries literals as
     /// well as Refs.
     Shapes,
-    // DatalogRules   — reserved
+    /// `f:rulesSource` → datalog rule definitions projected from
+    /// the model ledger's rules graph. The wire form carries the
+    /// raw JSON-LD rule bodies (term-portable: each rule's IRIs
+    /// resolve at parse time against D's snapshot, matching how
+    /// query-time rules in `opts.rules` are handled).
+    Rules,
 }
 
 impl std::fmt::Display for ArtifactKind {
@@ -45,6 +50,7 @@ impl std::fmt::Display for ArtifactKind {
             ArtifactKind::Constraints => f.write_str("Constraints"),
             ArtifactKind::SchemaClosure => f.write_str("SchemaClosure"),
             ArtifactKind::Shapes => f.write_str("Shapes"),
+            ArtifactKind::Rules => f.write_str("Rules"),
         }
     }
 }
@@ -104,7 +110,14 @@ pub enum GovernanceArtifact {
     /// encodable. M-only IRIs that D has never seen are dropped
     /// silently — those shapes can't apply to data D doesn't have.
     Shapes(ShapesArtifactWire),
-    // DatalogRules(DatalogRuleSetWire) — reserved
+    /// Datalog rule definitions in JSON-LD form. Each entry is
+    /// the raw `f:rule` body the model ledger stored as
+    /// `FlakeValue::Json`. Rule parsing happens against D's
+    /// snapshot at query time via the existing
+    /// [`fluree_db_query::datalog_rules`] code path —
+    /// no term translation is needed because rules are inherently
+    /// IRI-keyed JSON-LD documents.
+    Rules(RulesArtifactWire),
 }
 
 /// Term-neutral wire form for a constraints artifact.
@@ -400,6 +413,55 @@ fn literal_to_flake_value(value: &str, datatype: &str) -> fluree_db_core::FlakeV
             .map(FlakeValue::Double)
             .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
         _ => FlakeValue::String(value.to_string()),
+    }
+}
+
+/// Term-neutral wire form for a datalog rules artifact.
+///
+/// Rules are JSON-LD documents — IRI references inside `where` /
+/// `insert` patterns are resolved against the data ledger's
+/// snapshot at parse time by
+/// [`fluree_db_query::datalog_rules::parse_query_time_rule`], the
+/// same path query-time rules from `opts.rules` use. We therefore
+/// just carry the raw JSON bodies on the wire; no Sid mapping is
+/// performed up front.
+///
+/// The materializer scans M's rules graph for `f:rule` flakes
+/// whose object is `FlakeValue::Json` (the only form the rule
+/// extractor recognises) and emits one `String` per rule.
+#[derive(Debug, Clone)]
+pub struct RulesArtifactWire {
+    /// Provenance for diagnostics and cache key derivation.
+    pub origin: WireOrigin,
+    /// Raw JSON-LD bodies of each `f:rule` definition discovered
+    /// on M's rules graph. Order preserves the materializer's
+    /// scan order; deduplication is the consumer's concern.
+    pub rules: Vec<String>,
+}
+
+impl RulesArtifactWire {
+    /// Decode each rule body into a `serde_json::Value` ready for
+    /// `execute_datalog_rules_with_query_rules`'s
+    /// `query_time_rules` slot. Malformed JSON entries are
+    /// skipped with a warning — a single bad rule should not
+    /// poison the entire ledger's reasoning pass.
+    pub fn parsed_rules(&self) -> Vec<serde_json::Value> {
+        let mut out = Vec::with_capacity(self.rules.len());
+        for (idx, raw) in self.rules.iter().enumerate() {
+            match serde_json::from_str(raw) {
+                Ok(v) => out.push(v),
+                Err(e) => {
+                    tracing::warn!(
+                        rule_index = idx,
+                        error = %e,
+                        ledger = %self.origin.model_ledger_id,
+                        graph = %self.origin.graph_iri,
+                        "skipping malformed cross-ledger rule"
+                    );
+                }
+            }
+        }
+        out
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -16,7 +16,12 @@ use std::sync::Arc;
 ///
 /// Only `PolicyRules` is implemented in Phase 1a; the remaining
 /// variants land in later phases per the design doc's phasing table.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `ArtifactKind` is part of the memo / cycle-detection key so that
+/// when a later phase adds a second variant (e.g., `Shapes`), a
+/// memoized `PolicyRules` entry for the same `(ledger, graph, t)`
+/// can't be returned to a caller asking for `Shapes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ArtifactKind {
     /// `f:policySource` → policy rule set.
     PolicyRules,
@@ -25,6 +30,19 @@ pub enum ArtifactKind {
     // DatalogRules   — Phase 2
     // Constraints    — Phase 2
 }
+
+impl std::fmt::Display for ArtifactKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArtifactKind::PolicyRules => f.write_str("PolicyRules"),
+        }
+    }
+}
+
+/// Memo / cycle-detection key. Includes `ArtifactKind` so concurrent
+/// (within one request) resolutions for different artifact kinds
+/// against the same `(ledger, graph, t)` don't collide.
+pub(crate) type ResolutionKey = (ArtifactKind, String, String, i64);
 
 /// A successfully resolved, term-neutral governance artifact.
 ///
@@ -89,10 +107,14 @@ pub struct ResolveCtx<'a> {
     /// `resolved_t` for unpinned references. Pinned `f:atT` does NOT
     /// populate this map; pinned values are per-resolve.
     pub resolved_ts: HashMap<String, i64>,
-    /// Active resolution stack (cycle detection).
-    pub active: Vec<(String, String, i64)>,
-    /// Per-request completed memo.
-    pub memo: HashMap<(String, String, i64), Arc<ResolvedGraph>>,
+    /// Active resolution stack (cycle detection). Keyed on the full
+    /// resolution tuple including `ArtifactKind` so a `PolicyRules`
+    /// resolve doesn't see a `Shapes` resolution of the same
+    /// `(ledger, graph, t)` as a cycle (or vice versa).
+    pub active: Vec<ResolutionKey>,
+    /// Per-request completed memo, keyed on the same tuple so
+    /// different artifact kinds can't return each other's entries.
+    pub memo: HashMap<ResolutionKey, Arc<ResolvedGraph>>,
 }
 
 impl<'a> ResolveCtx<'a> {
@@ -134,26 +156,26 @@ pub(crate) fn reject_if_reserved_graph(
 /// Memo lookup for the per-request completed map.
 ///
 /// Memo hits short-circuit before `active` is consulted, so two
-/// subsystems referencing the same `(ledger, graph, t)` resolve once
-/// and never trip cycle detection.
+/// subsystems referencing the same `(kind, ledger, graph, t)` resolve
+/// once and never trip cycle detection.
 pub(crate) fn memo_hit(
-    memo: &HashMap<(String, String, i64), Arc<ResolvedGraph>>,
-    tuple: &(String, String, i64),
+    memo: &HashMap<ResolutionKey, Arc<ResolvedGraph>>,
+    key: &ResolutionKey,
 ) -> Option<Arc<ResolvedGraph>> {
-    memo.get(tuple).cloned()
+    memo.get(key).cloned()
 }
 
 /// Cycle check against the active resolution stack.
 ///
-/// Returns the cycle as a chain (active stack + the offending tuple
+/// Returns the cycle as a chain (active stack + the offending key
 /// appended) when one is detected.
 pub(crate) fn check_cycle(
-    active: &[(String, String, i64)],
-    tuple: &(String, String, i64),
+    active: &[ResolutionKey],
+    key: &ResolutionKey,
 ) -> Result<(), CrossLedgerError> {
-    if active.iter().any(|t| t == tuple) {
+    if active.iter().any(|k| k == key) {
         let mut chain = active.to_vec();
-        chain.push(tuple.clone());
+        chain.push(key.clone());
         return Err(CrossLedgerError::CycleDetected { chain });
     }
     Ok(())
@@ -190,68 +212,98 @@ mod tests {
         );
     }
 
+    fn key(ledger: &str, graph: &str, t: i64) -> ResolutionKey {
+        (ArtifactKind::PolicyRules, ledger.into(), graph.into(), t)
+    }
+
     #[test]
     fn cycle_check_passes_for_unique_tuples() {
         let active = vec![
-            ("a:main".to_string(), "http://ex.org/p".to_string(), 10),
-            ("b:main".to_string(), "http://ex.org/q".to_string(), 20),
+            key("a:main", "http://ex.org/p", 10),
+            key("b:main", "http://ex.org/q", 20),
         ];
-        let new_tuple = ("c:main".to_string(), "http://ex.org/r".to_string(), 30);
-        assert!(check_cycle(&active, &new_tuple).is_ok());
+        let new_key = key("c:main", "http://ex.org/r", 30);
+        assert!(check_cycle(&active, &new_key).is_ok());
     }
 
     #[test]
     fn cycle_check_fails_on_reentry_and_renders_full_chain() {
-        let cycle_tuple = ("a:main".to_string(), "http://ex.org/p".to_string(), 10);
-        let active = vec![
-            cycle_tuple.clone(),
-            ("b:main".to_string(), "http://ex.org/q".to_string(), 20),
-        ];
-        let err = check_cycle(&active, &cycle_tuple).unwrap_err();
+        let cycle_key = key("a:main", "http://ex.org/p", 10);
+        let active = vec![cycle_key.clone(), key("b:main", "http://ex.org/q", 20)];
+        let err = check_cycle(&active, &cycle_key).unwrap_err();
         match err {
             CrossLedgerError::CycleDetected { chain } => {
                 // The chain should contain the original active stack
-                // (in order) plus the offending tuple appended.
+                // (in order) plus the offending key appended.
                 assert_eq!(chain.len(), 3);
-                assert_eq!(chain[0], cycle_tuple);
-                assert_eq!(chain[2], cycle_tuple);
+                assert_eq!(chain[0], cycle_key);
+                assert_eq!(chain[2], cycle_key);
             }
             other => panic!("expected CycleDetected, got {other:?}"),
         }
     }
 
     #[test]
+    fn cycle_check_treats_different_artifact_kinds_on_same_graph_as_distinct() {
+        // Two artifact kinds resolving the same (ledger, graph, t)
+        // are NOT a cycle — they're materializing different things
+        // (policy rules vs shapes vs schema) from the same source.
+        // Phase 1a only has PolicyRules so this test uses a synthetic
+        // second variant by reusing PolicyRules with a sentinel
+        // pattern; it will be expanded in Phase 1b when SchemaClosure
+        // lands. The contract this guards: adding a new ArtifactKind
+        // doesn't make existing resolutions look cyclic.
+        let active = vec![(
+            ArtifactKind::PolicyRules,
+            "a:main".to_string(),
+            "http://ex.org/p".to_string(),
+            10,
+        )];
+        // Once Phase 1b adds e.g. ArtifactKind::SchemaClosure, this
+        // test should use that variant to verify cross-kind isolation.
+        // For now: same kind / different t (a clearly-non-cycle case)
+        // exercises the same code path under the new tuple shape.
+        let later_pin = (
+            ArtifactKind::PolicyRules,
+            "a:main".to_string(),
+            "http://ex.org/p".to_string(),
+            20,
+        );
+        assert!(check_cycle(&active, &later_pin).is_ok());
+    }
+
+    #[test]
     fn cycle_check_treats_different_t_pins_of_same_graph_as_distinct() {
-        // Two f:atT pins of the same (ledger, graph) are NOT a cycle.
-        // The design doc is explicit on this.
-        let active = vec![("a:main".to_string(), "http://ex.org/p".to_string(), 10)];
-        let later_pin = ("a:main".to_string(), "http://ex.org/p".to_string(), 20);
+        // Two pins of the same (kind, ledger, graph) at different t
+        // are NOT a cycle. The design doc is explicit on this.
+        let active = vec![key("a:main", "http://ex.org/p", 10)];
+        let later_pin = key("a:main", "http://ex.org/p", 20);
         assert!(check_cycle(&active, &later_pin).is_ok());
     }
 
     #[test]
     fn memo_returns_cloned_arc_on_hit_and_none_on_miss() {
         let mut memo = HashMap::new();
-        let tuple = ("a:main".to_string(), "http://ex.org/p".to_string(), 10);
+        let resolution_key = key("a:main", "http://ex.org/p", 10);
 
         let payload = Arc::new(ResolvedGraph {
-            model_ledger_id: tuple.0.clone(),
-            graph_iri: tuple.1.clone(),
-            resolved_t: tuple.2,
+            model_ledger_id: resolution_key.1.clone(),
+            graph_iri: resolution_key.2.clone(),
+            resolved_t: resolution_key.3,
             artifact: GovernanceArtifact::PolicyRules(PolicyArtifactWire {
                 origin: fluree_db_policy::WireOrigin {
-                    model_ledger_id: tuple.0.clone(),
-                    graph_iri: tuple.1.clone(),
-                    resolved_t: tuple.2,
+                    model_ledger_id: resolution_key.1.clone(),
+                    graph_iri: resolution_key.2.clone(),
+                    resolved_t: resolution_key.3,
                 },
                 restrictions: vec![],
             }),
         });
 
-        assert!(memo_hit(&memo, &tuple).is_none());
-        memo.insert(tuple.clone(), payload.clone());
+        assert!(memo_hit(&memo, &resolution_key).is_none());
+        memo.insert(resolution_key.clone(), payload.clone());
 
-        let hit = memo_hit(&memo, &tuple).expect("hit after insert");
+        let hit = memo_hit(&memo, &resolution_key).expect("hit after insert");
         assert!(Arc::ptr_eq(&hit, &payload), "memo must return shared Arc");
     }
 }

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -26,11 +26,15 @@ pub enum ArtifactKind {
     /// `f:enforceUnique true` on the model ledger.
     Constraints,
     /// `f:schemaSource` → schema/ontology axiom triples projected
-    /// from the model ledger's ontology graph. Single-graph only
-    /// in Phase 1b-a; transitive `owl:imports` recursion lands in
-    /// a follow-up.
+    /// from the model ledger's ontology graph. Single-graph only;
+    /// transitive `owl:imports` recursion across ledgers is
+    /// reserved.
     SchemaClosure,
-    // Shapes         — reserved
+    /// `f:shapesSource` → SHACL shape triples (whitelist + rdf:list
+    /// internals for sh:in / sh:and / sh:or / sh:xone) projected
+    /// from the model ledger's shapes graph. Carries literals as
+    /// well as Refs.
+    Shapes,
     // DatalogRules   — reserved
 }
 
@@ -40,6 +44,7 @@ impl std::fmt::Display for ArtifactKind {
             ArtifactKind::PolicyRules => f.write_str("PolicyRules"),
             ArtifactKind::Constraints => f.write_str("Constraints"),
             ArtifactKind::SchemaClosure => f.write_str("SchemaClosure"),
+            ArtifactKind::Shapes => f.write_str("Shapes"),
         }
     }
 }
@@ -92,7 +97,13 @@ pub enum GovernanceArtifact {
     /// `fluree_db_query::SchemaBundleFlakes` via
     /// [`SchemaArtifactWire::translate_to_schema_bundle_flakes`].
     SchemaClosure(SchemaArtifactWire),
-    // Shapes(ShapeSetWire)            — reserved
+    /// SHACL shape triples in IRI-form. Translate via
+    /// [`ShapesArtifactWire::translate_to_schema_bundle_flakes`]
+    /// against the *staged* `NamespaceRegistry` (not D's base
+    /// snapshot) so IRIs the in-flight transaction introduced are
+    /// encodable. M-only IRIs that D has never seen are dropped
+    /// silently — those shapes can't apply to data D doesn't have.
+    Shapes(ShapesArtifactWire),
     // DatalogRules(DatalogRuleSetWire) — reserved
 }
 
@@ -260,6 +271,135 @@ impl SchemaArtifactWire {
             collected,
         )
         .map(std::sync::Arc::new)
+    }
+}
+
+/// Term-neutral wire form for a SHACL shapes artifact.
+///
+/// Carries the SHACL whitelist triples (sh:targetClass / sh:property /
+/// sh:minCount / sh:pattern / ... — the full vocabulary
+/// `ShapeCompiler::compile_from_dbs` scans for) plus the
+/// rdf:first / rdf:rest internals needed for sh:in / sh:and /
+/// sh:or / sh:xone list expansion. Object positions handle both
+/// Ref and Literal via [`WireObject`].
+///
+/// **Translation timing matters.** The translator on D must run
+/// against the *staged* `NamespaceRegistry`, not the pre-staging
+/// snapshot. The staging registry contains IRIs that the in-flight
+/// transaction is introducing (e.g., `ex:User` declared by the
+/// tx being validated); the pre-stage snapshot does not.
+/// Translating against the wrong context drops everything and the
+/// shape silently doesn't apply.
+///
+/// IRIs the staged registry hasn't seen are dropped silently —
+/// the shape couldn't apply to data D doesn't have anyway, and
+/// allocating a fresh namespace code for an M-only IRI would
+/// introduce namespace churn into D for no benefit.
+#[derive(Debug, Clone)]
+pub struct ShapesArtifactWire {
+    /// Provenance for diagnostics and cache key derivation.
+    pub origin: WireOrigin,
+    /// SHACL whitelist triples + rdf:list internals in the order
+    /// the materializer read them from M.
+    pub triples: Vec<WireTriple>,
+}
+
+impl ShapesArtifactWire {
+    /// Translate to a Sid-form `SchemaBundleFlakes` against the
+    /// data ledger's *staged* namespace registry. The bundle is
+    /// then wrapped in `SchemaBundleOverlay` and fed to
+    /// `ShaclEngine::from_dbs_with_overlay`.
+    ///
+    /// `staged_ns` is the `NamespaceRegistry` that the staging
+    /// pipeline carries — it has D's snapshot namespaces *plus*
+    /// any IRIs the in-flight transaction has registered. Encoding
+    /// is lookup-only (`NamespaceRegistry::lookup_sid_for_iri`);
+    /// unknown IRIs drop their triples rather than allocating
+    /// fresh codes in D.
+    ///
+    /// Literal object values reconstruct via the same datatype
+    /// dispatch the schema translator uses — xsd:integer → Long,
+    /// xsd:boolean → Boolean, etc.; unknown datatypes fall back
+    /// to `FlakeValue::String`.
+    pub fn translate_to_schema_bundle_flakes(
+        &self,
+        staged_ns: &fluree_db_transact::namespace::NamespaceRegistry,
+    ) -> fluree_db_query::error::Result<std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>>
+    {
+        use fluree_db_core::flake::Flake;
+        use fluree_db_core::Sid;
+
+        let mut collected: Vec<Flake> = Vec::with_capacity(self.triples.len());
+        for t in &self.triples {
+            let (Some(s_sid), Some(p_sid)) = (
+                staged_ns.lookup_sid_for_iri(&t.s),
+                staged_ns.lookup_sid_for_iri(&t.p),
+            ) else {
+                continue;
+            };
+            let (o_value, dt_sid) = match &t.o {
+                WireObject::Ref(o_iri) => {
+                    let Some(o_sid) = staged_ns.lookup_sid_for_iri(o_iri) else {
+                        continue;
+                    };
+                    (
+                        fluree_db_core::FlakeValue::Ref(o_sid),
+                        Sid::new(fluree_vocab::namespaces::JSON_LD, "id"),
+                    )
+                }
+                WireObject::Literal {
+                    value,
+                    datatype,
+                    lang: _,
+                } => {
+                    let dt_sid = staged_ns.lookup_sid_for_iri(datatype).unwrap_or_else(
+                        || Sid::new(fluree_vocab::namespaces::XSD, "string"),
+                    );
+                    (literal_to_flake_value(value, datatype), dt_sid)
+                }
+            };
+            collected.push(Flake {
+                g: None,
+                s: s_sid,
+                p: p_sid,
+                o: o_value,
+                dt: dt_sid,
+                t: 0,
+                op: true,
+                m: None,
+            });
+        }
+        fluree_db_query::schema_bundle::SchemaBundleFlakes::from_collected_schema_triples(
+            collected,
+        )
+        .map(std::sync::Arc::new)
+    }
+}
+
+/// Decode a wire literal into the matching `FlakeValue`. Falls back
+/// to `String(value)` on parse failure or unknown datatype — the
+/// SHACL compiler will simply not match the value on type-sensitive
+/// constraints, same as if the constraint weren't authored.
+fn literal_to_flake_value(value: &str, datatype: &str) -> fluree_db_core::FlakeValue {
+    use fluree_db_core::FlakeValue;
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+    let local = datatype.strip_prefix(XSD).unwrap_or("");
+    match local {
+        "boolean" => value
+            .parse::<bool>()
+            .map(FlakeValue::Boolean)
+            .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
+        "integer" | "long" | "int" | "short" | "byte" | "nonNegativeInteger"
+        | "positiveInteger" | "negativeInteger" | "nonPositiveInteger"
+        | "unsignedLong" | "unsignedInt" | "unsignedShort" | "unsignedByte" => value
+            .parse::<i64>()
+            .map(FlakeValue::Long)
+            .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
+        "double" | "float" => value
+            .parse::<f64>()
+            .map(FlakeValue::Double)
+            .unwrap_or_else(|_| FlakeValue::String(value.to_string())),
+        _ => FlakeValue::String(value.to_string()),
     }
 }
 

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -461,9 +461,7 @@ impl RulesArtifactWire {
                     return Err(super::CrossLedgerError::TranslationFailed {
                         ledger_id: self.origin.model_ledger_id.clone(),
                         graph_iri: self.origin.graph_iri.clone(),
-                        detail: format!(
-                            "malformed cross-ledger rule at index {idx}: {e}"
-                        ),
+                        detail: format!("malformed cross-ledger rule at index {idx}: {e}"),
                     });
                 }
             }
@@ -540,6 +538,31 @@ impl<'a> ResolveCtx<'a> {
             data_ledger_id,
             fluree,
             resolved_ts: HashMap::new(),
+            active: Vec::new(),
+            memo: HashMap::new(),
+        }
+    }
+
+    /// Build a resolution context pre-seeded with `resolved_t`
+    /// captures from an earlier stage of the same logical request.
+    ///
+    /// Used by query preparation when a prior `wrap_policy` call on
+    /// the same view already pinned a model ledger's `resolved_t`:
+    /// the new context inherits that pin so a second cross-ledger
+    /// reference to the same M can't re-capture a later head and
+    /// disagree with policy on which M version is in effect.
+    /// `memo` and `active` are *not* shared — those are
+    /// per-resolution-call state (cycle detection, dedup within a
+    /// single dispatch tree) and don't carry across calls.
+    pub fn with_resolved_ts(
+        data_ledger_id: &'a str,
+        fluree: &'a Fluree,
+        resolved_ts: HashMap<String, i64>,
+    ) -> Self {
+        Self {
+            data_ledger_id,
+            fluree,
+            resolved_ts,
             active: Vec::new(),
             memo: HashMap::new(),
         }

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -46,8 +46,10 @@ pub(crate) type ResolutionKey = (ArtifactKind, String, String, i64);
 
 /// A successfully resolved, term-neutral governance artifact.
 ///
-/// Cached at the API layer by `(model_ledger_id, graph_iri,
-/// resolved_t)`; per-data-ledger interning is a separate step.
+/// Cached at the API layer by `(ArtifactKind, model_ledger_id,
+/// graph_iri, resolved_t)` — see [`ResolutionKey`]. Per-data-ledger
+/// interning is a separate step that happens at the wire→PolicySet
+/// boundary against D's snapshot.
 #[derive(Debug, Clone)]
 pub struct ResolvedGraph {
     /// Canonical model ledger id this artifact came from.
@@ -56,16 +58,18 @@ pub struct ResolvedGraph {
     pub graph_iri: String,
     /// Model ledger `t` at which the artifact was materialized.
     pub resolved_t: i64,
-    /// The artifact itself, tagged by subsystem.
+    /// The artifact itself, tagged by subsystem. Pattern-match this
+    /// against the expected `GovernanceArtifact` variant for the
+    /// requesting `ArtifactKind`.
     pub artifact: GovernanceArtifact,
 }
 
 /// Tagged union of governance artifacts.
 ///
-/// The kind is named so a `ResolveCtx` memo (which is keyed only on
-/// `(ledger, graph, t)`) can carry mixed artifact types without
-/// dynamic dispatch and so callers can pattern-match to extract the
-/// shape they expect.
+/// The variant is paired with [`ArtifactKind`] in [`ResolutionKey`]
+/// so the memo can carry mixed artifact types without dynamic
+/// dispatch — callers pattern-match to extract the shape they
+/// expect.
 #[derive(Debug, Clone)]
 pub enum GovernanceArtifact {
     /// Policy rule set in IRI-form. Translate to `PolicySet` via
@@ -79,24 +83,26 @@ pub enum GovernanceArtifact {
 
 /// Per-request resolution context.
 ///
-/// Born with the full lifetime / consistency model so the resolver
-/// API is correct from day one even before materialization lands:
+/// Holds the full lifetime / consistency model for cross-ledger
+/// resolution within a single request:
 ///
 /// - `resolved_ts` captures the lazy per-request head-t per
-///   canonical model ledger id (governance-context capture). Lookup
-///   on miss reads M's head once and stores it; later unpinned
+///   canonical model ledger id (governance-context capture).
+///   Lookup on miss reads M's head once and stores it; subsequent
 ///   references to the same M reuse the same value so policy and
 ///   shapes can never disagree about which version of M they're
-///   enforcing.
+///   enforcing. `f:atT` pins are rejected as
+///   [`CrossLedgerError::UnsupportedFeature`] until Phase 3 lands,
+///   so the only `resolved_t` source today is this lazy capture.
 ///
-/// - `active` is the resolution stack used for cycle detection. Push
-///   before recursion, pop after. A tuple is a cycle only when it is
+/// - `active` is the resolution stack used for cycle detection.
+///   Push before recursion, pop after. A key is a cycle only when
 ///   encountered while *already on the stack*.
 ///
 /// - `memo` is the per-request completed map. Subsequent references
-///   to the same `(ledger, graph, t)` tuple — from any subsystem —
-///   short-circuit on a memo hit. Memo hits never enter `active`,
-///   so cross-subsystem de-dup never trips cycle detection.
+///   to the same [`ResolutionKey`] — from any subsystem — short-
+///   circuit on a memo hit. Memo hits never enter `active`, so
+///   cross-subsystem de-dup never trips cycle detection.
 pub struct ResolveCtx<'a> {
     /// Canonical data-ledger id D.
     pub data_ledger_id: &'a str,
@@ -104,8 +110,9 @@ pub struct ResolveCtx<'a> {
     /// constraint) the referenced model ledger.
     pub fluree: &'a Fluree,
     /// Lazy governance-context capture: canonical model ledger id →
-    /// `resolved_t` for unpinned references. Pinned `f:atT` does NOT
-    /// populate this map; pinned values are per-resolve.
+    /// `resolved_t`. Phase 1a is the only producer (M's head at
+    /// first reference); pinned `f:atT` is rejected upstream until
+    /// Phase 3.
     pub resolved_ts: HashMap<String, i64>,
     /// Active resolution stack (cycle detection). Keyed on the full
     /// resolution tuple including `ArtifactKind` so a `PolicyRules`

--- a/fluree-db-api/src/cross_ledger/types.rs
+++ b/fluree-db-api/src/cross_ledger/types.rs
@@ -151,7 +151,7 @@ impl ConstraintsArtifactWire {
     ) -> Vec<fluree_db_core::Sid> {
         self.property_iris
             .iter()
-            .filter_map(|iri| snapshot.encode_iri(iri))
+            .filter_map(|iri| snapshot.encode_iri_strict(iri))
             .collect()
     }
 }
@@ -162,10 +162,10 @@ impl ConstraintsArtifactWire {
 /// owl:equivalentClass, owl:imports, rdf:type for owl:Class/etc.,
 /// plus the rest of the schema-bundle whitelist) in IRI form. The
 /// translator on D encodes each IRI against D's snapshot and builds
-/// a `SchemaBundleFlakes` from the result. IRIs that fail to encode
-/// drop their triples — same semantics as the same-ledger
-/// `build_schema_bundle_flakes` flow, where `encode_iri` returning
-/// `None` for an unseen IRI contributes nothing.
+/// a `SchemaBundleFlakes` from the result. Triples whose subject,
+/// predicate, or object IRI has no registered namespace on D are
+/// dropped — D has no instance data under those IRIs, so the missing
+/// axiom can't fire on data D doesn't have.
 ///
 /// Phase 1b-a constraint: the materializer projects only Ref-valued
 /// objects (every predicate / class in the schema whitelist is
@@ -207,8 +207,8 @@ pub struct WireTriple {
 /// as if the constraint weren't authored.
 #[derive(Debug, Clone)]
 pub enum WireObject {
-    /// IRI reference; encoded via `snapshot.encode_iri` at the data
-    /// ledger to produce a `FlakeValue::Ref(Sid)`.
+    /// IRI reference; encoded via `snapshot.encode_iri_strict` at the
+    /// data ledger to produce a `FlakeValue::Ref(Sid)`.
     Ref(String),
     /// Literal value in its canonical lexical form, paired with the
     /// datatype IRI and optional language tag. The datatype IRI is
@@ -234,11 +234,11 @@ impl SchemaArtifactWire {
     /// Translate to a Sid-form `SchemaBundleFlakes` against the
     /// data ledger's snapshot.
     ///
-    /// Each triple's IRIs are encoded via `snapshot.encode_iri`.
-    /// Failed encodings drop the triple — D has no data of those
-    /// IRIs so the missing axiom can't fire on instance data D
-    /// doesn't have, matching same-ledger semantics. The
-    /// downstream whitelist check in
+    /// Each triple's IRIs are encoded via `snapshot.encode_iri_strict`.
+    /// Triples whose subject, predicate, or object IRI has no
+    /// registered namespace on D are dropped — D has no instance
+    /// data under those IRIs so the missing axiom can't fire on data
+    /// D doesn't have. The downstream whitelist check in
     /// `SchemaBundleFlakes::from_collected_schema_triples` is the
     /// canonical filter; if a future cross-ledger producer emits
     /// non-whitelist triples they'll drop there.
@@ -262,9 +262,9 @@ impl SchemaArtifactWire {
                 continue;
             };
             let (Some(s_sid), Some(p_sid), Some(o_sid)) = (
-                snapshot.encode_iri(&t.s),
-                snapshot.encode_iri(&t.p),
-                snapshot.encode_iri(o_iri),
+                snapshot.encode_iri_strict(&t.s),
+                snapshot.encode_iri_strict(&t.p),
+                snapshot.encode_iri_strict(o_iri),
             ) else {
                 continue;
             };

--- a/fluree-db-api/src/error.rs
+++ b/fluree-db-api/src/error.rs
@@ -278,6 +278,18 @@ pub enum ApiError {
     /// Builder validation errors (one or more problems with builder configuration)
     #[error("{0}")]
     Builder(BuilderErrors),
+
+    /// Cross-ledger governance resolution failed.
+    ///
+    /// Wrapped variant carries the specific failure (missing ledger,
+    /// graph missing at t, retention pruned, reserved graph,
+    /// translation failure, trust failure, cross-instance, cycle).
+    /// HTTP layer maps this to 502; the variant is preserved in the
+    /// response body so callers can branch on it. Every variant is
+    /// fail-closed — there is no silent fallback to "no policy" or
+    /// "no shapes" when a cross-ledger dependency cannot be served.
+    #[error("Cross-ledger error: {0}")]
+    CrossLedger(#[from] crate::cross_ledger::CrossLedgerError),
 }
 
 impl ApiError {
@@ -396,6 +408,14 @@ impl ApiError {
             ) => 409,
             // Other transaction errors are usually validation failures
             ApiError::Transact(_) => 400,
+            // Cross-ledger model dependency could not be resolved /
+            // used. Conceptually an upstream-dependency failure, not
+            // an internal panic. 502 Bad Gateway is the pragmatic
+            // choice; 424 Failed Dependency is closer semantically
+            // but less commonly handled by client tooling. The
+            // wrapped variant is preserved for callers that branch
+            // on the specific failure.
+            ApiError::CrossLedger(_) => 502,
             // Internal/infrastructure errors
             _ => 500,
         }

--- a/fluree-db-api/src/inline_ontology.rs
+++ b/fluree-db-api/src/inline_ontology.rs
@@ -1,0 +1,119 @@
+//! Inline ontology (RDFS / OWL) axioms parsing for queries.
+//!
+//! Parses a JSON-LD document carrying schema axioms
+//! (rdfs:subClassOf, rdfs:subPropertyOf, owl:inverseOf,
+//! owl:equivalentClass / equivalentProperty, owl:imports,
+//! rdf:type for owl:Class / owl:TransitiveProperty / …) into a
+//! [`SchemaBundleFlakes`] suitable for layering onto
+//! `ReasoningConfig.schema_bundle` at query preparation time.
+//!
+//! Mirrors [`crate::inline_shapes::parse_inline_shapes_to_bundle`]
+//! but runs against the live snapshot's namespace registry instead
+//! of a staged-tx registry, because reasoning happens at query
+//! time. The registry is cloned for the parse so any ns-code
+//! allocations stay scoped to the request — the on-disk dictionary
+//! is untouched.
+
+use fluree_db_core::{Flake, LedgerSnapshot};
+use fluree_db_query::schema_bundle::SchemaBundleFlakes;
+use fluree_db_transact::flake_sink::FlakeSink;
+use fluree_db_transact::namespace::NamespaceRegistry;
+use fluree_graph_ir::GraphSink;
+use serde_json::Value as JsonValue;
+use std::sync::Arc;
+
+/// Parse a JSON-LD ontology document into a `SchemaBundleFlakes`.
+///
+/// Encoding runs against a `NamespaceRegistry` seeded from
+/// `snapshot`. IRIs the snapshot already knows reuse the existing
+/// codes (so reasoning joins line up); axioms naming previously
+/// unseen IRIs allocate fresh in-request codes that are discarded
+/// when the request returns.
+///
+/// Returns `Ok(None)` for a no-triple document so callers can
+/// skip overlay construction. Parse / event errors return
+/// [`ApiError::config`] — the inline ontology is admin-supplied
+/// for *this query*, so silently dropping it is the wrong
+/// failure mode.
+pub(crate) fn parse_inline_ontology_to_bundle(
+    ontology_json: &JsonValue,
+    snapshot: &LedgerSnapshot,
+) -> crate::Result<Option<Arc<SchemaBundleFlakes>>> {
+    let mut ns_registry = NamespaceRegistry::from_db(snapshot);
+    let txn_id = format!("inline-ontology-{}", snapshot.ledger_id);
+    let mut sink = FlakeSink::new(&mut ns_registry, 0, txn_id);
+
+    register_jsonld_prefixes(ontology_json, &mut sink);
+
+    let expanded = fluree_graph_json_ld::expand(ontology_json).map_err(|e| {
+        crate::ApiError::config(format!("inline ontology JSON-LD expand error: {e}"))
+    })?;
+    fluree_graph_json_ld::adapter::to_graph_events(&expanded, &mut sink).map_err(|e| {
+        crate::ApiError::config(format!(
+            "inline ontology JSON-LD event conversion error: {e}"
+        ))
+    })?;
+
+    let flakes: Vec<Flake> = sink
+        .finish()
+        .map_err(|e| crate::ApiError::config(format!("inline ontology flake build failed: {e}")))?;
+    if flakes.is_empty() {
+        return Ok(None);
+    }
+    let bundle = SchemaBundleFlakes::from_collected_schema_triples(flakes).map_err(|e| {
+        crate::ApiError::config(format!("inline ontology bundle construction failed: {e}"))
+    })?;
+    Ok(Some(Arc::new(bundle)))
+}
+
+/// Build a single `SchemaBundleFlakes` by concatenating the flakes
+/// from two bundles. `from_collected_schema_triples` dedupes,
+/// sorts each index ordering, and recomputes the epoch — so an
+/// inline ontology that repeats axioms already in the configured
+/// bundle costs nothing extra at reasoning time.
+pub(crate) fn merge_bundles(
+    a: Arc<SchemaBundleFlakes>,
+    b: Arc<SchemaBundleFlakes>,
+) -> crate::Result<Arc<SchemaBundleFlakes>> {
+    let mut combined = a.flakes_for_merge();
+    combined.extend(b.flakes_for_merge());
+    let bundle = SchemaBundleFlakes::from_collected_schema_triples(combined).map_err(|e| {
+        crate::ApiError::config(format!("inline ontology bundle merge failed: {e}"))
+    })?;
+    Ok(Arc::new(bundle))
+}
+
+/// Register JSON-LD `@context` prefix mappings into the sink's
+/// namespace allocator before `expand()` runs. Same shape as the
+/// helper in [`crate::inline_shapes`]; kept local so each inline
+/// surface stays self-contained.
+fn register_jsonld_prefixes(doc: &JsonValue, sink: &mut FlakeSink<'_>) {
+    fn visit_context(ctx: &JsonValue, sink: &mut FlakeSink<'_>) {
+        match ctx {
+            JsonValue::Object(obj) => {
+                for (key, val) in obj {
+                    if key.starts_with('@') {
+                        continue;
+                    }
+                    if let Some(iri) = val.as_str() {
+                        sink.on_prefix(key, iri);
+                    } else if let Some(obj_val) = val.as_object() {
+                        if let Some(id) = obj_val.get("@id").and_then(|v| v.as_str()) {
+                            sink.on_prefix(key, id);
+                        }
+                    }
+                }
+            }
+            JsonValue::Array(arr) => {
+                for item in arr {
+                    visit_context(item, sink);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(ctx) = doc.get("@context") {
+        visit_context(ctx, sink);
+    }
+}

--- a/fluree-db-api/src/inline_shapes.rs
+++ b/fluree-db-api/src/inline_shapes.rs
@@ -1,0 +1,105 @@
+//! Inline SHACL shapes parsing.
+//!
+//! Parses a JSON-LD document carrying SHACL shape definitions
+//! (`sh:NodeShape`, `sh:targetClass`, `sh:property`, …) into a
+//! `SchemaBundleFlakes` suitable for [`fluree_db_query::schema_bundle::SchemaBundleOverlay`].
+//!
+//! Reuses `FlakeSink` — the same direct-to-flakes sink that powers
+//! Turtle insert. Encoding happens against the data ledger's
+//! *staged* `NamespaceRegistry`, matching the term context used for
+//! cross-ledger shapes. Allocating fresh ns codes for inline shape
+//! vocabulary is acceptable: the user explicitly asked the engine
+//! to honor those IRIs for this transaction, which is functionally
+//! equivalent to staging the shapes directly.
+//!
+//! Inline shape flakes do *not* persist into the ledger — they live
+//! only on the in-memory overlay attached to this transaction's
+//! SHACL validation pass.
+
+use fluree_db_core::Flake;
+use fluree_db_query::schema_bundle::SchemaBundleFlakes;
+use fluree_db_transact::flake_sink::FlakeSink;
+use fluree_db_transact::namespace::NamespaceRegistry;
+use fluree_db_transact::TransactError;
+use fluree_graph_ir::GraphSink;
+use serde_json::Value as JsonValue;
+use std::sync::Arc;
+
+/// Parse a JSON-LD inline shapes document into a
+/// `SchemaBundleFlakes`. Encoding runs against `staged_ns`, which
+/// the staging pipeline has already updated with any namespaces
+/// the in-flight transaction introduced.
+///
+/// Returns `Ok(None)` for empty / no-triple documents so the caller
+/// can skip overlay construction entirely. Returns an error if the
+/// JSON-LD is malformed or contains unsupported constructs — the
+/// transaction is rejected rather than silently dropping shapes.
+pub(crate) fn parse_inline_shapes_to_bundle(
+    shapes_json: &JsonValue,
+    staged_ns: &mut NamespaceRegistry,
+    t: i64,
+    ledger_id: &str,
+) -> Result<Option<Arc<SchemaBundleFlakes>>, TransactError> {
+    // FlakeSink wants an owned txn_id for blank-node skolemization;
+    // the inline-shapes context is transient so a synthetic id is
+    // fine. Any blank-node shapes parsed here get unique sids.
+    let txn_id = format!("inline-shapes-{ledger_id}-{t}");
+
+    let mut sink = FlakeSink::new(staged_ns, t, txn_id);
+
+    // Pre-register @context prefixes so IRIs the parser produces
+    // align with the user's intended namespace boundaries.
+    register_jsonld_prefixes(shapes_json, &mut sink);
+
+    let expanded = fluree_graph_json_ld::expand(shapes_json)
+        .map_err(|e| TransactError::Parse(format!("inline shapes JSON-LD expand error: {e}")))?;
+    fluree_graph_json_ld::adapter::to_graph_events(&expanded, &mut sink).map_err(|e| {
+        TransactError::Parse(format!("inline shapes JSON-LD event conversion error: {e}"))
+    })?;
+
+    let flakes: Vec<Flake> = sink.finish()?;
+    if flakes.is_empty() {
+        return Ok(None);
+    }
+
+    let bundle = SchemaBundleFlakes::from_collected_schema_triples(flakes).map_err(|e| {
+        TransactError::Parse(format!("inline shapes bundle construction failed: {e}"))
+    })?;
+    Ok(Some(Arc::new(bundle)))
+}
+
+/// Register JSON-LD `@context` prefix mappings into the sink's
+/// namespace allocator before `expand()` runs. Mirrors the helper
+/// in `fluree-db-transact/src/import.rs` so the trie ends up with
+/// the same prefix codes whether shapes arrive via inline-opts or
+/// via a normal staged transaction.
+fn register_jsonld_prefixes(doc: &JsonValue, sink: &mut FlakeSink<'_>) {
+    fn visit_context(ctx: &JsonValue, sink: &mut FlakeSink<'_>) {
+        match ctx {
+            JsonValue::Object(obj) => {
+                for (key, val) in obj {
+                    if key.starts_with('@') {
+                        continue;
+                    }
+                    if let Some(iri) = val.as_str() {
+                        sink.on_prefix(key, iri);
+                    } else if let Some(obj_val) = val.as_object() {
+                        if let Some(id) = obj_val.get("@id").and_then(|v| v.as_str()) {
+                            sink.on_prefix(key, id);
+                        }
+                    }
+                }
+            }
+            JsonValue::Array(arr) => {
+                for item in arr {
+                    visit_context(item, sink);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(ctx) = doc.get("@context") {
+        visit_context(ctx, sink);
+    }
+}

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -56,6 +56,7 @@ pub mod graph_source;
 pub mod graph_transact_builder;
 pub mod import;
 mod indexer_fulltext_provider;
+mod inline_ontology;
 #[cfg(feature = "shacl")]
 mod inline_shapes;
 mod ledger;

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -39,9 +39,9 @@ pub mod bm25_worker;
 mod commit_data;
 pub mod commit_transfer;
 pub mod config_resolver;
-pub mod cross_ledger;
 #[cfg(feature = "credential")]
 pub mod credential;
+pub mod cross_ledger;
 pub mod dataset;
 mod error;
 pub mod explain;
@@ -56,6 +56,8 @@ pub mod graph_source;
 pub mod graph_transact_builder;
 pub mod import;
 mod indexer_fulltext_provider;
+#[cfg(feature = "shacl")]
+mod inline_shapes;
 mod ledger;
 pub mod ledger_info;
 mod merge;

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -39,6 +39,7 @@ pub mod bm25_worker;
 mod commit_data;
 pub mod commit_transfer;
 pub mod config_resolver;
+pub mod cross_ledger;
 #[cfg(feature = "credential")]
 pub mod credential;
 pub mod dataset;

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -2262,6 +2262,7 @@ impl FlureeBuilder {
             index_config,
         } = parts;
         let leaflet_cache = make_leaflet_cache(&config);
+        let governance_cache = std::sync::Arc::new(cross_ledger::GovernanceCache::new());
 
         let ledger_manager = ledger_cache_config.map(|mut lm_config| {
             if lm_config.leaflet_cache.is_none() {
@@ -2279,6 +2280,7 @@ impl FlureeBuilder {
             backend,
             nameservice_mode: nameservice,
             leaflet_cache,
+            governance_cache,
             indexing_mode,
             index_config,
             r2rml_cache: std::sync::Arc::new(graph_source::R2rmlCache::with_defaults()),
@@ -2513,6 +2515,13 @@ pub struct Fluree {
     nameservice_mode: NameServiceMode,
     /// Shared global cache for decoded index artifacts (one budget).
     leaflet_cache: std::sync::Arc<fluree_db_binary_index::LeafletCache>,
+    /// Per-instance cache for resolved cross-ledger governance
+    /// artifacts (`f:policySource` from a model ledger, etc.). Keyed
+    /// on `(ArtifactKind, model_ledger_id, graph_iri, resolved_t)`
+    /// so a single entry is reusable across every data ledger on
+    /// this instance that references the same model graph at the
+    /// same model `t`.
+    governance_cache: std::sync::Arc<cross_ledger::GovernanceCache>,
     /// Indexing mode (disabled or background with handle)
     pub indexing_mode: tx::IndexingMode,
     /// Novelty backpressure thresholds used by commits and soft-trigger logic.
@@ -2565,6 +2574,7 @@ impl Fluree {
             backend,
             nameservice_mode: nameservice,
             leaflet_cache,
+            governance_cache: std::sync::Arc::new(cross_ledger::GovernanceCache::new()),
             indexing_mode: tx::IndexingMode::Disabled,
             index_config: server_defaults::default_index_config(),
             r2rml_cache: std::sync::Arc::new(graph_source::R2rmlCache::with_defaults()),
@@ -2587,6 +2597,7 @@ impl Fluree {
             backend: StorageBackend::Managed(Arc::new(storage)),
             nameservice_mode: nameservice,
             leaflet_cache,
+            governance_cache: std::sync::Arc::new(cross_ledger::GovernanceCache::new()),
             indexing_mode,
             index_config: server_defaults::default_index_config(),
             r2rml_cache: std::sync::Arc::new(graph_source::R2rmlCache::with_defaults()),
@@ -2752,6 +2763,15 @@ impl Fluree {
                 cache_dir: self.binary_store_cache_dir(),
             },
         )
+    }
+
+    /// Per-instance cache for cross-ledger governance artifacts.
+    ///
+    /// Exposed so the resolver in `cross_ledger::resolver` can plug
+    /// the cache between per-request memo and materialization, and
+    /// for callers that want to introspect occupancy in tests.
+    pub fn governance_cache(&self) -> &Arc<cross_ledger::GovernanceCache> {
+        &self.governance_cache
     }
 
     /// Get the raw address-based storage for admin/GC operations.

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -503,7 +503,10 @@ async fn load_policies_of_classes(
 /// because the scan layer filters out internal `fluree:ledger` predicates
 /// when the predicate is a variable. Since all policy vocabulary predicates
 /// are in the `fluree:ledger` namespace, we must query them explicitly.
-async fn load_policy_restriction(
+///
+/// `pub(crate)` so the cross-ledger materializer can reuse the same
+/// per-policy predicate fan-out against a model ledger's snapshot.
+pub(crate) async fn load_policy_restriction(
     snapshot: &LedgerSnapshot,
     overlay: &dyn fluree_db_core::OverlayProvider,
     to_t: i64,

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -117,6 +117,65 @@ pub async fn build_policy_context_from_opts(
     opts: &QueryConnectionOptions,
     policy_graphs: &[fluree_db_core::GraphId],
 ) -> Result<PolicyContext> {
+    build_policy_context_from_opts_inner(
+        snapshot,
+        overlay,
+        novelty_for_stats,
+        to_t,
+        opts,
+        policy_graphs,
+        None,
+    )
+    .await
+}
+
+/// Cross-ledger variant of [`build_policy_context_from_opts`].
+///
+/// `cross_ledger_restrictions` is a pre-materialized list produced
+/// against a model ledger by the cross-ledger resolver and
+/// translated into D's term space via
+/// `fluree_db_policy::wire_to_restrictions` (with D's configured
+/// `policy_class` set already applied as a filter). When supplied,
+/// the local same-ledger policy load (`load_policies_by_class` /
+/// `parse_inline_policy`) is bypassed for the class / inline-policy
+/// branch — those restrictions are used as-is. Identity loading and
+/// `?$identity` binding still run locally against D per the
+/// identity contract in the design doc.
+///
+/// `policy_graphs` is still consulted for the identity-mode path
+/// (`opts.identity` set) because identity binding always resolves
+/// against the data ledger; cross-ledger never contributes identity
+/// records.
+pub async fn build_policy_context_from_opts_with_cross_ledger(
+    snapshot: &LedgerSnapshot,
+    overlay: &dyn fluree_db_core::OverlayProvider,
+    novelty_for_stats: Option<&Novelty>,
+    to_t: i64,
+    opts: &QueryConnectionOptions,
+    policy_graphs: &[fluree_db_core::GraphId],
+    cross_ledger_restrictions: Vec<PolicyRestriction>,
+) -> Result<PolicyContext> {
+    build_policy_context_from_opts_inner(
+        snapshot,
+        overlay,
+        novelty_for_stats,
+        to_t,
+        opts,
+        policy_graphs,
+        Some(cross_ledger_restrictions),
+    )
+    .await
+}
+
+async fn build_policy_context_from_opts_inner(
+    snapshot: &LedgerSnapshot,
+    overlay: &dyn fluree_db_core::OverlayProvider,
+    novelty_for_stats: Option<&Novelty>,
+    to_t: i64,
+    opts: &QueryConnectionOptions,
+    policy_graphs: &[fluree_db_core::GraphId],
+    cross_ledger_restrictions: Option<Vec<PolicyRestriction>>,
+) -> Result<PolicyContext> {
     struct PolicyStatsLookup<'a> {
         overlay: &'a dyn fluree_db_core::OverlayProvider,
     }
@@ -189,7 +248,18 @@ pub async fn build_policy_context_from_opts(
             None
         };
 
-        let restrictions = if let Some(classes) = &opts.policy_class {
+        let restrictions = if let Some(xl) = cross_ledger_restrictions.clone() {
+            // Cross-ledger short-circuit: the resolver already
+            // materialized restrictions from the model ledger and
+            // (per the identity contract) the wire artifact has been
+            // filtered by opts.policy_class. opts.policy (inline
+            // JSON-LD) still applies and gets merged below.
+            let mut merged = xl;
+            if let Some(policy_json) = &opts.policy {
+                merged.extend(parse_inline_policy(snapshot, policy_json)?);
+            }
+            merged
+        } else if let Some(classes) = &opts.policy_class {
             load_policies_by_class(snapshot, overlay, to_t, classes, policy_graphs).await?
         } else if let Some(policy_json) = &opts.policy {
             parse_inline_policy(snapshot, policy_json)?

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -248,13 +248,17 @@ async fn build_policy_context_from_opts_inner(
             None
         };
 
-        let restrictions = if let Some(xl) = cross_ledger_restrictions.clone() {
+        let restrictions = if let Some(mut merged) = cross_ledger_restrictions {
             // Cross-ledger short-circuit: the resolver already
             // materialized restrictions from the model ledger and
             // (per the identity contract) the wire artifact has been
             // filtered by opts.policy_class. opts.policy (inline
             // JSON-LD) still applies and gets merged below.
-            let mut merged = xl;
+            //
+            // Moving — not cloning — the owned input keeps
+            // model-ledger policy sets (which can be large: each
+            // `PolicyRestriction` carries strings + hash sets) from
+            // paying a per-request copy.
             if let Some(policy_json) = &opts.policy {
                 merged.extend(parse_inline_policy(snapshot, policy_json)?);
             }

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -422,8 +422,10 @@ async fn load_policies_by_identity(
 
 /// Load policies by querying for subjects of the given class types.
 ///
-/// Legacy equivalent: `wrap-class-policy`
-async fn load_policies_by_class(
+/// Legacy equivalent: `wrap-class-policy`. `pub(crate)` so the
+/// cross-ledger resolver can reuse the same load path against a
+/// model ledger's snapshot.
+pub(crate) async fn load_policies_by_class(
     snapshot: &LedgerSnapshot,
     overlay: &dyn fluree_db_core::OverlayProvider,
     to_t: i64,

--- a/fluree-db-api/src/policy_view.rs
+++ b/fluree-db-api/src/policy_view.rs
@@ -152,7 +152,7 @@ pub async fn wrap_policy_view<'a>(
 ) -> Result<PolicyWrappedView<'a>> {
     let policy_graphs =
         resolve_policy_graphs_from_config(&ledger.snapshot, ledger.novelty.as_ref(), ledger.t())
-            .await;
+            .await?;
 
     let policy_ctx = policy_builder::build_policy_context_from_opts(
         &ledger.snapshot,
@@ -177,7 +177,8 @@ pub async fn wrap_policy_view_historical<'a>(
     view: &'a HistoricalLedgerView,
     opts: &QueryConnectionOptions,
 ) -> Result<PolicyWrappedView<'a>> {
-    let policy_graphs = resolve_policy_graphs_from_config(&view.snapshot, view, view.to_t()).await;
+    let policy_graphs =
+        resolve_policy_graphs_from_config(&view.snapshot, view, view.to_t()).await?;
 
     // Extract novelty from the view for stats computation (needed for f:onClass)
     let novelty_for_stats: Option<&Novelty> = view.overlay().map(std::convert::AsRef::as_ref);
@@ -218,7 +219,7 @@ pub async fn build_policy_context(
     to_t: i64,
     opts: &QueryConnectionOptions,
 ) -> Result<PolicyContext> {
-    let policy_graphs = resolve_policy_graphs_from_config(snapshot, overlay, to_t).await;
+    let policy_graphs = resolve_policy_graphs_from_config(snapshot, overlay, to_t).await?;
 
     policy_builder::build_policy_context_from_opts(
         snapshot,
@@ -262,28 +263,33 @@ pub async fn wrap_identity_policy_view<'a>(
 
 /// Read the config graph and resolve `f:policySource` to graph IDs.
 ///
-/// Returns `[0]` (default graph) if the config graph is empty, unreadable,
-/// or doesn't specify a policy source.
+/// Fails closed: if a config exists but cannot be loaded, or if a configured
+/// `f:policySource` cannot be resolved (unknown graph selector, unsupported
+/// cross-ledger / temporal / trust fields), the error is propagated instead
+/// of silently falling back to the default graph.
+///
+/// Returns `[0]` (default graph) only when no config has been written to the
+/// ledger yet (`Ok(None)`) or no `f:policySource` is configured — in both
+/// cases the caller's policy rules, if any, live in the default graph.
 async fn resolve_policy_graphs_from_config(
     snapshot: &LedgerSnapshot,
     overlay: &dyn OverlayProvider,
     to_t: i64,
-) -> Vec<fluree_db_core::GraphId> {
+) -> Result<Vec<fluree_db_core::GraphId>> {
     let config = match crate::config_resolver::resolve_ledger_config(snapshot, overlay, to_t).await
     {
         Ok(Some(c)) => c,
-        _ => return vec![0],
+        Ok(None) => return Ok(vec![0]),
+        Err(e) => {
+            return Err(crate::error::ApiError::config(format!(
+                "Failed to load ledger config while resolving f:policySource: {e}"
+            )));
+        }
     };
     let resolved = crate::config_resolver::resolve_effective_config(&config, None);
     let source = resolved
         .policy
         .as_ref()
         .and_then(|p| p.policy_source.as_ref());
-    match policy_builder::resolve_policy_source_g_ids(source, snapshot) {
-        Ok(g_ids) => g_ids,
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to resolve f:policySource — using default graph");
-            vec![0]
-        }
-    }
+    policy_builder::resolve_policy_source_g_ids(source, snapshot)
 }

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -512,13 +512,19 @@ async fn stage_with_config_shacl(
 /// Loads config from the pre-txn state (via `view.base()`) and checks
 /// staged flakes against `f:enforceUnique` annotations. Zero-cost when
 /// no `f:transactDefaults` / `f:uniqueEnabled` is configured.
+///
+/// `fluree` is required so cross-ledger `f:constraintsSource` references
+/// can be resolved against the model ledger. Pass the parent `Fluree`
+/// instance — the staging path always has it on `&self`.
 async fn enforce_unique_after_staging(
     view: &StagedLedger,
     graph_delta: &FxHashMap<u16, String>,
+    fluree: &crate::Fluree,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
     let config = load_transaction_config(view.base()).await;
     if let Some(cfg) = &config {
-        let per_graph_unique = resolve_per_graph_unique_sids(view, cfg, graph_delta).await?;
+        let per_graph_unique =
+            resolve_per_graph_unique_sids(view, cfg, graph_delta, fluree).await?;
         enforce_unique_constraints(view, &per_graph_unique, graph_delta).await?;
     }
     Ok(())
@@ -535,8 +541,15 @@ async fn resolve_per_graph_unique_sids(
     view: &StagedLedger,
     config: &LedgerConfig,
     graph_delta: &FxHashMap<u16, String>,
+    fluree: &crate::Fluree,
 ) -> std::result::Result<HashMap<GraphId, FxHashSet<Sid>>, fluree_db_transact::TransactError> {
     let snapshot = view.db();
+    // One resolution context per tx — cross-ledger sources for
+    // different affected graphs in the same tx share memo / resolved_t.
+    let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(
+        snapshot.ledger_id.as_str(),
+        fluree,
+    );
 
     // Build reverse map: graph SID → g_id for flake graph resolution
     let mut sid_to_gid: HashMap<Sid, GraphId> = HashMap::new();
@@ -590,19 +603,78 @@ async fn resolve_per_graph_unique_sids(
             None => continue,
         };
 
-        // Resolve constraint source graph IDs
-        let source_g_ids = if transact_config.constraints_sources.is_empty() {
-            // Default: annotations in the default graph (g_id=0)
-            vec![0u16]
-        } else {
-            resolve_constraint_source_g_ids(&transact_config.constraints_sources, snapshot)?
-        };
-
-        // Load f:enforceUnique annotations from each source graph
+        // Split constraint sources by locality. Local sources read
+        // annotations from a graph on the data ledger; cross-ledger
+        // sources resolve via the shared cross-ledger resolver against
+        // a model ledger and translate back into D's Sid space.
         let mut unique_sids = FxHashSet::default();
-        for source_g_id in source_g_ids {
-            let annotations = read_enforce_unique_from_graph(view, source_g_id).await?;
+
+        if transact_config.constraints_sources.is_empty() {
+            // Default: annotations in the default graph (g_id=0)
+            let annotations = read_enforce_unique_from_graph(view, 0u16).await?;
             unique_sids.extend(annotations);
+        } else {
+            let mut local_sources: Vec<&fluree_db_core::ledger_config::GraphSourceRef> =
+                Vec::new();
+            let mut cross_sources: Vec<&fluree_db_core::ledger_config::GraphSourceRef> =
+                Vec::new();
+            for source in &transact_config.constraints_sources {
+                if source.ledger.is_some() {
+                    cross_sources.push(source);
+                } else {
+                    local_sources.push(source);
+                }
+            }
+
+            // Local: resolve to g_ids and scan.
+            if !local_sources.is_empty() {
+                let local_g_ids = resolve_constraint_source_g_ids_for(
+                    &local_sources,
+                    snapshot,
+                )?;
+                for source_g_id in local_g_ids {
+                    let annotations =
+                        read_enforce_unique_from_graph(view, source_g_id).await?;
+                    unique_sids.extend(annotations);
+                }
+            }
+
+            // Cross-ledger: materialize via the resolver, translate
+            // each property IRI back to a Sid on D.
+            for source in cross_sources {
+                let resolved = crate::cross_ledger::resolve_graph_ref(
+                    source,
+                    crate::cross_ledger::ArtifactKind::Constraints,
+                    &mut resolve_ctx,
+                )
+                .await
+                .map_err(|e| {
+                    // Resolver errors are operator-facing and need to
+                    // fail the transaction clearly. Wrap in
+                    // TransactError::Parse so the staging pipeline can
+                    // propagate; the API layer (ApiError::Transact) is
+                    // the resulting HTTP class. The detail string
+                    // preserves the underlying CrossLedgerError display
+                    // so operators see model_ledger_id / graph_iri /
+                    // failure variant in the body.
+                    fluree_db_transact::TransactError::Parse(format!(
+                        "f:constraintsSource cross-ledger resolution failed: {e}"
+                    ))
+                })?;
+                let crate::cross_ledger::GovernanceArtifact::Constraints(wire) =
+                    &resolved.artifact
+                else {
+                    return Err(fluree_db_transact::TransactError::Parse(
+                        "cross-ledger resolver returned a non-Constraints \
+                         artifact for ArtifactKind::Constraints (bug in \
+                         resolver dispatch)"
+                            .into(),
+                    ));
+                };
+                for sid in wire.translate_to_sids(snapshot) {
+                    unique_sids.insert(sid);
+                }
+            }
         }
 
         if !unique_sids.is_empty() {
@@ -613,23 +685,29 @@ async fn resolve_per_graph_unique_sids(
     Ok(per_graph)
 }
 
-/// Resolve `GraphSourceRef` list to graph IDs.
+/// Resolve a `GraphSourceRef` list to graph IDs on the local ledger.
 ///
 /// Maps each `f:graphSelector` IRI to a concrete graph ID:
 /// - `f:defaultGraph` → 0
 /// - Named graph IRI → lookup in `GraphRegistry`
 ///
 /// Fails closed: dropping a constraint source silently would weaken
-/// uniqueness enforcement under a misconfiguration, so unknown selectors
-/// and unsupported `GraphSourceRef` fields (`f:ledger`, `f:atT`,
-/// `f:trustPolicy`, `f:rollbackGuard`) return a parse error. Matches the
-/// shapes / policy resolvers.
-fn resolve_constraint_source_g_ids(
-    sources: &[fluree_db_core::ledger_config::GraphSourceRef],
+/// uniqueness enforcement under a misconfiguration, so unknown
+/// selectors and unsupported `GraphSourceRef` fields (`f:atT`,
+/// `f:trustPolicy`, `f:rollbackGuard`) return a parse error.
+///
+/// `f:ledger` (cross-ledger) is supported via
+/// `cross_ledger::resolve_graph_ref` and is dispatched at
+/// [`resolve_per_graph_unique_sids`]; this function sees only
+/// already-partitioned local sources and rejects `f:ledger` as a
+/// defensive guard against bypassing the partition.
+fn resolve_constraint_source_g_ids_for(
+    sources: &[&fluree_db_core::ledger_config::GraphSourceRef],
     snapshot: &fluree_db_core::LedgerSnapshot,
 ) -> std::result::Result<Vec<GraphId>, fluree_db_transact::TransactError> {
     let mut g_ids = Vec::new();
     for source in sources {
+        let source = *source;
         if source.ledger.is_some() {
             return Err(fluree_db_transact::TransactError::Parse(
                 "f:constraintsSource with cross-ledger f:ledger reference is not yet supported"
@@ -1215,7 +1293,7 @@ impl crate::Fluree {
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta).await?;
+        enforce_unique_after_staging(&view, &graph_delta, self).await?;
 
         Ok(StageResult {
             view,
@@ -1290,7 +1368,7 @@ impl crate::Fluree {
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta).await?;
+        enforce_unique_after_staging(&view, &graph_delta, self).await?;
 
         Ok(StageResult {
             view,
@@ -1345,7 +1423,7 @@ impl crate::Fluree {
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta)
+        enforce_unique_after_staging(&view, &graph_delta, self)
             .await
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
 

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -492,9 +492,19 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
     //     `f:shapesSource` resolution is skipped — the wire is
     //     the authoritative shape source for this transaction.
     // Overlay holders keep `SchemaBundleOverlay` alive for the
-    // lifetime of `shape_dbs`'s borrow. Cross-ledger shapes and
-    // inline-opts shapes live in separate holders so both can
-    // contribute additively when both are configured.
+    // lifetime of `shape_dbs`'s borrow.
+    //
+    // Source layering for SHACL shapes:
+    // - `f:shapesSource` is structurally singular
+    //   (`Option<GraphSourceRef>` on the config schema), so at
+    //   most one of {same-ledger, cross-ledger} can be the
+    //   configured source. The branch below picks whichever one
+    //   is active; they don't merge — a config can't represent
+    //   both at once.
+    // - Inline `opts.shapes` is *separate* from `f:shapesSource`
+    //   and layers additively with whichever configured source
+    //   ran. That's why this holder is independent — both bundles
+    //   can be live in the same tx.
     #[allow(unused_assignments)]
     let mut cl_overlay_holder = None;
     #[allow(unused_assignments)]

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -650,6 +650,14 @@ async fn stage_with_config_shacl(
     // path itself never reads `opts.shapes`. Taking avoids
     // cloning a potentially large JSON-LD doc just to keep both
     // copies for one extra moment.
+    //
+    // INVARIANT: `stage_with_config_shacl` is *not* retry-safe.
+    // The `take()` here moves `opts.shapes` out of the txn, so a
+    // retry on the same `Txn` value would silently skip inline
+    // SHACL validation on the second attempt. If a retry policy
+    // is ever added to the staging path, defer the take until
+    // after `stage_txn` returns successfully — or clone here
+    // and accept the cost.
     let inline_shapes_json = txn.opts.shapes.take();
     let inline_shapes_ledger_id = ledger.snapshot.ledger_id.to_string();
 

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -252,6 +252,96 @@ pub(crate) struct StagedShaclContext<'a> {
 
     /// Optional tracker for SHACL fuel accounting during validation.
     pub tracker: Option<&'a fluree_db_core::Tracker>,
+
+    /// Cross-ledger shapes artifact, pre-resolved at the API
+    /// boundary and threaded through staging as an internal
+    /// governance input. When `Some`, this artifact is the shape
+    /// source rather than `f:shapesSource`'s local graph selector.
+    /// The wire is compiled against `staged_ns` (below) so IRIs
+    /// the in-flight transaction introduced are encodable; M-only
+    /// IRIs are dropped (their shapes can't apply to data D
+    /// doesn't have).
+    pub cross_ledger_shapes: Option<&'a crate::cross_ledger::ShapesArtifactWire>,
+
+    /// Staged `NamespaceRegistry` — D's snapshot namespaces plus
+    /// any IRIs the in-flight transaction has registered. Required
+    /// when `cross_ledger_shapes` is `Some`; consulted as the term
+    /// context for compiling M's wire-form shapes against D.
+    pub staged_ns: Option<&'a fluree_db_transact::namespace::NamespaceRegistry>,
+}
+
+/// Inspect the data ledger's resolved config and, when
+/// `f:shapesSource` carries a cross-ledger `f:ledger` reference,
+/// resolve the model ledger's shapes graph into a wire artifact
+/// at transaction entry — before staging starts.
+///
+/// Returns `None` when no cross-ledger shapes are configured (so
+/// the staging path uses the unchanged same-ledger flow). Returns
+/// `Some(ResolvedGraph)` when a wire artifact has been
+/// materialized; the caller threads the artifact into the staging
+/// context so SHACL compilation at validation time can use the
+/// pre-resolved wire instead of querying the model ledger again.
+///
+/// All cross-ledger failure modes (missing model, reserved graph,
+/// unsupported phase fields) surface here as `TransactError::Parse`
+/// formatting the underlying `CrossLedgerError`. The HTTP layer
+/// maps these to 400 (TransactError → BAD_REQUEST), matching the
+/// constraints path's HTTP class. A future refactor that surfaces
+/// `ApiError::CrossLedger` (HTTP 502) through the staging error
+/// type would preserve the variant.
+#[cfg(feature = "shacl")]
+async fn resolve_cross_ledger_shapes_for_tx(
+    ledger: &LedgerState,
+    fluree: &crate::Fluree,
+) -> std::result::Result<
+    Option<std::sync::Arc<crate::cross_ledger::ResolvedGraph>>,
+    fluree_db_transact::TransactError,
+> {
+    // Load the same config the same-ledger SHACL path loads (from
+    // pre-tx state). resolve_ledger_config returns None on a fresh
+    // ledger with no #config — in that case there's no cross-ledger
+    // to dispatch.
+    let config = match crate::config_resolver::resolve_ledger_config(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        ledger.t(),
+    )
+    .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => return Ok(None),
+        Err(e) => {
+            return Err(fluree_db_transact::TransactError::Parse(format!(
+                "failed to load ledger config while resolving cross-ledger f:shapesSource: {e}"
+            )));
+        }
+    };
+    let shapes_source = config
+        .shacl
+        .as_ref()
+        .and_then(|s| s.shapes_source.as_ref());
+    let Some(source) = shapes_source else {
+        return Ok(None);
+    };
+    if source.ledger.is_none() {
+        return Ok(None);
+    }
+    let mut ctx = crate::cross_ledger::ResolveCtx::new(
+        ledger.snapshot.ledger_id.as_str(),
+        fluree,
+    );
+    let resolved = crate::cross_ledger::resolve_graph_ref(
+        source,
+        crate::cross_ledger::ArtifactKind::Shapes,
+        &mut ctx,
+    )
+    .await
+    .map_err(|e| {
+        fluree_db_transact::TransactError::Parse(format!(
+            "f:shapesSource cross-ledger resolution failed: {e}"
+        ))
+    })?;
+    Ok(Some(resolved))
 }
 
 /// Resolve `f:shapesSource` from a loaded `LedgerConfig` into concrete graph
@@ -384,18 +474,59 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
         return Ok(());
     }
 
-    // 4. Resolve `f:shapesSource` into concrete graph IDs. Defaults to
-    //    `[0]` when unset — preserves the historical "shapes in the default
-    //    graph" behavior for configs that don't opt into named-graph shape
-    //    storage.
-    let shapes_g_ids = resolve_shapes_source_g_ids(config.as_deref(), &base.snapshot)?;
+    // 4a. Cross-ledger shapes: when a `ShapesArtifactWire` is
+    //     threaded through `ctx`, compile it against the staged
+    //     `NamespaceRegistry` (which has D's snapshot namespaces
+    //     PLUS any IRIs the in-flight transaction registered).
+    //     This sidesteps the pre-staging-snapshot bug: IRIs that
+    //     the tx is introducing (e.g., the very `ex:Person`
+    //     instance being validated) are encodable here, where
+    //     they wouldn't be against `base.snapshot`. M-only IRIs
+    //     that D has never seen drop their triples — the shape
+    //     can't apply to data D doesn't have, and allocating a
+    //     fresh ns_code for every M-only term would churn D's
+    //     namespace map for no benefit.
+    //
+    //     When this branch is taken, the same-ledger
+    //     `f:shapesSource` resolution is skipped — the wire is
+    //     the authoritative shape source for this transaction.
+    // `cl_overlay_holder` keeps the SchemaBundleOverlay alive for
+    // the lifetime of `shape_dbs`'s borrow. Only the cross-ledger
+    // branch populates it; the same-ledger branch leaves it None.
+    #[allow(unused_assignments)]
+    let mut cl_overlay_holder = None;
+    let shape_dbs: Vec<fluree_db_core::GraphDbRef<'_>> =
+        if let (Some(wire), Some(staged_ns)) = (ctx.cross_ledger_shapes, ctx.staged_ns) {
+            let bundle = wire
+                .translate_to_schema_bundle_flakes(staged_ns)
+                .map_err(|e| {
+                    fluree_db_transact::TransactError::Parse(format!(
+                        "cross-ledger shapes wire translation failed: {e}"
+                    ))
+                })?;
+            cl_overlay_holder = Some(
+                fluree_db_query::schema_bundle::SchemaBundleOverlay::new(
+                    base.novelty.as_ref(),
+                    bundle,
+                ),
+            );
+            vec![fluree_db_core::GraphDbRef::new(
+                &base.snapshot,
+                0u16,
+                cl_overlay_holder.as_ref().expect("just set above"),
+                base.t(),
+            )]
+        } else {
+            // 4b. Same-ledger path. Resolve `f:shapesSource` into
+            //     concrete graph IDs; default to `[0]` when unset.
+            let shapes_g_ids =
+                resolve_shapes_source_g_ids(config.as_deref(), &base.snapshot)?;
+            shapes_g_ids
+                .iter()
+                .map(|g_id| base.as_graph_db_ref(*g_id))
+                .collect()
+        };
 
-    // Build one GraphDbRef per shape graph so shapes transacted into any of
-    // them — including the config graph itself — participate in compilation.
-    let shape_dbs: Vec<_> = shapes_g_ids
-        .iter()
-        .map(|g_id| base.as_graph_db_ref(*g_id))
-        .collect();
     let engine = ShaclEngine::from_dbs_with_overlay(&shape_dbs, base.ledger_id())
         .await
         .map_err(fluree_db_transact::TransactError::from)?;
@@ -475,6 +606,7 @@ async fn stage_with_config_shacl(
     txn: Txn,
     ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
+    fluree: &crate::Fluree,
 ) -> std::result::Result<(StagedLedger, NamespaceRegistry), fluree_db_transact::TransactError> {
     // Capture graph_delta + tracker before stage_txn consumes the options/txn.
     // graph_delta is used both for per-graph config lookup and for rebuilding
@@ -482,6 +614,15 @@ async fn stage_with_config_shacl(
     // sid_for_iri hits the trie cache — no new allocations).
     let graph_delta = txn.graph_delta.clone();
     let tracker = options.tracker;
+
+    // Detect cross-ledger SHACL config at the API boundary BEFORE
+    // staging starts: read D's resolved config and, if
+    // f:shapesSource carries f:ledger, resolve the wire artifact
+    // from M now so the per-tx ResolveCtx benefits from memo +
+    // governance cache. The wire is then threaded through
+    // staging as an internal governance input and compiled
+    // against the staged namespace registry at validation time.
+    let cross_ledger_shapes = resolve_cross_ledger_shapes_for_tx(&ledger, fluree).await?;
 
     let (view, mut ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
@@ -496,6 +637,11 @@ async fn stage_with_config_shacl(
             graph_delta: Some(&graph_delta),
             graph_sids: Some(&graph_sids),
             tracker,
+            cross_ledger_shapes: cross_ledger_shapes.as_deref().and_then(|r| match &r.artifact {
+                crate::cross_ledger::GovernanceArtifact::Shapes(wire) => Some(wire),
+                _ => None,
+            }),
+            staged_ns: cross_ledger_shapes.as_deref().map(|_| &ns_registry),
         },
     )
     .await?;
@@ -1288,7 +1434,7 @@ impl crate::Fluree {
 
         #[cfg(feature = "shacl")]
         let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options).await?;
+            stage_with_config_shacl(ledger, txn, ns_registry, options, self).await?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
@@ -1363,7 +1509,7 @@ impl crate::Fluree {
 
         #[cfg(feature = "shacl")]
         let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options).await?;
+            stage_with_config_shacl(ledger, txn, ns_registry, options, self).await?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
@@ -1414,7 +1560,7 @@ impl crate::Fluree {
         }
 
         #[cfg(feature = "shacl")]
-        let (view, ns_registry) = stage_with_config_shacl(ledger, txn, ns_registry, options)
+        let (view, ns_registry) = stage_with_config_shacl(ledger, txn, ns_registry, options, self)
             .await
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
         #[cfg(not(feature = "shacl"))]
@@ -2013,6 +2159,13 @@ impl crate::Fluree {
                 graph_delta: None,
                 graph_sids: None,
                 tracker: None,
+                // Turtle insert doesn't go through the
+                // cross-ledger dispatch path today; cross-ledger
+                // SHACL on Turtle inserts can be added by calling
+                // resolve_cross_ledger_shapes_for_tx here when
+                // the use case lands.
+                cross_ledger_shapes: None,
+                staged_ns: None,
             },
         )
         .await

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -624,7 +624,7 @@ fn format_violations(violations: &[fluree_db_shacl::ValidationResult]) -> String
 #[cfg(feature = "shacl")]
 async fn stage_with_config_shacl(
     ledger: LedgerState,
-    txn: Txn,
+    mut txn: Txn,
     ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
     resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
@@ -635,11 +635,12 @@ async fn stage_with_config_shacl(
     // sid_for_iri hits the trie cache — no new allocations).
     let graph_delta = txn.graph_delta.clone();
     let tracker = options.tracker;
-    // Capture inline shapes JSON now — stage_txn consumes `txn`.
-    // Parsing happens *after* staging so the FlakeSink encodes
-    // against the post-staging `ns_registry`, matching the term
-    // context cross-ledger shapes compile against.
-    let inline_shapes_json = txn.opts.shapes.clone();
+    // Move inline shapes JSON off the txn — stage_txn consumes
+    // `txn` immediately after this, and the in-flight staging
+    // path itself never reads `opts.shapes`. Taking avoids
+    // cloning a potentially large JSON-LD doc just to keep both
+    // copies for one extra moment.
+    let inline_shapes_json = txn.opts.shapes.take();
     let inline_shapes_ledger_id = ledger.snapshot.ledger_id.to_string();
 
     // Detect cross-ledger SHACL config at the API boundary BEFORE

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -713,6 +713,7 @@ async fn enforce_unique_after_staging(
     graph_delta: &FxHashMap<u16, String>,
     resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
     inline_unique_properties: Option<&[String]>,
+    staged_ns: &NamespaceRegistry,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
     let config = load_transaction_config(view.base()).await;
 
@@ -730,12 +731,36 @@ async fn enforce_unique_after_staging(
     // appear" — matching how `f:enforceUnique` annotations work
     // when configured in the default graph against a per-graph
     // tx.
+    //
+    // Lookup is against the *staged* `NamespaceRegistry`, not
+    // `view.db()` (which is the pre-stage snapshot). The staged
+    // registry sees IRIs the in-flight tx introduced, so a tx
+    // that declares `ex:email` and constrains it inline in one
+    // shot resolves correctly. `lookup_sid_for_iri` is pure-read,
+    // so an unknown IRI returns `None` rather than allocating —
+    // we then fail-closed with `TransactError::Parse`. The
+    // non-strict path would have folded unknown IRIs into the
+    // EMPTY namespace and silently produced a non-matching Sid,
+    // making the constraint *effectively unenforced* with no
+    // error and no warning.
     if let Some(iris) = inline_unique_properties.filter(|v| !v.is_empty()) {
-        let snapshot = view.db();
-        let inline_sids: FxHashSet<Sid> = iris
-            .iter()
-            .filter_map(|iri| snapshot.encode_iri(iri))
-            .collect();
+        let mut inline_sids: FxHashSet<Sid> = FxHashSet::default();
+        let mut unresolved: Vec<&str> = Vec::new();
+        for iri in iris {
+            match staged_ns.lookup_sid_for_iri(iri) {
+                Some(sid) => {
+                    inline_sids.insert(sid);
+                }
+                None => unresolved.push(iri),
+            }
+        }
+        if !unresolved.is_empty() {
+            return Err(fluree_db_transact::TransactError::Parse(format!(
+                "opts.uniqueProperties references IRIs not known to this ledger \
+                 (declare the property first, or correct the IRI): {}",
+                unresolved.join(", ")
+            )));
+        }
         if !inline_sids.is_empty() {
             for g_id in affected_graph_ids(view, graph_delta) {
                 per_graph_unique
@@ -1520,6 +1545,7 @@ impl crate::Fluree {
             &graph_delta,
             &mut resolve_ctx,
             inline_unique_properties.as_deref(),
+            &ns_registry,
         )
         .await?;
 
@@ -1608,6 +1634,7 @@ impl crate::Fluree {
             &graph_delta,
             &mut resolve_ctx,
             inline_unique_properties.as_deref(),
+            &ns_registry,
         )
         .await?;
 
@@ -1677,6 +1704,7 @@ impl crate::Fluree {
             &graph_delta,
             &mut resolve_ctx,
             inline_unique_properties.as_deref(),
+            &ns_registry,
         )
         .await
         .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -711,14 +711,80 @@ async fn enforce_unique_after_staging(
     view: &StagedLedger,
     graph_delta: &FxHashMap<u16, String>,
     resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
+    inline_unique_properties: Option<&[String]>,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
     let config = load_transaction_config(view.base()).await;
-    if let Some(cfg) = &config {
-        let per_graph_unique =
-            resolve_per_graph_unique_sids(view, cfg, graph_delta, resolve_ctx).await?;
-        enforce_unique_constraints(view, &per_graph_unique, graph_delta).await?;
+
+    // Start with config-resolved per-graph SIDs (same/cross ledger).
+    // No config → empty; inline properties below can still drive
+    // enforcement when set.
+    let mut per_graph_unique: HashMap<GraphId, FxHashSet<Sid>> = match &config {
+        Some(cfg) => resolve_per_graph_unique_sids(view, cfg, graph_delta, resolve_ctx).await?,
+        None => HashMap::new(),
+    };
+
+    // Layer inline `opts.uniqueProperties` additively. Apply to
+    // every affected graph so the constraint behaves as
+    // "for this tx, these properties must be unique wherever they
+    // appear" — matching how `f:enforceUnique` annotations work
+    // when configured in the default graph against a per-graph
+    // tx.
+    if let Some(iris) = inline_unique_properties.filter(|v| !v.is_empty()) {
+        let snapshot = view.db();
+        let inline_sids: FxHashSet<Sid> = iris
+            .iter()
+            .filter_map(|iri| snapshot.encode_iri(iri))
+            .collect();
+        if !inline_sids.is_empty() {
+            for g_id in affected_graph_ids(view, graph_delta) {
+                per_graph_unique
+                    .entry(g_id)
+                    .or_default()
+                    .extend(inline_sids.iter().cloned());
+            }
+        }
     }
+
+    if per_graph_unique.is_empty() {
+        return Ok(());
+    }
+    enforce_unique_constraints(view, &per_graph_unique, graph_delta).await?;
     Ok(())
+}
+
+/// Derive the set of graph IDs touched by staged flakes. Used by
+/// both the config-resolved constraints path and the inline
+/// `opts.uniqueProperties` path so they enforce against the same
+/// set of graphs.
+fn affected_graph_ids(
+    view: &StagedLedger,
+    graph_delta: &FxHashMap<u16, String>,
+) -> FxHashSet<GraphId> {
+    let snapshot = view.db();
+    let mut sid_to_gid: HashMap<Sid, GraphId> = HashMap::new();
+    for (&g_id, iri) in graph_delta {
+        if let Some(sid) = snapshot.encode_iri(iri) {
+            sid_to_gid.insert(sid, g_id);
+        }
+    }
+    for (g_id, iri) in snapshot.graph_registry.iter_entries() {
+        if let Some(sid) = snapshot.encode_iri(iri) {
+            sid_to_gid.entry(sid).or_insert(g_id);
+        }
+    }
+
+    let mut out: FxHashSet<GraphId> = FxHashSet::default();
+    for flake in view.staged_flakes() {
+        if !flake.op {
+            continue;
+        }
+        let g_id = match &flake.g {
+            None => 0u16,
+            Some(g_sid) => sid_to_gid.get(g_sid).copied().unwrap_or(0),
+        };
+        out.insert(g_id);
+    }
+    out
 }
 
 /// Resolve per-graph unique property SIDs from `f:enforceUnique` annotations.
@@ -735,40 +801,7 @@ async fn resolve_per_graph_unique_sids(
     resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
 ) -> std::result::Result<HashMap<GraphId, FxHashSet<Sid>>, fluree_db_transact::TransactError> {
     let snapshot = view.db();
-
-    // Build reverse map: graph SID → g_id for flake graph resolution
-    let mut sid_to_gid: HashMap<Sid, GraphId> = HashMap::new();
-    for (&g_id, iri) in graph_delta {
-        if let Some(sid) = snapshot.encode_iri(iri) {
-            sid_to_gid.insert(sid, g_id);
-        }
-    }
-    // Also include pre-existing named graphs from the registry
-    for (g_id, iri) in snapshot.graph_registry.iter_entries() {
-        if let Some(sid) = snapshot.encode_iri(iri) {
-            sid_to_gid.entry(sid).or_insert(g_id);
-        }
-    }
-
-    // Derive affected graph IDs from staged flakes (not graph_delta)
-    let mut affected_g_ids: FxHashSet<GraphId> = FxHashSet::default();
-    for flake in view.staged_flakes() {
-        if !flake.op {
-            continue;
-        }
-        let g_id = match &flake.g {
-            None => 0u16,
-            Some(g_sid) => sid_to_gid.get(g_sid).copied().unwrap_or_else(|| {
-                tracing::debug!(
-                    ?g_sid,
-                    "Staged flake with unknown graph SID — treating as default"
-                );
-                0
-            }),
-        };
-        affected_g_ids.insert(g_id);
-    }
-
+    let affected_g_ids = affected_graph_ids(view, graph_delta);
     let mut per_graph: HashMap<GraphId, FxHashSet<Sid>> = HashMap::new();
 
     for &g_id in &affected_g_ids {
@@ -1439,9 +1472,11 @@ impl crate::Fluree {
             txn.graph_delta.extend(named_graph_delta);
         }
 
-        // Extract txn_meta and graph_delta before staging consumes the Txn
+        // Extract txn_meta, graph_delta, and any inline uniqueness
+        // properties before staging consumes the Txn.
         let txn_meta = txn.txn_meta.clone();
         let graph_delta = txn.graph_delta.clone();
+        let inline_unique_properties = txn.opts.unique_properties.clone();
 
         // Use external tracker if provided, otherwise fall back to limits-only tracker
         let limits_tracker;
@@ -1479,7 +1514,13 @@ impl crate::Fluree {
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta, &mut resolve_ctx).await?;
+        enforce_unique_after_staging(
+            &view,
+            &graph_delta,
+            &mut resolve_ctx,
+            inline_unique_properties.as_deref(),
+        )
+        .await?;
 
         Ok(StageResult {
             view,
@@ -1530,9 +1571,11 @@ impl crate::Fluree {
                 })?;
         }
 
-        // Extract txn_meta and graph_delta before staging consumes the Txn
+        // Extract txn_meta, graph_delta, and any inline uniqueness
+        // properties before staging consumes the Txn.
         let txn_meta = txn.txn_meta.clone();
         let graph_delta = txn.graph_delta.clone();
+        let inline_unique_properties = txn.opts.unique_properties.clone();
 
         let mut options = match index_config {
             Some(cfg) => StageOptions::new().with_index_config(cfg),
@@ -1559,7 +1602,13 @@ impl crate::Fluree {
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta, &mut resolve_ctx).await?;
+        enforce_unique_after_staging(
+            &view,
+            &graph_delta,
+            &mut resolve_ctx,
+            inline_unique_properties.as_deref(),
+        )
+        .await?;
 
         Ok(StageResult {
             view,
@@ -1592,9 +1641,11 @@ impl crate::Fluree {
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?
         };
 
-        // Extract txn_meta and graph_delta before staging consumes the Txn
+        // Extract txn_meta, graph_delta, and any inline uniqueness
+        // properties before staging consumes the Txn.
         let txn_meta = txn.txn_meta.clone();
         let graph_delta = txn.graph_delta.clone();
+        let inline_unique_properties = txn.opts.unique_properties.clone();
 
         // Build stage options with policy and tracker
         let mut options = StageOptions::new()
@@ -1620,9 +1671,14 @@ impl crate::Fluree {
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta, &mut resolve_ctx)
-            .await
-            .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
+        enforce_unique_after_staging(
+            &view,
+            &graph_delta,
+            &mut resolve_ctx,
+            inline_unique_properties.as_deref(),
+        )
+        .await
+        .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
 
         Ok(StageResult {
             view,

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -595,7 +595,7 @@ async fn resolve_per_graph_unique_sids(
             // Default: annotations in the default graph (g_id=0)
             vec![0u16]
         } else {
-            resolve_constraint_source_g_ids(&transact_config.constraints_sources, snapshot)
+            resolve_constraint_source_g_ids(&transact_config.constraints_sources, snapshot)?
         };
 
         // Load f:enforceUnique annotations from each source graph
@@ -618,27 +618,56 @@ async fn resolve_per_graph_unique_sids(
 /// Maps each `f:graphSelector` IRI to a concrete graph ID:
 /// - `f:defaultGraph` → 0
 /// - Named graph IRI → lookup in `GraphRegistry`
+///
+/// Fails closed: dropping a constraint source silently would weaken
+/// uniqueness enforcement under a misconfiguration, so unknown selectors
+/// and unsupported `GraphSourceRef` fields (`f:ledger`, `f:atT`,
+/// `f:trustPolicy`, `f:rollbackGuard`) return a parse error. Matches the
+/// shapes / policy resolvers.
 fn resolve_constraint_source_g_ids(
     sources: &[fluree_db_core::ledger_config::GraphSourceRef],
     snapshot: &fluree_db_core::LedgerSnapshot,
-) -> Vec<GraphId> {
+) -> std::result::Result<Vec<GraphId>, fluree_db_transact::TransactError> {
     let mut g_ids = Vec::new();
     for source in sources {
+        if source.ledger.is_some() {
+            return Err(fluree_db_transact::TransactError::Parse(
+                "f:constraintsSource with cross-ledger f:ledger reference is not yet supported"
+                    .into(),
+            ));
+        }
+        if source.at_t.is_some() {
+            return Err(fluree_db_transact::TransactError::Parse(
+                "f:constraintsSource with f:atT (temporal pinning) is not yet supported".into(),
+            ));
+        }
+        if source.trust_policy.is_some() {
+            return Err(fluree_db_transact::TransactError::Parse(
+                "f:constraintsSource with f:trustPolicy is not yet supported".into(),
+            ));
+        }
+        if source.rollback_guard.is_some() {
+            return Err(fluree_db_transact::TransactError::Parse(
+                "f:constraintsSource with f:rollbackGuard is not yet supported".into(),
+            ));
+        }
+
         let g_id = match source.graph_selector.as_deref() {
             Some(iri) if iri == config_iris::DEFAULT_GRAPH => Some(0u16),
             Some(iri) => snapshot.graph_registry.graph_id_for_iri(iri),
             None => Some(0u16), // no selector → default graph
         };
-        if let Some(id) = g_id {
-            g_ids.push(id);
-        } else {
-            tracing::debug!(
-                selector = ?source.graph_selector,
-                "Constraint source graph not found in registry — skipping"
-            );
+        match g_id {
+            Some(id) => g_ids.push(id),
+            None => {
+                return Err(fluree_db_transact::TransactError::Parse(format!(
+                    "f:constraintsSource graph '{}' not found in this ledger's graph registry",
+                    source.graph_selector.as_deref().unwrap_or("<none>"),
+                )));
+            }
         }
     }
-    g_ids
+    Ok(g_ids)
 }
 
 /// Read `f:enforceUnique true` annotations from a single graph.

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -300,7 +300,7 @@ pub(crate) struct StagedShaclContext<'a> {
 #[cfg(feature = "shacl")]
 async fn resolve_cross_ledger_shapes_for_tx(
     ledger: &LedgerState,
-    fluree: &crate::Fluree,
+    ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
 ) -> std::result::Result<
     Option<std::sync::Arc<crate::cross_ledger::ResolvedGraph>>,
     fluree_db_transact::TransactError,
@@ -331,11 +331,10 @@ async fn resolve_cross_ledger_shapes_for_tx(
     if source.ledger.is_none() {
         return Ok(None);
     }
-    let mut ctx = crate::cross_ledger::ResolveCtx::new(ledger.snapshot.ledger_id.as_str(), fluree);
     let resolved = crate::cross_ledger::resolve_graph_ref(
         source,
         crate::cross_ledger::ArtifactKind::Shapes,
-        &mut ctx,
+        ctx,
     )
     .await
     .map_err(|e| {
@@ -628,7 +627,7 @@ async fn stage_with_config_shacl(
     txn: Txn,
     ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
-    fluree: &crate::Fluree,
+    resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
 ) -> std::result::Result<(StagedLedger, NamespaceRegistry), fluree_db_transact::TransactError> {
     // Capture graph_delta + tracker before stage_txn consumes the options/txn.
     // graph_delta is used both for per-graph config lookup and for rebuilding
@@ -650,7 +649,7 @@ async fn stage_with_config_shacl(
     // governance cache. The wire is then threaded through
     // staging as an internal governance input and compiled
     // against the staged namespace registry at validation time.
-    let cross_ledger_shapes = resolve_cross_ledger_shapes_for_tx(&ledger, fluree).await?;
+    let cross_ledger_shapes = resolve_cross_ledger_shapes_for_tx(&ledger, resolve_ctx).await?;
 
     let (view, mut ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
@@ -711,12 +710,12 @@ async fn stage_with_config_shacl(
 async fn enforce_unique_after_staging(
     view: &StagedLedger,
     graph_delta: &FxHashMap<u16, String>,
-    fluree: &crate::Fluree,
+    resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
     let config = load_transaction_config(view.base()).await;
     if let Some(cfg) = &config {
         let per_graph_unique =
-            resolve_per_graph_unique_sids(view, cfg, graph_delta, fluree).await?;
+            resolve_per_graph_unique_sids(view, cfg, graph_delta, resolve_ctx).await?;
         enforce_unique_constraints(view, &per_graph_unique, graph_delta).await?;
     }
     Ok(())
@@ -733,12 +732,9 @@ async fn resolve_per_graph_unique_sids(
     view: &StagedLedger,
     config: &LedgerConfig,
     graph_delta: &FxHashMap<u16, String>,
-    fluree: &crate::Fluree,
+    resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
 ) -> std::result::Result<HashMap<GraphId, FxHashSet<Sid>>, fluree_db_transact::TransactError> {
     let snapshot = view.db();
-    // One resolution context per tx — cross-ledger sources for
-    // different affected graphs in the same tx share memo / resolved_t.
-    let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(snapshot.ledger_id.as_str(), fluree);
 
     // Build reverse map: graph SID → g_id for flake graph resolution
     let mut sid_to_gid: HashMap<Sid, GraphId> = HashMap::new();
@@ -828,7 +824,7 @@ async fn resolve_per_graph_unique_sids(
                 let resolved = crate::cross_ledger::resolve_graph_ref(
                     source,
                     crate::cross_ledger::ArtifactKind::Constraints,
-                    &mut resolve_ctx,
+                    resolve_ctx,
                 )
                 .await
                 .map_err(|e| {
@@ -1468,14 +1464,22 @@ impl crate::Fluree {
             options = options.with_policy(p);
         }
 
+        // Single per-tx ResolveCtx shared by every cross-ledger
+        // governance lookup (SHACL shapes, constraints, …) so the
+        // tx observes a coherent `resolved_t` per model ledger
+        // across all subsystems. `ledger_id_owned` keeps a string
+        // alive past the `ledger` move into `stage_with_config_shacl`.
+        let ledger_id_owned: String = ledger.snapshot.ledger_id.to_string();
+        let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id_owned, self);
+
         #[cfg(feature = "shacl")]
         let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options, self).await?;
+            stage_with_config_shacl(ledger, txn, ns_registry, options, &mut resolve_ctx).await?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta, self).await?;
+        enforce_unique_after_staging(&view, &graph_delta, &mut resolve_ctx).await?;
 
         Ok(StageResult {
             view,
@@ -1543,14 +1547,19 @@ impl crate::Fluree {
             }
         }
 
+        // Single per-tx ResolveCtx; see comment on the matching
+        // block above for the consistency rationale.
+        let ledger_id_owned: String = ledger.snapshot.ledger_id.to_string();
+        let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id_owned, self);
+
         #[cfg(feature = "shacl")]
         let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options, self).await?;
+            stage_with_config_shacl(ledger, txn, ns_registry, options, &mut resolve_ctx).await?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta, self).await?;
+        enforce_unique_after_staging(&view, &graph_delta, &mut resolve_ctx).await?;
 
         Ok(StageResult {
             view,
@@ -1595,17 +1604,23 @@ impl crate::Fluree {
             options = options.with_index_config(cfg);
         }
 
+        // Single per-tx ResolveCtx; see comment on the matching
+        // block above for the consistency rationale.
+        let ledger_id_owned: String = ledger.snapshot.ledger_id.to_string();
+        let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id_owned, self);
+
         #[cfg(feature = "shacl")]
-        let (view, ns_registry) = stage_with_config_shacl(ledger, txn, ns_registry, options, self)
-            .await
-            .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
+        let (view, ns_registry) =
+            stage_with_config_shacl(ledger, txn, ns_registry, options, &mut resolve_ctx)
+                .await
+                .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options)
             .await
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
 
         // Enforce uniqueness constraints (independent of shacl feature)
-        enforce_unique_after_staging(&view, &graph_delta, self)
+        enforce_unique_after_staging(&view, &graph_delta, &mut resolve_ctx)
             .await
             .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
 

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -268,6 +268,14 @@ pub(crate) struct StagedShaclContext<'a> {
     /// when `cross_ledger_shapes` is `Some`; consulted as the term
     /// context for compiling M's wire-form shapes against D.
     pub staged_ns: Option<&'a fluree_db_transact::namespace::NamespaceRegistry>,
+
+    /// Inline shape bundle parsed from `txn.opts.shapes` against the
+    /// staged namespace registry. When `Some`, the bundle attaches
+    /// as an additional shape source alongside any same-ledger
+    /// `f:shapesSource` or cross-ledger wire — they enforce
+    /// additively. Inline shapes do not persist into the ledger.
+    pub inline_shape_bundle:
+        Option<std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>>,
 }
 
 /// Inspect the data ledger's resolved config and, when
@@ -316,20 +324,14 @@ async fn resolve_cross_ledger_shapes_for_tx(
             )));
         }
     };
-    let shapes_source = config
-        .shacl
-        .as_ref()
-        .and_then(|s| s.shapes_source.as_ref());
+    let shapes_source = config.shacl.as_ref().and_then(|s| s.shapes_source.as_ref());
     let Some(source) = shapes_source else {
         return Ok(None);
     };
     if source.ledger.is_none() {
         return Ok(None);
     }
-    let mut ctx = crate::cross_ledger::ResolveCtx::new(
-        ledger.snapshot.ledger_id.as_str(),
-        fluree,
-    );
+    let mut ctx = crate::cross_ledger::ResolveCtx::new(ledger.snapshot.ledger_id.as_str(), fluree);
     let resolved = crate::cross_ledger::resolve_graph_ref(
         source,
         crate::cross_ledger::ArtifactKind::Shapes,
@@ -490,12 +492,15 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
     //     When this branch is taken, the same-ledger
     //     `f:shapesSource` resolution is skipped — the wire is
     //     the authoritative shape source for this transaction.
-    // `cl_overlay_holder` keeps the SchemaBundleOverlay alive for
-    // the lifetime of `shape_dbs`'s borrow. Only the cross-ledger
-    // branch populates it; the same-ledger branch leaves it None.
+    // Overlay holders keep `SchemaBundleOverlay` alive for the
+    // lifetime of `shape_dbs`'s borrow. Cross-ledger shapes and
+    // inline-opts shapes live in separate holders so both can
+    // contribute additively when both are configured.
     #[allow(unused_assignments)]
     let mut cl_overlay_holder = None;
-    let shape_dbs: Vec<fluree_db_core::GraphDbRef<'_>> =
+    #[allow(unused_assignments)]
+    let mut inline_overlay_holder = None;
+    let mut shape_dbs: Vec<fluree_db_core::GraphDbRef<'_>> =
         if let (Some(wire), Some(staged_ns)) = (ctx.cross_ledger_shapes, ctx.staged_ns) {
             let bundle = wire
                 .translate_to_schema_bundle_flakes(staged_ns)
@@ -504,12 +509,10 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
                         "cross-ledger shapes wire translation failed: {e}"
                     ))
                 })?;
-            cl_overlay_holder = Some(
-                fluree_db_query::schema_bundle::SchemaBundleOverlay::new(
-                    base.novelty.as_ref(),
-                    bundle,
-                ),
-            );
+            cl_overlay_holder = Some(fluree_db_query::schema_bundle::SchemaBundleOverlay::new(
+                base.novelty.as_ref(),
+                bundle,
+            ));
             vec![fluree_db_core::GraphDbRef::new(
                 &base.snapshot,
                 0u16,
@@ -519,13 +522,32 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
         } else {
             // 4b. Same-ledger path. Resolve `f:shapesSource` into
             //     concrete graph IDs; default to `[0]` when unset.
-            let shapes_g_ids =
-                resolve_shapes_source_g_ids(config.as_deref(), &base.snapshot)?;
+            let shapes_g_ids = resolve_shapes_source_g_ids(config.as_deref(), &base.snapshot)?;
             shapes_g_ids
                 .iter()
                 .map(|g_id| base.as_graph_db_ref(*g_id))
                 .collect()
         };
+
+    // 4c. Inline `opts.shapes`: attach the per-transaction shape
+    //     bundle alongside whichever non-inline source ran above.
+    //     Inline shapes never replace configured shapes; they layer
+    //     additively (the SHACL engine treats multiple shape DBs as
+    //     a union). The bundle was already constructed against the
+    //     staged namespace registry at `stage_with_config_shacl`
+    //     entry, so encoding is consistent with the live tx.
+    if let Some(bundle) = ctx.inline_shape_bundle.clone() {
+        inline_overlay_holder = Some(fluree_db_query::schema_bundle::SchemaBundleOverlay::new(
+            base.novelty.as_ref(),
+            bundle,
+        ));
+        shape_dbs.push(fluree_db_core::GraphDbRef::new(
+            &base.snapshot,
+            0u16,
+            inline_overlay_holder.as_ref().expect("just set above"),
+            base.t(),
+        ));
+    }
 
     let engine = ShaclEngine::from_dbs_with_overlay(&shape_dbs, base.ledger_id())
         .await
@@ -614,6 +636,12 @@ async fn stage_with_config_shacl(
     // sid_for_iri hits the trie cache — no new allocations).
     let graph_delta = txn.graph_delta.clone();
     let tracker = options.tracker;
+    // Capture inline shapes JSON now — stage_txn consumes `txn`.
+    // Parsing happens *after* staging so the FlakeSink encodes
+    // against the post-staging `ns_registry`, matching the term
+    // context cross-ledger shapes compile against.
+    let inline_shapes_json = txn.opts.shapes.clone();
+    let inline_shapes_ledger_id = ledger.snapshot.ledger_id.to_string();
 
     // Detect cross-ledger SHACL config at the API boundary BEFORE
     // staging starts: read D's resolved config and, if
@@ -626,6 +654,21 @@ async fn stage_with_config_shacl(
 
     let (view, mut ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
+    // Parse inline shapes (if any) against the staged namespace
+    // registry. The bundle becomes an additional shape DB in
+    // `apply_shacl_policy_to_staged_view` alongside any same- or
+    // cross-ledger sources — enforcement is additive.
+    let inline_shape_bundle = if let Some(shapes_json) = inline_shapes_json.as_ref() {
+        crate::inline_shapes::parse_inline_shapes_to_bundle(
+            shapes_json,
+            &mut ns_registry,
+            view.base().t(),
+            &inline_shapes_ledger_id,
+        )?
+    } else {
+        None
+    };
+
     let graph_sids: HashMap<GraphId, Sid> = graph_delta
         .iter()
         .map(|(&g_id, iri)| (g_id, ns_registry.sid_for_iri(iri)))
@@ -637,11 +680,14 @@ async fn stage_with_config_shacl(
             graph_delta: Some(&graph_delta),
             graph_sids: Some(&graph_sids),
             tracker,
-            cross_ledger_shapes: cross_ledger_shapes.as_deref().and_then(|r| match &r.artifact {
-                crate::cross_ledger::GovernanceArtifact::Shapes(wire) => Some(wire),
-                _ => None,
-            }),
+            cross_ledger_shapes: cross_ledger_shapes
+                .as_deref()
+                .and_then(|r| match &r.artifact {
+                    crate::cross_ledger::GovernanceArtifact::Shapes(wire) => Some(wire),
+                    _ => None,
+                }),
             staged_ns: cross_ledger_shapes.as_deref().map(|_| &ns_registry),
+            inline_shape_bundle,
         },
     )
     .await?;
@@ -692,10 +738,7 @@ async fn resolve_per_graph_unique_sids(
     let snapshot = view.db();
     // One resolution context per tx — cross-ledger sources for
     // different affected graphs in the same tx share memo / resolved_t.
-    let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(
-        snapshot.ledger_id.as_str(),
-        fluree,
-    );
+    let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(snapshot.ledger_id.as_str(), fluree);
 
     // Build reverse map: graph SID → g_id for flake graph resolution
     let mut sid_to_gid: HashMap<Sid, GraphId> = HashMap::new();
@@ -760,10 +803,8 @@ async fn resolve_per_graph_unique_sids(
             let annotations = read_enforce_unique_from_graph(view, 0u16).await?;
             unique_sids.extend(annotations);
         } else {
-            let mut local_sources: Vec<&fluree_db_core::ledger_config::GraphSourceRef> =
-                Vec::new();
-            let mut cross_sources: Vec<&fluree_db_core::ledger_config::GraphSourceRef> =
-                Vec::new();
+            let mut local_sources: Vec<&fluree_db_core::ledger_config::GraphSourceRef> = Vec::new();
+            let mut cross_sources: Vec<&fluree_db_core::ledger_config::GraphSourceRef> = Vec::new();
             for source in &transact_config.constraints_sources {
                 if source.ledger.is_some() {
                     cross_sources.push(source);
@@ -774,13 +815,9 @@ async fn resolve_per_graph_unique_sids(
 
             // Local: resolve to g_ids and scan.
             if !local_sources.is_empty() {
-                let local_g_ids = resolve_constraint_source_g_ids_for(
-                    &local_sources,
-                    snapshot,
-                )?;
+                let local_g_ids = resolve_constraint_source_g_ids_for(&local_sources, snapshot)?;
                 for source_g_id in local_g_ids {
-                    let annotations =
-                        read_enforce_unique_from_graph(view, source_g_id).await?;
+                    let annotations = read_enforce_unique_from_graph(view, source_g_id).await?;
                     unique_sids.extend(annotations);
                 }
             }
@@ -807,8 +844,7 @@ async fn resolve_per_graph_unique_sids(
                         "f:constraintsSource cross-ledger resolution failed: {e}"
                     ))
                 })?;
-                let crate::cross_ledger::GovernanceArtifact::Constraints(wire) =
-                    &resolved.artifact
+                let crate::cross_ledger::GovernanceArtifact::Constraints(wire) = &resolved.artifact
                 else {
                     return Err(fluree_db_transact::TransactError::Parse(
                         "cross-ledger resolver returned a non-Constraints \
@@ -2166,6 +2202,10 @@ impl crate::Fluree {
                 // the use case lands.
                 cross_ledger_shapes: None,
                 staged_ns: None,
+                // Turtle insert API has no `opts.shapes` surface
+                // today — inline SHACL flows in over the JSON
+                // transaction path. Wireable later if needed.
+                inline_shape_bundle: None,
             },
         )
         .await

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -644,19 +644,33 @@ impl Fluree {
 
             // Apply the data ledger's configured policy_class set as
             // an exact-IRI intersection filter on the wire's
-            // restrictions. Empty / unset class set means "let every
-            // typed policy through" — typical when D wants M's full
-            // ruleset and trusts the model ledger's authoring.
-            let filter: Option<std::collections::HashSet<String>> = effective_opts
+            // restrictions. The contract is:
+            //
+            //   filter = effective_opts.policy_class, OR
+            //            {f:AccessPolicy} when no policy_class is set.
+            //
+            // f:AccessPolicy is the canonical / baseline policy class
+            // — declaring `f:policySource` cross-ledger pulls those
+            // rules in automatically. Custom-typed rules require
+            // an explicit `f:policyClass` in D's config to be
+            // enforced. This is the safer default than "load every
+            // structurally-policy-looking subject from M," which
+            // would silently include rules the operator never opted
+            // into.
+            const DEFAULT_POLICY_CLASS_IRI: &str = "https://ns.flur.ee/db#AccessPolicy";
+            let filter: std::collections::HashSet<String> = effective_opts
                 .policy_class
                 .as_ref()
                 .filter(|v| !v.is_empty())
-                .map(|v| v.iter().cloned().collect());
+                .map(|v| v.iter().cloned().collect())
+                .unwrap_or_else(|| {
+                    [DEFAULT_POLICY_CLASS_IRI.to_string()].into_iter().collect()
+                });
             let snapshot_ref = &view.snapshot;
             let restrictions = fluree_db_policy::wire_to_restrictions(
                 wire,
                 |iri| snapshot_ref.encode_iri(iri),
-                filter.as_ref(),
+                Some(&filter),
             )
             .map_err(crate::error::ApiError::from)?;
 

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -143,25 +143,20 @@ impl Fluree {
 
         // Pre-resolve `f:rulesSource` to a local graph id so the
         // datalog rule extractor scans the configured graph rather
-        // than the query graph. We do this here (not in
-        // apply_config_datalog) because the lookup is identity-
-        // independent — override gates affect *whether* datalog
-        // runs and which override identity may flip enabled/etc.,
-        // not where rules live.
+        // than the query graph. Identity-independent, so done here
+        // and not in apply_config_datalog (override gates affect
+        // *whether* datalog runs, not where rules live).
         //
-        // Cross-ledger references (`f:ledger` set) are skipped —
-        // they dispatch through the cross-ledger resolver at query
-        // time, not through a local graph id.
-        let rules_source_g_id = resolved
-            .datalog
-            .as_ref()
-            .and_then(|d| d.rules_source.as_ref())
-            .filter(|src| src.ledger.is_none())
-            .and_then(|src| match src.graph_selector.as_deref() {
-                Some(iri) if iri == fluree_vocab::config_iris::DEFAULT_GRAPH => Some(0u16),
-                Some(iri) => view.snapshot.graph_registry.graph_id_for_iri(iri),
-                None => Some(0u16),
-            });
+        // Cross-ledger references (`f:ledger` set) skip this path
+        // and dispatch through the cross-ledger resolver at query
+        // time. Misconfigured same-ledger references (unknown
+        // graph IRI, or unsupported `GraphSourceRef` dimensions
+        // like `f:atT` / `f:trustPolicy` / `f:rollbackGuard`) fail
+        // here — silently dropping a configured rules source would
+        // let a typo or premature feature use silently disable
+        // governance the operator believed to be in effect.
+        let rules_source_g_id =
+            resolve_local_rules_source_g_id(resolved.datalog.as_ref(), &view.snapshot)?;
 
         Ok(view
             .with_ledger_config(config)
@@ -863,6 +858,64 @@ impl Fluree {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/// Resolve a same-ledger `f:rulesSource` selector to a local graph id.
+///
+/// Returns:
+/// - `Ok(Some(g_id))` for a valid local reference (named graph or
+///   `f:defaultGraph` → `g_id=0`).
+/// - `Ok(None)` when there is no `f:datalogDefaults` block or no
+///   `f:rulesSource` inside it, or when the reference is
+///   cross-ledger (handled by the resolver at query time).
+/// - `Err(ApiError)` for misconfigurations the operator would
+///   want to know about: unsupported `GraphSourceRef` dimensions
+///   (`f:atT`, `f:trustPolicy`, `f:rollbackGuard`), or a
+///   `f:graphSelector` IRI that the snapshot's graph registry
+///   doesn't recognise.
+///
+/// Failing closed here matches the SHACL same-ledger resolver
+/// (`tx::resolve_shapes_source_g_ids`) — a typo in the config
+/// graph shouldn't silently downgrade the configured reasoning
+/// model.
+fn resolve_local_rules_source_g_id(
+    datalog: Option<&fluree_db_core::ledger_config::DatalogDefaults>,
+    snapshot: &fluree_db_core::LedgerSnapshot,
+) -> Result<Option<fluree_db_core::GraphId>> {
+    let Some(src) = datalog.and_then(|d| d.rules_source.as_ref()) else {
+        return Ok(None);
+    };
+    if src.ledger.is_some() {
+        // Cross-ledger — query-time resolver handles it.
+        return Ok(None);
+    }
+    if src.at_t.is_some() {
+        return Err(ApiError::config(
+            "f:rulesSource with f:atT (temporal pinning) is not yet supported",
+        ));
+    }
+    if src.trust_policy.is_some() {
+        return Err(ApiError::config(
+            "f:rulesSource with f:trustPolicy is not yet supported",
+        ));
+    }
+    if src.rollback_guard.is_some() {
+        return Err(ApiError::config(
+            "f:rulesSource with f:rollbackGuard is not yet supported",
+        ));
+    }
+    let g_id = match src.graph_selector.as_deref() {
+        Some(iri) if iri == fluree_vocab::config_iris::DEFAULT_GRAPH => Some(0u16),
+        Some(iri) => snapshot.graph_registry.graph_id_for_iri(iri),
+        None => Some(0u16),
+    };
+    match g_id {
+        Some(id) => Ok(Some(id)),
+        None => Err(ApiError::config(format!(
+            "f:rulesSource graph '{}' not found in this ledger's graph registry",
+            src.graph_selector.as_deref().unwrap_or("<none>"),
+        ))),
+    }
+}
 
 /// Populate `DictNovelty` from a view's novelty overlay, routing through the
 /// persisted dictionaries when a `BinaryIndexStore` is available.

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -633,7 +633,8 @@ impl Fluree {
             }
 
             let source = source.expect("checked above");
-            let mut ctx = crate::cross_ledger::ResolveCtx::new(view.snapshot.ledger_id.as_str(), self);
+            let mut ctx =
+                crate::cross_ledger::ResolveCtx::new(view.snapshot.ledger_id.as_str(), self);
             let resolved = crate::cross_ledger::resolve_graph_ref(
                 source,
                 crate::cross_ledger::ArtifactKind::PolicyRules,
@@ -680,9 +681,7 @@ impl Fluree {
                 .as_ref()
                 .filter(|v| !v.is_empty())
                 .map(|v| v.iter().cloned().collect())
-                .unwrap_or_else(|| {
-                    [DEFAULT_POLICY_CLASS_IRI.to_string()].into_iter().collect()
-                });
+                .unwrap_or_else(|| [DEFAULT_POLICY_CLASS_IRI.to_string()].into_iter().collect());
             let snapshot_ref = &view.snapshot;
             let restrictions = fluree_db_policy::wire_to_restrictions(
                 wire,
@@ -691,16 +690,17 @@ impl Fluree {
             )
             .map_err(crate::error::ApiError::from)?;
 
-            let policy_ctx = crate::policy_builder::build_policy_context_from_opts_with_cross_ledger(
-                &view.snapshot,
-                view.overlay.as_ref(),
-                view.novelty_for_stats(),
-                view.t,
-                &effective_opts,
-                &[0], // identity-mode uses [0]; unused under cross-ledger
-                restrictions,
-            )
-            .await?;
+            let policy_ctx =
+                crate::policy_builder::build_policy_context_from_opts_with_cross_ledger(
+                    &view.snapshot,
+                    view.overlay.as_ref(),
+                    view.novelty_for_stats(),
+                    view.t,
+                    &effective_opts,
+                    &[0], // identity-mode uses [0]; unused under cross-ledger
+                    restrictions,
+                )
+                .await?;
             return Ok(view.with_policy(Arc::new(policy_ctx)));
         }
 

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -651,8 +651,20 @@ impl Fluree {
             }
 
             let source = source.expect("checked above");
-            let mut ctx =
-                crate::cross_ledger::ResolveCtx::new(view.snapshot.ledger_id.as_str(), self);
+            // Seed from any prior governance-context capture stored
+            // on the view (e.g., an earlier `wrap_policy` in the
+            // same logical request). The merged resolved_ts is
+            // written back below so the subsequent `query` call's
+            // own ResolveCtx observes the same per-ledger head-t.
+            //
+            // `ledger_id_owned` keeps a string alive past the
+            // eventual `view` move at the end of this branch.
+            let ledger_id_owned: String = view.snapshot.ledger_id.to_string();
+            let mut ctx = crate::cross_ledger::ResolveCtx::with_resolved_ts(
+                &ledger_id_owned,
+                self,
+                (**view.cross_ledger_resolved_ts()).clone(),
+            );
             let resolved = crate::cross_ledger::resolve_graph_ref(
                 source,
                 crate::cross_ledger::ArtifactKind::PolicyRules,
@@ -719,7 +731,13 @@ impl Fluree {
                     restrictions,
                 )
                 .await?;
-            return Ok(view.with_policy(Arc::new(policy_ctx)));
+            // Carry the per-ledger head-t captures forward onto
+            // the returned view so any later `query()` in this same
+            // logical request sees the same M version policy did.
+            let view = view
+                .with_policy(Arc::new(policy_ctx))
+                .with_cross_ledger_resolved_ts(Arc::new(ctx.resolved_ts));
+            return Ok(view);
         }
 
         let policy_graphs = if let Some(ref resolved) = view.resolved_config {

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -141,9 +141,32 @@ impl Fluree {
         };
         let resolved = config_resolver::resolve_effective_config(&config, graph_iri);
 
+        // Pre-resolve `f:rulesSource` to a local graph id so the
+        // datalog rule extractor scans the configured graph rather
+        // than the query graph. We do this here (not in
+        // apply_config_datalog) because the lookup is identity-
+        // independent — override gates affect *whether* datalog
+        // runs and which override identity may flip enabled/etc.,
+        // not where rules live.
+        //
+        // Cross-ledger references (`f:ledger` set) are skipped —
+        // they dispatch through the cross-ledger resolver at query
+        // time, not through a local graph id.
+        let rules_source_g_id = resolved
+            .datalog
+            .as_ref()
+            .and_then(|d| d.rules_source.as_ref())
+            .filter(|src| src.ledger.is_none())
+            .and_then(|src| match src.graph_selector.as_deref() {
+                Some(iri) if iri == fluree_vocab::config_iris::DEFAULT_GRAPH => Some(0u16),
+                Some(iri) => view.snapshot.graph_registry.graph_id_for_iri(iri),
+                None => Some(0u16),
+            });
+
         Ok(view
             .with_ledger_config(config)
-            .with_resolved_config(resolved))
+            .with_resolved_config(resolved)
+            .with_rules_source_g_id(rules_source_g_id))
     }
 
     /// Load the current view (immutable snapshot) from a ledger.
@@ -824,13 +847,16 @@ impl Fluree {
             None => return view,
         };
 
-        match config_resolver::merge_datalog_opts(resolved, server_identity) {
-            Some(config) => view
-                .with_datalog_enabled(config.enabled)
-                .with_query_time_rules_allowed(config.allow_query_time_rules)
-                .with_datalog_override_allowed(config.override_allowed),
-            None => view,
-        }
+        let Some(config) = config_resolver::merge_datalog_opts(resolved, server_identity) else {
+            return view;
+        };
+
+        // `rules_source_g_id` is pre-resolved by
+        // `resolve_and_attach_config` (identity-independent), so
+        // we don't reapply it here.
+        view.with_datalog_enabled(config.enabled)
+            .with_query_time_rules_allowed(config.allow_query_time_rules)
+            .with_datalog_override_allowed(config.override_allowed)
     }
 }
 

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -705,7 +705,7 @@ impl Fluree {
             // structurally-policy-looking subject from M," which
             // would silently include rules the operator never opted
             // into.
-            const DEFAULT_POLICY_CLASS_IRI: &str = "https://ns.flur.ee/db#AccessPolicy";
+            const DEFAULT_POLICY_CLASS_IRI: &str = fluree_vocab::policy_iris::ACCESS_POLICY;
             let filter: std::collections::HashSet<String> = effective_opts
                 .policy_class
                 .as_ref()

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -608,6 +608,71 @@ impl Fluree {
             opts.clone()
         };
 
+        // Cross-ledger detection: if the resolved config's
+        // f:policySource carries an f:ledger reference, route through
+        // the cross-ledger resolver. Same-ledger configs continue
+        // through the unchanged local path.
+        let source = view
+            .resolved_config
+            .as_ref()
+            .and_then(|c| c.policy.as_ref())
+            .and_then(|p| p.policy_source.as_ref());
+
+        let is_cross_ledger = source.is_some_and(|s| s.ledger.is_some());
+
+        if is_cross_ledger {
+            // Phase 1a: cross-ledger + identity-mode is not supported.
+            // The model ledger contributes policy rules; the data
+            // ledger contributes identity binding. Mixing them
+            // ambiguously is a fail-closed config error.
+            if effective_opts.identity.is_some() {
+                return Err(crate::error::ApiError::config(
+                    "cross-ledger f:policySource cannot be combined with opts.identity \
+                     in Phase 1a; use opts.policy_class with the cross-ledger config",
+                ));
+            }
+
+            let source = source.expect("checked above");
+            let mut ctx = crate::cross_ledger::ResolveCtx::new(view.snapshot.ledger_id.as_str(), self);
+            let resolved = crate::cross_ledger::resolve_graph_ref(
+                source,
+                crate::cross_ledger::ArtifactKind::PolicyRules,
+                &mut ctx,
+            )
+            .await?;
+            let crate::cross_ledger::GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+
+            // Apply the data ledger's configured policy_class set as
+            // an exact-IRI intersection filter on the wire's
+            // restrictions. Empty / unset class set means "let every
+            // typed policy through" — typical when D wants M's full
+            // ruleset and trusts the model ledger's authoring.
+            let filter: Option<std::collections::HashSet<String>> = effective_opts
+                .policy_class
+                .as_ref()
+                .filter(|v| !v.is_empty())
+                .map(|v| v.iter().cloned().collect());
+            let snapshot_ref = &view.snapshot;
+            let restrictions = fluree_db_policy::wire_to_restrictions(
+                wire,
+                |iri| snapshot_ref.encode_iri(iri),
+                filter.as_ref(),
+            )
+            .map_err(crate::error::ApiError::from)?;
+
+            let policy_ctx = crate::policy_builder::build_policy_context_from_opts_with_cross_ledger(
+                &view.snapshot,
+                view.overlay.as_ref(),
+                view.novelty_for_stats(),
+                view.t,
+                &effective_opts,
+                &[0], // identity-mode uses [0]; unused under cross-ledger
+                restrictions,
+            )
+            .await?;
+            return Ok(view.with_policy(Arc::new(policy_ctx)));
+        }
+
         let policy_graphs = if let Some(ref resolved) = view.resolved_config {
             let source = resolved
                 .policy

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -640,7 +640,24 @@ impl Fluree {
                 &mut ctx,
             )
             .await?;
-            let crate::cross_ledger::GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+            let crate::cross_ledger::GovernanceArtifact::PolicyRules(wire) = &resolved.artifact
+            else {
+                // resolve_graph_ref dispatches on ArtifactKind, so
+                // requesting PolicyRules must yield PolicyRules.
+                // Surfacing this as TranslationFailed rather than
+                // panicking keeps the failure path uniform for
+                // operators reading the response body.
+                return Err(crate::error::ApiError::CrossLedger(
+                    crate::cross_ledger::CrossLedgerError::TranslationFailed {
+                        ledger_id: resolved.model_ledger_id.clone(),
+                        graph_iri: resolved.graph_iri.clone(),
+                        detail: "resolver returned a non-PolicyRules artifact for an \
+                                ArtifactKind::PolicyRules request; this is a bug in \
+                                the resolver dispatch"
+                            .into(),
+                    },
+                ));
+            };
 
             // Apply the data ledger's configured policy_class set as
             // an exact-IRI intersection filter on the wire's

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -514,16 +514,26 @@ impl Fluree {
         // query graph.
         executable.reasoning.rules_source_g_id = db.rules_source_g_id();
 
+        // Build a single per-request `ResolveCtx` so every
+        // cross-ledger artifact (rules, schema, …) captured by this
+        // query observes a coherent head-t per model ledger. Two
+        // separate contexts would each lazy-capture a head-t and
+        // could disagree if M advances between awaits — that breaks
+        // the resolver's per-request consistency contract.
+        let mut ctx = crate::cross_ledger::ResolveCtx::new(db.as_graph_db_ref().snapshot.ledger_id.as_str(), self);
+
         // Cross-ledger `f:rulesSource`: when M is referenced via
         // `f:ledger`, resolve M's rules graph through the
         // cross-ledger resolver and merge the JSON rule bodies into
         // `executable.reasoning.rules` so they pass through the
         // existing query-time rule code path. Same-ledger references
         // are handled above via `rules_source_g_id`.
-        self.attach_cross_ledger_rules(db, &mut executable).await?;
+        self.attach_cross_ledger_rules(db, &mut executable, &mut ctx)
+            .await?;
 
         // Resolve `f:schemaSource` + `owl:imports` closure, if configured.
-        self.attach_schema_bundle(db, &mut executable).await?;
+        self.attach_schema_bundle(db, &mut executable, &mut ctx)
+            .await?;
 
         Ok(executable)
     }
@@ -545,6 +555,7 @@ impl Fluree {
         &self,
         db: &GraphDb,
         executable: &mut ExecutableQuery,
+        ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
     ) -> Result<()> {
         if !executable.reasoning.modes.datalog {
             return Ok(());
@@ -562,13 +573,10 @@ impl Fluree {
             return Ok(());
         }
 
-        let db_ref = db.as_graph_db_ref();
-        let mut ctx =
-            crate::cross_ledger::ResolveCtx::new(db_ref.snapshot.ledger_id.as_str(), self);
         let resolved = crate::cross_ledger::resolve_graph_ref(
             source,
             crate::cross_ledger::ArtifactKind::Rules,
-            &mut ctx,
+            ctx,
         )
         .await?;
         let crate::cross_ledger::GovernanceArtifact::Rules(wire) = &resolved.artifact else {
@@ -582,7 +590,7 @@ impl Fluree {
                 },
             ));
         };
-        executable.reasoning.modes.rules.extend(wire.parsed_rules());
+        executable.reasoning.modes.rules.extend(wire.parsed_rules()?);
         Ok(())
     }
 
@@ -604,6 +612,7 @@ impl Fluree {
         &self,
         db: &GraphDb,
         executable: &mut ExecutableQuery,
+        ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
     ) -> Result<()> {
         if executable.reasoning.modes.is_disabled() {
             return Ok(());
@@ -627,12 +636,10 @@ impl Fluree {
         // configs go through the existing local path unchanged.
         let schema_source = reasoning.schema_source.as_ref().expect("checked above");
         if schema_source.ledger.is_some() {
-            let mut ctx =
-                crate::cross_ledger::ResolveCtx::new(db_ref.snapshot.ledger_id.as_str(), self);
             let resolved = crate::cross_ledger::resolve_graph_ref(
                 schema_source,
                 crate::cross_ledger::ArtifactKind::SchemaClosure,
-                &mut ctx,
+                ctx,
             )
             .await?;
             let crate::cross_ledger::GovernanceArtifact::SchemaClosure(wire) = &resolved.artifact

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -508,6 +508,12 @@ impl Fluree {
             }
         }
 
+        // Carry the pre-resolved `f:rulesSource` graph id (if any)
+        // into the executable so `compute_derived_facts` extracts
+        // datalog rules from the configured graph instead of the
+        // query graph.
+        executable.reasoning.rules_source_g_id = db.rules_source_g_id();
+
         // Resolve `f:schemaSource` + `owl:imports` closure, if configured.
         self.attach_schema_bundle(db, &mut executable).await?;
 

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -547,6 +547,42 @@ impl Fluree {
         }
 
         let db_ref = db.as_graph_db_ref();
+
+        // Cross-ledger detection: if `reasoning.schema_source` has
+        // `f:ledger` set, dispatch through the cross-ledger resolver
+        // and translate the resulting `SchemaArtifactWire` into a
+        // SchemaBundleFlakes against D's snapshot. Same-ledger
+        // configs go through the existing local path unchanged.
+        let schema_source = reasoning.schema_source.as_ref().expect("checked above");
+        if schema_source.ledger.is_some() {
+            let mut ctx = crate::cross_ledger::ResolveCtx::new(
+                db_ref.snapshot.ledger_id.as_str(),
+                self,
+            );
+            let resolved = crate::cross_ledger::resolve_graph_ref(
+                schema_source,
+                crate::cross_ledger::ArtifactKind::SchemaClosure,
+                &mut ctx,
+            )
+            .await?;
+            let crate::cross_ledger::GovernanceArtifact::SchemaClosure(wire) =
+                &resolved.artifact
+            else {
+                return Err(crate::error::ApiError::CrossLedger(
+                    crate::cross_ledger::CrossLedgerError::TranslationFailed {
+                        ledger_id: resolved.model_ledger_id.clone(),
+                        graph_iri: resolved.graph_iri.clone(),
+                        detail: "resolver returned a non-SchemaClosure artifact for a \
+                                SchemaClosure request; resolver dispatch bug"
+                            .into(),
+                    },
+                ));
+            };
+            let flakes = wire.translate_to_schema_bundle_flakes(db_ref.snapshot)?;
+            executable.reasoning.schema_bundle = Some(flakes);
+            return Ok(());
+        }
+
         let Some(bundle) = crate::ontology_imports::resolve_schema_bundle(
             db_ref.snapshot,
             db_ref.overlay,

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -520,7 +520,17 @@ impl Fluree {
         // separate contexts would each lazy-capture a head-t and
         // could disagree if M advances between awaits — that breaks
         // the resolver's per-request consistency contract.
-        let mut ctx = crate::cross_ledger::ResolveCtx::new(db.as_graph_db_ref().snapshot.ledger_id.as_str(), self);
+        //
+        // Seeded from `db.cross_ledger_resolved_ts` so a preceding
+        // `wrap_policy` call's captures carry forward: policy and
+        // reasoning/rules on the same M must agree on which
+        // version of M they're enforcing, even though they enter
+        // through separate Rust API calls.
+        let mut ctx = crate::cross_ledger::ResolveCtx::with_resolved_ts(
+            db.as_graph_db_ref().snapshot.ledger_id.as_str(),
+            self,
+            (**db.cross_ledger_resolved_ts()).clone(),
+        );
 
         // Cross-ledger `f:rulesSource`: when M is referenced via
         // `f:ledger`, resolve M's rules graph through the
@@ -590,7 +600,11 @@ impl Fluree {
                 },
             ));
         };
-        executable.reasoning.modes.rules.extend(wire.parsed_rules()?);
+        executable
+            .reasoning
+            .modes
+            .rules
+            .extend(wire.parsed_rules()?);
         Ok(())
     }
 

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -631,24 +631,62 @@ impl Fluree {
         if executable.reasoning.modes.is_disabled() {
             return Ok(());
         }
-        let Some(resolved) = db.resolved_config() else {
-            return Ok(());
-        };
-        let Some(reasoning) = resolved.reasoning.as_ref() else {
-            return Ok(());
-        };
-        if reasoning.schema_source.is_none() {
-            return Ok(());
-        }
 
         let db_ref = db.as_graph_db_ref();
 
-        // Cross-ledger detection: if `reasoning.schema_source` has
-        // `f:ledger` set, dispatch through the cross-ledger resolver
-        // and translate the resulting `SchemaArtifactWire` into a
-        // SchemaBundleFlakes against D's snapshot. Same-ledger
-        // configs go through the existing local path unchanged.
-        let schema_source = reasoning.schema_source.as_ref().expect("checked above");
+        // 1. Resolve the configured `f:schemaSource` (if any) into a
+        //    bundle. Either branch — cross-ledger or local — may yield
+        //    None when the field isn't configured.
+        let configured_bundle = self
+            .resolve_configured_schema_bundle(db, &db_ref, ctx)
+            .await?;
+
+        // 2. Parse inline `opts.ontology` axioms (if any) into a
+        //    bundle. Layered on top of `configured_bundle` so a
+        //    query can extend the ledger's reasoning with per-request
+        //    axioms without persisting them.
+        let inline_bundle = match executable.reasoning.modes.ontology.as_ref() {
+            Some(json) => {
+                crate::inline_ontology::parse_inline_ontology_to_bundle(json, db_ref.snapshot)?
+            }
+            None => None,
+        };
+
+        // 3. Merge.
+        executable.reasoning.schema_bundle = match (configured_bundle, inline_bundle) {
+            (None, None) => None,
+            (Some(b), None) | (None, Some(b)) => Some(b),
+            (Some(a), Some(b)) => Some(crate::inline_ontology::merge_bundles(a, b)?),
+        };
+        Ok(())
+    }
+
+    /// Resolve the configured `f:schemaSource` (same- or cross-ledger)
+    /// into a [`SchemaBundleFlakes`]. Returns `Ok(None)` when no
+    /// `f:schemaSource` is configured. Extracted so
+    /// [`attach_schema_bundle`] can layer the inline ontology on top
+    /// regardless of which configured branch ran (or whether either
+    /// ran).
+    async fn resolve_configured_schema_bundle(
+        &self,
+        db: &GraphDb,
+        db_ref: &fluree_db_core::GraphDbRef<'_>,
+        ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
+    ) -> Result<Option<std::sync::Arc<fluree_db_query::schema_bundle::SchemaBundleFlakes>>> {
+        let Some(resolved) = db.resolved_config() else {
+            return Ok(None);
+        };
+        let Some(reasoning) = resolved.reasoning.as_ref() else {
+            return Ok(None);
+        };
+        let Some(schema_source) = reasoning.schema_source.as_ref() else {
+            return Ok(None);
+        };
+
+        // Cross-ledger detection: if the source carries `f:ledger`,
+        // dispatch through the cross-ledger resolver and translate
+        // the resulting `SchemaArtifactWire` into a SchemaBundleFlakes
+        // against D's snapshot.
         if schema_source.ledger.is_some() {
             let resolved = crate::cross_ledger::resolve_graph_ref(
                 schema_source,
@@ -668,9 +706,9 @@ impl Fluree {
                     },
                 ));
             };
-            let flakes = wire.translate_to_schema_bundle_flakes(db_ref.snapshot)?;
-            executable.reasoning.schema_bundle = Some(flakes);
-            return Ok(());
+            return Ok(Some(
+                wire.translate_to_schema_bundle_flakes(db_ref.snapshot)?,
+            ));
         }
 
         let Some(bundle) = crate::ontology_imports::resolve_schema_bundle(
@@ -681,7 +719,7 @@ impl Fluree {
         )
         .await?
         else {
-            return Ok(());
+            return Ok(None);
         };
 
         let flakes = crate::ontology_imports::get_or_build_schema_bundle_flakes(
@@ -690,9 +728,7 @@ impl Fluree {
             &bundle,
         )
         .await?;
-
-        executable.reasoning.schema_bundle = Some(flakes);
-        Ok(())
+        Ok(Some(flakes))
     }
 
     /// Execute against a GraphDb with policy awareness.

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -555,18 +555,15 @@ impl Fluree {
         // configs go through the existing local path unchanged.
         let schema_source = reasoning.schema_source.as_ref().expect("checked above");
         if schema_source.ledger.is_some() {
-            let mut ctx = crate::cross_ledger::ResolveCtx::new(
-                db_ref.snapshot.ledger_id.as_str(),
-                self,
-            );
+            let mut ctx =
+                crate::cross_ledger::ResolveCtx::new(db_ref.snapshot.ledger_id.as_str(), self);
             let resolved = crate::cross_ledger::resolve_graph_ref(
                 schema_source,
                 crate::cross_ledger::ArtifactKind::SchemaClosure,
                 &mut ctx,
             )
             .await?;
-            let crate::cross_ledger::GovernanceArtifact::SchemaClosure(wire) =
-                &resolved.artifact
+            let crate::cross_ledger::GovernanceArtifact::SchemaClosure(wire) = &resolved.artifact
             else {
                 return Err(crate::error::ApiError::CrossLedger(
                     crate::cross_ledger::CrossLedgerError::TranslationFailed {

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -645,9 +645,15 @@ impl Fluree {
         //    bundle. Layered on top of `configured_bundle` so a
         //    query can extend the ledger's reasoning with per-request
         //    axioms without persisting them.
-        let inline_bundle = match executable.reasoning.modes.ontology.as_ref() {
+        //
+        //    `take()` so the (potentially large) raw JSON-LD doesn't
+        //    ride along on `ReasoningModes.ontology` for the rest of
+        //    query preparation — `Query::with_patterns` clones the
+        //    reasoning config downstream, and only the compiled
+        //    `SchemaBundleFlakes` overlay is needed past this point.
+        let inline_bundle = match executable.reasoning.modes.ontology.take() {
             Some(json) => {
-                crate::inline_ontology::parse_inline_ontology_to_bundle(json, db_ref.snapshot)?
+                crate::inline_ontology::parse_inline_ontology_to_bundle(&json, db_ref.snapshot)?
             }
             None => None,
         };

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -514,10 +514,76 @@ impl Fluree {
         // query graph.
         executable.reasoning.rules_source_g_id = db.rules_source_g_id();
 
+        // Cross-ledger `f:rulesSource`: when M is referenced via
+        // `f:ledger`, resolve M's rules graph through the
+        // cross-ledger resolver and merge the JSON rule bodies into
+        // `executable.reasoning.rules` so they pass through the
+        // existing query-time rule code path. Same-ledger references
+        // are handled above via `rules_source_g_id`.
+        self.attach_cross_ledger_rules(db, &mut executable).await?;
+
         // Resolve `f:schemaSource` + `owl:imports` closure, if configured.
         self.attach_schema_bundle(db, &mut executable).await?;
 
         Ok(executable)
+    }
+
+    /// If the resolved datalog config carries a cross-ledger
+    /// `f:rulesSource`, dispatch through the cross-ledger resolver
+    /// and append the parsed JSON rules to
+    /// `executable.reasoning.rules`. Short-circuits when:
+    /// - the view has no resolved config,
+    /// - no `f:rulesSource` is configured,
+    /// - `f:rulesSource` is purely local (`f:ledger` unset — handled
+    ///   by the `rules_source_g_id` pre-resolution path),
+    /// - datalog reasoning is not enabled on the executable (no point
+    ///   pulling rules we won't run).
+    ///
+    /// Errors propagate as `ApiError::CrossLedger`; the server maps
+    /// those to HTTP 502.
+    async fn attach_cross_ledger_rules(
+        &self,
+        db: &GraphDb,
+        executable: &mut ExecutableQuery,
+    ) -> Result<()> {
+        if !executable.reasoning.modes.datalog {
+            return Ok(());
+        }
+        let Some(resolved) = db.resolved_config() else {
+            return Ok(());
+        };
+        let Some(datalog) = resolved.datalog.as_ref() else {
+            return Ok(());
+        };
+        let Some(source) = datalog.rules_source.as_ref() else {
+            return Ok(());
+        };
+        if source.ledger.is_none() {
+            return Ok(());
+        }
+
+        let db_ref = db.as_graph_db_ref();
+        let mut ctx =
+            crate::cross_ledger::ResolveCtx::new(db_ref.snapshot.ledger_id.as_str(), self);
+        let resolved = crate::cross_ledger::resolve_graph_ref(
+            source,
+            crate::cross_ledger::ArtifactKind::Rules,
+            &mut ctx,
+        )
+        .await?;
+        let crate::cross_ledger::GovernanceArtifact::Rules(wire) = &resolved.artifact else {
+            return Err(crate::error::ApiError::CrossLedger(
+                crate::cross_ledger::CrossLedgerError::TranslationFailed {
+                    ledger_id: resolved.model_ledger_id.clone(),
+                    graph_iri: resolved.graph_iri.clone(),
+                    detail: "resolver returned a non-Rules artifact for a Rules request; \
+                             resolver dispatch bug"
+                        .into(),
+                },
+            ));
+        };
+        executable.reasoning.modes.rules.extend(wire.parsed_rules());
+        Ok(())
     }
 
     /// Resolve the schema bundle from the ledger's reasoning config and attach

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -166,6 +166,13 @@ pub struct GraphDb {
     pub(crate) query_time_rules_allowed: bool,
     /// Whether the query can override datalog config settings. Default: `true`.
     pub(crate) datalog_override_allowed: bool,
+    /// Pre-resolved graph id from `f:rulesSource.graphSelector` on
+    /// the local ledger. When `Some(g)`, the datalog rule extractor
+    /// scans graph `g` for `f:rule` flakes instead of the default
+    /// graph. `None` keeps the legacy behaviour (rules read from
+    /// the same graph as the query, defaulting to `g_id=0`).
+    /// Cross-ledger rules surface separately on `rules_source_iri`.
+    pub(crate) rules_source_g_id: Option<fluree_db_core::GraphId>,
 
     // ========================================================================
     // Graph source context (optional — set when view is created from a graph source)
@@ -236,6 +243,7 @@ impl GraphDb {
             datalog_enabled: true,
             query_time_rules_allowed: true,
             datalog_override_allowed: true,
+            rules_source_g_id: None,
             graph_source_id: None,
         }
     }
@@ -557,6 +565,20 @@ impl GraphDb {
     /// Check if queries can override datalog config settings.
     pub fn datalog_override_allowed(&self) -> bool {
         self.datalog_override_allowed
+    }
+
+    /// Set the local graph id that the datalog rule extractor should
+    /// scan for `f:rule` flakes (resolved from `f:rulesSource`).
+    pub fn with_rules_source_g_id(mut self, g_id: Option<fluree_db_core::GraphId>) -> Self {
+        self.rules_source_g_id = g_id;
+        self
+    }
+
+    /// Get the local graph id that the datalog rule extractor should
+    /// scan. `None` keeps the legacy behaviour (rules read from the
+    /// query graph).
+    pub fn rules_source_g_id(&self) -> Option<fluree_db_core::GraphId> {
+        self.rules_source_g_id
     }
 }
 

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -174,6 +174,20 @@ pub struct GraphDb {
     /// Cross-ledger rules surface separately on `rules_source_iri`.
     pub(crate) rules_source_g_id: Option<fluree_db_core::GraphId>,
 
+    /// Per-request governance-context capture carried across
+    /// cross-ledger entry points within the same logical request.
+    ///
+    /// `wrap_policy` and `query` are separate Rust API calls but
+    /// model a single HTTP request; if both touch the same model
+    /// ledger M, they must observe the same `resolved_t` for M.
+    /// Carrying this map on the view lets `wrap_policy` capture
+    /// M's head-t and the subsequent `query` reuse that capture
+    /// when building its own `ResolveCtx`.
+    ///
+    /// Empty by default. Cloned via `Arc` so policy-wrap doesn't
+    /// inflate the cached `GraphDb` cost.
+    pub(crate) cross_ledger_resolved_ts: Arc<std::collections::HashMap<String, i64>>,
+
     // ========================================================================
     // Graph source context (optional — set when view is created from a graph source)
     // ========================================================================
@@ -244,6 +258,7 @@ impl GraphDb {
             query_time_rules_allowed: true,
             datalog_override_allowed: true,
             rules_source_g_id: None,
+            cross_ledger_resolved_ts: Arc::new(std::collections::HashMap::new()),
             graph_source_id: None,
         }
     }
@@ -579,6 +594,21 @@ impl GraphDb {
     /// query graph).
     pub fn rules_source_g_id(&self) -> Option<fluree_db_core::GraphId> {
         self.rules_source_g_id
+    }
+
+    /// Replace the carried governance-context capture (per-ledger
+    /// `resolved_t`s seen so far in this logical request).
+    pub fn with_cross_ledger_resolved_ts(
+        mut self,
+        ts: Arc<std::collections::HashMap<String, i64>>,
+    ) -> Self {
+        self.cross_ledger_resolved_ts = ts;
+        self
+    }
+
+    /// Read the carried governance-context capture.
+    pub fn cross_ledger_resolved_ts(&self) -> &Arc<std::collections::HashMap<String, i64>> {
+        &self.cross_ledger_resolved_ts
     }
 }
 

--- a/fluree-db-api/tests/it_config_graph.rs
+++ b/fluree-db-api/tests/it_config_graph.rs
@@ -2657,3 +2657,140 @@ async fn configured_fulltext_properties_for_indexer_shape() {
         }
     }
 }
+
+// =============================================================================
+// f:policySource fail-closed behavior
+//
+// `build_policy_context` (the path used by server transact handlers and the CLI
+// insert command) must NOT silently fall back to the default graph when the
+// configured `f:policySource` cannot be resolved. Falling back would re-enable
+// any default-graph policy rules under a config the operator clearly intended
+// to redirect, and would also swallow the cross-ledger / temporal rejection
+// emitted by `resolve_policy_source_g_ids`.
+// =============================================================================
+
+#[tokio::test]
+async fn policy_source_unknown_graph_fails_closed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/policy-source-unknown:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Some data in the default graph (irrelevant to the assertion, but proves
+    // the fallback would have had something to enforce against).
+    let r1 = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "@type": "ex:User", "ex:name": "Alice"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Config points f:policySource at a graph IRI that does not exist in the
+    // registry. Pre-fix this logged a warning and returned `[0]`.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:policyDefaults <urn:config:policy> .
+            <urn:config:policy> f:policySource <urn:config:policy-ref> .
+            <urn:config:policy-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:policy-source> .
+            <urn:config:policy-source> f:graphSelector <http://example.org/does-not-exist> .
+        }}
+    "
+    );
+    let r2 = fluree
+        .stage_owned(r1.ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write");
+    let ledger = r2.ledger;
+
+    let opts = QueryConnectionOptions::default();
+    let err = fluree_db_api::build_policy_context(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &opts,
+    )
+    .await
+    .expect_err("unknown f:policySource graph must fail closed");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("policySource") && msg.contains("not found"),
+        "expected unknown-graph error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn policy_source_cross_ledger_fails_closed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/policy-source-xledger:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let r1 = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "@type": "ex:User"}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Config asks for cross-ledger policy via f:ledger. `resolve_policy_source_g_ids`
+    // already rejects this; the regression we're guarding is the prior fallback
+    // in `resolve_policy_graphs_from_config` that swallowed the error.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:policyDefaults <urn:config:policy> .
+            <urn:config:policy> f:policySource <urn:config:policy-ref> .
+            <urn:config:policy-ref> rdf:type f:GraphRef ;
+                                    f:graphSource <urn:config:policy-source> .
+            <urn:config:policy-source> f:ledger <urn:fluree:model-ledger:main> ;
+                                       f:graphSelector <http://example.org/policy> .
+        }}
+    "
+    );
+    let r2 = fluree
+        .stage_owned(r1.ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write");
+    let ledger = r2.ledger;
+
+    let opts = QueryConnectionOptions::default();
+    let err = fluree_db_api::build_policy_context(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &opts,
+    )
+    .await
+    .expect_err("cross-ledger f:policySource must fail closed");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cross-ledger") || msg.contains("f:ledger"),
+        "expected cross-ledger rejection, got: {msg}"
+    );
+}

--- a/fluree-db-api/tests/it_config_graph.rs
+++ b/fluree-db-api/tests/it_config_graph.rs
@@ -2794,3 +2794,153 @@ async fn policy_source_cross_ledger_fails_closed() {
         "expected cross-ledger rejection, got: {msg}"
     );
 }
+
+// =============================================================================
+// f:constraintsSource fail-closed behavior
+//
+// The previous resolver silently skipped unknown graph selectors (a
+// uniqueness constraint would just stop being enforced) and silently ignored
+// `f:ledger` / `f:atT` / `f:trustPolicy` / `f:rollbackGuard`. Both are
+// security-relevant: an operator who configures a constraint source
+// should never get less enforcement than they asked for. Each must now
+// surface as a parse error at transact time.
+// =============================================================================
+
+#[tokio::test]
+async fn constraints_source_unknown_graph_fails_closed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/constraints-source-unknown:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Seed annotation + data
+    let r1 = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {
+                    "ex": "http://example.org/",
+                    "f": "https://ns.flur.ee/db#"
+                },
+                "@graph": [
+                    {"@id": "ex:email", "f:enforceUnique": true},
+                    {"@id": "ex:alice", "ex:email": "alice@example.com"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Enable unique and point constraintsSource at a graph that doesn't exist.
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:transactDefaults <urn:config:transact> .
+            <urn:config:transact> f:uniqueEnabled true .
+            <urn:config:transact> f:constraintsSource <urn:config:constraints-ref> .
+            <urn:config:constraints-ref> rdf:type f:GraphRef ;
+                                         f:graphSource <urn:config:constraints-src> .
+            <urn:config:constraints-src> f:graphSelector <http://example.org/missing-constraints> .
+        }}
+    "
+    );
+    let r2 = fluree
+        .stage_owned(r1.ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write should succeed");
+
+    let err = fluree
+        .insert(
+            r2.ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id": "ex:bob",
+                "ex:email": "alice@example.com"
+            }),
+        )
+        .await
+        .expect_err("unknown constraintsSource graph must reject the transaction");
+
+    assert!(
+        matches!(
+            err,
+            fluree_db_api::ApiError::Transact(fluree_db_transact::TransactError::Parse(_))
+        ),
+        "expected TransactError::Parse, got: {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("constraintsSource") && msg.contains("not found"),
+        "expected unknown-graph diagnostic, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn constraints_source_cross_ledger_fails_closed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/constraints-source-xledger:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let r1 = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {
+                    "ex": "http://example.org/",
+                    "f": "https://ns.flur.ee/db#"
+                },
+                "@graph": [{"@id": "ex:email", "f:enforceUnique": true}]
+            }),
+        )
+        .await
+        .unwrap();
+
+    let config_iri = config_graph_iri(ledger_id);
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:transactDefaults <urn:config:transact> .
+            <urn:config:transact> f:uniqueEnabled true .
+            <urn:config:transact> f:constraintsSource <urn:config:constraints-ref> .
+            <urn:config:constraints-ref> rdf:type f:GraphRef ;
+                                         f:graphSource <urn:config:constraints-src> .
+            <urn:config:constraints-src> f:ledger <urn:fluree:model-ledger:main> ;
+                                         f:graphSelector <http://example.org/constraints> .
+        }}
+    "
+    );
+    let r2 = fluree
+        .stage_owned(r1.ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write should succeed");
+
+    let err = fluree
+        .insert(
+            r2.ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id": "ex:bob",
+                "ex:email": "bob@example.com"
+            }),
+        )
+        .await
+        .expect_err("cross-ledger constraintsSource must reject the transaction");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cross-ledger") || msg.contains("f:ledger"),
+        "expected cross-ledger rejection, got: {msg}"
+    );
+}

--- a/fluree-db-api/tests/it_constraints_cross_ledger.rs
+++ b/fluree-db-api/tests/it_constraints_cross_ledger.rs
@@ -1,0 +1,192 @@
+//! End-to-end cross-ledger uniqueness enforcement.
+//!
+//! Data ledger D's `#config` declares `f:constraintsSource` with
+//! `f:ledger` pointing at model ledger M, plus a named graph in M
+//! that holds `f:enforceUnique true` annotations on properties.
+//! A transaction against D that would create a duplicate value on
+//! one of those properties must be rejected — M's constraints
+//! govern D without any annotation triples ever being written into D.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::genesis_ledger;
+
+fn config_graph_iri(ledger_id: &str) -> String {
+    format!("urn:fluree:{ledger_id}#config")
+}
+
+/// M declares `ex:email` as `f:enforceUnique true`. D references M's
+/// constraints graph in its `#config`. Inserting ex:alice and then
+/// ex:bob with the same email on D must trigger
+/// `TransactError::UniqueConstraintViolation`.
+#[tokio::test]
+async fn data_ledger_tx_enforces_model_ledger_unique_constraint() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // --- model ledger M: annotates a property unique in a named graph
+    let model_id = "test/cross-ledger-constraints/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let constraints_graph_iri = "http://example.org/governance/constraints";
+    let m_trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{constraints_graph_iri}> {{
+            ex:email f:enforceUnique true .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&m_trig)
+        .execute()
+        .await
+        .expect("seed M constraints graph");
+
+    // --- data ledger D: seed data + cross-ledger constraints config.
+    let data_id = "test/cross-ledger-constraints/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    // Insert the first record. No config yet (config writes are
+    // lagging — they take effect on the next tx), so this insert
+    // never enforces anything.
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "ex:email": "alice@example.com"
+            }),
+        )
+        .await
+        .expect("seed alice");
+    let data = r1.ledger;
+
+    // Now write the config pointing f:constraintsSource cross-ledger
+    // at M, with uniqueEnabled. The next transaction will pick this up.
+    let config_iri = config_graph_iri(data_id);
+    let d_config = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:cfg:main> rdf:type f:LedgerConfig .
+            <urn:cfg:main> f:transactDefaults <urn:cfg:transact> .
+            <urn:cfg:transact> f:uniqueEnabled true .
+            <urn:cfg:transact> f:constraintsSource <urn:cfg:constraints-ref> .
+            <urn:cfg:constraints-ref> rdf:type f:GraphRef ;
+                                      f:graphSource <urn:cfg:constraints-src> .
+            <urn:cfg:constraints-src> f:ledger <{model_id}> ;
+                                      f:graphSelector <{constraints_graph_iri}> .
+        }}
+    "
+    );
+    let r2 = fluree
+        .stage_owned(data)
+        .upsert_turtle(&d_config)
+        .execute()
+        .await
+        .expect("seed D cross-ledger constraints config");
+    let data = r2.ledger;
+
+    // Insert a second record with the SAME email. M's cross-ledger
+    // constraint must apply against D's data and reject the tx.
+    let err = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:bob",
+                "ex:email": "alice@example.com"
+            }),
+        )
+        .await
+        .expect_err("duplicate email under cross-ledger constraint must be rejected");
+
+    assert!(
+        matches!(
+            err,
+            fluree_db_api::ApiError::Transact(
+                fluree_db_transact::TransactError::UniqueConstraintViolation { .. }
+            )
+        ),
+        "expected UniqueConstraintViolation from M's cross-ledger constraint, got: {err:?}"
+    );
+}
+
+/// When `f:constraintsSource` is cross-ledger but the model ledger
+/// has been retracted (or never created), the transaction must fail
+/// closed with a clear diagnostic naming the missing model ledger —
+/// not silently allow the duplicate.
+#[tokio::test]
+async fn cross_ledger_constraints_missing_model_fails_tx_closed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let data_id = "test/cross-ledger-constraints/no-model:main";
+    let model_id = "test/cross-ledger-constraints/never-created:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "ex:email": "alice@example.com"
+            }),
+        )
+        .await
+        .unwrap();
+    let data = r1.ledger;
+
+    let config_iri = config_graph_iri(data_id);
+    let r2 = fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:   <https://ns.flur.ee/db#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:transactDefaults <urn:cfg:transact> .
+                <urn:cfg:transact> f:uniqueEnabled true .
+                <urn:cfg:transact> f:constraintsSource <urn:cfg:cref> .
+                <urn:cfg:cref> rdf:type f:GraphRef ;
+                               f:graphSource <urn:cfg:csrc> .
+                <urn:cfg:csrc> f:ledger <{model_id}> ;
+                               f:graphSelector <http://example.org/whatever> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config (missing model)");
+    let data = r2.ledger;
+
+    let err = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:bob",
+                "ex:email": "bob@example.com"
+            }),
+        )
+        .await
+        .expect_err("tx must fail closed when cross-ledger constraints model is missing");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains(model_id) || msg.contains("not present on this instance"),
+        "error must name the missing model ledger, got: {msg}"
+    );
+}

--- a/fluree-db-api/tests/it_constraints_cross_ledger.rs
+++ b/fluree-db-api/tests/it_constraints_cross_ledger.rs
@@ -33,14 +33,14 @@ async fn data_ledger_tx_enforces_model_ledger_unique_constraint() {
 
     let constraints_graph_iri = "http://example.org/governance/constraints";
     let m_trig = format!(
-        r#"
+        r"
         @prefix f:    <https://ns.flur.ee/db#> .
         @prefix ex:   <http://example.org/ns/> .
 
         GRAPH <{constraints_graph_iri}> {{
             ex:email f:enforceUnique true .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)

--- a/fluree-db-api/tests/it_constraints_inline.rs
+++ b/fluree-db-api/tests/it_constraints_inline.rs
@@ -137,12 +137,14 @@ async fn inline_unique_property_accepts_unique_values() {
 }
 
 #[tokio::test]
-async fn inline_property_unknown_to_ledger_is_dropped_silently() {
-    // An inline IRI the ledger has never seen has no instances
-    // and cannot be violated; the enforcer drops it rather than
-    // failing the transaction. This matches the same-ledger
-    // contract where `encode_iri` returning None drops the
-    // would-be constraint.
+async fn inline_property_unknown_to_ledger_fails_loudly() {
+    // An inline IRI the ledger has never seen — neither
+    // pre-tx nor introduced by this tx — must surface as a
+    // parse error rather than silently becoming a no-op.
+    // The non-strict `encode_iri` folds unknown IRIs into the
+    // EMPTY namespace, which would match nothing and silently
+    // disable enforcement; the strict path used here rejects
+    // them up front so typos can't quietly weaken governance.
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = genesis_ledger(&fluree, "test/inline-constraints/unknown:main");
 
@@ -150,7 +152,7 @@ async fn inline_property_unknown_to_ledger_is_dropped_silently() {
         unique_properties: Some(vec!["http://never-seen.org/ns/whatever".to_string()]),
         ..TxnOpts::default()
     };
-    fluree
+    let err = fluree
         .insert_with_opts(
             ledger,
             &json!({
@@ -163,5 +165,11 @@ async fn inline_property_unknown_to_ledger_is_dropped_silently() {
             &test_index_cfg(),
         )
         .await
-        .expect("inline IRI absent from D's ns map must not fail the tx");
+        .expect_err("unknown inline-unique IRI must fail the tx, not silently no-op");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("opts.uniqueProperties") && msg.contains("never-seen.org"),
+        "expected explicit unresolved-IRI diagnostic, got: {msg}"
+    );
 }

--- a/fluree-db-api/tests/it_constraints_inline.rs
+++ b/fluree-db-api/tests/it_constraints_inline.rs
@@ -1,0 +1,167 @@
+//! Inline uniqueness constraints via `opts.uniqueProperties`.
+//!
+//! Per-transaction property-IRI list that the uniqueness enforcer
+//! treats as `f:enforceUnique true` for the duration of the
+//! transaction. Unions additively with any `f:constraintsSource`
+//! config; the list itself never persists into the ledger.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig};
+use fluree_db_transact::ir::TxnOpts;
+use serde_json::json;
+use support::genesis_ledger;
+
+fn test_index_cfg() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 1_000_000,
+    }
+}
+
+#[tokio::test]
+async fn inline_unique_property_rejects_duplicate() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-constraints/duplicate:main");
+
+    // Seed alice with email.
+    let seed = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id":       "ex:alice",
+        "ex:email":  "alice@example.org"
+    });
+    let r = fluree.insert(ledger, &seed).await.expect("seed alice");
+
+    // Second tx: bob with the same email, marking ex:email inline-unique.
+    let opts = TxnOpts {
+        unique_properties: Some(vec!["http://example.org/ns/email".to_string()]),
+        ..TxnOpts::default()
+    };
+    let err = fluree
+        .insert_with_opts(
+            r.ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":       "ex:bob",
+                "ex:email":  "alice@example.org"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect_err("duplicate value on inline-unique property must be rejected");
+
+    assert!(
+        err.to_string().to_lowercase().contains("unique"),
+        "expected uniqueness violation error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn inline_unique_property_does_not_persist() {
+    // After a tx that supplies opts.uniqueProperties, a later tx
+    // without it must accept a duplicate value — the inline list
+    // was transient.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-constraints/transient:main");
+
+    // Tx 1: seed alice under the inline-unique constraint.
+    let opts = TxnOpts {
+        unique_properties: Some(vec!["http://example.org/ns/email".to_string()]),
+        ..TxnOpts::default()
+    };
+    let r1 = fluree
+        .insert_with_opts(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":       "ex:alice",
+                "ex:email":  "alice@example.org"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect("seed alice with inline constraint");
+
+    // Tx 2: bob with the same email, NO opts.uniqueProperties.
+    // Without the inline list and no `f:constraintsSource` config,
+    // there's no constraint to violate — must be accepted.
+    fluree
+        .insert(
+            r1.ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":       "ex:bob",
+                "ex:email":  "alice@example.org"
+            }),
+        )
+        .await
+        .expect("without opts.uniqueProperties the prior tx's constraint must not apply");
+}
+
+#[tokio::test]
+async fn inline_unique_property_accepts_unique_values() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-constraints/distinct:main");
+
+    let seed = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id":       "ex:alice",
+        "ex:email":  "alice@example.org"
+    });
+    let r = fluree.insert(ledger, &seed).await.expect("seed alice");
+
+    let opts = TxnOpts {
+        unique_properties: Some(vec!["http://example.org/ns/email".to_string()]),
+        ..TxnOpts::default()
+    };
+    fluree
+        .insert_with_opts(
+            r.ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":       "ex:bob",
+                "ex:email":  "bob@example.org"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect("distinct value must satisfy inline-unique constraint");
+}
+
+#[tokio::test]
+async fn inline_property_unknown_to_ledger_is_dropped_silently() {
+    // An inline IRI the ledger has never seen has no instances
+    // and cannot be violated; the enforcer drops it rather than
+    // failing the transaction. This matches the same-ledger
+    // contract where `encode_iri` returning None drops the
+    // would-be constraint.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-constraints/unknown:main");
+
+    let opts = TxnOpts {
+        unique_properties: Some(vec!["http://never-seen.org/ns/whatever".to_string()]),
+        ..TxnOpts::default()
+    };
+    fluree
+        .insert_with_opts(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":       "ex:alice",
+                "ex:email":  "alice@example.org"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect("inline IRI absent from D's ns map must not fail the tx");
+}

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -118,6 +118,16 @@ async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
         r.value
     );
 
+    // policy_types must carry the rule's rdf:type set in IRI form —
+    // this is what the translation step intersects against the data
+    // ledger's configured f:policyClass set.
+    assert_eq!(
+        r.policy_types,
+        vec!["https://ns.flur.ee/db#AccessPolicy".to_string()],
+        "policy_types must record the rule's rdf:type IRIs, got {:?}",
+        r.policy_types
+    );
+
     // The wire artifact is also memoized — a second resolve of the
     // same (M, graph, t) tuple within the same context must return
     // the same Arc without re-materializing.
@@ -128,6 +138,124 @@ async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
         std::sync::Arc::ptr_eq(&resolved, &resolved2),
         "second resolve must be a memo hit, not a fresh materialization"
     );
+}
+
+/// Structural detection: a subject that has `f:allow` but declares a
+/// **non-`f:AccessPolicy`** rdf:type is still materialized. The
+/// translation step (slice 5) is where the data ledger's configured
+/// f:policyClass set gets intersected against the rule's policy_types.
+/// The wire materializer must not pre-filter by class.
+#[tokio::test]
+async fn structural_detection_picks_up_custom_typed_policies() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger/custom-typed:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let policy_graph_iri = "http://example.org/custom-policy-graph";
+    // Policy is typed as ex:OrgPolicy, NOT f:AccessPolicy. It has
+    // f:allow set so structural detection must include it. policy_types
+    // must record `ex:OrgPolicy` so slice 5 can filter appropriately.
+    let trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{policy_graph_iri}> {{
+            ex:orgRule
+                rdf:type    ex:OrgPolicy ;
+                f:action    f:view ;
+                f:onClass   ex:Document ;
+                f:allow     false .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("write custom-typed policy");
+
+    let data_id = "test/cross-ledger/custom-typed-d:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let graph_ref = cross_ref(model_id, policy_graph_iri);
+
+    let resolved = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx)
+        .await
+        .expect("cross-ledger resolution with custom-typed policy");
+
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    assert_eq!(
+        wire.restrictions.len(),
+        1,
+        "structural detection must pick up the f:allow-bearing subject regardless of class"
+    );
+    let r = &wire.restrictions[0];
+    assert!(r.id.contains("orgRule"));
+    assert_eq!(
+        r.policy_types,
+        vec!["http://example.org/ns/OrgPolicy".to_string()],
+        "policy_types must record ex:OrgPolicy, NOT f:AccessPolicy: got {:?}",
+        r.policy_types
+    );
+}
+
+/// A policy that declares **multiple** rdf:type values must surface
+/// every type in policy_types. The translation step uses set
+/// intersection against the data ledger's policy_class config; a
+/// rule typed as both `f:AccessPolicy` and `ex:OrgPolicy` must be
+/// selectable via either configured class.
+#[tokio::test]
+async fn multiple_rdf_types_are_all_captured_in_policy_types() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let model_id = "test/cross-ledger/multi-typed:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/multi-typed-graph";
+    let trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{policy_graph_iri}> {{
+            ex:dualTyped
+                rdf:type    f:AccessPolicy , ex:OrgPolicy ;
+                f:action    f:view ;
+                f:onClass   ex:Doc ;
+                f:allow     true .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("write dual-typed policy");
+
+    let data_id = "test/cross-ledger/multi-typed-d:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let resolved = resolve_graph_ref(
+        &cross_ref(model_id, policy_graph_iri),
+        ArtifactKind::PolicyRules,
+        &mut ctx,
+    )
+    .await
+    .expect("dual-typed resolves");
+
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    let r = &wire.restrictions[0];
+
+    // Both types must be present (order-independent).
+    assert_eq!(r.policy_types.len(), 2);
+    assert!(r.policy_types.contains(&"https://ns.flur.ee/db#AccessPolicy".to_string()));
+    assert!(r.policy_types.contains(&"http://example.org/ns/OrgPolicy".to_string()));
 }
 
 /// A cross-ledger ref to a graph IRI that doesn't exist on the model

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -1,0 +1,225 @@
+//! Cross-ledger resolver integration tests.
+//!
+//! End-to-end coverage that the Phase 1a resolver actually reads
+//! policy rules from a *different* ledger than the data ledger and
+//! returns them in term-neutral form. The translator-to-PolicySet
+//! step (slice 5) and enforcement against a real query (slice 9) are
+//! covered separately; this file's job is the wire-artifact contract.
+
+mod support;
+
+use fluree_db_api::cross_ledger::{
+    resolve_graph_ref, ArtifactKind, GovernanceArtifact, ResolveCtx,
+};
+use fluree_db_api::FlureeBuilder;
+use fluree_db_core::ledger_config::GraphSourceRef;
+use fluree_db_policy::TargetMode;
+use serde_json::json;
+use support::genesis_ledger;
+
+/// Build a cross-ledger GraphSourceRef.
+fn cross_ref(ledger: &str, graph: &str) -> GraphSourceRef {
+    GraphSourceRef {
+        ledger: Some(ledger.into()),
+        graph_selector: Some(graph.into()),
+        at_t: None,
+        trust_policy: None,
+        rollback_guard: None,
+    }
+}
+
+/// Resolve a cross-ledger ref to a model ledger M holding one
+/// f:AccessPolicy in a named graph, against an unrelated data
+/// ledger D on the same Fluree instance. The wire artifact returned
+/// must be IRI-form, attributed to M, and capture the rule's targets
+/// in M's IRI space — D's term space is untouched.
+#[tokio::test]
+async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // Model ledger M: holds one policy in a named graph.
+    let model_id = "test/cross-ledger/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    // Use TriG to drop the policy directly into a named graph (the
+    // simplest way to populate a non-default graph in one transaction).
+    let policy_graph_iri = "http://example.org/policy-graph";
+    let trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{policy_graph_iri}> {{
+            ex:denyUsers
+                rdf:type        f:AccessPolicy ;
+                f:action        f:view ;
+                f:onClass       ex:User ;
+                f:allow         false .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("write policy into model ledger named graph");
+
+    // Data ledger D: an unrelated ledger on the same instance. Its
+    // contents don't matter for the resolver — only the resolver's
+    // ability to find and read M without touching D.
+    let data_id = "test/cross-ledger/data:main";
+    let _data = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let graph_ref = cross_ref(model_id, policy_graph_iri);
+
+    let resolved = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx)
+        .await
+        .expect("cross-ledger resolution");
+
+    // Origin must point at M, not D.
+    assert_eq!(resolved.model_ledger_id, model_id);
+    assert_eq!(resolved.graph_iri, policy_graph_iri);
+    assert!(resolved.resolved_t > 0, "must resolve to a real commit t");
+
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    assert_eq!(wire.origin.model_ledger_id, model_id);
+    assert_eq!(wire.origin.graph_iri, policy_graph_iri);
+    assert_eq!(wire.origin.resolved_t, resolved.resolved_t);
+
+    // Exactly one restriction — `ex:denyUsers`.
+    assert_eq!(wire.restrictions.len(), 1, "expected one wire restriction");
+    let r = &wire.restrictions[0];
+
+    // The restriction's identifying IRI must round-trip from M's
+    // term space as a full IRI, not a curie.
+    assert!(
+        r.id.contains("denyUsers"),
+        "restriction id {:?} should reference denyUsers",
+        r.id
+    );
+
+    // Target mode is OnClass and the class IRI is in M's IRI space.
+    assert_eq!(r.target_mode, TargetMode::OnClass);
+    assert!(r.targets.is_empty());
+    assert_eq!(
+        r.for_classes,
+        vec!["http://example.org/ns/User".to_string()],
+        "for_classes must hold the expanded ex:User IRI, not a curie or Sid"
+    );
+    assert!(r.class_policy);
+
+    // Effect = Deny, action filtered correctly via the wire mirror.
+    assert!(
+        matches!(r.value, fluree_db_policy::WirePolicyValue::Deny),
+        "value must be Deny, got {:?}",
+        r.value
+    );
+
+    // The wire artifact is also memoized — a second resolve of the
+    // same (M, graph, t) tuple within the same context must return
+    // the same Arc without re-materializing.
+    let resolved2 = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx)
+        .await
+        .expect("second resolve");
+    assert!(
+        std::sync::Arc::ptr_eq(&resolved, &resolved2),
+        "second resolve must be a memo hit, not a fresh materialization"
+    );
+}
+
+/// A cross-ledger ref to a graph IRI that doesn't exist on the model
+/// ledger surfaces as GraphMissingAtT — not silently empty, not
+/// TranslationFailed. The fail-closed contract names this failure
+/// distinctly for audit.
+#[tokio::test]
+async fn unknown_graph_on_model_ledger_surfaces_graph_missing_at_t() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger/empty-model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    // Transact something into the default graph so the model has a
+    // commit t, but never touch any named graph.
+    fluree
+        .insert(
+            model,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:seed",
+                "ex:val": 1
+            }),
+        )
+        .await
+        .expect("seed model ledger");
+
+    let data_id = "test/cross-ledger/empty-data:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let graph_ref = cross_ref(model_id, "http://example.org/never-created");
+
+    let err = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx)
+        .await
+        .expect_err("missing graph on model must fail");
+
+    match err {
+        fluree_db_api::cross_ledger::CrossLedgerError::GraphMissingAtT {
+            ledger_id,
+            graph_iri,
+            ..
+        } => {
+            assert_eq!(ledger_id, model_id);
+            assert_eq!(graph_iri, "http://example.org/never-created");
+        }
+        other => panic!("expected GraphMissingAtT, got {other:?}"),
+    }
+}
+
+/// A cross-ledger ref where the named graph exists on the model
+/// ledger but contains no f:AccessPolicy-typed subjects yields a
+/// wire artifact with zero restrictions. This is a valid result —
+/// "no policies configured here" is not a failure.
+#[tokio::test]
+async fn empty_policy_graph_yields_empty_wire_artifact() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let model_id = "test/cross-ledger/no-policies:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    // Put NON-policy data in the named graph so the graph exists.
+    let graph_iri = "http://example.org/data-only";
+    let trig = format!(
+        r#"
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{graph_iri}> {{
+            ex:alice ex:name "Alice" .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("write non-policy data");
+
+    let data_id = "test/cross-ledger/no-policies-d:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let graph_ref = cross_ref(model_id, graph_iri);
+
+    let resolved = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx)
+        .await
+        .expect("empty graph resolves successfully");
+
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    assert!(
+        wire.restrictions.is_empty(),
+        "non-policy data in graph must yield zero restrictions, got {}",
+        wire.restrictions.len()
+    );
+}

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -45,7 +45,7 @@ async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
     // simplest way to populate a non-default graph in one transaction).
     let policy_graph_iri = "http://example.org/policy-graph";
     let trig = format!(
-        r#"
+        r"
         @prefix f:    <https://ns.flur.ee/db#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix ex:   <http://example.org/ns/> .
@@ -57,7 +57,7 @@ async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
                 f:onClass       ex:User ;
                 f:allow         false .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -85,7 +85,10 @@ async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
     assert!(resolved.resolved_t > 0, "must resolve to a real commit t");
 
     let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
-        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+        panic!(
+            "expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}",
+            resolved.artifact
+        );
     };
     assert_eq!(wire.origin.model_ledger_id, model_id);
     assert_eq!(wire.origin.graph_iri, policy_graph_iri);
@@ -159,7 +162,7 @@ async fn structural_detection_picks_up_custom_typed_policies() {
     // f:allow set so structural detection must include it. policy_types
     // must record `ex:OrgPolicy` so slice 5 can filter appropriately.
     let trig = format!(
-        r#"
+        r"
         @prefix f:    <https://ns.flur.ee/db#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix ex:   <http://example.org/ns/> .
@@ -171,7 +174,7 @@ async fn structural_detection_picks_up_custom_typed_policies() {
                 f:onClass   ex:Document ;
                 f:allow     false .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -191,7 +194,10 @@ async fn structural_detection_picks_up_custom_typed_policies() {
         .expect("cross-ledger resolution with custom-typed policy");
 
     let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
-        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+        panic!(
+            "expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}",
+            resolved.artifact
+        );
     };
     assert_eq!(
         wire.restrictions.len(),
@@ -220,7 +226,7 @@ async fn multiple_rdf_types_are_all_captured_in_policy_types() {
     let model = genesis_ledger(&fluree, model_id);
     let policy_graph_iri = "http://example.org/multi-typed-graph";
     let trig = format!(
-        r#"
+        r"
         @prefix f:    <https://ns.flur.ee/db#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix ex:   <http://example.org/ns/> .
@@ -232,7 +238,7 @@ async fn multiple_rdf_types_are_all_captured_in_policy_types() {
                 f:onClass   ex:Doc ;
                 f:allow     true .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -254,14 +260,21 @@ async fn multiple_rdf_types_are_all_captured_in_policy_types() {
     .expect("dual-typed resolves");
 
     let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
-        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+        panic!(
+            "expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}",
+            resolved.artifact
+        );
     };
     let r = &wire.restrictions[0];
 
     // Both types must be present (order-independent).
     assert_eq!(r.policy_types.len(), 2);
-    assert!(r.policy_types.contains(&"https://ns.flur.ee/db#AccessPolicy".to_string()));
-    assert!(r.policy_types.contains(&"http://example.org/ns/OrgPolicy".to_string()));
+    assert!(r
+        .policy_types
+        .contains(&"https://ns.flur.ee/db#AccessPolicy".to_string()));
+    assert!(r
+        .policy_types
+        .contains(&"http://example.org/ns/OrgPolicy".to_string()));
 }
 
 /// Cross-ledger schema materialization picks up the whitelisted
@@ -281,7 +294,7 @@ async fn cross_ledger_schema_materializes_whitelisted_axioms() {
     // M's schema graph: a small class hierarchy + a property
     // hierarchy that should both surface in the wire artifact.
     let trig = format!(
-        r#"
+        r"
         @prefix owl:  <http://www.w3.org/2002/07/owl#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -296,7 +309,7 @@ async fn cross_ledger_schema_materializes_whitelisted_axioms() {
             ex:friend  rdf:type           owl:ObjectProperty ;
                        rdfs:subPropertyOf ex:knows .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -431,7 +444,7 @@ async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
     // be discovered, and the deny would silently disappear cross-
     // ledger while still applying same-ledger.
     let trig = format!(
-        r#"
+        r"
         @prefix f:    <https://ns.flur.ee/db#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix ex:   <http://example.org/ns/> .
@@ -442,7 +455,7 @@ async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
                 f:action    f:view ;
                 f:onClass   ex:User .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -464,7 +477,10 @@ async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
     .expect("missing-effect typed policy resolves");
 
     let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
-        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+        panic!(
+            "expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}",
+            resolved.artifact
+        );
     };
     assert_eq!(
         wire.restrictions.len(),
@@ -506,7 +522,7 @@ async fn distinct_namespace_codes_canary_term_translation_still_works() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -518,7 +534,7 @@ async fn distinct_namespace_codes_canary_term_translation_still_works() {
                     f:onClass   ex:User ;
                     f:allow     false .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -668,7 +684,7 @@ async fn single_resolution_t_is_stable_within_a_request() {
     let r1 = fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -679,7 +695,7 @@ async fn single_resolution_t_is_stable_within_a_request() {
             GRAPH <{graph_b_iri}> {{
                 ex:ruleB rdf:type f:AccessPolicy ; f:action f:view ; f:allow false .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -755,7 +771,8 @@ async fn single_resolution_t_is_stable_within_a_request() {
     assert!(
         resolved_a_fresh.resolved_t > t_at_first_resolution,
         "a fresh request should see M's advanced head (got {}, expected > {})",
-        resolved_a_fresh.resolved_t, t_at_first_resolution
+        resolved_a_fresh.resolved_t,
+        t_at_first_resolution
     );
 }
 
@@ -774,7 +791,7 @@ async fn governance_cache_short_circuits_repeated_resolutions_across_contexts() 
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -782,7 +799,7 @@ async fn governance_cache_short_circuits_repeated_resolutions_across_contexts() 
             GRAPH <{policy_graph_iri}> {{
                 ex:rule rdf:type f:AccessPolicy ; f:action f:view ; f:allow true .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -814,8 +831,8 @@ async fn governance_cache_short_circuits_repeated_resolutions_across_contexts() 
     // best-effort; allow the rare zero-count race by also asserting
     // a direct get hit.
     let _ = fluree.governance_cache(); // touch
-    // (sync_for_test would be ideal but Moka doesn't expose one;
-    // the get below is the load-bearing check.)
+                                       // (sync_for_test would be ideal but Moka doesn't expose one;
+                                       // the get below is the load-bearing check.)
 
     let mut ctx_b = ResolveCtx::new(data_b, &fluree);
     let resolved_b = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx_b)
@@ -925,7 +942,10 @@ async fn empty_policy_graph_yields_empty_wire_artifact() {
         .expect("empty graph resolves successfully");
 
     let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
-        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+        panic!(
+            "expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}",
+            resolved.artifact
+        );
     };
     assert!(
         wire.restrictions.is_empty(),

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -418,15 +418,19 @@ async fn distinct_namespace_codes_canary_term_translation_still_works() {
         .encode_iri("http://example.org/ns/User")
         .expect("ex:User should resolve in D");
 
-    if m_user_sid.namespace_code == d_user_sid.namespace_code {
-        eprintln!(
-            "WARNING: canary test ended up with matching ns_codes for ex:User \
-             ({:?} == {:?}). The end-to-end assertion still holds but this run \
-             does not exercise the cross-namespace-code path. Consider adjusting \
-             the seed order if this happens consistently.",
-            m_user_sid.namespace_code, d_user_sid.namespace_code
-        );
-    }
+    // Hard assertion: a CI run where these happen to align would
+    // report the canary green without actually exercising the
+    // cross-namespace-code path. The seed order above (M seeded
+    // with ex: first, D seeded with an unrelated namespace before
+    // ex:) is constructed specifically to force divergence — if a
+    // future ns-allocation change ever makes these collide, the
+    // test needs to be re-seeded, not silently tolerated.
+    assert_ne!(
+        m_user_sid.namespace_code, d_user_sid.namespace_code,
+        "canary seeding must produce distinct ns_codes for ex:User on M vs D \
+         (got M={:?}, D={:?}); adjust the seed order until they diverge",
+        m_user_sid.namespace_code, d_user_sid.namespace_code,
+    );
 
     // Write D's cross-ledger config pointing at M.
     let config_iri = format!("urn:fluree:{data_id}#config");

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -324,6 +324,281 @@ async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
     );
 }
 
+/// Distinct-namespace-codes canary.
+///
+/// The design doc treats this as a mandatory cross-cutting test:
+/// term translation must operate on IRIs end-to-end, never on M's
+/// internal Sids. If a future change makes the wire form leak Sids
+/// from M's namespace map, this test would fail — D's lookup of
+/// the policy's class IRI would land on a different Sid than M
+/// embedded, and the enforcement would silently miss.
+///
+/// To make the canary non-trivial, D is pre-seeded with an
+/// unrelated namespace before its policy-relevant data lands, so
+/// D's `http://example.org/ns/` prefix is registered at a
+/// different `ns_code` than M's. The test asserts the codes
+/// actually diverge, then runs the end-to-end enforcement and
+/// confirms M's deny rule applies against D's data.
+#[tokio::test]
+async fn distinct_namespace_codes_canary_term_translation_still_works() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // Build M first with the policy graph using ex:User.
+    let model_id = "test/cross-ledger/canary/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/canary-policy";
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:denyUsers
+                    rdf:type    f:AccessPolicy ;
+                    f:action    f:view ;
+                    f:onClass   ex:User ;
+                    f:allow     false .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M");
+
+    // D pre-seeded with an UNRELATED namespace before its
+    // ex:-prefixed data lands. The unrelated insert allocates
+    // an ns_code first, so when ex:User finally lands, its prefix
+    // ends up at a different code than M assigned.
+    let data_id = "test/cross-ledger/canary/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"unrelated": "http://unrelated.example.org/v1/"},
+                "@graph": [
+                    {"@id": "unrelated:seed-a", "unrelated:tag": "first"},
+                    {"@id": "unrelated:seed-b", "unrelated:tag": "second"}
+                ]
+            }),
+        )
+        .await
+        .expect("seed unrelated namespace into D");
+    let data = r1.ledger;
+
+    let r2 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "@type": "ex:User",
+                "ex:name": "Alice"
+            }),
+        )
+        .await
+        .expect("seed ex:User data into D");
+    let data = r2.ledger;
+
+    // Inspect both ledgers' namespace maps. If allocation happens
+    // to align (e.g., a future change to ns_code assignment) the
+    // canary degenerates into a regular enforcement test rather
+    // than asserting divergence — flag that in the message so a
+    // failure here is actionable.
+    let m_snapshot = fluree.db(model_id).await.expect("open M");
+    let d_snapshot = &data.snapshot;
+    let m_user_sid = m_snapshot
+        .snapshot
+        .encode_iri("http://example.org/ns/User")
+        .expect("ex:User should resolve in M");
+    let d_user_sid = d_snapshot
+        .encode_iri("http://example.org/ns/User")
+        .expect("ex:User should resolve in D");
+
+    if m_user_sid.namespace_code == d_user_sid.namespace_code {
+        eprintln!(
+            "WARNING: canary test ended up with matching ns_codes for ex:User \
+             ({:?} == {:?}). The end-to-end assertion still holds but this run \
+             does not exercise the cross-namespace-code path. Consider adjusting \
+             the seed order if this happens consistently.",
+            m_user_sid.namespace_code, d_user_sid.namespace_code
+        );
+    }
+
+    // Write D's cross-ledger config pointing at M.
+    let config_iri = format!("urn:fluree:{data_id}#config");
+    let r3 = fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:defaultAllow true .
+                <urn:cfg:policy> f:policyClass f:AccessPolicy .
+                <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+                <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:policy-src> .
+                <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{policy_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D cross-ledger config");
+    let _ = r3;
+
+    // End-to-end: query D for ex:User. The materializer produced M's
+    // class IRI as a string ("http://example.org/ns/User"); the
+    // translator must re-intern that against D's namespace map and
+    // arrive at d_user_sid. If translation broke (Sids leaked from M
+    // into D's evaluation), the deny would miss and alice would be
+    // visible.
+    let wrapped = fluree
+        .db_with_policy(data_id, &fluree_db_api::QueryConnectionOptions::default())
+        .await
+        .expect("db_with_policy under cross-ledger");
+
+    let users = fluree
+        .query(
+            &wrapped,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "select": "?u",
+                "where": {"@id": "?u", "@type": "ex:User"}
+            }),
+        )
+        .await
+        .expect("query ex:User");
+    let users_jsonld = users.to_jsonld(&wrapped.snapshot).expect("jsonld");
+    assert_eq!(
+        users_jsonld,
+        json!([]),
+        "cross-ledger deny must apply against D's data even when D's \
+         ns_code for the class IRI differs from M's; got {users_jsonld}"
+    );
+}
+
+/// Single-resolution-t.
+///
+/// Within one request (one `ResolveCtx`), every cross-ledger
+/// reference to the same model ledger M must use the same
+/// `resolved_t` even if M advances in the middle. The design doc
+/// makes this property mandatory so policy / shapes / schema can
+/// never disagree about which version of M they're enforcing for
+/// a given request.
+#[tokio::test]
+async fn single_resolution_t_is_stable_within_a_request() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger/stable-t/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    // M holds two policy graphs from the start so both resolutions
+    // can succeed without M needing to advance for them to exist.
+    let graph_a_iri = "http://example.org/policy-a";
+    let graph_b_iri = "http://example.org/policy-b";
+    let r1 = fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{graph_a_iri}> {{
+                ex:ruleA rdf:type f:AccessPolicy ; f:action f:view ; f:allow true .
+            }}
+            GRAPH <{graph_b_iri}> {{
+                ex:ruleB rdf:type f:AccessPolicy ; f:action f:view ; f:allow false .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M with two policy graphs");
+    let model = r1.ledger;
+
+    let data_id = "test/cross-ledger/stable-t/data:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    // Single ResolveCtx = single request. Resolve A, advance M, then
+    // resolve B. B's resolved_t must equal A's — captured once at the
+    // first reference, not re-read between resolutions.
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+
+    let resolved_a = resolve_graph_ref(
+        &cross_ref(model_id, graph_a_iri),
+        ArtifactKind::PolicyRules,
+        &mut ctx,
+    )
+    .await
+    .expect("resolve A");
+    let t_at_first_resolution = resolved_a.resolved_t;
+
+    // Advance M between the two resolutions. Without single-
+    // resolution-t, the second resolve would pick up this new head.
+    fluree
+        .insert(
+            model,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:filler",
+                "ex:val": "advance M"
+            }),
+        )
+        .await
+        .expect("advance M's commit_t");
+
+    let resolved_b = resolve_graph_ref(
+        &cross_ref(model_id, graph_b_iri),
+        ArtifactKind::PolicyRules,
+        &mut ctx,
+    )
+    .await
+    .expect("resolve B");
+
+    assert_eq!(
+        resolved_b.resolved_t, t_at_first_resolution,
+        "second resolution within the same request must reuse the captured \
+         resolved_t (got {} after advancing M; first capture was {})",
+        resolved_b.resolved_t, t_at_first_resolution,
+    );
+
+    // Verify resolved_ts cached the head exactly once. A new
+    // request would re-capture against the advanced M; the cache
+    // is per-request, not per-instance.
+    assert_eq!(ctx.resolved_ts.len(), 1);
+    assert_eq!(
+        ctx.resolved_ts.get(model_id),
+        Some(&t_at_first_resolution),
+        "resolved_ts must store the captured t once per canonical model id"
+    );
+
+    // Sanity: a new ResolveCtx against the same Fluree DOES re-capture
+    // against M's current head.
+    let mut fresh_ctx = ResolveCtx::new(data_id, &fluree);
+    let resolved_a_fresh = resolve_graph_ref(
+        &cross_ref(model_id, graph_a_iri),
+        ArtifactKind::PolicyRules,
+        &mut fresh_ctx,
+    )
+    .await
+    .expect("resolve A in fresh ctx");
+    assert!(
+        resolved_a_fresh.resolved_t > t_at_first_resolution,
+        "a fresh request should see M's advanced head (got {}, expected > {})",
+        resolved_a_fresh.resolved_t, t_at_first_resolution
+    );
+}
+
 /// The per-instance governance cache makes the same (M, graph, t)
 /// reusable across requests and across every data ledger on the
 /// instance. Two independent ResolveCtxs (simulating two requests)

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -258,6 +258,72 @@ async fn multiple_rdf_types_are_all_captured_in_policy_types() {
     assert!(r.policy_types.contains(&"http://example.org/ns/OrgPolicy".to_string()));
 }
 
+/// A canonically-typed policy (`rdf:type f:AccessPolicy`) that has
+/// NEITHER `f:allow` nor `f:query` is treated as `Deny` by the same-
+/// ledger materializer (with a warning) — so the cross-ledger
+/// materializer must surface the same subject. Structural detection
+/// on `f:allow ∪ f:query` alone would miss it; the additional
+/// `rdf:type f:AccessPolicy` scan closes that gap.
+#[tokio::test]
+async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let model_id = "test/cross-ledger/missing-effect:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/missing-effect-graph";
+
+    // Policy is canonically typed but declares no f:allow / f:query.
+    // It does declare f:onClass so target_mode is OnClass — without
+    // the rdf:type-driven structural scan this subject would never
+    // be discovered, and the deny would silently disappear cross-
+    // ledger while still applying same-ledger.
+    let trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{policy_graph_iri}> {{
+            ex:incompleteDeny
+                rdf:type    f:AccessPolicy ;
+                f:action    f:view ;
+                f:onClass   ex:User .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("write canonical-typed effect-less policy");
+
+    let data_id = "test/cross-ledger/missing-effect-d:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let resolved = resolve_graph_ref(
+        &cross_ref(model_id, policy_graph_iri),
+        ArtifactKind::PolicyRules,
+        &mut ctx,
+    )
+    .await
+    .expect("missing-effect typed policy resolves");
+
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    assert_eq!(
+        wire.restrictions.len(),
+        1,
+        "canonical-typed policy must be surfaced even without f:allow / f:query"
+    );
+    let r = &wire.restrictions[0];
+    assert!(r.id.contains("incompleteDeny"));
+    assert!(
+        matches!(r.value, fluree_db_policy::WirePolicyValue::Deny),
+        "missing-effect on canonical type must materialize as Deny (mirroring same-ledger); got {:?}",
+        r.value
+    );
+}
+
 /// A cross-ledger ref to a graph IRI that doesn't exist on the model
 /// ledger surfaces as GraphMissingAtT — not silently empty, not
 /// TranslationFailed. The fail-closed contract names this failure

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -335,7 +335,7 @@ async fn cross_ledger_schema_materializes_whitelisted_axioms() {
     let subclass_axiom = triples.iter().find(|t| {
         t.s == "http://example.org/ns/Dog"
             && t.p == "http://www.w3.org/2000/01/rdf-schema#subClassOf"
-            && t.o == "http://example.org/ns/Animal"
+            && matches!(&t.o, fluree_db_api::cross_ledger::WireObject::Ref(o) if o == "http://example.org/ns/Animal")
     });
     assert!(
         subclass_axiom.is_some(),
@@ -346,7 +346,7 @@ async fn cross_ledger_schema_materializes_whitelisted_axioms() {
     let subproperty_axiom = triples.iter().find(|t| {
         t.s == "http://example.org/ns/friend"
             && t.p == "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
-            && t.o == "http://example.org/ns/knows"
+            && matches!(&t.o, fluree_db_api::cross_ledger::WireObject::Ref(o) if o == "http://example.org/ns/knows")
     });
     assert!(
         subproperty_axiom.is_some(),
@@ -357,7 +357,7 @@ async fn cross_ledger_schema_materializes_whitelisted_axioms() {
     let class_decl = triples.iter().find(|t| {
         t.s == "http://example.org/ns/Animal"
             && t.p == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-            && t.o == "http://www.w3.org/2002/07/owl#Class"
+            && matches!(&t.o, fluree_db_api::cross_ledger::WireObject::Ref(o) if o == "http://www.w3.org/2002/07/owl#Class")
     });
     assert!(
         class_decl.is_some(),

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -264,6 +264,154 @@ async fn multiple_rdf_types_are_all_captured_in_policy_types() {
     assert!(r.policy_types.contains(&"http://example.org/ns/OrgPolicy".to_string()));
 }
 
+/// Cross-ledger schema materialization picks up the whitelisted
+/// ontology axiom triples in M's schema graph and projects them
+/// into IRI form. Reasoner-level enforcement is exercised
+/// separately; this test pins the wire artifact contract — the
+/// materializer hits the right whitelist, decodes M's Sids to
+/// IRIs that survive transport, and origin metadata reflects M.
+#[tokio::test]
+async fn cross_ledger_schema_materializes_whitelisted_axioms() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger/schema:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let schema_graph_iri = "http://example.org/ontology/core";
+
+    // M's schema graph: a small class hierarchy + a property
+    // hierarchy that should both surface in the wire artifact.
+    let trig = format!(
+        r#"
+        @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{schema_graph_iri}> {{
+            ex:Animal  rdf:type           owl:Class .
+            ex:Dog     rdf:type           owl:Class ;
+                       rdfs:subClassOf    ex:Animal .
+
+            ex:knows   rdf:type           owl:ObjectProperty .
+            ex:friend  rdf:type           owl:ObjectProperty ;
+                       rdfs:subPropertyOf ex:knows .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("seed M schema graph");
+
+    let data_id = "test/cross-ledger/schema-d:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let resolved = resolve_graph_ref(
+        &cross_ref(model_id, schema_graph_iri),
+        ArtifactKind::SchemaClosure,
+        &mut ctx,
+    )
+    .await
+    .expect("cross-ledger schema resolution");
+
+    assert_eq!(resolved.model_ledger_id, model_id);
+    assert_eq!(resolved.graph_iri, schema_graph_iri);
+
+    let GovernanceArtifact::SchemaClosure(wire) = &resolved.artifact else {
+        panic!(
+            "expected SchemaClosure artifact for ArtifactKind::SchemaClosure, \
+             got {:?}",
+            resolved.artifact
+        );
+    };
+    assert_eq!(wire.origin.model_ledger_id, model_id);
+    assert_eq!(wire.origin.graph_iri, schema_graph_iri);
+
+    // The wire must include the rdfs:subClassOf axiom in IRI form.
+    let triples = &wire.triples;
+    let subclass_axiom = triples.iter().find(|t| {
+        t.s == "http://example.org/ns/Dog"
+            && t.p == "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+            && t.o == "http://example.org/ns/Animal"
+    });
+    assert!(
+        subclass_axiom.is_some(),
+        "wire must include ex:Dog rdfs:subClassOf ex:Animal in IRI form, got: {triples:?}"
+    );
+
+    // ...and the rdfs:subPropertyOf axiom.
+    let subproperty_axiom = triples.iter().find(|t| {
+        t.s == "http://example.org/ns/friend"
+            && t.p == "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+            && t.o == "http://example.org/ns/knows"
+    });
+    assert!(
+        subproperty_axiom.is_some(),
+        "wire must include ex:friend rdfs:subPropertyOf ex:knows, got: {triples:?}"
+    );
+
+    // ...and the rdf:type owl:Class declarations.
+    let class_decl = triples.iter().find(|t| {
+        t.s == "http://example.org/ns/Animal"
+            && t.p == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            && t.o == "http://www.w3.org/2002/07/owl#Class"
+    });
+    assert!(
+        class_decl.is_some(),
+        "wire must include ex:Animal rdf:type owl:Class, got: {triples:?}"
+    );
+}
+
+/// A cross-ledger schema reference against a model ledger that
+/// holds no schema triples (or no whitelisted axioms) yields a wire
+/// artifact with zero triples — not an error.
+#[tokio::test]
+async fn cross_ledger_schema_empty_graph_yields_empty_wire() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let model_id = "test/cross-ledger/schema-empty:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    // Non-schema data in a named graph so the graph EXISTS.
+    let graph_iri = "http://example.org/non-schema";
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix ex: <http://example.org/ns/> .
+
+            GRAPH <{graph_iri}> {{
+                ex:alice ex:name "Alice" .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed non-schema data");
+
+    let data_id = "test/cross-ledger/schema-empty-d:main";
+    let _ = genesis_ledger(&fluree, data_id);
+
+    let mut ctx = ResolveCtx::new(data_id, &fluree);
+    let resolved = resolve_graph_ref(
+        &cross_ref(model_id, graph_iri),
+        ArtifactKind::SchemaClosure,
+        &mut ctx,
+    )
+    .await
+    .expect("cross-ledger schema resolution against non-schema graph");
+
+    let GovernanceArtifact::SchemaClosure(wire) = &resolved.artifact else {
+        panic!("expected SchemaClosure");
+    };
+    assert!(
+        wire.triples.is_empty(),
+        "non-schema data in graph must yield zero whitelisted triples"
+    );
+}
+
 /// A canonically-typed policy (`rdf:type f:AccessPolicy`) that has
 /// NEITHER `f:allow` nor `f:query` is treated as `Deny` by the same-
 /// ledger materializer (with a warning) — so the cross-ledger

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -84,7 +84,9 @@ async fn resolves_policy_graph_from_model_ledger_into_term_neutral_wire() {
     assert_eq!(resolved.graph_iri, policy_graph_iri);
     assert!(resolved.resolved_t > 0, "must resolve to a real commit t");
 
-    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
+        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+    };
     assert_eq!(wire.origin.model_ledger_id, model_id);
     assert_eq!(wire.origin.graph_iri, policy_graph_iri);
     assert_eq!(wire.origin.resolved_t, resolved.resolved_t);
@@ -188,7 +190,9 @@ async fn structural_detection_picks_up_custom_typed_policies() {
         .await
         .expect("cross-ledger resolution with custom-typed policy");
 
-    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
+        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+    };
     assert_eq!(
         wire.restrictions.len(),
         1,
@@ -249,7 +253,9 @@ async fn multiple_rdf_types_are_all_captured_in_policy_types() {
     .await
     .expect("dual-typed resolves");
 
-    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
+        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+    };
     let r = &wire.restrictions[0];
 
     // Both types must be present (order-independent).
@@ -309,7 +315,9 @@ async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
     .await
     .expect("missing-effect typed policy resolves");
 
-    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
+        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+    };
     assert_eq!(
         wire.restrictions.len(),
         1,
@@ -768,7 +776,9 @@ async fn empty_policy_graph_yields_empty_wire_artifact() {
         .await
         .expect("empty graph resolves successfully");
 
-    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact;
+    let GovernanceArtifact::PolicyRules(wire) = &resolved.artifact else {
+        panic!("expected PolicyRules artifact for ArtifactKind::PolicyRules, got {:?}", resolved.artifact);
+    };
     assert!(
         wire.restrictions.is_empty(),
         "non-policy data in graph must yield zero restrictions, got {}",

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -324,6 +324,85 @@ async fn missing_effect_on_typed_policy_is_picked_up_as_deny() {
     );
 }
 
+/// The per-instance governance cache makes the same (M, graph, t)
+/// reusable across requests and across every data ledger on the
+/// instance. Two independent ResolveCtxs (simulating two requests)
+/// resolving the same key must end up sharing one Arc — the second
+/// resolution is a cache hit and never re-materializes.
+#[tokio::test]
+async fn governance_cache_short_circuits_repeated_resolutions_across_contexts() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger/cache:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/cache-policy";
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:rule rdf:type f:AccessPolicy ; f:action f:view ; f:allow true .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M");
+
+    // Two data ledgers — same Fluree instance, different identities.
+    // Both resolve the same (M, policy_graph, t). The second one
+    // must hit the per-instance governance cache.
+    let data_a = "test/cross-ledger/cache/d-a:main";
+    let _ = genesis_ledger(&fluree, data_a);
+    let data_b = "test/cross-ledger/cache/d-b:main";
+    let _ = genesis_ledger(&fluree, data_b);
+
+    let graph_ref = cross_ref(model_id, policy_graph_iri);
+
+    assert_eq!(
+        fluree.governance_cache().entry_count(),
+        0,
+        "cache must start empty"
+    );
+
+    let mut ctx_a = ResolveCtx::new(data_a, &fluree);
+    let resolved_a = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx_a)
+        .await
+        .expect("first resolve populates cache");
+
+    // After the first resolve, the cache must have exactly one
+    // entry for this (kind, M, graph, t). Moka's entry_count is
+    // best-effort; allow the rare zero-count race by also asserting
+    // a direct get hit.
+    let _ = fluree.governance_cache(); // touch
+    // (sync_for_test would be ideal but Moka doesn't expose one;
+    // the get below is the load-bearing check.)
+
+    let mut ctx_b = ResolveCtx::new(data_b, &fluree);
+    let resolved_b = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx_b)
+        .await
+        .expect("second resolve hits cache");
+
+    assert!(
+        std::sync::Arc::ptr_eq(&resolved_a, &resolved_b),
+        "second resolve in a fresh ResolveCtx must return the cached Arc, \
+         not a freshly materialized one"
+    );
+
+    // A new context against a third data ledger sees the same hit.
+    let data_c = "test/cross-ledger/cache/d-c:main";
+    let _ = genesis_ledger(&fluree, data_c);
+    let mut ctx_c = ResolveCtx::new(data_c, &fluree);
+    let resolved_c = resolve_graph_ref(&graph_ref, ArtifactKind::PolicyRules, &mut ctx_c)
+        .await
+        .expect("third resolve also a cache hit");
+    assert!(std::sync::Arc::ptr_eq(&resolved_a, &resolved_c));
+}
+
 /// A cross-ledger ref to a graph IRI that doesn't exist on the model
 /// ledger surfaces as GraphMissingAtT — not silently empty, not
 /// TranslationFailed. The fail-closed contract names this failure

--- a/fluree-db-api/tests/it_ontology_inline.rs
+++ b/fluree-db-api/tests/it_ontology_inline.rs
@@ -1,0 +1,153 @@
+//! Inline ontology axioms via `opts.ontology` (top-level
+//! `ontology` field on a JSON-LD query).
+//!
+//! The query supplies RDFS/OWL axioms inline; the reasoner parses
+//! them into a `SchemaBundleFlakes` overlay and layers it on top
+//! of any `f:schemaSource` configured on the ledger. The axioms
+//! themselves never persist.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::{genesis_ledger, normalize_rows};
+
+#[tokio::test]
+async fn inline_ontology_subclass_drives_rdfs_reasoning() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-ontology/subclass:main");
+
+    // Seed an instance whose type is a subclass of the target the
+    // query asks for. With no schema axioms, the query won't see it.
+    let seed = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id":   "ex:alice",
+        "@type": "ex:Employee",
+        "ex:name": "Alice"
+    });
+    let r = fluree.insert(ledger, &seed).await.expect("seed alice");
+    let ledger = r.ledger;
+
+    // Without inline ontology + reasoning: the query for ex:Person
+    // misses alice (no subclass entailment is in the ledger).
+    let baseline_q = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "select":   "?name",
+        "where":    {"@id": "?p", "@type": "ex:Person", "ex:name": "?name"}
+    });
+    let view = fluree
+        .db("test/inline-ontology/subclass:main")
+        .await
+        .expect("load db");
+    let rows = fluree
+        .query(&view, &baseline_q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    assert!(
+        normalize_rows(&rows).is_empty(),
+        "without inline ontology + rdfs reasoning the query must not see alice"
+    );
+
+    // With inline ontology declaring ex:Employee rdfs:subClassOf
+    // ex:Person, RDFS reasoning entails alice's type as ex:Person.
+    let q = json!({
+        "@context":  {"ex": "http://example.org/ns/"},
+        "select":    "?name",
+        "where":     {"@id": "?p", "@type": "ex:Person", "ex:name": "?name"},
+        "reasoning": "rdfs",
+        "ontology": {
+            "@context": {
+                "ex":   "http://example.org/ns/",
+                "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+            },
+            "@id":            "ex:Employee",
+            "rdfs:subClassOf": {"@id": "ex:Person"}
+        }
+    });
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .expect("inline ontology query must succeed")
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!("Alice")),
+        "inline rdfs:subClassOf must entail ex:Person; got: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn inline_ontology_does_not_persist_after_query() {
+    // Run a query with inline ontology that would entail more
+    // results; then run the same query without `ontology`. The
+    // second query must NOT see the inline axioms — they were
+    // transient.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-ontology/transient:main");
+
+    let seed = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id":   "ex:bob",
+        "@type": "ex:Contractor",
+        "ex:name": "Bob"
+    });
+    fluree.insert(ledger, &seed).await.expect("seed bob");
+
+    let view = fluree
+        .db("test/inline-ontology/transient:main")
+        .await
+        .expect("load db");
+    let ledger = fluree
+        .ledger("test/inline-ontology/transient:main")
+        .await
+        .expect("reload ledger");
+
+    // Query 1: with inline ontology → bob counts as Person.
+    let with_ontology = json!({
+        "@context":  {"ex": "http://example.org/ns/"},
+        "select":    "?name",
+        "where":     {"@id": "?p", "@type": "ex:Person", "ex:name": "?name"},
+        "reasoning": "rdfs",
+        "ontology": {
+            "@context": {
+                "ex":   "http://example.org/ns/",
+                "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+            },
+            "@id":             "ex:Contractor",
+            "rdfs:subClassOf": {"@id": "ex:Person"}
+        }
+    });
+    let rows = fluree
+        .query(&view, &with_ontology)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    assert!(
+        normalize_rows(&rows).contains(&json!("Bob")),
+        "first query with ontology should see bob"
+    );
+
+    // Query 2: no ontology → entailment is gone.
+    let no_ontology = json!({
+        "@context":  {"ex": "http://example.org/ns/"},
+        "select":    "?name",
+        "where":     {"@id": "?p", "@type": "ex:Person", "ex:name": "?name"},
+        "reasoning": "rdfs"
+    });
+    let rows = fluree
+        .query(&view, &no_ontology)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    assert!(
+        normalize_rows(&rows).is_empty(),
+        "without ontology on the second query the entailment must be gone"
+    );
+}

--- a/fluree-db-api/tests/it_policy_cross_ledger.rs
+++ b/fluree-db-api/tests/it_policy_cross_ledger.rs
@@ -1,0 +1,228 @@
+//! End-to-end cross-ledger policy enforcement.
+//!
+//! Data ledger D's `#config` declares `f:policySource` with `f:ledger`
+//! pointing at model ledger M and `f:graphSelector` pointing at a
+//! named graph in M that holds policy rules. A query against D under
+//! `db_with_policy` must enforce M's rules — the data D's own graphs
+//! never see the policy IRIs, the rules live exclusively in M.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, QueryConnectionOptions};
+use serde_json::json;
+use support::genesis_ledger;
+
+fn config_graph_iri(ledger_id: &str) -> String {
+    format!("urn:fluree:{ledger_id}#config")
+}
+
+/// Data ledger D references a deny-on-class policy in model ledger M.
+/// A query that targets the denied class against D must return empty;
+/// a query that targets unrelated data must return normally. M's rules
+/// govern D without any policy IRIs ever being written into D.
+#[tokio::test]
+async fn data_ledger_query_enforces_model_ledger_deny_policy() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // --- model ledger M: holds a deny-on-class policy in a named graph
+    let model_id = "test/cross-ledger-e2e/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let policy_graph_iri = "http://example.org/m-policies";
+    let m_trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{policy_graph_iri}> {{
+            ex:denyUsers
+                rdf:type    f:AccessPolicy ;
+                f:action    f:view ;
+                f:onClass   ex:User ;
+                f:allow     false .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&m_trig)
+        .execute()
+        .await
+        .expect("seed M policy graph");
+
+    // --- data ledger D: holds user data plus a cross-ledger config
+    let data_id = "test/cross-ledger-e2e/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    // First write the actual user data into D's default graph.
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:User", "ex:name": "Alice"},
+                    {"@id": "ex:doc1",  "@type": "ex:Doc",  "ex:title": "Spec"}
+                ]
+            }),
+        )
+        .await
+        .expect("seed D user + doc");
+    let data = r1.ledger;
+
+    // Then write D's #config: defaultAllow=false, policy_class points
+    // at f:AccessPolicy so the cross-ledger restriction's policy_types
+    // intersection passes, and f:policySource carries f:ledger so the
+    // resolver routes to M.
+    let config_iri = config_graph_iri(data_id);
+    let d_config = format!(
+        r"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:cfg:main> rdf:type f:LedgerConfig .
+            <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+            <urn:cfg:policy> f:defaultAllow false .
+            <urn:cfg:policy> f:policyClass f:AccessPolicy .
+            <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+            <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                 f:graphSource <urn:cfg:policy-src> .
+            <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                 f:graphSelector <{policy_graph_iri}> .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&d_config)
+        .execute()
+        .await
+        .expect("seed D cross-ledger config");
+
+    // --- query D under cross-ledger policy
+    let opts = QueryConnectionOptions::default();
+    let wrapped = fluree
+        .db_with_policy(data_id, &opts)
+        .await
+        .expect("db_with_policy must route cross-ledger config through M");
+
+    // Query 1: target the denied class (ex:User). M's deny rule must
+    // apply against D's data — alice is filtered out.
+    let q_users = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "select": "?u",
+        "where": {"@id": "?u", "@type": "ex:User"}
+    });
+    let users = fluree
+        .query(&wrapped, &q_users)
+        .await
+        .expect("query ex:User under cross-ledger policy");
+    let users_jsonld = users
+        .to_jsonld(&wrapped.snapshot)
+        .expect("jsonld users");
+    assert_eq!(
+        users_jsonld,
+        json!([]),
+        "M's deny-on-ex:User must filter alice out of D's results, got {users_jsonld}"
+    );
+
+    // Query 2: target an unrelated class (ex:Doc). M's rule doesn't
+    // touch ex:Doc, but the config's defaultAllow=false means every
+    // class must be governed by an explicit allow. Phase 1a's
+    // f:AccessPolicy filter only loaded the deny rule; ex:Doc has
+    // no allow policy, so it should also be denied under
+    // defaultAllow=false. This verifies the cross-ledger policies
+    // are the only ones in play (no silent fallthrough to default-
+    // graph rules in D).
+    let q_docs = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "select": "?d",
+        "where": {"@id": "?d", "@type": "ex:Doc"}
+    });
+    let docs = fluree
+        .query(&wrapped, &q_docs)
+        .await
+        .expect("query ex:Doc under cross-ledger policy");
+    let docs_jsonld = docs.to_jsonld(&wrapped.snapshot).expect("jsonld docs");
+    assert_eq!(
+        docs_jsonld,
+        json!([]),
+        "defaultAllow=false with only M's deny rule must also block ex:Doc, got {docs_jsonld}"
+    );
+}
+
+/// Combining `opts.identity` with cross-ledger `f:policySource` is
+/// a fail-closed config error in Phase 1a: the model ledger
+/// contributes policy rules, the data ledger contributes identity
+/// binding, and mixing them via identity-mode would attribute
+/// policies ambiguously across ledger boundaries.
+#[tokio::test]
+async fn cross_ledger_plus_identity_mode_fails_closed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-e2e/id-model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/id-policies";
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:rule1 rdf:type f:AccessPolicy ; f:action f:view ; f:allow true .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M");
+
+    let data_id = "test/cross-ledger-e2e/id-data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let config_iri = config_graph_iri(data_id);
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+                <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:policy-src> .
+                <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{policy_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config");
+
+    let opts = QueryConnectionOptions {
+        identity: Some("http://example.org/users/alice".into()),
+        ..Default::default()
+    };
+
+    let err = fluree
+        .db_with_policy(data_id, &opts)
+        .await
+        .expect_err("identity + cross-ledger must fail closed");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("identity") && msg.contains("cross-ledger"),
+        "expected fail-closed diagnostic mentioning both, got: {msg}"
+    );
+}

--- a/fluree-db-api/tests/it_policy_cross_ledger.rs
+++ b/fluree-db-api/tests/it_policy_cross_ledger.rs
@@ -482,6 +482,141 @@ async fn baseline_access_policy_class_enforced() {
     );
 }
 
+/// When D's config sets `f:policySource` cross-ledger but omits
+/// `f:policyClass` entirely, the filter must default to
+/// `{f:AccessPolicy}` — NOT "every rule in M's policy graph." A
+/// model graph containing both an `f:AccessPolicy` and an
+/// `ex:OrgPolicy` rule must enforce only the former; the operator
+/// has to opt into custom-class enforcement explicitly.
+#[tokio::test]
+async fn omitted_policy_class_defaults_to_access_policy_only() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-filter/default-class/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/mixed-policies";
+
+    // M holds two policies: one canonical, one custom-typed. Both
+    // are deny-on-class — the canonical one targets ex:User, the
+    // custom one targets ex:Doc. The custom one MUST NOT be picked
+    // up under default-class filtering.
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:denyUsers
+                    rdf:type    f:AccessPolicy ;
+                    f:action    f:view ;
+                    f:onClass   ex:User ;
+                    f:allow     false .
+
+                ex:orgDenyDocs
+                    rdf:type    ex:OrgPolicy ;
+                    f:action    f:view ;
+                    f:onClass   ex:Doc ;
+                    f:allow     false .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M with mixed policy classes");
+
+    let data_id = "test/cross-ledger-filter/default-class/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:User"},
+                    {"@id": "ex:doc1", "@type": "ex:Doc"}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    let data = r1.ledger;
+
+    // D config: defaultAllow=true; no f:policyClass set at all;
+    // f:policySource points at M.
+    let config_iri = config_graph_iri(data_id);
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:defaultAllow true .
+                <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+                <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:policy-src> .
+                <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{policy_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config (no policy_class)");
+
+    let wrapped = fluree
+        .db_with_policy(data_id, &QueryConnectionOptions::default())
+        .await
+        .expect("db_with_policy");
+
+    // ex:User: canonical f:AccessPolicy rule must enforce → empty.
+    let users = fluree
+        .query(
+            &wrapped,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "select": "?u",
+                "where": {"@id": "?u", "@type": "ex:User"}
+            }),
+        )
+        .await
+        .expect("query users");
+    let users_jsonld = users.to_jsonld(&wrapped.snapshot).expect("jsonld users");
+    assert_eq!(
+        users_jsonld,
+        json!([]),
+        "default f:AccessPolicy filter must enforce the canonical-typed rule; got {users_jsonld}"
+    );
+
+    // ex:Doc: only the custom-typed ex:OrgPolicy rule denies it. With
+    // no f:policyClass set, the default filter is {f:AccessPolicy},
+    // so the custom rule is dropped at translation. defaultAllow=true
+    // governs and ex:doc1 must remain visible.
+    let docs = fluree
+        .query(
+            &wrapped,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "select": "?d",
+                "where": {"@id": "?d", "@type": "ex:Doc"}
+            }),
+        )
+        .await
+        .expect("query docs");
+    let docs_rendered = docs.to_jsonld(&wrapped.snapshot).expect("jsonld docs").to_string();
+    assert!(
+        docs_rendered.contains("doc1"),
+        "omitted f:policyClass must NOT pick up ex:OrgPolicy-typed rules; \
+         ex:doc1 should remain visible, got {docs_rendered}"
+    );
+}
+
 /// Combining `opts.identity` with cross-ledger `f:policySource` is
 /// a fail-closed config error in Phase 1a: the model ledger
 /// contributes policy rules, the data ledger contributes identity

--- a/fluree-db-api/tests/it_policy_cross_ledger.rs
+++ b/fluree-db-api/tests/it_policy_cross_ledger.rs
@@ -32,7 +32,7 @@ async fn data_ledger_query_enforces_model_ledger_deny_policy() {
 
     let policy_graph_iri = "http://example.org/m-policies";
     let m_trig = format!(
-        r#"
+        r"
         @prefix f:    <https://ns.flur.ee/db#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix ex:   <http://example.org/ns/> .
@@ -44,7 +44,7 @@ async fn data_ledger_query_enforces_model_ledger_deny_policy() {
                 f:onClass   ex:User ;
                 f:allow     false .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -121,9 +121,7 @@ async fn data_ledger_query_enforces_model_ledger_deny_policy() {
         .query(&wrapped, &q_users)
         .await
         .expect("query ex:User under cross-ledger policy");
-    let users_jsonld = users
-        .to_jsonld(&wrapped.snapshot)
-        .expect("jsonld users");
+    let users_jsonld = users.to_jsonld(&wrapped.snapshot).expect("jsonld users");
     assert_eq!(
         users_jsonld,
         json!([]),
@@ -189,7 +187,7 @@ async fn custom_class_policy_enforced_when_data_ledger_includes_class() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -201,7 +199,7 @@ async fn custom_class_policy_enforced_when_data_ledger_includes_class() {
                     f:onClass   ex:User ;
                     f:allow     false .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -292,7 +290,7 @@ async fn custom_class_policy_skipped_when_data_ledger_omits_class() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -304,7 +302,7 @@ async fn custom_class_policy_skipped_when_data_ledger_omits_class() {
                     f:onClass   ex:User ;
                     f:allow     false .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -399,7 +397,7 @@ async fn baseline_access_policy_class_enforced() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -411,7 +409,7 @@ async fn baseline_access_policy_class_enforced() {
                     f:onClass   ex:User ;
                     f:allow     false .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -503,7 +501,7 @@ async fn omitted_policy_class_defaults_to_access_policy_only() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -521,7 +519,7 @@ async fn omitted_policy_class_defaults_to_access_policy_only() {
                     f:onClass   ex:Doc ;
                     f:allow     false .
             }}
-        "#
+        "
         ))
         .execute()
         .await
@@ -609,7 +607,10 @@ async fn omitted_policy_class_defaults_to_access_policy_only() {
         )
         .await
         .expect("query docs");
-    let docs_rendered = docs.to_jsonld(&wrapped.snapshot).expect("jsonld docs").to_string();
+    let docs_rendered = docs
+        .to_jsonld(&wrapped.snapshot)
+        .expect("jsonld docs")
+        .to_string();
     assert!(
         docs_rendered.contains("doc1"),
         "omitted f:policyClass must NOT pick up ex:OrgPolicy-typed rules; \
@@ -632,7 +633,7 @@ async fn cross_ledger_plus_identity_mode_fails_closed() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix f:    <https://ns.flur.ee/db#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix ex:   <http://example.org/ns/> .
@@ -640,7 +641,7 @@ async fn cross_ledger_plus_identity_mode_fails_closed() {
             GRAPH <{policy_graph_iri}> {{
                 ex:rule1 rdf:type f:AccessPolicy ; f:action f:view ; f:allow true .
             }}
-        "#
+        "
         ))
         .execute()
         .await

--- a/fluree-db-api/tests/it_policy_cross_ledger.rs
+++ b/fluree-db-api/tests/it_policy_cross_ledger.rs
@@ -155,6 +155,333 @@ async fn data_ledger_query_enforces_model_ledger_deny_policy() {
     );
 }
 
+// =============================================================================
+// Class-filter contract — exact-IRI resolution at the wire→Sid boundary.
+//
+// The cross-ledger contract says: the data ledger's configured
+// `f:policyClass` set is intersected against each wire restriction's
+// `policy_types` by exact IRI match (no subclass entailment). The three
+// tests below pin both sides of that filter:
+//
+//   1. A custom-typed policy in M is enforced iff D's config names the
+//      exact same class IRI in `f:policyClass`.
+//   2. The same policy is silently skipped (no enforcement) when D's
+//      config names any other class — even if M holds a perfectly valid
+//      policy resource and D would otherwise allow alice to be seen.
+//   3. Direct `f:AccessPolicy` remains the baseline / default —
+//      configurations targeting it work the same way they would in a
+//      same-ledger setup.
+// =============================================================================
+
+/// Custom-class enforcement: a policy typed as `ex:OrgPolicy` in M is
+/// enforced against D iff D's `f:policyClass` config lists exactly
+/// `ex:OrgPolicy`. This is the "include the class → enforcement
+/// applies" side of the filter contract.
+#[tokio::test]
+async fn custom_class_policy_enforced_when_data_ledger_includes_class() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-filter/custom-included/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/custom-policies";
+
+    // Policy typed as ex:OrgPolicy (NOT f:AccessPolicy).
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:orgDenyUsers
+                    rdf:type    ex:OrgPolicy ;
+                    f:action    f:view ;
+                    f:onClass   ex:User ;
+                    f:allow     false .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M custom-typed policy");
+
+    let data_id = "test/cross-ledger-filter/custom-included/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "@type": "ex:User",
+                "ex:name": "Alice"
+            }),
+        )
+        .await
+        .unwrap();
+    let data = r1.ledger;
+
+    // D config: defaultAllow=true so absence-of-deny means visible;
+    // policyClass names ex:OrgPolicy *exactly* — the same IRI M
+    // typed the policy with.
+    let config_iri = config_graph_iri(data_id);
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:defaultAllow true .
+                <urn:cfg:policy> f:policyClass ex:OrgPolicy .
+                <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+                <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:policy-src> .
+                <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{policy_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config including ex:OrgPolicy");
+
+    let wrapped = fluree
+        .db_with_policy(data_id, &QueryConnectionOptions::default())
+        .await
+        .expect("db_with_policy");
+
+    let users = fluree
+        .query(
+            &wrapped,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "select": "?u",
+                "where": {"@id": "?u", "@type": "ex:User"}
+            }),
+        )
+        .await
+        .expect("query ex:User");
+    let users_jsonld = users.to_jsonld(&wrapped.snapshot).expect("jsonld");
+    assert_eq!(
+        users_jsonld,
+        json!([]),
+        "policyClass = ex:OrgPolicy must include the custom-typed rule and deny ex:User, got {users_jsonld}"
+    );
+}
+
+/// Filter exclusion: the same custom-class policy in M is *not*
+/// enforced when D's `f:policyClass` config names a different class.
+/// Exact IRI matching, no subclass entailment — `f:AccessPolicy` does
+/// not subsume `ex:OrgPolicy`, even though both are policy types.
+#[tokio::test]
+async fn custom_class_policy_skipped_when_data_ledger_omits_class() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-filter/custom-omitted/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/custom-policies";
+
+    // Identical M setup to the previous test — custom-typed policy.
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:orgDenyUsers
+                    rdf:type    ex:OrgPolicy ;
+                    f:action    f:view ;
+                    f:onClass   ex:User ;
+                    f:allow     false .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M custom-typed policy");
+
+    let data_id = "test/cross-ledger-filter/custom-omitted/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "@type": "ex:User",
+                "ex:name": "Alice"
+            }),
+        )
+        .await
+        .unwrap();
+    let data = r1.ledger;
+
+    // D config: defaultAllow=true; policyClass names f:AccessPolicy,
+    // which is NOT what M's policy is typed as. The wire restriction
+    // must be filtered out at translation time and no deny applies.
+    let config_iri = config_graph_iri(data_id);
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:defaultAllow true .
+                <urn:cfg:policy> f:policyClass f:AccessPolicy .
+                <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+                <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:policy-src> .
+                <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{policy_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config naming f:AccessPolicy");
+
+    let wrapped = fluree
+        .db_with_policy(data_id, &QueryConnectionOptions::default())
+        .await
+        .expect("db_with_policy");
+
+    let users = fluree
+        .query(
+            &wrapped,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "select": "?u",
+                "where": {"@id": "?u", "@type": "ex:User"}
+            }),
+        )
+        .await
+        .expect("query ex:User");
+    let users_jsonld = users.to_jsonld(&wrapped.snapshot).expect("jsonld");
+    // alice MUST be visible — the policy was typed ex:OrgPolicy, the
+    // config asked only for f:AccessPolicy, the filter rejects it,
+    // defaultAllow=true governs and the data is returned. If the
+    // filter were absent or subsumptive, alice would be hidden.
+    let rendered = users_jsonld.to_string();
+    assert!(
+        rendered.contains("alice"),
+        "policyClass = f:AccessPolicy must NOT pull in ex:OrgPolicy-typed rules; \
+         alice should remain visible, got {users_jsonld}"
+    );
+}
+
+/// Baseline: direct `f:AccessPolicy` typing is the canonical policy
+/// class, and a configuration that names it enforces the rule. This
+/// is the same shape as the data-ledger-deny test at the top of the
+/// file, but with `defaultAllow=true` and a non-deny query so the
+/// assertion isolates "rule applied" from "default policy applied."
+#[tokio::test]
+async fn baseline_access_policy_class_enforced() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-filter/baseline/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    let policy_graph_iri = "http://example.org/access-policies";
+
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{policy_graph_iri}> {{
+                ex:denyUsers
+                    rdf:type    f:AccessPolicy ;
+                    f:action    f:view ;
+                    f:onClass   ex:User ;
+                    f:allow     false .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M baseline policy");
+
+    let data_id = "test/cross-ledger-filter/baseline/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+    let r1 = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "@type": "ex:User",
+                "ex:name": "Alice"
+            }),
+        )
+        .await
+        .unwrap();
+    let data = r1.ledger;
+
+    let config_iri = config_graph_iri(data_id);
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:    <https://ns.flur.ee/db#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:defaultAllow true .
+                <urn:cfg:policy> f:policyClass f:AccessPolicy .
+                <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+                <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:policy-src> .
+                <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{policy_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config with f:AccessPolicy class");
+
+    let wrapped = fluree
+        .db_with_policy(data_id, &QueryConnectionOptions::default())
+        .await
+        .expect("db_with_policy");
+
+    let users = fluree
+        .query(
+            &wrapped,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "select": "?u",
+                "where": {"@id": "?u", "@type": "ex:User"}
+            }),
+        )
+        .await
+        .expect("query ex:User");
+    let users_jsonld = users.to_jsonld(&wrapped.snapshot).expect("jsonld");
+    assert_eq!(
+        users_jsonld,
+        json!([]),
+        "policyClass = f:AccessPolicy must enforce M's deny on ex:User, got {users_jsonld}"
+    );
+}
+
 /// Combining `opts.identity` with cross-ledger `f:policySource` is
 /// a fail-closed config error in Phase 1a: the model ledger
 /// contributes policy rules, the data ledger contributes identity

--- a/fluree-db-api/tests/it_rules_cross_ledger.rs
+++ b/fluree-db-api/tests/it_rules_cross_ledger.rs
@@ -1,0 +1,178 @@
+//! End-to-end cross-ledger datalog rule routing.
+//!
+//! Data ledger D's `#config` declares `f:rulesSource` with
+//! `f:ledger` pointing at model ledger M's rules graph. At query
+//! time, `view/query.rs::attach_cross_ledger_rules` resolves M's
+//! rules into JSON bodies (via the cross-ledger resolver,
+//! `ArtifactKind::Rules`) and feeds them into
+//! `executable.reasoning.modes.rules`. The existing datalog
+//! evaluator parses each rule against D's snapshot and runs the
+//! fixpoint on D's data.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::{genesis_ledger, normalize_rows};
+
+fn config_iri(ledger_id: &str) -> String {
+    format!("urn:fluree:{ledger_id}#config")
+}
+
+#[tokio::test]
+async fn data_ledger_query_pulls_rules_from_model_ledger() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // --- M (model ledger): stash a grandparent rule in a named graph.
+    let model_id = "test/cross-ledger-rules/model:main";
+    let rules_graph_iri = "http://example.org/governance/rules";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let rule_tx = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f":  "https://ns.flur.ee/db#"
+        },
+        "insert": [
+            ["graph", rules_graph_iri, {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type":  "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where":    {"@id": "?p", "ex:parent": {"ex:parent": "?g"}},
+                        "insert":   {"@id": "?p", "ex:grandparent": {"@id": "?g"}}
+                    }
+                }
+            }]
+        ]
+    });
+    fluree
+        .update(model, &rule_tx)
+        .await
+        .expect("seed M with grandparent rule");
+
+    // --- D (data ledger): wire f:rulesSource → M's rules graph.
+    let data_id = "test/cross-ledger-rules/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let cfg = config_iri(data_id);
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>     rdf:type          f:LedgerConfig .
+            <urn:cfg:main>     f:datalogDefaults <urn:cfg:datalog> .
+            <urn:cfg:datalog>  f:datalogEnabled  true .
+            <urn:cfg:datalog>  f:rulesSource     <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type         f:GraphRef ;
+                                f:graphSource    <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:ledger         <{model_id}> ;
+                                f:graphSelector  <{rules_graph_iri}> .
+        }}
+    "
+    );
+    let r = fluree
+        .stage_owned(data)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed D config with cross-ledger f:rulesSource");
+    let data = r.ledger;
+
+    // --- D's data: alice → bob → charlie family chain.
+    let family = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}},
+            {"@id": "ex:bob",   "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    fluree
+        .insert(data, &family)
+        .await
+        .expect("insert family data into D");
+
+    // --- Query D for alice's grandparent with datalog reasoning.
+    //     Must load D's view via `fluree.db(...)` so the resolved
+    //     config (and the cross-ledger dispatch) actually runs.
+    let view = fluree.db(data_id).await.expect("load D with config");
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?grandparent",
+        "where":  {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let data = fluree.ledger(data_id).await.expect("reload D ledger");
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .expect("query D with cross-ledger rule")
+        .to_jsonld(&data.snapshot)
+        .expect("to_jsonld");
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:charlie")),
+        "M's grandparent rule (resolved cross-ledger) must derive \
+         charlie as alice's grandparent on D; got: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn missing_model_ledger_surfaces_cross_ledger_error() {
+    // f:rulesSource → a model ledger that doesn't exist. The
+    // resolver must return CrossLedgerError::ModelLedgerMissing
+    // (mapped to ApiError::CrossLedger), not silently fall back
+    // to "no rules".
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let data_id = "test/cross-ledger-rules/missing-model:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let cfg = config_iri(data_id);
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>      rdf:type          f:LedgerConfig .
+            <urn:cfg:main>      f:datalogDefaults <urn:cfg:datalog> .
+            <urn:cfg:datalog>   f:datalogEnabled  true .
+            <urn:cfg:datalog>   f:rulesSource     <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type          f:GraphRef ;
+                                f:graphSource     <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:ledger          <does-not-exist:main> ;
+                                f:graphSelector   <http://example.org/rules> .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed D config");
+
+    let view = fluree.db(data_id).await.expect("load D");
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?g",
+        "where":  {"@id": "ex:alice", "ex:grandparent": "?g"},
+        "reasoning": "datalog"
+    });
+    let err = fluree
+        .query(&view, &q)
+        .await
+        .expect_err("missing model ledger must surface as an error");
+
+    assert!(
+        matches!(err, fluree_db_api::ApiError::CrossLedger(_)),
+        "expected ApiError::CrossLedger for missing model ledger, got: {err:?}"
+    );
+}

--- a/fluree-db-api/tests/it_rules_cross_ledger.rs
+++ b/fluree-db-api/tests/it_rules_cross_ledger.rs
@@ -124,6 +124,132 @@ async fn data_ledger_query_pulls_rules_from_model_ledger() {
 }
 
 #[tokio::test]
+async fn cross_ledger_rules_with_default_graph_selector() {
+    // Cross-ledger f:rulesSource with `f:graphSelector f:defaultGraph`
+    // must resolve to M's g_id=0 (not collide with the named-graph
+    // registry lookup). Without the fix, this returned
+    // GraphMissingAtT because `https://ns.flur.ee/db#defaultGraph`
+    // isn't a registered graph IRI on M.
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-rules/default-graph-model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    // Insert the rule into M's *default* graph (no GRAPH wrapper).
+    let rule_doc = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f":  "https://ns.flur.ee/db#"
+        },
+        "@id": "ex:grandparentRule",
+        "f:rule": {
+            "@type":  "@json",
+            "@value": {
+                "@context": {"ex": "http://example.org/"},
+                "where":    {"@id": "?p", "ex:parent": {"ex:parent": "?g"}},
+                "insert":   {"@id": "?p", "ex:grandparent": {"@id": "?g"}}
+            }
+        }
+    });
+    fluree
+        .insert(model, &rule_doc)
+        .await
+        .expect("seed M default graph with rule");
+
+    // D's config points at M's default graph via f:defaultGraph.
+    let data_id = "test/cross-ledger-rules/default-graph-data:main";
+    let data = genesis_ledger(&fluree, data_id);
+    let cfg = config_iri(data_id);
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>      rdf:type          f:LedgerConfig .
+            <urn:cfg:main>      f:datalogDefaults <urn:cfg:datalog> .
+            <urn:cfg:datalog>   f:datalogEnabled  true .
+            <urn:cfg:datalog>   f:rulesSource     <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type          f:GraphRef ;
+                                f:graphSource     <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:ledger          <{model_id}> ;
+                                f:graphSelector   f:defaultGraph .
+        }}
+    "
+    );
+    let r = fluree
+        .stage_owned(data)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed D config (cross-ledger + f:defaultGraph)");
+    let data = r.ledger;
+
+    let family = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}},
+            {"@id": "ex:bob",   "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    fluree.insert(data, &family).await.expect("seed D family");
+
+    let view = fluree.db(data_id).await.expect("load D");
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?g",
+        "where":  {"@id": "ex:alice", "ex:grandparent": "?g"},
+        "reasoning": "datalog"
+    });
+    let data = fluree.ledger(data_id).await.expect("reload D");
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .expect("cross-ledger rule via f:defaultGraph must work")
+        .to_jsonld(&data.snapshot)
+        .expect("to_jsonld");
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!("ex:charlie")),
+        "expected charlie derived via cross-ledger f:defaultGraph; got: {results:?}"
+    );
+}
+
+/// Defense-in-depth: `RulesArtifactWire::parsed_rules` must
+/// `Err(CrossLedgerError::TranslationFailed)` on any malformed JSON
+/// body rather than silently dropping the entry. Cross-ledger
+/// governance is admin-authored; silently weakening the reasoning
+/// model is the worst failure mode.
+///
+/// Normal write paths (Turtle/JSON-LD insert) reject malformed JSON
+/// literals at the storage boundary — so this is structurally
+/// unreachable through user code today. The guard remains because
+/// the wire boundary can be reached by future formats, repairs, or
+/// out-of-band index writes; the unit test pins the behaviour.
+#[test]
+fn parsed_rules_fails_closed_on_malformed_json() {
+    use fluree_db_api::cross_ledger::{RulesArtifactWire, WireOrigin};
+
+    let wire = RulesArtifactWire {
+        origin: WireOrigin {
+            model_ledger_id: "test/m:main".into(),
+            graph_iri: "http://example.org/rules".into(),
+            resolved_t: 1,
+        },
+        rules: vec!["{ valid: false".into()],
+    };
+
+    let err = wire
+        .parsed_rules()
+        .expect_err("malformed JSON must fail closed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("malformed cross-ledger rule"),
+        "expected explicit malformed-rule diagnostic, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn missing_model_ledger_surfaces_cross_ledger_error() {
     // f:rulesSource → a model ledger that doesn't exist. The
     // resolver must return CrossLedgerError::ModelLedgerMissing

--- a/fluree-db-api/tests/it_rules_cross_ledger.rs
+++ b/fluree-db-api/tests/it_rules_cross_ledger.rs
@@ -250,6 +250,79 @@ fn parsed_rules_fails_closed_on_malformed_json() {
 }
 
 #[tokio::test]
+async fn cross_ledger_f_txn_meta_graph_selector_rejected() {
+    // `f:txnMetaGraph` is a reserved sentinel — the model
+    // ledger's txn-meta graph is never a legitimate cross-ledger
+    // target (it carries commit-time provenance). The selector
+    // helper must surface ReservedGraphSelected *before* any
+    // storage I/O on M.
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-rules/txn-meta-selector-model:main";
+    let model = genesis_ledger(&fluree, model_id);
+    // Commit one trivial fact so M is published to the nameservice;
+    // the resolver looks up M by id before reaching the selector
+    // check, and an unpublished M short-circuits as ModelLedgerMissing.
+    fluree
+        .insert(
+            model,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id":     "ex:bootstrap",
+                "ex:tag":  "init"
+            }),
+        )
+        .await
+        .expect("publish M");
+
+    let data_id = "test/cross-ledger-rules/txn-meta-selector-data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let cfg = config_iri(data_id);
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>      rdf:type          f:LedgerConfig .
+            <urn:cfg:main>      f:datalogDefaults <urn:cfg:datalog> .
+            <urn:cfg:datalog>   f:datalogEnabled  true .
+            <urn:cfg:datalog>   f:rulesSource     <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type          f:GraphRef ;
+                                f:graphSource     <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:ledger          <{model_id}> ;
+                                f:graphSelector   f:txnMetaGraph .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(data)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed D config selecting f:txnMetaGraph");
+
+    let view = fluree.db(data_id).await.expect("load D");
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?g",
+        "where":  {"@id": "ex:alice", "ex:grandparent": "?g"},
+        "reasoning": "datalog"
+    });
+    let err = fluree
+        .query(&view, &q)
+        .await
+        .expect_err("f:txnMetaGraph selector must surface ReservedGraphSelected");
+
+    let msg = err.to_string();
+    assert!(
+        matches!(err, fluree_db_api::ApiError::CrossLedger(_)) && msg.contains("txnMetaGraph"),
+        "expected ApiError::CrossLedger naming the reserved sentinel, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn missing_model_ledger_surfaces_cross_ledger_error() {
     // f:rulesSource → a model ledger that doesn't exist. The
     // resolver must return CrossLedgerError::ModelLedgerMissing

--- a/fluree-db-api/tests/it_rules_source.rs
+++ b/fluree-db-api/tests/it_rules_source.rs
@@ -147,6 +147,95 @@ async fn rules_source_in_named_graph_is_honored() {
 }
 
 #[tokio::test]
+async fn unknown_rules_source_graph_iri_fails_loudly() {
+    // Misconfiguration: f:rulesSource points at a graph IRI that
+    // doesn't exist in this ledger. Must surface as a config error
+    // at db() load time, not silently fall back to "no rules".
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "rules-src/unknown-graph:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let cfg = config_iri(ledger_id);
+    let bad_iri = "http://example.org/this-graph-does-not-exist";
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>      rdf:type          f:LedgerConfig .
+            <urn:cfg:main>      f:datalogDefaults <urn:cfg:datalog> .
+            <urn:cfg:datalog>   f:datalogEnabled  true .
+            <urn:cfg:datalog>   f:rulesSource     <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type          f:GraphRef ;
+                                f:graphSource     <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:graphSelector   <{bad_iri}> .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed misconfigured rulesSource");
+
+    let err = fluree
+        .db(ledger_id)
+        .await
+        .expect_err("unknown rulesSource graph IRI must fail loudly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("f:rulesSource") && msg.contains("not found"),
+        "expected explicit f:rulesSource error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn rules_source_with_unsupported_at_t_fails_loudly() {
+    // f:atT on f:rulesSource is reserved (Phase 3+). Must surface
+    // as a config error rather than silently disabling rules.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "rules-src/unsupported-at-t:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let cfg = config_iri(ledger_id);
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>      rdf:type          f:LedgerConfig .
+            <urn:cfg:main>      f:datalogDefaults <urn:cfg:datalog> .
+            <urn:cfg:datalog>   f:datalogEnabled  true .
+            <urn:cfg:datalog>   f:rulesSource     <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type          f:GraphRef ;
+                                f:graphSource     <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:graphSelector   f:defaultGraph ;
+                                f:atT             5 .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed config with reserved f:atT");
+
+    let err = fluree
+        .db(ledger_id)
+        .await
+        .expect_err("f:atT on f:rulesSource must surface as a config error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("f:atT"),
+        "expected f:atT mention in error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn rule_in_named_graph_without_rules_source_is_ignored() {
     // Negative control: same rule, same named graph, but NO
     // f:rulesSource configured. The extractor defaults to the

--- a/fluree-db-api/tests/it_rules_source.rs
+++ b/fluree-db-api/tests/it_rules_source.rs
@@ -1,0 +1,190 @@
+//! Same-ledger `f:rulesSource` routing.
+//!
+//! Datalog rules live in a non-default named graph; `f:rulesSource`
+//! on the config graph points the rule extractor at that graph. The
+//! extractor must scan the configured graph rather than the default
+//! graph, and the resulting rules must execute against the query
+//! graph as usual.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::{genesis_ledger, normalize_rows};
+
+fn config_iri(ledger_id: &str) -> String {
+    format!("urn:fluree:{ledger_id}#config")
+}
+
+/// Seed a non-default graph with a grandparent datalog rule and
+/// configure `f:rulesSource` to point at that graph. Returns the
+/// post-tx ledger.
+async fn seed_rules_in_named_graph(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+    rules_graph_iri: &str,
+) -> fluree_db_api::LedgerState {
+    let ledger = genesis_ledger(fluree, ledger_id);
+
+    // JSON-LD update with `["graph", <iri>, {…}]` sugar so the
+    // rule flake lands in the configured rules graph (rather than
+    // the default graph). The rule body keeps `@type: @json` so it
+    // stores as `FlakeValue::Json` — which `extract_datalog_rules`
+    // is the only path that picks up.
+    let rule_tx = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f":  "https://ns.flur.ee/db#"
+        },
+        "insert": [
+            ["graph", rules_graph_iri, {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type":  "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where":    {"@id": "?p", "ex:parent": {"ex:parent": "?g"}},
+                        "insert":   {"@id": "?p", "ex:grandparent": {"@id": "?g"}}
+                    }
+                }
+            }]
+        ]
+    });
+    let r = fluree
+        .update(ledger, &rule_tx)
+        .await
+        .expect("seed rule into named graph");
+    let ledger = r.ledger;
+
+    // Wire f:rulesSource → rules_graph_iri via the config graph.
+    let cfg = config_iri(ledger_id);
+    let cfg_trig = format!(
+        r"
+        @prefix f:   <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{cfg}> {{
+            <urn:cfg:main>     rdf:type           f:LedgerConfig .
+            <urn:cfg:main>     f:datalogDefaults  <urn:cfg:datalog> .
+            <urn:cfg:datalog>  f:datalogEnabled   true .
+            <urn:cfg:datalog>  f:rulesSource      <urn:cfg:rules-ref> .
+            <urn:cfg:rules-ref> rdf:type          f:GraphRef ;
+                                f:graphSource    <urn:cfg:rules-src> .
+            <urn:cfg:rules-src> f:graphSelector  <{rules_graph_iri}> .
+        }}
+    "
+    );
+    let r = fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&cfg_trig)
+        .execute()
+        .await
+        .expect("seed config with f:rulesSource");
+    r.ledger
+}
+
+async fn insert_family_data(
+    fluree: &fluree_db_api::Fluree,
+    ledger: fluree_db_api::LedgerState,
+) -> fluree_db_api::LedgerState {
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}},
+            {"@id": "ex:bob",   "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    fluree
+        .insert(ledger, &data)
+        .await
+        .expect("insert family data")
+        .ledger
+}
+
+async fn query_grandparent(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    ledger_id: &str,
+) -> Vec<serde_json::Value> {
+    // Use `fluree.db(...)` instead of `GraphDb::from_ledger_state`
+    // so the view has `resolved_config` applied — the f:rulesSource
+    // routing only takes effect once `apply_config_datalog` runs,
+    // which requires the resolved config.
+    let view = fluree.db(ledger_id).await.expect("load db with config");
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?grandparent",
+        "where":  {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let rows = fluree
+        .query(&view, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    normalize_rows(&rows)
+}
+
+#[tokio::test]
+async fn rules_source_in_named_graph_is_honored() {
+    // Rules live in a named graph; config wires f:rulesSource at it;
+    // the rule must fire and derive `ex:grandparent`.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let rules_iri = "http://example.org/governance/rules";
+    let ledger_id = "rules-src/honored:main";
+    let ledger = seed_rules_in_named_graph(&fluree, ledger_id, rules_iri).await;
+    let ledger = insert_family_data(&fluree, ledger).await;
+
+    let results = query_grandparent(&fluree, &ledger, ledger_id).await;
+    assert!(
+        results.contains(&json!("ex:charlie")),
+        "f:rulesSource → named graph must route rule extraction; \
+         expected charlie derived as alice's grandparent, got: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn rule_in_named_graph_without_rules_source_is_ignored() {
+    // Negative control: same rule, same named graph, but NO
+    // f:rulesSource configured. The extractor defaults to the
+    // query graph (g_id=0); the rule isn't visible there, so no
+    // grandparent fact is derived. This proves the wiring above
+    // is load-bearing, not a coincidence.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let rules_iri = "http://example.org/governance/rules";
+    let ledger_id = "rules-src/no-config:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Same rule, same named graph — but no `f:rulesSource` config.
+    let rule_tx = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f":  "https://ns.flur.ee/db#"
+        },
+        "insert": [
+            ["graph", rules_iri, {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type":  "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where":    {"@id": "?p", "ex:parent": {"ex:parent": "?g"}},
+                        "insert":   {"@id": "?p", "ex:grandparent": {"@id": "?g"}}
+                    }
+                }
+            }]
+        ]
+    });
+    let r = fluree.update(ledger, &rule_tx).await.expect("seed rule");
+    let ledger = insert_family_data(&fluree, r.ledger).await;
+
+    let results = query_grandparent(&fluree, &ledger, ledger_id).await;
+    assert!(
+        !results.contains(&json!("ex:charlie")),
+        "without f:rulesSource the named-graph rule must not be \
+         discovered; got an unexpected derived charlie: {results:?}"
+    );
+}

--- a/fluree-db-api/tests/it_shapes_cross_ledger.rs
+++ b/fluree-db-api/tests/it_shapes_cross_ledger.rs
@@ -31,7 +31,7 @@ async fn data_ledger_tx_rejected_by_cross_ledger_shape() {
 
     let shapes_graph_iri = "http://example.org/governance/shapes";
     let m_trig = format!(
-        r#"
+        r"
         @prefix sh:   <http://www.w3.org/ns/shacl#> .
         @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
@@ -47,7 +47,7 @@ async fn data_ledger_tx_rejected_by_cross_ledger_shape() {
                 sh:minCount 1 ;
                 sh:datatype xsd:string .
         }}
-    "#
+    "
     );
     fluree
         .stage_owned(model)
@@ -104,9 +104,7 @@ async fn data_ledger_tx_rejected_by_cross_ledger_shape() {
     assert!(
         matches!(
             err,
-            fluree_db_api::ApiError::Transact(
-                fluree_db_transact::TransactError::ShaclViolation(_)
-            )
+            fluree_db_api::ApiError::Transact(fluree_db_transact::TransactError::ShaclViolation(_))
         ),
         "expected ShaclViolation from M's cross-ledger shape, got: {err:?}"
     );
@@ -123,7 +121,7 @@ async fn data_ledger_tx_passes_when_cross_ledger_shape_satisfied() {
     fluree
         .stage_owned(model)
         .upsert_turtle(&format!(
-            r#"
+            r"
             @prefix sh:   <http://www.w3.org/ns/shacl#> .
             @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
             @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
@@ -139,7 +137,7 @@ async fn data_ledger_tx_passes_when_cross_ledger_shape_satisfied() {
                     sh:minCount 1 ;
                     sh:datatype xsd:string .
             }}
-        "#
+        "
         ))
         .execute()
         .await

--- a/fluree-db-api/tests/it_shapes_cross_ledger.rs
+++ b/fluree-db-api/tests/it_shapes_cross_ledger.rs
@@ -1,0 +1,189 @@
+//! End-to-end cross-ledger SHACL shape enforcement.
+//!
+//! Data ledger D's `#config` declares `f:shapesSource` with
+//! `f:ledger` pointing at model ledger M's shapes graph. The
+//! cross-ledger dispatch happens at the API boundary
+//! (`stage_with_config_shacl`): we resolve M's shapes to an
+//! IRI-form wire artifact before staging, thread the wire into
+//! `StagedShaclContext`, then at SHACL validation time compile
+//! the wire against the *staged* `NamespaceRegistry` (which has
+//! D's snapshot namespaces plus any IRIs the in-flight
+//! transaction introduced).
+
+#![cfg(all(feature = "native", feature = "shacl"))]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::genesis_ledger;
+
+fn config_graph_iri(ledger_id: &str) -> String {
+    format!("urn:fluree:{ledger_id}#config")
+}
+
+#[tokio::test]
+async fn data_ledger_tx_rejected_by_cross_ledger_shape() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-shapes/model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let shapes_graph_iri = "http://example.org/governance/shapes";
+    let m_trig = format!(
+        r#"
+        @prefix sh:   <http://www.w3.org/ns/shacl#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{shapes_graph_iri}> {{
+            ex:PersonShape
+                rdf:type        sh:NodeShape ;
+                sh:targetClass  ex:Person ;
+                sh:property     ex:pshape_name .
+            ex:pshape_name
+                sh:path     ex:name ;
+                sh:minCount 1 ;
+                sh:datatype xsd:string .
+        }}
+    "#
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&m_trig)
+        .execute()
+        .await
+        .expect("seed M shapes");
+
+    let data_id = "test/cross-ledger-shapes/data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let config_iri = config_graph_iri(data_id);
+    let r1 = fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:   <https://ns.flur.ee/db#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:shaclDefaults <urn:cfg:shacl> .
+                <urn:cfg:shacl> f:shaclEnabled true .
+                <urn:cfg:shacl> f:shapesSource <urn:cfg:shapes-ref> .
+                <urn:cfg:shapes-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:shapes-src> .
+                <urn:cfg:shapes-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{shapes_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D cross-ledger SHACL config");
+    let data = r1.ledger;
+
+    // ex:Person without ex:name → must be rejected by M's shape.
+    // This is the load-bearing assertion: the cross-ledger wire
+    // must compile against the staged namespace registry (where
+    // ex:Person is registered by the in-flight tx), not against
+    // D's pre-stage snapshot (where ex: hasn't been allocated).
+    let err = fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:alice",
+                "@type": "ex:Person"
+            }),
+        )
+        .await
+        .expect_err("violating Person under cross-ledger shape must be rejected");
+
+    assert!(
+        matches!(
+            err,
+            fluree_db_api::ApiError::Transact(
+                fluree_db_transact::TransactError::ShaclViolation(_)
+            )
+        ),
+        "expected ShaclViolation from M's cross-ledger shape, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn data_ledger_tx_passes_when_cross_ledger_shape_satisfied() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/cross-ledger-shapes/valid-model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let shapes_graph_iri = "http://example.org/governance/shapes";
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r#"
+            @prefix sh:   <http://www.w3.org/ns/shacl#> .
+            @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+            @prefix ex:   <http://example.org/ns/> .
+
+            GRAPH <{shapes_graph_iri}> {{
+                ex:PersonShape
+                    rdf:type        sh:NodeShape ;
+                    sh:targetClass  ex:Person ;
+                    sh:property     ex:pshape_name .
+                ex:pshape_name
+                    sh:path     ex:name ;
+                    sh:minCount 1 ;
+                    sh:datatype xsd:string .
+            }}
+        "#
+        ))
+        .execute()
+        .await
+        .expect("seed M shapes");
+
+    let data_id = "test/cross-ledger-shapes/valid-data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let config_iri = config_graph_iri(data_id);
+    let r1 = fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:   <https://ns.flur.ee/db#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:shaclDefaults <urn:cfg:shacl> .
+                <urn:cfg:shacl> f:shaclEnabled true .
+                <urn:cfg:shacl> f:shapesSource <urn:cfg:shapes-ref> .
+                <urn:cfg:shapes-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:shapes-src> .
+                <urn:cfg:shapes-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{shapes_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D config");
+    let data = r1.ledger;
+
+    // ex:bob has the required ex:name. Shape should accept.
+    fluree
+        .insert(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id": "ex:bob",
+                "@type": "ex:Person",
+                "ex:name": "Bob"
+            }),
+        )
+        .await
+        .expect("valid Person under cross-ledger shape must be accepted");
+}

--- a/fluree-db-api/tests/it_shapes_inline.rs
+++ b/fluree-db-api/tests/it_shapes_inline.rs
@@ -1,0 +1,270 @@
+//! Inline SHACL: per-transaction shape definitions passed via `opts.shapes`.
+//!
+//! Inline shapes parse against the *staged* `NamespaceRegistry`,
+//! same as cross-ledger shapes. They never persist into the ledger —
+//! the bundle is overlay-only, scoped to this validation pass.
+
+#![cfg(all(feature = "native", feature = "shacl"))]
+
+use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig};
+use fluree_db_transact::ir::TxnOpts;
+use serde_json::json;
+
+mod support;
+use support::genesis_ledger;
+
+fn test_index_cfg() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 1_000_000,
+    }
+}
+
+fn person_shape_jsonld() -> serde_json::Value {
+    json!({
+        "@context": {
+            "ex":  "http://example.org/ns/",
+            "sh":  "http://www.w3.org/ns/shacl#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": [
+            {
+                "@id":            "ex:PersonShape",
+                "@type":          "sh:NodeShape",
+                "sh:targetClass": {"@id": "ex:Person"},
+                "sh:property":    {"@id": "ex:pshape_name"}
+            },
+            {
+                "@id":         "ex:pshape_name",
+                "sh:path":     {"@id": "ex:name"},
+                "sh:minCount": 1,
+                "sh:datatype": {"@id": "xsd:string"}
+            }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn inline_shape_rejects_violating_tx() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-shapes/reject:main");
+
+    let opts = TxnOpts {
+        shapes: Some(person_shape_jsonld()),
+        ..TxnOpts::default()
+    };
+
+    // ex:Person without ex:name → reject (inline shape requires name).
+    let err = fluree
+        .insert_with_opts(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":   "ex:alice",
+                "@type": "ex:Person"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect_err("inline shape must reject Person without name");
+
+    assert!(
+        matches!(
+            err,
+            fluree_db_api::ApiError::Transact(fluree_db_transact::TransactError::ShaclViolation(_))
+        ),
+        "expected ShaclViolation from inline shape, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn inline_shape_accepts_valid_tx() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-shapes/accept:main");
+
+    let opts = TxnOpts {
+        shapes: Some(person_shape_jsonld()),
+        ..TxnOpts::default()
+    };
+
+    fluree
+        .insert_with_opts(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":    "ex:bob",
+                "@type":  "ex:Person",
+                "ex:name": "Bob"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect("valid Person under inline shape must be accepted");
+}
+
+#[tokio::test]
+async fn inline_shapes_do_not_persist_after_tx() {
+    // After a tx that supplies inline shapes, the shapes must not
+    // remain enforced on a subsequent tx without `opts.shapes`.
+    // (They were never staged into the ledger.)
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, "test/inline-shapes/transient:main");
+
+    // First tx: pass inline shape + a valid Person.
+    let opts = TxnOpts {
+        shapes: Some(person_shape_jsonld()),
+        ..TxnOpts::default()
+    };
+    let r1 = fluree
+        .insert_with_opts(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":    "ex:carol",
+                "@type":  "ex:Person",
+                "ex:name": "Carol"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect("first tx with inline shapes ok");
+    let ledger = r1.ledger;
+
+    // Second tx: NO opts.shapes. A Person without ex:name should
+    // be accepted — the inline shape was transient.
+    fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":   "ex:dave",
+                "@type": "ex:Person"
+            }),
+        )
+        .await
+        .expect("second tx without opts.shapes must not be subject to prior inline shape");
+}
+
+#[tokio::test]
+async fn inline_shape_layered_on_cross_ledger_shape_enforces_both() {
+    // M holds a shape requiring ex:name. Inline opts add a shape
+    // requiring ex:email. A Person missing either → reject.
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model_id = "test/inline-shapes/layered-model:main";
+    let model = genesis_ledger(&fluree, model_id);
+
+    let shapes_graph_iri = "http://example.org/governance/shapes";
+    let m_trig = format!(
+        r"
+        @prefix sh:   <http://www.w3.org/ns/shacl#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        GRAPH <{shapes_graph_iri}> {{
+            ex:PersonNameShape
+                rdf:type        sh:NodeShape ;
+                sh:targetClass  ex:Person ;
+                sh:property     ex:pshape_name .
+            ex:pshape_name
+                sh:path     ex:name ;
+                sh:minCount 1 ;
+                sh:datatype xsd:string .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&m_trig)
+        .execute()
+        .await
+        .expect("seed M name-shape");
+
+    let data_id = "test/inline-shapes/layered-data:main";
+    let data = genesis_ledger(&fluree, data_id);
+
+    let config_iri = format!("urn:fluree:{data_id}#config");
+    let r1 = fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:   <https://ns.flur.ee/db#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:shaclDefaults <urn:cfg:shacl> .
+                <urn:cfg:shacl> f:shaclEnabled true .
+                <urn:cfg:shacl> f:shapesSource <urn:cfg:shapes-ref> .
+                <urn:cfg:shapes-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:shapes-src> .
+                <urn:cfg:shapes-src> f:ledger <{model_id}> ;
+                                     f:graphSelector <{shapes_graph_iri}> .
+            }}
+        "
+        ))
+        .execute()
+        .await
+        .expect("seed D cross-ledger config");
+    let data = r1.ledger;
+
+    // Inline shape requires ex:email.
+    let email_shape = json!({
+        "@context": {
+            "ex":  "http://example.org/ns/",
+            "sh":  "http://www.w3.org/ns/shacl#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": [
+            {
+                "@id":            "ex:PersonEmailShape",
+                "@type":          "sh:NodeShape",
+                "sh:targetClass": {"@id": "ex:Person"},
+                "sh:property":    {"@id": "ex:pshape_email"}
+            },
+            {
+                "@id":         "ex:pshape_email",
+                "sh:path":     {"@id": "ex:email"},
+                "sh:minCount": 1,
+                "sh:datatype": {"@id": "xsd:string"}
+            }
+        ]
+    });
+
+    let opts = TxnOpts {
+        shapes: Some(email_shape.clone()),
+        ..TxnOpts::default()
+    };
+
+    // Has name (cross-ledger) but missing email (inline) → reject.
+    let err = fluree
+        .insert_with_opts(
+            data,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@id":    "ex:eve",
+                "@type":  "ex:Person",
+                "ex:name": "Eve"
+            }),
+            opts,
+            CommitOpts::default(),
+            &test_index_cfg(),
+        )
+        .await
+        .expect_err("inline shape (email) must reject Person without email");
+
+    assert!(
+        matches!(
+            err,
+            fluree_db_api::ApiError::Transact(fluree_db_transact::TransactError::ShaclViolation(_))
+        ),
+        "expected ShaclViolation from inline email shape, got: {err:?}"
+    );
+}

--- a/fluree-db-policy/Cargo.toml
+++ b/fluree-db-policy/Cargo.toml
@@ -10,6 +10,7 @@ description = "Policy enforcement for Fluree DB queries and transactions"
 fluree-db-core = { path = "../fluree-db-core" }
 fluree-vocab = { path = "../fluree-vocab" }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 uuid = { version = "1.0", features = ["v4"] }
 futures = { workspace = true }
 

--- a/fluree-db-policy/src/lib.rs
+++ b/fluree-db-policy/src/lib.rs
@@ -62,5 +62,6 @@ pub use types::{
     PolicyValue, PolicyWrapper, PropertyPolicyEntry, TargetMode,
 };
 pub use wire::{
-    build_policy_set_from_wire, PolicyArtifactWire, WireOrigin, WirePolicyValue, WireRestriction,
+    build_policy_set_from_wire, wire_to_restrictions, PolicyArtifactWire, WireOrigin,
+    WirePolicyValue, WireRestriction,
 };

--- a/fluree-db-policy/src/lib.rs
+++ b/fluree-db-policy/src/lib.rs
@@ -47,6 +47,7 @@ mod index;
 mod query_eval;
 mod schema;
 mod types;
+mod wire;
 
 pub use class_lookup::{lookup_subject_classes, populate_class_cache};
 pub use error::{PolicyError, Result};
@@ -59,4 +60,7 @@ pub use schema::is_schema_flake;
 pub use types::{
     FlakePolicyEntry, PolicyAction, PolicyDecision, PolicyQuery, PolicyRestriction, PolicySet,
     PolicyValue, PolicyWrapper, PropertyPolicyEntry, TargetMode,
+};
+pub use wire::{
+    build_policy_set_from_wire, PolicyArtifactWire, WireOrigin, WirePolicyValue, WireRestriction,
 };

--- a/fluree-db-policy/src/wire.rs
+++ b/fluree-db-policy/src/wire.rs
@@ -145,7 +145,11 @@ where
                 continue;
             }
         }
-        let targets: HashSet<Sid> = w.targets.iter().filter_map(|iri| resolve_iri(iri)).collect();
+        let targets: HashSet<Sid> = w
+            .targets
+            .iter()
+            .filter_map(|iri| resolve_iri(iri))
+            .collect();
         let for_classes: HashSet<Sid> = w
             .for_classes
             .iter()
@@ -271,7 +275,10 @@ mod tests {
             .expect("name should be indexed");
         assert_eq!(entries.len(), 1);
         let PropertyPolicyEntry { idx, .. } = entries[0];
-        assert_eq!(set.restrictions[idx].id, "http://example.org/rules/allow-name");
+        assert_eq!(
+            set.restrictions[idx].id,
+            "http://example.org/rules/allow-name"
+        );
     }
 
     #[test]
@@ -439,10 +446,11 @@ mod tests {
         assert_eq!(kept[0].id, "ex:r-org");
 
         // Both classes → keep both.
-        let both: HashSet<String> =
-            [access_iri.to_string(), org_iri.to_string()].into_iter().collect();
-        let kept = wire_to_restrictions(&wire, stub_resolver(&[]), Some(&both))
-            .expect("filter to both");
+        let both: HashSet<String> = [access_iri.to_string(), org_iri.to_string()]
+            .into_iter()
+            .collect();
+        let kept =
+            wire_to_restrictions(&wire, stub_resolver(&[]), Some(&both)).expect("filter to both");
         assert_eq!(kept.len(), 2);
 
         // Unrelated class → drop everything.
@@ -478,8 +486,9 @@ mod tests {
             }],
         };
 
-        let filter: HashSet<String> =
-            ["https://ns.flur.ee/db#AccessPolicy".to_string()].into_iter().collect();
+        let filter: HashSet<String> = ["https://ns.flur.ee/db#AccessPolicy".to_string()]
+            .into_iter()
+            .collect();
         let kept = wire_to_restrictions(&wire, stub_resolver(&[]), Some(&filter))
             .expect("filter with untyped");
         assert!(kept.is_empty(), "untyped restriction must be dropped");

--- a/fluree-db-policy/src/wire.rs
+++ b/fluree-db-policy/src/wire.rs
@@ -1,0 +1,365 @@
+//! Term-neutral wire form for cross-ledger policy artifacts.
+//!
+//! See `docs/design/cross-ledger-model-enforcement.md`. The wire form
+//! is what a cross-ledger resolver produces and what the per-instance
+//! governance-artifact cache stores: IRIs throughout, no Sids. It is
+//! shareable across every data ledger that references the same model
+//! graph at the same model-t.
+//!
+//! Translation to a Sid-form [`PolicySet`] happens at request time
+//! against the data ledger's term space via
+//! [`build_policy_set_from_wire`]. The translation function takes a
+//! closure for IRI resolution so this crate stays free of
+//! `LedgerSnapshot` references; production passes a closure wrapping
+//! `LedgerSnapshot::encode_iri`.
+
+use crate::error::Result;
+use crate::index::build_policy_set;
+use crate::types::{
+    PolicyAction, PolicyQuery, PolicyRestriction, PolicySet, PolicyValue, TargetMode,
+};
+use fluree_db_core::{IndexStats, Sid};
+use std::collections::HashSet;
+
+/// Term-neutral policy artifact materialized from a model ledger.
+///
+/// Cached by the API layer keyed on `(origin.model_ledger_id,
+/// origin.graph_iri, origin.resolved_t)`.
+#[derive(Debug, Clone)]
+pub struct PolicyArtifactWire {
+    /// Provenance for diagnostics and cache key derivation.
+    pub origin: WireOrigin,
+    /// Policy rules in the order they were read from the model graph.
+    pub restrictions: Vec<WireRestriction>,
+}
+
+/// Provenance for a wire artifact.
+#[derive(Debug, Clone)]
+pub struct WireOrigin {
+    /// Canonical model ledger id (`NsRecord.ledger_id`), never a
+    /// user-typed alias.
+    pub model_ledger_id: String,
+    /// Graph IRI within the model ledger whose triples produced this
+    /// artifact.
+    pub graph_iri: String,
+    /// Model ledger `t` at which the artifact was materialized.
+    pub resolved_t: i64,
+}
+
+/// IRI-form mirror of [`PolicyRestriction`].
+///
+/// `targets` and `for_classes` are `Vec<String>` (not `HashSet`)
+/// because ordering is irrelevant to PolicySet construction and Vec
+/// serializes more efficiently. They are rebuilt into HashSets during
+/// translation.
+#[derive(Debug, Clone)]
+pub struct WireRestriction {
+    /// Policy rule IRI (subject in the source graph).
+    pub id: String,
+    /// Targeting mode (`f:onSubject` / `f:onProperty` / `f:onClass` /
+    /// default).
+    pub target_mode: TargetMode,
+    /// Target IRIs — subjects, properties, or classes per `target_mode`.
+    pub targets: Vec<String>,
+    /// `f:action`.
+    pub action: PolicyAction,
+    /// `f:allow` / `f:query` effect.
+    pub value: WirePolicyValue,
+    /// `f:required` flag.
+    pub required: bool,
+    /// Optional `f:exMessage`.
+    pub message: Option<String>,
+    /// `f:onClass` was set (the restriction targets class instances).
+    pub class_policy: bool,
+    /// Target class IRIs for `f:onClass` policies.
+    pub for_classes: Vec<String>,
+}
+
+/// IRI-form mirror of [`PolicyValue`].
+///
+/// `Query` stores its JSON payload verbatim — it is already
+/// term-neutral; the policy query executor re-interns IRIs at
+/// execution time against the data ledger's term space.
+#[derive(Debug, Clone)]
+pub enum WirePolicyValue {
+    Allow,
+    Deny,
+    Query(String),
+}
+
+/// Translate a wire artifact into a Sid-form [`PolicySet`] against a
+/// data ledger's term space.
+///
+/// `resolve_iri` is the term-translation hook. Production wraps
+/// `LedgerSnapshot::encode_iri`. Tests can pass an in-memory stub.
+///
+/// IRIs that fail to resolve are dropped from their target set: the
+/// restriction is still included in the result with the unresolvable
+/// targets removed (its `id` remains observable for diagnostics).
+/// Whether unresolved IRIs should instead be interned on demand
+/// against D is a separate decision that lands with the resolver
+/// itself (a later slice); this function preserves whatever the
+/// closure returns and applies no policy of its own.
+pub fn build_policy_set_from_wire<R>(
+    wire: &PolicyArtifactWire,
+    resolve_iri: R,
+    stats: Option<&IndexStats>,
+    action_filter: PolicyAction,
+) -> Result<PolicySet>
+where
+    R: Fn(&str) -> Option<Sid>,
+{
+    let mut restrictions = Vec::with_capacity(wire.restrictions.len());
+    for w in &wire.restrictions {
+        let targets: HashSet<Sid> = w.targets.iter().filter_map(|iri| resolve_iri(iri)).collect();
+        let for_classes: HashSet<Sid> = w
+            .for_classes
+            .iter()
+            .filter_map(|iri| resolve_iri(iri))
+            .collect();
+        let value = match &w.value {
+            WirePolicyValue::Allow => PolicyValue::Allow,
+            WirePolicyValue::Deny => PolicyValue::Deny,
+            WirePolicyValue::Query(json) => PolicyValue::Query(PolicyQuery { json: json.clone() }),
+        };
+        restrictions.push(PolicyRestriction {
+            id: w.id.clone(),
+            target_mode: w.target_mode,
+            targets,
+            action: w.action,
+            value,
+            required: w.required,
+            message: w.message.clone(),
+            class_policy: w.class_policy,
+            for_classes,
+            // `class_check_needed` is recomputed by `build_policy_set`
+            // from the (for_classes, property, stats) triple.
+            class_check_needed: false,
+        });
+    }
+    Ok(build_policy_set(restrictions, stats, action_filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PropertyPolicyEntry;
+    use std::collections::HashMap;
+
+    /// Build an IRI→Sid resolver from a static map.
+    fn stub_resolver(entries: &[(&str, Sid)]) -> impl Fn(&str) -> Option<Sid> {
+        let map: HashMap<String, Sid> = entries
+            .iter()
+            .map(|(iri, sid)| ((*iri).to_string(), sid.clone()))
+            .collect();
+        move |iri| map.get(iri).cloned()
+    }
+
+    fn sid(ns: u16, name: &str) -> Sid {
+        Sid::new(ns, name)
+    }
+
+    fn wire_origin() -> WireOrigin {
+        WireOrigin {
+            model_ledger_id: "test/model:main".into(),
+            graph_iri: "http://example.org/policy".into(),
+            resolved_t: 42,
+        }
+    }
+
+    #[test]
+    fn empty_wire_produces_empty_policy_set() {
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![],
+        };
+        let set = build_policy_set_from_wire(&wire, stub_resolver(&[]), None, PolicyAction::View)
+            .expect("translate empty wire");
+        assert!(set.restrictions.is_empty());
+        assert!(set.by_property.is_empty());
+        assert!(set.by_subject.is_empty());
+        assert!(set.defaults.is_empty());
+    }
+
+    #[test]
+    fn on_property_restriction_indexed_under_translated_sid() {
+        let name_iri = "http://example.org/name";
+        let name_sid = sid(100, "name");
+
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![WireRestriction {
+                id: "http://example.org/rules/allow-name".into(),
+                target_mode: TargetMode::OnProperty,
+                targets: vec![name_iri.into()],
+                action: PolicyAction::View,
+                value: WirePolicyValue::Allow,
+                required: false,
+                message: None,
+                class_policy: false,
+                for_classes: vec![],
+            }],
+        };
+
+        let set = build_policy_set_from_wire(
+            &wire,
+            stub_resolver(&[(name_iri, name_sid.clone())]),
+            None,
+            PolicyAction::View,
+        )
+        .expect("translate property-target wire");
+
+        assert_eq!(set.restrictions.len(), 1);
+        let entries = set
+            .by_property
+            .get(&name_sid)
+            .expect("name should be indexed");
+        assert_eq!(entries.len(), 1);
+        let PropertyPolicyEntry { idx, .. } = entries[0];
+        assert_eq!(set.restrictions[idx].id, "http://example.org/rules/allow-name");
+    }
+
+    #[test]
+    fn unresolved_target_iri_is_dropped_from_set_but_restriction_preserved() {
+        // Two targets: one resolvable, one not. The restriction must
+        // still appear in the result so its presence is observable;
+        // only the unresolvable IRI is dropped from the index.
+        let name_iri = "http://example.org/name";
+        let unknown_iri = "http://example.org/never-seen";
+        let name_sid = sid(100, "name");
+
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![WireRestriction {
+                id: "http://example.org/rules/partial".into(),
+                target_mode: TargetMode::OnProperty,
+                targets: vec![name_iri.into(), unknown_iri.into()],
+                action: PolicyAction::View,
+                value: WirePolicyValue::Deny,
+                required: false,
+                message: None,
+                class_policy: false,
+                for_classes: vec![],
+            }],
+        };
+
+        let set = build_policy_set_from_wire(
+            &wire,
+            stub_resolver(&[(name_iri, name_sid.clone())]),
+            None,
+            PolicyAction::View,
+        )
+        .expect("translate partial-resolution wire");
+
+        assert_eq!(set.restrictions.len(), 1, "restriction must be preserved");
+        let restriction = &set.restrictions[0];
+        assert_eq!(restriction.targets.len(), 1);
+        assert!(restriction.targets.contains(&name_sid));
+        assert!(
+            set.by_property.contains_key(&name_sid),
+            "resolvable target must be indexed"
+        );
+    }
+
+    #[test]
+    fn behavior_matches_direct_local_construction() {
+        // Build the same policy two ways: (a) directly as a
+        // PolicyRestriction in the local Sid-form (the same-ledger
+        // materializer's output shape), and (b) through the wire
+        // form using equivalent IRIs and the same Sid bindings.
+        // Then exercise both PolicySets via the public
+        // restrictions_for_flake API and assert the decisions match.
+        // Asserts behavior, not byte-equality — HashSet iteration
+        // order and incidental diagnostic strings are not
+        // load-bearing.
+
+        let name_iri = "http://example.org/name";
+        let name_sid = sid(100, "name");
+        let alice_sid = sid(100, "alice");
+
+        // (a) Direct local construction.
+        let local_restriction = PolicyRestriction {
+            id: "http://example.org/rules/r1".into(),
+            target_mode: TargetMode::OnProperty,
+            targets: [name_sid.clone()].into_iter().collect(),
+            action: PolicyAction::View,
+            value: PolicyValue::Allow,
+            required: false,
+            message: None,
+            class_policy: false,
+            for_classes: HashSet::new(),
+            class_check_needed: false,
+        };
+        let local_set = build_policy_set(vec![local_restriction], None, PolicyAction::View);
+
+        // (b) Wire form translated against the same Sid bindings.
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![WireRestriction {
+                id: "http://example.org/rules/r1".into(),
+                target_mode: TargetMode::OnProperty,
+                targets: vec![name_iri.into()],
+                action: PolicyAction::View,
+                value: WirePolicyValue::Allow,
+                required: false,
+                message: None,
+                class_policy: false,
+                for_classes: vec![],
+            }],
+        };
+        let wire_set = build_policy_set_from_wire(
+            &wire,
+            stub_resolver(&[(name_iri, name_sid.clone())]),
+            None,
+            PolicyAction::View,
+        )
+        .expect("wire translate");
+
+        // Both must produce the same lookup result for a representative
+        // flake (alice's name) and the same empty result for an
+        // unrelated property.
+        let unrelated = sid(100, "age");
+
+        let local_hits = local_set.restrictions_for_flake(&alice_sid, &name_sid);
+        let wire_hits = wire_set.restrictions_for_flake(&alice_sid, &name_sid);
+        assert_eq!(local_hits.len(), wire_hits.len());
+        assert_eq!(local_hits[0].id, wire_hits[0].id);
+        assert!(matches!(local_hits[0].value, PolicyValue::Allow));
+        assert!(matches!(wire_hits[0].value, PolicyValue::Allow));
+
+        let local_miss = local_set.restrictions_for_flake(&alice_sid, &unrelated);
+        let wire_miss = wire_set.restrictions_for_flake(&alice_sid, &unrelated);
+        assert_eq!(local_miss.len(), 0);
+        assert_eq!(wire_miss.len(), 0);
+    }
+
+    #[test]
+    fn query_value_passes_through_verbatim() {
+        // Query JSON is term-neutral by construction (the query engine
+        // re-interns IRIs at execution time), so translation must not
+        // touch it.
+        let json_payload = r#"{"@id": "ex:Bob"}"#;
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![WireRestriction {
+                id: "http://example.org/rules/cond".into(),
+                target_mode: TargetMode::Default,
+                targets: vec![],
+                action: PolicyAction::View,
+                value: WirePolicyValue::Query(json_payload.into()),
+                required: false,
+                message: None,
+                class_policy: false,
+                for_classes: vec![],
+            }],
+        };
+        let set = build_policy_set_from_wire(&wire, stub_resolver(&[]), None, PolicyAction::View)
+            .expect("translate query-value wire");
+
+        assert_eq!(set.restrictions.len(), 1);
+        match &set.restrictions[0].value {
+            PolicyValue::Query(q) => assert_eq!(q.json, json_payload),
+            other => panic!("expected Query, got {other:?}"),
+        }
+    }
+}

--- a/fluree-db-policy/src/wire.rs
+++ b/fluree-db-policy/src/wire.rs
@@ -100,30 +100,51 @@ pub enum WirePolicyValue {
     Query(String),
 }
 
-/// Translate a wire artifact into a Sid-form [`PolicySet`] against a
-/// data ledger's term space.
+/// Translate a wire artifact into a list of Sid-form
+/// [`PolicyRestriction`]s against a data ledger's term space.
+///
+/// This is the lower-level entry point used by the API layer when it
+/// needs to merge cross-ledger restrictions into the existing
+/// `build_policy_context_from_opts` flow (which builds the indexed
+/// `PolicySet` itself with stats applied later). Callers that just
+/// want a ready-to-use `PolicySet` should use
+/// [`build_policy_set_from_wire`] instead.
 ///
 /// `resolve_iri` is the term-translation hook. Production wraps
-/// `LedgerSnapshot::encode_iri`. Tests can pass an in-memory stub.
+/// `LedgerSnapshot::encode_iri`; tests can pass an in-memory stub.
 ///
-/// IRIs that fail to resolve are dropped from their target set: the
+/// `policy_class_filter` (optional) is an exact IRI intersection
+/// against each restriction's `policy_types`. When `Some(set)`:
+///
+/// - A restriction passes if any IRI in its `policy_types` appears
+///   in `set`.
+/// - A restriction whose `policy_types` is empty is **dropped**
+///   (an untyped policy can never satisfy a class-based filter).
+///
+/// When `None`, every restriction in the wire artifact is included
+/// — useful for callers that have already filtered, or for tests.
+///
+/// IRIs that fail to resolve are dropped from their target set; the
 /// restriction is still included in the result with the unresolvable
-/// targets removed (its `id` remains observable for diagnostics).
-/// Whether unresolved IRIs should instead be interned on demand
-/// against D is a separate decision that lands with the resolver
-/// itself (a later slice); this function preserves whatever the
-/// closure returns and applies no policy of its own.
-pub fn build_policy_set_from_wire<R>(
+/// targets removed. Its `id` remains observable for diagnostics. The
+/// resolver itself decides whether unresolved IRIs should be
+/// interned on demand against D — this function preserves whatever
+/// the closure returns and applies no policy of its own.
+pub fn wire_to_restrictions<R>(
     wire: &PolicyArtifactWire,
     resolve_iri: R,
-    stats: Option<&IndexStats>,
-    action_filter: PolicyAction,
-) -> Result<PolicySet>
+    policy_class_filter: Option<&HashSet<String>>,
+) -> Result<Vec<PolicyRestriction>>
 where
     R: Fn(&str) -> Option<Sid>,
 {
-    let mut restrictions = Vec::with_capacity(wire.restrictions.len());
+    let mut out = Vec::with_capacity(wire.restrictions.len());
     for w in &wire.restrictions {
+        if let Some(filter) = policy_class_filter {
+            if !w.policy_types.iter().any(|t| filter.contains(t)) {
+                continue;
+            }
+        }
         let targets: HashSet<Sid> = w.targets.iter().filter_map(|iri| resolve_iri(iri)).collect();
         let for_classes: HashSet<Sid> = w
             .for_classes
@@ -135,7 +156,7 @@ where
             WirePolicyValue::Deny => PolicyValue::Deny,
             WirePolicyValue::Query(json) => PolicyValue::Query(PolicyQuery { json: json.clone() }),
         };
-        restrictions.push(PolicyRestriction {
+        out.push(PolicyRestriction {
             id: w.id.clone(),
             target_mode: w.target_mode,
             targets,
@@ -150,6 +171,26 @@ where
             class_check_needed: false,
         });
     }
+    Ok(out)
+}
+
+/// Translate a wire artifact directly into a Sid-form [`PolicySet`].
+///
+/// Thin wrapper over [`wire_to_restrictions`] + [`build_policy_set`]
+/// — useful for callers (and tests) that don't need to fold the
+/// restrictions into the same-ledger materializer's flow. Does no
+/// `policy_class` filtering; pass a pre-filtered wire artifact (or
+/// use `wire_to_restrictions` directly with a filter).
+pub fn build_policy_set_from_wire<R>(
+    wire: &PolicyArtifactWire,
+    resolve_iri: R,
+    stats: Option<&IndexStats>,
+    action_filter: PolicyAction,
+) -> Result<PolicySet>
+where
+    R: Fn(&str) -> Option<Sid>,
+{
+    let restrictions = wire_to_restrictions(wire, resolve_iri, None)?;
     Ok(build_policy_set(restrictions, stats, action_filter))
 }
 
@@ -347,6 +388,101 @@ mod tests {
         let wire_miss = wire_set.restrictions_for_flake(&alice_sid, &unrelated);
         assert_eq!(local_miss.len(), 0);
         assert_eq!(wire_miss.len(), 0);
+    }
+
+    #[test]
+    fn policy_class_filter_keeps_matching_restrictions_and_drops_others() {
+        // Two restrictions: one typed as f:AccessPolicy, one as
+        // ex:OrgPolicy. Filtering on {ex:OrgPolicy} must keep only
+        // the second; filtering on {f:AccessPolicy, ex:OrgPolicy}
+        // must keep both; filtering on {ex:Unrelated} must keep
+        // neither.
+        let access_iri = "https://ns.flur.ee/db#AccessPolicy";
+        let org_iri = "http://example.org/ns/OrgPolicy";
+        let unrelated_iri = "http://example.org/ns/Unrelated";
+
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![
+                WireRestriction {
+                    id: "ex:r-access".into(),
+                    policy_types: vec![access_iri.into()],
+                    target_mode: TargetMode::Default,
+                    targets: vec![],
+                    action: PolicyAction::View,
+                    value: WirePolicyValue::Allow,
+                    required: false,
+                    message: None,
+                    class_policy: false,
+                    for_classes: vec![],
+                },
+                WireRestriction {
+                    id: "ex:r-org".into(),
+                    policy_types: vec![org_iri.into()],
+                    target_mode: TargetMode::Default,
+                    targets: vec![],
+                    action: PolicyAction::View,
+                    value: WirePolicyValue::Allow,
+                    required: false,
+                    message: None,
+                    class_policy: false,
+                    for_classes: vec![],
+                },
+            ],
+        };
+
+        // Only ex:OrgPolicy → drop the access-typed rule.
+        let org_only: HashSet<String> = [org_iri.to_string()].into_iter().collect();
+        let kept = wire_to_restrictions(&wire, stub_resolver(&[]), Some(&org_only))
+            .expect("filter to org only");
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, "ex:r-org");
+
+        // Both classes → keep both.
+        let both: HashSet<String> =
+            [access_iri.to_string(), org_iri.to_string()].into_iter().collect();
+        let kept = wire_to_restrictions(&wire, stub_resolver(&[]), Some(&both))
+            .expect("filter to both");
+        assert_eq!(kept.len(), 2);
+
+        // Unrelated class → drop everything.
+        let unrelated: HashSet<String> = [unrelated_iri.to_string()].into_iter().collect();
+        let kept = wire_to_restrictions(&wire, stub_resolver(&[]), Some(&unrelated))
+            .expect("filter to unrelated");
+        assert!(kept.is_empty());
+
+        // None filter → keep everything.
+        let kept = wire_to_restrictions(&wire, stub_resolver(&[]), None).expect("no filter");
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn policy_class_filter_drops_untyped_restrictions() {
+        // A restriction with empty policy_types can never satisfy a
+        // class filter — even one with a permissive class set —
+        // because there's no rdf:type to match. Such restrictions
+        // are dropped when any filter is supplied.
+        let wire = PolicyArtifactWire {
+            origin: wire_origin(),
+            restrictions: vec![WireRestriction {
+                id: "ex:untyped".into(),
+                policy_types: vec![],
+                target_mode: TargetMode::Default,
+                targets: vec![],
+                action: PolicyAction::View,
+                value: WirePolicyValue::Allow,
+                required: false,
+                message: None,
+                class_policy: false,
+                for_classes: vec![],
+            }],
+        };
+
+        let filter: HashSet<String> =
+            ["https://ns.flur.ee/db#AccessPolicy".to_string()].into_iter().collect();
+        let kept = wire_to_restrictions(&wire, stub_resolver(&[]), Some(&filter))
+            .expect("filter with untyped");
+        assert!(kept.is_empty(), "untyped restriction must be dropped");
     }
 
     #[test]

--- a/fluree-db-policy/src/wire.rs
+++ b/fluree-db-policy/src/wire.rs
@@ -145,16 +145,52 @@ where
                 continue;
             }
         }
+        // Translate target IRIs against D's term space. IRIs M
+        // references but D has never seen drop here.
+        //
+        // A WARN log surfaces the drop so operators can debug a
+        // cross-ledger policy that quietly narrows scope: if every
+        // target IRI is M-only, the resulting restriction has an
+        // empty target set and `build_policy_set` treats it as
+        // "applies to nothing" — effectively a no-op. The
+        // alternative (dropping the entire restriction on
+        // any-targets-empty) would diverge from same-ledger
+        // semantics, where a same-ledger policy with the same IRI
+        // set also produces an empty `targets` and the same
+        // engine behavior. We surface the discrepancy via logs
+        // rather than silently changing scope OR diverging from
+        // the same-ledger contract.
+        let total_targets = w.targets.len();
         let targets: HashSet<Sid> = w
             .targets
             .iter()
             .filter_map(|iri| resolve_iri(iri))
             .collect();
+        if total_targets > 0 && targets.len() < total_targets {
+            tracing::warn!(
+                restriction_id = ?w.id,
+                requested = total_targets,
+                resolved = targets.len(),
+                "cross-ledger policy restriction has target IRIs not registered \
+                 on the data ledger; those targets will not be enforced. Register \
+                 the IRIs on D, or remove them from the model ledger restriction."
+            );
+        }
+        let total_for_classes = w.for_classes.len();
         let for_classes: HashSet<Sid> = w
             .for_classes
             .iter()
             .filter_map(|iri| resolve_iri(iri))
             .collect();
+        if total_for_classes > 0 && for_classes.len() < total_for_classes {
+            tracing::warn!(
+                restriction_id = ?w.id,
+                requested = total_for_classes,
+                resolved = for_classes.len(),
+                "cross-ledger policy restriction has for-class IRIs not registered \
+                 on the data ledger; class scope will be narrower than authored."
+            );
+        }
         let value = match &w.value {
             WirePolicyValue::Allow => PolicyValue::Allow,
             WirePolicyValue::Deny => PolicyValue::Deny,

--- a/fluree-db-policy/src/wire.rs
+++ b/fluree-db-policy/src/wire.rs
@@ -52,10 +52,23 @@ pub struct WireOrigin {
 /// because ordering is irrelevant to PolicySet construction and Vec
 /// serializes more efficiently. They are rebuilt into HashSets during
 /// translation.
+///
+/// `policy_types` carries the rule subject's `rdf:type` IRIs so the
+/// translation step can filter by the data ledger's configured
+/// `f:policyClass` set via exact IRI intersection. This keeps the
+/// cross-ledger cache shareable across every data ledger that
+/// references the same model graph — different policy-class
+/// configurations don't produce different wire artifacts.
 #[derive(Debug, Clone)]
 pub struct WireRestriction {
     /// Policy rule IRI (subject in the source graph).
     pub id: String,
+    /// Every `rdf:type` value declared on the rule subject in the
+    /// source graph (decoded to IRI form). Used by the translator to
+    /// intersect with the data ledger's configured `f:policyClass`
+    /// set. Phase 1a uses exact IRI matching only; subclass
+    /// entailment is a later enhancement.
+    pub policy_types: Vec<String>,
     /// Targeting mode (`f:onSubject` / `f:onProperty` / `f:onClass` /
     /// default).
     pub target_mode: TargetMode,
@@ -190,6 +203,7 @@ mod tests {
             origin: wire_origin(),
             restrictions: vec![WireRestriction {
                 id: "http://example.org/rules/allow-name".into(),
+                policy_types: vec!["https://ns.flur.ee/db#AccessPolicy".into()],
                 target_mode: TargetMode::OnProperty,
                 targets: vec![name_iri.into()],
                 action: PolicyAction::View,
@@ -232,6 +246,7 @@ mod tests {
             origin: wire_origin(),
             restrictions: vec![WireRestriction {
                 id: "http://example.org/rules/partial".into(),
+                policy_types: vec!["https://ns.flur.ee/db#AccessPolicy".into()],
                 target_mode: TargetMode::OnProperty,
                 targets: vec![name_iri.into(), unknown_iri.into()],
                 action: PolicyAction::View,
@@ -297,6 +312,7 @@ mod tests {
             origin: wire_origin(),
             restrictions: vec![WireRestriction {
                 id: "http://example.org/rules/r1".into(),
+                policy_types: vec!["https://ns.flur.ee/db#AccessPolicy".into()],
                 target_mode: TargetMode::OnProperty,
                 targets: vec![name_iri.into()],
                 action: PolicyAction::View,
@@ -343,6 +359,7 @@ mod tests {
             origin: wire_origin(),
             restrictions: vec![WireRestriction {
                 id: "http://example.org/rules/cond".into(),
+                policy_types: vec!["https://ns.flur.ee/db#AccessPolicy".into()],
                 target_mode: TargetMode::Default,
                 targets: vec![],
                 action: PolicyAction::View,

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -994,20 +994,33 @@ pub async fn execute_datalog_rules(
     db: GraphDbRef<'_>,
     max_iterations: usize,
 ) -> Result<DatalogExecutionResult> {
-    execute_datalog_rules_with_query_rules(db, max_iterations, &[]).await
+    execute_datalog_rules_with_query_rules(db, max_iterations, &[], None).await
 }
 
 /// Execute datalog rules with optional query-time rules
 ///
 /// This is the full implementation that supports both database-stored rules
 /// and query-time rules passed as JSON-LD.
+///
+/// `rules_source_g_id` overrides the graph that `extract_datalog_rules`
+/// scans for `f:rule` flakes. When `None`, extraction reads from
+/// `db.g_id` (legacy behaviour). When `Some(g)`, a separate
+/// `GraphDbRef` is built at graph `g` and used only for rule
+/// extraction — the fixpoint loop still executes against `db`.
 pub async fn execute_datalog_rules_with_query_rules(
     db: GraphDbRef<'_>,
     max_iterations: usize,
     query_time_rules: &[serde_json::Value],
+    rules_source_g_id: Option<fluree_db_core::GraphId>,
 ) -> Result<DatalogExecutionResult> {
-    // Extract rules from database
-    let mut rule_set = extract_datalog_rules(db).await?;
+    // Extract rules from the configured source graph if set,
+    // otherwise from the query graph. The fixpoint loop below
+    // continues to execute against `db` regardless.
+    let rules_db = match rules_source_g_id {
+        Some(rg) if rg != db.g_id => GraphDbRef::new(db.snapshot, rg, db.overlay, db.t),
+        _ => db,
+    };
+    let mut rule_set = extract_datalog_rules(rules_db).await?;
 
     // Parse and add query-time rules
     for (idx, rule_json) in query_time_rules.iter().enumerate() {

--- a/fluree-db-query/src/execute/reasoning_prep.rs
+++ b/fluree-db-query/src/execute/reasoning_prep.rs
@@ -170,6 +170,7 @@ pub async fn compute_derived_facts(
     overlay: &dyn fluree_db_core::OverlayProvider,
     to_t: i64,
     reasoning: &ReasoningModes,
+    rules_source_g_id: Option<GraphId>,
 ) -> Option<Arc<DerivedFactsOverlay>> {
     use crate::datalog_rules::execute_datalog_rules_with_query_rules;
 
@@ -213,6 +214,7 @@ pub async fn compute_derived_facts(
     if reasoning.datalog {
         tracing::debug!(
             query_time_rules = reasoning.rules.len(),
+            rules_source_g_id = ?rules_source_g_id,
             "executing user-defined datalog rules"
         );
         const MAX_DATALOG_ITERATIONS: usize = 100;
@@ -232,6 +234,7 @@ pub async fn compute_derived_facts(
                 combined_db,
                 MAX_DATALOG_ITERATIONS,
                 &reasoning.rules,
+                rules_source_g_id,
             )
             .await
         } else {
@@ -240,6 +243,7 @@ pub async fn compute_derived_facts(
                 base_db,
                 MAX_DATALOG_ITERATIONS,
                 &reasoning.rules,
+                rules_source_g_id,
             )
             .await
         };

--- a/fluree-db-query/src/execute/rewrite_glue.rs
+++ b/fluree-db-query/src/execute/rewrite_glue.rs
@@ -104,6 +104,7 @@ mod tests {
             owl_datalog: false,
             explicit_none: false,
             rules: vec![],
+            ontology: None,
         };
 
         let (rewritten, diag) = rewrite_query_patterns(&patterns, None, &modes, None);

--- a/fluree-db-query/src/execute/runner.rs
+++ b/fluree-db-query/src/execute/runner.rs
@@ -256,9 +256,15 @@ pub async fn prepare_execution_with_config(
             // axioms (e.g. `?p a owl:TransitiveProperty`) from the import
             // closure are visible when scanning g_id=0, and base-overlay
             // novelty remains visible for other graphs.
-            let derived_overlay =
-                compute_derived_facts(db.snapshot, db.g_id, effective_overlay, db.t, &reasoning)
-                    .await;
+            let derived_overlay = compute_derived_facts(
+                db.snapshot,
+                db.g_id,
+                effective_overlay,
+                db.t,
+                &reasoning,
+                query.reasoning.rules_source_g_id,
+            )
+            .await;
 
             // Step 4: Build ontology for OWL2-QL mode (if enabled)
             let reasoning_overlay_for_ontology: Option<ReasoningOverlay<'_>> = derived_overlay

--- a/fluree-db-query/src/ir/reasoning.rs
+++ b/fluree-db-query/src/ir/reasoning.rs
@@ -360,6 +360,20 @@ pub struct ReasoningConfig {
     ///
     /// When `None`, reasoning reads schema from `db.g_id` directly.
     pub schema_bundle: Option<Arc<SchemaBundleFlakes>>,
+    /// Pre-resolved local graph id from `f:rulesSource`.
+    ///
+    /// Populated upstream (in `fluree-db-api`) when the ledger
+    /// config points the datalog rule extractor at a non-default
+    /// graph. When `Some(g)`, `compute_derived_facts` extracts
+    /// `f:rule` flakes from graph `g`; the rules themselves still
+    /// execute against the query graph (`db.g_id`). When `None`,
+    /// extraction defaults to `db.g_id` — the legacy behaviour.
+    ///
+    /// Cross-ledger rules (where `f:rulesSource` carries
+    /// `f:ledger`) surface as resolved JSON-LD rule definitions
+    /// in [`ReasoningModes::rules`] before query execution; this
+    /// field stays `None` in that case.
+    pub rules_source_g_id: Option<fluree_db_core::GraphId>,
 }
 
 impl ReasoningConfig {
@@ -391,6 +405,12 @@ impl ReasoningConfig {
     /// `fluree_db_api::ontology_imports::resolve_schema_bundle`.
     pub fn with_schema_bundle(mut self, bundle: Arc<SchemaBundleFlakes>) -> Self {
         self.schema_bundle = Some(bundle);
+        self
+    }
+
+    /// Attach a pre-resolved local rules-source graph id.
+    pub fn with_rules_source_g_id(mut self, g_id: Option<fluree_db_core::GraphId>) -> Self {
+        self.rules_source_g_id = g_id;
         self
     }
 

--- a/fluree-db-query/src/ir/reasoning.rs
+++ b/fluree-db-query/src/ir/reasoning.rs
@@ -57,6 +57,23 @@ pub struct ReasoningModes {
     /// These rules are merged with database rules when datalog reasoning is enabled.
     /// Each rule should have `where` and `insert` clauses.
     pub rules: Vec<serde_json::Value>,
+
+    /// Inline ontology / schema axioms supplied with the query
+    /// (JSON-LD format).
+    ///
+    /// Carries RDFS / OWL axioms (rdfs:subClassOf,
+    /// rdfs:subPropertyOf, owl:inverseOf, owl:equivalentClass,
+    /// rdf:type owl:Class / owl:TransitiveProperty, …) that the
+    /// reasoner should treat as if they came from the ledger's
+    /// `f:schemaSource` graph. Layered additively on top of any
+    /// configured schemaSource bundle; never persisted.
+    ///
+    /// The runner parses these against a temporary
+    /// `NamespaceRegistry` seeded from the live snapshot, projects
+    /// them through the same whitelist as the cross-ledger schema
+    /// materializer, and merges the resulting flakes into
+    /// `ReasoningConfig.schema_bundle` before reasoning runs.
+    pub ontology: Option<serde_json::Value>,
 }
 
 impl ReasoningModes {
@@ -222,6 +239,17 @@ impl ReasoningModes {
                 _ => {
                     return Err("rules must be an array".to_string());
                 }
+            }
+        }
+
+        // Parse query-time ontology (RDFS / OWL axioms supplied
+        // inline). Layered on top of f:schemaSource at reasoning
+        // prep; doesn't itself flip any mode flag — reasoning is
+        // a separate decision (auto-RDFS still applies if a
+        // schema hierarchy exists).
+        if let Some(ontology) = query.get("ontology") {
+            if !ontology.is_null() {
+                modes.ontology = Some(ontology.clone());
             }
         }
 

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -1704,6 +1704,7 @@ fn lower_options(opts: &UnresolvedOptions) -> ReasoningConfig {
     ReasoningConfig {
         modes: opts.reasoning.clone().unwrap_or_default(),
         schema_bundle: None,
+        rules_source_g_id: None,
     }
 }
 

--- a/fluree-db-query/src/parse/options.rs
+++ b/fluree-db-query/src/parse/options.rs
@@ -477,11 +477,12 @@ fn rewrite_having_aggregates(
 pub fn parse_reasoning(
     obj: &serde_json::Map<String, JsonValue>,
 ) -> Result<Option<crate::ir::ReasoningModes>> {
-    // Check if either reasoning or rules is present
+    // Check if reasoning, rules, or ontology is present.
     let has_reasoning = obj.contains_key("reasoning");
     let has_rules = obj.contains_key("rules");
+    let has_ontology = obj.contains_key("ontology");
 
-    if !has_reasoning && !has_rules {
+    if !has_reasoning && !has_rules && !has_ontology {
         return Ok(None);
     }
 

--- a/fluree-db-query/src/schema_bundle.rs
+++ b/fluree-db-query/src/schema_bundle.rs
@@ -80,6 +80,55 @@ impl SchemaBundleFlakes {
         }
     }
 
+    /// Build a bundle from a pre-collected flake list. Shared by
+    /// the same-ledger ([`build_schema_bundle_flakes`]) and
+    /// cross-ledger (the API crate's `SchemaArtifactWire::translate_to_schema_bundle_flakes`)
+    /// paths so both apply the same sort + dedupe discipline and
+    /// produce the same four index orderings.
+    ///
+    /// The caller is responsible for whitelist correctness — both
+    /// callers project only whitelist-matching triples before
+    /// invoking this helper. The function does not re-validate.
+    pub fn from_collected_schema_triples(mut collected: Vec<Flake>) -> Result<Self> {
+        if collected.is_empty() {
+            return Ok(Self::empty());
+        }
+
+        collected.sort_by(|a, b| {
+            a.s.cmp(&b.s)
+                .then_with(|| a.p.cmp(&b.p))
+                .then_with(|| a.o.cmp(&b.o))
+                .then_with(|| a.t.cmp(&b.t))
+                .then_with(|| a.op.cmp(&b.op))
+        });
+        collected.dedup_by(|a, b| {
+            a.s == b.s && a.p == b.p && a.o == b.o && a.t == b.t && a.op == b.op
+        });
+
+        let mut spot = collected.clone();
+        let mut psot = collected.clone();
+        let mut post = collected.clone();
+        let mut opst = collected;
+
+        spot.sort_by(IndexType::Spot.comparator());
+        psot.sort_by(IndexType::Psot.comparator());
+        post.sort_by(IndexType::Post.comparator());
+        opst.sort_by(IndexType::Opst.comparator());
+
+        // Epoch is just the flake count for cross-ledger; same-ledger
+        // mixes in the source graph ids via the existing
+        // build_schema_bundle_flakes path.
+        let epoch: u64 = spot.len() as u64;
+
+        Ok(Self {
+            spot: spot.into(),
+            psot: psot.into(),
+            post: post.into(),
+            opst: opst.into(),
+            epoch,
+        })
+    }
+
     /// Total number of projected flakes (same across all index orderings).
     pub fn len(&self) -> usize {
         self.spot.len()

--- a/fluree-db-query/src/schema_bundle.rs
+++ b/fluree-db-query/src/schema_bundle.rs
@@ -101,9 +101,8 @@ impl SchemaBundleFlakes {
                 .then_with(|| a.t.cmp(&b.t))
                 .then_with(|| a.op.cmp(&b.op))
         });
-        collected.dedup_by(|a, b| {
-            a.s == b.s && a.p == b.p && a.o == b.o && a.t == b.t && a.op == b.op
-        });
+        collected
+            .dedup_by(|a, b| a.s == b.s && a.p == b.p && a.o == b.o && a.t == b.t && a.op == b.op);
 
         let mut spot = collected.clone();
         let mut psot = collected.clone();

--- a/fluree-db-query/src/schema_bundle.rs
+++ b/fluree-db-query/src/schema_bundle.rs
@@ -143,6 +143,15 @@ impl SchemaBundleFlakes {
         self.epoch
     }
 
+    /// Return the projected flakes as a flat `Vec`, suitable for
+    /// feeding back into [`Self::from_collected_schema_triples`]
+    /// (e.g., to merge with another bundle). Uses the SPOT
+    /// ordering as the canonical source — sort + dedupe + index
+    /// rebuild happens inside `from_collected_schema_triples`.
+    pub fn flakes_for_merge(&self) -> Vec<Flake> {
+        self.spot.iter().cloned().collect()
+    }
+
     fn flakes(&self, index: IndexType) -> &[Flake] {
         match index {
             IndexType::Spot => &self.spot,

--- a/fluree-db-server/src/error.rs
+++ b/fluree-db-server/src/error.rs
@@ -128,6 +128,12 @@ impl ServerError {
             ServerError::Api(ApiError::Config(_)) => errors::CONFIG,
             ServerError::Api(ApiError::Format(_)) => errors::FORMAT,
 
+            // Cross-ledger model dependency failure (502). The variant
+            // is preserved in ApiError::CrossLedger so structured
+            // callers can branch on the specific failure; the `@type`
+            // surfaced here is the umbrella IRI.
+            ServerError::Api(ApiError::CrossLedger(_)) => errors::CROSS_LEDGER,
+
             // Catch any new ApiError variants as internal
             #[allow(unreachable_patterns)]
             ServerError::Api(_) => errors::INTERNAL,
@@ -189,6 +195,15 @@ impl ServerError {
             ServerError::Api(ApiError::Internal(_)) => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::Api(ApiError::Drop(_)) => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::Api(ApiError::Json(_)) => StatusCode::INTERNAL_SERVER_ERROR,
+
+            // 502 - Bad Gateway. Cross-ledger model dependency failure
+            // is conceptually an upstream-dependency error, not an
+            // internal panic — operators can distinguish "your data
+            // ledger is broken" (500) from "the model ledger this
+            // data ledger depends on is broken" (502). The wrapped
+            // CrossLedgerError variant is preserved in the JSON body
+            // so callers can branch on the specific failure.
+            ServerError::Api(ApiError::CrossLedger(_)) => StatusCode::BAD_GATEWAY,
 
             // Catch any new ApiError variants as 500
             #[allow(unreachable_patterns)]

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -1279,16 +1279,35 @@ async fn execute_transaction(
         let mut txn_opts = TxnOpts::default();
         if let Some(shapes) = body.get("opts").and_then(|o| o.get("shapes")) {
             // Validate at the boundary: `shapes` must be a JSON-LD
-            // document (object) or list of documents (array).
+            // document (object) or an array of JSON-LD documents.
             // Letting scalars / nulls fall through to
             // `fluree_graph_json_ld::expand` surfaces as a fuzzy
             // internal parse error rather than the precise 400
             // the caller deserves.
-            if !shapes.is_object() && !shapes.is_array() {
-                set_span_error_code(&span, "error:BadRequest");
-                return Err(ServerError::bad_request(
-                    "opts.shapes must be a JSON-LD object or array of objects",
-                ));
+            //
+            // For the array form, every element must itself be an
+            // object — `[42]` or `[null]` would have passed the
+            // top-level type check, then failed downstream with a
+            // confusing message that doesn't match the documented
+            // contract.
+            match shapes {
+                JsonValue::Object(_) => {}
+                JsonValue::Array(arr) => {
+                    for (idx, item) in arr.iter().enumerate() {
+                        if !item.is_object() {
+                            set_span_error_code(&span, "error:BadRequest");
+                            return Err(ServerError::bad_request(format!(
+                                "opts.shapes[{idx}] must be a JSON-LD object; got {item}"
+                            )));
+                        }
+                    }
+                }
+                _ => {
+                    set_span_error_code(&span, "error:BadRequest");
+                    return Err(ServerError::bad_request(
+                        "opts.shapes must be a JSON-LD object or array of objects",
+                    ));
+                }
             }
             txn_opts.shapes = Some(shapes.clone());
         }

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -1278,17 +1278,43 @@ async fn execute_transaction(
         // or query params); add them here if a use case lands.
         let mut txn_opts = TxnOpts::default();
         if let Some(shapes) = body.get("opts").and_then(|o| o.get("shapes")) {
+            // Validate at the boundary: `shapes` must be a JSON-LD
+            // document (object) or list of documents (array).
+            // Letting scalars / nulls fall through to
+            // `fluree_graph_json_ld::expand` surfaces as a fuzzy
+            // internal parse error rather than the precise 400
+            // the caller deserves.
+            if !shapes.is_object() && !shapes.is_array() {
+                set_span_error_code(&span, "error:BadRequest");
+                return Err(ServerError::bad_request(
+                    "opts.shapes must be a JSON-LD object or array of objects",
+                ));
+            }
             txn_opts.shapes = Some(shapes.clone());
         }
-        if let Some(unique_props) = body
-            .get("opts")
-            .and_then(|o| o.get("uniqueProperties"))
-            .and_then(|v| v.as_array())
-        {
-            let iris: Vec<String> = unique_props
-                .iter()
-                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
-                .collect();
+        if let Some(unique_props_raw) = body.get("opts").and_then(|o| o.get("uniqueProperties")) {
+            // Must be a JSON array. A scalar (or null) is a type
+            // error, not "empty list".
+            let Some(arr) = unique_props_raw.as_array() else {
+                set_span_error_code(&span, "error:BadRequest");
+                return Err(ServerError::bad_request(
+                    "opts.uniqueProperties must be an array of property IRI strings",
+                ));
+            };
+            // Every element must be a string. `filter_map` would
+            // silently drop integers/bools/etc. — that's exactly
+            // the silent-weakening pattern this PR pulls out of
+            // the rest of the governance code.
+            let mut iris: Vec<String> = Vec::with_capacity(arr.len());
+            for (idx, v) in arr.iter().enumerate() {
+                let Some(s) = v.as_str() else {
+                    set_span_error_code(&span, "error:BadRequest");
+                    return Err(ServerError::bad_request(format!(
+                        "opts.uniqueProperties[{idx}] must be a string IRI; got {v}"
+                    )));
+                };
+                iris.push(s.to_string());
+            }
             if !iris.is_empty() {
                 txn_opts.unique_properties = Some(iris);
             }

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -1272,7 +1272,14 @@ async fn execute_transaction(
             .or_else(|| author.map(String::from));
 
         // TxnOpts: unchanged by identity; commit provenance flows through CommitOpts.
-        let txn_opts = TxnOpts::default();
+        // Pick up `opts.shapes` from the body so inline SHACL shapes
+        // reach the staging path. Other TxnOpts fields are not yet
+        // surfaced over HTTP (branch/context/etc. come from headers
+        // or query params); add them here if a use case lands.
+        let mut txn_opts = TxnOpts::default();
+        if let Some(shapes) = body.get("opts").and_then(|o| o.get("shapes")) {
+            txn_opts.shapes = Some(shapes.clone());
+        }
 
         // Build and execute the transaction via the builder API.
         // Hoisted above CommitOpts assembly so we can spawn the raw-txn upload

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -1334,6 +1334,14 @@ async fn execute_transaction(
                 };
                 iris.push(s.to_string());
             }
+            // Empty array (`"uniqueProperties": []`) is intentionally
+            // treated as "no inline constraints" rather than an error
+            // — operators may build the array dynamically server-side
+            // and end up with zero entries; that's a request for no
+            // constraint enforcement, not a misconfiguration. Leaving
+            // `TxnOpts.unique_properties` as `None` keeps the staging
+            // pipeline on its fast-path (skip the inline branch
+            // entirely).
             if !iris.is_empty() {
                 txn_opts.unique_properties = Some(iris);
             }

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -1280,6 +1280,19 @@ async fn execute_transaction(
         if let Some(shapes) = body.get("opts").and_then(|o| o.get("shapes")) {
             txn_opts.shapes = Some(shapes.clone());
         }
+        if let Some(unique_props) = body
+            .get("opts")
+            .and_then(|o| o.get("uniqueProperties"))
+            .and_then(|v| v.as_array())
+        {
+            let iris: Vec<String> = unique_props
+                .iter()
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
+                .collect();
+            if !iris.is_empty() {
+                txn_opts.unique_properties = Some(iris);
+            }
+        }
 
         // Build and execute the transaction via the builder API.
         // Hoisted above CommitOpts assembly so we can spawn the raw-txn upload

--- a/fluree-db-server/tests/cross_ledger_http_integration.rs
+++ b/fluree-db-server/tests/cross_ledger_http_integration.rs
@@ -1,0 +1,177 @@
+//! HTTP-layer integration test for cross-ledger failure propagation.
+//!
+//! Verifies that `ApiError::CrossLedger` actually surfaces as HTTP 502
+//! with a structured body. The api-crate already unit-tests the
+//! `status_code() == 502` mapping; this test closes the loop through
+//! the server's `ServerError` translation and Axum response chain.
+//! A regression where the server's status-code mapping omits the
+//! `CrossLedger` arm (and silently falls back to 500) would fail
+//! here even with all api-level tests passing.
+
+use axum::body::Body;
+use fluree_db_server::routes::build_router;
+use fluree_db_server::{AppState, ServerConfig, TelemetryConfig};
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value as JsonValue};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+async fn json_body(resp: http::Response<Body>) -> (StatusCode, JsonValue) {
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let json: JsonValue =
+        serde_json::from_slice(&bytes).unwrap_or(JsonValue::Null);
+    (status, json)
+}
+
+async fn server_state() -> (TempDir, Arc<AppState>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = ServerConfig {
+        cors_enabled: false,
+        indexing_enabled: false,
+        storage_path: Some(tmp.path().to_path_buf()),
+        ..Default::default()
+    };
+    let telemetry = TelemetryConfig::with_server_config(&cfg);
+    let state = Arc::new(AppState::new(cfg, telemetry).await.expect("AppState"));
+    (tmp, state)
+}
+
+/// A query against a data ledger whose `#config` declares
+/// `f:policySource` with a cross-ledger `f:ledger` pointing at a
+/// model ledger that does not exist on this instance must return
+/// HTTP 502, NOT 500. The body must carry the structured
+/// `err:system/CrossLedgerError` error_type so clients can branch.
+#[tokio::test]
+async fn query_under_cross_ledger_config_to_missing_model_returns_502() {
+    let (_tmp, state) = server_state().await;
+
+    let data_id = "test/xledger-http/data:main";
+    let model_id = "test/xledger-http/never-created:main";
+    let policy_graph_iri = "http://example.org/missing-policies";
+
+    // Create D through the HTTP layer. The model ledger is
+    // intentionally never created — the missing dependency is
+    // exactly what we're proving the server reports.
+    let create_resp = build_router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"ledger": data_id}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), StatusCode::CREATED, "create D");
+
+    // Seed D's data + cross-ledger config in one TriG transaction so
+    // the config that points at the missing model lands atomically.
+    let config_iri = format!("urn:fluree:{data_id}#config");
+    let trig = format!(
+        r#"
+        @prefix f:    <https://ns.flur.ee/db#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex:   <http://example.org/ns/> .
+
+        ex:alice rdf:type ex:User ; ex:name "Alice" .
+
+        GRAPH <{config_iri}> {{
+            <urn:cfg:main> rdf:type f:LedgerConfig .
+            <urn:cfg:main> f:policyDefaults <urn:cfg:policy> .
+            <urn:cfg:policy> f:defaultAllow true .
+            <urn:cfg:policy> f:policyClass f:AccessPolicy .
+            <urn:cfg:policy> f:policySource <urn:cfg:policy-ref> .
+            <urn:cfg:policy-ref> rdf:type f:GraphRef ;
+                                 f:graphSource <urn:cfg:policy-src> .
+            <urn:cfg:policy-src> f:ledger <{model_id}> ;
+                                 f:graphSelector <{policy_graph_iri}> .
+        }}
+    "#
+    );
+    let upsert_resp = build_router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/upsert/{data_id}"))
+                .header("content-type", "application/trig")
+                .body(Body::from(trig))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let upsert_status = upsert_resp.status();
+    let (_, upsert_body) = json_body(upsert_resp).await;
+    assert!(
+        upsert_status.is_success(),
+        "upsert TriG (data + config) should succeed; got {upsert_status}, body: {upsert_body}"
+    );
+
+    // --- query D. The cross-ledger config routes through
+    // resolve_graph_ref, which fails with ModelLedgerMissing since
+    // the model ledger was never created. That lifts through
+    // ApiError::CrossLedger and (this is what we're testing) the
+    // server should translate it to HTTP 502.
+    //
+    // The JSON-LD query route only engages policy enforcement when
+    // the request carries `opts.identity`, `opts.policy-class`, or
+    // `opts.policy` (see `has_policy_opts` in routes/query.rs). The
+    // server injects `fluree-policy-class` headers into
+    // `opts.policy-class`, so sending that header is the minimal
+    // way to engage the policy path without a credential. Setting
+    // it to `f:AccessPolicy` also matches the default class the
+    // cross-ledger filter applies, so the materialized restrictions
+    // would actually be enforced if the model ledger existed —
+    // here the missing-model surface is the failure mode we want
+    // to observe.
+    //
+    // Whether config-only policy should auto-engage without an
+    // explicit policy header is a separate concern from this slice;
+    // this test pins the 502 mapping, not that auto-engagement.
+    let query = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "select": "?u",
+        "where": {"@id": "?u", "@type": "ex:User"}
+    });
+    let resp = build_router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/query/{data_id}"))
+                .header("content-type", "application/json")
+                .header("fluree-policy-class", "https://ns.flur.ee/db#AccessPolicy")
+                .body(Body::from(query.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let (status, body) = json_body(resp).await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_GATEWAY,
+        "cross-ledger model missing must surface as 502 Bad Gateway, \
+         not 500 Internal Server Error. Body: {body}"
+    );
+
+    // Structured body shape: status echoes 502, @type names the
+    // cross-ledger error category, and the error message mentions
+    // the missing model ledger by id so operators can locate it
+    // without spelunking logs.
+    assert_eq!(body["status"], 502);
+    assert_eq!(body["@type"], "err:system/CrossLedgerError");
+    let msg = body["error"].as_str().unwrap_or("");
+    assert!(
+        msg.contains(model_id),
+        "error message must name the missing model ledger '{model_id}', got: {msg}"
+    );
+}

--- a/fluree-db-server/tests/cross_ledger_http_integration.rs
+++ b/fluree-db-server/tests/cross_ledger_http_integration.rs
@@ -26,8 +26,7 @@ async fn json_body(resp: http::Response<Body>) -> (StatusCode, JsonValue) {
         .await
         .expect("collect body")
         .to_bytes();
-    let json: JsonValue =
-        serde_json::from_slice(&bytes).unwrap_or(JsonValue::Null);
+    let json: JsonValue = serde_json::from_slice(&bytes).unwrap_or(JsonValue::Null);
     (status, json)
 }
 

--- a/fluree-db-transact/src/ir.rs
+++ b/fluree-db-transact/src/ir.rs
@@ -482,6 +482,27 @@ pub struct TxnOpts {
     /// prefer `f:shapesSource`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shapes: Option<serde_json::Value>,
+
+    /// Inline `f:enforceUnique` declarations for *this transaction only*.
+    ///
+    /// Each entry is a property IRI (full IRI; not compact prefix
+    /// form) that the uniqueness enforcer should treat as
+    /// `f:enforceUnique true` for the duration of this transaction.
+    /// IRIs the data ledger's namespace map has never seen are
+    /// dropped silently — no instance of the property exists on D,
+    /// so no constraint can be violated. The list is unioned with
+    /// whatever `f:constraintsSource` resolves to (same-ledger or
+    /// cross-ledger) and never replaces it.
+    ///
+    /// Inline constraints do not persist into the ledger. The next
+    /// transaction without `opts.uniqueProperties` runs without
+    /// them (same trade-off as `opts.shapes`).
+    ///
+    /// Use cases: enforce a constraint for an ad-hoc bulk-load
+    /// without committing the annotation to `#config`; per-tenant
+    /// uniqueness layered on top of operator-set baselines.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unique_properties: Option<Vec<String>>,
 }
 
 impl TxnOpts {

--- a/fluree-db-transact/src/ir.rs
+++ b/fluree-db-transact/src/ir.rs
@@ -460,6 +460,28 @@ pub struct TxnOpts {
     /// the transaction JSON, defaulting to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strict_compact_iri: Option<bool>,
+
+    /// Inline SHACL shape definitions for *this transaction only*.
+    ///
+    /// JSON-LD document carrying SHACL shapes (sh:NodeShape /
+    /// sh:targetClass / sh:property / ...). When set, the shapes are
+    /// parsed at SHACL validation time against the staged namespace
+    /// registry and added to the engine's shape source list — they
+    /// enforce additively alongside any same-ledger or cross-ledger
+    /// shapes configured via `f:shapesSource`. The shapes themselves
+    /// are not staged into the data ledger; they exist only for this
+    /// transaction's validation pass.
+    ///
+    /// Use cases: ad-hoc shape testing before committing to `#config`,
+    /// per-tenant validation layers, application-level shape governance
+    /// that should not live in the ledger's permanent state.
+    ///
+    /// Trade-off vs same-ledger shapes: inline shapes leave no audit
+    /// trail in the ledger ("which shapes validated which commit?"
+    /// can't be reconstructed from history). If auditability matters,
+    /// prefer `f:shapesSource`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shapes: Option<serde_json::Value>,
 }
 
 impl TxnOpts {

--- a/fluree-db-transact/src/lib.rs
+++ b/fluree-db-transact/src/lib.rs
@@ -43,7 +43,7 @@ pub mod namespace;
 pub mod parse;
 pub mod raw_txn_upload;
 pub mod stage;
-mod value_convert;
+pub mod value_convert;
 
 #[cfg(feature = "import")]
 pub mod import;

--- a/fluree-db-transact/src/namespace.rs
+++ b/fluree-db-transact/src/namespace.rs
@@ -154,6 +154,22 @@ impl NamespaceRegistry {
         self.codes.get_code(prefix)
     }
 
+    /// Look up the `Sid` for an IRI without allocating a fresh
+    /// namespace code if the prefix is new. Returns `None` when the
+    /// IRI's prefix is unknown to this registry.
+    ///
+    /// Use this from cross-ledger governance translation paths where
+    /// allocating a code for an IRI the data ledger has never seen
+    /// would be churn — the corresponding governance triple should
+    /// just be dropped, because the data ledger has no data of that
+    /// IRI for the governance assertion to apply against.
+    pub fn lookup_sid_for_iri(&self, iri: &str) -> Option<fluree_db_core::Sid> {
+        let (prefix, suffix) =
+            fluree_db_core::ns_encoding::canonical_split(iri, self.split_mode());
+        let code = self.codes.get_code(prefix)?;
+        Some(fluree_db_core::Sid::new(code, suffix))
+    }
+
     /// Look up a prefix by code
     pub fn get_prefix(&self, code: u16) -> Option<&str> {
         self.codes.get_prefix(code)

--- a/fluree-db-transact/src/namespace.rs
+++ b/fluree-db-transact/src/namespace.rs
@@ -164,8 +164,7 @@ impl NamespaceRegistry {
     /// just be dropped, because the data ledger has no data of that
     /// IRI for the governance assertion to apply against.
     pub fn lookup_sid_for_iri(&self, iri: &str) -> Option<fluree_db_core::Sid> {
-        let (prefix, suffix) =
-            fluree_db_core::ns_encoding::canonical_split(iri, self.split_mode());
+        let (prefix, suffix) = fluree_db_core::ns_encoding::canonical_split(iri, self.split_mode());
         let code = self.codes.get_code(prefix)?;
         Some(fluree_db_core::Sid::new(code, suffix))
     }

--- a/fluree-db-transact/src/value_convert.rs
+++ b/fluree-db-transact/src/value_convert.rs
@@ -158,6 +158,107 @@ pub(crate) fn convert_string_literal(
     (fv, dt_sid)
 }
 
+/// Parse a typed XSD-style lexical form into the matching
+/// `FlakeValue` variant, *without* touching the namespace
+/// allocator. Used by surfaces that already hold a resolved
+/// datatype Sid (e.g., the cross-ledger SHACL translator) and
+/// need same-ledger-parity parsing for SHACL `sh:hasValue` /
+/// range comparisons.
+///
+/// Return values:
+/// - `Ok(Some(fv))` — recognized XSD (or `rdf:JSON`) datatype
+///   parsed successfully.
+/// - `Err(msg)` — recognized datatype whose lexical form is
+///   invalid (e.g., `"abc"^^xsd:integer`). Callers should
+///   surface this as a hard error rather than silently
+///   coerce to `FlakeValue::String`.
+/// - `Ok(None)` — datatype IRI is not in the XSD / RDF /
+///   Fluree-recognized set. Callers store the value as
+///   `FlakeValue::String` and preserve the declared datatype
+///   Sid; the application is responsible for interpreting
+///   non-recognized datatypes.
+///
+/// `rdf:langString` is intentionally NOT handled here — the
+/// language tag rides on `FlakeMeta`, not on the FlakeValue,
+/// so the caller has to construct the meta separately and the
+/// value is just a plain string.
+pub fn parse_xsd_lexical(value: &str, dt_iri: &str) -> Result<Option<FlakeValue>, String> {
+    Ok(Some(match dt_iri {
+        xsd::STRING | xsd::NORMALIZED_STRING | xsd::TOKEN | xsd::LANGUAGE | xsd::ANY_URI => {
+            FlakeValue::String(value.to_string())
+        }
+        xsd::INTEGER
+        | xsd::LONG
+        | xsd::INT
+        | xsd::SHORT
+        | xsd::BYTE
+        | xsd::UNSIGNED_LONG
+        | xsd::UNSIGNED_INT
+        | xsd::UNSIGNED_SHORT
+        | xsd::UNSIGNED_BYTE
+        | xsd::NON_NEGATIVE_INTEGER
+        | xsd::POSITIVE_INTEGER
+        | xsd::NON_POSITIVE_INTEGER
+        | xsd::NEGATIVE_INTEGER => match parse_integer(value) {
+            FlakeValue::String(_) => {
+                return Err(format!("invalid {dt_iri} lexical `{value}`"));
+            }
+            other => other,
+        },
+        xsd::DOUBLE | xsd::FLOAT => value
+            .parse::<f64>()
+            .map(FlakeValue::Double)
+            .map_err(|e| format!("invalid {dt_iri} lexical `{value}`: {e}"))?,
+        xsd::DECIMAL => value
+            .parse::<bigdecimal::BigDecimal>()
+            .map(|d| FlakeValue::Decimal(Box::new(d)))
+            .map_err(|e| format!("invalid xsd:decimal lexical `{value}`: {e}"))?,
+        xsd::BOOLEAN => match value {
+            "true" | "1" => FlakeValue::Boolean(true),
+            "false" | "0" => FlakeValue::Boolean(false),
+            _ => return Err(format!("invalid xsd:boolean lexical `{value}`")),
+        },
+        xsd::DATE_TIME => DateTime::parse(value)
+            .map(|dt| FlakeValue::DateTime(Box::new(dt)))
+            .map_err(|e| format!("invalid xsd:dateTime lexical `{value}`: {e}"))?,
+        xsd::DATE => Date::parse(value)
+            .map(|d| FlakeValue::Date(Box::new(d)))
+            .map_err(|e| format!("invalid xsd:date lexical `{value}`: {e}"))?,
+        xsd::TIME => Time::parse(value)
+            .map(|t| FlakeValue::Time(Box::new(t)))
+            .map_err(|e| format!("invalid xsd:time lexical `{value}`: {e}"))?,
+        xsd::G_YEAR => GYear::parse(value)
+            .map(|v| FlakeValue::GYear(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:gYear lexical `{value}`: {e}"))?,
+        xsd::G_YEAR_MONTH => GYearMonth::parse(value)
+            .map(|v| FlakeValue::GYearMonth(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:gYearMonth lexical `{value}`: {e}"))?,
+        xsd::G_MONTH => GMonth::parse(value)
+            .map(|v| FlakeValue::GMonth(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:gMonth lexical `{value}`: {e}"))?,
+        xsd::G_DAY => GDay::parse(value)
+            .map(|v| FlakeValue::GDay(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:gDay lexical `{value}`: {e}"))?,
+        xsd::G_MONTH_DAY => GMonthDay::parse(value)
+            .map(|v| FlakeValue::GMonthDay(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:gMonthDay lexical `{value}`: {e}"))?,
+        xsd::DURATION => Duration::parse(value)
+            .map(|v| FlakeValue::Duration(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:duration lexical `{value}`: {e}"))?,
+        xsd::DAY_TIME_DURATION => DayTimeDuration::parse(value)
+            .map(|v| FlakeValue::DayTimeDuration(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:dayTimeDuration lexical `{value}`: {e}"))?,
+        xsd::YEAR_MONTH_DURATION => YearMonthDuration::parse(value)
+            .map(|v| FlakeValue::YearMonthDuration(Box::new(v)))
+            .map_err(|e| format!("invalid xsd:yearMonthDuration lexical `{value}`: {e}"))?,
+        rdf::JSON => FlakeValue::Json(value.to_string()),
+        // Non-XSD / non-Fluree-recognized datatype. Caller treats
+        // the value as a plain string under the (already-registered)
+        // application datatype Sid.
+        _ => return Ok(None),
+    }))
+}
+
 /// Parse an integer string into FlakeValue::Long or FlakeValue::BigInt.
 pub(crate) fn parse_integer(value: &str) -> FlakeValue {
     if let Ok(n) = value.parse::<i64>() {

--- a/fluree-vocab/src/errors.rs
+++ b/fluree-vocab/src/errors.rs
@@ -174,6 +174,15 @@ pub const INDEXING_DISABLED: &str = "err:system/IndexingDisabled";
 /// Reindex conflict
 pub const REINDEX_CONFLICT: &str = "err:system/ReindexConflict";
 
+/// Cross-ledger model dependency could not be resolved or used.
+///
+/// Surfaces from `f:GraphRef` with `f:ledger` pointing at a model
+/// ledger that is missing, retracted, structurally broken, or
+/// otherwise unable to provide the requested governance artifact.
+/// Mapped to HTTP 502 since this is an upstream-dependency
+/// failure rather than an internal server error.
+pub const CROSS_LEDGER: &str = "err:system/CrossLedgerError";
+
 // =============================================================================
 // Helper Functions
 // =============================================================================

--- a/fluree-vocab/src/lib.rs
+++ b/fluree-vocab/src/lib.rs
@@ -1740,6 +1740,16 @@ pub mod policy_iris {
     /// `https://ns.flur.ee/db#policyClass` - policy class marker
     pub const POLICY_CLASS: &str = "https://ns.flur.ee/db#policyClass";
 
+    /// `https://ns.flur.ee/db#AccessPolicy` - canonical / baseline
+    /// policy class IRI. Subjects typed exactly as this are
+    /// included in the default cross-ledger materialization set
+    /// when no `f:policyClass` filter is configured, and form the
+    /// implicit policy class on the same-ledger path. Hard-coded
+    /// references existed in `cross_ledger::policy_materializer`
+    /// and `view::fluree_ext`; promoted here so the IRI lives in
+    /// the vocab module like the rest of the policy vocab.
+    pub const ACCESS_POLICY: &str = "https://ns.flur.ee/db#AccessPolicy";
+
     /// `https://ns.flur.ee/db#allow` - allow/deny flag
     pub const ALLOW: &str = "https://ns.flur.ee/db#allow";
 


### PR DESCRIPTION
# Cross-ledger governance + inline opts for every subsystem

Closes the matrix of `(subsystem × scope)` for every `f:GraphRef`-shaped governance predicate in Fluree: every subsystem now supports same-graph, same-ledger named-graph, cross-ledger, and inline-opts routing.

## Matrix

| Subsystem | Inline (opts) | Same graph (default) | Same ledger (named) | Cross ledger (`f:ledger`) |
|---|---|---|---|---|
| Policy | ✓ `opts.policy` (+ `policy_class`, `policy_values`) | ✓ | ✓ | ✓ |
| Constraints (`f:enforceUnique`) | ✓ `opts.uniqueProperties` *(NEW)* | ✓ | ✓ | ✓ |
| Schema / reasoning | ✓ top-level `ontology` *(NEW)* | ✓ | ✓ | ✓ (single graph) |
| Shapes (SHACL) | ✓ `opts.shapes` *(NEW)* | ✓ | ✓ | ✓ *(NEW)* |
| Rules (datalog) | ✓ top-level `rules` | ✓ | ✓ *(NEW)* | ✓ *(NEW)* |

## What this PR adds

### Cross-ledger contract (shared)

- `fluree-db-api/src/cross_ledger/` — new module: `ResolveCtx`,  `resolver`, per-`ArtifactKind` materializers (policy / constraints  / schema / shapes / rules), `GovernanceCache` (per-`Fluree` Moka), term-neutral wire types, per-request memo + cycle  detection.
- A single `ResolveCtx` per logical request — threaded across `wrap_policy → query` (carried on `GraphDb.cross_ledger_resolved_ts`)  and per-tx across SHACL + constraints — so policy, reasoning,  and constraints on the same model ledger observe the same  `resolved_t`.
- `CrossLedgerError` taxonomy: `ModelLedgerMissing`,  `ReservedGraphSelected`, `GraphMissingAtT`, `TranslationFailed`,  `UnsupportedFeature` (atT / trustPolicy / rollbackGuard), `CycleDetected`. `ApiError::CrossLedger` → HTTP 502 (upstream  dependency failure).
- Reserved-graph rejection: `f:defaultGraph` resolves to `g_id=0`, `f:txnMetaGraph` rejects as `ReservedGraphSelected` *before* any  I/O on M.
- Fail-closed throughout: misconfigured same-ledger `f:rulesSource` (unknown selector, reserved dimensions) errors loudly at `db()` load; malformed cross-ledger rule JSON errors at parse rather than silently weakening governance.

### Per-subsystem cross-ledger materializers

Each follows the same shape: open M at `resolved_t`, project the relevant predicates against the in-flight `GovernanceArtifact` wire form, translate on D against the appropriate term context (snapshot or staged ns_registry).

- `policy_materializer.rs` — `PolicyArtifactWire` carries IRI-form  restrictions; `policy_class` filter (defaulting to `{f:AccessPolicy}`) intersected at the wire boundary.
- `constraints_materializer.rs` — `ConstraintsArtifactWire` carries property IRIs; translator → Sid set unioned with  config-resolved.
- `schema_materializer.rs` — `SchemaArtifactWire` carries the  schema whitelist (rdfs:subClassOf / subPropertyOf / domain /  range, owl:* axioms, rdf:type owl:Class / TransitiveProperty …) projected from M.
- `shapes_materializer.rs` — `ShapesArtifactWire` carries SHACL whitelist + `rdf:first/rest` for `sh:in / and / or / xone`  lists; *must* compile against D's staged namespace registry (post-stage, not the pre-stage snapshot) so IRIs the in-flight
  tx introduced are encodable. Documented in  `memory/inline_shapes_path.md`.
- `rules_materializer.rs` — `RulesArtifactWire` carries raw JSON  bodies (rules are inherently term-portable JSON-LD); merged into `ReasoningModes::rules` at query prep.

### Same-ledger gaps filled

- `f:rulesSource` was parsed by the config layer but ignored at query time. Now: `EffectiveDatalogConfig.rules_source` is resolved at `Fluree::resolve_and_attach_config` into `GraphDb.rules_source_g_id`, threaded through `ReasoningConfig.rules_source_g_id` → `compute_derived_facts` → `extract_datalog_rules` (which builds a `GraphDbRef` at the override g_id for the `f:rule` scan; the fixpoint still executes against the query graph).
- `enforce_unique_after_staging` factored to also enforce when  config is absent but inline `opts.uniqueProperties` is supplied.

### Inline opts (new fields)

- `TxnOpts.shapes: Option<JsonValue>` — JSON-LD SHACL shapes parsed via `FlakeSink` against staged ns_registry; layered as an additional `SchemaBundleOverlay` on `shape_dbs` alongside same-/cross-ledger sources. `fluree-db-api/src/inline_shapes.rs`.
- `TxnOpts.unique_properties: Option<Vec<String>>` — property IRIs unioned into every affected graph; unknown IRIs drop silently (no instance → no violation).
- `ReasoningModes.ontology: Option<JsonValue>` (top-level `"ontology"` on JSON-LD queries) — RDFS / OWL axioms parsed via `FlakeSink` against a per-request `NamespaceRegistry` clone; merged with the configured schemaSource bundle via `inline_ontology::merge_bundles`. `fluree-db-api/src/inline_ontology.rs`.

### HTTP wiring

- `routes/transact.rs::execute_transaction` pulls `body["opts"]["shapes"]` and `body["opts"]["uniqueProperties"]` into `TxnOpts` so REST clients use the new fields through the standard transaction body.
- Top-level `"ontology"` and `"rules"` on JSON-LD queries flow through the existing parser.

## Notable design decisions (preserved in `docs/design/cross-ledger-model-enforcement.md`)

- **Wire artifacts are term-neutral** — IRIs not Sids, so M-Sids  never leak into D's term space.
- **Resolve at the API boundary; inject artifact; keep downstream source-agnostic** — SHACL / constraints / policy code paths don't know whether a source was local or cross-ledger.
- **`f:atT` rejected until Phase 3** — lazy per-request `resolved_t` capture is the only producer today, so the head-t observed by the first reference is the version everything in the request enforces.
- **HTTP 502 for cross-ledger** — upstream dependency, not 400 (caller error) or 500 (internal).

## Out of scope (intentional)

- **Transitive `owl:imports` across model ledgers.** Cross-ledger schema projects axioms from one M graph; imports inside M's schema graph are followed locally but not across ledger boundaries. Acceptable: the ontology can live in a different  ledger from the instance data, just not span multiple ledgers via imports.
- **Cross-instance Fluree references** — the resolver requires the model and data ledgers be hosted by the same `Fluree` instance; cross-instance lookup would need a separate fetch layer.
- **Inline policy bundles at query time on cross-ledger configs with `opts.identity`** — explicitly rejected as `ApiError::config` (ambiguous: M contributes rules, D would need to contribute the identity binding). Use `opts.policy_class` instead.

## Docs

- `docs/design/cross-ledger-model-enforcement.md` — full design (resolver contract, term-space translation, cache shape, failure taxonomy, identity-mode contract).
- `docs/security/cross-ledger-policy.md` — user how-to covering all five subsystems.
- `docs/ledger-config/setting-groups.md` — `f:ledger` column  reflects full coverage.
- `docs/guides/cookbook-shacl.md` — new "Inline shapes per transaction" section.
- `docs/ledger-config/unique-constraints.md` — new "Inline `opts.uniqueProperties` per transaction" section.
- `docs/query/reasoning.md` — new "Inline ontology per query" section.

### New integration tests

| File | Tests |
|---|---|
| `it_cross_ledger_resolver.rs` | 11 — distinct-ns-codes canary, single-resolution-t, memo & cycle keys, error variants. |
| `it_policy_cross_ledger.rs` | 6 — model-ledger deny policy enforced on D, policy_class filtering (both sides), default `{f:AccessPolicy}`, identity-mode rejection. |
| `it_constraints_cross_ledger.rs` | 2 — cross-ledger `f:enforceUnique` translated against D. |
| `it_constraints_inline.rs` | 4 — inline `opts.uniqueProperties` rejects duplicate, accepts unique, doesn't persist, drops unknown IRI silently. |
| `it_shapes_cross_ledger.rs` | 2 — staged-namespace compilation of cross-ledger SHACL. |
| `it_shapes_inline.rs` | 4 — inline `opts.shapes` rejects/accepts/transient/layered-with-cross-ledger. |
| `it_rules_source.rs` | 4 — same-ledger `f:rulesSource` honored / negative control / fail-loud on misconfig (unknown IRI, `f:atT`). |
| `it_rules_cross_ledger.rs` | 5 — cross-ledger rule derives result on D, `f:defaultGraph` selector works, `f:txnMetaGraph` rejected, missing model ledger → `ApiError::CrossLedger`, malformed JSON fails closed (unit). |
| `it_ontology_inline.rs` | 2 — inline `rdfs:subClassOf` drives RDFS entailment, axioms don't persist. |
| `cross_ledger_http_integration.rs` (server) | 1 — HTTP 502 for cross-ledger errors. |
