### PR TITLE
fix: avoid full-predicate scans for bound-object queries

### DIFF
--- a/fluree-db-api/tests/it_query_fuel_bound_object.rs
+++ b/fluree-db-api/tests/it_query_fuel_bound_object.rs
@@ -1,18 +1,23 @@
-//! Regression test for bound-object scans against the binary (FIR6) index.
+//! Regression tests for bound-object queries whose object is **absent** from
+//! the persisted dictionary, against the binary (FIR6) index.
 //!
-//! Bug (fix #1): a constant object that is **absent** from the persisted
-//! dictionary (a class that no entity is typed as, or a ref IRI that no flake
-//! references) used to drop the object filter and fall into the un-narrowed
-//! catch-all in `BinaryScanOperator::open`, scanning the *entire* predicate and
-//! post-filtering to discover 0 matches. Cost scaled with predicate cardinality
-//! (e.g. ~1 fuel per `rdf:type` flake), so a query returning nothing could cost
-//! hundreds of thousands of fuel.
+//! Bug class: a constant object that no flake references (a class nothing is
+//! typed as, or a ref IRI never interned) used to be mishandled as "can't
+//! narrow" instead of "provably empty", causing a full predicate scan:
+//!   - `BinaryScanOperator::open` dropped the object filter into its
+//!     un-narrowed catch-all and post-filtered the whole predicate;
+//!   - `count_bound_object_v6` errored and fell back to a generic
+//!     scan + aggregate.
 //!
-//! An object value provably absent from the base dictionary cannot be
-//! referenced by any base flake, so the scan must short-circuit to the
-//! overlay-only (novelty) path instead. This test pins that invariant: the
-//! fuel for an absent-object query is bounded by a small constant **independent
-//! of dataset size**, while present-value lookups still return correct rows.
+//! Either way cost scaled with predicate cardinality (~1 fuel per `rdf:type`
+//! flake), so a query returning nothing could burn hundreds of thousands of
+//! fuel.
+//!
+//! An object provably absent from the base dictionary cannot be referenced by
+//! any base flake, so these paths must short-circuit (scan → overlay-only;
+//! count → 0). These tests pin that invariant: fuel for an absent-object query
+//! stays bounded by a small constant **independent of dataset size**, while
+//! present-value lookups still return correct rows/counts.
 
 #![cfg(feature = "native")]
 
