### PR TITLE
fix: consistent fuel reporting across import, query, server, and CLI

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1319,6 +1319,34 @@ mem:constraint-01kjte29y3cp8mae56xy6yfv2n a mem:Constraint ;
     mem:branch "main" ;
     mem:createdAt "2026-03-03T18:06:20.611062+00:00"^^xsd:dateTime .
 
+mem:constraint-01ksa8r11bg19hsb6wqnd9h8kp a mem:Constraint ;
+    mem:content "History scan persisted pass must skip when a literal-bound pattern component (subject Ref::Iri/Ref::Sid or predicate) fails to resolve to a store id. BinaryFilter currently only constrains s_id/p_id (object filtering is not applied in the persisted scan), so leaving them None walks every leaflet and emits every base row whose t falls in range — surfacing as \"non-matching @id returns all genesis facts\". Novelty still runs because flake_matches_range_eq is keyed on the snapshot-space s_sid/p_sid and short-circuits to empty correctly.</content>\n<severity>must</severity>\n<refs>[\"fluree-db-query/src/binary_history.rs\", \"fluree-db-api/tests/it_query_history_range.rs\"]</refs>\n</invoke>" ;
+    mem:tag "binary-scan" ;
+    mem:tag "filter" ;
+    mem:tag "gotcha" ;
+    mem:tag "history" ;
+    mem:tag "query" ;
+    mem:scope mem:repo ;
+    mem:branch "main" ;
+    mem:createdAt "2026-05-23T11:15:22.795697+00:00"^^xsd:dateTime .
+
+mem:decision-01ksj0awgy3h55453a7p40tw30 a mem:Decision ;
+    mem:content "Fuel charging is now per-flake without schema exclusion. stage.rs previously skipped schema flakes via is_schema_flake with a misleading comment claiming it 'mirrors query-side fuel'; query-side scans actually charge per-flake unconditionally. Removed the filter and applied the same 100 fuel baseline + 1 micro-fuel/flake formula to bulk imports (per-chunk). ImportBuilder::tracker(Tracker) attaches an external tracker; ImportResult.tally returns the final TrackingTally; mid-import limit exhaustion surfaces as ImportError::FuelExceeded." ;
+    mem:tag "fuel" ;
+    mem:tag "import" ;
+    mem:tag "stage" ;
+    mem:tag "tracking" ;
+    mem:tag "transact" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/query/tracking-and-fuel.md" ;
+    mem:artifactRef "fluree-db-api/src/import.rs" ;
+    mem:artifactRef "fluree-db-core/src/tracking.rs" ;
+    mem:artifactRef "fluree-db-transact/src/stage.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-05-26T11:22:19.038786+00:00"^^xsd:dateTime ;
+    mem:rationale "Consistent fuel semantics across stage, query, and import. Schema-flake exclusion was undocumented and under-charged schema-heavy work; also dropped a hot-path dependency on fluree-db-policy." ;
+    mem:alternatives "Keep schema exclusion in stage and add a matching filter to import; charge import on a per-flake basis without a per-chunk baseline." .
+
 mem:fact-01kjte0r70p5ppv4cjkfyyedpe a mem:Fact ;
     mem:content "SPARQL Testsuite critical gotchas:\n- MUST `cd testsuite-sparql/` first — excluded from workspace, `cargo test -p testsuite-sparql` from root FAILS\n- Syntax tests run by default; eval tests need `--include-ignored`\n- Each test runs in subprocess with 5s/10s timeouts — panics show as \"Subprocess error\"\n- W3C data in git submodule `rdf-tests/`; URL→local: strip `https://w3c.github.io/rdf-tests/`, prepend `testsuite-sparql/rdf-tests/`\n- `make investigate` only searches syntax report — use `make investigate-eval` for eval failures\n- Key commands: `make count-eval`, `make test-eval-cat CAT=functions`, `make summary`, `make classify`" ;
     mem:tag "commands" ;

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -341,6 +341,84 @@ PolicyContext construction) lives in
 `fluree-db-server/src/routes/policy_auth.rs` — useful as a concrete
 implementation reference if you're porting the contract to another server.
 
+## Tracking Contract
+
+CLI tracking flags (`--track`, `--track-fuel`, `--track-time`,
+`--track-policy`, `--max-fuel`) ride on every query request as HTTP headers.
+A server that implements this contract makes the same flags Just Work
+against the bundled Fluree server, a CLI-auto-routed local server, an
+explicit `--remote`, and any custom HTTP implementation.
+
+### Request headers
+
+| Header | CLI flag(s) | Type | Notes |
+|---|---|---|---|
+| `fluree-track-meta` | `--track` | `"true"` (presence-truthy) | Shorthand: enable fuel + time + policy. |
+| `fluree-track-fuel` | `--track-fuel` (also implied by `--max-fuel`) | `"true"` | Report total fuel consumed. |
+| `fluree-track-time` | `--track-time` | `"true"` | Report query execution time. |
+| `fluree-track-policy` | `--track-policy` | `"true"` | Report per-policy executed/allowed counts. |
+| `fluree-max-fuel` | `--max-fuel <N>` | decimal string | Abort with `400` (or equivalent) when fuel exceeds `N`. Implies fuel tracking. |
+
+The CLI only sends headers that map to enabled flags — a server should
+treat each header as independent. `fluree-track-meta` is a shorthand that
+the server may expand to all three; alternatively, when `--track` is set
+the CLI may collapse to the single `fluree-track-meta` header for cleaner
+wire format.
+
+For JSON-LD requests, equivalent body opts exist (`opts.meta`,
+`opts.max-fuel`); the CLI prefers headers so a single transport works
+across JSON-LD and SPARQL. Servers should accept either.
+
+### Required server behavior
+
+1. **Inspect the headers (and body opts) and build a tracker** before
+   executing the query. Tracker construction is per-request — never reuse
+   one across requests.
+
+2. **Enforce `fluree-max-fuel` strictly**: abort the query as soon as
+   accumulated fuel would exceed the limit and return an error response.
+   The reference server returns `400 Bad Request` with a body describing
+   the limit and the amount used.
+
+3. **Return a `TrackedQueryResponse`-shaped body** when any tracking
+   header is present:
+
+   ```json
+   {
+     "status": 200,
+     "result": <the normal query result body>,
+     "time": "12.34ms",
+     "fuel": 1234.567,
+     "policy": { "<policy-id>": { "executed": 3, "allowed": 2 } }
+   }
+   ```
+
+   Only include `time`, `fuel`, `policy` for metrics the client actually
+   requested. The `result` field carries whatever the untracked response
+   body would have been (SPARQL JSON, JSON-LD, agent-json, etc.). For
+   agent-json responses the server SHOULD return the bare agent-json
+   envelope as the response body and surface the tally only via the
+   response headers below, so agents see the same shape they always do.
+
+4. **Echo the tally on response headers** so callers that don't parse
+   the JSON body (e.g. delimited or binary formats) can still read them:
+
+   | Response header | Source | Format |
+   |---|---|---|
+   | `x-fdb-fuel` | tracker.fuel | decimal string |
+   | `x-fdb-time` | tracker.time | duration string, e.g. `"12.34ms"` |
+   | `x-fdb-policy` | tracker.policy | JSON object |
+
+### Reference behavior
+
+The reference server's per-route wiring lives in
+`fluree-db-server/src/routes/query.rs` (see the `has_tracking()` branch
+on the ledger-scoped and connection-scoped query handlers). The tracker
+implementation, micro-fuel internals (1 fuel = 1000 micro-fuel), and the
+`TrackedQueryResponse` / `PolicyStats` shapes are defined in
+`fluree-db-core/src/tracking.rs`. The full fuel cost ladder for queries
+and transactions is in `docs/query/tracking-and-fuel.md`.
+
 ## Merge Preview Contract
 
 `fluree branch diff` issues a single read-only request:

--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -59,8 +59,8 @@ Cost ladder (per event):
 | Flake returned from a `db.range` call (e.g. SHACL graph reads, graph crawl) | 0.001 |
 | Overlay/novelty row materialized | 0.001 |
 | R2RML row emitted (Iceberg/Parquet) | 0.001 |
-| Transaction commit baseline (once per commit) | 100.000 |
-| Staged flake (per non-schema flake in a transaction) | 0.001 |
+| Transaction commit baseline (once per commit, including each bulk-import chunk) | 100.000 |
+| Staged flake (per flake in a transaction or bulk-import chunk) | 0.001 |
 | `REGEX` / `REPLACE` evaluation | 0.001 |
 | Hash function (`MD5`, `SHA1`, `SHA256`, `SHA384`, `SHA512`) | 0.001 |
 | `UUID` / `STRUUID` | 0.001 |

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -31,7 +31,10 @@
 //! even though chunk parsing is parallel.
 
 use crate::error::ApiError;
