### PR TITLE
feat: drop_named_graph + `fluree graph` CLI (list, drop)

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1168,6 +1168,26 @@ mem:fact-01km06dhjzpgyvbs1yc5h0h28e a mem:Fact ;
     mem:branch "feature/default-context" ;
     mem:createdAt "2026-03-18T10:03:48.703812+00:00"^^xsd:dateTime .
 
+mem:decision-01krvht9hdmca3m5j1rz761g46 a mem:Decision ;
+    mem:content "`Fluree::drop_named_graph(ledger_id, graph_iri)` is a **transactional, history-preserving, per-branch** retract: it stages a SPARQL `DELETE { GRAPH <iri> { ?s ?p ?o } } WHERE { GRAPH <iri> { ?s ?p ?o } }` through `stage(&handle).txn(...)` and produces one normal commit. System graphs (default, txn-meta g_id=1, config g_id=2) are rejected with 400; unknown graph IRIs return 404 *before* staging so the registry isn't silently extended. `graph_iri` must be an absolute IRI per `validate_absolute_iri` (no whitespace, no C0/DEL controls, no RFC 3987-excluded chars, `<scheme>:<rest>` head). Idempotent: re-dropping an empty graph reports `committed=false`, `retracted=0` without creating a commit. Wire endpoint: `POST /drop-graph` admin-protected; CLI: `fluree graph drop <iri> --ledger <id> [--remote]`; companion read-only `fluree graph list` reads `named-graphs` from `/info`." ;
+    mem:tag "admin" ;
+    mem:tag "api-design" ;
+    mem:tag "drop" ;
+    mem:tag "named-graph" ;
+    mem:tag "transactional" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/api/endpoints.md" ;
+    mem:artifactRef "docs/cli/graph.md" ;
+    mem:artifactRef "docs/cli/server-integration.md" ;
+    mem:artifactRef "fluree-db-api/src/admin.rs" ;
+    mem:artifactRef "fluree-db-api/tests/it_drop_named_graph.rs" ;
+    mem:artifactRef "fluree-db-cli/src/commands/graph.rs" ;
+    mem:artifactRef "fluree-db-server/src/routes/ledger.rs" ;
+    mem:branch "feature/drop-branch" ;
+    mem:createdAt "2026-05-17T18:05:17.741794+00:00"^^xsd:dateTime ;
+    mem:rationale "Named-graph data is interleaved in the same index/leaves/dicts as the rest of the ledger — there is no storage prefix to wipe the way drop_branch/drop_ledger do. A transactional retract is the only approach that composes cleanly with branches, rebases, replication, and Fluree's immutable history model. Alternative: structural drop + reindex (rejected as a needless rewrite of history)." ;
+    mem:alternatives "structural drop with graph_registry mark + reindex skip; soft/hard mode like drop_ledger" .
+
 mem:fact-01kjg3zmevnz6mdn53wkqn08p0 a mem:Fact ;
     mem:content "Fluree uses CIDv1 for all content-addressed blobs. Implementation in fluree-db-core/src/content_id.rs wrapping `cid` crate.\n\nFormat: CIDv1 = version(1) + multicodec + multihash(SHA2-256, 32 bytes). Multicodec values in private-use range 0x300000+: Commit(0x300001), Txn(0x300002), IndexRoot(0x300003), IndexBranch/Leaf, DictBlob, Garbage, LedgerConfig, StatsSketch, GraphSourceSnapshot, SpatialIndex.\n\nKey APIs: ContentId::new(kind, bytes) hashes with SHA-256; verify(bytes) re-hashes and compares (NOT valid for commit-v2 which excludes trailing hash+sig); digest_hex() returns 64-char hex; Display uses base32-lower multibase." ;
     mem:tag "CIDv1" ;

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
   - [info](cli/info.md)
   - [branch](cli/branch.md)
   - [drop](cli/drop.md)