@@ -92,6 +97,61 @@ async fn tracked(fluree: &fluree_db_api::Fluree, where_obj: JsonValue) -> (usize
         .expect("result should be a JSON array");
     let fuel = result.fuel.expect("fuel should be present under track_all");
     (rows, fuel)
+}
+
+/// Run a tracked SPARQL scalar COUNT, returning `(count, fuel)`. Uses SPARQL so
+/// the planner selects the `count_bound_object_v6` fast path.
+async fn tracked_count(fluree: &fluree_db_api::Fluree, class_iri: &str) -> (Option<i64>, f64) {
+    let sparql =
+        format!("SELECT (COUNT(?s) AS ?n) FROM <{LEDGER_ID}> WHERE {{ ?s a <{class_iri}> }}");
+    let result = fluree
+        .query_from()
+        .sparql(&sparql)
+        .track_all()
+        .execute_tracked()
+        .await
+        .expect("tracked count query should succeed");
+
+    assert_eq!(result.status, 200, "count query status");
+    let fuel = result.fuel.expect("fuel should be present under track_all");
+    // W3C SPARQL JSON: results.bindings[0].<var>.value
+    let count = result
+        .result
+        .get("results")
+        .and_then(|r| r.get("bindings"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|b| b.first())
+        .and_then(|row| row.as_object())
+        .and_then(|row| row.values().next())
+        .and_then(|cell| cell.get("value"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| s.parse::<i64>().ok());
+    (count, fuel)
+}
+
+#[tokio::test]
+async fn bound_object_absent_count_does_not_scan_predicate() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed(&fluree).await;
+
+    // Present class: the fast COUNT path returns the correct total. (Note: the
+    // V6 count fast path reads leaflets directly and is currently unmetered, so
+    // we don't assert on its fuel — only on correctness.)
+    let (present_count, _present_fuel) =
+        tracked_count(&fluree, "http://example.org/ns#Widget").await;
+    assert_eq!(present_count, Some(N as i64), "present class count");
+
+    // Absent class: COUNT must short-circuit to 0 instead of falling back to a
+    // full predicate scan + aggregate. The fallback IS metered, so pre-fix this
+    // burned ~N fuel; post-fix it stays bounded regardless of N.
+    let (ghost_count, ghost_fuel) = tracked_count(&fluree, "http://example.org/ns#Ghost").await;
+    assert_eq!(ghost_count, Some(0), "absent class counts 0");
+    assert!(
+        ghost_fuel <= ABSENT_FUEL_CEILING,
+        "absent-class COUNT burned {ghost_fuel} fuel (ceiling {ABSENT_FUEL_CEILING}); \
+         it fell back to a full rdf:type scan (~{N} flakes) instead of returning 0"
+    );
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_fuel_bound_object.rs
+++ b/fluree-db-api/tests/it_query_fuel_bound_object.rs
@@ -199,14 +199,17 @@ async fn bound_object_absent_string_does_not_scan_predicate() {
 
 #[tokio::test]
 async fn untyped_string_on_langstring_predicate_stays_lenient_and_short_circuits_absent() {
-    // `ns:label` has BOTH xsd:string and rdf:langString values, so the gate must
-    // DECLINE to narrow (langString present). Two things to verify:
-    //   1. Negative guard: a present untyped string stays lenient — it matches
-    //      across both datatypes (xsd:string "shared" and "shared"@en).
-    //   2. The non-narrowable path's absent-string short-circuit still works: an
-    //      absent string hits the `(None,None)` find_string_id probe → NotFound
-    //      → overlay-only, so it must NOT full-scan the (large) ns:label predicate.
-    // The bulk of distinct labels makes a full scan visibly exceed the ceiling.
+    // `ns:label` has BOTH xsd:string and rdf:langString values, so it can't be
+    // narrowed to a single (o_type, str_id) seek. Three things to verify:
+    //   1. Lenient: a present untyped string still matches across both datatypes
+    //      (xsd:string "shared" and "shared"@en).
+    //   2. Bounded fuel anyway: all string forms share the interned str_id, so the
+    //      cursor filters non-matching rows before value decode; leaflets it empties
+    //      return no batch, so present "shared" stays cheap without dropping the
+    //      langString match.
+    //   3. Absent string short-circuits: find_string_id miss → overlay-only, so it
+    //      must NOT full-scan the (large) ns:label predicate.
+    // The bulk of distinct labels makes a value-decoding full scan exceed the ceiling.
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "fuel-langstring:main";
@@ -225,10 +228,12 @@ async fn untyped_string_on_langstring_predicate_stays_lenient_and_short_circuits
         .expect("insert");
     rebuild_and_publish_index(&fluree, ledger_id).await;
 
-    // (1) Present "shared" → lenient match across xsd:string + langString. This
-    // predicate has langString, so it intentionally does NOT narrow (Phase 2),
-    // hence we assert correctness only, not fuel.
-    let (present_rows, _present_fuel) = tracked_on(
+    // (1) Present "shared" → lenient match across xsd:string + langString, AND
+    // bounded fuel: the predicate can't narrow to one (o_type, str_id) seek, but
+    // all string forms share the interned str_id, so the cursor filters
+    // non-matching rows before value decode — leaflets it empties return no batch,
+    // so they cost no fuel — without dropping the langString match.
+    let (present_rows, present_fuel) = tracked_on(
         &fluree,
         ledger_id,
         json!({ "@id": "?s", "ns:label": "shared" }),
@@ -238,6 +243,11 @@ async fn untyped_string_on_langstring_predicate_stays_lenient_and_short_circuits
         present_rows, 2,
         "untyped 'shared' must match both xsd:string and langString (lenient); \
          optimizer must not narrow when langString is present"
+    );
+    assert!(
+        present_fuel <= ABSENT_FUEL_CEILING,
+        "present string on a langString predicate burned {present_fuel} fuel; \
+         expected the o_key filter to drop non-matching rows before value decode"
     );
 
     // (2) Absent string → short-circuit via the find_string_id probe, no scan.

--- a/fluree-db-api/tests/it_query_fuel_bound_object.rs
+++ b/fluree-db-api/tests/it_query_fuel_bound_object.rs
@@ -56,11 +56,20 @@ async fn seed(fluree: &fluree_db_api::Fluree) {
         }));
     }
     for i in 0..N {
+        // `ns:tag` is deliberately mixed-datatype (string on even, integer on
+        // odd), so a plain-string object on it can't be narrowed to a single
+        // datatype and exercises the "type ambiguous" path in scan `open()`.
+        let tag = if i % 2 == 0 {
+            json!(format!("tag-{i}"))
+        } else {
+            json!(i)
+        };
         graph.push(json!({
             "@id": format!("ns:widget-{i}"),
             "@type": "ns:Widget",
             "ns:name": format!("widget name {i}"),
             "ns:owner": { "@id": format!("ns:owner-{}", i % 5) },
+            "ns:tag": tag,
         }));
     }
 
@@ -127,6 +136,37 @@ async fn tracked_count(fluree: &fluree_db_api::Fluree, class_iri: &str) -> (Opti
         .and_then(serde_json::Value::as_str)
         .and_then(|s| s.parse::<i64>().ok());
     (count, fuel)
+}
+
+#[tokio::test]
+async fn bound_object_absent_string_does_not_scan_predicate() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed(&fluree).await;
+
+    // `ns:tag` is mixed-datatype, so a plain-string object hits the
+    // "type ambiguous (xsd:string vs langString)" path — it can't be narrowed
+    // to one (o_type, o_key) range. An *absent* string still must short-circuit:
+    // xsd:string and langString share an interned string id, so a dict miss
+    // proves no string-typed flake can match. Must NOT full-scan ns:tag.
+    let (ghost_rows, ghost_fuel) = tracked(
+        &fluree,
+        json!({ "@id": "?s", "ns:tag": "tag-nonexistent-value" }),
+    )
+    .await;
+    assert_eq!(ghost_rows, 0, "absent string matches nothing");
+    assert!(
+        ghost_fuel <= ABSENT_FUEL_CEILING,
+        "absent string burned {ghost_fuel} fuel (ceiling {ABSENT_FUEL_CEILING}); \
+         a full ns:tag predicate scan regressed"
+    );
+
+    // Present string still resolves correctly. Narrowing the present ambiguous
+    // case is intentionally not attempted (it would change langString match
+    // semantics), so this path still full-scans — assert correctness only.
+    let (present_rows, _present_fuel) =
+        tracked(&fluree, json!({ "@id": "?s", "ns:tag": "tag-0" })).await;
+    assert_eq!(present_rows, 1, "present string matches exactly widget-0");
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_fuel_bound_object.rs
+++ b/fluree-db-api/tests/it_query_fuel_bound_object.rs
@@ -57,8 +57,9 @@ async fn seed(fluree: &fluree_db_api::Fluree) {
     }
     for i in 0..N {
         // `ns:tag` is deliberately mixed-datatype (string on even, integer on
-        // odd), so a plain-string object on it can't be narrowed to a single
-        // datatype and exercises the "type ambiguous" path in scan `open()`.
+        // odd). xsd:string is its only string-compatible datatype, so a
+        // plain-string lookup still narrows to a tight xsd:string seek — the
+        // integer values can't match a string and don't block the narrowing.
         let tag = if i % 2 == 0 {
             json!(format!("tag-{i}"))
         } else {
@@ -81,11 +82,21 @@ async fn seed(fluree: &fluree_db_api::Fluree) {
     rebuild_and_publish_index(fluree, LEDGER_ID).await;
 }
 
-/// Run a tracked JSON-LD query, returning `(row_count, fuel)`.
+/// Run a tracked JSON-LD `select ["?s"]` query against `LEDGER_ID`.
 async fn tracked(fluree: &fluree_db_api::Fluree, where_obj: JsonValue) -> (usize, f64) {
+    tracked_on(fluree, LEDGER_ID, where_obj).await
+}
+
+/// Run a tracked JSON-LD `select ["?s"]` query against an explicit ledger,
+/// returning `(row_count, fuel)`.
+async fn tracked_on(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+    where_obj: JsonValue,
+) -> (usize, f64) {
     let query = json!({
         "@context": ctx(),
-        "from": LEDGER_ID,
+        "from": ledger_id,
         "select": ["?s"],
         "where": where_obj,
     });
@@ -144,11 +155,11 @@ async fn bound_object_absent_string_does_not_scan_predicate() {
     let fluree = FlureeBuilder::memory().build_memory();
     seed(&fluree).await;
 
-    // `ns:tag` is mixed-datatype, so a plain-string object hits the
-    // "type ambiguous (xsd:string vs langString)" path — it can't be narrowed
-    // to one (o_type, o_key) range. An *absent* string still must short-circuit:
-    // xsd:string and langString share an interned string id, so a dict miss
-    // proves no string-typed flake can match. Must NOT full-scan ns:tag.
+    // `ns:tag` mixes xsd:string + int; xsd:string is its only string-compatible
+    // datatype, so a plain-string lookup narrows to a tight xsd:string seek. An
+    // *absent* string resolves to no str_id → NotFound → overlay-only, returning
+    // nothing without a full predicate scan. (The `(None,None)` find_string_id
+    // probe for non-narrowable predicates is covered by the langString test.)
     let (ghost_rows, ghost_fuel) = tracked(
         &fluree,
         json!({ "@id": "?s", "ns:tag": "tag-nonexistent-value" }),
@@ -161,12 +172,87 @@ async fn bound_object_absent_string_does_not_scan_predicate() {
          a full ns:tag predicate scan regressed"
     );
 
-    // Present string still resolves correctly. Narrowing the present ambiguous
-    // case is intentionally not attempted (it would change langString match
-    // semantics), so this path still full-scans — assert correctness only.
-    let (present_rows, _present_fuel) =
+    // Present string now narrows via per-predicate datatype stats: ns:tag is
+    // mixed xsd:string + int, but xsd:string is the only string-compatible tag,
+    // so a plain-string lookup seeks (XSD_STRING, str_id) — bounded fuel + correct.
+    let (present_rows, present_fuel) =
         tracked(&fluree, json!({ "@id": "?s", "ns:tag": "tag-0" })).await;
     assert_eq!(present_rows, 1, "present string matches exactly widget-0");
+    assert!(
+        present_fuel <= ABSENT_FUEL_CEILING,
+        "present string on mixed string+int predicate burned {present_fuel} fuel; \
+         expected a tight xsd:string seek, not a full scan"
+    );
+
+    // Pure xsd:string predicate (ns:name) also narrows to a tight seek.
+    let (name_rows, name_fuel) =
+        tracked(&fluree, json!({ "@id": "?s", "ns:name": "widget name 0" })).await;
+    assert_eq!(
+        name_rows, 1,
+        "present string on pure-string predicate matches widget-0"
+    );
+    assert!(
+        name_fuel <= ABSENT_FUEL_CEILING,
+        "present string on pure xsd:string predicate burned {name_fuel} fuel; expected a tight seek"
+    );
+}
+
+#[tokio::test]
+async fn untyped_string_on_langstring_predicate_stays_lenient_and_short_circuits_absent() {
+    // `ns:label` has BOTH xsd:string and rdf:langString values, so the gate must
+    // DECLINE to narrow (langString present). Two things to verify:
+    //   1. Negative guard: a present untyped string stays lenient — it matches
+    //      across both datatypes (xsd:string "shared" and "shared"@en).
+    //   2. The non-narrowable path's absent-string short-circuit still works: an
+    //      absent string hits the `(None,None)` find_string_id probe → NotFound
+    //      → overlay-only, so it must NOT full-scan the (large) ns:label predicate.
+    // The bulk of distinct labels makes a full scan visibly exceed the ceiling.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "fuel-langstring:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    let mut graph = vec![
+        json!({ "@id": "ns:plain", "ns:label": "shared" }),
+        json!({ "@id": "ns:tagged", "ns:label": { "@value": "shared", "@language": "en" } }),
+    ];
+    for i in 0..N {
+        graph.push(json!({ "@id": format!("ns:row-{i}"), "ns:label": format!("label-{i}") }));
+    }
+    fluree
+        .insert(ledger0, &json!({ "@context": ctx(), "@graph": graph }))
+        .await
+        .expect("insert");
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+
+    // (1) Present "shared" → lenient match across xsd:string + langString. This
+    // predicate has langString, so it intentionally does NOT narrow (Phase 2),
+    // hence we assert correctness only, not fuel.
+    let (present_rows, _present_fuel) = tracked_on(
+        &fluree,
+        ledger_id,
+        json!({ "@id": "?s", "ns:label": "shared" }),
+    )
+    .await;
+    assert_eq!(
+        present_rows, 2,
+        "untyped 'shared' must match both xsd:string and langString (lenient); \
+         optimizer must not narrow when langString is present"
+    );
+
+    // (2) Absent string → short-circuit via the find_string_id probe, no scan.
+    let (absent_rows, absent_fuel) = tracked_on(
+        &fluree,
+        ledger_id,
+        json!({ "@id": "?s", "ns:label": "no-such-label" }),
+    )
+    .await;
+    assert_eq!(absent_rows, 0, "absent string matches nothing");
+    assert!(
+        absent_fuel <= ABSENT_FUEL_CEILING,
+        "absent string on a langString predicate burned {absent_fuel} fuel (ceiling \
+         {ABSENT_FUEL_CEILING}); the find_string_id short-circuit regressed"
+    );
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_fuel_bound_object.rs
+++ b/fluree-db-api/tests/it_query_fuel_bound_object.rs
@@ -1,0 +1,150 @@
+//! Regression test for bound-object scans against the binary (FIR6) index.
+//!
+//! Bug (fix #1): a constant object that is **absent** from the persisted
+//! dictionary (a class that no entity is typed as, or a ref IRI that no flake
+//! references) used to drop the object filter and fall into the un-narrowed
+//! catch-all in `BinaryScanOperator::open`, scanning the *entire* predicate and
+//! post-filtering to discover 0 matches. Cost scaled with predicate cardinality
+//! (e.g. ~1 fuel per `rdf:type` flake), so a query returning nothing could cost
+//! hundreds of thousands of fuel.
+//!
+//! An object value provably absent from the base dictionary cannot be
+//! referenced by any base flake, so the scan must short-circuit to the
+//! overlay-only (novelty) path instead. This test pins that invariant: the
+//! fuel for an absent-object query is bounded by a small constant **independent
+//! of dataset size**, while present-value lookups still return correct rows.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+use support::{assert_index_defaults, genesis_ledger, rebuild_and_publish_index};
+
+const LEDGER_ID: &str = "fuel-bound-object:main";
+
+/// Number of typed entities. Large enough that a full predicate scan (the
+/// pre-fix behavior) would consume fuel far above `ABSENT_FUEL_CEILING`.
+const N: usize = 500;
+
+/// Upper bound on fuel for any query whose constant object is absent from the
+/// dictionary. With no novelty, the overlay-only fallback does zero index work,
+/// so this is generous headroom. Pre-fix, these queries cost ~N fuel.
+const ABSENT_FUEL_CEILING: f64 = 25.0;
+
+fn ctx() -> JsonValue {
+    json!({ "ns": "http://example.org/ns#" })
+}
+
+/// Seed N widgets (`ns:Widget`), each owned by one of 5 owner entities, then
+/// rebuild the binary index so the data lives in persisted base leaflets.
+async fn seed(fluree: &fluree_db_api::Fluree) {
+    let ledger0 = genesis_ledger(fluree, LEDGER_ID);
+
+    let mut graph = Vec::with_capacity(N + 5);
+    for i in 0..5 {
+        graph.push(json!({
+            "@id": format!("ns:owner-{i}"),
+            "@type": "ns:Owner",
+            "ns:label": format!("Owner {i}"),
+        }));
+    }
+    for i in 0..N {
+        graph.push(json!({
+            "@id": format!("ns:widget-{i}"),
+            "@type": "ns:Widget",
+            "ns:name": format!("widget name {i}"),
+            "ns:owner": { "@id": format!("ns:owner-{}", i % 5) },
+        }));
+    }
+
+    fluree
+        .insert(ledger0, &json!({ "@context": ctx(), "@graph": graph }))
+        .await
+        .expect("insert seed data");
+
+    rebuild_and_publish_index(fluree, LEDGER_ID).await;
+}
+
+/// Run a tracked JSON-LD query, returning `(row_count, fuel)`.
+async fn tracked(fluree: &fluree_db_api::Fluree, where_obj: JsonValue) -> (usize, f64) {
+    let query = json!({
+        "@context": ctx(),
+        "from": LEDGER_ID,
+        "select": ["?s"],
+        "where": where_obj,
+    });
+
+    let result = fluree
+        .query_from()
+        .jsonld(&query)
+        .track_all()
+        .execute_tracked()
+        .await
+        .expect("tracked query should succeed");
+
+    assert_eq!(result.status, 200, "query status");
+    let rows = result
+        .result
+        .as_array()
+        .map(std::vec::Vec::len)
+        .expect("result should be a JSON array");
+    let fuel = result.fuel.expect("fuel should be present under track_all");
+    (rows, fuel)
+}
+
+#[tokio::test]
+async fn bound_object_absent_from_dict_does_not_scan_predicate() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed(&fluree).await;
+
+    // Baseline: present class returns all widgets via a tight (o_type,o_key)
+    // seek. This is the legitimate, result-proportional cost we contrast against.
+    let (present_rows, present_fuel) =
+        tracked(&fluree, json!({ "@id": "?s", "@type": "ns:Widget" })).await;
+    assert_eq!(present_rows, N, "present class should match every widget");
+    assert!(
+        present_fuel > 0.0,
+        "present-class query should consume fuel"
+    );
+
+    // Absent class: no entity is typed `ns:Ghost`. Must NOT scan the rdf:type
+    // predicate — fuel stays bounded regardless of N.
+    let (ghost_rows, ghost_fuel) =
+        tracked(&fluree, json!({ "@id": "?s", "@type": "ns:Ghost" })).await;
+    assert_eq!(ghost_rows, 0, "absent class matches nothing");
+    assert!(
+        ghost_fuel <= ABSENT_FUEL_CEILING,
+        "absent class burned {ghost_fuel} fuel (ceiling {ABSENT_FUEL_CEILING}); \
+         a full rdf:type predicate scan regressed (~{N} flakes)"
+    );
+
+    // Absent ref object: `ns:owner-999` is never referenced. Same invariant.
+    let (absent_ref_rows, absent_ref_fuel) = tracked(
+        &fluree,
+        json!({ "@id": "?s", "ns:owner": { "@id": "ns:owner-999" } }),
+    )
+    .await;
+    assert_eq!(absent_ref_rows, 0, "absent ref matches nothing");
+    assert!(
+        absent_ref_fuel <= ABSENT_FUEL_CEILING,
+        "absent ref burned {absent_ref_fuel} fuel (ceiling {ABSENT_FUEL_CEILING}); \
+         a full ns:owner predicate scan regressed"
+    );
+
+    // Correctness guard: a present ref object still resolves and narrows.
+    // owner-0 owns widgets 0,5,10,... = ceil(N/5) of them.
+    let expected_owned = N.div_ceil(5);
+    let (owned_rows, owned_fuel) = tracked(
+        &fluree,
+        json!({ "@id": "?s", "ns:owner": { "@id": "ns:owner-0" } }),
+    )
+    .await;
+    assert_eq!(
+        owned_rows, expected_owned,
+        "present ref should return owner-0's widgets"
+    );
+    assert!(owned_fuel > 0.0, "present-ref query should consume fuel");
+}

--- a/fluree-db-core/src/value_id.rs
+++ b/fluree-db-core/src/value_id.rs
@@ -604,6 +604,29 @@ impl ValueTypeTag {
     pub const FULL_TEXT: Self = Self(39);
     pub const UNKNOWN: Self = Self(255);
 
+    /// String-compatible datatypes: those whose values decode to
+    /// `FlakeValue::String`. An untyped string query value can only match flakes
+    /// of these datatypes, so an optimizer may narrow a bare-string lookup to a
+    /// single one of these — but only when exactly one is present for the
+    /// predicate (and it is non-lang; langString also needs a language id).
+    ///
+    /// `UNKNOWN` is intentionally excluded: it may stand in for an unrecognized
+    /// string-valued datatype, so its presence must be treated as unsafe to narrow.
+    #[inline]
+    pub const fn is_string_compatible(self) -> bool {
+        matches!(
+            self,
+            Self::STRING
+                | Self::LANG_STRING
+                | Self::ANY_URI
+                | Self::NORMALIZED_STRING
+                | Self::TOKEN
+                | Self::LANGUAGE
+                | Self::BASE64_BINARY
+                | Self::HEX_BINARY
+        )
+    }
+
     /// Resolve a (namespace_code, local_name) pair to a ValueTypeTag.
     ///
     /// This is the primary entry point for the resolver. Matches against

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2549,11 +2549,41 @@ fn infer_exact_datatype_sid_from_stats(
     value: &FlakeValue,
 ) -> Option<Sid> {
     let stats = stats_view?.get_graph_property(g_id, p_id)?;
-    let mut tags = stats
+    let present: Vec<fluree_db_core::ValueTypeTag> = stats
         .datatypes
         .iter()
         .filter_map(|(tag, count)| (*count > 0).then_some(*tag))
-        .collect::<Vec<_>>();
+        .collect();
+
+    // Untyped string values can only match string-compatible datatypes, so
+    // non-string tags on the predicate (int/date/ref/…) are irrelevant. Narrow
+    // when exactly one string-compatible tag is present and it is non-lang
+    // (langString needs a language id → multi-slice path). UNKNOWN is unsafe —
+    // it may stand in for a string-valued datatype, so its presence declines
+    // narrowing. These stats are novelty-aware (the datatype set reflects base +
+    // novelty), so "only one string-compatible tag" is a conclusive statement
+    // about the whole logical DB, not just the base index.
+    if matches!(value, FlakeValue::String(_)) {
+        if present.contains(&fluree_db_core::ValueTypeTag::UNKNOWN) {
+            return None;
+        }
+        let mut strs: Vec<fluree_db_core::ValueTypeTag> = present
+            .iter()
+            .copied()
+            .filter(|t| t.is_string_compatible())
+            .collect();
+        strs.sort();
+        strs.dedup();
+        return match strs.as_slice() {
+            [only] if *only != fluree_db_core::ValueTypeTag::LANG_STRING => {
+                datatype_sid_for_untyped_value(value, *only)
+            }
+            _ => None,
+        };
+    }
+
+    // Non-string values: exact single-datatype inference.
+    let mut tags = present;
     tags.sort();
     tags.dedup();
     if tags.len() != 1 {
@@ -2618,6 +2648,33 @@ fn datatype_sid_for_untyped_value(
             }
             fluree_db_core::ValueTypeTag::LONG => Some(Sid::new(namespaces::XSD, xsd_names::LONG)),
             fluree_db_core::ValueTypeTag::INT => Some(Sid::new(namespaces::XSD, xsd_names::INT)),
+            _ => None,
+        },
+        // Untyped string → the single string-compatible datatype the caller's
+        // stats gate selected. langString is intentionally absent: it needs a
+        // language id, so it routes through the (future) multi-slice path.
+        FlakeValue::String(_) => match tag {
+            fluree_db_core::ValueTypeTag::STRING => {
+                Some(Sid::new(namespaces::XSD, xsd_names::STRING))
+            }
+            fluree_db_core::ValueTypeTag::ANY_URI => {
+                Some(Sid::new(namespaces::XSD, xsd_names::ANY_URI))
+            }
+            fluree_db_core::ValueTypeTag::NORMALIZED_STRING => {
+                Some(Sid::new(namespaces::XSD, xsd_names::NORMALIZED_STRING))
+            }
+            fluree_db_core::ValueTypeTag::TOKEN => {
+                Some(Sid::new(namespaces::XSD, xsd_names::TOKEN))
+            }
+            fluree_db_core::ValueTypeTag::LANGUAGE => {
+                Some(Sid::new(namespaces::XSD, xsd_names::LANGUAGE))
+            }
+            fluree_db_core::ValueTypeTag::BASE64_BINARY => {
+                Some(Sid::new(namespaces::XSD, xsd_names::BASE64_BINARY))
+            }
+            fluree_db_core::ValueTypeTag::HEX_BINARY => {
+                Some(Sid::new(namespaces::XSD, xsd_names::HEX_BINARY))
+            }
             _ => None,
         },
         _ => None,

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -30,7 +30,7 @@ use fluree_db_core::{
 use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
-use crate::fast_path_common::contiguous_id_range;
+use crate::fast_path_common::{contiguous_id_range, subject_ref_to_s_id};
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::{Expression, Function};
 use crate::object_binding::{late_materialized_object_binding, materialized_object_binding};
@@ -1662,44 +1662,64 @@ impl Operator for BinaryScanOperator {
                 None
             };
 
-            let encoded = match (dt_sid.or(inferred_dt_sid.as_ref()), lang) {
-                (Some(dt_sid), lang) => {
-                    value_to_otype_okey(bound_o, dt_sid, lang, store_ref, dict_novelty)
+            // Refs carry no datatype/lang, so they bypass the literal-value
+            // machinery entirely and resolve snapshot-aware (decode_sid → store
+            // IRI lookup) via `subject_ref_to_s_id`. This mirrors the subject path
+            // (`build_filter_from_snapshot_sids`) and the count path, so a raw
+            // `Term::Sid` object whose namespace code the store can't decode isn't
+            // mistaken for absent (which would route to overlay-only and wrongly
+            // drop a present base match). `Ok(None)` is a conclusive base miss.
+            let encoded: std::io::Result<(OType, u64)> = if let FlakeValue::Ref(sid) = bound_o {
+                match subject_ref_to_s_id(ctx.active_snapshot, store_ref, &Ref::Sid(sid.clone())) {
+                    Ok(Some(s_id)) => Ok((OType::IRI_REF, s_id)),
+                    Ok(None) => Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "ref object not found in base dict",
+                    )),
+                    Err(e) => Err(std::io::Error::other(e.to_string())),
                 }
-                (None, None) => {
-                    match bound_o {
-                        // A string without a datatype constraint is ambiguous: it
-                        // could be xsd:string or rdf:langString, which encode to
-                        // different o_types, so we can't build one tight
-                        // (o_type, o_key) range and must leave the scan un-narrowed.
-                        //
-                        // BUT both share the same interned string id, so if the
-                        // string isn't in the dict at all, no string-typed flake
-                        // (any datatype/lang) can match. Surface NotFound in that
-                        // case to short-circuit to the overlay-only path instead of
-                        // a full predicate scan. (A NotFound here is a base-dict
-                        // miss; the overlay-only fallback still checks novelty, so
-                        // this stays correct when the value is novelty-only.)
-                        FlakeValue::String(s) => match store_ref.find_string_id(s) {
-                            Ok(Some(_)) => Err(std::io::Error::other(
-                                "string without dtc: type ambiguous (could be langString)",
-                            )),
-                            Ok(None) => Err(std::io::Error::new(
-                                std::io::ErrorKind::NotFound,
-                                "string value not found in V6 dict",
-                            )),
-                            Err(e) => Err(std::io::Error::other(format!("find_string_id: {e}"))),
-                        },
-                        // Propagate the io::Error kind unchanged: a NotFound here
-                        // (value absent from the persisted dict) routes to the
-                        // overlay-only fallback below instead of a wide base scan.
-                        _ => value_to_otype_okey_simple(bound_o, store_ref),
+            } else {
+                match (dt_sid.or(inferred_dt_sid.as_ref()), lang) {
+                    (Some(dt_sid), lang) => {
+                        value_to_otype_okey(bound_o, dt_sid, lang, store_ref, dict_novelty)
                     }
+                    (None, None) => {
+                        match bound_o {
+                            // A string without a datatype constraint is ambiguous: it
+                            // could be xsd:string or rdf:langString, which encode to
+                            // different o_types, so we can't build one tight
+                            // (o_type, o_key) range and must leave the scan un-narrowed.
+                            //
+                            // BUT both share the same interned string id, so if the
+                            // string isn't in the dict at all, no string-typed flake
+                            // (any datatype/lang) can match. Surface NotFound in that
+                            // case to short-circuit to the overlay-only path instead of
+                            // a full predicate scan. (A NotFound here is a base-dict
+                            // miss; the overlay-only fallback still checks novelty, so
+                            // this stays correct when the value is novelty-only.)
+                            FlakeValue::String(s) => match store_ref.find_string_id(s) {
+                                Ok(Some(_)) => Err(std::io::Error::other(
+                                    "string without dtc: type ambiguous (could be langString)",
+                                )),
+                                Ok(None) => Err(std::io::Error::new(
+                                    std::io::ErrorKind::NotFound,
+                                    "string value not found in V6 dict",
+                                )),
+                                Err(e) => {
+                                    Err(std::io::Error::other(format!("find_string_id: {e}")))
+                                }
+                            },
+                            // Propagate the io::Error kind unchanged: a NotFound here
+                            // (value absent from the persisted dict) routes to the
+                            // overlay-only fallback below instead of a wide base scan.
+                            _ => value_to_otype_okey_simple(bound_o, store_ref),
+                        }
+                    }
+                    (None, Some(_lang)) => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "lang tag requires datatype constraint",
+                    )),
                 }
-                (None, Some(_lang)) => Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "lang tag requires datatype constraint",
-                )),
             };
 
             match encoded {

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1667,13 +1667,29 @@ impl Operator for BinaryScanOperator {
                     value_to_otype_okey(bound_o, dt_sid, lang, store_ref, dict_novelty)
                 }
                 (None, None) => {
-                    // Without a datatype constraint, we can only safely encode non-string
-                    // values. String values are ambiguous — could be xsd:string or
-                    // rdf:langString — so skip them to avoid type mismatch.
                     match bound_o {
-                        FlakeValue::String(_) => Err(std::io::Error::other(
-                            "string without dtc: type ambiguous (could be langString)",
-                        )),
+                        // A string without a datatype constraint is ambiguous: it
+                        // could be xsd:string or rdf:langString, which encode to
+                        // different o_types, so we can't build one tight
+                        // (o_type, o_key) range and must leave the scan un-narrowed.
+                        //
+                        // BUT both share the same interned string id, so if the
+                        // string isn't in the dict at all, no string-typed flake
+                        // (any datatype/lang) can match. Surface NotFound in that
+                        // case to short-circuit to the overlay-only path instead of
+                        // a full predicate scan. (A NotFound here is a base-dict
+                        // miss; the overlay-only fallback still checks novelty, so
+                        // this stays correct when the value is novelty-only.)
+                        FlakeValue::String(s) => match store_ref.find_string_id(s) {
+                            Ok(Some(_)) => Err(std::io::Error::other(
+                                "string without dtc: type ambiguous (could be langString)",
+                            )),
+                            Ok(None) => Err(std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "string value not found in V6 dict",
+                            )),
+                            Err(e) => Err(std::io::Error::other(format!("find_string_id: {e}"))),
+                        },
                         // Propagate the io::Error kind unchanged: a NotFound here
                         // (value absent from the persisted dict) routes to the
                         // overlay-only fallback below instead of a wide base scan.

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1662,77 +1662,78 @@ impl Operator for BinaryScanOperator {
                 None
             };
 
-            // Refs carry no datatype/lang, so they bypass the literal-value
-            // machinery entirely and resolve snapshot-aware (decode_sid → store
-            // IRI lookup) via `subject_ref_to_s_id`. This mirrors the subject path
-            // (`build_filter_from_snapshot_sids`) and the count path, so a raw
-            // `Term::Sid` object whose namespace code the store can't decode isn't
-            // mistaken for absent (which would route to overlay-only and wrongly
-            // drop a present base match). `Ok(None)` is a conclusive base miss.
-            let encoded: std::io::Result<(OType, u64)> = if let FlakeValue::Ref(sid) = bound_o {
+            // An untyped string that stats couldn't pin to a single datatype:
+            // the predicate has langString and/or multiple string-compatible
+            // datatypes, so we can't build one tight (o_type, o_key) seek.
+            let untyped_string = dt_sid.is_none()
+                && lang.is_none()
+                && inferred_dt_sid.is_none()
+                && matches!(bound_o, FlakeValue::String(_));
+
+            if let FlakeValue::Ref(sid) = bound_o {
+                // Refs carry no datatype/lang, so they bypass the literal-value
+                // machinery and resolve snapshot-aware (decode_sid → store IRI
+                // lookup) via `subject_ref_to_s_id` — mirroring the subject path
+                // (`build_filter_from_snapshot_sids`) and the count path. A raw
+                // `Term::Sid` whose namespace code the store can't decode is thus
+                // not mistaken for absent. `Ok(None)` is a conclusive base miss.
                 match subject_ref_to_s_id(ctx.active_snapshot, store_ref, &Ref::Sid(sid.clone())) {
-                    Ok(Some(s_id)) => Ok((OType::IRI_REF, s_id)),
-                    Ok(None) => Err(std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "ref object not found in base dict",
-                    )),
-                    Err(e) => Err(std::io::Error::other(e.to_string())),
+                    Ok(Some(s_id)) => {
+                        filter.o_type = Some(OType::IRI_REF.as_u16());
+                        filter.o_key = Some(s_id);
+                    }
+                    Ok(None) => return self.open_overlay_only_fallback(ctx, &s_sid, &p_sid).await,
+                    // Genuine error — keep correctness by leaving the filter un-narrowed.
+                    Err(_) => {}
+                }
+            } else if untyped_string {
+                // All string datatypes/langs share one interned string id, so set it
+                // as the `o_key` filter (o_type left wild). POST orders
+                // (p_id, o_type, o_key), so o_key without o_type is NOT a tight key
+                // range — the cursor still scans the predicate's broad leaf range and
+                // loads candidate leaflets, but `filter_batch` drops rows whose o_key
+                // differs *before* value decode. Leaflets emptied by that filter
+                // return no batch, so they incur neither the per-leaflet fuel charge
+                // nor a dict decode — cutting the dominant cost while the value
+                // post-filter preserves lenient matching across string datatypes/langs
+                // (overlay rows are filtered the same way, so novelty langStrings
+                // aren't dropped). Mirrors the untyped-numeric o_key prefilter. An
+                // absent string can't be in the base dict at all → overlay-only.
+                if let FlakeValue::String(s) = bound_o {
+                    match store_ref.find_string_id(s) {
+                        Ok(Some(str_id)) => filter.o_key = Some(str_id as u64),
+                        Ok(None) => {
+                            return self.open_overlay_only_fallback(ctx, &s_sid, &p_sid).await
+                        }
+                        Err(_) => {}
+                    }
                 }
             } else {
-                match (dt_sid.or(inferred_dt_sid.as_ref()), lang) {
+                let encoded = match (dt_sid.or(inferred_dt_sid.as_ref()), lang) {
                     (Some(dt_sid), lang) => {
                         value_to_otype_okey(bound_o, dt_sid, lang, store_ref, dict_novelty)
                     }
-                    (None, None) => {
-                        match bound_o {
-                            // A string without a datatype constraint is ambiguous: it
-                            // could be xsd:string or rdf:langString, which encode to
-                            // different o_types, so we can't build one tight
-                            // (o_type, o_key) range and must leave the scan un-narrowed.
-                            //
-                            // BUT both share the same interned string id, so if the
-                            // string isn't in the dict at all, no string-typed flake
-                            // (any datatype/lang) can match. Surface NotFound in that
-                            // case to short-circuit to the overlay-only path instead of
-                            // a full predicate scan. (A NotFound here is a base-dict
-                            // miss; the overlay-only fallback still checks novelty, so
-                            // this stays correct when the value is novelty-only.)
-                            FlakeValue::String(s) => match store_ref.find_string_id(s) {
-                                Ok(Some(_)) => Err(std::io::Error::other(
-                                    "string without dtc: type ambiguous (could be langString)",
-                                )),
-                                Ok(None) => Err(std::io::Error::new(
-                                    std::io::ErrorKind::NotFound,
-                                    "string value not found in V6 dict",
-                                )),
-                                Err(e) => {
-                                    Err(std::io::Error::other(format!("find_string_id: {e}")))
-                                }
-                            },
-                            // Propagate the io::Error kind unchanged: a NotFound here
-                            // (value absent from the persisted dict) routes to the
-                            // overlay-only fallback below instead of a wide base scan.
-                            _ => value_to_otype_okey_simple(bound_o, store_ref),
-                        }
-                    }
+                    // Refs and untyped strings are handled above; this is reached
+                    // for untyped non-string values (numeric/bool/date/…).
+                    (None, None) => value_to_otype_okey_simple(bound_o, store_ref),
                     (None, Some(_lang)) => Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         "lang tag requires datatype constraint",
                     )),
-                }
-            };
+                };
 
-            match encoded {
-                Ok((ot, key)) => {
-                    filter.o_type = Some(ot.as_u16());
-                    filter.o_key = Some(key);
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    // Novelty may contain the value, but base index can't; avoid wide base scan.
-                    return self.open_overlay_only_fallback(ctx, &s_sid, &p_sid).await;
-                }
-                Err(_) => {
-                    // If encoding fails, keep correctness by leaving the filter un-narrowed.
+                match encoded {
+                    Ok((ot, key)) => {
+                        filter.o_type = Some(ot.as_u16());
+                        filter.o_key = Some(key);
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        // Value absent from base dict; overlay-only still checks novelty.
+                        return self.open_overlay_only_fallback(ctx, &s_sid, &p_sid).await;
+                    }
+                    Err(_) => {
+                        // If encoding fails, keep correctness by leaving the filter un-narrowed.
+                    }
                 }
             }
         }

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1674,8 +1674,10 @@ impl Operator for BinaryScanOperator {
                         FlakeValue::String(_) => Err(std::io::Error::other(
                             "string without dtc: type ambiguous (could be langString)",
                         )),
-                        _ => value_to_otype_okey_simple(bound_o, store_ref)
-                            .map_err(|e| std::io::Error::other(e.to_string())),
+                        // Propagate the io::Error kind unchanged: a NotFound here
+                        // (value absent from the persisted dict) routes to the
+                        // overlay-only fallback below instead of a wide base scan.
+                        _ => value_to_otype_okey_simple(bound_o, store_ref),
                     }
                 }
                 (None, Some(_lang)) => Err(std::io::Error::new(
@@ -2612,50 +2614,68 @@ fn otype_from_dt_sid(dt_sid: &Sid, store: &BinaryIndexStore) -> Option<OType> {
 pub(crate) fn value_to_otype_okey_simple(
     val: &FlakeValue,
     store: &BinaryIndexStore,
-) -> Result<(OType, u64)> {
+) -> std::io::Result<(OType, u64)> {
     use fluree_db_core::value_id::ObjKey;
+    use std::io::{Error, ErrorKind};
 
     match val {
         FlakeValue::Null => Ok((OType::NULL, 0)),
         FlakeValue::Boolean(b) => Ok((OType::XSD_BOOLEAN, *b as u64)),
         FlakeValue::Long(n) => Ok((OType::XSD_INTEGER, ObjKey::encode_i64(*n).as_u64())),
         FlakeValue::Double(d) => {
+            // Encoding failures are NOT NotFound: the value could still exist in
+            // the base index under a representation we can't compute, so callers
+            // must leave the scan un-narrowed (correctness-preserving) rather
+            // than treating it as provably absent.
             if d.is_finite() {
                 ObjKey::encode_f64(*d)
                     .map(|key| (OType::XSD_DOUBLE, key.as_u64()))
                     .map_err(|_| {
-                        QueryError::execution("cannot encode f64 for V6 index".to_string())
+                        Error::new(ErrorKind::InvalidData, "cannot encode f64 for V6 index")
                     })
             } else {
-                Err(QueryError::execution(
-                    "non-finite double in bound object".to_string(),
+                Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "non-finite double in bound object",
                 ))
             }
         }
         FlakeValue::Ref(sid) => {
-            let s_id = store
-                .find_subject_id_by_parts(sid.namespace_code, &sid.name)
-                .map_err(|e| QueryError::execution(format!("find_subject_id_by_parts: {e}")))?
-                .ok_or_else(|| {
-                    QueryError::execution("ref object not found in V6 dict".to_string())
-                })?;
+            // Resolve via `sid_to_store_s_id`: a fast by-parts lookup, then a
+            // fallback that rebuilds the IRI *from the store's own namespace
+            // table* (`store.sid_to_iri`) and re-finds it. This recovers the
+            // common by-parts miss where the SID is EMPTY/OVERFLOW-coded and
+            // carries the full IRI in `name` (e.g. an rdfs:Class object after
+            // bulk import), so a *present* ref isn't mistaken for absent.
+            //
+            // It is NOT a general "decode via the query snapshot" fallback —
+            // this helper only has the store, so for non-EMPTY codes it relies
+            // on canonical encoding keeping snapshot/store namespace codes in
+            // agreement. Only a miss through both steps is treated as absent,
+            // letting the caller short-circuit to the overlay-only path
+            // (NotFound) instead of scanning the whole predicate.
+            let s_id = crate::sid_iri::sid_to_store_s_id(store, sid)?.ok_or_else(|| {
+                Error::new(ErrorKind::NotFound, "ref object not found in V6 dict")
+            })?;
             Ok((OType::IRI_REF, s_id))
         }
         FlakeValue::String(s) => {
+            // String interning has no namespace dimension, so a miss here is a
+            // reliable "absent from base dict" signal (NotFound).
             let str_id = store
                 .find_string_id(s)
-                .map_err(|e| QueryError::execution(format!("find_string_id: {e}")))?
+                .map_err(|e| Error::other(format!("find_string_id: {e}")))?
                 .ok_or_else(|| {
-                    QueryError::execution("string value not found in V6 dict".to_string())
+                    Error::new(ErrorKind::NotFound, "string value not found in V6 dict")
                 })?;
             Ok((OType::XSD_STRING, str_id as u64))
         }
         FlakeValue::Json(s) => {
             let str_id = store
                 .find_string_id(s)
-                .map_err(|e| QueryError::execution(format!("find_string_id: {e}")))?
+                .map_err(|e| Error::other(format!("find_string_id: {e}")))?
                 .ok_or_else(|| {
-                    QueryError::execution("JSON value not found in V6 dict".to_string())
+                    Error::new(ErrorKind::NotFound, "JSON value not found in V6 dict")
                 })?;
             Ok((OType::RDF_JSON, str_id as u64))
         }
@@ -2685,9 +2705,10 @@ pub(crate) fn value_to_otype_okey_simple(
             OType::XSD_G_MONTH_DAY,
             ObjKey::encode_g_month_day(g.month(), g.day()).as_u64(),
         )),
-        _ => Err(QueryError::execution(format!(
-            "unsupported FlakeValue variant for V6 fast-path: {val:?}"
-        ))),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            format!("unsupported FlakeValue variant for V6 fast-path: {val:?}"),
+        )),
     }
 }
 

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -1,8 +1,8 @@
 use crate::binding::Binding;
 use crate::context::{ExecutionContext, WellKnownDatatypes};
 use crate::error::{QueryError, Result};
-use crate::fast_path_common::{fast_path_store, normalize_pred_sid};
-use crate::ir::triple::Term;
+use crate::fast_path_common::{fast_path_store, normalize_pred_sid, subject_ref_to_s_id};
+use crate::ir::triple::{Ref, Term};
 use crate::operator::BoxedOperator;
 use crate::operator::{Operator, OperatorState};
 use crate::var_registry::VarId;
@@ -23,7 +23,7 @@ use fluree_db_binary_index::{
 };
 use fluree_db_core::o_type::OType;
 use fluree_db_core::subject_id::SubjectId;
-use fluree_db_core::{FlakeValue, GraphId, Sid};
+use fluree_db_core::{FlakeValue, GraphId, LedgerSnapshot, Sid};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -432,6 +432,7 @@ impl Operator for PredicateObjectCountFirstsOperator {
         {
             if let Some(binary_index_store) = ctx.binary_store.as_ref() {
                 match count_bound_object_v6(
+                    ctx.active_snapshot,
                     binary_index_store,
                     ctx.binary_g_id,
                     &self.predicate,
@@ -583,15 +584,23 @@ fn resolve_predicate_id_v6(
 /// `(o_type, o_key)` to skip whole leaflets, and decodes only `o_key` + `o_type`
 /// columns when needed.
 fn count_bound_object_v6(
+    snapshot: &LedgerSnapshot,
     store: &BinaryIndexStore,
     g_id: GraphId,
-    predicate: &crate::ir::triple::Ref,
+    predicate: &Ref,
     object: &Term,
 ) -> Result<i64> {
     let p_id = resolve_predicate_id_v6(predicate, store)?;
 
-    // Translate the bound object term into V6 (o_type, o_key).
-    let (target_o_type, target_o_key) = translate_term_to_v6(object, store, p_id, g_id)?;
+    // Translate the bound object term into V6 (o_type, o_key). A `None` here is
+    // a *conclusive* base-dict miss (refs are resolved snapshot-aware); since
+    // this path runs only with no novelty overlay, the count is exactly 0 —
+    // return without a fallback full-predicate scan.
+    let Some((target_o_type, target_o_key)) =
+        translate_term_to_v6(object, snapshot, store, p_id, g_id)?
+    else {
+        return Ok(0);
+    };
 
     let branch = store
         .branch_for_order(g_id, RunSortOrder::Post)
@@ -880,37 +889,48 @@ fn group_count_v6(
 }
 
 /// Translate a bound object `Term` to V6 `(o_type, o_key)`.
+///
+/// Return values:
+/// - `Ok(Some(..))` — resolved to a persisted `(o_type, o_key)`.
+/// - `Ok(None)` — the object is **conclusively absent from the base dict**.
+///   Combined with the caller's no-novelty (`epoch == 0`) gate, "absent from
+///   base dict" implies "absent from the logical DB", so the caller reports a
+///   0 count.
+/// - `Err(..)` — genuine error or unbound object; routes to the generic
+///   fallback.
+///
+/// Refs (`Term::Iri` and `Term::Sid`) resolve through `subject_ref_to_s_id`,
+/// which is snapshot-aware: a `Sid` is decoded via `snapshot.decode_sid` (then
+/// `store.sid_to_iri`) and re-looked-up by full IRI. This makes a `None` a
+/// genuine base miss rather than a "store can't decode this snapshot namespace
+/// code" false negative — so returning a 0 count stays sound even for
+/// pre-encoded `Term::Sid` objects of unknown provenance.
 fn translate_term_to_v6(
     term: &Term,
+    snapshot: &LedgerSnapshot,
     store: &BinaryIndexStore,
     _p_id: u32,
     _g_id: GraphId,
-) -> Result<(u16, u64)> {
+) -> Result<Option<(u16, u64)>> {
     match term {
-        Term::Sid(sid) => {
-            let s_id = store
-                .find_subject_id_by_parts(sid.namespace_code, &sid.name)
-                .map_err(|e| QueryError::execution(format!("find_subject_id_by_parts: {e}")))?
-                .ok_or_else(|| {
-                    QueryError::execution("bound object SID not found in V6 dict".to_string())
-                })?;
-            Ok((OType::IRI_REF.as_u16(), s_id))
-        }
-        Term::Iri(iri) => {
-            let s_id = store
-                .find_subject_id(iri)
-                .map_err(|e| QueryError::execution(format!("find_subject_id: {e}")))?
-                .ok_or_else(|| {
-                    QueryError::execution("bound object IRI not found in V6 dict".to_string())
-                })?;
-            Ok((OType::IRI_REF.as_u16(), s_id))
-        }
+        Term::Iri(iri) => Ok(
+            subject_ref_to_s_id(snapshot, store, &Ref::Iri(iri.clone()))?
+                .map(|s_id| (OType::IRI_REF.as_u16(), s_id)),
+        ),
+        Term::Sid(sid) => Ok(
+            subject_ref_to_s_id(snapshot, store, &Ref::Sid(sid.clone()))?
+                .map(|s_id| (OType::IRI_REF.as_u16(), s_id)),
+        ),
         Term::Value(val) => {
-            // For literal values, we need the FlakeValue → (o_type, o_key) translation.
-            // Use the Sid-based dt info from the FlakeValue if available.
-            let (ot, ok) = crate::binary_scan::value_to_otype_okey_simple(val, store)
-                .map_err(|e| QueryError::from_io("value_to_otype_okey_simple", e))?;
-            Ok((ot.as_u16(), ok))
+            // Literal values: the FlakeValue → (o_type, o_key) translation.
+            // A NotFound means the value isn't in the persisted dict — conclusive
+            // for literals (no namespace ambiguity). Other errors are genuine and
+            // propagate to the fallback. (Ref-valued objects arrive as Term::Iri.)
+            match crate::binary_scan::value_to_otype_okey_simple(val, store) {
+                Ok((ot, ok)) => Ok(Some((ot.as_u16(), ok))),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(QueryError::from_io("value_to_otype_okey_simple", e)),
+            }
         }
         Term::Var(_) => Err(QueryError::InvalidQuery(
             "fast-path requires a bound object".to_string(),

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -908,7 +908,8 @@ fn translate_term_to_v6(
         Term::Value(val) => {
             // For literal values, we need the FlakeValue → (o_type, o_key) translation.
             // Use the Sid-based dt info from the FlakeValue if available.
-            let (ot, ok) = crate::binary_scan::value_to_otype_okey_simple(val, store)?;
+            let (ot, ok) = crate::binary_scan::value_to_otype_okey_simple(val, store)
+                .map_err(|e| QueryError::from_io("value_to_otype_okey_simple", e))?;
             Ok((ot.as_u16(), ok))
         }
         Term::Var(_) => Err(QueryError::InvalidQuery(


### PR DESCRIPTION
Several common bound-object query shapes were silently doing **full predicate
scans** when they should have been cheap — either provably empty or a tight
index seek. The cost scales with predicate cardinality, so a query that returns
**nothing** could burn hundreds of thousands of fuel. This PR closes that class
across the scan, count, and string-object paths, and adds present-string
narrowing.

Concretely, on a large ledger, `@type {rdfs:Class, rdf:Property}`
returned **0 rows** but consumed **705K fuel** — two full scans of the entire
`rdf:type` predicate to discover that those classes are never used as type
objects. After this PR that query is ~0 fuel.

## Root cause

When `BinaryScanOperator::open` couldn't encode a bound object to a tight
`(o_type, o_key)` range, it fell into an un-narrowed catch-all and post-filtered
the whole predicate. The cases that hit this:

1. **Object absent from the dictionary** (a class nothing is typed as, a ref IRI
   never interned, a string value never stored). This was misclassified as
   "can't narrow" instead of "provably empty" — so the *cheapest* possible query
   became the *most expensive*.
2. **`Term::Sid` objects resolved store-only**, so a snapshot↔store
   namespace-code divergence (e.g. after bulk import) made a *present* ref look
   absent — a latent correctness risk, not just a perf one.
3. **Untyped string objects never narrowed at all** — `datatype_sid_for_untyped_value`
   had no `String` arm, so even a pure `xsd:string` predicate full-scanned.
4. The **`count_bound_object_v6`** fast path errored on an absent object and fell
   back to a generic scan + aggregate (counted zero via a full scan).

## What changed

| Commit | Path | Fix |
|--------|------|-----|
| scan refs absent | `binary_scan.rs` | absent ref object → overlay-only short-circuit (checks novelty, no base scan) |
| count refs absent | `fast_group_count_firsts.rs` | absent count object → `Ok(0)`; snapshot-aware resolution |
| absent strings | `binary_scan.rs` | absent untyped string → overlay-only (shared `str_id`, so a dict miss means no string-typed flake matches under any datatype/lang) |
| scan refs snapshot-aware | `binary_scan.rs` | object-ref resolution routed through `subject_ref_to_s_id` (decode_sid → store IRI lookup), matching the subject and count paths — closes the `Term::Sid` false-negative |
| present strings narrow | `binary_scan.rs`, `value_id.rs` | untyped string narrows to the predicate's lone string datatype when stats prove there's exactly one (non-lang) string-compatible type |
| string o_key prefilter | `binary_scan.rs` | untyped string on a langString / multi-string-compatible predicate uses the interned `str_id` as an `o_key` pre-filter (drops rows before value decode), preserving lenient matching |

The bound-object block in `open()` is restructured into three branches: **ref**
(snapshot-aware tight seek), **untyped non-narrowable string** (`o_key`
pre-filter), and **typed/inferred values** (exact encode).

## Correctness invariants

- **Base-dict miss ≠ logical-DB miss.** A miss in the persisted dictionary only
  becomes "no match" when novelty is also accounted for. The scan path routes
  misses to the overlay-only fallback (which checks novelty); the count fast path
  is gated on no-novelty (`epoch == 0`), so a base-dict miss there *is* a logical
  miss.
- **Novelty-aware stats.** The per-predicate datatype stats used for narrowing
  are novelty-aware (`assemble_fast_stats` merges novelty), so "only `xsd:string`
  present" reflects base **and** novelty — a novelty langString surfaces as a
  second string-compatible tag and declines narrowing. No epoch guard needed for
  string narrowing.
- **Snapshot-aware ref resolution.** Refs (subject, object, and count object) all
  resolve through `subject_ref_to_s_id` (by-parts, then `snapshot.decode_sid` /
  `store.sid_to_iri` → full-IRI lookup), so a raw `Term::Sid` of unknown
  provenance can't be mistaken for absent.
- **Lenient string semantics preserved.** An untyped `"foo"` still matches the
  value across all string datatypes/langs (`xsd:string`, `langString`, etc.). The
  narrowing only fires when a single string-compatible type is present; otherwise
  the `o_key` pre-filter keeps the lenient match while cutting the per-row decode.
  `UNKNOWN` datatype is treated as unsafe (declines narrowing).

## Performance / fuel

- `@type <absent-class>` (0 rows): **~352K → ~0 fuel** per absent class.
- `?s <p> "absent-string"`: full predicate scan → **~0 fuel**.
- `COUNT WHERE { ?s a <absent-class> }`: full scan + aggregate → **`Ok(0)`** with no scan.
- Present untyped string on a pure / mixed-with-non-string predicate: full scan →
  **tight `(XSD_STRING, str_id)` seek**.
- Present untyped string on a langString / multi-string-compatible predicate:
  full value-decode scan → **`o_key` pre-filter** (measured: a 502-flake
  string+langString predicate dropped from a full decode scan to ~3 fuel), still
  returning all lenient matches.

These reduce the actual work (and lambda cost), not just the reported fuel number.

## Testing

- New `it_query_fuel_bound_object.rs`: absent ref/class/string/count all return
  bounded fuel independent of dataset size; present-value lookups still return
  correct rows/counts; present untyped strings narrow (pure + mixed); a
  negative guard proves a `xsd:string + langString` predicate still returns **all**
  lenient matches (declines to narrow) and an absent string there still
  short-circuits.
- Existing guards: `it_query_rdfs_class_repro` (present classes on bulk-imported
  data must return correct counts/rows — covers the `Term::Sid` snapshot path),
  `it_query_datatype` (full datatype/lang semantics suite), and
  `it_import` / `it_query_time_travel` (caught the `Ok(None)` count regression
  during development; now pass and guard `Term::Sid` count objects).
- CI: `cargo fmt --all -- --check`, `cargo clippy --all --all-features
  --all-targets -- -D warnings`, `cargo nextest run --workspace --all-features`
  (clean apart from environment-only Docker/testcontainers and a transient
  swagger-ui asset download).