-use fluree_db_core::{ContentId, ContentKind, ContentStore, RemoteObject, Storage, StorageRead};
+use fluree_db_core::{
+    ContentId, ContentKind, ContentStore, FuelExceededError, RemoteObject, Storage, StorageRead,
+    Tracker, TrackingTally,
+};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -144,6 +147,12 @@ pub struct ImportConfig {
     pub leaf_target_rows: usize,
     /// Optional progress callback invoked at key pipeline milestones.
     pub progress: Option<ProgressFn>,
+    /// Optional execution tracker. When enabled, fuel is charged per chunk
+    /// using the same formula as `stage_transaction`: 100 fuel baseline per
+    /// commit plus 1 micro-fuel per encoded flake. If the tracker carries a
+    /// `max_fuel` limit, the import aborts with `ImportError::FuelExceeded`
+    /// as soon as the limit is exceeded. Default: `Tracker::disabled()`.
+    pub tracker: Tracker,
 }
 
 impl std::fmt::Debug for ImportConfig {
@@ -154,6 +163,7 @@ impl std::fmt::Debug for ImportConfig {
             .field("chunk_size_mb", &self.chunk_size_mb)
             .field("chunk_max_flakes", &self.chunk_max_flakes)
             .field("progress", &self.progress.as_ref().map(|_| "..."))
+            .field("tracker_enabled", &self.tracker.is_enabled())
             .finish_non_exhaustive()
     }
 }
@@ -179,6 +189,7 @@ impl Default for ImportConfig {
             leaflets_per_leaf: 10,
             leaf_target_rows: 250_000,
             progress: None,
+            tracker: Tracker::disabled(),
         }
     }
 }
@@ -368,6 +379,9 @@ pub struct ImportResult {
     pub index_t: i64,
     /// Optional summary of top classes, properties, and connections.
     pub summary: Option<ImportSummary>,
+    /// Tracking tally (fuel, time) when a tracker was supplied via
+    /// `ImportBuilder::tracker(...)`. `None` when tracking was disabled.
+    pub tally: Option<TrackingTally>,
 }
 
 /// Lightweight summary of the imported dataset for CLI display.
@@ -406,6 +420,8 @@ pub enum ImportError {
     NoChunks(String),
     /// Directory contains both Turtle and JSON-LD files.
     MixedFormats(String),
+    /// Tracker max-fuel limit exceeded mid-import.
+    FuelExceeded(FuelExceededError),
 }
 
 impl std::fmt::Display for ImportError {
@@ -420,6 +436,12 @@ impl std::fmt::Display for ImportError {
             Self::Io(e) => write!(f, "I/O: {e}"),
             Self::NoChunks(msg) => write!(f, "no chunks: {msg}"),
             Self::MixedFormats(msg) => write!(f, "mixed formats: {msg}"),
+            Self::FuelExceeded(e) => write!(
+                f,
+                "fuel limit exceeded: used {} of {} fuel",
+                e.used_fuel(),
+                e.limit_fuel()
+            ),
         }
     }
 }
@@ -441,6 +463,12 @@ impl From<std::io::Error> for ImportError {
 impl From<fluree_db_core::Error> for ImportError {
     fn from(e: fluree_db_core::Error) -> Self {
         Self::Storage(e.to_string())
+    }
+}
+
+impl From<FuelExceededError> for ImportError {
+    fn from(e: FuelExceededError) -> Self {
+        Self::FuelExceeded(e)
     }
 }
 
@@ -1048,6 +1076,16 @@ impl<'a> ImportBuilder<'a> {
         self
     }
 
+    /// Attach an execution tracker for fuel accounting. Mirrors transaction
+    /// fuel charging: 100 fuel baseline per commit + 1 micro-fuel per flake.
+    /// When the tracker carries a `max_fuel` limit, the import aborts with
+    /// `ImportError::FuelExceeded` as soon as the limit is hit. The final
+    /// tally is returned on `ImportResult::tally`.
+    pub fn tracker(mut self, tracker: Tracker) -> Self {
+        self.config.tracker = tracker;
+        self
+    }
+
     /// Effective resource settings that will be used for this import (auto-derived when not set).
     /// Use this to report to the user what memory budget and parallelism the import will use.
     pub fn effective_import_settings(&self) -> EffectiveImportSettings {
@@ -1574,6 +1612,7 @@ where
         root_id,
         index_t,
         summary,
+        tally: config.tracker.tally(),
     })
 }
 
@@ -1780,6 +1819,15 @@ where
                 let result = finalize_parsed_chunk(state, parsed, ns_delta, env.storage, env.alias)
                     .await
                     .map_err(|e| ImportError::Transact(e.to_string()))?;