+  - [graph](cli/graph.md)
   - [insert](cli/insert.md)
   - [upsert](cli/upsert.md)
   - [update](cli/update.md)

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1584,6 +1584,82 @@ curl -X POST http://localhost:8090/v1/fluree/drop-branch \
   -d '{"ledger": "mydb", "branch": "dev"}'
 ```
 
+### POST /drop-graph
+
+Drop a single named graph from one branch of a ledger by transactionally
+retracting every triple currently asserted under that graph IRI. The drop
+runs as a normal commit at `t = current_t + 1` — history at earlier `t`
+values is preserved. Admin-protected.
+
+**URL:**
+```
+POST /drop-graph
+```
+
+**Request body:**
+
+```json
+{
+  "ledger": "mydb:main",
+  "graph": "urn:example:org/payroll"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ledger` | string | Yes | Full ledger identifier. A bare ledger name (`"mydb"`) is normalized to `"mydb:main"`. |
+| `graph` | string | Yes | Full **absolute** IRI of the named graph to drop. Must have a `<scheme>:<rest>` head (relative references like `payroll` are rejected) and contain no whitespace or RFC 3987-excluded characters. Leading/trailing whitespace is rejected, not trimmed. |
+
+**Response body (200 OK):**
+
+```json
+{
+  "ledger_id": "mydb:main",
+  "graph_iri": "urn:example:org/payroll",
+  "retracted": 42,
+  "committed": true,
+  "t": 18
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ledger_id` | string | Normalized `ledger:branch` identifier the drop targeted |
+| `graph_iri` | string | Graph IRI that was dropped (echoed) |
+| `retracted` | integer | Number of flakes retracted by the drop commit; `0` for a no-op |
+| `committed` | boolean | `true` when a new commit was produced; `false` for a no-op drop on an empty graph |
+| `t` | integer | Current commit `t` for the branch after the drop |
+
+**Behavior:**
+
+- **Transactional and history-preserving.** A query `as-of` an earlier `t` still sees the graph populated.
+- **Per-branch.** Only affects the targeted branch — sibling branches that share the same graph IRI are not touched.
+- **Refuses system graphs.** The default graph, `urn:fluree:{ledger_id}#txn-meta`, and `urn:fluree:{ledger_id}#config` cannot be dropped (400 Bad Request).
+- **Refuses unknown graphs.** Returns 404 when `graph` is not registered in the ledger's graph registry — the call never auto-registers a new graph slot.
+- **Idempotent.** A second call on an already-empty graph returns `committed: false`, `retracted: 0` without producing a commit.
+
+**Status codes:**
+
+- `200 OK` - Drop succeeded (commit produced or no-op)
+- `400 Bad Request` - Malformed IRI, empty IRI, or system-graph IRI
+- `401`/`403` - Admin token required and absent/invalid
+- `404 Not Found` - Ledger or graph IRI not found
+- `500 Internal Server Error` - Server error
+
+**Examples:**
+
+```bash
+# Drop a named graph on the default branch
+curl -X POST http://localhost:8090/v1/fluree/drop-graph \
+  -H "Content-Type: application/json" \
+  -d '{"ledger": "mydb", "graph": "urn:example:org/payroll"}'
+
+# Drop on a non-default branch
+curl -X POST http://localhost:8090/v1/fluree/drop-graph \
+  -H "Content-Type: application/json" \
+  -d '{"ledger": "mydb:feature-x", "graph": "http://example.org/graphs/scratch"}'
+```
+
 ### POST /rebase
 
 Rebase a branch onto its source branch's current HEAD. Admin-protected.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -54,6 +54,7 @@ fluree query 'SELECT ?name WHERE { ?s <http://example.org/name> ?name }'
 | [`list`](list.md) | List all ledgers |
 | [`info`](info.md) | Show detailed information about a ledger |
 | [`drop`](drop.md) | Drop (delete) a ledger |
+| [`graph`](graph.md) | Manage named graphs within a ledger (list, drop) |
 | [`insert`](insert.md) | Insert data into a ledger |
 | [`upsert`](upsert.md) | Upsert data (insert or update existing) |
 | [`update`](update.md) | Update with WHERE/DELETE/INSERT patterns |

--- a/docs/cli/drop.md
+++ b/docs/cli/drop.md
@@ -71,6 +71,36 @@ error: drop_ledger drops the whole ledger and does not accept a non-default
        branch, or pass "mydb" to drop the whole ledger.
 ```
 
+## Dropping a single named graph
+
+To drop just one **named graph** inside a ledger (without removing the
+ledger, the branch, or any other graph), use `fluree graph drop`:
+
+```bash
+# Drop one named graph (active ledger, default branch)
+fluree graph drop urn:example:org/payroll
+
+# Drop on a specific ledger / branch
+fluree graph drop urn:example:org/payroll --ledger mydb
+fluree graph drop http://example.org/graphs/scratch --ledger mydb:feature-x
+
+# Drop via a tracked remote server
+fluree graph drop urn:example:org/payroll --ledger mydb --remote origin
+```
+
+Unlike `fluree drop`, `fluree graph drop` is **transactional and history-
+preserving**: it produces a normal commit at `t = current + 1` whose
+flakes retract every triple currently asserted in the graph, leaves the
+graph IRI registered (so subsequent inserts land in the same graph slot),
+and lets queries `as-of` an earlier `t` still see the dropped data.
+
+The graph IRI must be an absolute IRI (e.g. `urn:...`, `http://...`).
+The default graph and the system graphs (`urn:fluree:{ledger_id}#txn-meta`
+and `urn:fluree:{ledger_id}#config`) cannot be dropped.
+
+To see what graphs exist on a ledger, use `fluree graph list` (or look
+at the `named-graphs` section of `fluree info <ledger>`).
+
 ## See Also
 
 - [create](create.md) - Create a new ledger

--- a/docs/cli/graph.md
+++ b/docs/cli/graph.md
@@ -1,0 +1,125 @@
+# fluree graph
+
+Manage **named graphs** within a single branch of a ledger.
+
+Named graphs are created implicitly: the first time you transact a triple under a new graph IRI (via TriG `GRAPH <iri> { ... }`, JSON-LD `@graph` with an `@id`, or SPARQL `INSERT DATA { GRAPH <iri> { ... } }`), the graph is registered and assigned a deterministic `g_id`. There is no separate "create graph" command — `fluree graph` only exposes the operations that don't fall out of `insert` / `upsert` / `update` for free.
+
+## Subcommands
+
+### fluree graph list
+
+List the user-defined named graphs registered on a branch.
+
+**Usage:**
+
+```bash
+fluree graph list [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--ledger <LEDGER>` | Ledger identifier (e.g. `mydb` or `mydb:feature-x`). Defaults to the active ledger. |
+| `--remote <REMOTE>` | List graphs on a remote server by remote name (e.g. `origin`). |
+| `--json` | Emit the filtered `named-graphs` JSON array instead of a table. |
+| `--include-system` | Include the default graph and the system `txn-meta` / `config` graphs. Off by default. |
+
+**Description:**
+
+Reads the `named-graphs` section of the standard `info` payload for the targeted branch — no new endpoint is required. By default, the output is restricted to user-defined graphs (`g_id >= 3`); pass `--include-system` to also surface the default graph (`g_id 0`), `txn-meta` (`g_id 1`), and `config` (`g_id 2`).
+
+Each row reports the graph IRI, kind (`user`, `default`, `system:txn-meta`, `system:config`), `g_id`, current flake count, and on-disk size.
+
+**Auto-routing:** like other read commands, `fluree graph list` auto-routes through a running local `fluree server` if one is up, or through the tracked remote when the active ledger has a `track` config. Pass `--direct` to bypass auto-routing and read from the local store, or `--remote <name>` to force a specific remote.
+
+**Examples:**
+
+```bash
+# Active ledger, user graphs only
+fluree graph list
+
+# Specific ledger / branch
+fluree graph list --ledger mydb:feature-x
+
+# Remote
+fluree graph list --ledger mydb --remote origin
+
+# JSON output including system graphs
+fluree graph list --ledger mydb --include-system --json
+```
+
+### fluree graph drop
+
+Drop a single named graph from one branch by transactionally retracting every triple currently asserted in it.
+
+**Usage:**
+
+```bash
+fluree graph drop <IRI> [OPTIONS]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<IRI>` | Full absolute IRI of the named graph to drop (e.g. `urn:example:org/payroll`). |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--ledger <LEDGER>` | Ledger identifier. Defaults to the active ledger. |
+| `--remote <REMOTE>` | Execute against a remote server by remote name. |
+
+**Description:**
+
+`fluree graph drop` is **transactional and history-preserving**:
+
+- The drop produces one new commit at `t = current + 1` whose flakes are retractions of every triple currently asserted under the target graph IRI.
+- A query `as-of` an earlier `t` (e.g. via `--at t:<N>`, `--at-time`, or a dataset `TimeSpec`) still sees the graph populated.
+- The graph IRI keeps its `g_id`; a subsequent insert into the same IRI lands in the same logical graph rather than a new slot.
+- Drops are per-branch — sibling branches that share the same graph IRI are not touched.
+- Idempotent: re-running the drop on an already-empty graph reports `committed: false`, `retracted: 0` and produces no new commit.
+
+The following are rejected with a clear error (no commit is produced):
+
+- The **default graph** — refuses an empty IRI, since the default graph cannot be dropped.
+- The **system graphs** — `urn:fluree:{ledger_id}#txn-meta` and `urn:fluree:{ledger_id}#config`.
+- **Relative references** — `<IRI>` must be an absolute IRI with a valid `<scheme>:<rest>` head (e.g. `urn:...`, `http://...`).
+- **Whitespace / control characters / RFC 3987-excluded characters** — leading/trailing whitespace is rejected, not silently trimmed.
+- **Unknown graph IRIs** — return a 404-shaped "not registered" error; the registry is never silently extended by a drop.
+
+**Examples:**
+
+```bash
+# Drop on the active ledger
+fluree graph drop urn:example:org/payroll
+
+# Specific ledger or branch
+fluree graph drop urn:example:org/payroll --ledger mydb
+fluree graph drop http://example.org/graphs/scratch --ledger mydb:feature-x
+
+# Via a tracked remote server
+fluree graph drop urn:example:org/payroll --ledger mydb --remote origin
+```
+
+**Output (committed):**
+
+```
+Dropped graph <urn:example:org/payroll> from 'mydb:main' — retracted 42 flakes (t=18).
+```
+
+**Output (no-op):**
+
+```
+Graph <urn:example:org/payroll> in 'mydb:main' was already empty — no commit produced (t=17).
+```
+
+## See Also
+
+- [drop](drop.md) — drop a whole ledger or graph source
+- [branch](branch.md) — branch management (drop, list, rebase, merge, diff)
+- [info](info.md) — full ledger info, including the underlying `named-graphs` payload
+- [Datasets and named graphs](../concepts/datasets-and-named-graphs.md) — concept doc
+- [server-integration](server-integration.md) — wire contract for custom servers (`POST /drop-graph`, `GET /info`)

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -147,6 +147,28 @@ Same admin auth bracket as `/create`, `/drop`, `/reindex`. See
 Same admin auth bracket as `/create`, `/drop`, `/reindex`. See
 [Branch Drop Contract](#branch-drop-contract).
 
+### `fluree graph drop --remote <name>` (admin-protected)
+
+- `POST {api_base_url}/drop-graph` with `{ ledger, graph }`
+
+Drops a single named graph from one branch of a ledger by transactionally
+retracting every triple currently asserted in it. History is preserved —
+queries `as-of` an earlier `t` still see the graph populated. The graph IRI
+remains registered so it can be re-populated by a later insert. Refuses the
+default graph and the system `txn-meta` / `config` graphs. Same admin auth
+bracket as `/create`, `/drop`, `/reindex`. See
+[Drop Named Graph Contract](#drop-named-graph-contract).
+
+### `fluree graph list` (read-only)
+
+- `GET {api_base_url}/info/*ledger`
+
+Lists the user-defined named graphs registered on the targeted branch by
+parsing the `named-graphs` section of the standard `/info` response. No
+new endpoint is required. The CLI hides the default graph and the system
+`txn-meta` / `config` graphs by default; `--include-system` surfaces them
+alongside user graphs. See [Graph List Contract](#graph-list-contract).
+
 ### `fluree branch rebase --remote <name>` (admin-protected)
 
 - `POST {api_base_url}/rebase` with `{ ledger, branch, strategy? }`
@@ -663,6 +685,162 @@ The CLI's `print_branch_dropped` reads `ledger_id`, `deferred`,
 | Underlying API | `fluree_db_api::Fluree::drop_branch` (`fluree-db-api/src/admin.rs`) |
 | Report struct | `fluree_db_api::BranchDropReport` |
 
+## Graph List Contract
+
+`fluree graph list --ledger <ledger> [--remote <name>] [--include-system] [--json]` does **not** call a dedicated endpoint. It reuses:
+
+```
+GET {api_base_url}/info/*ledger
+```
+
+and parses the `named-graphs` array out of the response. Servers that already implement the [`/info` Response Contract](#info-response-contract-cli-minimum) below are compatible with `fluree graph list` as long as they populate that array.
+
+### Auth
+
+Read-only. Same auth bracket as `GET /info/*ledger`.
+
+### Required response field
+
+The CLI requires `info.ledger.named-graphs` (or top-level `named-graphs` for older response shapes) to be a JSON array. Each entry must be a JSON object with at least:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `iri` | string | Full IRI of the named graph. Use `"urn:default"` for the default graph slot (`g-id = 0`) so the CLI can recognize it and filter it under `--include-system`. |
+| `g-id` | integer | Stable graph identifier in the registry. `0` = default, `1` = `urn:fluree:{ledger_id}#txn-meta`, `2` = `urn:fluree:{ledger_id}#config`, `>= 3` = user-defined graphs. |
+| `flakes` | integer | Number of currently-asserted flakes in this graph at the response's `t`. May be `0`. |
+| `size` | integer | On-disk size in bytes attributed to this graph in the binary index. May be `0`. |
+
+Additional fields are allowed and ignored by the CLI. Returning a stable order is recommended for paginated UIs but not required by the CLI.
+
+### CLI filtering
+
+The CLI's table and `--json` output both apply the same filter:
+
+- By default, entries with `g-id ∈ {0, 1, 2}` or `iri == "urn:default"` or `iri` equal to the ledger's `txn-meta` / `config` IRI are **omitted**.
+- `--include-system` shows all four kinds (default, `txn-meta`, `config`, user).
+
+The table view computes a `Kind` column from `g-id` plus the well-known IRI helpers in `fluree_db_core::graph_registry`.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `401` | Bearer required and absent/invalid (same as `/info`). |
+| `404` | Ledger does not exist. |
+| `5xx` | Storage / nameservice errors. |
+
+A response that omits `named-graphs` is treated by the CLI as an outdated server; it prints a clear "info response is missing `named-graphs`" usage error rather than silently showing an empty list.
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route | `fluree-db-server/src/routes/ledger.rs::info_ledger_tail` |
+| Payload assembly | `fluree-db-api/src/ledger_info.rs::build_ledger_info` (populates `named-graphs`) |
+| CLI dispatcher | `fluree-db-cli/src/commands/graph.rs::run_list` |
+| System-graph constants | `fluree_db_core::graph_registry::{DEFAULT_GRAPH_ID, TXN_META_GRAPH_ID, CONFIG_GRAPH_ID, txn_meta_graph_iri, config_graph_iri}` |
+
+## Drop Named Graph Contract
+
+`fluree graph drop <graph-iri> --ledger <ledger> --remote <name>` issues:
+
+```
+POST {api_base_url}/drop-graph
+Content-Type: application/json
+
+{
+  "ledger": "mydb:main",
+  "graph": "urn:example:org/payroll"
+}
+```
+
+Note the endpoint is `/drop-graph` (hyphenated) — separate from the
+ledger-level `POST /drop` and branch-level `POST /drop-branch` endpoints.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ledger` | string | Yes | Full ledger identifier. A bare ledger name (`"mydb"`) is normalized to `"mydb:main"`. To target a branch other than the root, use the explicit `"mydb:feature-x"` form. |
+| `graph` | string | Yes | Full **absolute** IRI of the named graph to drop. Must have a valid `<scheme>:<rest>` head per RFC 3986 §3.1 and contain none of the characters RFC 3987 excludes from an IRI (whitespace, `<`, `>`, `"`, `{`, `}`, <code>&#124;</code>, `\`, `^`, `` ` ``). Relative references (e.g. `payroll`) and leading/trailing whitespace are rejected — not trimmed. |
+
+### Auth
+
+Admin-protected (same bracket as `/create`, `/drop`, `/drop-branch`,
+`/branch`, `/rebase`, `/merge`, `/reindex`).
+
+### Behavior
+
+The reference server's `Fluree::drop_named_graph`:
+
+1. **Normalizes** the ledger id (`:main` default).
+2. **Validates** the graph IRI as an absolute IRI (`<scheme>:<rest>` with
+   no whitespace or RFC 3987-excluded characters), then rejects the system
+   graphs:
+   - the default graph (empty / `g_id == 0`),
+   - the `txn-meta` graph (`urn:fluree:{ledger_id}#txn-meta`, `g_id == 1`),
+   - the `config` graph (`urn:fluree:{ledger_id}#config`, `g_id == 2`).
+3. **Resolves** `graph` against the snapshot's `GraphRegistry`. An unknown
+   IRI returns `404` rather than silently registering a new graph slot.
+4. **Stages and commits** a SPARQL UPDATE equivalent to
+   `DELETE { GRAPH <iri> { ?s ?p ?o } } WHERE { GRAPH <iri> { ?s ?p ?o } }`
+   through the same pipeline used by user updates. This produces one new
+   commit at `t = current_t + 1` whose flakes are retractions only.
+5. **Reports a no-op** (`committed: false`, `retracted: 0`) when the graph
+   was already empty — no new commit is created.
+
+Key properties:
+
+- **History preserving.** A query `as-of` an earlier `t` still sees every
+  triple that was previously asserted in the graph.
+- **Per-branch scope.** Drops only affect the branch in `ledger`. Sibling
+  branches that share the same graph IRI are not touched.
+- **Registry stable.** The graph IRI keeps its `g_id`; a subsequent
+  insert into the same IRI lands in the same logical graph rather than a
+  new slot.
+
+### Response (`200 OK`)
+
+```jsonc
+{
+  "ledger_id": "mydb:main",
+  "graph_iri": "urn:example:org/payroll",
+  "retracted": 42,
+  "committed": true,
+  "t": 18
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ledger_id` | string | Normalized `ledger:branch` identifier the drop targeted. |
+| `graph_iri` | string | Graph IRI that was dropped (echoed). |
+| `retracted` | integer | Number of flakes retracted by the drop commit. `0` when the graph was already empty. |
+| `committed` | bool | `true` when a new commit was produced; `false` for a no-op drop on an empty graph. |
+| `t` | integer | Current commit `t` for the branch after the drop. Equal to the pre-drop `t` when `committed` is `false`. |
+
+The CLI's `fluree graph drop` printer (`commands/graph.rs`) reads
+`ledger_id`, `graph_iri`, `retracted`, `committed`, and `t` — populate
+them all.
+
+### Error responses
+
+| Status | When |
+|--------|------|
+| `400` | `graph` is empty, has whitespace or any IRI-excluded character, lacks a `<scheme>:<rest>` head (relative reference), or names a system graph (default, `txn-meta`, `config`); malformed JSON body. |
+| `401` / `403` | Admin token required and absent/invalid. |
+| `404` | Ledger does not exist; or `graph` is not registered in the ledger's graph registry. |
+| `5xx` | Storage / nameservice / commit-write errors during the retract commit. |
+
+### Reference implementation
+
+| Concern | Canonical location |
+|---------|-------------------|
+| HTTP route + auth | `fluree-db-server/src/routes/ledger.rs::drop_named_graph` |
+| Request / response shapes | `DropNamedGraphRequest`, `DropNamedGraphResponse` (same file) |
+| Underlying API | `fluree_db_api::Fluree::drop_named_graph` (`fluree-db-api/src/admin.rs`) |
+| Absolute-IRI validator | `validate_absolute_iri` (same file) |
+| Report struct | `fluree_db_api::DropNamedGraphReport` |
+| Graph registry | `fluree_db_core::graph_registry` (system graph constants and IRI helpers) |
+
 ## Rebase Contract
 
 `fluree branch rebase <branch> --remote <name>` issues:
@@ -938,6 +1116,7 @@ The CLI currently treats `GET {api_base_url}/info/*ledger` as an opaque JSON obj
 
 - `t` (integer): required for `fluree clone` and `fluree pull` preflight and for `fluree push` conflict checks.
 - `commitId` (string CID): required for `fluree push` when `t > 0` so it can detect divergence.
+- `ledger.named-graphs` (array): required for `fluree graph list`. See the [Graph List Contract](#graph-list-contract) for the per-entry schema (`iri`, `g-id`, `flakes`, `size`). A top-level `named-graphs` array is also accepted for older response shapes; new implementations should nest it under `ledger`.
 
 Other fields are optional and may be used only for display.
 

--- a/docs/concepts/datasets-and-named-graphs.md
+++ b/docs/concepts/datasets-and-named-graphs.md
@@ -253,6 +253,19 @@ WHERE {
 }
 ```
 
+### Creation is implicit
+
+There is no "create graph" operation. The first transaction that targets a new graph IRI — via TriG, JSON-LD with `@graph`, or SPARQL `INSERT … GRAPH <iri> …` — registers it and assigns a stable `g_id` (3+ for user graphs). Subsequent inserts into the same IRI land in the same registered slot.
+
+### Listing and dropping graphs
+
+Two CLI commands cover the rest of the lifecycle:
+
+- **[`fluree graph list`](../cli/graph.md#fluree-graph-list)** — lists user graphs registered on a branch (with `--include-system` to also show the default and system graphs). Reads the `named-graphs` section of the standard `/info` response.
+- **[`fluree graph drop`](../cli/graph.md#fluree-graph-drop)** — transactionally retracts every triple currently asserted under a named graph. Produces one new commit at `t + 1` whose flakes are all retractions; history at older `t` values is preserved, and the graph IRI keeps its `g_id` so future inserts land in the same slot. Drops are per-branch.
+
+The default graph, `urn:fluree:{ledger_id}#txn-meta`, and `urn:fluree:{ledger_id}#config` cannot be dropped. The Rust API entry point is `Fluree::drop_named_graph(ledger_id, graph_iri)`; over HTTP it is `POST /v1/fluree/drop-graph` (admin-protected). See the [server-integration contract](../cli/server-integration.md#drop-named-graph-contract) for the wire details.
+
 ### Graph Metadata
 
 For transaction-scoped metadata, Fluree uses the **`txn-meta`** named graph (see above). Transaction metadata is stored as properties on commit subjects in `txn-meta`, and can be queried independently of user data.

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -107,6 +107,36 @@ pub struct GraphSourceDropReport {
     pub warnings: Vec<String>,
 }
 
+/// Report of a `drop_named_graph` call.
+///
+/// Named-graph drops are **transactional**: they produce a normal commit that
+/// retracts every triple currently asserted in `graph_iri` at the time the
+/// drop runs. History is preserved — queries `as-of` an earlier `t` still see
+/// the graph populated; only HEAD-time queries see it empty. The graph IRI
+/// remains registered so it can be re-populated by a later insert.
+///
+/// `retracted` and `committed` together describe the outcome:
+/// - graph existed and had data → `retracted > 0`, `committed = true`
+/// - graph existed but was already empty → `retracted = 0`, `committed = false`
+/// - graph IRI was unknown → the call returns `ApiError::NotFound` instead of
+///   producing a report.
+#[derive(Debug, Clone, Default)]
+pub struct DropNamedGraphReport {
+    /// Full `ledger:branch` identifier the drop targeted.
+    pub ledger_id: String,
+    /// Graph IRI that was dropped (echoed for clarity).
+    pub graph_iri: String,
+    /// Number of flakes retracted by the drop commit. `0` if the graph was
+    /// already empty (no commit was produced in that case).
+    pub retracted: usize,
+    /// Whether a new commit was created. `false` when there was nothing to
+    /// retract and the call was a no-op.
+    pub committed: bool,
+    /// Current commit `t` for the branch after the drop. Equal to the
+    /// pre-drop `t` when `committed = false`.
+    pub t: i64,
+}
+
 /// Report of a branch drop operation
 #[derive(Debug, Clone, Default)]
 pub struct BranchDropReport {
@@ -216,6 +246,129 @@ pub struct IndexStatusResult {
 /// Otherwise, `:main` is appended as the default branch.
 fn normalize_ledger_id(ledger_id: &str) -> String {
     fluree_db_core::normalize_ledger_id(ledger_id).unwrap_or_else(|_| ledger_id.to_string())
+}
+
+/// Validate that `value` is an absolute IRI suitable for admin lookup.
+///
+/// This is intentionally a minimal check, not a full RFC 3987 parser. It
+/// enforces only the properties the admin path actually needs:
+///
+/// - No leading/trailing whitespace, and no whitespace anywhere in the
+///   value (preserves caller-exact identity in error messages).
+/// - None of the characters RFC 3987 excludes from an IRI
+///   (`<`, `>`, `"`, `{`, `}`, `|`, `\`, `^`, `` ` ``).
+/// - A valid `<scheme>:<rest>` head per RFC 3986 §3.1: `scheme` starts
+///   with ALPHA and contains only ALPHA / DIGIT / `+` / `-` / `.`,
+///   `rest` is non-empty.
+///
+/// Returns the error message to surface as `400` on failure.
+fn validate_absolute_iri(value: &str) -> std::result::Result<(), String> {
+    if value.is_empty() {
+        return Err("graph IRI is required and cannot be empty".to_string());
+    }
+    // RFC 3987 excludes whitespace, C0 controls (`U+0000..=U+001F`), DEL
+    // (`U+007F`), and the bracket/quote characters below. The C0 check is
+    // important because callers can otherwise sneak a ` ` past
+    // `is_whitespace` and have it surface as a SPARQL parse 500 instead
+    // of the documented 400.
+    if value.chars().any(|c| {
+        matches!(c, '<' | '>' | '"' | '{' | '}' | '|' | '\\' | '^' | '`')
+            || c.is_whitespace()
+            || c <= '\u{20}'
+            || c == '\u{7F}'
+    }) {
+        return Err(format!(
+            "Invalid graph IRI '{value}': contains whitespace, a control character, \
+             or a character not allowed in an IRI \
+             (one of `<`, `>`, `\"`, `{{`, `}}`, `|`, `\\`, `^`, `` ` ``)"
+        ));
+    }
+    // `<scheme>:<rest>` per RFC 3986 §3.1.
+    let (scheme, rest) = value.split_once(':').ok_or_else(|| {
+        format!("Invalid graph IRI '{value}': missing scheme (expected an absolute IRI like 'urn:...' or 'http://...')")
+    })?;
+    let mut sc = scheme.chars();
+    let first = sc
+        .next()
+        .ok_or_else(|| format!("Invalid graph IRI '{value}': scheme is empty"))?;
+    if !first.is_ascii_alphabetic() {
+        return Err(format!(
+            "Invalid graph IRI '{value}': scheme must start with an ASCII letter"
+        ));
+    }
+    if !sc.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')) {
+        return Err(format!(
+            "Invalid graph IRI '{value}': scheme contains a character outside ALPHA / DIGIT / '+' / '-' / '.'"
+        ));
+    }
+    if rest.is_empty() {
+        return Err(format!(
+            "Invalid graph IRI '{value}': scheme is followed by an empty body"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod validate_absolute_iri_tests {
+    use super::validate_absolute_iri;
+
+    #[test]
+    fn accepts_typical_iris() {
+        assert!(validate_absolute_iri("http://example.org/g").is_ok());
+        assert!(validate_absolute_iri("https://example.org/path?x=1").is_ok());
+        assert!(validate_absolute_iri("urn:example:org/payroll").is_ok());
+        assert!(validate_absolute_iri("urn:fluree:mydb:main#config").is_ok());
+        assert!(validate_absolute_iri("ftp://example.org").is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_absolute_iri("").is_err());
+    }
+
+    #[test]
+    fn rejects_relative_iri() {
+        assert!(validate_absolute_iri("payroll").is_err());
+        assert!(validate_absolute_iri("/absolute/path").is_err());
+        assert!(validate_absolute_iri("ex:").is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace() {
+        assert!(validate_absolute_iri(" http://example.org").is_err());
+        assert!(validate_absolute_iri("http://example.org ").is_err());
+        assert!(validate_absolute_iri("http://example.org/with space").is_err());
+        assert!(validate_absolute_iri("http://example.org\n").is_err());
+    }
+
+    #[test]
+    fn rejects_disallowed_iri_characters() {
+        for bad in ['<', '>', '"', '{', '}', '|', '\\', '^', '`'] {
+            assert!(
+                validate_absolute_iri(&format!("http://example.org/{bad}")).is_err(),
+                "should reject {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_c0_and_del_controls() {
+        for cp in [0u32, 0x01, 0x09, 0x0A, 0x0D, 0x1F, 0x7F] {
+            let c = char::from_u32(cp).unwrap();
+            assert!(
+                validate_absolute_iri(&format!("http://example.org/{c}")).is_err(),
+                "should reject control U+{cp:04X}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bad_scheme() {
+        assert!(validate_absolute_iri("1http://example.org").is_err());
+        assert!(validate_absolute_iri("ht_tp://example.org").is_err());
+        assert!(validate_absolute_iri(":nopath").is_err());
+    }
 }
 
 /// Parse a `drop_ledger` input.
@@ -613,6 +766,174 @@ impl crate::Fluree {
             "Branch dropped"
         );
         Ok(report)
+    }
+
+    /// Drop a named graph from a single branch by retracting every triple
+    /// currently asserted under `graph_iri`.
+    ///
+    /// This is a **transactional** drop: it produces one normal commit at
+    /// `t = current_t + 1` whose flakes are all retractions of the graph's
+    /// current contents. History is preserved — a query `as-of` an earlier
+    /// `t` still sees the graph populated. The graph IRI remains registered
+    /// so it can be re-populated by a later insert.
+    ///
+    /// # Arguments
+    ///
+    /// * `ledger_id` - Full ledger identifier (`"mydb"` is normalized to
+    ///   `"mydb:main"`). The drop only affects the targeted branch.
+    /// * `graph_iri` - Full IRI of the named graph to drop (matched exactly
+    ///   against the ledger's graph registry).
+    ///
+    /// # Restrictions
+    ///
+    /// The following graph identifiers are **always** rejected with
+    /// `ApiError::Http(400)`:
+    /// - The default graph (`graph_iri` is empty or refers to g_id 0).
+    /// - The system `txn-meta` graph (`urn:fluree:{ledger_id}#txn-meta`,
+    ///   g_id 1).
+    /// - The system `config` graph (`urn:fluree:{ledger_id}#config`, g_id 2).
+    ///
+    /// An unknown user graph IRI (one that is not in the ledger's graph
+    /// registry) returns `ApiError::NotFound`.
+    ///
+    /// # Behavior
+    ///
+    /// 1. Normalizes the ledger id (`":main"` default).
+    /// 2. Resolves `graph_iri` against the snapshot's `GraphRegistry`.
+    /// 3. Builds a `DELETE { GRAPH <iri> { ?s ?p ?o } } WHERE { ... }`
+    ///    transaction and stages it through the same pipeline used by user
+    ///    SPARQL updates.
+    /// 4. If the WHERE matches zero flakes (graph already empty), no commit
+    ///    is produced and `committed = false` is reported.
+    ///
+    /// # Errors
+    ///
+    /// - `ApiError::Http(400)` — `graph_iri` is empty, malformed, or names a
+    ///   protected system graph.
+    /// - `ApiError::NotFound` — the ledger does not exist, or `graph_iri` is
+    ///   not registered in this ledger's graph registry.
+    pub async fn drop_named_graph(
+        &self,
+        ledger_id: &str,
+        graph_iri: &str,
+    ) -> Result<DropNamedGraphReport> {
+        use fluree_db_core::graph_registry::{
+            config_graph_iri, txn_meta_graph_iri, CONFIG_GRAPH_ID, DEFAULT_GRAPH_ID,
+            TXN_META_GRAPH_ID,
+        };
+        use fluree_db_transact::{NamespaceRegistry, TxnOpts};
+
+        let bad_request = |msg: String| ApiError::Http {
+            status: 400,
+            message: msg,
+        };
+
+        if graph_iri.is_empty() {
+            return Err(bad_request(
+                "graph IRI is required and cannot drop the default graph".to_string(),
+            ));
+        }
+        // The CLI / HTTP contract is "full graph IRI". We enforce that
+        // exactly here so an accidentally trimmed value or a relative
+        // reference that happens to match a registry entry can't slip
+        // through. `validate_absolute_iri` rejects whitespace, the
+        // characters RFC 3987 excludes from an IRI, and any value
+        // lacking a proper `<scheme>:<rest>` head.
+        validate_absolute_iri(graph_iri).map_err(bad_request)?;
+
+        let ledger_id = normalize_ledger_id(ledger_id);
+
+        // Reject system graphs purely by IRI shape — this catches the case
+        // even on ledgers whose registry was seeded permissively without
+        // the config graph (legacy roots).
+        if graph_iri == txn_meta_graph_iri(&ledger_id) {
+            return Err(bad_request(format!(
+                "Cannot drop the txn-meta system graph '{graph_iri}'"
+            )));
+        }
+        if graph_iri == config_graph_iri(&ledger_id) {
+            return Err(bad_request(format!(
+                "Cannot drop the config system graph '{graph_iri}'"
+            )));
+        }
+
+        info!(ledger_id = %ledger_id, graph_iri = %graph_iri, "Dropping named graph");
+
+        let handle = self.ledger_cached(&ledger_id).await?;
+        let pre_drop_t = handle.t().await;
+        let view = handle.snapshot().await;
+        let snapshot = &view.snapshot;
+
+        let g_id = snapshot
+            .graph_registry
+            .graph_id_for_iri(graph_iri)
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Named graph '{graph_iri}' is not registered in ledger '{ledger_id}'"
+                ))
+            })?;
+
+        // Belt-and-suspenders: a registry built from a non-standard root could
+        // theoretically map a user-supplied IRI to a system slot. Refuse it.
+        if matches!(g_id, DEFAULT_GRAPH_ID | TXN_META_GRAPH_ID | CONFIG_GRAPH_ID) {
+            return Err(bad_request(format!(
+                "Cannot drop system graph '{graph_iri}' (g_id={g_id})"
+            )));
+        }
+
+        // Build and lower the SPARQL DELETE. We use the explicit
+        // `DELETE { GRAPH <g> { ... } } WHERE { GRAPH <g> { ... } }` form
+        // because `DELETE WHERE` does not yet support GRAPH blocks.
+        let sparql = format!(
+            "DELETE {{ GRAPH <{graph_iri}> {{ ?s ?p ?o }} }} \
+             WHERE {{ GRAPH <{graph_iri}> {{ ?s ?p ?o }} }}"
+        );
+        let parsed = fluree_db_sparql::parse_sparql(&sparql);
+        if parsed.has_errors() {
+            return Err(ApiError::internal(format!(
+                "drop_named_graph: SPARQL parse failed for graph IRI '{graph_iri}': {:?}",
+                parsed.diagnostics
+            )));
+        }
+        let ast = parsed.ast.ok_or_else(|| {
+            ApiError::internal("drop_named_graph: SPARQL parser returned no AST".to_string())
+        })?;
+
+        let mut ns_registry = NamespaceRegistry::from_db(snapshot);
+        let txn =
+            fluree_db_transact::lower_sparql_update_ast(&ast, &mut ns_registry, TxnOpts::default())
+                .map_err(|e| {
+                    ApiError::internal(format!(
+                        "drop_named_graph: failed to lower SPARQL update: {e}"
+                    ))
+                })?;
+        drop(view);
+
+        let result = self.stage(&handle).txn(txn).execute().await?;
+        let retracted = result.receipt.flake_count;
+        let committed = retracted > 0;
+        let new_t = if committed {
+            result.receipt.t
+        } else {
+            pre_drop_t
+        };
+
+        info!(
+            ledger_id = %ledger_id,
+            graph_iri = %graph_iri,
+            retracted,
+            committed,
+            t = new_t,
+            "Named graph dropped",
+        );
+
+        Ok(DropNamedGraphReport {
+            ledger_id,
+            graph_iri: graph_iri.to_string(),
+            retracted,
+            committed,
+            t: new_t,
+        })
     }
 
     /// Cancel indexing, delete storage artifacts, purge nameservice record,

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -268,10 +268,7 @@ pub async fn build_ledger_info_with_options<S: Storage + Clone>(
     let mut result = Map::new();
 
     // 1. Ledger block (ledger-wide metadata)
-    result.insert(
-        "ledger".to_string(),
-        build_ledger_block(ledger, &stats, binary_store.as_deref()),
-    );
+    result.insert("ledger".to_string(), build_ledger_block(ledger, &stats));
 
     // 2. Graph name
     result.insert("graph".to_string(), json!(graph_name));
@@ -408,11 +405,7 @@ fn graph_display_name(g_id: GraphId, store: Option<&BinaryIndexStore>) -> String
 // ============================================================================
 
 /// Build the `ledger` block with ledger-wide metadata.
-fn build_ledger_block(
-    ledger: &LedgerState,
-    stats: &IndexStats,
-    store: Option<&BinaryIndexStore>,
-) -> JsonValue {
+fn build_ledger_block(ledger: &LedgerState, stats: &IndexStats) -> JsonValue {
     let index_t = ledger
         .ns_record
         .as_ref()
@@ -434,10 +427,18 @@ fn build_ledger_block(
             .unwrap_or((0, 0))
     };
 
-    // Build named-graphs list (include per-graph flakes/size when available).
-    // The "iri" is the full graph IRI, usable directly in FROM / FROM NAMED clauses.
+    // Build the `named-graphs` list from the **live** `GraphRegistry` on the
+    // snapshot, not from the binary index store. The registry is updated at
+    // commit-apply time, so it includes graphs registered since the last
+    // index build (and stays correct for ledgers with no index at all).
+    // `flakes` / `size` still come from `IndexStats.graphs` when available
+    // and fall back to `0` when no per-graph stats are present.
+    //
+    // The `"iri"` value is the full graph IRI, usable directly in
+    // FROM / FROM NAMED clauses.
     let mut named_graphs = Vec::new();
-    // Always include default graph
+    // Always include the default graph (g_id=0). The registry does not
+    // store an IRI for it, so we synthesize `urn:default` here.
     let (default_flakes, default_size) = graph_totals(0);
     named_graphs.push(json!({
         "iri": "urn:default",
@@ -445,17 +446,17 @@ fn build_ledger_block(
         "flakes": default_flakes,
         "size": default_size,
     }));
-    // Add named graphs from binary store (including txn-meta and config)
-    if let Some(store) = store {
-        for (g_id, iri) in store.graph_entries() {
-            let (flakes, size) = graph_totals(g_id);
-            named_graphs.push(json!({
-                "iri": iri,
-                "g-id": g_id,
-                "flakes": flakes,
-                "size": size,
-            }));
-        }
+    // Then every registered graph (txn-meta at g_id=1, config at g_id=2,
+    // user-defined at g_id>=3). `iter_entries` is dense and ordered by
+    // g_id, so the response is deterministic.
+    for (g_id, iri) in ledger.snapshot.graph_registry.iter_entries() {
+        let (flakes, size) = graph_totals(g_id);
+        named_graphs.push(json!({
+            "iri": iri,
+            "g-id": g_id,
+            "flakes": flakes,
+            "size": size,
+        }));
     }
 
     json!({

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -91,6 +91,7 @@ pub mod search;
 pub use admin::{
     BranchDropReport,
     DropMode,
+    DropNamedGraphReport,
     DropReport,
     DropStatus,
     GraphSourceDropReport,

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -455,6 +455,7 @@ async fn drop_branch_leaf() {
         .unwrap();
     let report = fluree.drop_branch("mydb", "dev").await.unwrap();
 
+    assert_eq!(report.status, fluree_db_api::DropStatus::Dropped);
     assert!(!report.deferred, "leaf branch should not be deferred");
     assert_eq!(report.ledger_id, "mydb:dev");
 
@@ -462,6 +463,48 @@ async fn drop_branch_leaf() {
     let branches = fluree.list_branches("mydb").await.unwrap();
     let names: Vec<&str> = branches.iter().map(|r| r.branch.as_str()).collect();
     assert_eq!(names, vec!["main"]);
+}
+
+/// A second `drop_branch` on the same branch must report
+/// `DropStatus::AlreadyRetracted` (not silently re-report `Dropped`).
+/// The CLI relies on this to render a "no-op" message instead of
+/// claiming a successful drop the second time.
+#[tokio::test]
+async fn drop_branch_is_idempotent_already_retracted() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let txn = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [{"@id": "ex:seed", "ex:val": 1}]
+    });
+    fluree.insert(ledger, &txn).await.unwrap();
+
+    // Create a child off "dev" so the first drop on "dev" is forced into
+    // the deferred / soft-retract path. That preserves the nameservice
+    // record (retracted = true) and lets a second drop_branch observe it.
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    fluree
+        .create_branch("mydb", "feature", Some("dev"), None)
+        .await
+        .unwrap();
+
+    let first = fluree.drop_branch("mydb", "dev").await.unwrap();
+    assert_eq!(first.status, fluree_db_api::DropStatus::Dropped);
+    assert!(
+        first.deferred,
+        "drop with children must defer (record kept, retracted = true)"
+    );
+
+    let second = fluree.drop_branch("mydb", "dev").await.unwrap();
+    assert_eq!(
+        second.status,
+        fluree_db_api::DropStatus::AlreadyRetracted,
+        "second drop must observe the retracted record and report AlreadyRetracted",
+    );
 }
 
 /// Cannot drop the root branch. "main" is the default, so dropping it on a

--- a/fluree-db-api/tests/it_drop_named_graph.rs
+++ b/fluree-db-api/tests/it_drop_named_graph.rs
@@ -1,0 +1,367 @@
+//! Drop named graph integration tests.
+//!
+//! `drop_named_graph` is a transactional retract: it produces one normal
+//! commit at `t = current + 1` whose flakes are retractions of every
+//! triple currently asserted in the target graph. History at earlier `t`
+//! values is preserved.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::genesis_ledger;
+
+const ALPHA_IRI: &str = "http://example.org/graphs/alpha";
+const BETA_IRI: &str = "http://example.org/graphs/beta";
+
+/// Insert a default-graph triple plus one triple each into graphs alpha and beta.
+/// Returns the post-insert commit `t`.
+async fn seed_two_graphs(fluree: &fluree_db_api::Fluree, ledger_id: &str) -> i64 {
+    let ledger = genesis_ledger(fluree, ledger_id);
+    let trig = format!(
+        r#"
+        @prefix ex: <http://example.org/> .
+
+        ex:default-subject ex:p "default-graph-value" .
+
+        GRAPH <{ALPHA_IRI}> {{
+            ex:alice ex:name "Alice" .
+            ex:alice ex:role "engineer" .
+        }}
+
+        GRAPH <{BETA_IRI}> {{
+            ex:bob ex:name "Bob" .
+        }}
+        "#,
+    );
+
+    let result = fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("seed insert");
+    result.receipt.t
+}
+
+async fn count_in_graph(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+    graph_iri: Option<&str>,
+) -> i64 {
+    let from = match graph_iri {
+        Some(iri) => format!("{ledger_id}#{iri}"),
+        None => ledger_id.to_string(),
+    };
+    // Return the (s, p, o) rows, then count them on the client side. Avoids
+    // depending on the exact shape of aggregate `select` projections in
+    // JSON-LD queries.
+    let q = json!({
+        "from": from,
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let result = fluree.query_connection(&q).await.expect("query connection");
+    let ledger = fluree.ledger(ledger_id).await.expect("load ledger");
+    let rows = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    rows.as_array().map(|arr| arr.len() as i64).unwrap_or(0)
+}
+
+#[tokio::test]
+async fn drop_named_graph_retracts_only_target_graph() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/basic:main";
+
+    let pre_drop_t = seed_two_graphs(&fluree, ledger_id).await;
+    assert_eq!(pre_drop_t, 1);
+
+    // Sanity: each graph has expected counts before the drop.
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(ALPHA_IRI)).await, 2);
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(BETA_IRI)).await, 1);
+    assert_eq!(count_in_graph(&fluree, ledger_id, None).await, 1);
+
+    let report = fluree
+        .drop_named_graph(ledger_id, ALPHA_IRI)
+        .await
+        .expect("drop alpha");
+
+    assert_eq!(report.ledger_id, ledger_id);
+    assert_eq!(report.graph_iri, ALPHA_IRI);
+    assert_eq!(report.retracted, 2, "should retract both alpha triples");
+    assert!(report.committed, "non-empty graph drop produces a commit");
+    assert_eq!(report.t, pre_drop_t + 1);
+
+    // Alpha is empty at HEAD; beta and default are untouched.
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(ALPHA_IRI)).await, 0);
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(BETA_IRI)).await, 1);
+    assert_eq!(count_in_graph(&fluree, ledger_id, None).await, 1);
+}
+
+#[tokio::test]
+async fn drop_named_graph_is_idempotent_when_empty() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/idempotent:main";
+
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let first = fluree
+        .drop_named_graph(ledger_id, ALPHA_IRI)
+        .await
+        .expect("first drop");
+    assert!(first.committed);
+    assert_eq!(first.retracted, 2);
+
+    let second = fluree
+        .drop_named_graph(ledger_id, ALPHA_IRI)
+        .await
+        .expect("second drop");
+    assert_eq!(second.retracted, 0);
+    assert!(!second.committed, "no-op drop must not produce a commit");
+    assert_eq!(
+        second.t, first.t,
+        "no-op drop should report the unchanged t"
+    );
+}
+
+#[tokio::test]
+async fn drop_named_graph_rejects_default_graph() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/default:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let err = fluree
+        .drop_named_graph(ledger_id, "")
+        .await
+        .expect_err("empty IRI must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("default") || msg.contains("required"),
+        "error should mention default graph: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn drop_named_graph_rejects_txn_meta_graph() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/txn-meta:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let txn_meta_iri = fluree_db_core::graph_registry::txn_meta_graph_iri(ledger_id);
+    let err = fluree
+        .drop_named_graph(ledger_id, &txn_meta_iri)
+        .await
+        .expect_err("txn-meta drop must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("txn-meta"),
+        "error should mention txn-meta: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn drop_named_graph_rejects_config_graph() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/config:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let config_iri = fluree_db_core::graph_registry::config_graph_iri(ledger_id);
+    let err = fluree
+        .drop_named_graph(ledger_id, &config_iri)
+        .await
+        .expect_err("config drop must be rejected");
+    let msg = format!("{err}");
+    assert!(msg.contains("config"), "error should mention config: {msg}",);
+}
+
+#[tokio::test]
+async fn drop_named_graph_returns_not_found_for_unknown_iri() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/not-found:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let unknown = "http://example.org/graphs/does-not-exist";
+    let err = fluree
+        .drop_named_graph(ledger_id, unknown)
+        .await
+        .expect_err("unknown graph IRI must return NotFound");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not registered") || msg.contains("not found") || msg.contains("Not"),
+        "error should be a NotFound-shaped message: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn drop_named_graph_rejects_malformed_iri() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/malformed:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let err = fluree
+        .drop_named_graph(ledger_id, "http://example.org/with space")
+        .await
+        .expect_err("space in IRI must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Invalid graph IRI") || msg.contains("not allowed"),
+        "error should call out the malformed IRI: {msg}",
+    );
+}
+
+/// Whitespace at the edges is not silently trimmed — the value must be
+/// supplied exactly, so a leading-space variant of a registered IRI is
+/// rejected up front rather than re-resolved to the trimmed form.
+#[tokio::test]
+async fn drop_named_graph_rejects_whitespace_padded_iri() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/whitespace:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let padded = format!(" {ALPHA_IRI}");
+    let err = fluree
+        .drop_named_graph(ledger_id, &padded)
+        .await
+        .expect_err("padded IRI must be rejected, not silently trimmed");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Invalid graph IRI"),
+        "error should call out the malformed IRI: {msg}",
+    );
+}
+
+/// The contract is "full IRI"; a relative reference (no scheme) is a 400.
+#[tokio::test]
+async fn drop_named_graph_rejects_relative_iri() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/relative:main";
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    let err = fluree
+        .drop_named_graph(ledger_id, "alpha")
+        .await
+        .expect_err("relative IRI must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("scheme") || msg.contains("Invalid graph IRI"),
+        "error should mention missing scheme: {msg}",
+    );
+}
+
+/// Drop is history-preserving: querying the same ledger at the pre-drop `t`
+/// must still see every triple in the graph.
+#[tokio::test]
+async fn drop_named_graph_preserves_history_at_older_t() {
+    use fluree_db_api::{DatasetSpec, GraphSource, TimeSpec};
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/history:main";
+
+    let pre_drop_t = seed_two_graphs(&fluree, ledger_id).await;
+    assert_eq!(
+        count_in_graph(&fluree, ledger_id, Some(ALPHA_IRI)).await,
+        2,
+        "sanity: alpha has 2 flakes at HEAD pre-drop",
+    );
+
+    let report = fluree
+        .drop_named_graph(ledger_id, ALPHA_IRI)
+        .await
+        .expect("drop alpha");
+    assert!(report.committed);
+    assert_eq!(report.t, pre_drop_t + 1);
+
+    // HEAD: alpha is empty.
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(ALPHA_IRI)).await, 0,);
+
+    // pre-drop t via DatasetSpec: alpha is still populated.
+    let alpha_alias = format!("{ledger_id}#{ALPHA_IRI}");
+    let spec = DatasetSpec::new()
+        .with_default(GraphSource::new(&alpha_alias).with_time(TimeSpec::AtT(pre_drop_t)));
+    let dataset = fluree
+        .build_dataset_view(&spec)
+        .await
+        .expect("dataset at pre-drop t");
+    let q = serde_json::json!({
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let pre_drop_result = fluree
+        .query_dataset(&dataset, &q)
+        .await
+        .expect("history query");
+    let primary = dataset.primary().expect("primary view");
+    let rows = pre_drop_result
+        .to_jsonld(primary.snapshot.as_ref())
+        .expect("to_jsonld");
+    let rows = rows.as_array().expect("array");
+    assert_eq!(
+        rows.len(),
+        2,
+        "pre-drop snapshot must still expose every flake in alpha; got {rows:?}",
+    );
+}
+
+#[tokio::test]
+async fn drop_named_graph_other_branches_unaffected() {
+    // Per-branch scope: dropping graph G on `main` must not affect the
+    // same IRI's data on a sibling branch.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/drop-named-graph/branch-scope:main";
+
+    seed_two_graphs(&fluree, ledger_id).await;
+
+    // Fork a sibling branch and seed its alpha graph independently.
+    let branch_record = fluree
+        .create_branch(
+            "it/drop-named-graph/branch-scope",
+            "feature",
+            Some("main"),
+            None,
+        )
+        .await
+        .expect("create branch");
+    let sibling_id = branch_record.ledger_id.clone();
+
+    // Add additional alpha data on the sibling branch.
+    let sibling_ledger = fluree.ledger(&sibling_id).await.expect("load sibling");
+    let extra = format!(
+        r#"
+        @prefix ex: <http://example.org/> .
+        GRAPH <{ALPHA_IRI}> {{
+            ex:carol ex:name "Carol" .
+        }}
+        "#,
+    );
+    fluree
+        .stage_owned(sibling_ledger)
+        .upsert_turtle(&extra)
+        .execute()
+        .await
+        .expect("sibling insert");
+
+    // Sanity: sibling now has 3 alpha triples (the 2 inherited + 1 new),
+    // main still has 2.
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(ALPHA_IRI)).await, 2);
+    assert_eq!(
+        count_in_graph(&fluree, &sibling_id, Some(ALPHA_IRI)).await,
+        3
+    );
+
+    // Drop alpha on main only.
+    let report = fluree
+        .drop_named_graph(ledger_id, ALPHA_IRI)
+        .await
+        .expect("drop alpha on main");
+    assert_eq!(report.retracted, 2);
+    assert!(report.committed);
+
+    // Sibling branch's alpha graph is untouched.
+    assert_eq!(count_in_graph(&fluree, ledger_id, Some(ALPHA_IRI)).await, 0);
+    assert_eq!(
+        count_in_graph(&fluree, &sibling_id, Some(ALPHA_IRI)).await,
+        3,
+        "drop on `main` must not touch sibling branches",
+    );
+}

--- a/fluree-db-api/tests/it_ledger_info_named_graphs.rs
+++ b/fluree-db-api/tests/it_ledger_info_named_graphs.rs
@@ -1,0 +1,179 @@
+//! Regression: `ledger.named-graphs` must reflect the **live** graph
+//! registry, not just whatever the binary index store happens to know
+//! about.
+//!
+//! Before the fix, `build_ledger_block` iterated
+//! `BinaryIndexStore::graph_entries()`, so:
+//!   - a ledger with no index at all reported only `urn:default`, and
+//!   - a ledger with an index but a newer commit that registered a
+//!     fresh named graph would omit the new graph until the next
+//!     index build.
+//!
+//! The fix iterates `LedgerSnapshot.graph_registry.iter_entries()`,
+//! which is updated at commit-apply time and is therefore registry-
+//! accurate at every `t`. These tests pin both scenarios.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::Value as JsonValue;
+use support::genesis_ledger;
+
+const ALPHA_IRI: &str = "http://example.org/graphs/alpha";
+const BETA_IRI: &str = "http://example.org/graphs/beta";
+
+fn graph_iris(info: &JsonValue) -> Vec<String> {
+    info["ledger"]["named-graphs"]
+        .as_array()
+        .expect("named-graphs is array")
+        .iter()
+        .filter_map(|e| e["iri"].as_str().map(String::from))
+        .collect()
+}
+
+/// A ledger with no index built yet still surfaces every user-registered
+/// graph in `info.ledger.named-graphs`. Pre-fix the binary index store
+/// was absent and the list contained only `urn:default`.
+#[tokio::test]
+async fn named_graphs_visible_without_an_index() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/ledger-info-named-graphs/no-index:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    let trig = format!(
+        r#"
+        @prefix ex: <http://example.org/> .
+
+        GRAPH <{ALPHA_IRI}> {{
+            ex:alice ex:name "Alice" .
+        }}
+
+        GRAPH <{BETA_IRI}> {{
+            ex:bob ex:name "Bob" .
+        }}
+        "#,
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("seed insert");
+
+    let info = fluree
+        .ledger_info(ledger_id)
+        .execute()
+        .await
+        .expect("ledger_info");
+
+    let iris = graph_iris(&info);
+
+    assert!(
+        iris.contains(&"urn:default".to_string()),
+        "default graph must always appear; got {iris:?}",
+    );
+    assert!(
+        iris.contains(&ALPHA_IRI.to_string()),
+        "alpha must appear pre-index; got {iris:?}",
+    );
+    assert!(
+        iris.contains(&BETA_IRI.to_string()),
+        "beta must appear pre-index; got {iris:?}",
+    );
+
+    // System graphs are seeded into the registry by genesis and should
+    // also be reported.
+    let txn_meta = fluree_db_core::graph_registry::txn_meta_graph_iri(ledger_id);
+    let config = fluree_db_core::graph_registry::config_graph_iri(ledger_id);
+    assert!(
+        iris.contains(&txn_meta),
+        "txn-meta must appear pre-index; got {iris:?}",
+    );
+    assert!(
+        iris.contains(&config),
+        "config must appear pre-index; got {iris:?}",
+    );
+
+    // Pre-index, per-graph flake/size totals are best-effort: they may
+    // be 0 because IndexStats.graphs is not populated until an index is
+    // built. The point of this test is registry visibility, not stats.
+    let entries = info["ledger"]["named-graphs"]
+        .as_array()
+        .expect("named-graphs is array");
+    let alpha_entry = entries
+        .iter()
+        .find(|e| e["iri"].as_str() == Some(ALPHA_IRI))
+        .expect("alpha entry present");
+    assert!(
+        alpha_entry["g-id"].as_u64().unwrap_or(0) >= 3,
+        "user graphs must report a g-id in the user range (>=3); got {alpha_entry:?}",
+    );
+}
+
+/// A graph registered by a commit **after** the last index build must
+/// still appear in `info.ledger.named-graphs`. Pre-fix the binary index
+/// store was frozen at the indexed `t`, so the post-index registration
+/// was silently missing.
+#[tokio::test]
+async fn named_graphs_include_post_index_registrations() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/ledger-info-named-graphs/post-index:main";
+    let ledger = genesis_ledger(&fluree, ledger_id);
+
+    // Seed alpha and build an index at this t.
+    let trig_alpha = format!(
+        r#"
+        @prefix ex: <http://example.org/> .
+        GRAPH <{ALPHA_IRI}> {{ ex:alice ex:name "Alice" . }}
+        "#,
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&trig_alpha)
+        .execute()
+        .await
+        .expect("seed alpha");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+
+    let info_pre_beta = fluree
+        .ledger_info(ledger_id)
+        .execute()
+        .await
+        .expect("ledger_info after first index");
+    let iris_pre = graph_iris(&info_pre_beta);
+    assert!(iris_pre.contains(&ALPHA_IRI.to_string()));
+    assert!(!iris_pre.contains(&BETA_IRI.to_string()));
+
+    // Now register a brand new graph *without* rebuilding the index.
+    let ledger = fluree.ledger(ledger_id).await.expect("reload ledger");
+    let trig_beta = format!(
+        r#"
+        @prefix ex: <http://example.org/> .
+        GRAPH <{BETA_IRI}> {{ ex:bob ex:name "Bob" . }}
+        "#,
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&trig_beta)
+        .execute()
+        .await
+        .expect("seed beta post-index");
+
+    let info_post_beta = fluree
+        .ledger_info(ledger_id)
+        .execute()
+        .await
+        .expect("ledger_info after post-index registration");
+    let iris_post = graph_iris(&info_post_beta);
+    assert!(
+        iris_post.contains(&ALPHA_IRI.to_string()),
+        "alpha must still appear; got {iris_post:?}",
+    );
+    assert!(
+        iris_post.contains(&BETA_IRI.to_string()),
+        "beta must appear even though it was registered after the last \
+         index build; got {iris_post:?}",
+    );
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -295,6 +295,12 @@ pub enum Commands {
         force: bool,
     },
 
+    /// Manage named graphs within a ledger
+    Graph {
+        #[command(subcommand)]
+        action: GraphAction,
+    },
+
     /// Insert data into a ledger
     ///
     /// Examples:
@@ -743,6 +749,72 @@ pub enum Commands {
     Iceberg {
         #[command(subcommand)]
         action: IcebergAction,
+    },
+}
+
+/// Named-graph subcommands.
+#[derive(Subcommand)]
+pub enum GraphAction {
+    /// List the user-defined named graphs registered on a branch
+    ///
+    /// Reads the `named-graphs` section of the standard `info` payload
+    /// for the targeted branch and, by default, hides the default graph
+    /// and the system `txn-meta` / `config` graphs. Pass
+    /// `--include-system` to show all four kinds.
+    ///
+    /// Examples:
+    ///   fluree graph list
+    ///   fluree graph list --ledger mydb:feature-x
+    ///   fluree graph list --ledger mydb --remote origin
+    ///   fluree graph list --ledger mydb --include-system --json
+    List {
+        /// Ledger identifier (e.g. "mydb" or "mydb:feature-x").
+        /// Defaults to the active ledger.
+        #[arg(long)]
+        ledger: Option<String>,
+
+        /// List graphs on a remote server (by remote name, e.g. "origin")
+        #[arg(long)]
+        remote: Option<String>,
+
+        /// Emit the filtered `named-graphs` JSON array instead of a table.
+        /// The same `--include-system` filter applies as for the table view.
+        #[arg(long)]
+        json: bool,
+
+        /// Include the default graph and the system `txn-meta` / `config`
+        /// graphs in the output. Off by default.
+        #[arg(long)]
+        include_system: bool,
+    },
+
+    /// Drop a named graph from a single branch of a ledger
+    ///
+    /// Issues a transactional retract: every triple currently asserted
+    /// in the target graph is retracted in one new commit. History is
+    /// preserved — queries `as-of` an earlier `t` still see the graph
+    /// populated. The graph IRI remains registered so it can be
+    /// re-populated by a later insert.
+    ///
+    /// Refuses the default graph and the system `txn-meta` / `config`
+    /// graphs.
+    ///
+    /// Examples:
+    ///   fluree graph drop urn:example:org/payroll --ledger mydb
+    ///   fluree graph drop urn:example:org/payroll --ledger mydb:feature-x
+    ///   fluree graph drop urn:example:org/payroll --ledger mydb --remote origin
+    Drop {
+        /// Full IRI of the named graph to drop.
+        iri: String,
+
+        /// Ledger identifier (e.g. "mydb" or "mydb:feature-x").
+        /// Defaults to the active ledger.
+        #[arg(long)]
+        ledger: Option<String>,
+
+        /// Execute against a remote server (by remote name, e.g. "origin")
+        #[arg(long)]
+        remote: Option<String>,
     },
 }
 

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -4,6 +4,7 @@ use crate::error::{CliError, CliResult};
 use crate::remote_client::RevertPayload;
 use comfy_table::{ContentArrangement, Table};
 use fluree_db_api::server_defaults::FlureeDir;
+use fluree_db_api::DropStatus;
 use fluree_db_core::ledger_id::split_ledger_id;
 
 pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliResult<()> {
@@ -379,10 +380,23 @@ async fn run_drop(
             let (ledger_name, _) = split_ledger_id(&alias)?;
             let report = fluree.drop_branch(&ledger_name, name).await?;
 
-            if report.deferred {
-                println!("Branch '{name}' retracted (has children, storage preserved).");
-            } else {
-                println!("Dropped branch '{name}'.");
+            match report.status {
+                DropStatus::AlreadyRetracted => {
+                    println!("Branch '{name}' was already retracted (no-op).");
+                }
+                DropStatus::NotFound => {
+                    // `drop_branch` surfaces a missing branch as
+                    // `ApiError::NotFound`, so this arm shouldn't normally fire,
+                    // but be defensive in case that contract changes.
+                    println!("Branch '{name}' not found.");
+                }
+                DropStatus::Dropped => {
+                    if report.deferred {
+                        println!("Branch '{name}' retracted (has children, storage preserved).");
+                    } else {
+                        println!("Dropped branch '{name}'.");
+                    }
+                }
             }
             if report.artifacts_deleted > 0 {
                 println!("  Artifacts deleted: {}", report.artifacts_deleted);
@@ -947,21 +961,41 @@ fn print_revert_result(result: &serde_json::Value) -> CliResult<()> {
     Ok(())
 }
 
-fn print_branch_dropped(result: &serde_json::Value) -> CliResult<()> {
+/// Pick the headline message for a drop-branch response. The `status`
+/// field is authoritative: a second drop on an already-retracted branch
+/// reports `"already_retracted"` and must not be re-rendered as a
+/// successful drop.
+fn format_drop_branch_headline(result: &serde_json::Value) -> String {
     let ledger_id = result
         .get("ledger_id")
         .and_then(|v| v.as_str())
         .unwrap_or("(unknown)");
+    let status = result
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("dropped");
     let deferred = result
         .get("deferred")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
-    if deferred {
-        println!("Branch retracted (has children, storage preserved): {ledger_id}");
-    } else {
-        println!("Dropped branch: {ledger_id}");
+    match status {
+        "already_retracted" => format!("Branch was already retracted (no-op): {ledger_id}"),
+        "not_found" => format!("Branch not found: {ledger_id}"),
+        _ => {
+            // "dropped" (and any unknown status falls back to the success
+            // message rather than silently swallowing the response).
+            if deferred {
+                format!("Branch retracted (has children, storage preserved): {ledger_id}")
+            } else {
+                format!("Dropped branch: {ledger_id}")
+            }
+        }
     }
+}
+
+fn print_branch_dropped(result: &serde_json::Value) -> CliResult<()> {
+    println!("{}", format_drop_branch_headline(result));
 
     if let Some(artifacts) = result
         .get("files_deleted")
@@ -1349,5 +1383,91 @@ fn print_delta_json(label: &str, d: &serde_json::Value) {
                 println!("  t={t} +{asserts}/-{retracts} {time} {id} | {msg}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_drop_branch_headline;
+    use serde_json::json;
+
+    #[test]
+    fn drop_branch_headline_already_retracted() {
+        let resp = json!({
+            "ledger_id": "mydb:dev",
+            "status": "already_retracted",
+            "deferred": false,
+        });
+        assert_eq!(
+            format_drop_branch_headline(&resp),
+            "Branch was already retracted (no-op): mydb:dev",
+        );
+    }
+
+    #[test]
+    fn drop_branch_headline_already_retracted_with_stale_deferred_flag() {
+        // Even if a server happens to send `deferred: true` alongside
+        // `status: "already_retracted"`, the status field is
+        // authoritative — we must not render the deferred success
+        // message in that case.
+        let resp = json!({
+            "ledger_id": "mydb:dev",
+            "status": "already_retracted",
+            "deferred": true,
+        });
+        assert_eq!(
+            format_drop_branch_headline(&resp),
+            "Branch was already retracted (no-op): mydb:dev",
+        );
+    }
+
+    #[test]
+    fn drop_branch_headline_dropped_leaf() {
+        let resp = json!({
+            "ledger_id": "mydb:dev",
+            "status": "dropped",
+            "deferred": false,
+        });
+        assert_eq!(
+            format_drop_branch_headline(&resp),
+            "Dropped branch: mydb:dev",
+        );
+    }
+
+    #[test]
+    fn drop_branch_headline_dropped_deferred() {
+        let resp = json!({
+            "ledger_id": "mydb:dev",
+            "status": "dropped",
+            "deferred": true,
+        });
+        assert_eq!(
+            format_drop_branch_headline(&resp),
+            "Branch retracted (has children, storage preserved): mydb:dev",
+        );
+    }
+
+    #[test]
+    fn drop_branch_headline_not_found() {
+        let resp = json!({
+            "ledger_id": "mydb:does-not-exist",
+            "status": "not_found",
+            "deferred": false,
+        });
+        assert_eq!(
+            format_drop_branch_headline(&resp),
+            "Branch not found: mydb:does-not-exist",
+        );
+    }
+
+    #[test]
+    fn drop_branch_headline_missing_fields_falls_back_to_dropped() {
+        // No `status` and no `deferred` — should still render the
+        // legacy success message rather than swallowing the response.
+        let resp = json!({ "ledger_id": "mydb:dev" });
+        assert_eq!(
+            format_drop_branch_headline(&resp),
+            "Dropped branch: mydb:dev",
+        );
     }
 }

--- a/fluree-db-cli/src/commands/graph.rs
+++ b/fluree-db-cli/src/commands/graph.rs
@@ -1,0 +1,321 @@
+use crate::cli::GraphAction;
+use crate::context::{self, LedgerMode};
+use crate::error::{CliError, CliResult};
+use comfy_table::{ContentArrangement, Table};
+use fluree_db_api::server_defaults::FlureeDir;
+use fluree_db_core::graph_registry::{
+    config_graph_iri, txn_meta_graph_iri, CONFIG_GRAPH_ID, DEFAULT_GRAPH_ID, TXN_META_GRAPH_ID,
+};
+
+pub async fn run(action: GraphAction, dirs: &FlureeDir, direct: bool) -> CliResult<()> {
+    match action {
+        GraphAction::List {
+            ledger,
+            remote,
+            json,
+            include_system,
+        } => {
+            run_list(
+                ledger.as_deref(),
+                dirs,
+                remote.as_deref(),
+                direct,
+                json,
+                include_system,
+            )
+            .await
+        }
+        GraphAction::Drop {
+            iri,
+            ledger,
+            remote,
+        } => run_drop(&iri, ledger.as_deref(), dirs, remote.as_deref(), direct).await,
+    }
+}
+
+async fn run_list(
+    ledger: Option<&str>,
+    dirs: &FlureeDir,
+    remote_flag: Option<&str>,
+    direct: bool,
+    json: bool,
+    include_system: bool,
+) -> CliResult<()> {
+    let payload = if let Some(remote_name) = remote_flag {
+        let alias = context::resolve_ledger(ledger, dirs)?;
+        let client = context::build_remote_client(remote_name, dirs).await?;
+        let info = client.ledger_info(&alias, None).await?;
+        context::persist_refreshed_tokens(&client, remote_name, dirs).await;
+        info
+    } else {
+        let mode = {
+            let mode = context::resolve_ledger_mode(ledger, dirs).await?;
+            if direct {
+                mode
+            } else {
+                context::try_server_route(mode, dirs)
+            }
+        };
+        match mode {
+            LedgerMode::Tracked {
+                client,
+                remote_alias,
+                remote_name,
+                ..
+            } => {
+                let info = client.ledger_info(&remote_alias, None).await?;
+                context::persist_refreshed_tokens(&client, &remote_name, dirs).await;
+                info
+            }
+            LedgerMode::Local { fluree, alias } => {
+                let ledger_id = context::to_ledger_id(&alias);
+                fluree.ledger_info(&ledger_id).execute().await?
+            }
+        }
+    };
+
+    let ledger_id = payload
+        .get("ledger")
+        .and_then(|v| v.get("alias"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| payload.get("alias").and_then(serde_json::Value::as_str));
+
+    let graphs = extract_named_graphs(&payload).ok_or_else(|| {
+        CliError::Usage(
+            "info response is missing `named-graphs`; the targeted server may be too old"
+                .to_string(),
+        )
+    })?;
+
+    let resolved_ledger = ledger_id.unwrap_or("");
+    let txn_meta = if resolved_ledger.is_empty() {
+        String::new()
+    } else {
+        txn_meta_graph_iri(resolved_ledger)
+    };
+    let config = if resolved_ledger.is_empty() {
+        String::new()
+    } else {
+        config_graph_iri(resolved_ledger)
+    };
+
+    let entries: Vec<&serde_json::Value> = graphs
+        .iter()
+        .filter(|entry| {
+            if include_system {
+                return true;
+            }
+            let g_id = entry
+                .get("g-id")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(u64::MAX) as u16;
+            let iri = entry
+                .get("iri")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            !is_system_graph(g_id, iri, &txn_meta, &config)
+        })
+        .collect();
+
+    if json {
+        let arr = serde_json::Value::Array(entries.into_iter().cloned().collect());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&arr).unwrap_or_else(|_| arr.to_string()),
+        );
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        if include_system {
+            println!("No graphs registered.");
+        } else {
+            println!(
+                "No user named graphs registered. (Pass --include-system to see default, txn-meta, config.)",
+            );
+        }
+        return Ok(());
+    }
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec!["IRI", "Kind", "g-id", "Flakes", "Size"]);
+    for entry in entries {
+        let iri = entry
+            .get("iri")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("-");
+        let g_id_u64 = entry.get("g-id").and_then(serde_json::Value::as_u64);
+        let g_id_label = g_id_u64
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let kind = match g_id_u64 {
+            Some(0) => "default",
+            Some(id) if (id as u16) == TXN_META_GRAPH_ID => "system:txn-meta",
+            Some(id) if (id as u16) == CONFIG_GRAPH_ID => "system:config",
+            Some(_) => "user",
+            None => "?",
+        };
+        let flakes = entry
+            .get("flakes")
+            .and_then(serde_json::Value::as_u64)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let size = entry
+            .get("size")
+            .and_then(serde_json::Value::as_u64)
+            .map(format_bytes)
+            .unwrap_or_else(|| "-".to_string());
+        table.add_row(vec![
+            iri.to_string(),
+            kind.to_string(),
+            g_id_label,
+            flakes,
+            size,
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+fn extract_named_graphs(payload: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    payload
+        .get("ledger")
+        .and_then(|v| v.get("named-graphs"))
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| {
+            payload
+                .get("named-graphs")
+                .and_then(serde_json::Value::as_array)
+        })
+}
+
+fn is_system_graph(g_id: u16, iri: &str, txn_meta: &str, config: &str) -> bool {
+    if matches!(g_id, DEFAULT_GRAPH_ID | TXN_META_GRAPH_ID | CONFIG_GRAPH_ID) {
+        return true;
+    }
+    if !txn_meta.is_empty() && iri == txn_meta {
+        return true;
+    }
+    if !config.is_empty() && iri == config {
+        return true;
+    }
+    iri == "urn:default"
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1_024;
+    const MB: u64 = KB * 1_024;
+    const GB: u64 = MB * 1_024;
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+async fn run_drop(
+    iri: &str,
+    ledger: Option<&str>,
+    dirs: &FlureeDir,
+    remote_flag: Option<&str>,
+    direct: bool,
+) -> CliResult<()> {
+    if iri.is_empty() {
+        return Err(CliError::Usage(
+            "graph IRI must not be empty (the default graph cannot be dropped)".to_string(),
+        ));
+    }
+
+    if let Some(remote_name) = remote_flag {
+        let alias = context::resolve_ledger(ledger, dirs)?;
+        let client = context::build_remote_client(remote_name, dirs).await?;
+        let response = client.drop_named_graph(&alias, iri).await?;
+        context::persist_refreshed_tokens(&client, remote_name, dirs).await;
+        print_remote_response(&response);
+        return Ok(());
+    }
+
+    let mode = {
+        let mode = context::resolve_ledger_mode(ledger, dirs).await?;
+        if direct {
+            mode
+        } else {
+            context::try_server_route(mode, dirs)
+        }
+    };
+
+    match mode {
+        LedgerMode::Tracked {
+            client,
+            remote_alias,
+            remote_name,
+            ..
+        } => {
+            let response = client.drop_named_graph(&remote_alias, iri).await?;
+            context::persist_refreshed_tokens(&client, &remote_name, dirs).await;
+            print_remote_response(&response);
+        }
+        LedgerMode::Local { fluree, alias } => {
+            let report = fluree.drop_named_graph(&alias, iri).await?;
+            print_local_report(&report);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_local_report(report: &fluree_db_api::DropNamedGraphReport) {
+    if report.committed {
+        println!(
+            "Dropped graph <{}> from '{}' — retracted {} flake{} (t={}).",
+            report.graph_iri,
+            report.ledger_id,
+            report.retracted,
+            if report.retracted == 1 { "" } else { "s" },
+            report.t,
+        );
+    } else {
+        println!(
+            "Graph <{}> in '{}' was already empty — no commit produced (t={}).",
+            report.graph_iri, report.ledger_id, report.t,
+        );
+    }
+}
+
+fn print_remote_response(value: &serde_json::Value) {
+    let graph_iri = value
+        .get("graph_iri")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    let ledger_id = value
+        .get("ledger_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    let retracted = value
+        .get("retracted")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let committed = value
+        .get("committed")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let t = value
+        .get("t")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+    if committed {
+        println!(
+            "Dropped graph <{graph_iri}> from '{ledger_id}' — retracted {retracted} flake{plural} (t={t}).",
+            plural = if retracted == 1 { "" } else { "s" },
+        );
+    } else {
+        println!(
+            "Graph <{graph_iri}> in '{ledger_id}' was already empty — no commit produced (t={t}).",
+        );
+    }
+}

--- a/fluree-db-cli/src/commands/graph.rs
+++ b/fluree-db-cli/src/commands/graph.rs
@@ -99,16 +99,26 @@ async fn run_list(
         config_graph_iri(resolved_ledger)
     };
 
-    let entries: Vec<&serde_json::Value> = graphs
-        .iter()
-        .filter(|entry| {
+    let mut parsed: Vec<(&serde_json::Value, Option<u16>)> = Vec::with_capacity(graphs.len());
+    for entry in graphs {
+        let g_id = match entry.get("g-id").and_then(serde_json::Value::as_u64) {
+            Some(n) => Some(u16::try_from(n).map_err(|_| {
+                CliError::Usage(format!(
+                    "info response contains out-of-range g-id {n}; GraphId is u16 (max 65535)"
+                ))
+            })?),
+            None => None,
+        };
+        parsed.push((entry, g_id));
+    }
+
+    let entries: Vec<(&serde_json::Value, Option<u16>)> = parsed
+        .into_iter()
+        .filter(|(entry, g_id)| {
             if include_system {
                 return true;
             }
-            let g_id = entry
-                .get("g-id")
-                .and_then(serde_json::Value::as_u64)
-                .unwrap_or(u64::MAX) as u16;
+            let g_id = g_id.unwrap_or(u16::MAX);
             let iri = entry
                 .get("iri")
                 .and_then(serde_json::Value::as_str)
@@ -118,7 +128,7 @@ async fn run_list(
         .collect();
 
     if json {
-        let arr = serde_json::Value::Array(entries.into_iter().cloned().collect());
+        let arr = serde_json::Value::Array(entries.iter().map(|(e, _)| (*e).clone()).collect());
         println!(
             "{}",
             serde_json::to_string_pretty(&arr).unwrap_or_else(|_| arr.to_string()),
@@ -140,19 +150,18 @@ async fn run_list(
     let mut table = Table::new();
     table.set_content_arrangement(ContentArrangement::Dynamic);
     table.set_header(vec!["IRI", "Kind", "g-id", "Flakes", "Size"]);
-    for entry in entries {
+    for (entry, g_id) in entries {
         let iri = entry
             .get("iri")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("-");
-        let g_id_u64 = entry.get("g-id").and_then(serde_json::Value::as_u64);
-        let g_id_label = g_id_u64
+        let g_id_label = g_id
             .map(|v| v.to_string())
             .unwrap_or_else(|| "-".to_string());
-        let kind = match g_id_u64 {
-            Some(0) => "default",
-            Some(id) if (id as u16) == TXN_META_GRAPH_ID => "system:txn-meta",
-            Some(id) if (id as u16) == CONFIG_GRAPH_ID => "system:config",
+        let kind = match g_id {
+            Some(DEFAULT_GRAPH_ID) => "default",
+            Some(TXN_META_GRAPH_ID) => "system:txn-meta",
+            Some(CONFIG_GRAPH_ID) => "system:config",
             Some(_) => "user",
             None => "?",
         };

--- a/fluree-db-cli/src/commands/mod.rs
+++ b/fluree-db-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod context_cmd;
 pub mod create;
 pub mod drop;
 pub mod export;
+pub mod graph;
 pub mod history;
 pub mod iceberg;
 pub mod index;

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -133,6 +133,11 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             commands::drop::run(&name, force, &fluree_dir).await
         }
 
+        Commands::Graph { action } => {
+            let fluree_dir = config::require_fluree_dir(config_path)?;
+            commands::graph::run(action, &fluree_dir, direct).await
+        }
+
         Commands::Insert {
             args,
             expr,

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -1203,6 +1203,30 @@ impl RemoteLedgerClient {
         .await
     }
 
+    /// Drop a named graph from a branch on the remote server.
+    ///
+    /// Calls `POST {base_url}/drop-graph` with a JSON body. `ledger` is a
+    /// full ledger identifier (e.g. `"mydb:main"`); `graph` is the full
+    /// IRI of the named graph to drop.
+    pub async fn drop_named_graph(
+        &self,
+        ledger: &str,
+        graph: &str,
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let url = self.op_url_root("drop-graph");
+        let body = serde_json::json!({
+            "ledger": ledger,
+            "graph": graph,
+        });
+        self.send_json(
+            reqwest::Method::POST,
+            &url,
+            "application/json",
+            Some(RequestBody::Json(&body)),
+        )
+        .await
+    }
+
     /// Rebase a branch on the remote server.
     ///
     /// Calls `POST {base_url}/rebase` with a JSON body.

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -12,7 +12,9 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use fluree_db_api::wire::{ReindexRequest, ReindexResponse};
-use fluree_db_api::{ApiError, BranchDropReport, DropMode, DropReport, DropStatus};
+use fluree_db_api::{
+    ApiError, BranchDropReport, DropMode, DropNamedGraphReport, DropReport, DropStatus,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
@@ -1190,6 +1192,122 @@ async fn drop_branch_local(
             "branch dropped"
         );
         Ok(Json(DropBranchResponse::from(report)))
+    }
+    .instrument(span)
+    .await
+}
+
+// =============================================================================
+// Drop Named Graph
+// =============================================================================
+
+/// Drop named graph request body
+#[derive(Deserialize)]
+pub struct DropNamedGraphRequest {
+    /// Full ledger identifier (e.g. `"mydb:main"`; the server defaults to
+    /// the `:main` branch when no branch is supplied).
+    pub ledger: String,
+    /// Full IRI of the named graph to drop.
+    pub graph: String,
+}
+
+/// Drop named graph response
+#[derive(Serialize)]
+pub struct DropNamedGraphResponse {
+    /// Full ledger:branch identifier the drop targeted (echoed)
+    pub ledger_id: String,
+    /// Graph IRI that was dropped (echoed)
+    pub graph_iri: String,
+    /// Number of flakes retracted by the drop commit (0 when no-op).
+    pub retracted: usize,
+    /// `true` when a new commit was produced; `false` when the target graph
+    /// was already empty and the call was a no-op.
+    pub committed: bool,
+    /// Current commit `t` for the branch after the drop (unchanged when
+    /// `committed = false`).
+    pub t: i64,
+}
+
+impl From<DropNamedGraphReport> for DropNamedGraphResponse {
+    fn from(report: DropNamedGraphReport) -> Self {
+        DropNamedGraphResponse {
+            ledger_id: report.ledger_id,
+            graph_iri: report.graph_iri,
+            retracted: report.retracted,
+            committed: report.committed,
+            t: report.t,
+        }
+    }
+}
+
+/// Drop a named graph from a single branch.
+///
+/// POST /fluree/drop-graph
+///
+/// Request body:
+/// - `ledger`: Full ledger identifier (e.g. `"mydb"` or `"mydb:main"`)
+/// - `graph`: Full IRI of the named graph to drop
+///
+/// Refuses the default graph, the system `txn-meta` graph, and the system
+/// `config` graph. Unknown graph IRIs return `404`.
+pub async fn drop_named_graph(State(state): State<Arc<AppState>>, request: Request) -> Response {
+    if state.config.server_role == ServerRole::Peer {
+        return forward_write_request(&state, request).await;
+    }
+
+    drop_named_graph_local(state, request).await.into_response()
+}
+
+async fn drop_named_graph_local(
+    state: Arc<AppState>,
+    request: Request,
+) -> Result<Json<DropNamedGraphResponse>> {
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+
+    let body_bytes = axum::body::to_bytes(request.into_body(), 50 * 1024 * 1024)
+        .await
+        .map_err(|e| ServerError::bad_request(format!("Failed to read body: {e}")))?;
+    let req: DropNamedGraphRequest = serde_json::from_slice(&body_bytes)
+        .map_err(|e| ServerError::bad_request(format!("Invalid JSON: {e}")))?;
+
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+
+    let span = create_request_span(
+        "graph:drop",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        Some(&req.ledger),
+        None,
+        None,
+    );
+    async move {
+        let span = tracing::Span::current();
+
+        tracing::info!(
+            status = "start",
+            graph = %req.graph,
+            "named graph drop requested"
+        );
+
+        let report = match state.fluree.drop_named_graph(&req.ledger, &req.graph).await {
+            Ok(report) => report,
+            Err(e) => {
+                let server_error = ServerError::Api(e);
+                set_span_error_code(&span, "error:DropNamedGraphFailed");
+                tracing::error!(error = %server_error, "named graph drop failed");
+                return Err(server_error);
+            }
+        };
+
+        tracing::info!(
+            status = "success",
+            retracted = report.retracted,
+            committed = report.committed,
+            t = report.t,
+            "named graph dropped"
+        );
+        Ok(Json(DropNamedGraphResponse::from(report)))
     }
     .instrument(span)
     .await

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -41,6 +41,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/reindex", post(ledger::reindex))
         .route("/branch", post(ledger::create_branch))
         .route("/drop-branch", post(ledger::drop_branch))
+        .route("/drop-graph", post(ledger::drop_named_graph))
         .route("/rebase", post(ledger::rebase))
         .route("/merge", post(ledger::merge))
         .route("/revert", post(ledger::revert));


### PR DESCRIPTION
# Summary

- Adds a per-branch **named-graph drop**: `Fluree::drop_named_graph(ledger_id, graph_iri)` retracts every triple currently asserted under a named graph in a single new commit. History at older `t` is preserved, the graph IRI keeps its `g_id`, and the operation is idempotent on an empty graph (no commit produced).
- Wires up a wire endpoint `POST /v1/fluree/drop-graph` (admin-protected) and a matching CLI: `fluree graph drop <iri>` plus a companion `fluree graph list`. Both subcommands support `--remote`, tracked-remote auto-routing, and `--direct`.
- Fixes the `ledger.named-graphs` block in the `/info` payload so newly registered graphs show up immediately (not after the next index build).
- Fixes `fluree branch drop` so a second drop of an already-retracted branch prints "no-op" instead of "Dropped branch".

# Details

## `drop_named_graph` (new)

`Fluree::drop_named_graph(ledger_id, graph_iri) -> Result<DropNamedGraphReport>` walks the live triples under `graph_iri` and stages a single retract-only commit. Concrete behavior:

- **History preserved.** Time-travel reads at any prior `t` see the old graph contents. The graph IRI keeps its assigned `g_id`; later inserts re-populate it normally.
- **Per-branch.** Dropping on `mydb:dev` leaves `mydb:main` untouched.
- **Idempotent.** An already-empty graph short-circuits with no commit produced and a `DropStatus::AlreadyRetracted` outcome.
- **System graphs rejected.** `urn:fluree:default`, `urn:fluree:txn-meta`, `urn:fluree:config` (the three system graphs) return `ApiError::Http(400)`. Unknown IRIs return `404` before staging so the graph registry isn't silently extended.
- **IRI validation.** `graph_iri` is validated as an absolute IRI: requires a `<scheme>:<rest>` head, no whitespace, no C0/DEL control characters, and rejects RFC 3987-excluded characters. Leading/trailing whitespace is rejected outright, not silently trimmed (7 unit tests in `validate_absolute_iri`).

## Wire endpoint: `POST /v1/fluree/drop-graph`

Admin-protected — same bracket as `/drop`, `/create`, `/reindex`. Body and response specified in `docs/api/endpoints.md`; full server-side contract documented in `docs/cli/server-integration.md` ("Drop Named Graph Contract").

## CLI

### `fluree graph drop <iri>`

```text
fluree graph drop <IRI> [--ledger <name>] [--remote <name>] [--direct]
```

Three-mode dispatch matching the rest of the `--remote` family: explicit `--remote <name>` → named remote; otherwise auto-route through a locally running `fluree server start` if `server.meta.json` is present; otherwise direct local execution. `--direct` skips auto-routing.

### `fluree graph list`

```text
fluree graph list [--ledger <name>] [--include-system] [--json] [--remote <name>] [--direct]
```

Parses the existing `/info` payload's `ledger.named-graphs` section. By default hides the three system graphs; `--include-system` shows them.

## Companion fixes

### `ledger.named-graphs` now built from the live registry

`build_ledger_block` used to enumerate named graphs via `BinaryIndexStore::graph_entries()`. Two failure modes:

- A ledger with no index ever built reported only `urn:default`.
- A graph registered in a commit after the last index build was silently missing from `info.ledger.named-graphs` until the next index ran.

Since `fluree graph list` parses that same payload, the bug surfaced there as well — newly registered user graphs wouldn't show up between drops or right after an insert.

Fixed by iterating `ledger.snapshot.graph_registry.iter_entries()` instead, which is mutated at commit-apply time and so is always current. Per-graph `flakes` / `size` totals still come from `IndexStats.graphs` when populated and fall back to `0` otherwise.

### `fluree branch drop` honors `DropStatus::AlreadyRetracted`

Both the local and remote branch-drop paths in `fluree-db-cli/src/commands/branch.rs` were only inspecting the `deferred` field when deciding what to print, so a second drop of an already-retracted branch was reported as a successful "Dropped branch" instead of a no-op. The bug applied to the local report and to the JSON response handler (`print_branch_dropped`).

Both paths now branch on the authoritative `status` / `DropStatus` field:

| Status | Output |
|---|---|
| `AlreadyRetracted` | "Branch '\<name\>' was already retracted (no-op)." |
| `NotFound` | "Branch '\<name\>' not found." |
| `Dropped` | Existing dropped / deferred-retract messages, keyed on `deferred`. |

# Docs

- **New:** `docs/cli/graph.md` — full reference for the `fluree graph` subcommand family.
- **New:** "Drop Named Graph Contract" and "Graph List Contract" sections in `docs/cli/server-integration.md`.
- **New:** `POST /drop-graph` spec in `docs/api/endpoints.md`.
- **Cross-links:** `docs/cli/drop.md` and `docs/concepts/datasets-and-named-graphs.md` point at the new graph reference.
- **Updated:** `docs/SUMMARY.md`, `docs/cli/README.md` table of contents.
- **Updated:** `/info` contract entry in `server-integration.md` now notes `ledger.named-graphs` as required for `fluree graph list`.

# Tests

- **11 integration tests** in `fluree-db-api/tests/it_drop_named_graph.rs` covering:
  - Happy path single-graph drop, multi-triple graph drop.
  - Idempotency on an already-empty graph (no commit produced).
  - History preservation via `DatasetSpec` + `TimeSpec` lookups at older `t`.
  - Per-branch isolation: drop on one branch leaves the other intact.
  - Every validation / rejection branch (system graphs, unknown IRI, whitespace, invalid scheme, control characters, RFC 3987 excluded chars).
- **7 unit tests** for `validate_absolute_iri`.
- **`it_ledger_info_named_graphs.rs`** (179 lines) covers the `/info` registry fix — pre-index, post-insert, post-drop snapshots all agree with the live registry.
- **Existing `it_branch` extended** with assertions for the `AlreadyRetracted` CLI output fix.



