### PR TITLE
release v4.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,7 +2287,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "cid",
@@ -2988,14 +2988,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3137,14 +3137,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.3"
+version = "4.0.4"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 exclude = ["testsuite-sparql"]
 
 [workspace.package]
-version = "4.0.3"
+version = "4.0.4"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"

--- a/docs/getting-started/quickstart-server.md
+++ b/docs/getting-started/quickstart-server.md
@@ -118,7 +118,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "4.0.3"
+  "version": "4.0.4"
 }
 ```
 

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "base64",
  "bs58",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -983,14 +983,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.3"
+version = "4.0.4"
 
 [[package]]
 name = "foldhash"
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-sparql"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-sparql/Cargo.toml
+++ b/testsuite-sparql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-sparql"
-version = "4.0.3"
+version = "4.0.4"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
For final and accurate changes, check the official changeling after release, but this release includes:

  ## Highlights

  ### Fixes
  - Exact-precision SUM/AVG over `xsd:decimal` / `xsd:integer` (#1249)
  - Complete incremental indexing on Standard S3 (#1245)
  - Hard ledger drop fully cleans up on S3 + DynamoDB (#1243)
  - Report tracked transaction fuel (#1241)
  - Import issue fixes (#1240)  
  - Share EXISTS strategy with `OPTIONAL + !bound` rewrite (#1238)
  - Accept time-travel `from` in explain endpoints (#1236)
  - Batched join probes now honor time-travel snapshot (#1223)
  - Vector retraction round-trips across rebuild/overlay/incremental publish
  (#1221)   
  - SPARQL UPDATE referencing fresh namespaces queryable post-publish (#1217)
  - JSON-LD context-coerced `@vector` arrays produce single `FlakeValue::Vector`
  (#1216)
  - Restore host ownership in AUR publish docker step (#1225)

  ### Features
  - `drop_ledger` drops the whole ledger; root-branch check is structural (#1244)
  - Close `--remote` coverage gaps + ledger archive + auth-scoping (#1237)
  - Scalar expressions in JSON-LD `select` (parity with SPARQL) (#1227)
  - Remote-source bulk import via `import_from_storage` (#1214)
  - Arch Linux PKGBUILD (#1213)

  ### Performance & Refactors   
  - Improve novelty and property-path query performance (#1239)
  - Workspace-wide benchmarking foundation (#1228)
  - Streamline query internal representation (#1226)
  - Restructure query output type hierarchy (#1220)
  - Reorganize query IR module (#1219)
  - Consolidate query execution and rewrite pipelines (#1215)
  - Remove `history_mode` from `ExecutionContext` (#1212)
  - Reindex rebuild performance regression fix (#1211)
  - `rdfs:Class` COUNT misses fix (#1209)