### PR TITLE
refactor: rescale query fuel charges and add per-query floor

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -2348,7 +2348,8 @@ curl -X POST http://localhost:8090/v1/fluree/reindex \
     "leaf_count": 614,
     "branch_count": 23,
     "total_bytes": 47185920
-  }
+  },
+  "fuel": 1734.0
 }
 ```
 
@@ -2361,6 +2362,7 @@ curl -X POST http://localhost:8090/v1/fluree/reindex \
 | `stats.leaf_count` | Number of leaf nodes written |
 | `stats.branch_count` | Number of branch nodes written |
 | `stats.total_bytes` | Bytes written to storage during the reindex |
+| `fuel` | Total decimal fuel charged for the reindex's CAS writes (1.000 per write + 1.000 per re-encoded leaflet in FLI3 leaves). `0.0` if the index was already current. See [Tracking and Fuel](../query/tracking-and-fuel.md#indexing-fuel) for the full schedule. |
 
 **Status Codes:**
 - `200 OK` — reindex complete

--- a/docs/indexing-and-search/background-indexing.md
+++ b/docs/indexing-and-search/background-indexing.md
@@ -198,6 +198,14 @@ is optional and should generally be chosen by the caller. Leave
 explicitly for bounded environments such as Lambda jobs, HTTP gateways, or
 other workers with a fixed maximum runtime.
 
+`TriggerIndexResult` carries `fuel: Option<f64>` — the total fuel charged for
+the build that satisfied the trigger. The background indexer always meters
+each build, so callers see `Some(N)` for a real build, `Some(0.0)` when the
+requested t was already indexed (no work was needed), and the same value for
+all coalesced trigger callers satisfied by a single underlying build. See
+[Tracking and Fuel](../query/tracking-and-fuel.md#indexing-fuel) for the
+cost-ladder and rate semantics.
+
 ### Health Indicators
 
 **Healthy:**

--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -54,10 +54,13 @@ Cost ladder (per event):
 
 | Event | Cost (fuel) |
 |---|---|
-| Index leaflet touched (per scan batch, regardless of cache state) | 1.000 |
-| Forward-dict touch (per dict-backed value resolved during result materialization) | 1.000 |
+| Query floor (once per query, charged at entry before parsing) | 1.000 |
+| Index leaflet touched (per scan batch, regardless of cache state) | 0.010 |
+| Forward-dict touch (per dict-backed value resolved during result materialization) | 0.010 |
+| History-scan leaflet base (per leaflet; per-row costs below add on top) | 0.010 |
 | Flake returned from a `db.range` call (e.g. SHACL graph reads, graph crawl) | 0.001 |
 | Overlay/novelty row materialized | 0.001 |
+| History row scanned (base + in-range sidecar rows) | 0.001 |
 | R2RML row emitted (Iceberg/Parquet) | 0.001 |
 | Transaction commit baseline (once per commit, including each bulk-import chunk) | 100.000 |
 | Staged flake (per flake in a transaction or bulk-import chunk) | 0.001 |
@@ -69,6 +72,8 @@ Cost ladder (per event):
 | `Fulltext` (per-row BM25 scoring) | 0.005 |
 
 Cheap operations (comparisons, arithmetic, type checks, simple string ops, datetime extraction, etc.) cost zero — instrumentation overhead would dwarf the actual cost.
+
+The **query floor** guarantees every fuel-tracked query reports at least `1.000` fuel: a query touching no persisted data still costs the floor, and a query that errors during parsing/planning still reports it. I/O "touches" cost `0.010` each, so a scan-dominated query reports roughly `1.000 + 0.010 × (leaflet/dict touches)`. The fuel schedule above is defined in one place — `fluree-db-core/src/tracking.rs` (`tracking::schedule`).
 
 ### Setting Fuel Limits
 
@@ -86,6 +91,12 @@ Set fuel limits via `opts.max-fuel` (decimal allowed). Setting a fuel limit impl
 ```
 
 You can also use `"maxFuel"` or `"max_fuel"` as alternative key names. The HTTP equivalent is the `fluree-max-fuel` header.
+
+Because the `1.000` query floor is charged before execution and counts toward the limit, `max-fuel` must leave room for it:
+
+- `max-fuel: 1` permits exactly the floor — a query that needs even one persisted touch is rejected.
+- `max-fuel: 1.01` permits the floor plus one persisted touch.
+- `max-fuel` below `1.0` (e.g. `0.5`) is rejected up front, before parsing.
 
 ### Fuel Limit Behavior
 

--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -83,7 +83,16 @@ Indexer CAS writes are billed through a `MeteredContentStore` wrapper that the b
 
 FLI3 leaf writes carry an additional per-leaflet charge of **1.000 fuel per re-encoded leaflet**. Passthrough leaflets (byte-copies carried forward from a prior leaf during an incremental update) are **not** charged because no zstd encoding work was performed — so a 100-leaflet leaf where only two leaflets were touched by novelty bills `1 + 2 = 3` fuel, not `1 + 100`. The two FLI3 leaf upload sites (`build::upload::upload_indexes_to_cas` for full rebuild, `build::incremental::upload_leaf_blobs` for incremental) compute the count from `LeafInfo::re_encoded_leaflet_count`.
 
-Indexing fuel is **measurement only**: indexer trackers are no-limit. A partial index is worse than a slow one, so the indexer never aborts mid-build on a fuel limit. The plain public entry points (`build_index_for_record`, `rebuild_index_from_commits`) pass a disabled tracker and report `fuel: None`. The `*_with_tracker` variants (used by `/reindex`) wrap the store, propagate a fuel-enabled tracker, and stamp the final tally on `IndexResult::fuel` — `Some(0.0)` for an already-current build, `Some(N)` for one that did real work. `/reindex` always populates `fuel`; the wire response carries it as `fuel` (omitted when `None`).
+Indexing fuel is **measurement only**: indexer trackers are no-limit. A partial index is worse than a slow one, so the indexer never aborts mid-build on a fuel limit. The plain public entry points (`build_index_for_record`, `rebuild_index_from_commits`) pass a disabled tracker and report `fuel: None`. The `*_with_tracker` variants wrap the store, propagate a fuel-enabled tracker, and stamp the final tally on `IndexResult::fuel` — `Some(0.0)` for an already-current build, `Some(N)` for one that did real work.
+
+Where fuel surfaces depends on who initiated the build:
+
+- **`/reindex` (standalone, user-triggered):** the API creates a per-request fuel tracker, returns `ReindexResponse.fuel`. CLI prints `Fuel: N.NNN`.
+- **`trigger_index` (standalone, waits for background completion):** the orchestrator creates a per-build tracker; `TriggerIndexResult.fuel` carries the result. **Coalesced trigger callers** all receive the fuel of the single build that satisfied them.
+- **Background indexer (no caller waiting):** the orchestrator still creates a per-build tracker and logs the tally on the completion `info!` line (`fuel = ...`), but does not return it anywhere.
+- **Combined transactor + post-commit indexing (`maybe_refresh_after_commit` / `require_refresh_before_commit`):** measured with a per-build tracker and logged on the completion line; intentionally **not** attributed to the transaction's tracking response.
+
+`IndexOutcome::Completed` carries `fuel: Option<f64>` so `wait()` callers and waiter handles see the same value. Already-satisfied early-returns (waiter satisfied by a previously-published index) report `Some(0.0)` so callers can distinguish "no work" from "not tracked".
 
 ### Setting Fuel Limits
 

--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -64,6 +64,8 @@ Cost ladder (per event):
 | R2RML row emitted (Iceberg/Parquet) | 0.001 |
 | Transaction commit baseline (once per commit, including each bulk-import chunk) | 10.000 |
 | Staged flake (per flake in a transaction or bulk-import chunk) | 0.001 |
+| Indexer CAS write (per successful `put` / `put_with_id` / `content_write_bytes` made by an index build) | 1.000 |
+| Re-encoded leaflet inside an FLI3 leaf write (passthrough leaflets are not charged) | 1.000 |
 | `REGEX` / `REPLACE` evaluation | 0.001 |
 | Hash function (`MD5`, `SHA1`, `SHA256`, `SHA384`, `SHA512`) | 0.001 |
 | `UUID` / `STRUUID` | 0.001 |
@@ -74,6 +76,14 @@ Cost ladder (per event):
 Cheap operations (comparisons, arithmetic, type checks, simple string ops, datetime extraction, etc.) cost zero — instrumentation overhead would dwarf the actual cost.
 
 The **query floor** guarantees every fuel-tracked query reports at least `1.000` fuel: a query touching no persisted data still costs the floor, and a query that errors during parsing/planning still reports it. I/O "touches" cost `0.010` each, so a scan-dominated query reports roughly `1.000 + 0.010 × (leaflet/dict touches)`. The fuel schedule above is defined in one place — `fluree-db-core/src/tracking.rs` (`tracking::schedule`).
+
+### Indexing Fuel
+
+Indexer CAS writes are billed through a `MeteredContentStore` wrapper that the build entry points install around the caller-supplied content store. Every successful `put` / `put_with_id` / `content_write_bytes` charges the base **1.000 fuel** rate — including index leaves, branch manifests, root manifests, dict packs / reverse-tree nodes, history sidecars, garbage records, stats sketches, and (incremental) spatial / fulltext arenas.
+
+FLI3 leaf writes carry an additional per-leaflet charge of **1.000 fuel per re-encoded leaflet**. Passthrough leaflets (byte-copies carried forward from a prior leaf during an incremental update) are **not** charged because no zstd encoding work was performed — so a 100-leaflet leaf where only two leaflets were touched by novelty bills `1 + 2 = 3` fuel, not `1 + 100`. The two FLI3 leaf upload sites (`build::upload::upload_indexes_to_cas` for full rebuild, `build::incremental::upload_leaf_blobs` for incremental) compute the count from `LeafInfo::re_encoded_leaflet_count`.
+
+Indexing fuel is **measurement only**: indexer trackers are no-limit. A partial index is worse than a slow one, so the indexer never aborts mid-build on a fuel limit. The plain public entry points (`build_index_for_record`, `rebuild_index_from_commits`) pass a disabled tracker and report `fuel: None`. The `*_with_tracker` variants (used by `/reindex`) wrap the store, propagate a fuel-enabled tracker, and stamp the final tally on `IndexResult::fuel` — `Some(0.0)` for an already-current build, `Some(N)` for one that did real work. `/reindex` always populates `fuel`; the wire response carries it as `fuel` (omitted when `None`).
 
 ### Setting Fuel Limits
 

--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -62,7 +62,7 @@ Cost ladder (per event):
 | Overlay/novelty row materialized | 0.001 |
 | History row scanned (base + in-range sidecar rows) | 0.001 |
 | R2RML row emitted (Iceberg/Parquet) | 0.001 |
-| Transaction commit baseline (once per commit, including each bulk-import chunk) | 100.000 |
+| Transaction commit baseline (once per commit, including each bulk-import chunk) | 10.000 |
 | Staged flake (per flake in a transaction or bulk-import chunk) | 0.001 |
 | `REGEX` / `REPLACE` evaluation | 0.001 |
 | Hash function (`MD5`, `SHA1`, `SHA256`, `SHA384`, `SHA512`) | 0.001 |

--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -64,7 +64,7 @@ Cost ladder (per event):
 | R2RML row emitted (Iceberg/Parquet) | 0.001 |
 | Transaction commit baseline (once per commit, including each bulk-import chunk) | 10.000 |
 | Staged flake (per flake in a transaction or bulk-import chunk) | 0.001 |
-| Indexer CAS write (per successful `put` / `put_with_id` / `content_write_bytes` made by an index build) | 1.000 |
+| Indexer CAS write (per successful `ContentStore::put` / `put_with_id` made by an index build) | 1.000 |
 | Re-encoded leaflet inside an FLI3 leaf write (passthrough leaflets are not charged) | 1.000 |
 | `REGEX` / `REPLACE` evaluation | 0.001 |
 | Hash function (`MD5`, `SHA1`, `SHA256`, `SHA384`, `SHA512`) | 0.001 |
@@ -79,7 +79,7 @@ The **query floor** guarantees every fuel-tracked query reports at least `1.000`
 
 ### Indexing Fuel
 
-Indexer CAS writes are billed through a `MeteredContentStore` wrapper that the build entry points install around the caller-supplied content store. Every successful `put` / `put_with_id` / `content_write_bytes` charges the base **1.000 fuel** rate — including index leaves, branch manifests, root manifests, dict packs / reverse-tree nodes, history sidecars, garbage records, stats sketches, and (incremental) spatial / fulltext arenas.
+Indexer CAS writes are billed through a `MeteredContentStore` wrapper that the build entry points install around the caller-supplied content store. Every successful `ContentStore::put` / `put_with_id` charges the base **1.000 fuel** rate — including index leaves, branch manifests, root manifests, dict packs / reverse-tree nodes, history sidecars, garbage records, stats sketches, and (incremental) spatial / fulltext arenas. The lower-level `Storage::content_write_bytes` is **not** currently wrapped; the only indexer code path that uses it is the dead-code spatial rebuild helper. If that path is wired up, add a storage-level wrapper first (or migrate it to `ContentStore::put`).
 
 FLI3 leaf writes carry an additional per-leaflet charge of **1.000 fuel per re-encoded leaflet**. Passthrough leaflets (byte-copies carried forward from a prior leaf during an incremental update) are **not** charged because no zstd encoding work was performed — so a 100-leaflet leaf where only two leaflets were touched by novelty bills `1 + 2 = 3` fuel, not `1 + 100`. The two FLI3 leaf upload sites (`build::upload::upload_indexes_to_cas` for full rebuild, `build::incremental::upload_leaf_blobs` for incremental) compute the count from `LeafInfo::re_encoded_leaflet_count`.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -376,9 +376,9 @@ Example: `http://schema.org/name` compacts to `schema:name`
 
 ### Fuel
 
-A measure of query/transaction execution cost. One unit of fuel is consumed for each item processed (flakes matched, items expanded during graph crawl, etc.). Used to prevent runaway queries from consuming excessive resources.
+A decimal measure of query/transaction execution cost, reported to 3 decimal places. Cost reflects actual work — dominated by I/O "touches" (an index leaflet or persisted-dict read costs `0.010` fuel each) rather than output cardinality. Every query is also charged a one-time `1.000` floor, so a fuel-tracked query never reports less than `1.000`. Used to prevent runaway queries from consuming excessive resources. See [Tracking and Fuel](../query/tracking-and-fuel.md) for the full cost ladder.
 
-Example: `"opts": {"max-fuel": 10000}` limits query to 10,000 fuel units.
+Example: `"opts": {"max-fuel": 10000}` limits a query to 10,000 fuel.
 
 ### Tracking
 

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -10,11 +10,11 @@
 //! available on read-only storage.
 
 use crate::{error::ApiError, tx::IndexingMode, Result};
+use fluree_db_core::tracking::{Tracker, TrackingOptions};
 use fluree_db_core::{
     address_path::{ledger_id_to_path_prefix, shared_prefix_for_path},
     format_ledger_id, DEFAULT_BRANCH,
 };
-use fluree_db_core::tracking::{Tracker, TrackingOptions};
 use fluree_db_indexer::{
     clean_garbage, rebuild_index_from_commits_with_tracker, CleanGarbageConfig,
 };

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -14,7 +14,10 @@ use fluree_db_core::{
     address_path::{ledger_id_to_path_prefix, shared_prefix_for_path},
     format_ledger_id, DEFAULT_BRANCH,
 };
-use fluree_db_indexer::{clean_garbage, rebuild_index_from_commits, CleanGarbageConfig};
+use fluree_db_core::tracking::{Tracker, TrackingOptions};
+use fluree_db_indexer::{
+    clean_garbage, rebuild_index_from_commits_with_tracker, CleanGarbageConfig,
+};
 use fluree_db_nameservice::NsRecord;
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -215,6 +218,9 @@ pub struct ReindexResult {
     pub root_id: fluree_db_core::ContentId,
     /// Build statistics
     pub stats: fluree_db_indexer::IndexStats,
+    /// Total fuel charged for this reindex (decimal). `None` only if fuel
+    /// tracking was disabled at the caller; `/reindex` always populates it.
+    pub fuel: Option<f64>,
 }
 
 /// Result of index_status query
@@ -1670,8 +1676,17 @@ impl crate::Fluree {
             }
         }
 
-        let index_result = rebuild_index_from_commits(
+        // Reindex is a user-triggered API call; create a fuel-enabled,
+        // no-limit tracker per request so the response can report total fuel.
+        // Indexing never enforces a fuel limit (measurement only) — a partial
+        // index is worse than a slow one.
+        let reindex_tracker = Tracker::new(TrackingOptions {
+            track_fuel: true,
+            ..Default::default()
+        });
+        let index_result = rebuild_index_from_commits_with_tracker(
             self.content_store(&ledger_id),
+            reindex_tracker,
             &ledger_id,
             &record,
             indexer_config,
@@ -1748,6 +1763,7 @@ impl crate::Fluree {
             index_t: index_result.index_t,
             root_id: index_result.root_id,
             stats: index_result.stats,
+            fuel: index_result.fuel,
         })
     }
 }

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -205,6 +205,12 @@ pub struct TriggerIndexResult {
     pub index_t: i64,
     /// Content identifier of the index root (when available)
     pub root_id: Option<fluree_db_core::ContentId>,
+    /// Total fuel charged for the build that satisfied this trigger. The
+    /// background orchestrator always measures with a per-build tracker, so
+    /// this is normally `Some(N)` (or `Some(0.0)` when the requested t was
+    /// already indexed and no work was needed). Coalesced trigger callers
+    /// all receive the fuel of the single build that satisfied them.
+    pub fuel: Option<f64>,
 }
 
 /// Result of reindex operation
@@ -1416,6 +1422,7 @@ impl crate::Fluree {
                 ledger_id,
                 index_t: 0,
                 root_id: None,
+                fuel: Some(0.0),
             });
         }
 
