### PR TITLE
fix: history query with non-matching `@id` returns all genesis facts

### DIFF
--- a/fluree-db-api/tests/it_query_history_range.rs
+++ b/fluree-db-api/tests/it_query_history_range.rs
@@ -680,3 +680,112 @@ async fn history_range_iri_object_novelty_only() {
         "novelty-only history over a ref-valued predicate must bind @t and @op"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Case: literal `@id` that does not resolve to any subject in the data.
+//
+// Bug report: a history query with `{"@id": "<non-existent IRI>", ...}` was
+// silently dropping the subject filter and returning every history row for
+// the genesis transaction (t=1). The filter binding for a non-matching
+// subject literal must behave the same as a non-matching pattern in a
+// regular query — return zero rows.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn history_range_nonexistent_id_returns_empty() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-nonexistent-id:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    // Genesis transaction with several subjects so the t=1 leaflet has
+    // enough rows that the bug — falling back to an unconstrained scan —
+    // would surface as a non-empty result.
+    let tx1 = json!({
+        "@context": ctx(),
+        "@graph": [
+            {"@id": "ex:alice",   "ex:name": "Alice"},
+            {"@id": "ex:bob",     "ex:name": "Bob"},
+            {"@id": "ex:carol",   "ex:name": "Carol"},
+        ],
+    });
+    let r1 = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    assert_eq!(r1.receipt.t, 1);
+    assert_eq!(reindex_to_current(&fluree, ledger_id).await, 1);
+
+    // Sanity: real subject returns its row.
+    let q_real = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "ex:alice",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+    });
+    let real_rows = run_history_query(&fluree, &q_real).await;
+    assert_eq!(
+        real_rows,
+        vec![("Alice".to_string(), 1, true)],
+        "control: existing subject must still return its history"
+    );
+
+    // Bug repro: non-existent subject IRI.
+    let q_missing = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "http://does-not-exist.example/x",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+    });
+    let missing_rows = run_history_query(&fluree, &q_missing).await;
+    assert!(
+        missing_rows.is_empty(),
+        "non-matching @id must return zero rows; got {missing_rows:#?}"
+    );
+}
+
+/// Same as above but novelty-only (no reindex) — verifies the novelty
+/// path also treats a non-matching literal subject as empty rather than
+/// falling through to an unconstrained scan.
+#[tokio::test]
+async fn history_range_nonexistent_id_returns_empty_novelty_only() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = "test/history-nonexistent-id-novelty:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+
+    let tx1 = json!({
+        "@context": ctx(),
+        "@graph": [
+            {"@id": "ex:alice",   "ex:name": "Alice"},
+            {"@id": "ex:bob",     "ex:name": "Bob"},
+            {"@id": "ex:carol",   "ex:name": "Carol"},
+        ],
+    });
+    let r1 = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    assert_eq!(r1.receipt.t, 1);
+
+    let q_missing = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to":   format!("{ledger_id}@t:latest"),
+        "select": ["?v", "?t", "?op"],
+        "where": [{
+            "@id": "http://does-not-exist.example/x",
+            "ex:name": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+    });
+    let missing_rows = run_history_query(&fluree, &q_missing).await;
+    assert!(
+        missing_rows.is_empty(),
+        "non-matching @id must return zero rows (novelty-only); got {missing_rows:#?}"
+    );
+}

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -89,7 +89,7 @@ use crate::binary_scan::{BinaryScanOperator, EmitMask};
 use crate::binding::Batch;
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
-use crate::ir::triple::TriplePattern;
+use crate::ir::triple::{Ref, TriplePattern};
 use crate::operator::inline::InlineOperator;
 use crate::operator::Operator;
 use crate::var_registry::VarId;
@@ -211,8 +211,29 @@ impl BinaryHistoryScanOperator {
                     &p_sid,
                 )
                 .map_err(|e| QueryError::Internal(format!("history scan: build_filter: {e}")))?;
+
+                // If a literal-bound pattern component (subject or predicate)
+                // failed to resolve to a store id, the persisted index cannot
+                // contain a match. Skipping is essential — `BinaryFilter`
+                // currently constrains only s_id/p_id, so leaving them `None`
+                // here would walk every leaflet and emit every base row whose
+                // `t` falls in range (i.e. all genesis facts for a `from:t:1,
+                // to:t:1` history query). Novelty still runs, since the
+                // subject/predicate may exist in unindexed data and the
+                // novelty walk's `flake_matches_range_eq` filter is keyed on
+                // `s_sid`/`p_sid` (snapshot space) and short-circuits to
+                // empty when the literal doesn't appear there either.
+                let s_literal_unresolvable =
+                    matches!(self.pattern.s, Ref::Iri(_) | Ref::Sid(_)) && filter.s_id.is_none();
+                let p_literal_unresolvable =
+                    matches!(self.pattern.p, Ref::Iri(_) | Ref::Sid(_)) && filter.p_id.is_none();
+                let skip_persisted = s_literal_unresolvable || p_literal_unresolvable;
+
                 let order = self.pick_order(&filter);
-                if let Some(branch) = store.branch_for_order(g_id, order) {
+                if let Some(branch) = store
+                    .branch_for_order(g_id, order)
+                    .filter(|_| !skip_persisted)
+                {
                     let leaf_indices = leaf_index_range(branch, &filter, order);
                     let view = BinaryGraphView::with_novelty(
                         Arc::clone(store),


### PR DESCRIPTION
History queries with a literal `@id` that doesn't match any subject silently
dropped the subject filter and returned every base row at `t:1`. On larger
ledgers this blew past Lambda's 6 MB response limit and surfaced as a generic
upstream 502; on smaller ledgers it returned plausible-looking garbage.

## Root cause

`BinaryHistoryScanOperator::collect_history_flakes` builds a `BinaryFilter` from
the pattern. When the subject literal doesn't exist in the persisted store,
`store.find_subject_id(iri)` returns `None`, so `filter.s_id = None`. The
persisted pass only constrains by `s_id`/`p_id` (object filtering isn't applied
there), so an unconstrained filter walked every leaflet and emitted every base
row whose `t` fell in range.

Novelty was unaffected — it filters via `flake_matches_range_eq` keyed on the
snapshot-space `s_sid`, which correctly short-circuits to empty.

## Fix

Before opening the persisted branch, detect literal-bound pattern components
(subject `Ref::Iri`/`Ref::Sid`, same for predicate) that failed store
resolution and skip the persisted pass entirely. Novelty still runs so subjects
present only in unindexed data continue to match.
