### PR TITLE
feat: Gate hydration SPOT crawl by projection predicates

### DIFF
--- a/docs/query/tracking-and-fuel.md
+++ b/docs/query/tracking-and-fuel.md
@@ -77,6 +77,22 @@ Cheap operations (comparisons, arithmetic, type checks, simple string ops, datet
 
 The **query floor** guarantees every fuel-tracked query reports at least `1.000` fuel: a query touching no persisted data still costs the floor, and a query that errors during parsing/planning still reports it. I/O "touches" cost `0.010` each, so a scan-dominated query reports roughly `1.000 + 0.010 × (leaflet/dict touches)`. The fuel schedule above is defined in one place — `fluree-db-core/src/tracking.rs` (`tracking::schedule`).
 
+#### Graph-crawl projection: materialization fuel scales with selected predicates
+
+When a JSON-LD query's projection lists explicit forward predicates (e.g. `select: {"?x": ["@id", "ex:a", "ex:b"]}`), the range provider receives a predicate allow-list via `RangeOptions::predicate_filter` and drops base flakes for non-listed predicates **before** decoding the object value, resolving the subject Sid, or charging dict-touch fuel.
+
+What this changes:
+- **Per-flake (`0.001`), subject-resolve, object-decode, and dict-touch (`0.010`) fuel** all scale with the number of selected predicates rather than the subject's total predicate count.
+
+What this does **not** change:
+- **Index leaflet touches (`0.010` each)** still scale with the cursor's scanned subject range. For K ≥ 2 the cursor opens `SPOT(s,*,*)` and pays one `INDEX_TOUCH` per leaflet batch returned, the same as a full crawl over the subject — the filter narrows which rows get *materialized*, not how many leaflets get *read*. For K = 1 the cursor opens `SPOT(s,p,*)` directly via `RangeMatch::subject_predicate`, which narrows the leaflet key-range to the `(s, p)` prefix — same `INDEX_TOUCH` count for small subjects (one batch either way), strictly fewer touches for subjects whose flakes span multiple batches.
+
+Wildcard projections (`select: {"?x": ["*"]}`) take the unchanged decode-everything path — every flake on the subject is materialized and charged. Refinements on a wildcard level (e.g. `{"ex:friend": ["*"]}` inside a `["*", ...]` selection) keep the parent level wildcard; only the explicit-list form opts into the filter.
+
+Explicit projections with no forward predicates (e.g. `["@id"]` or reverse-only) skip the forward SPOT scan entirely — no cursor, no `INDEX_TOUCH`. `@id` is derived from the subject Sid and reverse properties go through a dedicated POST scan.
+
+The overlay path also honors the filter, so per-subject hydration over a ledger with uncommitted novelty pays only for retracts / asserts on predicates the projection cares about. Novelty-only predicates (no persisted p_id yet) are honored too: the row-loop allow-set is extended with ephemeral p_ids the overlay translator assigned for any selected predicate Sid.
+
 ### Indexing Fuel
 
 Indexer CAS writes are billed through a `MeteredContentStore` wrapper that the build entry points install around the caller-supplied content store. Every successful `ContentStore::put` / `put_with_id` charges the base **1.000 fuel** rate — including index leaves, branch manifests, root manifests, dict packs / reverse-tree nodes, history sidecars, garbage records, stats sketches, and (incremental) spatial / fulltext arenas. The lower-level `Storage::content_write_bytes` is **not** currently wrapped; the only indexer code path that uses it is the dead-code spatial rebuild helper. If that path is wired up, add a storage-level wrapper first (or migrate it to `ContentStore::put`).

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -46,6 +46,7 @@ use super::iri::IriCompactor;
 use super::{FormatError, Result};
 use crate::QueryResult;
 use fluree_db_core::comparator::IndexType;
+use fluree_db_core::query_bounds::RangeOptions;
 use fluree_db_core::range::{RangeMatch, RangeTest};
 use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{Flake, GraphDbRef, Sid, Tracker};
@@ -58,6 +59,7 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 use serde_json::{json, Value as JsonValue};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 /// Cache key: (Sid, local_spec_hash, depth_remaining)
 ///
@@ -117,6 +119,38 @@ struct PredicateContext<'a> {
     flakes: &'a [&'a Flake],
     /// Explicit nested selection spec for this predicate (if any).
     explicit_sub_spec: Option<&'a NestedSelectSpec>,
+}
+
+/// Build the forward-predicate allow-list for one hydration level.
+///
+/// Returned to the range provider via [`RangeOptions::predicate_filter`] so
+/// the SPOT-per-subject scan can skip dict touches on unselected predicates.
+///
+/// - `Wildcard`: returns `None` — the projection wants every predicate, so
+///   no filter is applied and the legacy decode-everything path runs.
+/// - `Explicit` with no `ForwardItem::Property` entries (e.g., `@id`-only or
+///   reverse-only): still returns `Some(empty)`. The range provider will
+///   short-circuit every base row, which is correct — no forward predicate
+///   was selected.
+///
+/// `ForwardItem::Id` is skipped because `@id` is derived from the subject
+/// Sid in the caller, not from a flake. Reverse predicates are not included
+/// either — they go through `fetch_reverse_properties`, which already does
+/// a single-predicate POST scan and isn't affected by this filter.
+fn predicate_filter_for_level(level: &NestedSelectSpec) -> Option<Arc<[Sid]>> {
+    match level {
+        NestedSelectSpec::Wildcard { .. } => None,
+        NestedSelectSpec::Explicit { forward, .. } => {
+            let preds: Vec<Sid> = forward
+                .iter()
+                .filter_map(|item| match item {
+                    ForwardItem::Property { predicate, .. } => Some(predicate.clone()),
+                    ForwardItem::Id => None,
+                })
+                .collect();
+            Some(Arc::from(preds))
+        }
+    }
 }
 
 /// Hash a `NestedSelectSpec` to a u64 cache key. We can't derive `Hash`
@@ -449,8 +483,13 @@ impl<'a> HydrationFormatter<'a> {
                 obj.insert("@id".to_string(), json!(self.compactor.compact_sid(sid)?));
             }
 