@@ -1470,10 +1477,15 @@ impl crate::Fluree {
         macro_rules! finish_wait {
             ($outcome:expr) => {
                 match $outcome {
-                    IndexOutcome::Completed { index_t, root_id } => {
+                    IndexOutcome::Completed {
+                        index_t,
+                        root_id,
+                        fuel,
+                    } => {
                         info!(
                             ledger_id = %ledger_id,
                             index_t = index_t,
+                            fuel = ?fuel,
                             elapsed_ms = wait_started.elapsed().as_millis() as u64,
                             "Indexing completed"
                         );
@@ -1481,6 +1493,7 @@ impl crate::Fluree {
                             ledger_id: ledger_id.clone(),
                             index_t,
                             root_id,
+                            fuel,
                         });
                     }
                     IndexOutcome::Failed(msg) => {

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -148,7 +148,7 @@ pub struct ImportConfig {
     /// Optional progress callback invoked at key pipeline milestones.
     pub progress: Option<ProgressFn>,
     /// Optional execution tracker. When enabled, fuel is charged per chunk
-    /// using the same formula as `stage_transaction`: 100 fuel baseline per
+    /// using the same formula as `stage_transaction`: 10 fuel baseline per
     /// commit plus 1 micro-fuel per encoded flake. If the tracker carries a
     /// `max_fuel` limit, the import aborts with `ImportError::FuelExceeded`
     /// as soon as the limit is exceeded. Default: `Tracker::disabled()`.
@@ -221,7 +221,7 @@ pub fn detect_system_memory_mb() -> usize {
     16 * 1024
 }
 
-/// Charge the per-commit fuel cost: 100 fuel baseline + 1 micro-fuel
+/// Charge the per-commit fuel cost: 10 fuel baseline + 1 micro-fuel
 /// per flake. No-op when tracking is disabled. Used by every commit
 /// loop (parallel, remote-serial, local-serial) to keep the import
 /// fuel formula identical to the per-transaction `stage.rs` path.
@@ -1089,7 +1089,7 @@ impl<'a> ImportBuilder<'a> {
     }
 
     /// Attach an execution tracker for fuel accounting. Mirrors transaction
-    /// fuel charging: 100 fuel baseline per commit + 1 micro-fuel per flake.
+    /// fuel charging: 10 fuel baseline per commit + 1 micro-fuel per flake.
     /// When the tracker carries a `max_fuel` limit, the import aborts with
     /// `ImportError::FuelExceeded` as soon as the limit is hit. The final
     /// tally is returned on `ImportResult::tally`.
@@ -1832,7 +1832,7 @@ where
                     .await
                     .map_err(|e| ImportError::Transact(e.to_string()))?;
 
-                // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake,
+                // Fuel: 10 fuel baseline per commit + 1 micro-fuel per flake,
                 // matching the per-chunk-as-transaction model in `stage.rs`.
                 charge_commit_fuel(&env.config.tracker, result.flake_count as u64)?;
 
@@ -2517,7 +2517,7 @@ where
                     .map_err(|e| ImportError::Transact(e.to_string()))?
             };
 
-            // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake.
+            // Fuel: 10 fuel baseline per commit + 1 micro-fuel per flake.
             charge_commit_fuel(&config.tracker, result.flake_count as u64)?;
 
             // Collect txn-meta for this commit.
@@ -2750,7 +2750,7 @@ where
                         .map_err(|e| ImportError::Transact(e.to_string()))?
                 };
 
-                // Fuel: 100 fuel baseline per commit + 1 micro-fuel per flake.
+                // Fuel: 10 fuel baseline per commit + 1 micro-fuel per flake.
                 charge_commit_fuel(&config.tracker, result.flake_count as u64)?;
 
                 // Collect txn-meta for this commit.

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -227,7 +227,7 @@ pub fn detect_system_memory_mb() -> usize {
 /// fuel formula identical to the per-transaction `stage.rs` path.
 fn charge_commit_fuel(tracker: &Tracker, flake_count: u64) -> Result<(), FuelExceededError> {
     if tracker.is_enabled() {
-        tracker.consume_fuel(100_000)?;
+        tracker.consume_fuel(fluree_db_core::tracking::schedule::TXN_BASELINE_MICRO_FUEL)?;
         tracker.consume_fuel(flake_count)?;
     }
     Ok(())

--- a/fluree-db-api/src/query/bm25.rs
+++ b/fluree-db-api/src/query/bm25.rs
@@ -1,6 +1,6 @@
 use serde_json::Value as JsonValue;
 
-use crate::query::helpers::{parse_dataset_spec, tracker_for_limits};
+use crate::query::helpers::{charge_query_floor, parse_dataset_spec, tracker_for_limits};
 use crate::{
     ApiError, DataSetDb, ExecutableQuery, Fluree, FlureeIndexProvider, QueryResult, Result,
     VarRegistry,
@@ -23,6 +23,13 @@ impl Fluree {
         let primary = dataset
             .primary()
             .ok_or_else(|| ApiError::query("Dataset has no graphs for query execution"))?;
+
+        // Tracker (fuel limits only). Charge the floor before parsing so a
+        // sub-floor `max-fuel` is rejected up front; no-op when fuel isn't
+        // tracked.
+        let tracker = tracker_for_limits(query_json);
+        charge_query_floor(&tracker).map_err(fluree_db_query::QueryError::from)?;
+
         // Parse the query using the primary ledger's DB for IRI encoding
         let mut vars = VarRegistry::new();
         let parsed = parse_query(query_json, primary.snapshot.as_ref(), &mut vars, None)?;
@@ -40,7 +47,6 @@ impl Fluree {
         //
         // Vector provider support is feature-gated. When disabled,
         // f:queryVector patterns are not available and we run the BM25-only path.
-        let tracker = tracker_for_limits(query_json);
         let db = primary.as_graph_db_ref();
         let tracker_ref = if tracker.is_enabled() {
             Some(&tracker)

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -2,9 +2,10 @@ use serde_json::Value as JsonValue;
 use std::sync::Arc;
 
 use crate::query::helpers::{
-    extract_sparql_dataset_spec, parse_and_validate_sparql, parse_dataset_spec,
+    charge_query_floor, extract_sparql_dataset_spec, parse_and_validate_sparql, parse_dataset_spec,
+    tracked_query_tracker,
 };
-use crate::view::{DataSetDb, GraphDb};
+use crate::view::{DataSetDb, GraphDb, QueryInput};
 use crate::{
     ApiError, DatasetSpec, Fluree, FormatterConfig, PolicyContext, QueryConnectionOptions,
     QueryResult, Result,
@@ -189,14 +190,24 @@ impl Fluree {
         tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let (spec, qc_opts) = parse_dataset_spec(query_json)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // Enforce the query floor up front: a sub-floor `max-fuel` fails here
+        // (before parsing the dataset spec), matching the per-view tracked
+        // path. On success `floor` is a throwaway used only to tally the floor
+        // for connection-level parse/spec errors; the per-view delegate charges
+        // its own floor downstream, so the reported fuel is never double-counted.
+        let input = QueryInput::JsonLd(query_json);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let (spec, qc_opts) = parse_dataset_spec(query_json).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing ledger specification in connection query",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -296,14 +307,20 @@ impl Fluree {
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let (spec, qc_opts) = parse_dataset_spec(query_json)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::JsonLd(query_json);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let (spec, qc_opts) = parse_dataset_spec(query_json).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing ledger specification in connection query",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -348,14 +365,20 @@ impl Fluree {
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let (spec, _qc_opts) = parse_dataset_spec(query_json)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::JsonLd(query_json);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let (spec, _qc_opts) = parse_dataset_spec(query_json).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing ledger specification in connection query",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -406,14 +429,20 @@ impl Fluree {
         tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let (spec, _qc_opts) = parse_dataset_spec(query_json)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::JsonLd(query_json);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let (spec, _qc_opts) = parse_dataset_spec(query_json).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing ledger specification in connection query",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -572,16 +601,23 @@ impl Fluree {
         tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let ast = parse_and_validate_sparql(sparql)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
-        let spec = extract_sparql_dataset_spec(&ast)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::Sparql(sparql);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let ast = parse_and_validate_sparql(sparql).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
+        let spec = extract_sparql_dataset_spec(&ast).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing dataset specification in SPARQL connection query (no FROM / FROM NAMED)",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -603,16 +639,23 @@ impl Fluree {
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let ast = parse_and_validate_sparql(sparql)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
-        let spec = extract_sparql_dataset_spec(&ast)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::Sparql(sparql);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let ast = parse_and_validate_sparql(sparql).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
+        let spec = extract_sparql_dataset_spec(&ast).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing dataset specification in SPARQL connection query (no FROM / FROM NAMED)",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -645,16 +688,23 @@ impl Fluree {
         tracking_override: Option<TrackingOptions>,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let ast = parse_and_validate_sparql(sparql)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
-        let spec = extract_sparql_dataset_spec(&ast)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::Sparql(sparql);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let ast = parse_and_validate_sparql(sparql).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
+        let spec = extract_sparql_dataset_spec(&ast).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing dataset specification in SPARQL connection query (no FROM / FROM NAMED)",
-                None,
+                floor.tally(),
             ));
         }
 
@@ -678,16 +728,23 @@ impl Fluree {
         r2rml_table_provider: &dyn R2rmlTableProvider,
     ) -> std::result::Result<crate::query::TrackedQueryResponse, crate::query::TrackedErrorResponse>
     {
-        let ast = parse_and_validate_sparql(sparql)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
-        let spec = extract_sparql_dataset_spec(&ast)
-            .map_err(|e| crate::query::TrackedErrorResponse::new(400, e.to_string(), None))?;
+        // See `query_connection_jsonld_tracked` for the up-front floor enforcement.
+        let input = QueryInput::Sparql(sparql);
+        let floor = tracked_query_tracker(&input, &tracking_override);
+        charge_query_floor(&floor)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, floor.tally()))?;
+        let ast = parse_and_validate_sparql(sparql).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
+        let spec = extract_sparql_dataset_spec(&ast).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), floor.tally())
+        })?;
 
         if spec.is_empty() {
             return Err(crate::query::TrackedErrorResponse::new(
                 400,
                 "Missing dataset specification in SPARQL connection query (no FROM / FROM NAMED)",
-                None,
+                floor.tally(),
             ));
         }
 

--- a/fluree-db-api/src/query/helpers.rs
+++ b/fluree-db-api/src/query/helpers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
 
+use crate::view::QueryInput;
 use crate::{
     ApiError, Batch, DatasetSpec, ExecutableQuery, OverlayProvider, QueryConnectionOptions, Result,
     Tracker, TrackingOptions, VarRegistry,
@@ -219,6 +220,40 @@ pub(crate) fn tracker_for_tracked_endpoint(query_json: &JsonValue) -> Tracker {
         Tracker::new(tracking)
     } else {
         Tracker::new(TrackingOptions::all_enabled())
+    }
+}
+
+/// Charge the one-time query floor at execution entry.
+///
+/// Every fuel-tracked query is charged [`schedule::QUERY_FLOOR_MICRO_FUEL`]
+/// once, before parsing, so that (a) a successful query always reports at least
+/// 1.000 fuel, (b) a parse/plan error with tracking still reports the floor, and
+/// (c) the floor counts toward any `max-fuel` budget. No-op when fuel isn't
+/// tracked (disabled tracker or `track_fuel == false`), since `consume_fuel`
+/// short-circuits in that case.
+///
+/// Returns the same `FuelExceededError` a mid-execution overrun would, so a
+/// `max-fuel` below the floor is rejected up front.
+pub(crate) fn charge_query_floor(
+    tracker: &Tracker,
+) -> std::result::Result<(), fluree_db_core::FuelExceededError> {
+    tracker.consume_fuel(fluree_db_core::tracking::schedule::QUERY_FLOOR_MICRO_FUEL)
+}
+
+/// Tracker for a "tracked" query path: an explicit `tracking_override` if given,
+/// otherwise the per-input default — opts-derived for JSON-LD, all-enabled for
+/// SPARQL (which has no `opts` carrier). This is the single derivation shared by
+/// the view/dataset tracked entry points and [`floor_only_tally`].
+pub(crate) fn tracked_query_tracker(
+    input: &QueryInput<'_>,
+    tracking_override: &Option<TrackingOptions>,
+) -> Tracker {
+    match tracking_override {
+        Some(opts) => Tracker::new(opts.clone()),
+        None => match input {
+            QueryInput::JsonLd(json) => tracker_for_tracked_endpoint(json),
+            QueryInput::Sparql(_) => Tracker::new(TrackingOptions::all_enabled()),
+        },
     }
 }
 

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -3,9 +3,9 @@
 //! Provides `query_dataset` for multi-ledger queries.
 
 use crate::query::helpers::{
-    build_query_result, parse_and_validate_sparql, parse_jsonld_query, parse_sparql_to_ir,
-    prepare_for_execution, status_for_query_error, tracker_for_limits,
-    tracker_for_tracked_endpoint,
+    build_query_result, charge_query_floor, parse_and_validate_sparql, parse_jsonld_query,
+    parse_sparql_to_ir, prepare_for_execution, status_for_query_error, tracked_query_tracker,
+    tracker_for_limits,
 };
 use crate::view::{DataSetDb, QueryInput};
 use crate::{ApiError, ExecutableQuery, Fluree, QueryResult, Result, Tracker, TrackingOptions};
@@ -81,6 +81,17 @@ impl Fluree {
             .primary()
             .ok_or_else(|| ApiError::query("Dataset has no graphs for query execution"))?;
 
+        // 0. Tracker for fuel limits. Charge the floor up front so a sub-floor
+        // `max-fuel` is rejected before parse/plan; no-op when fuel isn't
+        // tracked. (The single-ledger fast path above delegates to `query`,
+        // which charges the floor itself — so we only reach here, and charge
+        // once, on the genuine multi-ledger/dataset path.)
+        let tracker = match &input {
+            QueryInput::JsonLd(json) => tracker_for_limits(json),
+            QueryInput::Sparql(_) => Tracker::disabled(),
+        };
+        charge_query_floor(&tracker).map_err(fluree_db_query::QueryError::from)?;
+
         // 1. Parse to common IR (using primary db for namespace resolution).
         let (vars, mut parsed) = match &input {
             QueryInput::JsonLd(json) => parse_jsonld_query(
@@ -101,12 +112,6 @@ impl Fluree {
 
         // 2. Build executable with optional reasoning override from primary view
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
-
-        // 3. Get tracker for fuel limits
-        let tracker = match &input {
-            QueryInput::JsonLd(json) => tracker_for_limits(json),
-            QueryInput::Sparql(_) => Tracker::disabled(),
-        };
 
         // 4. Execute against merged dataset
         let batches = self
@@ -175,6 +180,16 @@ impl Fluree {
             .primary()
             .ok_or_else(|| ApiError::query("Dataset has no graphs for query execution"))?;
 
+        // 0. Tracker for fuel limits. Charge the floor up front so a sub-floor
+        // `max-fuel` is rejected before parse/plan; no-op when fuel isn't
+        // tracked. (The single-ledger fast path above delegates to
+        // `query_view_with_r2rml`, which charges the floor — so we charge once.)
+        let tracker = match &input {
+            QueryInput::JsonLd(json) => tracker_for_limits(json),
+            QueryInput::Sparql(_) => Tracker::disabled(),
+        };
+        charge_query_floor(&tracker).map_err(fluree_db_query::QueryError::from)?;
+
         // 1. Parse to common IR (using primary db for namespace resolution).
         let (vars, mut parsed) = match &input {
             QueryInput::JsonLd(json) => parse_jsonld_query(
@@ -193,12 +208,6 @@ impl Fluree {
 
         // 2. Build executable with optional reasoning override from primary view
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
-
-        // 3. Get tracker for fuel limits
-        let tracker = match &input {
-            QueryInput::JsonLd(json) => tracker_for_limits(json),
-            QueryInput::Sparql(_) => Tracker::disabled(),
-        };
 
         // 4. Execute against merged dataset
         let batches = self
@@ -236,16 +245,12 @@ impl Fluree {
     {
         let input = q.into();
 
-        // Get tracker: use caller-provided options if given, otherwise fall back
-        // to defaults (all-enabled for SPARQL, opts-derived for JSON-LD).
-        let tracker = if let Some(opts) = tracking_override {
-            Tracker::new(opts)
-        } else {
-            match &input {
-                QueryInput::JsonLd(json) => tracker_for_tracked_endpoint(json),
-                QueryInput::Sparql(_) => Tracker::new(TrackingOptions::all_enabled()),
-            }
-        };
+        // Tracker: caller-provided options if given, else per-input defaults.
+        let tracker = tracked_query_tracker(&input, &tracking_override);
+
+        // Charge the one-time query floor before parsing (see `query_tracked`).
+        charge_query_floor(&tracker)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, tracker.tally()))?;
 
         // Determine output format: caller override > input-type default
         let default_format = match &input {
@@ -356,14 +361,11 @@ impl Fluree {
     {
         let input = q.into();
 
-        let tracker = if let Some(opts) = tracking_override {
-            Tracker::new(opts)
-        } else {
-            match &input {
-                QueryInput::JsonLd(json) => tracker_for_tracked_endpoint(json),
-                QueryInput::Sparql(_) => Tracker::new(TrackingOptions::all_enabled()),
-            }
-        };
+        let tracker = tracked_query_tracker(&input, &tracking_override);
+
+        // Charge the one-time query floor before parsing (see `query_tracked`).
+        charge_query_floor(&tracker)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, tracker.tally()))?;
 
         let default_format = match &input {
             QueryInput::Sparql(_) => crate::format::FormatterConfig::sparql_json(),

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -4,9 +4,9 @@
 //! a GraphDb, respecting policy and reasoning wrappers.
 
 use crate::query::helpers::{
-    build_query_result, parse_and_validate_sparql, parse_jsonld_query, parse_sparql_to_ir,
-    prepare_for_execution, status_for_query_error, tracker_for_limits,
-    tracker_for_tracked_endpoint,
+    build_query_result, charge_query_floor, parse_and_validate_sparql, parse_jsonld_query,
+    parse_sparql_to_ir, prepare_for_execution, status_for_query_error, tracked_query_tracker,
+    tracker_for_limits,
 };
 use crate::view::{GraphDb, QueryInput};
 use crate::{ApiError, ExecutableQuery, Fluree, QueryResult, Result, Tracker, TrackingOptions};
@@ -72,6 +72,15 @@ impl Fluree {
     pub async fn query(&self, db: &GraphDb, q: impl Into<QueryInput<'_>>) -> Result<QueryResult> {
         let input = q.into();
 
+        // 0. Tracker for fuel limits only (no tracking overhead for non-tracked
+        // calls). Charge the floor up front so a sub-floor `max-fuel` is
+        // rejected before we spend parse/plan work; no-op when fuel isn't tracked.
+        let tracker = match &input {
+            QueryInput::JsonLd(json) => tracker_for_limits(json),
+            QueryInput::Sparql(_) => Tracker::disabled(),
+        };
+        charge_query_floor(&tracker).map_err(fluree_db_query::QueryError::from)?;
+
         // 1. Parse to common IR
         let parse_start = std::time::Instant::now();
         let (vars, mut parsed) = match &input {
@@ -93,12 +102,6 @@ impl Fluree {
         let plan_start = std::time::Instant::now();
         let executable = self.build_executable_for_view(db, &parsed).await?;
         let plan_ms = plan_start.elapsed().as_secs_f64() * 1000.0;
-
-        // 3. Get tracker for fuel limits only (no tracking overhead for non-tracked calls)
-        let tracker = match &input {
-            QueryInput::JsonLd(json) => tracker_for_limits(json),
-            QueryInput::Sparql(_) => Tracker::disabled(),
-        };
 
         // 4. Execute
         let exec_start = std::time::Instant::now();
@@ -139,6 +142,14 @@ impl Fluree {
     ) -> Result<QueryResult> {
         let input = q.into();
 
+        // 0. Tracker (fuel limits only). Charge the floor up front so a
+        // sub-floor `max-fuel` is rejected before parse/plan; no-op untracked.
+        let tracker = match &input {
+            QueryInput::JsonLd(json) => tracker_for_limits(json),
+            QueryInput::Sparql(_) => Tracker::disabled(),
+        };
+        charge_query_floor(&tracker).map_err(fluree_db_query::QueryError::from)?;
+
         // 1. Parse to common IR
         let (vars, mut parsed) = match &input {
             QueryInput::JsonLd(json) => {
@@ -156,12 +167,6 @@ impl Fluree {
 
         // 2. Build executable with optional reasoning override
         let executable = self.build_executable_for_view(db, &parsed).await?;
-
-        // 3. Tracker (fuel limits only)
-        let tracker = match &input {
-            QueryInput::JsonLd(json) => tracker_for_limits(json),
-            QueryInput::Sparql(_) => Tracker::disabled(),
-        };
 
         // 4. Execute
         let batches = self
@@ -223,16 +228,13 @@ impl Fluree {
     {
         let input = q.into();
 
-        // Get tracker: use caller-provided options if given, otherwise fall back
-        // to defaults (all-enabled for SPARQL, opts-derived for JSON-LD).
-        let tracker = if let Some(opts) = tracking_override {
-            Tracker::new(opts)
-        } else {
-            match &input {
-                QueryInput::JsonLd(json) => tracker_for_tracked_endpoint(json),
-                QueryInput::Sparql(_) => Tracker::new(TrackingOptions::all_enabled()),
-            }
-        };
+        // Tracker: caller-provided options if given, else per-input defaults.
+        let tracker = tracked_query_tracker(&input, &tracking_override);
+
+        // Charge the one-time query floor before parsing so a parse/plan error
+        // still reports it and a sub-floor max-fuel is rejected up front.
+        charge_query_floor(&tracker)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, tracker.tally()))?;
 
         // Determine output format: caller override > input-type default
         let default_format = match &input {
@@ -338,14 +340,11 @@ impl Fluree {
     {
         let input = q.into();
 
-        let tracker = if let Some(opts) = tracking_override {
-            Tracker::new(opts)
-        } else {
-            match &input {
-                QueryInput::JsonLd(json) => tracker_for_tracked_endpoint(json),
-                QueryInput::Sparql(_) => Tracker::new(TrackingOptions::all_enabled()),
-            }
-        };
+        let tracker = tracked_query_tracker(&input, &tracking_override);
+
+        // Charge the one-time query floor before parsing (see `query_tracked`).
+        charge_query_floor(&tracker)
+            .map_err(|e| crate::query::TrackedErrorResponse::fuel_exceeded(&e, tracker.tally()))?;
 
         let default_format = match &input {
             QueryInput::Sparql(_) => crate::format::FormatterConfig::sparql_json(),

--- a/fluree-db-api/src/wire.rs
+++ b/fluree-db-api/src/wire.rs
@@ -50,6 +50,11 @@ pub struct ReindexResponse {
     pub index_t: i64,
     pub root_id: String,
     pub stats: ReindexStats,
+    /// Total fuel charged for the reindex (decimal). Omitted from the wire
+    /// payload when unavailable (e.g., reindex went through a non-tracking
+    /// path); `/reindex` always populates it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fuel: Option<f64>,
 }
 
 impl From<ReindexResult> for ReindexResponse {
@@ -64,6 +69,7 @@ impl From<ReindexResult> for ReindexResponse {
                 branch_count: r.stats.branch_count,
                 total_bytes: r.stats.total_bytes,
             },
+            fuel: r.fuel,
         }
     }
 }

--- a/fluree-db-api/tests/it_fuel_floor.rs
+++ b/fluree-db-api/tests/it_fuel_floor.rs
@@ -1,0 +1,271 @@
+//! Query fuel floor + touch-rescale integration tests.
+//!
+//! Companion to the unit tests in `fluree-db-core/src/tracking.rs`, which pin
+//! the schedule values (floor = 1.000, I/O touch = 0.010). These tests verify
+//! the floor is wired into the query entry paths: every fuel-tracked query
+//! reports at least the floor, a parse error still reports it, and a `max-fuel`
+//! below the floor is rejected up front.
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+
+/// Seed a tiny in-memory ledger with a single named subject.
+async fn seed_one() -> (support::MemoryFluree, support::MemoryLedger) {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = support::genesis_ledger(&fluree, "fuel/floor:main");
+    let seed = json!({
+        "@context": { "a": "http://a.co/" },
+        "@graph": [{ "@id": "http://a.co/x", "a:name": "X" }]
+    });
+    let ledger = fluree.insert(ledger0, &seed).await.expect("seed").ledger;
+    (fluree, ledger)
+}
+
+#[tokio::test]
+async fn tracked_query_reports_at_least_floor() {
+    let (fluree, ledger) = seed_one().await;
+
+    let query = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": { "@id": "?s", "a:name": "?name" },
+        "opts": { "meta": true }
+    });
+
+    let tracked = support::query_jsonld_tracked(&fluree, &ledger, &query)
+        .await
+        .expect("query should succeed");
+    let fuel = tracked.fuel.expect("fuel should be present when meta=true");
+
+    // Floor is always charged; this tiny overlay scan adds only a few 0.001
+    // rows on top, so the floor dominates.
+    assert!(fuel >= 1.0, "fuel ({fuel}) should include the 1.0 floor");
+    assert!(
+        fuel < 2.0,
+        "tiny query fuel ({fuel}) should be dominated by the floor"
+    );
+}
+
+#[tokio::test]
+async fn parse_error_with_tracking_still_reports_floor() {
+    let (fluree, ledger) = seed_one().await;
+
+    // `where` must be an object/array; a scalar fails parsing. The floor is
+    // charged before parsing, so the error response still reports it.
+    let bad = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": 42,
+        "opts": { "meta": true }
+    });
+
+    let err = support::query_jsonld_tracked(&fluree, &ledger, &bad)
+        .await
+        .expect_err("malformed query should fail to parse");
+
+    assert_eq!(err.status, 400);
+    assert_eq!(
+        err.fuel,
+        Some(1.0),
+        "a parse error with tracking should still report the floor"
+    );
+}
+
+#[tokio::test]
+async fn max_fuel_below_floor_is_rejected() {
+    let (fluree, ledger) = seed_one().await;
+
+    // max-fuel: 0.5 leaves no room for the 1.0 floor → rejected up front.
+    let query = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": { "@id": "?s", "a:name": "?name" },
+        "opts": { "max-fuel": 0.5, "meta": true }
+    });
+
+    let err = support::query_jsonld_tracked(&fluree, &ledger, &query)
+        .await
+        .expect_err("sub-floor max-fuel should fail");
+
+    assert!(
+        err.error.to_lowercase().contains("fuel"),
+        "error should mention fuel, got: {}",
+        err.error
+    );
+    // The floor was added before the limit check, so the reported usage is 1.0.
+    assert_eq!(err.fuel, Some(1.0));
+}
+
+#[tokio::test]
+async fn max_fuel_just_above_floor_allows_query() {
+    let (fluree, ledger) = seed_one().await;
+
+    // 1.5 fuel = floor (1.0) + room for ~50 touches / 500 rows; the tiny scan
+    // fits comfortably.
+    let query = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": { "@id": "?s", "a:name": "?name" },
+        "opts": { "max-fuel": 1.5, "meta": true }
+    });
+
+    let tracked = support::query_jsonld_tracked(&fluree, &ledger, &query)
+        .await
+        .expect("query within budget should succeed");
+    let fuel = tracked.fuel.expect("fuel should be present");
+    assert!(
+        (1.0..=1.5).contains(&fuel),
+        "fuel ({fuel}) should fit budget"
+    );
+}
+
+/// Untracked (`max-fuel` only, no `meta`) path: the floor is charged before
+/// parsing, so a sub-floor budget is rejected as a *fuel* error even when the
+/// query is also malformed — the parse never runs.
+#[tokio::test]
+async fn untracked_max_fuel_below_floor_rejected_before_parse() {
+    let (fluree, ledger) = seed_one().await;
+
+    let q = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": 42, // malformed: would fail parsing if we got that far
+        "opts": { "max-fuel": 0.5 }
+    });
+
+    let err = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .expect_err("sub-floor max-fuel should fail");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("fuel"),
+        "should fail on the floor before parsing, got: {msg}"
+    );
+}
+
+/// Connection-level tracked JSON-LD error (missing ledger spec) is raised
+/// before delegating to the per-view tracked query, yet still reports the floor.
+#[tokio::test]
+async fn connection_tracked_missing_spec_reports_floor() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // No `from`/ledger spec → rejected at the connection layer.
+    let q = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": { "@id": "?s", "a:name": "?name" }
+    });
+
+    let err = fluree
+        .query_connection_tracked(&q)
+        .await
+        .expect_err("missing ledger spec should error");
+    assert_eq!(err.status, 400);
+    assert_eq!(
+        err.fuel,
+        Some(1.0),
+        "connection-level spec error should still report the floor"
+    );
+}
+
+/// Connection-level tracked SPARQL parse error reports the floor.
+#[tokio::test]
+async fn connection_sparql_tracked_parse_error_reports_floor() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let err = fluree
+        .query_connection_sparql_tracked("SELECT ?x WHERE {", None, None)
+        .await
+        .expect_err("malformed SPARQL should error");
+    assert_eq!(err.status, 400);
+    assert_eq!(
+        err.fuel,
+        Some(1.0),
+        "SPARQL connection parse error should report the floor"
+    );
+}
+
+/// Connection JSON-LD: a sub-floor `max-fuel` (via `opts`) is enforced at the
+/// connection layer *before* the dataset spec is parsed — so even a query that
+/// would otherwise fail spec validation fails as a fuel error first.
+#[tokio::test]
+async fn connection_tracked_sub_floor_max_fuel_rejected_before_spec() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // No `from` (would be a "missing ledger spec" error) AND sub-floor budget.
+    let q = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": { "@id": "?s", "a:name": "?name" },
+        "opts": { "max-fuel": 0.5 }
+    });
+
+    let err = fluree
+        .query_connection_tracked(&q)
+        .await
+        .expect_err("sub-floor max-fuel should fail");
+    assert_eq!(err.status, 400);
+    assert!(
+        err.error.to_lowercase().contains("fuel"),
+        "should be rejected on the floor before spec parsing, got: {}",
+        err.error
+    );
+    assert_eq!(err.fuel, Some(1.0));
+}
+
+/// Connection SPARQL: a sub-floor `max-fuel` supplied via the tracking override
+/// (the header path) is enforced before the SPARQL is parsed.
+#[tokio::test]
+async fn connection_sparql_tracked_sub_floor_override_rejected_before_parse() {
+    use fluree_db_api::TrackingOptions;
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // 500 micro-fuel = 0.5 fuel, below the 1000 micro-fuel (1.0) floor.
+    let override_opts = TrackingOptions {
+        track_time: false,
+        track_fuel: true,
+        track_policy: false,
+        max_fuel: Some(500),
+    };
+
+    // Malformed SPARQL: would fail parsing, but the floor is enforced first.
+    let err = fluree
+        .query_connection_sparql_tracked("SELECT ?x WHERE {", None, Some(override_opts))
+        .await
+        .expect_err("sub-floor override should fail");
+    assert_eq!(err.status, 400);
+    assert!(
+        err.error.to_lowercase().contains("fuel"),
+        "should be rejected on the floor before parsing, got: {}",
+        err.error
+    );
+    assert_eq!(err.fuel, Some(1.0));
+}
+
+/// BM25/vector graph-source path: a sub-floor `max-fuel` is enforced before the
+/// query is parsed, so a malformed query fails as a fuel error.
+#[tokio::test]
+async fn bm25_sub_floor_max_fuel_rejected_before_parse() {
+    use fluree_db_api::{DataSetDb, GraphDb};
+    let (fluree, ledger) = seed_one().await;
+    let dataset = DataSetDb::new().with_default(GraphDb::from_ledger_state(&ledger));
+
+    let q = json!({
+        "@context": { "a": "http://a.co/" },
+        "select": ["?name"],
+        "where": 42, // malformed: would fail parsing if we got that far
+        "opts": { "max-fuel": 0.5 }
+    });
+
+    let err = fluree
+        .query_dataset_with_bm25(&dataset, &q)
+        .await
+        .expect_err("sub-floor max-fuel should fail");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("fuel"),
+        "should reject on the floor before parsing, got: {msg}"
+    );
+}

--- a/fluree-db-api/tests/it_indexing_fuel.rs
+++ b/fluree-db-api/tests/it_indexing_fuel.rs
@@ -1,0 +1,194 @@
+//! End-to-end checks that indexer CAS writes are billed against a fuel tracker
+//! and that the resulting fuel surfaces through `IndexResult`.
+//!
+//! These tests cover the wrapper-based fuel pipeline added on top of #1255:
+//! `MeteredContentStore` charges each CAS write, the two FLI3 leaf upload
+//! sites add the per-leaflet extra charge, and the entry-point stamp surfaces
+//! the tally on the returned `IndexResult`.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{Fluree, FlureeBuilder, LedgerState, Novelty};
+use fluree_db_core::tracking::{Tracker, TrackingOptions};
+use fluree_db_core::LedgerSnapshot;
+use fluree_db_indexer::{
+    build_index_for_record_with_tracker, rebuild_index_from_commits_with_tracker, IndexerConfig,
+};
+use serde_json::json;
+
+async fn insert_one(fluree: &Fluree, ledger: LedgerState, tx: serde_json::Value) -> LedgerState {
+    let outcome = fluree.insert(ledger, &tx).await.expect("insert");
+    outcome.ledger
+}
+
+fn enabled_tracker() -> Tracker {
+    Tracker::new(TrackingOptions {
+        track_fuel: true,
+        ..Default::default()
+    })
+}
+
+#[tokio::test]
+async fn reindex_with_tracker_reports_positive_fuel() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/indexing-fuel:main";
+
+    let db0 = LedgerSnapshot::genesis(ledger_id);
+    let mut state = LedgerState::new(db0, Novelty::new(0));
+
+    // Seed a couple of small commits so the rebuild has real CAS work.
+    state = insert_one(
+        &fluree,
+        state,
+        json!({
+            "@context": {"ex": "http://example.org/"},
+            "@graph": [
+                {"@id": "ex:a", "@type": "ex:Person", "ex:name": "Alice"},
+                {"@id": "ex:b", "@type": "ex:Person", "ex:name": "Bob"},
+            ]
+        }),
+    )
+    .await;
+    let _ = insert_one(
+        &fluree,
+        state,
+        json!({
+            "@context": {"ex": "http://example.org/"},
+            "@graph": [
+                {"@id": "ex:c", "@type": "ex:Person", "ex:name": "Carol"},
+            ]
+        }),
+    )
+    .await;
+
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("record");
+
+    let tracker = enabled_tracker();
+    let result = rebuild_index_from_commits_with_tracker(
+        fluree.content_store(ledger_id),
+        tracker,
+        ledger_id,
+        &record,
+        IndexerConfig::default(),
+    )
+    .await
+    .expect("rebuild succeeds");
+
+    let fuel = result.fuel.expect("tracker was enabled");
+    assert!(
+        fuel > 0.0,
+        "rebuild over real commits must charge non-zero fuel; got {fuel}"
+    );
+}
+
+#[tokio::test]
+async fn build_index_for_record_already_current_reports_zero_fuel() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/indexing-fuel-current:main";
+
+    let db0 = LedgerSnapshot::genesis(ledger_id);
+    let mut state = LedgerState::new(db0, Novelty::new(0));
+    state = insert_one(
+        &fluree,
+        state,
+        json!({
+            "@context": {"ex": "http://example.org/"},
+            "@graph": [{"@id": "ex:a", "@type": "ex:Person"}]
+        }),
+    )
+    .await;
+    let _ = state;
+
+    // First reindex to make the index current.
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("record");
+    let result = rebuild_index_from_commits_with_tracker(
+        fluree.content_store(ledger_id),
+        enabled_tracker(),
+        ledger_id,
+        &record,
+        IndexerConfig::default(),
+    )
+    .await
+    .expect("rebuild");
+    fluree
+        .publisher()
+        .expect("publisher")
+        .publish_index(ledger_id, result.index_t, &result.root_id)
+        .await
+        .expect("publish");
+
+    // Now go through `build_index_for_record_with_tracker` — it should hit the
+    // already-current early return and report Some(0.0) (no CAS work, but the
+    // caller asked for fuel tracking).
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("record");
+    let result = build_index_for_record_with_tracker(
+        fluree.content_store(ledger_id),
+        enabled_tracker(),
+        &record,
+        IndexerConfig::default(),
+    )
+    .await
+    .expect("build");
+
+    assert_eq!(
+        result.fuel,
+        Some(0.0),
+        "already-current build with tracking enabled should report Some(0.0)"
+    );
+}
+
+#[tokio::test]
+async fn non_tracked_rebuild_reports_fuel_none() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/indexing-fuel-none:main";
+
+    let db0 = LedgerSnapshot::genesis(ledger_id);
+    let mut state = LedgerState::new(db0, Novelty::new(0));
+    state = insert_one(
+        &fluree,
+        state,
+        json!({
+            "@context": {"ex": "http://example.org/"},
+            "@graph": [{"@id": "ex:a", "@type": "ex:Person"}]
+        }),
+    )
+    .await;
+    let _ = state;
+
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("ns lookup")
+        .expect("record");
+    let result = fluree_db_indexer::rebuild_index_from_commits(
+        fluree.content_store(ledger_id),
+        ledger_id,
+        &record,
+        IndexerConfig::default(),
+    )
+    .await
+    .expect("rebuild");
+
+    assert_eq!(
+        result.fuel, None,
+        "rebuild via the non-tracking API should report fuel=None"
+    );
+}

--- a/fluree-db-api/tests/it_indexing_fuel.rs
+++ b/fluree-db-api/tests/it_indexing_fuel.rs
@@ -155,6 +155,60 @@ async fn build_index_for_record_already_current_reports_zero_fuel() {
 }
 
 #[tokio::test]
+async fn trigger_index_reports_positive_fuel() {
+    use fluree_db_api::tx::IndexingMode;
+    use fluree_db_api::TriggerIndexOptions;
+    use std::sync::Arc;
+    use support::start_background_indexer_local;
+
+    let mut fluree = FlureeBuilder::memory().build_memory();
+    let (local, indexer_handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::default(),
+    );
+    fluree.set_indexing_mode(IndexingMode::Background(indexer_handle));
+
+    local
+        .run_until(async move {
+            let ledger = fluree
+                .create_ledger("it-indexing-fuel-trigger")
+                .await
+                .expect("create_ledger");
+            let tx = json!({
+                "@context": {"ex": "http://example.org/"},
+                "@graph": [
+                    {"@id": "ex:a", "@type": "ex:Person", "ex:name": "Alice"},
+                    {"@id": "ex:b", "@type": "ex:Person", "ex:name": "Bob"},
+                ]
+            });
+            let result = fluree.insert(ledger, &tx).await.expect("insert");
+            let committed_t = result.ledger.t();
+
+            let trigger = fluree
+                .trigger_index(
+                    "it-indexing-fuel-trigger:main",
+                    TriggerIndexOptions::default(),
+                )
+                .await
+                .expect("trigger_index");
+
+            assert!(
+                trigger.index_t >= committed_t,
+                "indexed to >= committed t"
+            );
+            let fuel = trigger
+                .fuel
+                .expect("background indexer always populates fuel");
+            assert!(
+                fuel > 0.0,
+                "background indexer should charge non-zero fuel for real work; got {fuel}"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
 async fn non_tracked_rebuild_reports_fuel_none() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/indexing-fuel-none:main";

--- a/fluree-db-api/tests/it_indexing_fuel.rs
+++ b/fluree-db-api/tests/it_indexing_fuel.rs
@@ -193,10 +193,7 @@ async fn trigger_index_reports_positive_fuel() {
                 .await
                 .expect("trigger_index");
 
-            assert!(
-                trigger.index_t >= committed_t,
-                "indexed to >= committed t"
-            );
+            assert!(trigger.index_t >= committed_t, "indexed to >= committed t");
             let fuel = trigger
                 .fuel
                 .expect("background indexer always populates fuel");

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -161,6 +161,7 @@ async fn property_and_class_statistics_persist_in_db_root() {
             let fluree_db_api::IndexOutcome::Completed {
                 index_t,
                 root_id,
+                ..
             } = outcome
             else {
                 unreachable!("helper only returns Completed")
@@ -1811,7 +1812,10 @@ async fn large_dataset_statistics_accuracy() {
 
                 let outcome =
                     trigger_index_and_wait_outcome(&handle, ledger.ledger_id(), commit_t).await;
-                let fluree_db_api::IndexOutcome::Completed { index_t, root_id } = outcome else {
+                let fluree_db_api::IndexOutcome::Completed {
+                    index_t, root_id, ..
+                } = outcome
+                else {
                     unreachable!("helper only returns Completed")
                 };
                 assert!(

--- a/fluree-db-api/tests/it_indexing_wait.rs
+++ b/fluree-db-api/tests/it_indexing_wait.rs
@@ -82,7 +82,9 @@ async fn background_indexing_trigger_wait_then_load_index_root() {
 
             // 3) Wait + assert we can load the persisted root
             match completion.wait().await {
-                fluree_db_api::IndexOutcome::Completed { index_t, root_id } => {
+                fluree_db_api::IndexOutcome::Completed {
+                    index_t, root_id, ..
+                } => {
                     assert!(
                         index_t >= commit_t,
                         "index_t ({index_t}) should be >= commit_t ({commit_t})"

--- a/fluree-db-api/tests/it_indexing_workflow.rs
+++ b/fluree-db-api/tests/it_indexing_workflow.rs
@@ -238,7 +238,9 @@ async fn indexing_coalesces_multiple_commits_and_latest_root_is_queryable() {
             let c2 = handle.trigger(ledger_id, t2).await;
 
             let (index_t2, _root_id2) = match c2.wait().await {
-                fluree_db_api::IndexOutcome::Completed { index_t, root_id } => (index_t, root_id),
+                fluree_db_api::IndexOutcome::Completed {
+                    index_t, root_id, ..
+                } => (index_t, root_id),
                 fluree_db_api::IndexOutcome::Failed(e) => panic!("indexing failed: {e}"),
                 fluree_db_api::IndexOutcome::Cancelled => panic!("indexing cancelled"),
             };

--- a/fluree-db-api/tests/it_ledger_lifecycle.rs
+++ b/fluree-db-api/tests/it_ledger_lifecycle.rs
@@ -275,8 +275,9 @@ async fn fuel_integration_test() {
     );
 
     // Fuel should roughly correspond to the number of flakes traversed
-    // (may not be exact due to query optimization differences). Per-row charge
-    // is 1 fuel each in this step.
+    // (may not be exact due to query optimization differences). This in-memory
+    // fixture scans the overlay path at 1 micro-fuel (0.001 fuel) per row, plus
+    // the one-time 1.000-fuel query floor.
     let total_flakes = ledger.current_stats().flakes as f64;
     // Some in-memory fixtures don't materialize stats; avoid asserting against zero.
     if total_flakes > 0.0 {
@@ -290,10 +291,9 @@ async fn fuel_integration_test() {
     // Test fuel limits (short-circuiting)
     // =========================================================================
 
-    // Query with very low fuel limit should fail. The fixture is in-memory
-    // (genesis, no binary index), so this exercises the overlay path which
-    // charges 1 micro-fuel per row; a 0.001-fuel limit (1 micro-fuel) trips
-    // on the second row.
+    // Query with very low fuel limit should fail. Every query is charged a
+    // 1.000-fuel floor at entry (before parsing), so a 0.001-fuel limit is
+    // tripped by the floor itself, before any rows are scanned.
     let query_with_limit = json!({
         "@context": support::default_context(),
         "select": ["?s", "?p", "?o"],

--- a/fluree-db-api/tests/it_policy_tracking.rs
+++ b/fluree-db-api/tests/it_policy_tracking.rs
@@ -124,7 +124,7 @@ async fn transact_policy_denied_includes_policy_and_fuel_tracking() {
         0
     );
 
-    // Fuel should be tracked when opts.meta=true. Cost = 100 fuel transaction
-    // baseline + 1 micro-fuel per non-schema flake (3 here) = 100.003 fuel.
-    assert_eq!(err.fuel, Some(100.003));
+    // Fuel should be tracked when opts.meta=true. Cost = 10 fuel transaction
+    // baseline + 1 micro-fuel per non-schema flake (3 here) = 10.003 fuel.
+    assert_eq!(err.fuel, Some(10.003));
 }

--- a/fluree-db-api/tests/it_storage_s3_testcontainers.rs
+++ b/fluree-db-api/tests/it_storage_s3_testcontainers.rs
@@ -343,7 +343,9 @@ async fn s3_testcontainers_indexing_test() {
                 .trigger(result.ledger.ledger_id(), result.receipt.t)
                 .await;
             match completion.wait().await {
-                fluree_db_api::IndexOutcome::Completed { index_t, root_id } => {
+                fluree_db_api::IndexOutcome::Completed {
+                    index_t, root_id, ..
+                } => {
                     assert!(index_t >= result.receipt.t);
                     assert!(root_id.is_some(), "expected root_id after indexing");
                 }

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -72,6 +72,12 @@ pub struct LeafInfo {
     pub first_key: RunRecordV2,
     /// Last routing key of the leaf.
     pub last_key: RunRecordV2,
+    /// Number of leaflets in this leaf that were freshly (re-)encoded, as
+    /// opposed to passthrough byte-copies of an existing leaflet. Drives the
+    /// per-leaflet portion of indexer CAS-write fuel charges. For full-rebuild
+    /// output this equals the total leaflet count; for incremental updates it
+    /// counts only the leaflets that were merged + re-encoded.
+    pub re_encoded_leaflet_count: u32,
 }
 
 // ── Writer ─────────────────────────────────────────────────────────────
@@ -286,6 +292,7 @@ impl LeafWriter {
 
         // 2. Build the leaf blob.
         let leaflets = std::mem::take(&mut self.encoded_leaflets);
+        let re_encoded_leaflet_count = leaflets.len() as u32;
         let leaf_bytes = build_leaf_blob(
             self.order,
             &leaflets,
@@ -305,6 +312,7 @@ impl LeafWriter {
             total_rows,
             first_key: first_record,
             last_key: last_record,
+            re_encoded_leaflet_count,
         });
 
         // Reset for next leaf.

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -57,7 +57,7 @@ pub struct BinaryCursor {
     epoch: u64,
     /// Time bound for overlay ops (only emit ops with t <= to_t).
     to_t: i64,
-    /// Optional fuel tracker. When set, charges 1 fuel per leaflet returned.
+    /// Optional fuel tracker. When set, charges one index touch per leaflet returned.
     tracker: Option<Tracker>,
 }
 
@@ -130,8 +130,9 @@ impl BinaryCursor {
         }
     }
 
-    /// Attach a fuel tracker. Charges 1 fuel (1000 micro-fuel) per leaflet
-    /// returned by `next_batch` (regardless of cache hit/miss).
+    /// Attach a fuel tracker. Charges one index touch
+    /// (`schedule::INDEX_TOUCH_MICRO_FUEL`) per leaflet returned by
+    /// `next_batch` (regardless of cache hit/miss).
     pub fn with_tracker(mut self, tracker: Tracker) -> Self {
         if tracker.is_enabled() {
             self.tracker = Some(tracker);
@@ -317,11 +318,13 @@ impl BinaryCursor {
                         continue;
                     }
 
-                    // Charge 1 fuel per leaflet returned (per-touch, regardless
-                    // of cache state). Caller can downcast the io::Error to
-                    // recover the original FuelExceededError.
+                    // Charge one index touch per leaflet returned (per-touch,
+                    // regardless of cache state). Caller can downcast the
+                    // io::Error to recover the original FuelExceededError.
                     if let Some(tracker) = &self.tracker {
-                        if let Err(e) = tracker.consume_fuel(1000) {
+                        if let Err(e) = tracker.consume_fuel(
+                            fluree_db_core::tracking::schedule::INDEX_TOUCH_MICRO_FUEL,
+                        ) {
                             return Err(io::Error::other(e));
                         }
                     }

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -1749,7 +1749,7 @@ impl BinaryGraphView {
 
     /// Attach a fuel tracker. When set, each forward-pack dict touch (a call
     /// into the persisted dict that didn't short-circuit through novelty)
-    /// charges 1 fuel.
+    /// charges one dict touch (`schedule::DICT_TOUCH_MICRO_FUEL`).
     pub fn with_tracker(mut self, tracker: fluree_db_core::Tracker) -> Self {
         if tracker.is_enabled() {
             self.tracker = Some(tracker);
@@ -1760,7 +1760,8 @@ impl BinaryGraphView {
     #[inline]
     fn charge_dict_touch(&self) -> io::Result<()> {
         if let Some(t) = &self.tracker {
-            t.consume_fuel(1000).map_err(io::Error::other)?;
+            t.consume_fuel(fluree_db_core::tracking::schedule::DICT_TOUCH_MICRO_FUEL)
+                .map_err(io::Error::other)?;
         }
         Ok(())
     }

--- a/fluree-db-cli/src/commands/index.rs
+++ b/fluree-db-cli/src/commands/index.rs
@@ -123,6 +123,9 @@ pub async fn run_reindex(
                 "Reindexed {} to t={} (root: {})",
                 alias, result.index_t, result.root_id
             );
+            if let Some(fuel) = result.fuel {
+                println!("Fuel: {fuel:.3}");
+            }
         }
     }
 

--- a/fluree-db-cli/src/commands/index.rs
+++ b/fluree-db-cli/src/commands/index.rs
@@ -134,4 +134,7 @@ fn print_reindex_result(result: &ReindexResponse) {
         "Reindexed {} to t={} (root: {})",
         result.ledger_id, result.index_t, result.root_id
     );
+    if let Some(fuel) = result.fuel {
+        println!("Fuel: {fuel:.3}");
+    }
 }

--- a/fluree-db-core/src/tracking.rs
+++ b/fluree-db-core/src/tracking.rs
@@ -78,6 +78,13 @@ pub mod schedule {
     /// Transaction/commit baseline, charged once per `stage` and once per
     /// bulk-import commit chunk.
     pub const TXN_BASELINE_MICRO_FUEL: u64 = 10_000;
+
+    /// Per successful indexer CAS write. Charged once per `put`, `put_with_id`,
+    /// or `content_write_bytes` call made by the indexer. For `IndexLeaf` writes
+    /// an additional charge of this same rate is applied per *re-encoded*
+    /// leaflet inside the leaf (passthrough leaflets are byte-copied and not
+    /// charged).
+    pub const INDEX_CAS_WRITE_MICRO_FUEL: u64 = 1000;
 }
 
 /// Tracking options parsed from query `opts`

--- a/fluree-db-core/src/tracking.rs
+++ b/fluree-db-core/src/tracking.rs
@@ -77,7 +77,7 @@ pub mod schedule {
 
     /// Transaction/commit baseline, charged once per `stage` and once per
     /// bulk-import commit chunk.
-    pub const TXN_BASELINE_MICRO_FUEL: u64 = 100_000;
+    pub const TXN_BASELINE_MICRO_FUEL: u64 = 10_000;
 }
 
 /// Tracking options parsed from query `opts`

--- a/fluree-db-core/src/tracking.rs
+++ b/fluree-db-core/src/tracking.rs
@@ -36,6 +36,50 @@ pub fn fuel_to_micro(fuel: f64) -> u64 {
     (fuel * MICRO_FUEL_PER_FUEL as f64).round().max(0.0) as u64
 }
 
+/// Fuel schedule — the central, named source for the engine's structural fuel
+/// charges: the query floor, I/O "touches", the per-row/per-flake rate, and the
+/// transaction baseline. All values are **micro-fuel** (1 fuel = 1000 micro-fuel).
+///
+/// Not (yet) centralized here: per-call expression/function micro-charges
+/// (1–5 µf for hashing, UUID, geo, vector, fulltext, etc.) and R2RML row
+/// charges, which are applied inline at their `eval`/r2rml sites. The public
+/// cost ladder in `docs/query/tracking-and-fuel.md` lists all of them.
+///
+/// To re-scale a charge defined here, change it once and every call site picks
+/// it up. History: I/O "touches" were rescaled from 1000 µf (1.000 fuel) to
+/// 10 µf (0.010 fuel) so scan-dominated queries report fuel proportionate to a
+/// transaction's flat baseline. The per-row/per-flake rate (1 µf) is the floor
+/// of the integer unit and was left unchanged.
+pub mod schedule {
+    /// One-time floor charged once at query entry (before parsing). Guarantees
+    /// a fuel-tracked query reports at least 1.000 fuel and that parse/plan
+    /// errors still reflect a non-zero cost.
+    pub const QUERY_FLOOR_MICRO_FUEL: u64 = 1000;
+
+    /// Per index-leaflet batch read during a binary cursor scan, charged once
+    /// per batch returned regardless of cache state.
+    pub const INDEX_TOUCH_MICRO_FUEL: u64 = 10;
+
+    /// Per persisted forward-dict decode (id → value) during result
+    /// materialization.
+    pub const DICT_TOUCH_MICRO_FUEL: u64 = 10;
+
+    /// Base charge per history-scan leaflet. Per-row costs (base rows +
+    /// in-range sidecar rows, at [`PER_ROW_MICRO_FUEL`] each) are added on top
+    /// at the call site.
+    pub const HISTORY_LEAF_TOUCH_MICRO_FUEL: u64 = 10;
+
+    /// Per row/flake materialized from in-memory state: `db.range` flakes,
+    /// overlay/novelty rows, and history rows. The same 1 µf-per-unit rate also
+    /// applies to staged flakes during transactions and bulk imports, where it
+    /// is charged as a raw count (`flakes.len()`) at those call sites.
+    pub const PER_ROW_MICRO_FUEL: u64 = 1;
+
+    /// Transaction/commit baseline, charged once per `stage` and once per
+    /// bulk-import commit chunk.
+    pub const TXN_BASELINE_MICRO_FUEL: u64 = 100_000;
+}
+
 /// Tracking options parsed from query `opts`
 #[derive(Debug, Clone, Default)]
 pub struct TrackingOptions {
@@ -285,4 +329,63 @@ pub struct TrackingTally {
 fn format_time_ms(duration: Duration) -> String {
     let ms = duration.as_secs_f64() * 1000.0;
     format!("{ms:.2}ms")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::schedule::*;
+    use super::*;
+
+    fn fuel_tracker(max_fuel: Option<u64>) -> Tracker {
+        Tracker::new(TrackingOptions {
+            track_fuel: true,
+            max_fuel,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn query_floor_reports_one_fuel() {
+        let t = fuel_tracker(None);
+        t.consume_fuel(QUERY_FLOOR_MICRO_FUEL).unwrap();
+        assert_eq!(t.tally().unwrap().fuel, Some(1.0));
+    }
+
+    #[test]
+    fn index_dict_history_touches_are_one_hundredth_fuel() {
+        for touch in [
+            INDEX_TOUCH_MICRO_FUEL,
+            DICT_TOUCH_MICRO_FUEL,
+            HISTORY_LEAF_TOUCH_MICRO_FUEL,
+        ] {
+            let t = fuel_tracker(None);
+            t.consume_fuel(touch).unwrap();
+            assert_eq!(t.tally().unwrap().fuel, Some(0.01), "touch={touch}");
+        }
+    }
+
+    #[test]
+    fn floor_plus_one_touch_reports_one_point_zero_one() {
+        let t = fuel_tracker(None);
+        t.consume_fuel(QUERY_FLOOR_MICRO_FUEL).unwrap();
+        t.consume_fuel(INDEX_TOUCH_MICRO_FUEL).unwrap();
+        assert_eq!(t.tally().unwrap().fuel, Some(1.01));
+    }
+
+    #[test]
+    fn floor_exceeds_max_fuel_below_one() {
+        // max-fuel: 0.5 leaves no room for the 1.000 floor.
+        let t = fuel_tracker(Some(fuel_to_micro(0.5)));
+        let err = t.consume_fuel(QUERY_FLOOR_MICRO_FUEL).unwrap_err();
+        assert_eq!(err.limit_fuel(), 0.5);
+        assert_eq!(err.used_fuel(), 1.0);
+    }
+
+    #[test]
+    fn max_fuel_one_admits_floor_but_not_a_touch() {
+        // max-fuel: 1 permits exactly the floor; the next persisted touch fails.
+        let t = fuel_tracker(Some(fuel_to_micro(1.0)));
+        t.consume_fuel(QUERY_FLOOR_MICRO_FUEL).unwrap();
+        assert!(t.consume_fuel(INDEX_TOUCH_MICRO_FUEL).is_err());
+    }
 }

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -524,11 +524,13 @@ pub async fn incremental_index(
 
     if novelty.records.is_empty() {
         tracing::debug!("no new records resolved; returning existing V6 root");
+        // fuel is filled in by the outer entry point from the tracker tally.
         return Ok(IndexResult {
             root_id: base_root_id,
             index_t: novelty.max_t,
             ledger_id: ledger_id.to_string(),
             stats: IndexStats::default(),
+            fuel: None,
         });
     }
 
@@ -2808,6 +2810,8 @@ pub async fn incremental_index(
                 branch_count: by_graph.len(),
                 total_bytes: root_bytes.len(),
             },
+            // Outer entry point fills fuel from the tracker tally.
+            fuel: None,
         })
     } else {
         let mut final_root = new_root;
@@ -2858,6 +2862,7 @@ pub async fn incremental_index(
                 branch_count: by_graph.len(),
                 total_bytes: root_bytes.len(),
             },
+            fuel: None,
         })
     }
 }

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -322,6 +322,7 @@ async fn execute_phase2_task(
     task: Phase2Task,
     config: &IndexerConfig,
     content_store: Arc<dyn fluree_db_core::storage::ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
     cache_dir: std::path::PathBuf,
 ) -> Result<Phase2TaskOutput> {
     let Phase2Task {
@@ -358,7 +359,7 @@ async fn execute_phase2_task(
                 cache_dir.clone(),
             )
             .await?;
-            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
+            upload_leaf_blobs(content_store.as_ref(), &tracker, &result, &cache_dir).await?;
             Phase2TaskOutput {
                 seq,
                 g_id,
@@ -375,7 +376,7 @@ async fn execute_phase2_task(
         Phase2TaskKind::DefaultFresh => {
             let result =
                 build_fresh_default_graph_v3(&sorted_records, &sorted_ops, order, g_id, config)?;
-            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
+            upload_leaf_blobs(content_store.as_ref(), &tracker, &result, &cache_dir).await?;
             Phase2TaskOutput {
                 seq,
                 g_id,
@@ -406,7 +407,7 @@ async fn execute_phase2_task(
                 cache_dir.clone(),
             )
             .await?;
-            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
+            upload_leaf_blobs(content_store.as_ref(), &tracker, &result, &cache_dir).await?;
             let branch_cid = content_store
                 .put(ContentKind::IndexBranch, &result.branch_bytes)
                 .await
@@ -431,7 +432,7 @@ async fn execute_phase2_task(
         }
         Phase2TaskKind::NamedFresh => {
             let result = build_fresh_named_graph_v3(&sorted_records, order, g_id, config)?;
-            upload_leaf_blobs(content_store.as_ref(), &result, &cache_dir).await?;
+            upload_leaf_blobs(content_store.as_ref(), &tracker, &result, &cache_dir).await?;
             let branch_cid = content_store
                 .put(ContentKind::IndexBranch, &result.branch_bytes)
                 .await
@@ -485,6 +486,7 @@ async fn execute_phase2_task(
 /// incremental conditions are met.
 pub async fn incremental_index(
     content_store: Arc<dyn ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
     ledger_id: &str,
     record: &fluree_db_nameservice::NsRecord,
     config: IndexerConfig,
@@ -627,7 +629,10 @@ pub async fn incremental_index(
         .map(|task| {
             let content_store = content_store.clone();
             let cache_dir = cache_dir.clone();
-            async move { execute_phase2_task(task, config_ref, content_store, cache_dir).await }
+            let task_tracker = tracker.clone();
+            async move {
+                execute_phase2_task(task, config_ref, content_store, task_tracker, cache_dir).await
+            }
         })
         .buffer_unordered(concurrency)
         .collect::<Vec<_>>()
@@ -2864,8 +2869,14 @@ pub async fn incremental_index(
 /// Upload leaf and sidecar blobs from a branch update result.
 ///
 /// Shared by all four code paths: default-graph existing/fresh, named-graph existing/fresh.
+///
+/// `tracker` is used only for the per-leaflet portion of FLI3 leaf fuel
+/// charges. The base per-write fuel is charged automatically by
+/// [`crate::fuel::MeteredContentStore`] when `content_store` is the metered
+/// wrapper.
 async fn upload_leaf_blobs(
     content_store: &dyn ContentStore,
+    tracker: &fluree_db_core::tracking::Tracker,
     result: &BranchUpdateResult,
     cache_dir: &std::path::Path,
 ) -> Result<()> {
@@ -2877,6 +2888,7 @@ async fn upload_leaf_blobs(
             .put(ContentKind::IndexLeaf, &blob.info.leaf_bytes)
             .await
             .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+        crate::fuel::charge_extra_leaflets(tracker, blob.info.re_encoded_leaflet_count)?;
         debug_assert!(leaf_cid == blob.info.leaf_cid);
         cache_artifact_bytes(cache_dir, &leaf_cid, &blob.info.leaf_bytes, "index_leaf");
         leaf_bytes += blob.info.leaf_bytes.len() as u64;

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -33,11 +33,12 @@ use tracing::Instrument;
 /// 6. Upload artifacts to CAS and write BinaryIndexRoot
 pub async fn rebuild_index_from_commits(
     content_store: std::sync::Arc<dyn ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
     ledger_id: &str,
     record: &fluree_db_nameservice::NsRecord,
     config: IndexerConfig,
 ) -> Result<IndexResult> {
-    rebuild_index_from_commits_with_store(content_store, ledger_id, record, config).await
+    rebuild_index_from_commits_with_store(content_store, tracker, ledger_id, record, config).await
 }
 
 /// Like [`rebuild_index_from_commits`], but accepts a caller-provided
@@ -46,6 +47,7 @@ pub async fn rebuild_index_from_commits(
 /// chain falls through to parent namespaces via `BranchedContentStore`).
 pub async fn rebuild_index_from_commits_with_store<C>(
     commit_store: C,
+    tracker: fluree_db_core::tracking::Tracker,
     ledger_id: &str,
     record: &fluree_db_nameservice::NsRecord,
     config: IndexerConfig,
@@ -916,9 +918,10 @@ where
             );
 
             // Phase E-V3: Upload V3 artifacts to CAS.
-            let v3_uploaded = super::upload::upload_indexes_to_cas(&content_store, &v3_result)
-                .instrument(tracing::debug_span!("upload_v3_indexes"))
-                .await?;
+            let v3_uploaded =
+                super::upload::upload_indexes_to_cas(&content_store, &tracker, &v3_result)
+                    .instrument(tracing::debug_span!("upload_v3_indexes"))
+                    .await?;
 
             // Phase F-V3: Upload dicts + assemble FIR6 root.
             let uploaded_dicts =

--- a/fluree-db-indexer/src/build/root_assembly.rs
+++ b/fluree-db-indexer/src/build/root_assembly.rs
@@ -150,6 +150,8 @@ pub(crate) async fn encode_and_write_root(
             total_bytes: root_bytes.len(),
             ..result_stats
         },
+        // Outer entry point fills fuel from the tracker tally.
+        fuel: None,
     })
 }
 
@@ -356,6 +358,8 @@ pub(crate) async fn encode_and_write_root_v6(
             total_bytes: root_bytes.len(),
             ..result_stats
         },
+        // Outer entry point fills fuel from the tracker tally.
+        fuel: None,
     })
 }
 

--- a/fluree-db-indexer/src/build/upload.rs
+++ b/fluree-db-indexer/src/build/upload.rs
@@ -5,13 +5,18 @@
 //! `upload_indexes_to_cas` function for uploading index branches and leaves.
 
 use fluree_db_binary_index::RunSortOrder;
+use fluree_db_core::tracking::Tracker;
 use fluree_db_core::{ContentId, ContentKind, ContentStore, GraphId};
 
 use crate::error::{IndexerError, Result};
+use crate::fuel::charge_extra_leaflets;
 
 use super::types::UploadedIndexes;
 
 /// Upload a single dict blob (already in memory) to the content store and return its CID.
+///
+/// The base per-write fuel is charged by [`crate::fuel::MeteredContentStore`]
+/// when `cs` is the metered wrapper; this helper does not need a tracker.
 pub(crate) async fn upload_dict_blob(
     cs: &dyn ContentStore,
     dict: fluree_db_core::DictKind,
@@ -46,8 +51,15 @@ pub(crate) async fn upload_dict_file(
 ///
 /// Default graph (g_id=0) collects inline `LeafEntry` for root embedding.
 /// Named graphs upload branch manifests and return branch CIDs.
+///
+/// The base per-write fuel for every CAS write is charged by
+/// [`crate::fuel::MeteredContentStore`] when `cs` is the metered wrapper.
+/// The `tracker` param is used here only for the additional per-leaflet
+/// charge on FLI3 leaf writes (passthrough leaflets are not charged because
+/// no zstd encoding work was performed).
 pub(crate) async fn upload_indexes_to_cas(
     cs: &dyn ContentStore,
+    tracker: &Tracker,
     build_result: &crate::BuildResult,
 ) -> Result<UploadedIndexes> {
     use fluree_db_binary_index::format::branch::LeafEntry;
@@ -102,6 +114,7 @@ pub(crate) async fn upload_indexes_to_cas(
                 cs.put_with_id(&leaf_info.leaf_cid, &leaf_bytes)
                     .await
                     .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+                charge_extra_leaflets(tracker, leaf_info.re_encoded_leaflet_count)?;
             }
 
             // Upload branch manifest for named graphs.

--- a/fluree-db-indexer/src/error.rs
+++ b/fluree-db-indexer/src/error.rs
@@ -60,6 +60,13 @@ pub enum IndexerError {
     /// General-purpose error for spatial index building and other auxiliary pipelines.
     #[error("{0}")]
     Other(String),
+
+    /// Fuel limit exceeded during an indexer CAS write. Indexing trackers are
+    /// expected to be no-limit (measurement only), so in normal use this is
+    /// unreachable — it exists for defensive type safety if a caller supplies
+    /// a limited tracker.
+    #[error("Indexer fuel limit exceeded: {0}")]
+    FuelExceeded(#[from] fluree_db_core::tracking::FuelExceededError),
 }
 
 impl From<serde_json::Error> for IndexerError {

--- a/fluree-db-indexer/src/fuel.rs
+++ b/fluree-db-indexer/src/fuel.rs
@@ -4,97 +4,163 @@
 //!
 //! - 1 [`INDEX_CAS_WRITE_MICRO_FUEL`] per successful indexer CAS write
 //!   (`put`, `put_with_id`, or `content_write_bytes`).
-//! - **Additionally**, for `ContentKind::IndexLeaf` writes that contain an
-//!   FLI3 leaf with leaflets, 1 [`INDEX_CAS_WRITE_MICRO_FUEL`] per *re-encoded*
-//!   leaflet in the leaf. Passthrough leaflets (byte-copied from a prior leaf
-//!   in an incremental update) are not charged because no zstd encoding work
-//!   was performed.
+//! - **Additionally**, for FLI3 leaf writes, 1 [`INDEX_CAS_WRITE_MICRO_FUEL`]
+//!   per *re-encoded* leaflet in the leaf. Passthrough leaflets (byte-copied
+//!   from a prior leaf in an incremental update) are not charged because no
+//!   zstd encoding work was performed.
 //!
-//! The thin `charged_*` wrappers exist so call sites stay one line and the
-//! "charge after a successful write" invariant is enforced in one place. New
-//! CAS write sites in the indexer should go through these wrappers.
+//! ## Wiring
+//!
+//! The build entry points wrap the caller-supplied [`ContentStore`] in
+//! [`MeteredContentStore`] once at the boundary. From that point on the entire
+//! build pipeline writes through the wrapper, and every `put` /
+//! `put_with_id` is automatically billed at the base per-write rate — so new
+//! upload sites need no changes to be billed correctly. Only the **two** FLI3
+//! leaf upload sites (`upload_indexes_to_cas` for full rebuild and
+//! `upload_leaf_blobs` for incremental) need an explicit extra call to
+//! [`charge_extra_leaflets`] for the per-leaflet portion, because the wrapper
+//! has no way to know how many leaflets in the blob were freshly encoded.
+//!
+//! ## Limits
 //!
 //! Indexer trackers are expected to be **no-limit** (measurement, not
 //! enforcement). A partial index is worse than a slow one, so we never want a
-//! mid-build abort. The wrappers still propagate `FuelExceededError` for type
-//! safety, surfaced via [`crate::IndexerError::FuelExceeded`].
+//! mid-build abort. The wrappers still propagate [`FuelExceededError`] via
+//! [`crate::IndexerError::FuelExceeded`] for type safety.
 
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fluree_db_core::error::Result as StorageResult;
 use fluree_db_core::tracking::{schedule::INDEX_CAS_WRITE_MICRO_FUEL, Tracker};
 use fluree_db_core::{ContentId, ContentKind, ContentStore};
 
-use crate::{IndexerError, Result};
+use crate::Result;
 
 /// Charge the per-CAS-write fuel for a write that has already succeeded.
 ///
-/// `leaflet_count` is the *re-encoded* leaflet count for FLI3 leaf writes (0
-/// for any other kind, including non-FLI3 blobs tagged as `IndexLeaf` such as
-/// fulltext segments). Prefer the `charged_*` wrappers below; this is exposed
-/// for the rare site that must call `ContentStore` directly.
+/// `leaflet_count` is the *re-encoded* leaflet count to charge in **addition**
+/// to the base write fee. Pass 0 for non-leaf writes.
 pub fn charge_index_write(tracker: &Tracker, leaflet_count: u32) -> Result<()> {
     tracker.consume_fuel(INDEX_CAS_WRITE_MICRO_FUEL)?;
-    if leaflet_count > 0 {
-        let extra = (leaflet_count as u64).saturating_mul(INDEX_CAS_WRITE_MICRO_FUEL);
+    charge_extra_leaflets(tracker, leaflet_count)
+}
+
+/// Charge the per-leaflet extra fuel for an FLI3 leaf write that has already
+/// succeeded through a [`MeteredContentStore`] (which has already charged the
+/// base write fee).
+///
+/// `re_encoded_leaflet_count` is the number of leaflets inside the leaf that
+/// were freshly encoded — passthrough byte-copies are not charged because no
+/// zstd encoding work was performed. Pass 0 to no-op.
+pub fn charge_extra_leaflets(tracker: &Tracker, re_encoded_leaflet_count: u32) -> Result<()> {
+    if re_encoded_leaflet_count > 0 {
+        let extra = (re_encoded_leaflet_count as u64).saturating_mul(INDEX_CAS_WRITE_MICRO_FUEL);
         tracker.consume_fuel(extra)?;
     }
     Ok(())
 }
 
-/// `ContentStore::put` + per-write fuel charge.
+/// A [`ContentStore`] wrapper that charges fuel for every successful CAS
+/// write the indexer makes through it.
 ///
-/// For `IndexLeaf` writes prefer [`charged_put_leaf`]; this helper passes 0
-/// for the leaflet count and so under-bills FLI3 leaves.
-pub async fn charged_put(
-    store: &dyn ContentStore,
-    tracker: &Tracker,
-    kind: ContentKind,
-    bytes: &[u8],
-) -> Result<ContentId> {
-    let cid = store
-        .put(kind, bytes)
-        .await
-        .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
-    charge_index_write(tracker, 0)?;
-    Ok(cid)
+/// Delegates all read paths (`has`, `get`, `get_range`, `release`,
+/// `resolve_local_path`) and the `put` / `put_with_id` writes to the inner
+/// store. After each successful write the wrapper charges
+/// [`INDEX_CAS_WRITE_MICRO_FUEL`] against the tracker — once per CAS call,
+/// regardless of `ContentKind`.
+///
+/// FLI3 leaf writes need an **extra** per-leaflet charge that the wrapper
+/// cannot compute from blob bytes alone (it cannot distinguish passthrough
+/// from re-encoded leaflets). The two leaf upload sites
+/// (`build::upload::upload_indexes_to_cas` and
+/// `build::incremental::upload_leaf_blobs`) add that charge explicitly via
+/// [`charge_extra_leaflets`] using the
+/// [`re_encoded_leaflet_count`](fluree_db_binary_index::format::leaf::LeafInfo::re_encoded_leaflet_count)
+/// they already carry.
+///
+/// On a failed write the underlying store's error is propagated and no fuel
+/// is charged.
+pub struct MeteredContentStore {
+    inner: Arc<dyn ContentStore>,
+    tracker: Tracker,
 }
 
-/// `ContentStore::put` for an `IndexLeaf` blob, charging the base write fee
-/// plus the per-leaflet fee for `re_encoded_leaflet_count` leaflets.
-pub async fn charged_put_leaf(
-    store: &dyn ContentStore,
-    tracker: &Tracker,
-    bytes: &[u8],
-    re_encoded_leaflet_count: u32,
-) -> Result<ContentId> {
-    let cid = store
-        .put(ContentKind::IndexLeaf, bytes)
-        .await
-        .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
-    charge_index_write(tracker, re_encoded_leaflet_count)?;
-    Ok(cid)
+impl MeteredContentStore {
+    pub fn new(inner: Arc<dyn ContentStore>, tracker: Tracker) -> Self {
+        Self { inner, tracker }
+    }
+
+    /// The wrapped store, primarily for paths that need to clone the inner
+    /// `Arc<dyn ContentStore>` directly (e.g. plumbing into helpers that
+    /// don't go through the wrapper).
+    pub fn inner(&self) -> &Arc<dyn ContentStore> {
+        &self.inner
+    }
+
+    /// The tracker the wrapper charges against. Exposed so leaf upload sites
+    /// can call [`charge_extra_leaflets`] for the per-leaflet portion.
+    pub fn tracker(&self) -> &Tracker {
+        &self.tracker
+    }
 }
 
-/// `ContentStore::put_with_id` + per-write fuel charge.
-///
-/// `leaflet_count` should be 0 for any kind other than an FLI3 `IndexLeaf`.
-pub async fn charged_put_with_id(
-    store: &dyn ContentStore,
-    tracker: &Tracker,
-    id: &ContentId,
-    bytes: &[u8],
-    leaflet_count: u32,
-) -> Result<()> {
-    store
-        .put_with_id(id, bytes)
-        .await
-        .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
-    charge_index_write(tracker, leaflet_count)?;
-    Ok(())
+impl fmt::Debug for MeteredContentStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MeteredContentStore")
+            .field("inner", &self.inner)
+            .field("tracker_enabled", &self.tracker.is_enabled())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl ContentStore for MeteredContentStore {
+    async fn has(&self, id: &ContentId) -> StorageResult<bool> {
+        self.inner.has(id).await
+    }
+
+    async fn get(&self, id: &ContentId) -> StorageResult<Vec<u8>> {
+        self.inner.get(id).await
+    }
+
+    async fn put(&self, kind: ContentKind, bytes: &[u8]) -> StorageResult<ContentId> {
+        let cid = self.inner.put(kind, bytes).await?;
+        // Tracker is no-limit by design; FuelExceededError → core::Error via
+        // the trait's existing From impl preserves the trait contract.
+        self.tracker.consume_fuel(INDEX_CAS_WRITE_MICRO_FUEL)?;
+        Ok(cid)
+    }
+
+    async fn put_with_id(&self, id: &ContentId, bytes: &[u8]) -> StorageResult<()> {
+        self.inner.put_with_id(id, bytes).await?;
+        self.tracker.consume_fuel(INDEX_CAS_WRITE_MICRO_FUEL)?;
+        Ok(())
+    }
+
+    fn resolve_local_path(&self, id: &ContentId) -> Option<std::path::PathBuf> {
+        self.inner.resolve_local_path(id)
+    }
+
+    async fn release(&self, id: &ContentId) -> StorageResult<()> {
+        self.inner.release(id).await
+    }
+
+    async fn get_range(
+        &self,
+        id: &ContentId,
+        range: std::ops::Range<u64>,
+    ) -> StorageResult<Vec<u8>> {
+        self.inner.get_range(id, range).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use fluree_db_core::tracking::{micro_to_fuel, TrackingOptions};
+    use fluree_db_core::storage::MemoryContentStore;
 
     fn enabled_tracker() -> Tracker {
         Tracker::new(TrackingOptions {
@@ -129,8 +195,42 @@ mod tests {
     fn disabled_tracker_is_noop() {
         let t = Tracker::disabled();
         charge_index_write(&t, 100).unwrap();
-        // tally() returns None on a disabled tracker; the call must not panic
-        // and must succeed regardless of the leaflet count.
         assert!(t.tally().is_none());
+    }
+
+    #[tokio::test]
+    async fn metered_store_charges_one_fuel_per_put() {
+        let inner: Arc<dyn ContentStore> = Arc::new(MemoryContentStore::new());
+        let tracker = enabled_tracker();
+        let metered = MeteredContentStore::new(inner, tracker.clone());
+
+        metered
+            .put(ContentKind::IndexBranch, b"branch-bytes")
+            .await
+            .unwrap();
+        assert_eq!(used(&tracker), 1.0);
+
+        // Second write adds another fuel.
+        metered
+            .put(ContentKind::GarbageRecord, b"{}")
+            .await
+            .unwrap();
+        assert_eq!(used(&tracker), 2.0);
+    }
+
+    #[tokio::test]
+    async fn metered_store_plus_extra_leaflets_for_fli3_leaf() {
+        let inner: Arc<dyn ContentStore> = Arc::new(MemoryContentStore::new());
+        let tracker = enabled_tracker();
+        let metered = MeteredContentStore::new(inner, tracker.clone());
+
+        // Simulate an FLI3 leaf upload: 1 fuel for the put + 5 fuel for the
+        // re-encoded leaflets inside it.
+        metered
+            .put(ContentKind::IndexLeaf, b"leaf-bytes")
+            .await
+            .unwrap();
+        charge_extra_leaflets(metered.tracker(), 5).unwrap();
+        assert_eq!(used(&tracker), 6.0);
     }
 }

--- a/fluree-db-indexer/src/fuel.rs
+++ b/fluree-db-indexer/src/fuel.rs
@@ -1,0 +1,136 @@
+//! Indexer CAS-write fuel charging.
+//!
+//! Centralises the rule for billing indexer work to a fuel `Tracker`:
+//!
+//! - 1 [`INDEX_CAS_WRITE_MICRO_FUEL`] per successful indexer CAS write
+//!   (`put`, `put_with_id`, or `content_write_bytes`).
+//! - **Additionally**, for `ContentKind::IndexLeaf` writes that contain an
+//!   FLI3 leaf with leaflets, 1 [`INDEX_CAS_WRITE_MICRO_FUEL`] per *re-encoded*
+//!   leaflet in the leaf. Passthrough leaflets (byte-copied from a prior leaf
+//!   in an incremental update) are not charged because no zstd encoding work
+//!   was performed.
+//!
+//! The thin `charged_*` wrappers exist so call sites stay one line and the
+//! "charge after a successful write" invariant is enforced in one place. New
+//! CAS write sites in the indexer should go through these wrappers.
+//!
+//! Indexer trackers are expected to be **no-limit** (measurement, not
+//! enforcement). A partial index is worse than a slow one, so we never want a
+//! mid-build abort. The wrappers still propagate `FuelExceededError` for type
+//! safety, surfaced via [`crate::IndexerError::FuelExceeded`].
+
+use fluree_db_core::tracking::{schedule::INDEX_CAS_WRITE_MICRO_FUEL, Tracker};
+use fluree_db_core::{ContentId, ContentKind, ContentStore};
+
+use crate::{IndexerError, Result};
+
+/// Charge the per-CAS-write fuel for a write that has already succeeded.
+///
+/// `leaflet_count` is the *re-encoded* leaflet count for FLI3 leaf writes (0
+/// for any other kind, including non-FLI3 blobs tagged as `IndexLeaf` such as
+/// fulltext segments). Prefer the `charged_*` wrappers below; this is exposed
+/// for the rare site that must call `ContentStore` directly.
+pub fn charge_index_write(tracker: &Tracker, leaflet_count: u32) -> Result<()> {
+    tracker.consume_fuel(INDEX_CAS_WRITE_MICRO_FUEL)?;
+    if leaflet_count > 0 {
+        let extra = (leaflet_count as u64).saturating_mul(INDEX_CAS_WRITE_MICRO_FUEL);
+        tracker.consume_fuel(extra)?;
+    }
+    Ok(())
+}
+
+/// `ContentStore::put` + per-write fuel charge.
+///
+/// For `IndexLeaf` writes prefer [`charged_put_leaf`]; this helper passes 0
+/// for the leaflet count and so under-bills FLI3 leaves.
+pub async fn charged_put(
+    store: &dyn ContentStore,
+    tracker: &Tracker,
+    kind: ContentKind,
+    bytes: &[u8],
+) -> Result<ContentId> {
+    let cid = store
+        .put(kind, bytes)
+        .await
+        .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+    charge_index_write(tracker, 0)?;
+    Ok(cid)
+}
+
+/// `ContentStore::put` for an `IndexLeaf` blob, charging the base write fee
+/// plus the per-leaflet fee for `re_encoded_leaflet_count` leaflets.
+pub async fn charged_put_leaf(
+    store: &dyn ContentStore,
+    tracker: &Tracker,
+    bytes: &[u8],
+    re_encoded_leaflet_count: u32,
+) -> Result<ContentId> {
+    let cid = store
+        .put(ContentKind::IndexLeaf, bytes)
+        .await
+        .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+    charge_index_write(tracker, re_encoded_leaflet_count)?;
+    Ok(cid)
+}
+
+/// `ContentStore::put_with_id` + per-write fuel charge.
+///
+/// `leaflet_count` should be 0 for any kind other than an FLI3 `IndexLeaf`.
+pub async fn charged_put_with_id(
+    store: &dyn ContentStore,
+    tracker: &Tracker,
+    id: &ContentId,
+    bytes: &[u8],
+    leaflet_count: u32,
+) -> Result<()> {
+    store
+        .put_with_id(id, bytes)
+        .await
+        .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
+    charge_index_write(tracker, leaflet_count)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::tracking::{micro_to_fuel, TrackingOptions};
+
+    fn enabled_tracker() -> Tracker {
+        Tracker::new(TrackingOptions {
+            track_fuel: true,
+            ..Default::default()
+        })
+    }
+
+    fn used(tracker: &Tracker) -> f64 {
+        tracker
+            .tally()
+            .and_then(|t| t.fuel)
+            .unwrap_or_else(|| micro_to_fuel(0))
+    }
+
+    #[test]
+    fn base_write_no_leaflets_charges_one_fuel() {
+        let t = enabled_tracker();
+        charge_index_write(&t, 0).unwrap();
+        assert_eq!(used(&t), 1.0);
+    }
+
+    #[test]
+    fn leaf_with_three_re_encoded_leaflets_charges_four_fuel() {
+        // 1 (write) + 3 (leaflets) = 4 fuel.
+        let t = enabled_tracker();
+        charge_index_write(&t, 3).unwrap();
+        assert_eq!(used(&t), 4.0);
+    }
+
+    #[test]
+    fn disabled_tracker_is_noop() {
+        let t = Tracker::disabled();
+        charge_index_write(&t, 100).unwrap();
+        // tally() returns None on a disabled tracker; the call must not panic
+        // and must succeed regardless of the leaflet count.
+        assert!(t.tally().is_none());
+    }
+}

--- a/fluree-db-indexer/src/fuel.rs
+++ b/fluree-db-indexer/src/fuel.rs
@@ -161,8 +161,8 @@ impl ContentStore for MeteredContentStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fluree_db_core::tracking::{micro_to_fuel, TrackingOptions};
     use fluree_db_core::storage::MemoryContentStore;
+    use fluree_db_core::tracking::{micro_to_fuel, TrackingOptions};
 
     fn enabled_tracker() -> Tracker {
         Tracker::new(TrackingOptions {

--- a/fluree-db-indexer/src/fuel.rs
+++ b/fluree-db-indexer/src/fuel.rs
@@ -3,7 +3,9 @@
 //! Centralises the rule for billing indexer work to a fuel `Tracker`:
 //!
 //! - 1 [`INDEX_CAS_WRITE_MICRO_FUEL`] per successful indexer CAS write
-//!   (`put`, `put_with_id`, or `content_write_bytes`).
+//!   (`ContentStore::put` or `put_with_id`). The lower-level
+//!   `Storage::content_write_bytes` path is not wrapped — it has no active
+//!   indexer call site today.
 //! - **Additionally**, for FLI3 leaf writes, 1 [`INDEX_CAS_WRITE_MICRO_FUEL`]
 //!   per *re-encoded* leaflet in the leaf. Passthrough leaflets (byte-copied
 //!   from a prior leaf in an incremental update) are not charged because no

--- a/fluree-db-indexer/src/lib.rs
+++ b/fluree-db-indexer/src/lib.rs
@@ -86,6 +86,11 @@ pub struct IndexResult {
     pub ledger_id: String,
     /// Index build statistics
     pub stats: IndexStats,
+    /// Total fuel charged for this build. `Some(_)` when fuel tracking was
+    /// enabled at the entry point (see [`build_index_for_record_with_tracker`]),
+    /// `None` when the build went through the plain non-tracking API. An
+    /// already-current build reports `Some(0.0)` if tracking was enabled.
+    pub fuel: Option<f64>,
 }
 
 /// Statistics from index building
@@ -176,7 +181,9 @@ pub async fn build_index_for_record_with_tracker(
             "loaded ledger state for index build"
         );
 
-        // If index is already current, return it
+        // If index is already current, return it. Report fuel as Some(0.0)
+        // when tracking is enabled (no CAS work was done) so callers can
+        // distinguish "no work" from "not tracked".
         if let Some(ref root_id) = record.index_head_id {
             if record.index_t >= record.commit_t {
                 tracing::info!(
@@ -185,11 +192,13 @@ pub async fn build_index_for_record_with_tracker(
                     commit_t = record.commit_t,
                     "index already current; returning existing root"
                 );
+                let fuel = tracker.tracks_fuel().then_some(0.0);
                 return Ok(IndexResult {
                     root_id: root_id.clone(),
                     index_t: record.index_t,
                     ledger_id: ledger_id.to_string(),
                     stats: IndexStats::default(),
+                    fuel,
                 });
             }
         }
@@ -217,7 +226,8 @@ pub async fn build_index_for_record_with_tracker(
             )
             .await
             {
-                Ok(result) => {
+                Ok(mut result) => {
+                    result.fuel = tally_fuel(&tracker);
                     return Ok(result);
                 }
                 Err(e) => {
@@ -243,17 +253,26 @@ pub async fn build_index_for_record_with_tracker(
             commit_gap,
             "starting full rebuild path"
         );
-        build::rebuild::rebuild_index_from_commits(
+        let mut result = build::rebuild::rebuild_index_from_commits(
             content_store,
-            tracker,
+            tracker.clone(),
             ledger_id,
             record,
             config,
         )
-        .await
+        .await?;
+        result.fuel = tally_fuel(&tracker);
+        Ok(result)
     }
     .instrument(span)
     .await
+}
+
+/// Snapshot the tracker's current decimal fuel total, or `None` when fuel
+/// tracking was not enabled at this tracker (so callers can distinguish
+/// "no work" from "not tracked").
+fn tally_fuel(tracker: &fluree_db_core::tracking::Tracker) -> Option<f64> {
+    tracker.tally().and_then(|t| t.fuel)
 }
 
 /// External indexer entry point
@@ -320,6 +339,32 @@ pub async fn rebuild_index_from_commits(
         config,
     )
     .await
+}
+
+/// Same as [`rebuild_index_from_commits`], but wraps `content_store` in a
+/// [`crate::fuel::MeteredContentStore`] so the rebuild's CAS writes are
+/// billed against `tracker`, and stamps the resulting [`IndexResult::fuel`]
+/// with the tracker's final tally.
+pub async fn rebuild_index_from_commits_with_tracker(
+    content_store: std::sync::Arc<dyn ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
+    ledger_id: &str,
+    record: &fluree_db_nameservice::NsRecord,
+    config: IndexerConfig,
+) -> Result<IndexResult> {
+    let metered: std::sync::Arc<dyn ContentStore> = std::sync::Arc::new(
+        crate::fuel::MeteredContentStore::new(content_store, tracker.clone()),
+    );
+    let mut result = build::rebuild::rebuild_index_from_commits(
+        metered,
+        tracker.clone(),
+        ledger_id,
+        record,
+        config,
+    )
+    .await?;
+    result.fuel = tally_fuel(&tracker);
+    Ok(result)
 }
 
 /// Like [`rebuild_index_from_commits`], but accepts a caller-provided

--- a/fluree-db-indexer/src/lib.rs
+++ b/fluree-db-indexer/src/lib.rs
@@ -31,6 +31,7 @@ mod build;
 pub mod config;
 pub mod drop;
 pub mod error;
+pub mod fuel;
 pub mod fulltext_hook;
 pub mod gc;
 #[path = "stats/hll256.rs"]

--- a/fluree-db-indexer/src/lib.rs
+++ b/fluree-db-indexer/src/lib.rs
@@ -140,11 +140,9 @@ pub async fn build_index_for_record_with_tracker(
     record: &fluree_db_nameservice::NsRecord,
     mut config: IndexerConfig,
 ) -> Result<IndexResult> {
-    let content_store: std::sync::Arc<dyn ContentStore> =
-        std::sync::Arc::new(crate::fuel::MeteredContentStore::new(
-            content_store,
-            tracker.clone(),
-        ));
+    let content_store: std::sync::Arc<dyn ContentStore> = std::sync::Arc::new(
+        crate::fuel::MeteredContentStore::new(content_store, tracker.clone()),
+    );
     let ledger_id = record.ledger_id.as_str();
 
     // If a config provider is attached, let it refresh the per-run

--- a/fluree-db-indexer/src/lib.rs
+++ b/fluree-db-indexer/src/lib.rs
@@ -113,8 +113,33 @@ pub const CURRENT_INDEX_VERSION: i32 = 2;
 pub async fn build_index_for_record(
     content_store: std::sync::Arc<dyn ContentStore>,
     record: &fluree_db_nameservice::NsRecord,
+    config: IndexerConfig,
+) -> Result<IndexResult> {
+    build_index_for_record_with_tracker(
+        content_store,
+        fluree_db_core::tracking::Tracker::disabled(),
+        record,
+        config,
+    )
+    .await
+}
+
+/// Same as [`build_index_for_record`], but wraps `content_store` in a
+/// [`crate::fuel::MeteredContentStore`] for the duration of the build and
+/// charges fuel against `tracker`. Pass a fuel-enabled, no-limit tracker
+/// created at the API boundary; the indexer never enforces a fuel limit
+/// (measurement only).
+pub async fn build_index_for_record_with_tracker(
+    content_store: std::sync::Arc<dyn ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
+    record: &fluree_db_nameservice::NsRecord,
     mut config: IndexerConfig,
 ) -> Result<IndexResult> {
+    let content_store: std::sync::Arc<dyn ContentStore> =
+        std::sync::Arc::new(crate::fuel::MeteredContentStore::new(
+            content_store,
+            tracker.clone(),
+        ));
     let ledger_id = record.ledger_id.as_str();
 
     // If a config provider is attached, let it refresh the per-run
@@ -183,7 +208,14 @@ pub async fn build_index_for_record(
                 "attempting incremental index"
             );
 
-            match incremental_index(content_store.clone(), ledger_id, record, config.clone()).await
+            match incremental_index(
+                content_store.clone(),
+                tracker.clone(),
+                ledger_id,
+                record,
+                config.clone(),
+            )
+            .await
             {
                 Ok(result) => {
                     return Ok(result);
@@ -211,7 +243,14 @@ pub async fn build_index_for_record(
             commit_gap,
             "starting full rebuild path"
         );
-        rebuild_index_from_commits(content_store, ledger_id, record, config).await
+        build::rebuild::rebuild_index_from_commits(
+            content_store,
+            tracker,
+            ledger_id,
+            record,
+            config,
+        )
+        .await
     }
     .instrument(span)
     .await
@@ -232,13 +271,32 @@ pub async fn build_index_for_ledger(
     ledger_id: &str,
     config: IndexerConfig,
 ) -> Result<IndexResult> {
+    build_index_for_ledger_with_tracker(
+        content_store,
+        fluree_db_core::tracking::Tracker::disabled(),
+        nameservice,
+        ledger_id,
+        config,
+    )
+    .await
+}
+
+/// Same as [`build_index_for_ledger`], but takes a fuel tracker; see
+/// [`build_index_for_record_with_tracker`] for the semantics.
+pub async fn build_index_for_ledger_with_tracker(
+    content_store: std::sync::Arc<dyn ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
+    nameservice: &dyn NameService,
+    ledger_id: &str,
+    config: IndexerConfig,
+) -> Result<IndexResult> {
     let record = nameservice
         .lookup(ledger_id)
         .await
         .map_err(|e| IndexerError::NameService(e.to_string()))?
         .ok_or_else(|| IndexerError::LedgerNotFound(ledger_id.to_string()))?;
 
-    build_index_for_record(content_store, &record, config).await
+    build_index_for_record_with_tracker(content_store, tracker, &record, config).await
 }
 
 /// Build a binary index from an existing nameservice record.
@@ -254,7 +312,14 @@ pub async fn rebuild_index_from_commits(
     record: &fluree_db_nameservice::NsRecord,
     config: IndexerConfig,
 ) -> Result<IndexResult> {
-    build::rebuild::rebuild_index_from_commits(content_store, ledger_id, record, config).await
+    build::rebuild::rebuild_index_from_commits(
+        content_store,
+        fluree_db_core::tracking::Tracker::disabled(),
+        ledger_id,
+        record,
+        config,
+    )
+    .await
 }
 
 /// Like [`rebuild_index_from_commits`], but accepts a caller-provided
@@ -270,8 +335,14 @@ pub async fn rebuild_index_from_commits_with_store<C>(
 where
     C: ContentStore + Clone + Send + Sync + 'static,
 {
-    build::rebuild::rebuild_index_from_commits_with_store(commit_store, ledger_id, record, config)
-        .await
+    build::rebuild::rebuild_index_from_commits_with_store(
+        commit_store,
+        fluree_db_core::tracking::Tracker::disabled(),
+        ledger_id,
+        record,
+        config,
+    )
+    .await
 }
 
 /// Incremental index from an existing FIR6 root.
@@ -280,11 +351,12 @@ where
 /// novelty into affected FLI3 leaves, and publishes a new FIR6 root.
 async fn incremental_index(
     content_store: std::sync::Arc<dyn fluree_db_core::ContentStore>,
+    tracker: fluree_db_core::tracking::Tracker,
     ledger_id: &str,
     record: &fluree_db_nameservice::NsRecord,
     config: IndexerConfig,
 ) -> Result<IndexResult> {
-    build::incremental::incremental_index(content_store, ledger_id, record, config).await
+    build::incremental::incremental_index(content_store, tracker, ledger_id, record, config).await
 }
 
 /// Upload index artifacts (FLI3 leaves, FHS1 sidecars, FBR3 branches) to CAS.
@@ -292,7 +364,12 @@ pub async fn upload_indexes_to_cas(
     content_store: &dyn fluree_db_core::ContentStore,
     build_result: &BuildResult,
 ) -> Result<UploadedIndexes> {
-    build::upload::upload_indexes_to_cas(content_store, build_result).await
+    build::upload::upload_indexes_to_cas(
+        content_store,
+        &fluree_db_core::tracking::Tracker::disabled(),
+        build_result,
+    )
+    .await
 }
 
 /// Upload dictionary artifacts from persisted flat files to CAS.

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -1039,12 +1039,11 @@ impl BackgroundIndexerWorker {
         // so we can still read its tally if the build fails after partial CAS
         // writes. Without this the only fuel signal for failed background
         // builds would be lost when no caller is waiting.
-        let build_tracker = fluree_db_core::tracking::Tracker::new(
-            fluree_db_core::tracking::TrackingOptions {
+        let build_tracker =
+            fluree_db_core::tracking::Tracker::new(fluree_db_core::tracking::TrackingOptions {
                 track_fuel: true,
                 ..Default::default()
-            },
-        );
+            });
         let result = crate::build_index_for_record_with_tracker(
             content_store,
             build_tracker.clone(),

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -117,6 +117,13 @@ pub enum IndexOutcome {
         index_t: i64,
         /// Content identifier of the index root
         root_id: Option<fluree_db_core::ContentId>,
+        /// Total fuel charged for the build that satisfied this waiter.
+        /// `Some(0.0)` when no work was needed (the waiter was satisfied by
+        /// an already-published index); `Some(N)` for a build that ran;
+        /// `None` only if fuel tracking was disabled for this orchestrator.
+        /// Coalesced waiters all receive the fuel total for the single build
+        /// that satisfied them.
+        fuel: Option<f64>,
     },
     /// Indexing failed after retries exhausted or fatal error
     Failed(String),
@@ -848,6 +855,7 @@ impl BackgroundIndexerWorker {
                             let outcome = IndexOutcome::Completed {
                                 index_t: current_index_t,
                                 root_id: Some(root_id),
+                                fuel: Some(0.0),
                             };
                             state.resolve_waiters_below(current_index_t, outcome);
                             state.recalculate_pending_min_t();
@@ -876,6 +884,7 @@ impl BackgroundIndexerWorker {
                             let outcome = IndexOutcome::Completed {
                                 index_t: current_index_t,
                                 root_id: None,
+                                fuel: Some(0.0),
                             };
                             state.resolve_waiters_below(current_index_t, outcome);
                             state.recalculate_pending_min_t();
@@ -954,6 +963,7 @@ impl BackgroundIndexerWorker {
                     let outcome = IndexOutcome::Completed {
                         index_t: current_index_t,
                         root_id: Some(root_id.clone()),
+                        fuel: Some(0.0),
                     };
                     state.resolve_waiters_below(current_index_t, outcome);
                 } else if current_index_t == 0 {
@@ -961,6 +971,7 @@ impl BackgroundIndexerWorker {
                     let outcome = IndexOutcome::Completed {
                         index_t: current_index_t,
                         root_id: None,
+                        fuel: Some(0.0),
                     };
                     state.resolve_waiters_below(current_index_t, outcome);
                 } else {
@@ -1019,8 +1030,23 @@ impl BackgroundIndexerWorker {
                 return;
             }
         };
-        let result =
-            crate::build_index_for_record(content_store, &record, self.config.clone()).await;
+        // Always create a fuel-enabled, no-limit tracker per build so each
+        // background indexing pass is measured. Indexing never enforces a
+        // limit — measurement only. The tally is logged on success and
+        // propagated to all waiters via IndexOutcome::Completed::fuel.
+        let build_tracker = fluree_db_core::tracking::Tracker::new(
+            fluree_db_core::tracking::TrackingOptions {
+                track_fuel: true,
+                ..Default::default()
+            },
+        );
+        let result = crate::build_index_for_record_with_tracker(
+            content_store,
+            build_tracker,
+            &record,
+            self.config.clone(),
+        )
+        .await;
 
         match result {
             Ok(index_result) => {
@@ -1038,6 +1064,7 @@ impl BackgroundIndexerWorker {
                     info!(
                     ledger_id = %ledger_id,
                             index_t = index_result.index_t,
+                            fuel = ?index_result.fuel,
                             "Successfully indexed ledger"
                         );
 
@@ -1084,12 +1111,15 @@ impl BackgroundIndexerWorker {
                         });
                     }
 
-                    // Resolve waiters
+                    // Resolve waiters. Coalesced waiters all receive the same
+                    // fuel value — the cost of the single build that
+                    // satisfied them.
                     let mut states = self.states.lock().await;
                     if let Some(state) = states.get_mut(ledger_id) {
                         let outcome = IndexOutcome::Completed {
                             index_t: index_result.index_t,
                             root_id: Some(index_result.root_id.clone()),
+                            fuel: index_result.fuel,
                         };
                         state.resolve_waiters_below(index_result.index_t, outcome);
                         state.last_index_t = index_result.index_t;
@@ -1273,14 +1303,43 @@ where
         indexer_config.incremental_max_commit_bytes = Some(index_config.reindex_max_bytes);
     }
 
+    // Per-build fuel tracker — the transactor combined path measures but does
+    // not surface fuel back through the transaction response. The resulting
+    // IndexResult.fuel is logged below; callers may also read it via
+    // PostCommitIndexResult.refresh but should not attribute it to their
+    // commit's tracking response.
+    let build_tracker =
+        fluree_db_core::tracking::Tracker::new(fluree_db_core::tracking::TrackingOptions {
+            track_fuel: true,
+            ..Default::default()
+        });
     let build_result = if let Some(record) = current_ns_record(&ledger) {
-        crate::build_index_for_record(cs.clone(), record, indexer_config).await
+        crate::build_index_for_record_with_tracker(
+            cs.clone(),
+            build_tracker,
+            record,
+            indexer_config,
+        )
+        .await
     } else {
-        crate::build_index_for_ledger(cs.clone(), nameservice, &ledger_addr, indexer_config).await
+        crate::build_index_for_ledger_with_tracker(
+            cs.clone(),
+            build_tracker,
+            nameservice,
+            &ledger_addr,
+            indexer_config,
+        )
+        .await
     };
 
     match build_result {
         Ok(result) => {
+            tracing::info!(
+                ledger_id = %ledger_addr,
+                index_t = result.index_t,
+                fuel = ?result.fuel,
+                "post-commit index build complete"
+            );
             // Track publish result but continue regardless
             let publish_result = nameservice
                 .publish_index(&ledger_addr, result.index_t, &result.root_id)
@@ -1356,11 +1415,39 @@ where
         .await
         .map_err(|e| IndexerError::NameService(e.to_string()))?;
 
+    // Per-build fuel tracker — measurement only; the pre-commit refresh path
+    // returns Ok(LedgerState) and so cannot surface fuel back to the caller.
+    // The tally is logged below.
+    let build_tracker =
+        fluree_db_core::tracking::Tracker::new(fluree_db_core::tracking::TrackingOptions {
+            track_fuel: true,
+            ..Default::default()
+        });
     let result = if let Some(record) = current_ns_record(&ledger) {
-        crate::build_index_for_record(cs.clone(), record, indexer_config).await?
+        crate::build_index_for_record_with_tracker(
+            cs.clone(),
+            build_tracker,
+            record,
+            indexer_config,
+        )
+        .await?
     } else {
-        crate::build_index_for_ledger(cs.clone(), nameservice, &ledger_addr, indexer_config).await?
+        crate::build_index_for_ledger_with_tracker(
+            cs.clone(),
+            build_tracker,
+            nameservice,
+            &ledger_addr,
+            indexer_config,
+        )
+        .await?
     };
+
+    tracing::info!(
+        ledger_id = %ledger_addr,
+        index_t = result.index_t,
+        fuel = ?result.fuel,
+        "pre-commit index refresh complete"
+    );
 
     nameservice
         .publish_index(&ledger_addr, result.index_t, &result.root_id)
@@ -2009,6 +2096,7 @@ mod tests {
         let outcome = IndexOutcome::Completed {
             index_t: 5,
             root_id: None,
+            fuel: Some(0.0),
         };
         let cloned = outcome.clone();
         assert!(matches!(cloned, IndexOutcome::Completed { index_t: 5, .. }));

--- a/fluree-db-indexer/src/orchestrator.rs
+++ b/fluree-db-indexer/src/orchestrator.rs
@@ -1034,6 +1034,11 @@ impl BackgroundIndexerWorker {
         // background indexing pass is measured. Indexing never enforces a
         // limit — measurement only. The tally is logged on success and
         // propagated to all waiters via IndexOutcome::Completed::fuel.
+        //
+        // The tracker is kept by reference (clone is cheap — Option<Arc<...>>)
+        // so we can still read its tally if the build fails after partial CAS
+        // writes. Without this the only fuel signal for failed background
+        // builds would be lost when no caller is waiting.
         let build_tracker = fluree_db_core::tracking::Tracker::new(
             fluree_db_core::tracking::TrackingOptions {
                 track_fuel: true,
@@ -1042,7 +1047,7 @@ impl BackgroundIndexerWorker {
         );
         let result = crate::build_index_for_record_with_tracker(
             content_store,
-            build_tracker,
+            build_tracker.clone(),
             &record,
             self.config.clone(),
         )
@@ -1054,11 +1059,16 @@ impl BackgroundIndexerWorker {
                 if let Err(e) =
                     crate::publish_index_result(self.nameservice.as_ref(), &index_result).await
                 {
+                    // Surface the build's fuel + index_t on publish failure —
+                    // in background mode there is no caller, so this is the
+                    // only place the (already-paid-for) work shows up.
                     warn!(
-                    ledger_id = %ledger_id,
-                            error = %e,
-                            "Failed to publish index, will retry"
-                        );
+                        ledger_id = %ledger_id,
+                        index_t = index_result.index_t,
+                        fuel = ?index_result.fuel,
+                        error = %e,
+                        "Failed to publish index, will retry"
+                    );
                     self.schedule_retry(ledger_id, &e.to_string()).await;
                 } else {
                     info!(
@@ -1134,11 +1144,16 @@ impl BackgroundIndexerWorker {
                 }
             }
             Err(e) => {
+                // Partial fuel from CAS writes that happened before the
+                // build failed. Best-effort signal — disabled tracker or
+                // a failure before the first write reports None / 0.
+                let partial_fuel = build_tracker.tally().and_then(|t| t.fuel);
                 warn!(
-                ledger_id = %ledger_id,
-                        error = %e,
-                        "Indexing failed, will retry"
-                    );
+                    ledger_id = %ledger_id,
+                    partial_fuel = ?partial_fuel,
+                    error = %e,
+                    "Indexing failed, will retry"
+                );
                 self.schedule_retry(ledger_id, &e.to_string()).await;
             }
         }

--- a/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
@@ -246,6 +246,7 @@ fn passthrough_entire_leaf(input: &LeafUpdateInput<'_>) -> io::Result<LeafUpdate
                 total_rows: header.total_rows,
                 first_key,
                 last_key,
+                re_encoded_leaflet_count: 0,
             },
         }],
     })
@@ -477,24 +478,26 @@ fn assemble_output_leaves(
         return Ok(LeafUpdateOutput { leaves: vec![] });
     }
 
-    // Convert ProcessedLeafletV3 into (EncodedLeaflet, Vec<HistEntryV2>) pairs
-    // for assembly.
-    let mut leaflet_data: Vec<(EncodedLeaflet, Vec<HistEntryV2>)> =
+    // Convert ProcessedLeafletV3 into (EncodedLeaflet, Vec<HistEntryV2>, was_re_encoded)
+    // triples for assembly. `was_re_encoded` distinguishes passthrough byte-copies
+    // from leaflets that the merge actually re-encoded; the count is propagated
+    // into LeafInfo and drives the per-leaflet portion of CAS-write fuel.
+    let mut leaflet_data: Vec<(EncodedLeaflet, Vec<HistEntryV2>, bool)> =
         Vec::with_capacity(processed.len());
 
     for p in processed {
-        let encoded = match p.encoded {
+        let (encoded, was_re_encoded) = match p.encoded {
             EncodedLeafletInfo::Passthrough { dir_entry, payload } => {
-                reconstruct_encoded_leaflet(dir_entry, payload)
+                (reconstruct_encoded_leaflet(dir_entry, payload), false)
             }
-            EncodedLeafletInfo::Encoded(e) => e,
+            EncodedLeafletInfo::Encoded(e) => (e, true),
         };
-        leaflet_data.push((encoded, p.history));
+        leaflet_data.push((encoded, p.history, was_re_encoded));
     }
 
     // Group leaflets into leaves by row count.
     let mut leaves = Vec::new();
-    let mut current_group: Vec<(EncodedLeaflet, Vec<HistEntryV2>)> = Vec::new();
+    let mut current_group: Vec<(EncodedLeaflet, Vec<HistEntryV2>, bool)> = Vec::new();
     let mut current_rows: u64 = 0;
 
     for item in leaflet_data {
@@ -521,11 +524,12 @@ fn assemble_output_leaves(
     Ok(LeafUpdateOutput { leaves: output })
 }
 
-/// Build a single leaf blob from a group of (EncodedLeaflet, history) pairs.
+/// Build a single leaf blob from a group of (EncodedLeaflet, history, was_re_encoded) triples.
 fn build_leaf_from_group(
     group: Vec<(
         fluree_db_binary_index::format::leaflet::EncodedLeaflet,
         Vec<HistEntryV2>,
+        bool,
     )>,
     order: RunSortOrder,
 ) -> io::Result<LeafInfo> {
@@ -533,7 +537,7 @@ fn build_leaf_from_group(
 
     // Build sidecar from history entries.
     let mut sidecar_builder = HistSidecarBuilder::new();
-    for (_, history) in &group {
+    for (_, history, _) in &group {
         sidecar_builder.start_leaflet();
         for entry in history {
             sidecar_builder.push_entry(*entry);
@@ -551,14 +555,15 @@ fn build_leaf_from_group(
     // Extract first/last routing keys (raw ordered key bytes).
     let first_key_bytes = group
         .first()
-        .map(|(e, _)| e.first_key)
+        .map(|(e, _, _)| e.first_key)
         .unwrap_or([0u8; ORDERED_KEY_V2_SIZE]);
     let last_key_bytes = group
         .last()
-        .map(|(e, _)| e.last_key)
+        .map(|(e, _, _)| e.last_key)
         .unwrap_or([0u8; ORDERED_KEY_V2_SIZE]);
 
-    let owned_leaflets: Vec<EncodedLeaflet> = group.into_iter().map(|(e, _)| e).collect();
+    let re_encoded_leaflet_count = group.iter().filter(|(_, _, was_re)| *was_re).count() as u32;
+    let owned_leaflets: Vec<EncodedLeaflet> = group.into_iter().map(|(e, _, _)| e).collect();
 
     let leaf_bytes = build_leaf_blob_raw_keys(
         order,
@@ -584,6 +589,7 @@ fn build_leaf_from_group(
         total_rows,
         first_key,
         last_key,
+        re_encoded_leaflet_count,
     })
 }
 

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -70,6 +70,10 @@ pub struct PersistedLeafInfo {
     pub total_rows: u64,
     pub first_key: fluree_db_binary_index::format::run_record_v2::RunRecordV2,
     pub last_key: fluree_db_binary_index::format::run_record_v2::RunRecordV2,
+    /// See [`LeafInfo::re_encoded_leaflet_count`]. Carried through the
+    /// rebuild's spool-to-disk step so the upload step can charge the
+    /// correct per-leaflet fuel.
+    pub re_encoded_leaflet_count: u32,
 }
 
 /// Result for a single graph's V2 index build.
@@ -280,6 +284,7 @@ pub(crate) fn finish_graph_v2(
                 total_rows,
                 first_key,
                 last_key,
+                re_encoded_leaflet_count,
             } = info;
 
             let leaf_path = graph_dir.join(leaf_cid.to_string());
@@ -307,6 +312,7 @@ pub(crate) fn finish_graph_v2(
                 total_rows,
                 first_key,
                 last_key,
+                re_encoded_leaflet_count,
             })
         })
         .collect::<io::Result<Vec<_>>>()?;

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -274,7 +274,7 @@ impl BinaryHistoryScanOperator {
                             };
                             let base_rows = leaflet.row_count as u64;
                             ctx.tracker.consume_fuel(
-                                1000u64
+                                fluree_db_core::tracking::schedule::HISTORY_LEAF_TOUCH_MICRO_FUEL
                                     .saturating_add(sidecar_rows)
                                     .saturating_add(base_rows),
                             )?;
@@ -407,7 +407,10 @@ impl BinaryHistoryScanOperator {
                             return;
                         }
                     }
-                    if let Err(e) = ctx.tracker.consume_fuel(1) {
+                    if let Err(e) = ctx
+                        .tracker
+                        .consume_fuel(fluree_db_core::tracking::schedule::PER_ROW_MICRO_FUEL)
+                    {
                         fuel_err = Some(e);
                         return;
                     }

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1997,7 +1997,8 @@ impl Operator for BinaryScanOperator {
             // Overlay/novelty rows are in-memory; charge per row at 1 micro-fuel.
             let n = self.flakes_to_bindings(&mut columns, ctx, batch_size - produced)?;
             for _ in 0..n {
-                ctx.tracker.consume_fuel(1)?;
+                ctx.tracker
+                    .consume_fuel(fluree_db_core::tracking::schedule::PER_ROW_MICRO_FUEL)?;
             }
             produced += n;
         }

--- a/fluree-db-server/tests/integration.rs
+++ b/fluree-db-server/tests/integration.rs
@@ -2564,8 +2564,10 @@ async fn json_transaction_with_meta_reports_decimal_fuel() {
         .and_then(JsonValue::as_f64)
         .expect("tracked transaction response should include decimal fuel");
     assert_eq!(fuel, fuel_header);
+    // Transaction baseline is 10.000 fuel + 1 µfuel/flake; any small txn
+    // should land between the baseline and well under raw-micro-fuel scale.
     assert!(
-        (100.0..1000.0).contains(&fuel),
+        (10.0..1000.0).contains(&fuel),
         "fuel should be reported in fuel units, not raw micro-fuel: {fuel}"
     );
 }
@@ -2623,8 +2625,10 @@ async fn sparql_update_with_tracking_header_reports_decimal_fuel() {
         .and_then(JsonValue::as_f64)
         .expect("tracked SPARQL UPDATE response should include decimal fuel");
     assert_eq!(fuel, fuel_header);
+    // Transaction baseline is 10.000 fuel + 1 µfuel/flake; any small txn
+    // should land between the baseline and well under raw-micro-fuel scale.
     assert!(
-        (100.0..1000.0).contains(&fuel),
+        (10.0..1000.0).contains(&fuel),
         "fuel should be reported in fuel units, not raw micro-fuel: {fuel}"
     );
 }

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -14,6 +14,7 @@ use crate::generate::{infer_datatype, FlakeAccumulator, FlakeGenerator};
 use crate::ir::InlineValues;
 use crate::ir::{TemplateTerm, TripleTemplate, Txn, TxnType};
 use crate::namespace::NamespaceRegistry;
+use fluree_db_core::tracking::schedule::TXN_BASELINE_MICRO_FUEL;
 use fluree_db_core::OverlayProvider;
 use fluree_db_core::Tracker;
 use fluree_db_core::{Flake, FlakeValue, GraphId, Sid};
@@ -198,7 +199,7 @@ pub async fn stage(
         // commit log write, and indexing overhead. Per-flake cost (1 micro-fuel)
         // is charged later against the staged flake set.
         if let Some(tracker) = options.tracker {
-            tracker.consume_fuel(100_000)?;
+            tracker.consume_fuel(TXN_BASELINE_MICRO_FUEL)?;
         }
 
         let new_t = ledger.t() + 1;
@@ -452,7 +453,7 @@ pub async fn stage_flakes(
         // commit log write, and indexing overhead. Per-flake cost (1 micro-fuel)
         // is charged below.
         if let Some(tracker) = options.tracker {
-            tracker.consume_fuel(100_000)?;
+            tracker.consume_fuel(TXN_BASELINE_MICRO_FUEL)?;
         }
 
         // 2. Build graph routing map.

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -195,7 +195,7 @@ pub async fn stage(
             }
         }
 
-        // Per-transaction baseline (100 fuel) covering parse, validation,
+        // Per-transaction baseline (10 fuel) covering parse, validation,
         // commit log write, and indexing overhead. Per-flake cost (1 micro-fuel)
         // is charged later against the staged flake set.
         if let Some(tracker) = options.tracker {
@@ -449,7 +449,7 @@ pub async fn stage_flakes(
             }
         }
 
-        // Per-transaction baseline (100 fuel) covering parse, validation,
+        // Per-transaction baseline (10 fuel) covering parse, validation,
         // commit log write, and indexing overhead. Per-flake cost (1 micro-fuel)
         // is charged below.
         if let Some(tracker) = options.tracker {


### PR DESCRIPTION
Query fuel was dominated by three "1 fuel per I/O touch" charges (index-leaflet
batch reads, persisted dict decodes, history-scan leaflets), so a scan-heavy
query could report fuel thousands of times larger than a transaction's flat
100-fuel baseline. At the same time, a query that touched no persisted data —
or errored during planning — could report `0` fuel. The indexer wasn't metered
at all: a full rebuild on a large ledger reported nothing.

This PR (1) rescales query I/O touches **100×** down, (2) adds a one-time
**query floor**, (3) drops the **transaction baseline** from 100 → 10 fuel so
it sits proportionate to scan-dominated queries, and (4) introduces **indexer
fuel accounting** that bills every CAS write the indexer makes and surfaces
the tally through `/reindex`, `trigger_index`, and the background indexer
logs.

## What changed

### 1. Query touch rescale (1.000 → 0.010 fuel)
The three "touch" charges drop from `1000` to `10` micro-fuel:
- index-leaflet batch read (`binary_cursor`)
- persisted forward-dict decode (`binary_index_store::charge_dict_touch`)
- history-scan leaflet base charge (`binary_history`)

Per-row/per-flake (1 µf), overlay rows, and the per-call function/expression
micro-charges (1–5 µf) are unchanged.

### 2. Query floor (1.000 fuel, once per query)
A one-time floor is charged at query entry, **before parsing**, so that:
- a successful query always reports ≥ `1.000` fuel,
- a parse/plan error on a tracked query still reports the floor, and
- a sub-floor `max-fuel` is rejected up front (before parse/plan work).

Wired into every query entry path: view + dataset tracked paths (`query_tracked`,
`query_dataset_tracked`, R2RML variants), view + dataset untracked
`max-fuel`-limit paths (placed after the single-ledger fast-path delegate to
avoid double-charging), the BM25 / vector graph-source path
(`query_dataset_with_bm25`), and all eight connection tracked entry points
(JSON-LD/SPARQL × policy/r2rml). The floor is **not** applied to transactions.

### 3. Transaction baseline 100 → 10 fuel
With touches now at 0.010 fuel, a 100-fuel commit baseline overstated the
relative cost of small transactions by ~10×. `TXN_BASELINE_MICRO_FUEL` drops
from `100_000` to `10_000` (10.000 fuel). All commit / bulk-import paths pick
it up via the centralized constant.

### 4. Indexer fuel accounting (new)

**Where the charges land:**
- **1.000 fuel per successful CAS write** the indexer makes (every
  `ContentStore::put` / `put_with_id` — leaves, branch manifests, roots, dict
  packs, reverse-tree nodes, history sidecars, garbage records, stats
  sketches, spatial / fulltext arenas).
- **+1.000 fuel per re-encoded leaflet** inside an FLI3 leaf write.
  Passthrough leaflets (byte-copies carried forward during an incremental
  update) are **not** charged — no zstd work was performed. So a 100-leaflet
  leaf where only two leaflets were touched by novelty bills `1 + 2 = 3` fuel,
  not `1 + 100`.

**Implementation: wrap once at the entry point.** A new
`fluree_db_indexer::fuel::MeteredContentStore` wraps the caller-supplied
`ContentStore` for the duration of a build; every CAS write through it
charges the base per-write fee automatically. Only the two FLI3 leaf upload
sites (`build::upload::upload_indexes_to_cas` for full rebuild,
`build::incremental::upload_leaf_blobs` for incremental) add the per-leaflet
extra charge explicitly (from
`LeafInfo::re_encoded_leaflet_count`, surfaced through the leaf assembly
code). New CAS write sites get billed for free with no signature churn.

**Measurement only — never enforced.** Indexer trackers are no-limit; a
partial index is worse than a slow one, so the indexer never aborts mid-build
on a fuel limit.

### 5. Where fuel surfaces

| Path | Tracker | Fuel returned via |
|---|---|---|
| `/reindex` HTTP | API per request | `ReindexResponse.fuel` (CLI prints `Fuel: N.NNN`) |
| `trigger_index` Rust API | Orchestrator per build | `TriggerIndexResult.fuel`; coalesced trigger callers share the same value |
| Background indexer (no waiter) | Orchestrator per build | `IndexOutcome::Completed.fuel` + completion `info!` log line |
| Combined transactor + post-commit (`maybe_refresh_after_commit`, `require_refresh_before_commit`) | Per-build tracker | Logged on the completion line; intentionally **not** attributed to the transaction response |

`IndexResult.fuel`, `ReindexResult.fuel`, `TriggerIndexResult.fuel`, and
`IndexOutcome::Completed.fuel` are all `Option<f64>`:
- `Some(N)` for a build that did work,
- `Some(0.0)` when no work was needed (already-current early return,
  waiter satisfied by an already-published index, no-commit ledger),
- `None` only when going through the non-tracking public API.

The background worker logs `fuel = ?` on:
- the `info!` "Successfully indexed ledger" line,
- the `warn!` "Failed to publish index, will retry" line (so the
  already-paid-for fuel is visible even when no caller is waiting), and
- the `warn!` "Indexing failed, will retry" line (as `partial_fuel`,
  from a Tracker clone kept across the build call).

### 6. Centralized fuel schedule

All structural charges live in `fluree_db_core::tracking::schedule`:
`QUERY_FLOOR_MICRO_FUEL`, `INDEX_TOUCH_MICRO_FUEL`, `DICT_TOUCH_MICRO_FUEL`,
`HISTORY_LEAF_TOUCH_MICRO_FUEL`, `PER_ROW_MICRO_FUEL`, `TXN_BASELINE_MICRO_FUEL`,
and the new `INDEX_CAS_WRITE_MICRO_FUEL`. Per-call function and R2RML
micro-charges remain inline at their eval sites.

### Public API

Existing entry points (`build_index_for_record`, `build_index_for_ledger`,
`rebuild_index_from_commits`, `rebuild_index_from_commits_with_store`,
`upload_indexes_to_cas`) are **unchanged** and continue to pass a disabled
tracker internally — `fuel` is reported as `None` on those paths. New
`*_with_tracker` variants take a `Tracker` and wrap the store; `/reindex` and
the background indexer call those. No existing caller breaks.

## Behavior changes / breaking notes

- **Breaking re-scale (queries + transactions).** Historical fuel numbers and
  dashboards are not comparable across the cutover. Existing `max-fuel`
  limits now permit ~100× more scan work. Re-derive any externally-configured
  limits.
- **`max-fuel` semantics.** `max-fuel: 1` permits exactly the query floor;
  `max-fuel: 1.01` permits the floor plus one persisted touch; `max-fuel`
  below `1.0` is rejected before parsing.
- **Transaction read-side cost drops.** Upsert lookups / SHACL reads /
  UPDATE-WHERE matching go through the same scan path, so their I/O touches
  get the 100× cut too (transaction baseline + write cost unchanged).
- **`/reindex` response shape (additive).** `ReindexResponse` gains
  `fuel: Option<f64>`; the field is omitted from JSON when `None` so existing
  clients keep working.
- No default `max-fuel` exists in the server/CLI (limits are always
  user-supplied), so there was nothing to re-derive there.

## Docs

- `docs/query/tracking-and-fuel.md`: updated cost ladder (query floor +
  rescaled touches + 10-fuel txn baseline + indexer CAS write + re-encoded
  leaflet); new "Indexing Fuel" section spelling out where fuel surfaces per
  path and the measurement-only semantics.
- `docs/reference/glossary.md`: corrected the inaccurate "1 unit per item"
  Fuel definition.
- `docs/api/endpoints.md` (`POST /reindex`): example response and field table
  now include `fuel`.
- `docs/indexing-and-search/background-indexing.md`: `trigger_index()`
  paragraph describes `TriggerIndexResult.fuel` and coalesced-trigger
  semantics.

## Testing

- **Unit** (`fluree-db-core/src/tracking.rs`): floor = `1.000`, each touch =
  `0.010`, floor + touch = `1.010`, sub-floor `max-fuel` rejected, and the
  add-then-check ordering so an exceeded floor still tallies `1.000`.
- **Unit** (`fluree-db-indexer/src/fuel.rs`, 5 tests): base write = 1 fuel,
  leaf + 3 re-encoded leaflets = 4 fuel, disabled tracker is a no-op,
  `MeteredContentStore` charges 1 fuel per put, leaf + extra leaflets sum
  correctly.
- **Integration — query** (`fluree-db-api/tests/it_fuel_floor.rs`, 10 tests):
  tiny query ≥ floor, parse error reports floor, sub-floor `max-fuel`
  rejected on tracked, untracked-limit, connection JSON-LD (`opts`),
  connection SPARQL (header override), and BM25 paths; connection
  missing-spec / SPARQL parse errors report the floor.
- **Integration — indexing** (`fluree-db-api/tests/it_indexing_fuel.rs`,
  4 tests): rebuild-with-tracker reports `Some(N)` > 0; already-current build
  reports `Some(0.0)`; non-tracking rebuild reports `None`; `trigger_index`
  via the background indexer reports `Some(N)` > 0 end-to-end.
- Exhaustive `IndexOutcome::Completed` pattern matches in 5 existing
  integration tests updated for the new `fuel` field.
- Comments in `it_ledger_lifecycle.rs` updated to reflect the new mechanism;
  `it_policy_tracking.rs` assertion updated to the new 10-fuel baseline
  (`10.003` not `100.003`).