+
+                // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake,
+                // matching the per-chunk-as-transaction model in `stage.rs`.
+                if env.config.tracker.is_enabled() {
+                    env.config.tracker.consume_fuel(100_000)?;
+                    env.config
+                        .tracker
+                        .consume_fuel(result.flake_count as u64)?;
+                }
 
                 // Collect txn-meta for this commit (no I/O, just captures data already in scope).
                 commit_metas.push(CommitMeta {
@@ -2462,6 +2510,12 @@ where
                     .map_err(|e| ImportError::Transact(e.to_string()))?
             };
 
+            // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake.
+            if config.tracker.is_enabled() {
+                config.tracker.consume_fuel(100_000)?;
+                config.tracker.consume_fuel(result.flake_count as u64)?;
+            }
+
             // Collect txn-meta for this commit.
             {
                 let previous_commit_hex = commit_metas.last().map(|m| m.commit_hash_hex.clone());
@@ -2691,6 +2745,12 @@ where
                         .await
                         .map_err(|e| ImportError::Transact(e.to_string()))?
                 };
+
+                // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake.
+                if config.tracker.is_enabled() {
+                    config.tracker.consume_fuel(100_000)?;
+                    config.tracker.consume_fuel(result.flake_count as u64)?;
+                }
 
                 // Collect txn-meta for this commit.
                 {

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -221,6 +221,18 @@ pub fn detect_system_memory_mb() -> usize {
     16 * 1024
 }
 
+/// Charge the per-commit fuel cost: 100 fuel baseline + 1 micro-fuel
+/// per flake. No-op when tracking is disabled. Used by every commit
+/// loop (parallel, remote-serial, local-serial) to keep the import
+/// fuel formula identical to the per-transaction `stage.rs` path.
+fn charge_commit_fuel(tracker: &Tracker, flake_count: u64) -> Result<(), FuelExceededError> {
+    if tracker.is_enabled() {
+        tracker.consume_fuel(100_000)?;
+        tracker.consume_fuel(flake_count)?;
+    }
+    Ok(())
+}
+
 fn env_flag(name: &str) -> bool {
     std::env::var(name)
         .map(|value| {
@@ -1822,10 +1834,7 @@ where
 
                 // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake,
                 // matching the per-chunk-as-transaction model in `stage.rs`.
-                if env.config.tracker.is_enabled() {
-                    env.config.tracker.consume_fuel(100_000)?;
-                    env.config.tracker.consume_fuel(result.flake_count as u64)?;
-                }
+                charge_commit_fuel(&env.config.tracker, result.flake_count as u64)?;
 
                 // Collect txn-meta for this commit (no I/O, just captures data already in scope).
                 commit_metas.push(CommitMeta {
@@ -2509,10 +2518,7 @@ where
             };
 
             // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake.
-            if config.tracker.is_enabled() {
-                config.tracker.consume_fuel(100_000)?;
-                config.tracker.consume_fuel(result.flake_count as u64)?;
-            }
+            charge_commit_fuel(&config.tracker, result.flake_count as u64)?;
 
             // Collect txn-meta for this commit.
             {
@@ -2745,10 +2751,7 @@ where
                 };
 
                 // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake.
-                if config.tracker.is_enabled() {
-                    config.tracker.consume_fuel(100_000)?;
-                    config.tracker.consume_fuel(result.flake_count as u64)?;
-                }
+                charge_commit_fuel(&config.tracker, result.flake_count as u64)?;
 
                 // Collect txn-meta for this commit.
                 {

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -1824,9 +1824,7 @@ where
                 // matching the per-chunk-as-transaction model in `stage.rs`.
                 if env.config.tracker.is_enabled() {
                     env.config.tracker.consume_fuel(100_000)?;
-                    env.config
-                        .tracker
-                        .consume_fuel(result.flake_count as u64)?;
+                    env.config.tracker.consume_fuel(result.flake_count as u64)?;
                 }
 
                 // Collect txn-meta for this commit (no I/O, just captures data already in scope).

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -717,6 +717,18 @@ impl<'a> FromQueryBuilder<'a> {
         self
     }
 
+    /// Enable tracking of all metrics (fuel, time, policy).
+    pub fn track_all(mut self) -> Self {
+        self.core.set_track_all();
+        self
+    }
+
+    /// Set custom tracking options.
+    pub fn tracking(mut self, opts: TrackingOptions) -> Self {
+        self.core.set_tracking(opts);
+        self
+    }
+
     /// Enable BM25/Vector index providers.
     pub fn with_index_providers(mut self) -> Self {
         self.core.set_index_providers();
@@ -1059,8 +1071,10 @@ impl<'a> FromQueryBuilder<'a> {
 
     /// Execute with tracking (fuel, time, policy stats).
     ///
-    /// The connection layer constructs its own tracker from the query body,
-    /// so custom tracking options are not supported on this builder.
+    /// When `.tracking()` or `.track_all()` has been called, the supplied
+    /// `TrackingOptions` are used. Otherwise the connection layer falls back
+    /// to its defaults (JSON-LD reads `opts.meta` / `opts.max-fuel` from the
+    /// query body; SPARQL defaults to all-enabled).
     pub async fn execute_tracked(
         mut self,
     ) -> std::result::Result<TrackedQueryResponse, TrackedErrorResponse> {
@@ -1072,6 +1086,7 @@ impl<'a> FromQueryBuilder<'a> {
 
         let r2rml = self.core.r2rml.take();
         let format_config = self.core.format.take();
+        let tracking = self.core.tracking.take();
         let input = self.core.input.take().unwrap();
         match input {
             QueryInput::JsonLd(json) => match &self.policy {
@@ -1082,6 +1097,7 @@ impl<'a> FromQueryBuilder<'a> {
                                 json,
                                 policy,
                                 format_config,
+                                tracking,
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                             )
@@ -1093,6 +1109,7 @@ impl<'a> FromQueryBuilder<'a> {
                                 json,
                                 policy,
                                 format_config,
+                                tracking,
                             )
                             .await
                     }
@@ -1103,6 +1120,7 @@ impl<'a> FromQueryBuilder<'a> {
                             .query_connection_jsonld_tracked_with_r2rml(
                                 json,
                                 format_config,
+                                tracking,
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                             )
@@ -1110,7 +1128,7 @@ impl<'a> FromQueryBuilder<'a> {
                     }
                     None => {
                         self.fluree
-                            .query_connection_jsonld_tracked(json, format_config)
+                            .query_connection_jsonld_tracked(json, format_config, tracking)
                             .await
                     }
                 },
@@ -1123,7 +1141,7 @@ impl<'a> FromQueryBuilder<'a> {
                                 sparql,
                                 policy,
                                 format_config,
-                                None,
+                                tracking,
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                             )
@@ -1135,7 +1153,7 @@ impl<'a> FromQueryBuilder<'a> {
                                 sparql,
                                 policy,
                                 format_config,
-                                None,
+                                tracking,
                             )
                             .await
                     }
@@ -1146,7 +1164,7 @@ impl<'a> FromQueryBuilder<'a> {
                             .query_connection_sparql_tracked_with_r2rml(
                                 sparql,
                                 format_config,
-                                None,
+                                tracking,
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                             )
@@ -1154,7 +1172,7 @@ impl<'a> FromQueryBuilder<'a> {
                     }
                     None => {
                         self.fluree
-                            .query_connection_sparql_tracked(sparql, format_config, None)
+                            .query_connection_sparql_tracked(sparql, format_config, tracking)
                             .await
                     }
                 },

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -1123,6 +1123,7 @@ impl<'a> FromQueryBuilder<'a> {
                                 sparql,
                                 policy,
                                 format_config,
+                                None,
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                             )
@@ -1134,6 +1135,7 @@ impl<'a> FromQueryBuilder<'a> {
                                 sparql,
                                 policy,
                                 format_config,
+                                None,
                             )
                             .await
                     }
@@ -1144,6 +1146,7 @@ impl<'a> FromQueryBuilder<'a> {
                             .query_connection_sparql_tracked_with_r2rml(
                                 sparql,
                                 format_config,
+                                None,
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                             )
@@ -1151,7 +1154,7 @@ impl<'a> FromQueryBuilder<'a> {
                     }
                     None => {
                         self.fluree
-                            .query_connection_sparql_tracked(sparql, format_config)
+                            .query_connection_sparql_tracked(sparql, format_config, None)
                             .await
                     }
                 },

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -186,6 +186,7 @@ impl Fluree {
         &self,
         query_json: &JsonValue,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
         let (spec, qc_opts) = parse_dataset_spec(query_json)
@@ -204,7 +205,7 @@ impl Fluree {
             .await?
         {
             return self
-                .query_tracked(&view, query_json, format_config, None)
+                .query_tracked(&view, query_json, format_config, tracking_override)
                 .await;
         }
 
@@ -213,7 +214,7 @@ impl Fluree {
             .build_dataset_for_connection_tracked(&spec, &qc_opts)
             .await?;
 
-        self.query_dataset_tracked(&dataset, query_json, format_config, None)
+        self.query_dataset_tracked(&dataset, query_json, format_config, tracking_override)
             .await
     }
 
@@ -223,7 +224,8 @@ impl Fluree {
         query_json: &JsonValue,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        self.query_connection_jsonld_tracked(query_json, None).await
+        self.query_connection_jsonld_tracked(query_json, None, None)
+            .await
     }
 
     /// Execute a JSON-LD query via connection with explicit policy context.
@@ -289,6 +291,7 @@ impl Fluree {
         &self,
         query_json: &JsonValue,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
         r2rml_provider: &dyn R2rmlProvider,
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
@@ -313,7 +316,7 @@ impl Fluree {
                     &view,
                     query_json,
                     format_config,
-                    None,
+                    tracking_override,
                     r2rml_provider,
                     r2rml_table_provider,
                 )
@@ -328,7 +331,7 @@ impl Fluree {
             &dataset,
             query_json,
             format_config,
-            None,
+            tracking_override,
             r2rml_provider,
             r2rml_table_provider,
         )
@@ -340,6 +343,7 @@ impl Fluree {
         query_json: &JsonValue,
         policy: &PolicyContext,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
         r2rml_provider: &dyn R2rmlProvider,
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
@@ -368,7 +372,7 @@ impl Fluree {
                     &view,
                     query_json,
                     format_config,
-                    None,
+                    tracking_override,
                     r2rml_provider,
                     r2rml_table_provider,
                 )
@@ -384,7 +388,7 @@ impl Fluree {
             &dataset,
             query_json,
             format_config,
-            None,
+            tracking_override,
             r2rml_provider,
             r2rml_table_provider,
         )
@@ -399,6 +403,7 @@ impl Fluree {
         query_json: &JsonValue,
         policy: &PolicyContext,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
         let (spec, _qc_opts) = parse_dataset_spec(query_json)
@@ -422,7 +427,7 @@ impl Fluree {
             let view = view.with_policy(Arc::new(policy.clone()));
             let view = self.apply_config_defaults(view, None);
             return self
-                .query_tracked(&view, query_json, format_config, None)
+                .query_tracked(&view, query_json, format_config, tracking_override)
                 .await;
         }
 
@@ -432,7 +437,7 @@ impl Fluree {
             .await
             .map_err(|e| crate::query::TrackedErrorResponse::new(500, e.to_string(), None))?;
         let dataset = apply_policy_to_dataset(dataset, policy);
-        self.query_dataset_tracked(&dataset, query_json, format_config, None)
+        self.query_dataset_tracked(&dataset, query_json, format_config, tracking_override)
             .await
     }
 

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -9,6 +9,7 @@ use crate::{
     ApiError, DatasetSpec, Fluree, FormatterConfig, PolicyContext, QueryConnectionOptions,
     QueryResult, Result,
 };
+use fluree_db_core::TrackingOptions;
 use fluree_db_query::r2rml::{R2rmlProvider, R2rmlTableProvider};
 
 type TrackedResult<T> = std::result::Result<T, crate::query::TrackedErrorResponse>;
@@ -563,6 +564,7 @@ impl Fluree {
         &self,
         sparql: &str,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
         let ast = parse_and_validate_sparql(sparql)
@@ -583,7 +585,7 @@ impl Fluree {
             .await
             .map_err(|e| crate::query::TrackedErrorResponse::new(500, e.to_string(), None))?;
 
-        self.query_dataset_tracked(&dataset, sparql, format_config, None)
+        self.query_dataset_tracked(&dataset, sparql, format_config, tracking_override)
             .await
     }
 
@@ -591,6 +593,7 @@ impl Fluree {
         &self,
         sparql: &str,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
         r2rml_provider: &dyn R2rmlProvider,
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
@@ -617,7 +620,7 @@ impl Fluree {
             &dataset,
             sparql,
             format_config,
-            None,
+            tracking_override,
             r2rml_provider,
             r2rml_table_provider,
         )
@@ -634,6 +637,7 @@ impl Fluree {
         sparql: &str,
         policy: &PolicyContext,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
         let ast = parse_and_validate_sparql(sparql)
@@ -655,7 +659,7 @@ impl Fluree {
             .map_err(|e| crate::query::TrackedErrorResponse::new(500, e.to_string(), None))?;
         let dataset = apply_policy_to_dataset(dataset, policy);
 
-        self.query_dataset_tracked(&dataset, sparql, format_config, None)
+        self.query_dataset_tracked(&dataset, sparql, format_config, tracking_override)
             .await
     }
 
@@ -664,6 +668,7 @@ impl Fluree {
         sparql: &str,
         policy: &PolicyContext,
         format_config: Option<FormatterConfig>,
+        tracking_override: Option<TrackingOptions>,
         r2rml_provider: &dyn R2rmlProvider,
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
@@ -691,7 +696,7 @@ impl Fluree {
             &dataset,
             sparql,
             format_config,
-            None,
+            tracking_override,
             r2rml_provider,
             r2rml_table_provider,
         )

--- a/fluree-db-api/tests/it_query_connection.rs
+++ b/fluree-db-api/tests/it_query_connection.rs
@@ -570,3 +570,77 @@ WHERE {
     );
     assert!(tracked.fuel.unwrap() > 0.0, "fuel should be positive");
 }
+
+#[tokio::test]
+async fn query_from_sparql_with_tracking_setter_reports_fuel() {
+    use fluree_db_api::TrackingOptions;
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_people_ledger(&fluree, "people:main").await;
+
+    let sparql = r"
+PREFIX ex: <http://example.org/ns/>
+PREFIX schema: <http://schema.org/>
+SELECT ?name
+FROM <people:main>
+WHERE {
+  ?person a ex:Person ;
+          schema:name ?name .
+}
+";
+
+    let tracked = fluree
+        .query_from()
+        .sparql(sparql)
+        .tracking(TrackingOptions {
+            track_time: true,
+            track_fuel: true,
+            track_policy: false,
+            max_fuel: None,
+        })
+        .execute_tracked()
+        .await
+        .expect("query_from().sparql().tracking().execute_tracked() should succeed");
+
+    assert_eq!(tracked.status, 200);
+    assert!(
+        tracked.fuel.is_some(),
+        "fuel should be present when tracking() was set on the builder"
+    );
+    assert!(tracked.fuel.unwrap() > 0.0, "fuel should be positive");
+    assert!(
+        tracked.policy.is_none(),
+        "policy should not be present when track_policy = false"
+    );
+}
+
+#[tokio::test]
+async fn query_from_jsonld_with_track_all_reports_fuel_and_time() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_people_ledger(&fluree, "people:main").await;
+
+    let query = json!({
+        "@context": {
+            "ex": "http://example.org/ns/",
+            "schema": "http://schema.org/"
+        },
+        "from": "people:main",
+        "select": "?name",
+        "where": [
+            { "@id": "?person", "@type": "ex:Person", "schema:name": "?name" }
+        ]
+    });
+
+    let tracked = fluree
+        .query_from()
+        .jsonld(&query)
+        .track_all()
+        .execute_tracked()
+        .await
+        .expect("query_from().jsonld().track_all().execute_tracked() should succeed");
+
+    assert_eq!(tracked.status, 200);
+    assert!(tracked.fuel.is_some() && tracked.fuel.unwrap() > 0.0);
+    assert!(tracked.time.is_some());
+}

--- a/fluree-db-api/tests/it_query_connection.rs
+++ b/fluree-db-api/tests/it_query_connection.rs
@@ -534,7 +534,7 @@ WHERE {
 ";
 
     let tracked = fluree
-        .query_connection_sparql_tracked(sparql, None)
+        .query_connection_sparql_tracked(sparql, None, None)
         .await
         .expect("query_connection_sparql_tracked should succeed");
 

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -478,13 +478,26 @@ pub enum Commands {
         #[arg(long)]
         remote: Option<String>,
 
-        /// Report tracking tally (fuel, time, policy) to stderr after results.
-        /// Implied by --max-fuel.
+        /// Report tracking tally (fuel + time + policy) to stderr after results.
+        /// Shorthand for `--track-fuel --track-time --track-policy`.
         #[arg(long)]
         track: bool,
 
+        /// Report fuel consumption to stderr after results.
+        /// Implied by --max-fuel.
+        #[arg(long)]
+        track_fuel: bool,
+
+        /// Report query execution time to stderr after results.
+        #[arg(long)]
+        track_time: bool,
+
+        /// Report per-policy executed/allowed counts to stderr after results.
+        #[arg(long)]
+        track_policy: bool,
+
         /// Abort the query if fuel consumption exceeds this decimal limit
-        /// (e.g. `--max-fuel 1000`). Implies `--track`.
+        /// (e.g. `--max-fuel 1000`). Implies `--track-fuel`.
         #[arg(long)]
         max_fuel: Option<f64>,
 

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -478,6 +478,16 @@ pub enum Commands {
         #[arg(long)]
         remote: Option<String>,
 
+        /// Report tracking tally (fuel, time, policy) to stderr after results.
+        /// Implied by --max-fuel.
+        #[arg(long)]
+        track: bool,
+
+        /// Abort the query if fuel consumption exceeds this decimal limit
+        /// (e.g. `--max-fuel 1000`). Implies `--track`.
+        #[arg(long)]
+        max_fuel: Option<f64>,
+
         #[command(flatten)]
         policy: PolicyArgs,
     },

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -602,12 +602,8 @@ pub async fn run(
                 output::format_result(&result, output_format, query_format, effective_limit)?;
             println!("{}", output.text);
             if let Some((fuel, time, policy)) = tracked_tally {
-                let tally_suffix = format_tally_suffix(
-                    fuel,
-                    time.as_deref(),
-                    policy.as_ref(),
-                    tracking_metrics,
-                );
+                let tally_suffix =
+                    format_tally_suffix(fuel, time.as_deref(), policy.as_ref(), tracking_metrics);
                 let time_str = format_duration(elapsed);
                 let total = output.total_rows;
                 match effective_limit {
@@ -616,10 +612,7 @@ pub async fn run(
                         format_count(n),
                         format_count(total),
                     ),
-                    _ => eprintln!(
-                        "({} rows, {time_str}{tally_suffix})",
-                        format_count(total),
-                    ),
+                    _ => eprintln!("({} rows, {time_str}{tally_suffix})", format_count(total),),
                 }
             } else {
                 print_footer(output.total_rows, effective_limit, elapsed);
@@ -670,14 +663,16 @@ pub async fn run(
                     detect::QueryFormat::Sparql => None,
                 };
                 let timer = Instant::now();
-                let builder = GraphSnapshotQueryBuilder::new_from_parts(&fluree, &view).tracking(opts);
+                let builder =
+                    GraphSnapshotQueryBuilder::new_from_parts(&fluree, &view).tracking(opts);
                 let builder = match query_format {
                     detect::QueryFormat::Sparql => builder.sparql(content.as_str()),
                     detect::QueryFormat::JsonLd => builder.jsonld(json_query.as_ref().unwrap()),
                 };
-                let response = builder.execute_tracked().await.map_err(|e| {
-                    CliError::Api(fluree_db_api::ApiError::http(e.status, e.error))
-                })?;
+                let response = builder
+                    .execute_tracked()
+                    .await
+                    .map_err(|e| CliError::Api(fluree_db_api::ApiError::http(e.status, e.error)))?;
                 let elapsed = timer.elapsed();
 
                 // Render the formatted result through the existing output pipeline so

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -10,6 +10,123 @@ use fluree_db_api::{GraphSnapshotQueryBuilder, TrackingOptions};
 use std::path::Path;
 use std::time::Instant;
 
+/// CLI tracking flags (mirrors the granular `fluree-track-*` HTTP headers
+/// and the `fluree-max-fuel` cap). `--track` is shorthand for fuel + time +
+/// policy; `--max-fuel` implies `--track-fuel`.
+#[derive(Clone, Copy, Default)]
+pub struct TrackingFlags {
+    pub track: bool,
+    pub track_fuel: bool,
+    pub track_time: bool,
+    pub track_policy: bool,
+    pub max_fuel: Option<f64>,
+}
+
+impl TrackingFlags {
+    /// Whether any tracking output was requested by the user.
+    fn any(&self) -> bool {
+        self.track
+            || self.track_fuel
+            || self.track_time
+            || self.track_policy
+            || self.max_fuel.is_some()
+    }
+
+    /// Resolve which individual metrics should be enabled, after applying
+    /// shorthand semantics: `--track` enables all three; `--max-fuel`
+    /// enables `track_fuel`.
+    fn effective(&self) -> (bool, bool, bool) {
+        let fuel = self.track || self.track_fuel || self.max_fuel.is_some();
+        let time = self.track || self.track_time;
+        let policy = self.track || self.track_policy;
+        (fuel, time, policy)
+    }
+
+    /// Build SDK TrackingOptions from the flag set, or None when no metrics
+    /// are requested.
+    fn as_options(&self) -> Option<TrackingOptions> {
+        if !self.any() {
+            return None;
+        }
+        let (fuel, time, policy) = self.effective();
+        let max_fuel_micro = self
+            .max_fuel
+            .filter(|f| *f > 0.0)
+            .map(|f| (f * 1000.0).round().max(0.0) as u64);
+        Some(TrackingOptions {
+            track_time: time,
+            track_fuel: fuel,
+            track_policy: policy,
+            max_fuel: max_fuel_micro,
+        })
+    }
+
+    /// Build the HTTP request headers that map 1:1 to the flag set.
+    /// Empty when no tracking was requested.
+    fn as_request_headers(&self) -> Vec<(&'static str, String)> {
+        let mut out = Vec::new();
+        if !self.any() {
+            return out;
+        }
+        let (fuel, time, policy) = self.effective();
+        // `--track` collapses to the meta omnibus header for cleaner wire format.
+        if self.track {
+            out.push(("fluree-track-meta", "true".to_string()));
+        } else {
+            if fuel {
+                out.push(("fluree-track-fuel", "true".to_string()));
+            }
+            if time {
+                out.push(("fluree-track-time", "true".to_string()));
+            }
+            if policy {
+                out.push(("fluree-track-policy", "true".to_string()));
+            }
+        }
+        if let Some(limit) = self.max_fuel.filter(|f| *f > 0.0) {
+            out.push(("fluree-max-fuel", format!("{limit}")));
+        }
+        out
+    }
+}
+
+/// Append fuel/time/policy fields from a tracked response to the existing
+/// row/time footer. `metrics` is `(track_fuel, track_time, track_policy)` —
+/// only requested fields are shown, even if the server returned more.
+fn format_tally_suffix(
+    fuel: Option<f64>,
+    time: Option<&str>,
+    policy: Option<&std::collections::HashMap<String, fluree_db_api::PolicyStats>>,
+    metrics: (bool, bool, bool),
+) -> String {
+    let (want_fuel, want_time, want_policy) = metrics;
+    let mut parts: Vec<String> = Vec::new();
+    if want_time {
+        if let Some(t) = time {
+            parts.push(format!("time {t}"));
+        }
+    }
+    if want_fuel {
+        if let Some(f) = fuel {
+            parts.push(format!("fuel {f}"));
+        }
+    }
+    if want_policy {
+        if let Some(p) = policy {
+            if !p.is_empty() {
+                let total_exec: u64 = p.values().map(|s| s.executed).sum();
+                let total_allowed: u64 = p.values().map(|s| s.allowed).sum();
+                parts.push(format!("policy {total_allowed}/{total_exec}"));
+            }
+        }
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(", {}", parts.join(", "))
+    }
+}
+
 /// Parse a `--at` value into a `TimeSpec`.
 ///
 /// Accepts:
@@ -102,8 +219,7 @@ pub async fn run(
     dirs: &FlureeDir,
     remote_flag: Option<&str>,
     direct: bool,
-    track: bool,
-    max_fuel: Option<f64>,
+    tracking: TrackingFlags,
     policy: &PolicyArgs,
 ) -> CliResult<()> {
     const BENCH_ROWS: usize = 5;
@@ -159,38 +275,29 @@ pub async fn run(
         }
     }
 
-    // --track / --max-fuel: validate combinations and build tracking options.
-    // --max-fuel implies --track. Tracking uses an alternate SDK path that
-    // returns a pre-formatted result, so it is incompatible with --bench,
-    // --explain, and the delimited fast paths (TSV/CSV).
-    let tracking_opts = if track || max_fuel.is_some() {
+    // --track* / --max-fuel: validate combinations and resolve metrics.
+    // Tracking uses an alternate code path that emits a tally to stderr, so
+    // it is incompatible with --bench, --explain, and the delimited fast
+    // paths (TSV/CSV).
+    if tracking.any() {
         if bench {
             return Err(CliError::Usage(
-                "--track is not compatible with --bench".to_string(),
+                "--track* / --max-fuel are not compatible with --bench".to_string(),
             ));
         }
         if explain {
             return Err(CliError::Usage(
-                "--track is not compatible with --explain".to_string(),
+                "--track* / --max-fuel are not compatible with --explain".to_string(),
             ));
         }
         if matches!(output_format, OutputFormatKind::Tsv | OutputFormatKind::Csv) {
             return Err(CliError::Usage(
-                "--track is not compatible with --format tsv/csv".to_string(),
+                "--track* / --max-fuel are not compatible with --format tsv/csv".to_string(),
             ));
         }
-        let max_fuel_micro = max_fuel
-            .filter(|f| *f > 0.0)
-            .map(|f| (f * 1000.0).round().max(0.0) as u64);
-        Some(TrackingOptions {
-            track_time: true,
-            track_fuel: true,
-            track_policy: true,
-            max_fuel: max_fuel_micro,
-        })
-    } else {
-        None
-    };
+    }
+    let tracking_opts = tracking.as_options();
+    let tracking_metrics = tracking.effective();
 
     // Resolve ledger mode: --remote flag, local, tracked, or auto-route to local server
     let mode = if let Some(remote_name) = remote_flag {
@@ -212,16 +319,14 @@ pub async fn run(
             remote_name,
             ..
         } => {
-            // --track / --max-fuel are not yet wired through the remote HTTP
-            // client. The server itself supports tracking (hit the endpoint
-            // with `fluree-track-fuel: true` directly); the CLI wiring is a
-            // follow-up.
-            if tracking_opts.is_some() {
-                eprintln!(
-                    "warning: --track / --max-fuel are not yet wired through the remote \
-                     query client; ignoring for this request"
-                );
-            }
+            // Resolve tracking headers once; empty when no --track* / --max-fuel
+            // flag was set. Sent on every non-explain query path below.
+            let tracking_headers = tracking.as_request_headers();
+            let is_tracked = tracking_opts.is_some();
+            // Tracking is incompatible with TSV/CSV and explain (already
+            // rejected up-front by the early validation block). It is, however,
+            // compatible with --at: time-travel headers (FROM injection for
+            // SPARQL, body `from` for JSON-LD) compose with tracking headers.
             // Attach policy flags to the remote client so headers + body opts
             // ride through on every request (see RemoteLedgerClient::with_policy).
             let client = client.with_policy(policy.clone());
@@ -378,7 +483,13 @@ pub async fn run(
                             )
                         },
                     )?;
-                    client.query_sparql(&remote_alias, &injected).await?
+                    if is_tracked {
+                        client
+                            .query_sparql_with_headers(&remote_alias, &injected, &tracking_headers)
+                            .await?
+                    } else {
+                        client.query_sparql(&remote_alias, &injected).await?
+                    }
                 }
                 (detect::QueryFormat::JsonLd, Some(at_str), false) => {
                     // Remote time-travel via ledger-scoped JSON-LD: path
@@ -394,14 +505,40 @@ pub async fn run(
                             "JSON-LD query must be a JSON object".to_string(),
                         ));
                     }
-                    client.query_jsonld(&remote_alias, &json_query).await?
+                    if is_tracked {
+                        client
+                            .query_jsonld_with_headers(
+                                &remote_alias,
+                                &json_query,
+                                &tracking_headers,
+                            )
+                            .await?
+                    } else {
+                        client.query_jsonld(&remote_alias, &json_query).await?
+                    }
                 }
                 (detect::QueryFormat::Sparql, None, false) => {
-                    client.query_sparql(&remote_alias, &content).await?
+                    if is_tracked {
+                        client
+                            .query_sparql_with_headers(&remote_alias, &content, &tracking_headers)
+                            .await?
+                    } else {
+                        client.query_sparql(&remote_alias, &content).await?
+                    }
                 }
                 (detect::QueryFormat::JsonLd, None, false) => {
                     let json_query: serde_json::Value = serde_json::from_str(&content)?;
-                    client.query_jsonld(&remote_alias, &json_query).await?
+                    if is_tracked {
+                        client
+                            .query_jsonld_with_headers(
+                                &remote_alias,
+                                &json_query,
+                                &tracking_headers,
+                            )
+                            .await?
+                    } else {
+                        client.query_jsonld(&remote_alias, &json_query).await?
+                    }
                 }
             };
             let elapsed = timer.elapsed();
@@ -413,6 +550,32 @@ pub async fn run(
                 eprintln!("(explain, {})", format_duration(elapsed));
                 return Ok(());
             }
+
+            // When tracking was requested, the server returned a
+            // `TrackedQueryResponse` envelope `{ status, result, time, fuel,
+            // policy }`. Peel off the result for rendering and capture the
+            // tally for the footer.
+            let (result, tracked_tally) = if is_tracked {
+                let envelope = result;
+                let inner = envelope
+                    .get("result")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let time = envelope
+                    .get("time")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from);
+                let fuel = envelope.get("fuel").and_then(serde_json::Value::as_f64);
+                let policy = envelope.get("policy").and_then(|v| {
+                    serde_json::from_value::<
+                        std::collections::HashMap<String, fluree_db_api::PolicyStats>,
+                    >(v.clone())
+                    .ok()
+                });
+                (inner, Some((fuel, time, policy)))
+            } else {
+                (result, None)
+            };
 
             // Safety: rendering a `table` for millions of rows will effectively hang the CLI.
             // For table output, show a preview unless the result set is small (or --bench is used).
@@ -438,7 +601,29 @@ pub async fn run(
             let output =
                 output::format_result(&result, output_format, query_format, effective_limit)?;
             println!("{}", output.text);
-            print_footer(output.total_rows, effective_limit, elapsed);
+            if let Some((fuel, time, policy)) = tracked_tally {
+                let tally_suffix = format_tally_suffix(
+                    fuel,
+                    time.as_deref(),
+                    policy.as_ref(),
+                    tracking_metrics,
+                );
+                let time_str = format_duration(elapsed);
+                let total = output.total_rows;
+                match effective_limit {
+                    Some(n) if n < total => eprintln!(
+                        "(first {} of {} rows, {time_str}{tally_suffix})",
+                        format_count(n),
+                        format_count(total),
+                    ),
+                    _ => eprintln!(
+                        "({} rows, {time_str}{tally_suffix})",
+                        format_count(total),
+                    ),
+                }
+            } else {
+                print_footer(output.total_rows, effective_limit, elapsed);
+            }
         }
         LedgerMode::Local { fluree, alias } => {
             // Load a single view (optionally time-traveled) and execute against it.
@@ -506,30 +691,14 @@ pub async fn run(
                     output::format_result(&response.result, display_format, query_format, None)?;
                 println!("{}", output.text);
 
-                // Tally to stderr; preserve the existing row/time footer too.
-                let mut tally_parts: Vec<String> = Vec::new();
-                if let Some(t) = &response.time {
-                    tally_parts.push(format!("time {t}"));
-                }
-                if let Some(f) = response.fuel {
-                    tally_parts.push(format!("fuel {f}"));
-                }
-                if let Some(policy) = &response.policy {
-                    if !policy.is_empty() {
-                        let total_exec: u64 = policy.values().map(|s| s.executed).sum();
-                        let total_allowed: u64 = policy.values().map(|s| s.allowed).sum();
-                        tally_parts.push(format!(
-                            "policy {total_allowed}/{total_exec}"
-                        ));
-                    }
-                }
-                let tally_suffix = if tally_parts.is_empty() {
-                    String::new()
-                } else {
-                    format!(", {}", tally_parts.join(", "))
-                };
+                let tally_suffix = format_tally_suffix(
+                    response.fuel,
+                    response.time.as_deref(),
+                    response.policy.as_ref(),
+                    tracking_metrics,
+                );
                 eprintln!(
-                    "({} rows, query: {}{tally_suffix})",
+                    "({} rows, {}{tally_suffix})",
                     format_count(output.total_rows),
                     format_duration(elapsed),
                 );

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -6,6 +6,7 @@ use crate::error::{CliError, CliResult};
 use crate::input;
 use crate::output::{self, OutputFormatKind};
 use fluree_db_api::server_defaults::FlureeDir;
+use fluree_db_api::{GraphSnapshotQueryBuilder, TrackingOptions};
 use std::path::Path;
 use std::time::Instant;
 
@@ -101,6 +102,8 @@ pub async fn run(
     dirs: &FlureeDir,
     remote_flag: Option<&str>,
     direct: bool,
+    track: bool,
+    max_fuel: Option<f64>,
     policy: &PolicyArgs,
 ) -> CliResult<()> {
     const BENCH_ROWS: usize = 5;
@@ -156,6 +159,39 @@ pub async fn run(
         }
     }
 
+    // --track / --max-fuel: validate combinations and build tracking options.
+    // --max-fuel implies --track. Tracking uses an alternate SDK path that
+    // returns a pre-formatted result, so it is incompatible with --bench,
+    // --explain, and the delimited fast paths (TSV/CSV).
+    let tracking_opts = if track || max_fuel.is_some() {
+        if bench {
+            return Err(CliError::Usage(
+                "--track is not compatible with --bench".to_string(),
+            ));
+        }
+        if explain {
+            return Err(CliError::Usage(
+                "--track is not compatible with --explain".to_string(),
+            ));
+        }
+        if matches!(output_format, OutputFormatKind::Tsv | OutputFormatKind::Csv) {
+            return Err(CliError::Usage(
+                "--track is not compatible with --format tsv/csv".to_string(),
+            ));
+        }
+        let max_fuel_micro = max_fuel
+            .filter(|f| *f > 0.0)
+            .map(|f| (f * 1000.0).round().max(0.0) as u64);
+        Some(TrackingOptions {
+            track_time: true,
+            track_fuel: true,
+            track_policy: true,
+            max_fuel: max_fuel_micro,
+        })
+    } else {
+        None
+    };
+
     // Resolve ledger mode: --remote flag, local, tracked, or auto-route to local server
     let mode = if let Some(remote_name) = remote_flag {
         let alias = context::resolve_ledger(explicit_ledger, dirs)?;
@@ -176,6 +212,16 @@ pub async fn run(
             remote_name,
             ..
         } => {
+            // --track / --max-fuel are not yet wired through the remote HTTP
+            // client. The server itself supports tracking (hit the endpoint
+            // with `fluree-track-fuel: true` directly); the CLI wiring is a
+            // follow-up.
+            if tracking_opts.is_some() {
+                eprintln!(
+                    "warning: --track / --max-fuel are not yet wired through the remote \
+                     query client; ignoring for this request"
+                );
+            }
             // Attach policy flags to the remote client so headers + body opts
             // ride through on every request (see RemoteLedgerClient::with_policy).
             let client = client.with_policy(policy.clone());
@@ -427,6 +473,66 @@ pub async fn run(
                 let elapsed = timer.elapsed();
                 println!("{}", serde_json::to_string_pretty(&resp)?);
                 eprintln!("(explain, {})", format_duration(elapsed));
+                return Ok(());
+            }
+
+            // Tracked path: route through the tracked SDK builder so we get a
+            // pre-formatted JsonValue plus fuel/time/policy tally. Mutually
+            // exclusive with --bench / --explain / TSV / CSV (checked above).
+            if let Some(opts) = tracking_opts.clone() {
+                let json_query: Option<serde_json::Value> = match query_format {
+                    detect::QueryFormat::JsonLd => Some(serde_json::from_str(&content)?),
+                    detect::QueryFormat::Sparql => None,
+                };
+                let timer = Instant::now();
+                let builder = GraphSnapshotQueryBuilder::new_from_parts(&fluree, &view).tracking(opts);
+                let builder = match query_format {
+                    detect::QueryFormat::Sparql => builder.sparql(content.as_str()),
+                    detect::QueryFormat::JsonLd => builder.jsonld(json_query.as_ref().unwrap()),
+                };
+                let response = builder.execute_tracked().await.map_err(|e| {
+                    CliError::Api(fluree_db_api::ApiError::http(e.status, e.error))
+                })?;
+                let elapsed = timer.elapsed();
+
+                // Render the formatted result through the existing output pipeline so
+                // --format {json,typed-json,table} continues to apply.
+                let display_format = match output_format {
+                    OutputFormatKind::TypedJson => OutputFormatKind::TypedJson,
+                    _ if query_format == detect::QueryFormat::JsonLd => OutputFormatKind::Json,
+                    _ => output_format,
+                };
+                let output =
+                    output::format_result(&response.result, display_format, query_format, None)?;
+                println!("{}", output.text);
+
+                // Tally to stderr; preserve the existing row/time footer too.
+                let mut tally_parts: Vec<String> = Vec::new();
+                if let Some(t) = &response.time {
+                    tally_parts.push(format!("time {t}"));
+                }
+                if let Some(f) = response.fuel {
+                    tally_parts.push(format!("fuel {f}"));
+                }
+                if let Some(policy) = &response.policy {
+                    if !policy.is_empty() {
+                        let total_exec: u64 = policy.values().map(|s| s.executed).sum();
+                        let total_allowed: u64 = policy.values().map(|s| s.allowed).sum();
+                        tally_parts.push(format!(
+                            "policy {total_allowed}/{total_exec}"
+                        ));
+                    }
+                }
+                let tally_suffix = if tally_parts.is_empty() {
+                    String::new()
+                } else {
+                    format!(", {}", tally_parts.join(", "))
+                };
+                eprintln!(
+                    "({} rows, query: {}{tally_suffix})",
+                    format_count(output.total_rows),
+                    format_duration(elapsed),
+                );
                 return Ok(());
             }
 

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -234,6 +234,8 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             jsonld,
             at,
             remote,
+            track,
+            max_fuel,
             policy,
         } => {
             let fluree_dir = config::require_fluree_dir_or_global(config_path)?;
@@ -251,6 +253,8 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
                 &fluree_dir,
                 remote.as_deref(),
                 direct,
+                track,
+                max_fuel,
                 &policy,
             )
             .await

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -235,6 +235,9 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             at,
             remote,
             track,
+            track_fuel,
+            track_time,
+            track_policy,
             max_fuel,
             policy,
         } => {
@@ -253,8 +256,13 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
                 &fluree_dir,
                 remote.as_deref(),
                 direct,
-                track,
-                max_fuel,
+                commands::query::TrackingFlags {
+                    track,
+                    track_fuel,
+                    track_time,
+                    track_policy,
+                    max_fuel,
+                },
                 &policy,
             )
             .await

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -793,6 +793,89 @@ impl RemoteLedgerClient {
         .await
     }
 
+    // -------------------------------------------------------------------------
+    // Tracked variants
+    //
+    // These mirror the four query methods above but attach arbitrary extra
+    // request headers (typically `fluree-track-*` / `fluree-max-fuel`). When
+    // tracking headers are present the server returns a `TrackedQueryResponse`
+    // JSON envelope `{ status, result, time, fuel, policy }`; the caller is
+    // responsible for extracting `result` for display and the sibling fields
+    // for the tally.
+    // -------------------------------------------------------------------------
+
+    /// JSON-LD ledger-scoped query with extra request headers.
+    pub async fn query_jsonld_with_headers(
+        &self,
+        ledger: &str,
+        body: &serde_json::Value,
+        extra_headers: &[(&'static str, String)],
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let url = Self::with_default_context_param(self.op_url("query", ledger));
+        self.send_json_with_headers(
+            reqwest::Method::POST,
+            &url,
+            "application/json",
+            extra_headers,
+            Some(RequestBody::Json(body)),
+        )
+        .await
+    }
+
+    /// SPARQL ledger-scoped query with extra request headers.
+    pub async fn query_sparql_with_headers(
+        &self,
+        ledger: &str,
+        sparql: &str,
+        extra_headers: &[(&'static str, String)],
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let url = Self::with_default_context_param(self.op_url("query", ledger));
+        self.send_json_with_headers(
+            reqwest::Method::POST,
+            &url,
+            "application/sparql-query",
+            extra_headers,
+            Some(RequestBody::Text(sparql)),
+        )
+        .await
+    }
+
+    /// JSON-LD connection-scoped query (ledger in body `from`) with extra
+    /// request headers.
+    pub async fn query_connection_jsonld_with_headers(
+        &self,
+        body: &serde_json::Value,
+        extra_headers: &[(&'static str, String)],
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let url = Self::with_default_context_param(self.op_url_root("query"));
+        self.send_json_with_headers(
+            reqwest::Method::POST,
+            &url,
+            "application/json",
+            extra_headers,
+            Some(RequestBody::Json(body)),
+        )
+        .await
+    }
+
+    /// SPARQL connection-scoped query (ledger in `FROM` clause) with extra
+    /// request headers.
+    pub async fn query_connection_sparql_with_headers(
+        &self,
+        sparql: &str,
+        extra_headers: &[(&'static str, String)],
+    ) -> Result<serde_json::Value, RemoteLedgerError> {
+        let url = self.op_url_root("query");
+        self.send_json_with_headers(
+            reqwest::Method::POST,
+            &url,
+            "application/sparql-query",
+            extra_headers,
+            Some(RequestBody::Text(sparql)),
+        )
+        .await
+    }
+
     // =========================================================================
     // Explain
     // =========================================================================

--- a/fluree-db-core/src/tracking.rs
+++ b/fluree-db-core/src/tracking.rs
@@ -7,7 +7,7 @@
 //! micro-fuel. Use the helper methods (`limit_fuel`, `used_fuel`) for
 //! user-facing decimal representations.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -106,7 +106,7 @@ impl TrackingOptions {
 }
 
 /// Policy execution statistics: `{:executed N :allowed M}`
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PolicyStats {
     pub executed: u64,
     pub allowed: u64,

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -369,6 +369,40 @@ pub async fn query(
             };
         }
 
+        // Tracked path: if fluree-track-* / fluree-max-fuel headers are present,
+        // run through the tracking pipeline and emit fuel/time headers + tally body.
+        if headers.has_tracking() {
+            let tracking_opts = headers.to_tracking_options();
+            let response = state
+                .fluree
+                .query_connection_sparql_tracked(&sparql, None, Some(tracking_opts))
+                .await;
+            let response = match response {
+                Ok(r) => r,
+                Err(e) => {
+                    let server_error =
+                        ServerError::Api(fluree_db_api::ApiError::http(e.status, e.error));
+                    set_span_error_code(&span, "error:QueryFailed");
+                    tracing::error!(error = %server_error, query_kind = "sparql", "tracked SPARQL connection query failed");
+                    return Err(server_error);
+                }
+            };
+            let tally = TrackingTally {
+                time: response.time.clone(),
+                fuel: response.fuel,
+                policy: response.policy.clone(),
+            };
+            let resp_headers = tracking_headers(&tally);
+            tracing::info!(
+                status = "success",
+                query_kind = "sparql",
+                tracked = true,
+                time = ?response.time,
+                fuel = response.fuel
+            );
+            return Ok((resp_headers, Json(response)).into_response());
+        }
+
         match state.fluree.query_from().sparql(&sparql).execute_formatted().await {
             Ok(result) => {
                 tracing::info!(

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -353,11 +353,57 @@ pub async fn query(
             if let Some(max_bytes) = headers.max_bytes() {
                 config = config.with_max_bytes(max_bytes);
             }
+            let content_type = "application/vnd.fluree.agent+json; charset=utf-8";
+
+            // Tracked agent-json: keep the agent envelope as the response body
+            // (so agents see the same shape), but surface fuel/time/policy via
+            // x-fdb-* response headers.
+            if headers.has_tracking() {
+                let tracking_opts = headers.to_tracking_options();
+                let response = state
+                    .fluree
+                    .query_from()
+                    .sparql(&sparql)
+                    .format(config)
+                    .tracking(tracking_opts)
+                    .execute_tracked()
+                    .await;
+                return match response {
+                    Ok(r) => {
+                        let tally = TrackingTally {
+                            time: r.time.clone(),
+                            fuel: r.fuel,
+                            policy: r.policy.clone(),
+                        };
+                        let mut resp_headers = tracking_headers(&tally);
+                        resp_headers.insert(
+                            axum::http::header::CONTENT_TYPE,
+                            content_type.parse().expect("content-type parses"),
+                        );
+                        tracing::info!(
+                            status = "success",
+                            query_kind = "sparql",
+                            format = "agent-json",
+                            tracked = true,
+                            time = ?r.time,
+                            fuel = r.fuel,
+                        );
+                        Ok((resp_headers, Json(r.result)).into_response())
+                    }
+                    Err(e) => {
+                        let server_error =
+                            ServerError::Api(fluree_db_api::ApiError::http(e.status, e.error));
+                        set_span_error_code(&span, "error:QueryFailed");
+                        tracing::error!(error = %server_error, query_kind = "sparql", "tracked agent-json SPARQL connection query failed");
+                        Err(server_error)
+                    }
+                };
+            }
+
             let result = state.fluree.query_from().sparql(&sparql).format(config).execute_formatted().await;
             return match result {
                 Ok(json) => {
                     tracing::info!(status = "success", query_kind = "sparql", format = "agent-json");
-                    let content_type = "application/vnd.fluree.agent+json; charset=utf-8";
                     Ok(([(axum::http::header::CONTENT_TYPE, content_type)], Json(json)).into_response())
                 }
                 Err(e) => {

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -1057,6 +1057,100 @@ async fn sparql_query_connection_with_tracking_header_reports_decimal_fuel() {
 }
 
 #[tokio::test]
+async fn sparql_query_connection_agent_json_with_tracking_reports_fuel_header() {
+    let (_tmp, state) = test_state().await;
+    let app = build_router(state.clone());
+
+    let create_body = serde_json::json!({ "ledger": "test:agentfuel" });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let insert_body = serde_json::json!({
+      "@context": { "ex": "http://example.org/" },
+      "@id": "ex:alice",
+      "ex:name": "Alice"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/insert")
+                .header("content-type", "application/json")
+                .header("fluree-ledger", "test:agentfuel")
+                .body(Body::from(insert_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let sparql = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?name
+        FROM <test:agentfuel>
+        WHERE { ?s ex:name ?name }
+    ";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/query")
+                .header("content-type", "application/sparql-query")
+                .header("accept", "application/vnd.fluree.agent+json")
+                .header("fluree-track-fuel", "true")
+                .body(Body::from(sparql))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Content type should remain the agent-json type, not the tracked envelope.
+    let content_type = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .expect("response should set content-type")
+        .to_str()
+        .expect("content-type should be ASCII");
+    assert!(
+        content_type.starts_with("application/vnd.fluree.agent+json"),
+        "expected agent-json content-type, got: {content_type}"
+    );
+
+    // Fuel should be surfaced via the x-fdb-fuel header.
+    let fuel_header = resp
+        .headers()
+        .get("x-fdb-fuel")
+        .expect("tracked agent-json SPARQL should include x-fdb-fuel")
+        .to_str()
+        .expect("fuel header should be ASCII")
+        .parse::<f64>()
+        .expect("fuel header should parse as decimal fuel");
+    assert!(fuel_header > 0.0, "fuel should be > 0, got: {fuel_header}");
+
+    // The body should still be the agent-json envelope (not a TrackedQueryResponse).
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        json.get("fuel").is_none(),
+        "agent-json body should not embed `fuel` (it goes in the x-fdb-fuel header)"
+    );
+}
+
+#[tokio::test]
 async fn sparql_query_ledger_scoped_path_finds_value_without_from() {
     let (_tmp, state) = test_state().await;
     let app = build_router(state.clone());

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -979,6 +979,84 @@ async fn sparql_query_connection_from_clause_finds_value() {
 }
 
 #[tokio::test]
+async fn sparql_query_connection_with_tracking_header_reports_decimal_fuel() {
+    let (_tmp, state) = test_state().await;
+    let app = build_router(state.clone());
+
+    let create_body = serde_json::json!({ "ledger": "test:sparqlqfuel" });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let insert_body = serde_json::json!({
+      "@context": { "ex": "http://example.org/" },
+      "@id": "ex:alice",
+      "ex:name": "Alice"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/insert")
+                .header("content-type", "application/json")
+                .header("fluree-ledger", "test:sparqlqfuel")
+                .body(Body::from(insert_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let sparql = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?name
+        FROM <test:sparqlqfuel>
+        WHERE { ?s ex:name ?name }
+    ";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/query")
+                .header("content-type", "application/sparql-query")
+                .header("fluree-track-fuel", "true")
+                .body(Body::from(sparql))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let fuel_header = resp
+        .headers()
+        .get("x-fdb-fuel")
+        .expect("tracked connection-scoped SPARQL should include x-fdb-fuel")
+        .to_str()
+        .expect("fuel header should be valid ASCII")
+        .parse::<f64>()
+        .expect("fuel header should parse as decimal fuel");
+    let (status, json) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let fuel = json
+        .get("fuel")
+        .and_then(JsonValue::as_f64)
+        .expect("tracked connection-scoped SPARQL response should include decimal fuel");
+    assert_eq!(fuel, fuel_header);
+    assert!(fuel > 0.0, "fuel should be > 0, got: {fuel}");
+}
+
+#[tokio::test]
 async fn sparql_query_ledger_scoped_path_finds_value_without_from() {
     let (_tmp, state) = test_state().await;
     let app = build_router(state.clone());

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -369,16 +369,12 @@ pub async fn stage(
             f
         };
 
-        // Count fuel per staged non-schema flake (mirrors query-side fuel counting).
-        // NOTE: fuel exhaustion now returns an error (previously silently ignored).
-        // This is intentional — transactions exceeding fuel limits should fail
-        // before policy enforcement runs.
+        // Charge 1 micro-fuel per staged flake. Matches query-side scan fuel,
+        // which also charges per flake without filtering schema flakes.
+        // Fuel exhaustion returns an error so transactions exceeding fuel
+        // limits fail before policy enforcement runs.
         if let Some(tracker) = options.tracker {
-            for flake in &flakes {
-                if !is_schema_flake(&flake.p, &flake.o) {
-                    tracker.consume_fuel(1)?;
-                }
-            }
+            tracker.consume_fuel(flakes.len() as u64)?;
         }
 
         // Enforce modify policies (if policy context provided and not root)
@@ -478,14 +474,9 @@ pub async fn stage_flakes(
             }
         };
 
-        // 3. Count fuel per staged non-schema flake.
-        // NOTE: fuel exhaustion now returns an error (previously silently ignored).
+        // 3. Charge 1 micro-fuel per staged flake.
         if let Some(tracker) = options.tracker {
-            for flake in &flakes {
-                if !is_schema_flake(&flake.p, &flake.o) {
-                    tracker.consume_fuel(1)?;
-                }
-            }
+            tracker.consume_fuel(flakes.len() as u64)?;
         }
 
         // 4. Policy enforcement


### PR DESCRIPTION
Before this branch, fuel/time/policy reporting was inconsistent across the surfaces a user actually touches:

- **Bulk imports** silently skipped fuel accounting entirely — a 100M-flake import returned `flake_count` but no `TrackingTally`, and `max-fuel` caps had no effect.
- **`stage.rs`** filtered out "schema flakes" from the per-flake charge using a misleading "mirrors query-side fuel counting" comment — query-side actually charges per flake unconditionally. The filter under-charged schema-heavy transactions and added a cross-crate hot-path dependency on `fluree-db-policy` with no documented rationale.
- **Connection-scoped SPARQL** on `POST /v1/fluree/query` ignored `fluree-track-*` / `fluree-max-fuel` headers and returned no tally, while JSON-LD on the same endpoint honored body opts. The AgentJson SPARQL variant on the same route had the same gap.
- **`FromQueryBuilder`** (`Fluree::query_from()`) had no `.tracking()` / `.track_all()` setters, so SDK callers couldn't request tracking from the connection-scoped builder. The four `query_connection_jsonld_tracked*` helpers also hard-coded `None` for tracking overrides.
- **`fluree query`** CLI had no flag to report fuel for either language, against any backend.

Net: fuel only worked correctly on the ledger-scoped SDK paths and the ledger-scoped HTTP route. Everywhere else it was silently absent or inconsistently shaped.

## What changed

### Engine (`fluree-db-transact`, `fluree-db-api`, `fluree-db-core`)

- **`stage.rs`** now charges 1 micro-fuel per staged flake unconditionally — dropped the `is_schema_flake` filter (and its premise), collapsed the per-flake loop into a single `consume_fuel(flakes.len())`. Comment updated to reflect reality.
- **Bulk import** (`fluree-db-api/src/import.rs`) accepts an optional `Tracker` via the new `ImportBuilder::tracker()` setter. After each `finalize_parsed_chunk`, the pipeline charges `100_000 + flake_count` micro-fuel — same formula as the per-transaction stage path — across all three commit loops (parallel `commit_parsed_chunks_in_order`, remote-serial, local-serial fallback). `ImportResult` gained `tally: Option<TrackingTally>` and `ImportError::FuelExceeded`.
- **`PolicyStats`** now derives `Deserialize` so the CLI can round-trip the policy tally from JSON responses.

### Server (`fluree-db-server`)

- Connection-scoped SPARQL on `POST /v1/fluree/query` now checks `headers.has_tracking()`, builds `TrackingOptions` from headers, calls `query_connection_sparql_tracked` with the override, and returns a `TrackedQueryResponse` body plus `x-fdb-fuel` / `x-fdb-time` / `x-fdb-policy` headers — mirroring the JSON-LD pattern already on that route.
- The agent-json branch of the same route does the same, but preserves the bare agent-json envelope as the response body and surfaces the tally only via the `x-fdb-*` headers so LLM agents see the shape they expect.

### SDK builder (`fluree-db-api`)

- Threaded `tracking_override: Option<TrackingOptions>` through the four `query_connection_sparql_tracked*` AND the four `query_connection_jsonld_tracked*` helpers (forwarded to `query_tracked` / `query_dataset_tracked`, which already honored it).
- Added `.tracking(opts)` and `.track_all()` setters to `FromQueryBuilder`; `execute_tracked` now pulls `core.tracking` and forwards it to both JSON-LD and SPARQL helpers instead of hard-coding `None`.

### CLI (`fluree-db-cli`)

- New `fluree query` flags that map 1:1 to the HTTP header vocabulary:
  - `--track` — fuel + time + policy (shorthand)
  - `--track-fuel`, `--track-time`, `--track-policy` — granular, additive
  - `--max-fuel <N>` — abort at N decimal fuel; implies `--track-fuel`
- Footer prints only the metrics actually requested (no noise when only `--track-fuel`).
- **Remote mode wiring**: the same flags now work against an explicit `--remote`, the auto-routed local server, and any custom HTTP server speaking the same contract. The CLI sends `fluree-track-*` / `fluree-max-fuel` request headers via the new `_with_headers` variants on `RemoteLedgerClient` and parses the `TrackedQueryResponse` envelope back into a (result, tally) pair.
- Mutually exclusive with `--bench`, `--explain`, `--format tsv/csv` (those would bypass the tracked path).

### Docs

- New "Tracking Contract" section in `docs/cli/server-integration.md` documenting the request headers, response envelope, x-fdb-* response headers, and required server behavior — so a third-party HTTP server can support the CLI's tracking flags by implementing one header family + one response shape.
- `docs/query/tracking-and-fuel.md` updated to reflect the new per-flake (no schema filter) and per-import-chunk (100 fuel baseline) accounting.