-            // Fetch forward properties
-            let flakes = self.fetch_subject_properties(sid).await?;
+            // Fetch forward properties. For Explicit projections we hand the
+            // range provider a predicate allow-list so it can skip object
+            // decode / dict touches / subject re-resolve on discarded rows;
+            // Wildcard projections want every predicate, so the filter stays
+            // None and the legacy SPOT-everything path runs unchanged.
+            let predicate_filter = predicate_filter_for_level(level);
+            let flakes = self.fetch_subject_properties(sid, predicate_filter).await?;
 
             // Group flakes by predicate
             let mut by_pred: HashMap<Sid, Vec<&Flake>> = HashMap::new();
@@ -1015,17 +1054,36 @@ impl<'a> HydrationFormatter<'a> {
         }
     }
 
-    /// Fetch all properties for a subject using SPOT index
+    /// Fetch a subject's forward flakes via the SPOT index, optionally
+    /// narrowed to a projection-predicate allow-list.
     ///
-    /// When policy is set, filters flakes according to view policies.
-    /// When policy is None, returns all flakes (zero overhead).
-    async fn fetch_subject_properties(&self, sid: &Sid) -> Result<Vec<Flake>> {
+    /// `predicate_filter` mirrors [`RangeOptions::predicate_filter`]: when
+    /// `Some`, the range provider drops non-listed predicates **before**
+    /// resolving the subject Sid, decoding the object, or charging
+    /// dict-touch fuel. When `None`, behavior matches the legacy
+    /// SPOT-everything path (used for `*`-wildcard projections where every
+    /// predicate is wanted).
+    ///
+    /// When policy is set, the returned flakes are post-filtered by view
+    /// policy. Per-flake / per-leaflet / per-dict-touch fuel charges happen
+    /// inside `db.range_with_opts` via the `GraphDbRef` tracker.
+    async fn fetch_subject_properties(
+        &self,
+        sid: &Sid,
+        predicate_filter: Option<Arc<[Sid]>>,
+    ) -> Result<Vec<Flake>> {
+        let opts = RangeOptions::default();
+        let opts = match predicate_filter {
+            Some(allow) => opts.with_predicate_filter(allow),
+            None => opts,
+        };
         let flakes = self
             .db
-            .range(
+            .range_with_opts(
                 IndexType::Spot,
                 RangeTest::Eq,
                 RangeMatch::subject(sid.clone()),
+                opts,
             )
             .await
             .map_err(|e| {
@@ -1033,8 +1091,6 @@ impl<'a> HydrationFormatter<'a> {
             })?;
 
         // Policy filtering: only when policy is Some and not root.
-        // Per-flake / per-leaflet / per-dict-touch fuel charges happen inside
-        // db.range via the GraphDbRef tracker — no extra charge needed here.
         if let Some(policy_ctx) = self.policy {
             if !policy_ctx.wrapper().is_root() {
                 return Ok(self.filter_flakes_by_policy(flakes, policy_ctx));

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -488,8 +488,19 @@ impl<'a> HydrationFormatter<'a> {
             // decode / dict touches / subject re-resolve on discarded rows;
             // Wildcard projections want every predicate, so the filter stays
             // None and the legacy SPOT-everything path runs unchanged.
+            //
+            // Single-predicate fast path: SPOT(s,p,*) narrows the cursor's
+            // leaflet key-range to the (s, p) prefix directly, skipping the
+            // predicate-filter machinery and the in-batch scan over the
+            // subject's other predicate rows. K ≥ 2 stays on the
+            // SPOT(s,*,*) + predicate_filter path because two cursor
+            // descents would each pay their own INDEX_TOUCH (0.010 fuel)
+            // and beat the single-scan baseline.
             let predicate_filter = predicate_filter_for_level(level);
-            let flakes = self.fetch_subject_properties(sid, predicate_filter).await?;
+            let flakes = match predicate_filter.as_deref() {
+                Some([only]) => self.fetch_subject_predicate_pair(sid, only).await?,
+                _ => self.fetch_subject_properties(sid, predicate_filter).await?,
+            };
 
             // Group flakes by predicate
             let mut by_pred: HashMap<Sid, Vec<&Flake>> = HashMap::new();
@@ -1091,6 +1102,39 @@ impl<'a> HydrationFormatter<'a> {
             })?;
 
         // Policy filtering: only when policy is Some and not root.
+        if let Some(policy_ctx) = self.policy {
+            if !policy_ctx.wrapper().is_root() {
+                return Ok(self.filter_flakes_by_policy(flakes, policy_ctx));
+            }
+        }
+
+        Ok(flakes)
+    }
+
+    /// Fetch one `(subject, predicate)` pair via the SPOT index.
+    ///
+    /// Caller invariant: the projection's level is Explicit with exactly
+    /// one forward `Property` item. This narrows the cursor's leaflet
+    /// key-range to the `(s, p)` prefix — same number of cursor descents
+    /// and same `INDEX_TOUCH` fuel as the SPOT(s,*,*) + `predicate_filter`
+    /// path, but skips the per-row `binary_search` against the filter and
+    /// the in-batch scan over the subject's other predicate rows. Worth it
+    /// on fat subjects; a CPU/clarity wash on small ones.
+    async fn fetch_subject_predicate_pair(&self, sid: &Sid, pred: &Sid) -> Result<Vec<Flake>> {
+        let flakes = self
+            .db
+            .range(
+                IndexType::Spot,
+                RangeTest::Eq,
+                RangeMatch::subject_predicate(sid.clone(), pred.clone()),
+            )
+            .await
+            .map_err(|e| {
+                FormatError::InvalidBinding(format!(
+                    "Failed to fetch (subject, predicate) pair: {e}"
+                ))
+            })?;
+
         if let Some(policy_ctx) = self.policy {
             if !policy_ctx.wrapper().is_root() {
                 return Ok(self.filter_flakes_by_policy(flakes, policy_ctx));

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -496,8 +496,16 @@ impl<'a> HydrationFormatter<'a> {
             // SPOT(s,*,*) + predicate_filter path because two cursor
             // descents would each pay their own INDEX_TOUCH (0.010 fuel)
             // and beat the single-scan baseline.
+            //
+            // Zero-predicate fast path (K = 0): an Explicit level with no
+            // forward `Property` items — e.g. `["@id"]` or reverse-only —
+            // skips the forward fetch entirely. Opening the cursor would
+            // still pay one INDEX_TOUCH (0.010 fuel) per leaflet batch
+            // even though the row loop drops every row. `@id` and reverse
+            // properties are emitted by the dedicated paths further down.
             let predicate_filter = predicate_filter_for_level(level);
             let flakes = match predicate_filter.as_deref() {
+                Some([]) => Vec::new(),
                 Some([only]) => self.fetch_subject_predicate_pair(sid, only).await?,
                 _ => self.fetch_subject_properties(sid, predicate_filter).await?,
             };

--- a/fluree-db-api/tests/it_hydration_predicate_gating.rs
+++ b/fluree-db-api/tests/it_hydration_predicate_gating.rs
@@ -1,0 +1,291 @@
+//! Tests for projection-predicate gating in hydration / graph-crawl.
+//!
+//! When a JSON-LD query's `select` lists explicit forward predicates (rather
+//! than `*`), the range provider receives a `predicate_filter` allow-list via
+//! [`RangeOptions::predicate_filter`] and drops non-listed rows BEFORE the
+//! per-row subject resolve, object decode, and dict-touch fuel charge.
+//!
+//! These tests exercise the boundary cases:
+//!
+//! 1. **Fuel scales with projection field count.** A subject with N
+//!    dict-backed forward predicates costs less tracked fuel under a narrow
+//!    Explicit projection than under a full-Explicit projection of the same
+//!    subject — the delta corresponds to saved dict touches (10 µf each) +
+//!    saved per-row charges (1 µf each) on the dropped predicates.
+//! 2. **Wildcard projections preserve the legacy decode-everything path.**
+//!    `select: ["*"]` does not opt into filtering and emits every predicate.
+//! 3. **Overlay parity.** A novelty assert / retract on an unselected
+//!    predicate doesn't leak into the result, and one on a selected
+//!    predicate is honored.
+
+#![cfg(feature = "native")]
+
+use fluree_db_api::{FlureeBuilder, ReindexOptions};
+use serde_json::{json, Value};
+
+fn ctx() -> Value {
+    json!({
+        "ex": "http://example.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    })
+}
+
+/// Seed a subject with 8 dict-backed (string) predicates.
+///
+/// All eight values are strings — each one is a `StringDict`-backed object,
+/// so each row decode in the range provider triggers a `DICT_TOUCH_MICRO_FUEL`
+/// (10 µf = 0.010 fuel) charge under the legacy "decode every row" path.
+async fn seed_eight_string_predicates(path: &str, ledger_id: &str) {
+    let fluree = FlureeBuilder::file(path).build().expect("build");
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
+    let tx = json!({
+        "@context": ctx(),
+        "@id": "ex:subj-1",
+        "@type": "ex:Thing",
+        "ex:p1": "value-1",
+        "ex:p2": "value-2",
+        "ex:p3": "value-3",
+        "ex:p4": "value-4",
+        "ex:p5": "value-5",
+        "ex:p6": "value-6",
+        "ex:p7": "value-7",
+        "ex:p8": "value-8",
+    });
+    fluree.insert(ledger0, &tx).await.expect("insert");
+
+    // Reindex so the eight predicates land in the persisted dict and the
+    // SPOT scan path (not novelty-only) handles the subsequent crawls.
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+}
+
+fn explicit_query(ledger: &str, picks: &[&str]) -> Value {
+    let mut list: Vec<Value> = picks
+        .iter()
+        .map(|p| Value::String((*p).to_string()))
+        .collect();
+    list.insert(0, Value::String("@id".to_string()));
+    json!({
+        "@context": ctx(),
+        "from": ledger,
+        "select": { "ex:subj-1": list },
+    })
+}
+
+fn wildcard_query(ledger: &str) -> Value {
+    json!({
+        "@context": ctx(),
+        "from": ledger,
+        "select": { "ex:subj-1": ["*"] },
+    })
+}
+
+async fn tracked_fuel(fluree: &fluree_db_api::Fluree, query: &Value) -> f64 {
+    let resp = fluree
+        .query_from()
+        .jsonld(query)
+        .track_all()
+        .execute_tracked()
+        .await
+        .expect("execute_tracked");
+    assert_eq!(resp.status, 200, "query failed: {resp:?}");
+    resp.fuel.expect("fuel is tracked")
+}
+
+/// Narrow projections consume strictly less tracked fuel than wide ones on
+/// the same subject — proves the dict-touch gate fires on dropped predicates.
+#[tokio::test]
+async fn narrow_projection_costs_less_fuel_than_wide() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/scaling:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+
+    // Wide: project all 8 predicates explicitly. The range provider hands us
+    // all 8 string flakes; each pays a dict touch.
+    let wide = explicit_query(
+        ledger_id,
+        &[
+            "ex:p1", "ex:p2", "ex:p3", "ex:p4", "ex:p5", "ex:p6", "ex:p7", "ex:p8",
+        ],
+    );
+    let wide_fuel = tracked_fuel(&fluree, &wide).await;
+
+    // Narrow: project only 2 of the 8. The range provider drops the other 6
+    // before decode — 6 dict touches + 6 per-row charges saved.
+    let narrow = explicit_query(ledger_id, &["ex:p1", "ex:p2"]);
+    let narrow_fuel = tracked_fuel(&fluree, &narrow).await;
+
+    // Expected saving on 6 dropped string-valued predicates:
+    //   6 × DICT_TOUCH (0.010)  = 0.060
+    // + 6 × PER_ROW    (0.001)  = 0.006
+    //                  total    = 0.066 fuel
+    // We assert at least 0.040 fuel saved to leave headroom for unrelated
+    // micro-charges shifting between runs (object-decode bookkeeping, etc.).
+    let saved = wide_fuel - narrow_fuel;
+    assert!(
+        saved >= 0.040,
+        "narrow projection should save at least 0.040 fuel vs wide (saw {saved:.3}: wide={wide_fuel:.3}, narrow={narrow_fuel:.3})",
+    );
+}
+
+/// Wildcard projections never opt into the predicate filter, so they cost
+/// the same as a full Explicit projection over the same subject.
+#[tokio::test]
+async fn wildcard_projection_matches_full_explicit_projection() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/wildcard-eq:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+
+    let wild = wildcard_query(ledger_id);
+    let wild_fuel = tracked_fuel(&fluree, &wild).await;
+
+    // Full Explicit list (all 8 user predicates + @type the schema emitted)
+    // — the predicate set is the same set the wildcard wants, so fuel must
+    // be within a tiny epsilon.
+    let full = explicit_query(
+        ledger_id,
+        &[
+            "ex:p1", "ex:p2", "ex:p3", "ex:p4", "ex:p5", "ex:p6", "ex:p7", "ex:p8",
+        ],
+    );
+    let full_fuel = tracked_fuel(&fluree, &full).await;
+
+    // @type isn't in the Explicit list, so the Explicit fuel is actually
+    // slightly LOWER (one fewer dict touch for the @type flake). Just sanity-
+    // check they're in the same ballpark — within 0.030 fuel.
+    let delta = (wild_fuel - full_fuel).abs();
+    assert!(
+        delta < 0.030,
+        "wildcard and full-explicit fuel should be within 0.030 (wild={wild_fuel:.3}, full={full_fuel:.3}, delta={delta:.3})",
+    );
+}
+
+/// Per-key bytes also drop: the formatter only emits keys for predicates the
+/// projection asked for. (Same as today — this is a smoke test that we
+/// haven't broken the actual JSON output shape.)
+#[tokio::test]
+async fn narrow_projection_emits_only_selected_keys() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/narrow-keys:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+
+    let narrow = explicit_query(ledger_id, &["ex:p1", "ex:p3"]);
+    let resp = fluree
+        .query_from()
+        .jsonld(&narrow)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted");
+
+    // Single-column projection emits a bare object per row.
+    let row = resp
+        .as_array()
+        .expect("rows array")
+        .first()
+        .expect("at least one row");
+    let obj = row.as_object().expect("object row");
+    assert!(
+        obj.contains_key("@id"),
+        "row keys: {:?}",
+        obj.keys().collect::<Vec<_>>()
+    );
+    assert!(obj.contains_key("ex:p1"));
+    assert!(obj.contains_key("ex:p3"));
+    for unselected in ["ex:p2", "ex:p4", "ex:p5", "ex:p6", "ex:p7", "ex:p8"] {
+        assert!(
+            !obj.contains_key(unselected),
+            "narrow projection should not emit `{unselected}` — row: {row:?}",
+        );
+    }
+}
+
+/// Overlay retract on a SELECTED predicate is honored: the retracted value
+/// is dropped from the result. Catches a regression where the overlay filter
+/// might accidentally drop retracts before they cancel base assertions.
+#[tokio::test]
+async fn overlay_retract_on_selected_predicate_is_honored() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/overlay-selected-retract:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+
+    // Retract ex:p1 — this lands in novelty (no reindex after).
+    let retract = json!({
+        "@context": ctx(),
+        "delete": {
+            "@id": "ex:subj-1",
+            "ex:p1": "value-1",
+        }
+    });
+    fluree.update(ledger, &retract).await.expect("retract");
+
+    // Project ex:p1 explicitly. The overlay retract must remove it from the
+    // result even though the persisted base scan still has the assertion.
+    let q = explicit_query(ledger_id, &["ex:p1", "ex:p2"]);
+    let resp = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted");
+    let row = resp.as_array().expect("rows").first().expect("row");
+    let obj = row.as_object().expect("obj");
+    assert!(
+        !obj.contains_key("ex:p1"),
+        "selected-predicate retract should remove the key — row: {row:?}",
+    );
+    assert!(
+        obj.contains_key("ex:p2"),
+        "non-retracted selected predicate should remain — row: {row:?}",
+    );
+}
+
+/// Overlay retract on an UNSELECTED predicate is invisible — the discarded
+/// retract should never surface as either an absent key (it wasn't selected)
+/// or a smuggled-in row (overlay filter must not promote non-selected ops).
+#[tokio::test]
+async fn overlay_retract_on_unselected_predicate_does_not_leak() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/overlay-unselected-retract:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+
+    // Retract ex:p7 (not in the projection below).
+    let retract = json!({
+        "@context": ctx(),
+        "delete": {
+            "@id": "ex:subj-1",
+            "ex:p7": "value-7",
+        }
+    });
+    fluree.update(ledger, &retract).await.expect("retract");
+
+    // Project only ex:p1, ex:p2 — the ex:p7 retract isn't relevant.
+    let q = explicit_query(ledger_id, &["ex:p1", "ex:p2"]);
+    let resp = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted");
+    let row = resp.as_array().expect("rows").first().expect("row");
+    let obj = row.as_object().expect("obj");
+    assert!(obj.contains_key("ex:p1"));
+    assert!(obj.contains_key("ex:p2"));
+    assert!(
+        !obj.contains_key("ex:p7"),
+        "unselected predicate must not appear"
+    );
+}

--- a/fluree-db-api/tests/it_hydration_predicate_gating.rs
+++ b/fluree-db-api/tests/it_hydration_predicate_gating.rs
@@ -298,6 +298,101 @@ async fn overlay_retract_on_selected_predicate_is_honored() {
     );
 }
 
+/// Regression: a novelty-only selected predicate must survive the K≥2 gate.
+///
+/// Setup: seed + reindex base (so `ex:p1` is in the persisted predicate dict),
+/// then INSERT a brand-new `ex:noveltyPred` without reindexing — its Sid has
+/// no persisted p_id, only a novelty assignment, and surfaces in the cursor
+/// stream under an ephemeral p_id assigned by the overlay translator.
+///
+/// Before the ephemeral-p_id extension fix, the row-loop gate was built
+/// from persisted-dict resolutions only; the ephemeral p_id was unknown to
+/// the allow-list and the row got silently dropped. Projection should now
+/// include both values.
+#[tokio::test]
+async fn novelty_only_predicate_survives_k_ge_2_gate() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/novelty-only-pred:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+
+    // Assert a brand-new predicate that doesn't exist in the persisted dict.
+    let insert = json!({
+        "@context": ctx(),
+        "@id": "ex:subj-1",
+        "ex:noveltyPred": "novelty-value",
+    });
+    fluree
+        .insert(ledger, &insert)
+        .await
+        .expect("insert novelty");
+
+    // K=2 projection: one persisted predicate + the novelty-only one. Both
+    // must come back. (K=2 → goes through SPOT(s,*,*) + predicate_filter,
+    // which is the path the bug lived on.)
+    let q = explicit_query(ledger_id, &["ex:p1", "ex:noveltyPred"]);
+    let resp = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted");
+    let row = resp.as_array().expect("rows").first().expect("row");
+    let obj = row.as_object().expect("obj");
+    assert!(
+        obj.contains_key("ex:p1"),
+        "persisted predicate: row: {row:?}"
+    );
+    assert!(
+        obj.contains_key("ex:noveltyPred"),
+        "novelty-only predicate must not be dropped by the persisted-id gate \
+         — row: {row:?}",
+    );
+}
+
+/// Regression: an Explicit projection with no forward `Property` items
+/// (e.g. `["@id"]`) must NOT open the SPOT cursor. Opening it would still
+/// pay one INDEX_TOUCH (0.010 fuel) per leaflet batch even though every
+/// row is filtered out by the row loop.
+#[tokio::test]
+async fn id_only_projection_skips_forward_cursor() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/id-only:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+
+    // K=0 projection: just `@id`. No forward predicates → no SPOT scan.
+    let q = json!({
+        "@context": ctx(),
+        "from": ledger_id,
+        "select": { "ex:subj-1": ["@id"] },
+    });
+    let resp = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted");
+    let row = resp.as_array().expect("rows").first().expect("row");
+    let obj = row.as_object().expect("obj");
+    assert_eq!(obj.len(), 1, "only @id should appear — row: {row:?}");
+    assert!(obj.contains_key("@id"));
+
+    // Fuel sanity: K=0 should cost strictly less than K=1 on the same subject.
+    // K=1 still opens the cursor (one INDEX_TOUCH + one survivor row +
+    // one dict touch); K=0 doesn't open the cursor at all (saves at minimum
+    // one INDEX_TOUCH per surveyed subject root).
+    let k0_fuel = tracked_fuel(&fluree, &q).await;
+    let k1_fuel = tracked_fuel(&fluree, &explicit_query(ledger_id, &["ex:p1"])).await;
+    assert!(
+        k0_fuel + 0.005 < k1_fuel,
+        "K=0 ({k0_fuel:.3}) should be measurably cheaper than K=1 ({k1_fuel:.3})",
+    );
+}
+
 /// Overlay retract on an UNSELECTED predicate is invisible — the discarded
 /// retract should never surface as either an absent key (it wasn't selected)
 /// or a smuggled-in row (overlay filter must not promote non-selected ops).

--- a/fluree-db-api/tests/it_hydration_predicate_gating.rs
+++ b/fluree-db-api/tests/it_hydration_predicate_gating.rs
@@ -166,6 +166,54 @@ async fn wildcard_projection_matches_full_explicit_projection() {
     );
 }
 
+/// K=1 single-predicate fast path: a projection naming exactly one forward
+/// predicate routes through `SPOT(s,p,*)` (via `RangeMatch::subject_predicate`)
+/// rather than `SPOT(s,*,*)` + predicate_filter. Correctness contract: the
+/// JSON output must include the requested predicate and `@id`, and nothing
+/// else.
+///
+/// Fuel-wise, K=1 should be ≤ a K=2 narrow projection on the same subject —
+/// one fewer survivor row, one fewer dict touch.
+#[tokio::test]
+async fn single_predicate_projection_uses_sp_pair_path() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path().to_str().unwrap();
+    let ledger_id = "hyd/single-pred:main";
+    seed_eight_string_predicates(path, ledger_id).await;
+    let fluree = FlureeBuilder::file(path).build().expect("reopen");
+
+    // K=1: just one forward predicate.
+    let single = explicit_query(ledger_id, &["ex:p3"]);
+    let resp = fluree
+        .query_from()
+        .jsonld(&single)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted");
+    let row = resp.as_array().expect("rows").first().expect("row");
+    let obj = row.as_object().expect("obj");
+
+    assert!(obj.contains_key("@id"));
+    assert!(obj.contains_key("ex:p3"), "row: {row:?}");
+    for unselected in [
+        "ex:p1", "ex:p2", "ex:p4", "ex:p5", "ex:p6", "ex:p7", "ex:p8",
+    ] {
+        assert!(
+            !obj.contains_key(unselected),
+            "K=1 projection should not emit `{unselected}` — row: {row:?}",
+        );
+    }
+
+    // Fuel sanity: K=1 should not cost MORE than K=2 on the same subject.
+    // (Strict-less is harder to assert without flake; same-or-less is safe.)
+    let k1_fuel = tracked_fuel(&fluree, &single).await;
+    let k2_fuel = tracked_fuel(&fluree, &explicit_query(ledger_id, &["ex:p3", "ex:p4"])).await;
+    assert!(
+        k1_fuel <= k2_fuel + 0.001,
+        "K=1 fuel ({k1_fuel:.3}) should be ≤ K=2 fuel ({k2_fuel:.3}) on the same subject",
+    );
+}
+
 /// Per-key bytes also drop: the formatter only emits keys for predicates the
 /// projection asked for. (Same as today — this is a smoke test that we
 /// haven't broken the actual JSON output shape.)

--- a/fluree-db-core/src/query_bounds.rs
+++ b/fluree-db-core/src/query_bounds.rs
@@ -3,6 +3,8 @@
 //! These types define the query interface (what to match, how to compare,
 //! query options) and are independent of the underlying index implementation.
 
+use std::sync::Arc;
+
 use crate::sid::Sid;
 use crate::temporal;
 use crate::value::FlakeValue;
@@ -306,6 +308,20 @@ pub struct RangeOptions {
     /// Set to 0 to disable prefetch. Default is 3.
     /// Prefetch overlaps I/O with processing to reduce cold query latency.
     pub prefetch_n: Option<usize>,
+    /// Optional forward-predicate allow-list (by `Sid`).
+    ///
+    /// When set, the range provider drops rows whose predicate is not in the
+    /// list **before** decoding the object value, resolving the subject Sid,
+    /// or charging dict-touch fuel — i.e., it converts a single SPOT(s,*,*)
+    /// scan into a selective subject crawl without forcing per-predicate
+    /// probes. None preserves the previous behavior (decode every row).
+    ///
+    /// Hint to providers; cursor work is unchanged (one bounded scan over
+    /// the subject's range). Used by graph-crawl hydration when the
+    /// projection lists explicit forward predicates (non-wildcard).
+    /// Use `Arc<[Sid]>` so the same allow-list is shared cheaply across the
+    /// N per-subject range calls a single hydration emits.
+    pub predicate_filter: Option<Arc<[Sid]>>,
 }
 
 impl RangeOptions {
@@ -389,6 +405,17 @@ impl RangeOptions {
     /// Disable prefetch
     pub fn without_prefetch(mut self) -> Self {
         self.prefetch_n = Some(0);
+        self
+    }
+
+    /// Set the forward-predicate allow-list.
+    ///
+    /// See [`RangeOptions::predicate_filter`] for semantics. Callers should
+    /// keep the slice small (typical hydration projections: <16 entries) and
+    /// share the `Arc<[Sid]>` across all the range calls a single subject
+    /// crawl emits.
+    pub fn with_predicate_filter(mut self, preds: Arc<[Sid]>) -> Self {
+        self.predicate_filter = Some(preds);
         self
     }
 }

--- a/fluree-db-memory/src/store.rs
+++ b/fluree-db-memory/src/store.rs
@@ -764,44 +764,6 @@ WHERE {{\n\
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fluree_db_api::FlureeBuilder;
-
-    #[tokio::test]
-    async fn is_initialized_finds_memory_ledger_by_normalized_id() {
-        let fluree = FlureeBuilder::memory().build_memory();
-        fluree
-            .create_ledger(MEMORY_LEDGER)
-            .await
-            .expect("create memory ledger");
-        let store = MemoryStore::new(fluree, None);
-
-        assert!(
-            store.is_initialized().await.expect("check initialized"),
-            "ledger_exists should accept the normalized __memory:main ledger id"
-        );
-    }
-
-    #[tokio::test]
-    async fn drop_and_reinit_drops_by_whole_ledger_name() {
-        let fluree = FlureeBuilder::memory().build_memory();
-        let store = MemoryStore::new(fluree, None);
-        store.initialize().await.expect("initialize memory store");
-
-        store
-            .drop_and_reinit()
-            .await
-            .expect("drop and reinitialize memory ledger");
-
-        assert!(
-            store.is_initialized().await.expect("check initialized"),
-            "memory ledger should exist after drop_and_reinit"
-        );
-    }
-}
-
 // ---------------------------------------------------------------------------
 // SPARQL result parsing helpers
 // ---------------------------------------------------------------------------
@@ -1094,5 +1056,43 @@ fn iri_to_kind(iri: &str) -> Option<MemoryKind> {
         // Backwards compat: map removed kinds to Fact
         "Preference" | "Artifact" => Some(MemoryKind::Fact),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_api::FlureeBuilder;
+
+    #[tokio::test]
+    async fn is_initialized_finds_memory_ledger_by_normalized_id() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        fluree
+            .create_ledger(MEMORY_LEDGER)
+            .await
+            .expect("create memory ledger");
+        let store = MemoryStore::new(fluree, None);
+
+        assert!(
+            store.is_initialized().await.expect("check initialized"),
+            "ledger_exists should accept the normalized __memory:main ledger id"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_and_reinit_drops_by_whole_ledger_name() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let store = MemoryStore::new(fluree, None);
+        store.initialize().await.expect("initialize memory store");
+
+        store
+            .drop_and_reinit()
+            .await
+            .expect("drop and reinitialize memory ledger");
+
+        assert!(
+            store.is_initialized().await.expect("check initialized"),
+            "memory ledger should exist after drop_and_reinit"
+        );
     }
 }

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -360,6 +360,21 @@ fn binary_range_eq_v3(
         }
     };
 
+    // Resolve the optional projection-predicate allow-list once.
+    //
+    // `predicate_filter_p_ids` is the persisted-dict p_id set used in the row
+    // loop to skip decode/resolve for unselected base flakes; unresolvable
+    // Sids simply don't appear (the base scan can't surface them). The
+    // original Sid slice still gates the overlay translator so novel
+    // predicates in the allow-list survive the overlay path even without a
+    // persisted p_id.
+    let predicate_filter_p_ids: Option<Vec<u32>> = opts.predicate_filter.as_deref().map(|sids| {
+        let mut ids: Vec<u32> = sids.iter().filter_map(|s| store.sid_to_p_id(s)).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    });
+
     // Create cursor: use range-narrowed scan when any filter field is bound,
     // matching the pattern in BinaryScanOperator::open. For novelty-only subjects
     // this yields an empty leaf_range, so the cursor drains overlay ops directly
@@ -410,7 +425,12 @@ fn binary_range_eq_v3(
     let effective_to_t = opts.to_t.unwrap_or_else(|| store.max_t());
     cursor.set_to_t(effective_to_t);
 
-    // Overlay translation.
+    // Overlay translation. When the caller supplied a projection-predicate
+    // allow-list, filter overlay flakes by `flake.p` before translation —
+    // this both skips work on discarded overlay rows and ensures the
+    // untranslated raw-fallback set doesn't smuggle non-selected predicates
+    // back in. Sid match (vs persisted p_id) so novel predicates still pass.
+    let predicate_filter_sids = opts.predicate_filter.clone();
     let OverlayTranslateV3Result {
         mut ops,
         raw: untranslated,
@@ -424,7 +444,10 @@ fn binary_range_eq_v3(
         store,
         dict_novelty,
         runtime_small_dicts,
-        |_| true,
+        move |flake| match &predicate_filter_sids {
+            Some(allow) => allow.iter().any(|p| p == &flake.p),
+            None => true,
+        },
         "V3 range",
     );
 
@@ -445,15 +468,31 @@ fn binary_range_eq_v3(
 
     while let Some(batch) = cursor.next_batch()? {
         for i in 0..batch.row_count {
-            let s_id = batch.s_id.get(i);
             let p_id = batch.p_id.get_or(i, 0);
+
+            // Projection-predicate gate. Skip discarded predicates before any
+            // dict touch (subject resolve, predicate IRI, object decode,
+            // datatype/lang lookups) — purely an integer probe.
+            if let Some(allow) = &predicate_filter_p_ids {
+                if allow.binary_search(&p_id).is_err() {
+                    continue;
+                }
+            }
+
+            let s_id = batch.s_id.get(i);
             let o_type = batch.o_type.get_or(i, 0);
             let o_key = batch.o_key.get(i);
             let t = batch.t.get_or(i, 0) as i64;
             let o_i = batch.o_i.get_or(i, u32::MAX);
 
-            // Resolve subject.
-            let s_sid = resolve_sid(s_id, &view)?;
+            // Resolve subject. Reuse the caller-supplied Sid when present —
+            // the bound `match_val.s` IS the subject for every base row this
+            // scan returns, so the per-row `resolve_subject_sid` (a dict
+            // touch on the persisted path) is redundant.
+            let s_sid = match &match_val.s {
+                Some(sid) => sid.clone(),
+                None => resolve_sid(s_id, &view)?,
+            };
             // Resolve predicate: persisted dict first, then ephemeral overlay map.
             let p_sid = match store.resolve_predicate_iri(p_id) {
                 Some(iri) => store.encode_iri(iri),
@@ -1293,6 +1332,16 @@ fn overlay_only_flakes(
             }
             if let Some(ref o_val) = match_val.o {
                 if flake.o != *o_val {
+                    return;
+                }
+            }
+
+            // Projection-predicate allow-list (parity with the indexed path).
+            // Applied here for novelty-only subjects that bypass the cursor
+            // loop above (subject/predicate/object Sid unresolvable in the
+            // persisted dict, or no branch manifest for this order).
+            if let Some(ref allow) = opts.predicate_filter {
+                if !allow.iter().any(|p| p == &flake.p) {
                     return;
                 }
             }

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -362,18 +362,20 @@ fn binary_range_eq_v3(
 
     // Resolve the optional projection-predicate allow-list once.
     //
-    // `predicate_filter_p_ids` is the persisted-dict p_id set used in the row
-    // loop to skip decode/resolve for unselected base flakes; unresolvable
-    // Sids simply don't appear (the base scan can't surface them). The
-    // original Sid slice still gates the overlay translator so novel
-    // predicates in the allow-list survive the overlay path even without a
-    // persisted p_id.
-    let predicate_filter_p_ids: Option<Vec<u32>> = opts.predicate_filter.as_deref().map(|sids| {
-        let mut ids: Vec<u32> = sids.iter().filter_map(|s| store.sid_to_p_id(s)).collect();
-        ids.sort_unstable();
-        ids.dedup();
-        ids
-    });
+    // `predicate_filter_p_ids` is the row-loop's allow-set of `u32` p_ids.
+    // We seed it with persisted-dict resolutions here; novelty-only
+    // predicates (no persisted p_id yet) get appended below after overlay
+    // translation surfaces their ephemeral p_ids via `ephemeral_p_id_to_sid`.
+    // Without that extension, an overlay assert on a novelty-only selected
+    // predicate would survive the overlay translator's Sid filter, land in
+    // the cursor stream with an ephemeral p_id, and then get silently
+    // dropped here.
+    let mut predicate_filter_p_ids: Option<Vec<u32>> =
+        opts.predicate_filter.as_deref().map(|sids| {
+            sids.iter()
+                .filter_map(|s| store.sid_to_p_id(s))
+                .collect::<Vec<u32>>()
+        });
 
     // Create cursor: use range-narrowed scan when any filter field is bound,
     // matching the pattern in BinaryScanOperator::open. For novelty-only subjects
@@ -457,6 +459,25 @@ fn binary_range_eq_v3(
         let epoch = overlay.epoch();
         cursor.set_overlay_ops(ops);
         cursor.set_epoch(epoch);
+    }
+
+    // Extend the row-loop allow-set with ephemeral p_ids whose mapped Sid is
+    // in the caller's allow-list — these are novelty-only predicates that
+    // have no persisted p_id yet, so they were not captured during the
+    // initial Sid-to-p_id resolution. The overlay translator already let
+    // them through via Sid match; without this step the row loop would
+    // drop them under their cursor-side ephemeral p_id.
+    if let (Some(allow_sids), Some(allow_ids)) = (
+        opts.predicate_filter.as_deref(),
+        predicate_filter_p_ids.as_mut(),
+    ) {
+        for (eph_p_id, sid) in &ephemeral_p_id_to_sid {
+            if allow_sids.iter().any(|s| s == sid) {
+                allow_ids.push(*eph_p_id);
+            }
+        }
+        allow_ids.sort_unstable();
+        allow_ids.dedup();
     }
 
     // Iterate and decode to Flakes.


### PR DESCRIPTION
Hydration / graph-crawl SELECT projections now hand the range provider a forward-predicate allow-list so the per-subject SPOT scan skips object decode, subject resolve, predicate IRI lookup, and dict-touch fuel charges on rows whose predicate isn't in the projection. For Explicit projections (`select: {"?x": ["ex:a", "ex:b", …]}`) this turns the projection's field count into a real cost lever — both work and fuel scale with selected predicates rather than the subject's total predicate count. Wildcard projections (`["*"]`) take the unchanged decode-everything path. K=1 projections get a further narrow-scan fast path via `RangeMatch::subject_predicate`.

## Why

Before this change, `fetch_subject_properties` issued a single `SPOT(s,*,*)` range per subject. The row loop in `binary_range_eq_v3` materialized every flake — subject Sid resolve, persisted predicate IRI lookup, **eager object decode (one dict touch per dict-backed value)**, datatype + lang resolution — *before* the caller's projection got to drop the predicates it didn't want. Two queries against the same WHERE clause but different projections (9 fields vs 4) consumed identical tracked fuel because all the per-row charges had already fired. More importantly, the per-row dict reads happened whether or not the projection cared about the value — real I/O and cache pressure spent on objects the formatter would throw away.

This PR moves the projection filter down into the range provider so unselected predicates are dropped before any of that work happens. The savings on a typical narrow projection are a handful of dict touches per subject, which multiply across rows; on fat subjects with narrow projections the effect compounds.

## What scales now

| Cost | Behavior |
|---|---|
| **Per-flake (`0.001`), subject-resolve, object-decode, dict-touch (`0.010`)** | Scales with the **number of selected predicates** |
| **Index leaflet touches (`0.010` each)** | Still scales with the cursor's scanned subject range — the filter narrows which rows get materialized, not how many leaflets get read. K=1 gets a narrower cursor key-range via `SPOT(s,p,*)`. |
| **Wildcard projections** | Unchanged — every flake materialized and charged |
| **Explicit projection with no forward `Property` items** (e.g. `["@id"]`, reverse-only) | Skips the forward SPOT scan entirely — no `INDEX_TOUCH` |

## How

### `RangeOptions::predicate_filter`

New optional field carrying the projection's forward-predicate Sids:

```rust
pub struct RangeOptions {
    // …existing fields…
    pub predicate_filter: Option<Arc<[Sid]>>,
}
```

`None` preserves the legacy decode-everything path with zero overhead. `Arc<[Sid]>` so the same allow-list is shared cheaply across the N per-subject range calls a single hydration emits.

### `binary_range_eq_v3` row loop

The row loop hoists a `binary_search` against a sorted `Vec<u32>` of persisted `p_id`s above every per-row resolve / decode:

```rust
let p_id = batch.p_id.get_or(i, 0);

if let Some(allow) = &predicate_filter_p_ids {
    if allow.binary_search(&p_id).is_err() {
        continue;                                    // ← bail BEFORE any dict touch
    }
}

// only survivors reach these:
let s_sid  = match &match_val.s {
    Some(sid) => sid.clone(),                        // reuse bound subject Sid
    None => resolve_sid(s_id, &view)?,
};
let p_sid  = store.resolve_predicate_iri(p_id);
let o_val  = view.decode_value(o_type, o_key, p_id)?;   // ← dict touch fires here
// …datatype, lang, FlakeMeta…
```

Also reuses the caller-supplied `match_val.s` instead of calling `resolve_subject_sid` per row — one fewer dict touch per scanned base row on the indexed path (every hydration call already has the subject Sid in hand).

### Overlay translator filter

The overlay translator's `include` closure now filters by Sid match before calling `translate_one_flake_v3_pub`, so overlay asserts/retracts on non-selected predicates never enter the merge stream. Novelty-only predicates (no persisted `p_id` yet) are honored: after overlay translation surfaces ephemeral `p_id`s via `ephemeral_p_id_to_sid`, the row-loop's allow-set is extended with any ephemeral `p_id` whose mapped Sid is in the caller's filter. Without that extension, an overlay assert on a selected novelty-only predicate would survive the Sid filter, land in the cursor stream under an ephemeral `p_id`, and get silently dropped by the gate.

### `overlay_only_flakes` fallback

Same predicate filter applied to the novelty-only fast path (subject/predicate/object Sid unresolvable in the persisted dict, or no branch manifest for this order). Keeps parity between indexed and overlay-only subjects.

### Hydration formatter dispatch

`format_subject` derives the allow-list from each level's `NestedSelectSpec` and picks the cheapest path:

```rust
let predicate_filter = predicate_filter_for_level(level);
let flakes = match predicate_filter.as_deref() {
    Some([])    => Vec::new(),                                      // K=0: skip cursor
    Some([p])   => self.fetch_subject_predicate_pair(sid, p).await?, // K=1: SPOT(s,p,*)
    _           => self.fetch_subject_properties(sid, predicate_filter).await?,  // K=N or wildcard
};
```

- **K = 0** (Explicit `["@id"]` or reverse-only): skip the forward fetch entirely. Saves one `INDEX_TOUCH` per surveyed subject; `@id` is derived from the subject Sid by the caller, reverse properties go through the dedicated POST scan further down.
- **K = 1**: `SPOT(s, p, *)` via `RangeMatch::subject_predicate` — narrows the cursor's leaflet key-range to the `(s, p)` prefix. Same `INDEX_TOUCH` count for small subjects, strictly fewer for subjects whose flakes span multiple leaflet batches. Also skips the row-loop `binary_search`.
- **K ≥ 2**: `SPOT(s, *, *)` + `predicate_filter` — one cursor descent, drops non-listed rows before decode/dict-touch. Two probes would each pay their own `INDEX_TOUCH` and beat the single-scan baseline; one batched scan + cheap row-loop gate wins.

The same pattern repeats recursively through nested hydrations — every `format_subject` call (for ref-expansions, reverse properties, etc.) re-derives the filter from its own level's spec.

## Tests

New `fluree-db-api/tests/it_hydration_predicate_gating.rs` (8 tests):

| Test | What it pins |
|---|---|
| `narrow_projection_costs_less_fuel_than_wide` | Tracked fuel on a 2-of-8 projection ≥ 0.040 less than 8-of-8 — proves dict-touch + per-row gate fires on dropped predicates |
| `wildcard_projection_matches_full_explicit_projection` | `["*"]` and the 8-predicate Explicit list cost within 0.030 fuel — wildcard isn't accidentally opting into the filter |
| `single_predicate_projection_uses_sp_pair_path` | K=1 routes through `SPOT(s,p,*)` (correctness contract); K=1 fuel ≤ K=2 fuel |
| `narrow_projection_emits_only_selected_keys` | JSON output shape: narrow projection only emits selected keys + `@id` |
| `overlay_retract_on_selected_predicate_is_honored` | Novelty retract on a selected predicate drops the value (overlay filter doesn't mask the retract) |
| `overlay_retract_on_unselected_predicate_does_not_leak` | Novelty retract on a non-selected predicate doesn't surface |
| `novelty_only_predicate_survives_k_ge_2_gate` | **Regression**: novelty-only selected predicate (no persisted `p_id`) survives the K≥2 gate via the ephemeral-p_id extension |
| `id_only_projection_skips_forward_cursor` | K=0 projection (`["@id"]`) emits just `@id` and costs measurably less than K=1 — proves the cursor is skipped |

## Docs

`docs/query/tracking-and-fuel.md` gets a new **Graph-crawl projection: materialization fuel scales with selected predicates** subsection that:
- Names what scales (per-flake, subject-resolve, object-decode, dict-touch) and what doesn't (index leaflet touches still depend on the scanned subject range)
- Calls out the K=1 narrowed-cursor path and the K=0 skip
- Documents the wildcard preservation and the overlay filter behavior (including novelty-only predicate handling)

## Side commit

`chore: silence clippy items_after_test_module in memory store` — pure relocation in `fluree-db-memory/src/store.rs`: the SPARQL result parsing helpers were defined after `mod tests`, which trips `clippy::items_after_test_module` under `-D warnings`. Moves the `mod tests` block to the bottom of the file. No behavior change. Surfaced during this PR's CI parity check; unrelated to the feature but needed for the workspace clippy gate to pass.

## Breaking changes

None at the wire layer. New `RangeOptions::predicate_filter: Option<Arc<[Sid]>>` field is optional; existing callers (every range caller outside hydration) leave it `None` and observe identical behavior. Hydration formatter's `fetch_subject_properties` gained a `predicate_filter` parameter — only used internally by `format_subject`.

## Future work (not in this PR)

- **Parallelize hydration rows.** Today `format_subject` is awaited serially per row (see `hydration.rs:368-389`). Row-level fanout via `FuturesUnordered` or a bounded `JoinSet` (mirroring the multi-query dispatcher) would parallelize independent row expansions; the shared result cache would need to move to `Arc<DashMap>` (sharded locking matches the access pattern). Fuel/policy already use atomic counters and would survive parallel tasks unchanged.
- **Per-predicate cardinality stats** would enable promoting K=2/K=3 narrow projections on fat subjects to per-predicate `SPOT(s,p,*)` probes when the savings beat the extra `INDEX_TOUCH` cost. Not worth pursuing until query telemetry shows fat-subject hydration is a real bottleneck.
