### PR TITLE
feature: Expand bulk-import format coverage: N-Triples, N-Quads, TriG named graphs, transparent gzip/zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "colored",
  "comfy-table",
  "dirs 5.0.1",
+ "flate2",
  "fluree-db-api",
  "fluree-db-binary-index",
  "fluree-db-core",
@@ -2450,6 +2451,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "urlencoding",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "criterion",
  "dirs 5.0.1",
  "ed25519-dalek",
+ "flate2",
  "fluree-bench-support",
  "fluree-db-binary-index",
  "fluree-db-connection",
@@ -2362,6 +2363,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ wiremock = "0.6"
 
 # Compression
 zstd = "0.13"
+flate2 = "1"
 
 # Iceberg format support (manifest Avro, data Parquet)
 apache-avro = "0.21.0"

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -198,6 +198,7 @@ POST /insert/{ledger-id}
 **Supported Content Types:**
 - `application/json` - JSON-LD
 - `text/turtle` - Turtle (fast direct flake path)
+- `application/n-triples` - N-Triples (parsed as Turtle)
 
 **Note:** TriG (`application/trig`) is **not supported** on the insert endpoint. Named graph ingestion via GRAPH blocks requires the upsert path. Use `/upsert` for TriG data.
 
@@ -232,6 +233,7 @@ POST /upsert/{ledger-id}
 **Supported Content Types:**
 - `application/json` - JSON-LD
 - `text/turtle` - Turtle
+- `application/n-triples` - N-Triples (parsed as Turtle)
 - `application/trig` - TriG with named graphs
 
 **Example (JSON-LD):**

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -18,7 +18,7 @@ fluree create <LEDGER> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--from <PATH>` | Import data from a file (Turtle, N-Triples, or JSON-LD). N-Triples (`.nt`) is parsed as Turtle. |
+| `--from <PATH>` | Import data from a file (Turtle, N-Triples, N-Quads, TriG, or JSON-LD), optionally `.gz`- or `.zst`-compressed. N-Triples (`.nt`) parses as Turtle; N-Quads (`.nq`) converts to TriG (named graphs supported). |
 | `--memory [PATH]` | Import memory history from a git-tracked `.fluree-memory/` directory. Defaults to the current repo if no path is given. Mutually exclusive with `--from`. |
 | `--no-user` | Exclude user-scoped memories (`.local/user.ttl`) from `--memory` import |
 | `--chunk-size-mb <MB>` | Chunk size in MB for splitting large Turtle files (0 = derive from memory budget). Only used when `--from` points to a `.ttl` or `.nt` file. |
@@ -34,7 +34,7 @@ fluree create <LEDGER> [OPTIONS]
 
 Creates a new empty ledger with the given name and sets it as the active ledger. The ledger is stored in `.fluree/storage/`.
 
-Use `--from` to create a ledger pre-populated with data from a Turtle, N-Triples, or JSON-LD file (or a directory of same-format files). N-Triples (`.nt`) is a strict subset of Turtle and is parsed by the same parser. For large Turtle/N-Triples files, the CLI splits work into chunks and runs parallel parse threads; tune with `--memory-budget-mb` and `--parallelism` if needed.
+Use `--from` to create a ledger pre-populated with data from a Turtle, N-Triples, N-Quads, TriG, or JSON-LD file (or a directory of same-format files). Any input may be gzip- or zstd-compressed and is decoded transparently (`data.ttl.gz`, `dump.nq.zst`, mixed directories — the underlying RDF extension classifies the file). N-Triples (`.nt`) is a strict subset of Turtle and is parsed by the same parser. N-Quads (`.nq`) and TriG (`.trig`) support named graphs — queryable after import via the `#<graph-iri>` fragment. For large Turtle/N-Triples files (including `.ttl.gz`/`.nt.gz`), the CLI splits work into chunks and runs parallel parse threads — though compressed inputs decode single-threaded; TriG/N-Quads/JSON-LD use a serial path. Tune with `--memory-budget-mb` and `--parallelism` if needed.
 
 Use `--memory` to import your project's developer memory history into a time-travel-capable Fluree ledger. Each git commit that touched `.fluree-memory/repo.ttl` (and `.local/user.ttl` unless `--no-user` is set) becomes a Fluree transaction. The git commit message, SHA, and author date are stored as transaction metadata, so you can correlate Fluree `t` values with git history.
 

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -18,10 +18,10 @@ fluree create <LEDGER> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--from <PATH>` | Import data from a file (Turtle or JSON-LD) |
+| `--from <PATH>` | Import data from a file (Turtle, N-Triples, or JSON-LD). N-Triples (`.nt`) is parsed as Turtle. |
 | `--memory [PATH]` | Import memory history from a git-tracked `.fluree-memory/` directory. Defaults to the current repo if no path is given. Mutually exclusive with `--from`. |
 | `--no-user` | Exclude user-scoped memories (`.local/user.ttl`) from `--memory` import |
-| `--chunk-size-mb <MB>` | Chunk size in MB for splitting large Turtle files (0 = derive from memory budget). Only used when `--from` points to a `.ttl` file. |
+| `--chunk-size-mb <MB>` | Chunk size in MB for splitting large Turtle files (0 = derive from memory budget). Only used when `--from` points to a `.ttl` or `.nt` file. |
 | `--leaflet-rows <N>` | Rows per leaflet in the binary index (default: 25000). Larger values produce fewer, bigger leaflets — less I/O per scan, more memory per read. |
 | `--leaflets-per-leaf <N>` | Leaflets per leaf file (default: 10). Larger values produce fewer leaf files — shallower tree, bigger reads. |
 
@@ -34,7 +34,7 @@ fluree create <LEDGER> [OPTIONS]
 
 Creates a new empty ledger with the given name and sets it as the active ledger. The ledger is stored in `.fluree/storage/`.
 
-Use `--from` to create a ledger pre-populated with data from a Turtle or JSON-LD file. For large Turtle files, the CLI splits work into chunks and runs parallel parse threads; tune with `--memory-budget-mb` and `--parallelism` if needed.
+Use `--from` to create a ledger pre-populated with data from a Turtle, N-Triples, or JSON-LD file (or a directory of same-format files). N-Triples (`.nt`) is a strict subset of Turtle and is parsed by the same parser. For large Turtle/N-Triples files, the CLI splits work into chunks and runs parallel parse threads; tune with `--memory-budget-mb` and `--parallelism` if needed.
 
 Use `--memory` to import your project's developer memory history into a time-travel-capable Fluree ledger. Each git commit that touched `.fluree-memory/repo.ttl` (and `.local/user.ttl` unless `--no-user` is set) becomes a Fluree transaction. The git commit message, SHA, and author date are stored as transaction metadata, so you can correlate Fluree `t` values with git history.
 

--- a/docs/cli/insert.md
+++ b/docs/cli/insert.md
@@ -74,7 +74,7 @@ Commit ID: bafybeig...
 The format is auto-detected:
 - `@prefix` or `@base` at line start → Turtle
 - Starts with `{` or `[` → JSON-LD
-- `.ttl` file extension → Turtle
+- `.ttl` or `.nt` file extension → Turtle (N-Triples is parsed as Turtle)
 - `.json` or `.jsonld` extension → JSON-LD
 
 Override with `--format turtle` or `--format jsonld`.

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -59,6 +59,8 @@ fluree-search-protocol = { path = "../fluree-search-protocol" }
 fluree-graph-ir = { path = "../fluree-graph-ir" }
 fluree-graph-format = { path = "../fluree-graph-format" }
 fluree-graph-turtle = { path = "../fluree-graph-turtle" }
+flate2 = { workspace = true }
+zstd = { workspace = true }
 fluree-db-credential = { path = "../fluree-db-credential", optional = true }
 fluree-db-shacl = { path = "../fluree-db-shacl", optional = true }
 fluree-vocab = { path = "../fluree-vocab" }
@@ -103,6 +105,9 @@ tracing-subscriber.workspace = true
 tempfile = "3.19"
 mimalloc.workspace = true
 fs2 = "0.4"
+# Used by import tests to produce .gz / .zst fixtures inline.
+flate2 = { workspace = true }
+zstd = { workspace = true }
 # Numeric types used by datatype tests
 num-bigint = "0.4"
 num-bigdecimal = { package = "bigdecimal", version = "0.4" }

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -694,9 +694,9 @@ impl ChunkSource {
 
 /// Resolve the import path into a `ChunkSource`.
 ///
-/// - If `path` is a directory: discover `.ttl`/`.trig`/`.jsonld` files (sorted lexicographically).
+/// - If `path` is a directory: discover `.ttl`/`.nt`/`.trig`/`.jsonld` files (sorted lexicographically).
 /// - If `path` is a single large `.ttl` file: auto-split using `TurtleChunkReader`.
-/// - If `path` is a single small `.ttl`/`.trig`/`.jsonld` file: treat as a single-element `Files` source.
+/// - If `path` is a single small `.ttl`/`.nt`/`.trig`/`.jsonld` file: treat as a single-element `Files` source.
 fn resolve_chunk_source(
     path: &Path,
     config: &ImportConfig,
@@ -717,10 +717,12 @@ fn resolve_chunk_source(
     let file_size = std::fs::metadata(path)?.len();
     let chunk_size_bytes = config.effective_chunk_size_mb() as u64 * 1024 * 1024;
 
+    // `.nt` (N-Triples) is a strict subset of Turtle, so it streams/splits
+    // through the same triple-boundary reader as `.ttl`.
     let is_ttl = path
         .extension()
         .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("ttl"));
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ttl") || ext.eq_ignore_ascii_case("nt"));
 
     if is_ttl && file_size > chunk_size_bytes {
         // Large file: stream chunks via background reader thread.
@@ -812,7 +814,8 @@ async fn resolve_remote_objects(
             .and_then(|e| e.to_str())
             .map(str::to_ascii_lowercase);
         match ext.as_deref() {
-            Some("ttl") => {
+            // `.nt` (N-Triples) is a Turtle subset — parse it as Turtle.
+            Some("ttl" | "nt") => {
                 has_ttl = true;
                 accepted.push(obj);
                 extensions.push(RemoteFormat::Ttl);
@@ -844,7 +847,7 @@ async fn resolve_remote_objects(
 
     if accepted.is_empty() {
         return Err(ImportError::NoChunks(
-            "remote source contains no .ttl/.trig/.jsonld objects".into(),
+            "remote source contains no .ttl/.nt/.trig/.jsonld objects".into(),
         ));
     }
 
@@ -1143,7 +1146,7 @@ impl<'a> CreateBuilder<'a> {
 
     /// Attach a bulk import to this create operation.
     ///
-    /// `path` can be a directory containing `.ttl`/`.trig`/`.jsonld` files
+    /// `path` can be a directory containing `.ttl`/`.nt`/`.trig`/`.jsonld` files
     /// (sorted lexicographically), or a single `.ttl`/`.jsonld` file.
     pub fn import(self, path: impl AsRef<Path>) -> ImportBuilder<'a> {
         ImportBuilder::new(self.fluree, self.ledger_id, path.as_ref().to_path_buf())
@@ -1186,7 +1189,7 @@ impl<'a> CreateBuilder<'a> {
 /// What kind of data files a directory contains.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirectoryFormat {
-    /// Only `.ttl` / `.trig` files found.
+    /// Only `.ttl` / `.nt` / `.trig` files found.
     Turtle,
     /// Only `.jsonld` files found.
     JsonLd,
@@ -1194,7 +1197,7 @@ pub enum DirectoryFormat {
 
 /// Scan a directory and determine its data format.
 ///
-/// Returns [`DirectoryFormat::Turtle`] if all supported files are `.ttl`/`.trig`,
+/// Returns [`DirectoryFormat::Turtle`] if all supported files are `.ttl`/`.nt`/`.trig`,
 /// [`DirectoryFormat::JsonLd`] if all are `.jsonld`.
 /// Returns [`ImportError::MixedFormats`] on mixed formats,
 /// [`ImportError::NoChunks`] on empty directories or directories with no supported files.
@@ -1212,7 +1215,7 @@ pub fn scan_directory_format(dir: &Path) -> std::result::Result<DirectoryFormat,
         }
         if let Some(ext) = entry.path().extension().and_then(|e| e.to_str()) {
             match ext.to_ascii_lowercase().as_str() {
-                "ttl" | "trig" => has_turtle = true,
+                "ttl" | "trig" | "nt" => has_turtle = true,
                 "jsonld" => has_jsonld = true,
                 _ => {}
             }
@@ -1228,7 +1231,7 @@ pub fn scan_directory_format(dir: &Path) -> std::result::Result<DirectoryFormat,
         (true, false) => Ok(DirectoryFormat::Turtle),
         (false, true) => Ok(DirectoryFormat::JsonLd),
         (false, false) => Err(ImportError::NoChunks(format!(
-            "no supported data files (.ttl, .trig, .jsonld) found in {}",
+            "no supported data files (.ttl, .nt, .trig, .jsonld) found in {}",
             dir.display()
         ))),
     }
@@ -1238,7 +1241,7 @@ pub fn scan_directory_format(dir: &Path) -> std::result::Result<DirectoryFormat,
 // Chunk discovery
 // ============================================================================
 
-/// Discover and sort `.ttl`, `.trig`, or `.jsonld` files from a directory (case-insensitive).
+/// Discover and sort `.ttl`, `.nt`, `.trig`, or `.jsonld` files from a directory (case-insensitive).
 ///
 /// Returns an error if the directory contains a mix of Turtle (`.ttl`/`.trig`) and
 /// JSON-LD (`.jsonld`) files — all files must be the same format family.
@@ -1266,6 +1269,7 @@ fn discover_chunks(dir: &Path) -> std::result::Result<Vec<PathBuf>, ImportError>
                 .and_then(|ext| ext.to_str())
                 .is_some_and(|ext| {
                     ext.eq_ignore_ascii_case("ttl")
+                        || ext.eq_ignore_ascii_case("nt")
                         || ext.eq_ignore_ascii_case("trig")
                         || ext.eq_ignore_ascii_case("jsonld")
                 })

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -515,6 +515,7 @@ pub(crate) enum ImportSource {
 pub(crate) enum RemoteFormat {
     Ttl,
     Trig,
+    Nquads,
     JsonLd,
 }
 
@@ -610,7 +611,9 @@ impl ChunkSource {
     /// Panics if called on `Streaming`/`Remote` — use `recv_next` instead.
     pub fn read_chunk(&self, index: usize) -> std::io::Result<String> {
         match self {
-            Self::Files(files) => std::fs::read_to_string(&files[index]),
+            // Transparently decodes `.gz` / `.zst` wrappers; plain files use
+            // the original `read_to_string` fast path inside `read_decoded_to_string`.
+            Self::Files(files) => read_decoded_to_string(&files[index]),
             Self::Streaming(_) | Self::Remote(_) => {
                 panic!("read_chunk not supported for channel-fed source; use recv_next")
             }
@@ -648,27 +651,55 @@ impl ChunkSource {
         }
     }
 
-    /// Whether chunk at `index` is a TriG file (case-insensitive).
+    /// Whether chunk at `index` is a TriG file (case-insensitive), including
+    /// compressed variants (`.trig.gz`, `.trig.zst`).
     pub fn is_trig(&self, index: usize) -> bool {
         match self {
             Self::Files(files) => files
                 .get(index)
-                .and_then(|p| p.extension())
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("trig")),
+                .is_some_and(|p| effective_extension(p).0.as_deref() == Some("trig")),
             Self::Streaming(_) => false, // Streaming is Turtle only.
             Self::Remote(producer) => matches!(producer.format_at(index), Some(RemoteFormat::Trig)),
         }
     }
 
-    /// Whether chunk at `index` is a JSON-LD file (case-insensitive `.jsonld`).
+    /// Whether chunk at `index` is an N-Quads file (`.nq`, also compressed).
+    ///
+    /// N-Quads is converted to TriG and dispatched through the same serial
+    /// `import_trig_commit` path, so it is handled wherever `is_trig` is.
+    pub fn is_nquads(&self, index: usize) -> bool {
+        match self {
+            Self::Files(files) => files
+                .get(index)
+                .is_some_and(|p| effective_extension(p).0.as_deref() == Some("nq")),
+            Self::Streaming(_) => false, // Streaming is Turtle only.
+            Self::Remote(producer) => {
+                matches!(producer.format_at(index), Some(RemoteFormat::Nquads))
+            }
+        }
+    }
+
+    /// Whether any chunk is N-Quads. Used to force serial import — the parallel
+    /// pipeline only handles plain Turtle.
+    pub fn has_nquads(&self) -> bool {
+        match self {
+            Self::Files(files) => files
+                .iter()
+                .any(|p| effective_extension(p).0.as_deref() == Some("nq")),
+            Self::Streaming(_) => false,
+            Self::Remote(producer) => producer
+                .per_chunk_format
+                .iter()
+                .any(|f| matches!(f, RemoteFormat::Nquads)),
+        }
+    }
+
+    /// Whether chunk at `index` is a JSON-LD file (`.jsonld`, also compressed).
     pub fn is_jsonld(&self, index: usize) -> bool {
         match self {
             Self::Files(files) => files
                 .get(index)
-                .and_then(|p| p.extension())
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonld")),
+                .is_some_and(|p| effective_extension(p).0.as_deref() == Some("jsonld")),
             Self::Streaming(_) => false,
             Self::Remote(producer) => {
                 matches!(producer.format_at(index), Some(RemoteFormat::JsonLd))
@@ -681,22 +712,101 @@ impl ChunkSource {
     /// Used to force serial import — the parallel pipeline only handles Turtle.
     pub fn has_jsonld(&self) -> bool {
         match self {
-            Self::Files(files) => files.iter().any(|p| {
-                p.extension()
-                    .and_then(|ext| ext.to_str())
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonld"))
-            }),
+            Self::Files(files) => files
+                .iter()
+                .any(|p| effective_extension(p).0.as_deref() == Some("jsonld")),
             Self::Streaming(_) => false,
             Self::Remote(producer) => producer.has_jsonld(),
         }
     }
 }
 
+// ============================================================================
+// Compression: transparent gzip / zstd support for any RDF input format
+// ============================================================================
+
+/// Optional outer-extension compression layer detected on an input file.
+///
+/// `data.ttl.gz` → `Gzip`; `data.nq.zst` → `Zstd`; `data.ttl` → `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Compression {
+    None,
+    Gzip,
+    Zstd,
+}
+
+/// Return the underlying RDF extension (lowercased) after stripping any
+/// outer `.gz`/`.zst`/`.zstd`, along with the detected compression layer.
+///
+/// Examples:
+/// - `foo.ttl.gz`  → `(Some("ttl"), Gzip)`
+/// - `foo.nq.zst`  → `(Some("nq"),  Zstd)`
+/// - `foo.ttl`     → `(Some("ttl"), None)`
+/// - `foo.gz`      → `(None,        Gzip)` (caller will reject — no RDF ext)
+/// - `foo`         → `(None,        None)`
+pub(crate) fn effective_extension(path: &Path) -> (Option<String>, Compression) {
+    let outer = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    let comp = match outer.as_deref() {
+        Some("gz") => Compression::Gzip,
+        Some("zst" | "zstd") => Compression::Zstd,
+        _ => return (outer, Compression::None),
+    };
+    let inner = path
+        .file_stem()
+        .map(Path::new)
+        .and_then(|p| p.extension())
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    (inner, comp)
+}
+
+/// Open `path` as a buffered byte stream, transparently decoding `.gz` / `.zst`.
+///
+/// Gzip uses `MultiGzDecoder` (handles concatenated streams from `pigz` /
+/// `bgzip`). The outer `BufReader` is sized to match the splitter's scan
+/// buffer for cache-friendly chunked reads.
+fn open_decoded(path: &Path) -> std::io::Result<Box<dyn std::io::BufRead + Send>> {
+    let file = std::fs::File::open(path)?;
+    let (_, comp) = effective_extension(path);
+    const BUF: usize = 256 * 1024;
+    let reader: Box<dyn std::io::BufRead + Send> = match comp {
+        Compression::None => Box::new(std::io::BufReader::with_capacity(BUF, file)),
+        Compression::Gzip => Box::new(std::io::BufReader::with_capacity(
+            BUF,
+            flate2::read::MultiGzDecoder::new(file),
+        )),
+        Compression::Zstd => Box::new(std::io::BufReader::with_capacity(
+            BUF,
+            zstd::stream::read::Decoder::new(file)?,
+        )),
+    };
+    Ok(reader)
+}
+
+/// Read the entire (possibly-compressed) file into a `String`.
+///
+/// Used by the small-file `Files` path. For plain inputs this is just
+/// `std::fs::read_to_string`; compressed inputs stream through the decoder.
+fn read_decoded_to_string(path: &Path) -> std::io::Result<String> {
+    let (_, comp) = effective_extension(path);
+    if matches!(comp, Compression::None) {
+        return std::fs::read_to_string(path);
+    }
+    let mut reader = open_decoded(path)?;
+    let mut s = String::new();
+    std::io::Read::read_to_string(&mut reader, &mut s)?;
+    Ok(s)
+}
+
 /// Resolve the import path into a `ChunkSource`.
 ///
-/// - If `path` is a directory: discover `.ttl`/`.nt`/`.trig`/`.jsonld` files (sorted lexicographically).
+/// - If `path` is a directory: discover `.ttl`/`.nt`/`.nq`/`.trig`/`.jsonld` files (sorted lexicographically).
 /// - If `path` is a single large `.ttl` file: auto-split using `TurtleChunkReader`.
-/// - If `path` is a single small `.ttl`/`.nt`/`.trig`/`.jsonld` file: treat as a single-element `Files` source.
+/// - If `path` is a single small `.ttl`/`.nt`/`.nq`/`.trig`/`.jsonld` file: treat as a single-element `Files` source.
+/// - All extensions above also accept `.gz` and `.zst` suffixes (e.g. `data.ttl.gz`).
 fn resolve_chunk_source(
     path: &Path,
     config: &ImportConfig,
@@ -714,15 +824,20 @@ fn resolve_chunk_source(
     }
 
     // Single file — decide whether to auto-split based on size.
+    //
+    // For a compressed file, `metadata().len()` reports the *compressed* size,
+    // which is what we want for the parallel-split threshold (a 200 MB .gz
+    // expanding to 2 GB still warrants streaming). The uncompressed size is
+    // unknown ahead of time; the streaming reader treats `0` as "unknown" for
+    // its progress denominator.
     let file_size = std::fs::metadata(path)?.len();
     let chunk_size_bytes = config.effective_chunk_size_mb() as u64 * 1024 * 1024;
 
     // `.nt` (N-Triples) is a strict subset of Turtle, so it streams/splits
-    // through the same triple-boundary reader as `.ttl`.
-    let is_ttl = path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("ttl") || ext.eq_ignore_ascii_case("nt"));
+    // through the same triple-boundary reader as `.ttl`. `.ttl.gz` / `.nt.gz`
+    // and the `.zst` variants stream too — via the new factory constructor.
+    let (inner_ext, compression) = effective_extension(path);
+    let is_ttl = matches!(inner_ext.as_deref(), Some("ttl" | "nt"));
 
     if is_ttl && file_size > chunk_size_bytes {
         // Large file: stream chunks via background reader thread.
@@ -747,22 +862,42 @@ fn resolve_chunk_source(
                 f
             });
 
-        let reader = fluree_graph_turtle::splitter::StreamingTurtleReader::new(
-            path,
-            chunk_size_bytes,
-            reader_channel_capacity,
-            scan_progress,
-        )
-        .map_err(|e| ImportError::NoChunks(format!("turtle file split failed: {e}")))?;
+        let reader = if matches!(compression, Compression::None) {
+            // Plain file: original seek-backed fast path.
+            fluree_graph_turtle::splitter::StreamingTurtleReader::new(
+                path,
+                chunk_size_bytes,
+                reader_channel_capacity,
+                scan_progress,
+            )
+            .map_err(|e| ImportError::NoChunks(format!("turtle file split failed: {e}")))?
+        } else {
+            // Compressed file: hand the splitter a factory that opens a fresh
+            // decoder on demand. Uncompressed size is unknown — pass 0 so
+            // the splitter omits a percentage denominator (estimated_chunks
+            // will be 0, which is fine for serial-equivalent throughput).
+            let path_owned = path.to_path_buf();
+            let factory = move || open_decoded(&path_owned);
+            fluree_graph_turtle::splitter::StreamingTurtleReader::new_from_factory(
+                factory,
+                0,
+                chunk_size_bytes,
+                reader_channel_capacity,
+                scan_progress,
+            )
+            .map_err(|e| ImportError::NoChunks(format!("compressed turtle split failed: {e}")))?
+        };
         tracing::info!(
             estimated_chunks = reader.estimated_chunk_count(),
             chunk_size_mb = config.effective_chunk_size_mb(),
             file_size_mb = file_size / (1024 * 1024),
+            compression = ?compression,
             "streaming large Turtle file (no pre-scan)"
         );
         Ok(ChunkSource::Streaming(reader))
     } else {
-        // Small file or non-TTL: treat as a single-element source.
+        // Small file or non-TTL: treat as a single-element source. The Files
+        // variant's `read_chunk` transparently decodes `.gz` / `.zst`.
         Ok(ChunkSource::Files(vec![path.to_path_buf()]))
     }
 }
@@ -825,6 +960,12 @@ async fn resolve_remote_objects(
                 accepted.push(obj);
                 extensions.push(RemoteFormat::Trig);
             }
+            // N-Quads → converted to TriG and dispatched via the serial path.
+            Some("nq") => {
+                has_trig = true;
+                accepted.push(obj);
+                extensions.push(RemoteFormat::Nquads);
+            }
             Some("jsonld") => {
                 has_jsonld = true;
                 accepted.push(obj);
@@ -847,26 +988,15 @@ async fn resolve_remote_objects(
 
     if accepted.is_empty() {
         return Err(ImportError::NoChunks(
-            "remote source contains no .ttl/.nt/.trig/.jsonld objects".into(),
+            "remote source contains no .ttl/.nt/.nq/.trig/.jsonld objects".into(),
         ));
     }
 
-    // `.trig` import is wired through the same serial path the local
-    // `.import(dir)` uses, but that path has a documented upstream limitation
-    // in `import_trig_commit` (fluree-db-transact/src/import.rs): the Tier 2
-    // spool/index pipeline does not fully capture TriG content. Imported TriG
-    // data may not become queryable. Fail loud rather than silently producing
-    // a half-imported ledger.
-    if has_trig {
-        return Err(ImportError::NoChunks(
-            "remote .trig import is not currently supported: the Tier 2 import \
-             pipeline does not fully capture named-graph or default-graph TriG \
-             content, so imported data may not become queryable. Convert TriG \
-             to .ttl or .jsonld before import. See `import_trig_commit` in \
-             fluree-db-transact/src/import.rs for context."
-                .into(),
-        ));
-    }
+    // `.trig` import (including named GRAPH blocks) is fully supported: it runs
+    // through the same serial `import_trig_commit` path the local `.import(dir)`
+    // uses. Default-graph and named-graph flakes are both spooled and indexed,
+    // and named graphs are queryable via the `#<graph-iri>` fragment. See the
+    // named-graph spool wiring in `import_trig_commit` (fluree-db-transact).
 
     Ok((accepted, extensions))
 }
@@ -1146,7 +1276,7 @@ impl<'a> CreateBuilder<'a> {
 
     /// Attach a bulk import to this create operation.
     ///
-    /// `path` can be a directory containing `.ttl`/`.nt`/`.trig`/`.jsonld` files
+    /// `path` can be a directory containing `.ttl`/`.nt`/`.nq`/`.trig`/`.jsonld` files
     /// (sorted lexicographically), or a single `.ttl`/`.jsonld` file.
     pub fn import(self, path: impl AsRef<Path>) -> ImportBuilder<'a> {
         ImportBuilder::new(self.fluree, self.ledger_id, path.as_ref().to_path_buf())
@@ -1189,7 +1319,7 @@ impl<'a> CreateBuilder<'a> {
 /// What kind of data files a directory contains.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirectoryFormat {
-    /// Only `.ttl` / `.nt` / `.trig` files found.
+    /// Only `.ttl` / `.nt` / `.nq` / `.trig` files found.
     Turtle,
     /// Only `.jsonld` files found.
     JsonLd,
@@ -1197,7 +1327,7 @@ pub enum DirectoryFormat {
 
 /// Scan a directory and determine its data format.
 ///
-/// Returns [`DirectoryFormat::Turtle`] if all supported files are `.ttl`/`.nt`/`.trig`,
+/// Returns [`DirectoryFormat::Turtle`] if all supported files are `.ttl`/`.nt`/`.nq`/`.trig`,
 /// [`DirectoryFormat::JsonLd`] if all are `.jsonld`.
 /// Returns [`ImportError::MixedFormats`] on mixed formats,
 /// [`ImportError::NoChunks`] on empty directories or directories with no supported files.
@@ -1213,12 +1343,13 @@ pub fn scan_directory_format(dir: &Path) -> std::result::Result<DirectoryFormat,
         if !entry.file_type().is_ok_and(|ft| ft.is_file()) {
             continue;
         }
-        if let Some(ext) = entry.path().extension().and_then(|e| e.to_str()) {
-            match ext.to_ascii_lowercase().as_str() {
-                "ttl" | "trig" | "nt" => has_turtle = true,
-                "jsonld" => has_jsonld = true,
-                _ => {}
-            }
+        // `effective_extension` strips an outer `.gz`/`.zst` so compressed
+        // RDF files (`foo.ttl.gz`, `foo.nq.zst`, …) classify identically.
+        let inner = effective_extension(&entry.path()).0;
+        match inner.as_deref() {
+            Some("ttl" | "trig" | "nt" | "nq") => has_turtle = true,
+            Some("jsonld") => has_jsonld = true,
+            _ => {}
         }
     }
 
@@ -1231,7 +1362,7 @@ pub fn scan_directory_format(dir: &Path) -> std::result::Result<DirectoryFormat,
         (true, false) => Ok(DirectoryFormat::Turtle),
         (false, true) => Ok(DirectoryFormat::JsonLd),
         (false, false) => Err(ImportError::NoChunks(format!(
-            "no supported data files (.ttl, .nt, .trig, .jsonld) found in {}",
+            "no supported data files (.ttl, .nt, .nq, .trig, .jsonld) found in {}",
             dir.display()
         ))),
     }
@@ -1241,7 +1372,7 @@ pub fn scan_directory_format(dir: &Path) -> std::result::Result<DirectoryFormat,
 // Chunk discovery
 // ============================================================================
 
-/// Discover and sort `.ttl`, `.nt`, `.trig`, or `.jsonld` files from a directory (case-insensitive).
+/// Discover and sort `.ttl`, `.nt`, `.nq`, `.trig`, or `.jsonld` files from a directory (case-insensitive).
 ///
 /// Returns an error if the directory contains a mix of Turtle (`.ttl`/`.trig`) and
 /// JSON-LD (`.jsonld`) files — all files must be the same format family.
@@ -1264,15 +1395,13 @@ fn discover_chunks(dir: &Path) -> std::result::Result<Vec<PathBuf>, ImportError>
         .filter_map(std::result::Result::ok)
         .filter(|e| e.file_type().is_ok_and(|ft| ft.is_file()))
         .map(|e| e.path())
+        // `effective_extension` strips compression suffixes, so `.ttl.gz`,
+        // `.nq.zst`, etc. are accepted alongside their plain counterparts.
         .filter(|p| {
-            p.extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| {
-                    ext.eq_ignore_ascii_case("ttl")
-                        || ext.eq_ignore_ascii_case("nt")
-                        || ext.eq_ignore_ascii_case("trig")
-                        || ext.eq_ignore_ascii_case("jsonld")
-                })
+            matches!(
+                effective_extension(p).0.as_deref(),
+                Some("ttl" | "nt" | "trig" | "nq" | "jsonld")
+            )
         })
         .collect();
 
@@ -1519,6 +1648,9 @@ struct IndexBuildInput<'a> {
     collect_id_stats: bool,
     /// Turtle @prefix IRI → short prefix name, for IRI compaction in display.
     prefix_map: &'a HashMap<String, String>,
+    /// User-defined named graph g_ids (>= 2) to build index segments for.
+    /// Empty for single-graph imports.
+    named_g_ids: Vec<u16>,
 }
 
 /// Run phases 2-6: import chunks, build indexes, upload to CAS, write V4 root, publish.
@@ -1576,6 +1708,7 @@ where
             rdf_type_p_id: import_result.rdf_type_p_id,
             collect_id_stats: config.collect_id_stats,
             prefix_map: &import_result.prefix_map,
+            named_g_ids: import_result.named_g_ids,
         };
         let index_result = build_and_upload(
             storage,
@@ -1680,6 +1813,9 @@ struct ChunkImportResult {
     dt_width: u8,
     /// Predicate ID for rdf:type (for inline class stats during SPOT merge).
     rdf_type_p_id: u32,
+    /// User-defined named graph g_ids (>= 2) to build index segments for.
+    /// Empty for single-graph imports.
+    named_g_ids: Vec<u16>,
 }
 
 /// Import all TTL chunks: parallel parse + serial commit + streaming runs.
@@ -2471,10 +2607,19 @@ where
                 .map_err(|e| ImportError::Transact(format!("chunk {idx} invalid UTF-8: {e}")))?;
             let t = (idx + 1) as i64;
 
-            let result = if chunk_source.is_trig(idx) {
+            let result = if chunk_source.is_trig(idx) || chunk_source.is_nquads(idx) {
+                // N-Quads is converted to TriG up front; TriG passes through.
+                let nq_converted;
+                let trig_content: &str = if chunk_source.is_nquads(idx) {
+                    nq_converted = fluree_db_transact::parse::nquads_to_trig(&content)
+                        .map_err(|e| ImportError::Transact(e.to_string()))?;
+                    &nq_converted
+                } else {
+                    &content
+                };
                 let r = import_trig_commit(
                     &mut state,
-                    &content,
+                    trig_content,
                     storage,
                     alias,
                     compress,
@@ -2587,9 +2732,11 @@ where
         );
     } else {
         // File-based path: index-based access to chunk files.
+        // TriG and N-Quads (converted to TriG) both use the serial path.
         let has_trig = (0..estimated_total).any(|i| chunk_source.is_trig(i));
+        let has_nquads = chunk_source.has_nquads();
         let has_jsonld = chunk_source.has_jsonld();
-        if estimated_total > 0 && num_threads > 0 && !has_trig && !has_jsonld {
+        if estimated_total > 0 && num_threads > 0 && !has_trig && !has_nquads && !has_jsonld {
             let ledger = alias.to_string();
 
             let next_chunk = Arc::new(AtomicUsize::new(0));
@@ -2697,13 +2844,22 @@ where
                 let content = chunk_source.read_chunk(i)?;
                 let t = (i + 1) as i64;
 
-                let result = if chunk_source.is_trig(i) {
-                    // TriG uses its own commit function (named graph handling).
-                    // It allocates codes in state.ns_registry; sync them to
-                    // shared_alloc afterward for subsequent chunks' spool writes.
+                let result = if chunk_source.is_trig(i) || chunk_source.is_nquads(i) {
+                    // TriG (and N-Quads, converted to TriG) use the dedicated
+                    // commit function for named-graph handling. It allocates
+                    // codes in state.ns_registry; sync them to shared_alloc
+                    // afterward for subsequent chunks' spool writes.
+                    let nq_converted;
+                    let trig_content: &str = if chunk_source.is_nquads(i) {
+                        nq_converted = fluree_db_transact::parse::nquads_to_trig(&content)
+                            .map_err(|e| ImportError::Transact(e.to_string()))?;
+                        &nq_converted
+                    } else {
+                        &content
+                    };
                     let r = import_trig_commit(
                         &mut state,
-                        &content,
+                        trig_content,
                         storage,
                         alias,
                         compress,
@@ -3249,6 +3405,21 @@ where
         write_predicate_dict(&run_dir.join("datatypes.dict"), &datatypes_dict)?;
     }
 
+    // User-defined named graphs to build index segments for. Allocator
+    // convention is `graph dict_id + 1 = g_id`; the graph allocator is always
+    // seeded with txn-meta (g_id 1) and config (g_id 2), so user graphs occupy
+    // g_ids `FIRST_USER_GRAPH_ID..=graph_count` (g_id 3+). This is EMPTY for
+    // single-graph imports (graph_count == 2), so the named-graph build loop is
+    // skipped entirely and the optimized default-graph path pays nothing. g_id 1
+    // (txn-meta) is built separately; g_id 2 (config) is not populated by bulk
+    // RDF import.
+    let v3_named_g_ids: Vec<u16> = {
+        let graph_count = spool_config.graph_alloc.len();
+        (u32::from(fluree_db_core::graph_registry::FIRST_USER_GRAPH_ID)..=graph_count)
+            .map(|g| g as u16)
+            .collect()
+    };
+
     // Persist namespaces.json from shared allocator.
     persist_namespaces(namespace_codes.as_ref(), run_dir)?;
 
@@ -3377,6 +3548,7 @@ where
         p_width,
         dt_width,
         rdf_type_p_id,
+        named_g_ids: v3_named_g_ids,
     })
 }
 
@@ -3484,6 +3656,7 @@ where
         let v3_remap_counter = remap_counter.clone();
         let v3_build_counter = build_counter.clone();
         let v3_stage_marker = stage_marker.clone();
+        let v3_named_g_ids = input.named_g_ids;
 
         config.emit_progress(ImportPhase::PreparingIndex {
             stage: "Generating per-order runs",
@@ -3591,7 +3764,7 @@ where
                 let g1_result = if let Some(meta_commit) = commits.last() {
                     let cfg_g1 = fluree_db_indexer::BuildConfig {
                         run_dir: v3_runs_g1,
-                        index_dir: v3_index_dir,
+                        index_dir: v3_index_dir.clone(),
                         g_id: 1,
                         leaflet_target_rows: v3_leaflet_target_rows,
                         leaf_target_rows: v3_leaf_target_rows,
@@ -3616,6 +3789,39 @@ where
                 } else {
                     None
                 };
+
+                // Build index segments for each user-defined named graph
+                // (g_id >= 2). Each is a separate pass over the commit blobs
+                // filtered to its g_id, mirroring the g_id=1 (txn-meta) build.
+                // Empty for single-graph imports — zero cost on that hot path.
+                // Done before stats finalize so named-graph flakes contribute
+                // to the shared IdStatsHook (per-graph stats).
+                let mut v3_named_results: Vec<fluree_db_indexer::BuildResult> = Vec::new();
+                for &ng_id in &v3_named_g_ids {
+                    let cfg_ng = fluree_db_indexer::BuildConfig {
+                        run_dir: v3_run_dir.join(format!("v3_runs_g{ng_id}")),
+                        index_dir: v3_index_dir.clone(),
+                        g_id: ng_id,
+                        leaflet_target_rows: v3_leaflet_target_rows,
+                        leaf_target_rows: v3_leaf_target_rows,
+                        zstd_level: 1,
+                        run_budget_bytes: v3_run_budget,
+                        worker_count: 1,
+                        remap_progress: None,
+                        build_progress: None,
+                        stage_marker: None,
+                    };
+                    std::fs::create_dir_all(&cfg_ng.run_dir)
+                        .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+
+                    let (ng_result, _) = fluree_db_indexer::build_indexes_from_commits(
+                        &commits,
+                        &cfg_ng,
+                        stats_hook.as_mut(),
+                    )
+                    .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                    v3_named_results.push(ng_result);
+                }
 
                 let stats_output = stats_hook.map(|h| {
                     let stats_finalize_start = Instant::now();
@@ -3649,6 +3855,25 @@ where
                             existing.total_rows += g1_order.total_rows;
                         } else {
                             order_results.push((order, g1_order));
+                        }
+                    }
+                }
+
+                // Merge each user-defined named graph's results (same pattern).
+                for ng in v3_named_results {
+                    total_rows += ng.total_rows;
+                    total_remapped += ng.total_remapped;
+                    remap_elapsed += ng.remap_elapsed;
+                    build_elapsed += ng.build_elapsed;
+
+                    for (order, ng_order) in ng.order_results {
+                        if let Some((_, existing)) =
+                            order_results.iter_mut().find(|(o, _)| *o == order)
+                        {
+                            existing.graphs.extend(ng_order.graphs);
+                            existing.total_rows += ng_order.total_rows;
+                        } else {
+                            order_results.push((order, ng_order));
                         }
                     }
                 }

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -4143,9 +4143,11 @@ where
 
             (class_counts, class_ref_targets)
         } else {
-            // Clone — the uncapped id_hook_class_ref_targets is also used
-            // below as the authoritative source for class stats ref_classes.
-            (id_hook_class_counts, id_hook_class_ref_targets.clone())
+            // No SPOT class stats (no rdf:type data) — fall back to the id-hook
+            // maps. These are empty in the import path now that worker hooks no
+            // longer build per-subject maps, which is correct: no classes ⇒ no
+            // class ref-targets.
+            (id_hook_class_counts, id_hook_class_ref_targets)
         };
 
         let stats_v6: Option<fluree_db_core::IndexStats> = id_stats_result.map(|id_stats| {
@@ -4207,10 +4209,11 @@ where
                     cs,
                     &predicate_sids_v6,
                     &uploaded_dicts.language_tags,
-                    // Use the uncapped per-class ref-targets from IdStatsHook
-                    // instead of `cs.class_prop_refs` (which is populated via
-                    // the 64-class-capped ClassBitsetTable).
-                    Some(&id_hook_class_ref_targets),
+                    // `cs.class_prop_refs` is now uncapped (ClassMembership
+                    // promotes past 64 classes to a sparse map), so it is the
+                    // authoritative source. The import no longer builds the
+                    // expensive per-subject IdStatsHook maps for ref-targets.
+                    None,
                     input.run_dir,
                     input.namespace_codes,
                 )

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -963,3 +963,126 @@ async fn import_single_malformed_jsonld_file_errors() {
         "expected a parse/transact error for malformed JSON-LD, got: {msg}"
     );
 }
+
+// ============================================================================
+// N-Triples (.nt) import tests
+//
+// N-Triples is a strict subset of Turtle, so `.nt` files dispatch to the same
+// Turtle parser. These verify the import pipeline discovers and parses `.nt`
+// for both single-file and directory imports.
+// ============================================================================
+
+/// Write a string to a temp file with the given name and return the path.
+fn write_data(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).expect("create data file");
+    f.write_all(content.as_bytes()).expect("write data");
+    path
+}
+
+#[tokio::test]
+async fn import_single_nt_file_then_query() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // N-Triples: full IRIs, one triple per line.
+    let nt = "\
+<http://example.org/ns/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/User> .
+<http://example.org/ns/alice> <http://schema.org/name> \"Alice\" .
+<http://example.org/ns/bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/User> .
+<http://example.org/ns/bob> <http://schema.org/name> \"Bob\" .
+";
+
+    let nt_path = write_data(data_dir.path(), "people.nt", nt);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/import-nt-single:main")
+        .import(&nt_path)
+        .threads(2)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("single .nt import should succeed");
+
+    assert!(result.flake_count > 0, "should have flakes");
+    assert!(result.root_id.is_some(), "index should have been built");
+
+    let ledger = fluree
+        .ledger("test/import-nt-single:main")
+        .await
+        .expect("load ledger after .nt import");
+
+    let query = json!({
+        "@context": { "schema": "http://schema.org/" },
+        "select": ["?name"],
+        "where": { "schema:name": "?name" }
+    });
+
+    let qr = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query after .nt import");
+    let json = qr.to_jsonld(&ledger.snapshot).expect("format jsonld");
+    let names = extract_sorted_strings(&json);
+
+    assert_eq!(names, vec!["Alice", "Bob"]);
+}
+
+#[tokio::test]
+async fn import_nt_directory_then_query() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // Two .nt files with disjoint subjects. Directory discovery must recognize
+    // the `.nt` extension (previously only .ttl/.trig/.jsonld were discovered).
+    write_data(
+        data_dir.path(),
+        "a_people.nt",
+        "<http://example.org/ns/alice> <http://schema.org/name> \"Alice\" .\n",
+    );
+    write_data(
+        data_dir.path(),
+        "b_people.nt",
+        "<http://example.org/ns/bob> <http://schema.org/name> \"Bob\" .\n",
+    );
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/import-nt-dir:main")
+        .import(data_dir.path())
+        .threads(2)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("directory .nt import should succeed");
+
+    assert_eq!(result.t, 2, "two .nt files => t=2");
+    assert!(result.flake_count > 0);
+
+    let ledger = fluree
+        .ledger("test/import-nt-dir:main")
+        .await
+        .expect("load ledger");
+
+    let query = json!({
+        "@context": { "schema": "http://schema.org/" },
+        "select": ["?name"],
+        "where": { "schema:name": "?name" }
+    });
+
+    let qr = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query after .nt directory import");
+    let json = qr.to_jsonld(&ledger.snapshot).expect("format jsonld");
+    let names = extract_sorted_strings(&json);
+
+    assert_eq!(names, vec!["Alice", "Bob"]);
+}

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -41,6 +41,20 @@ fn extract_sorted_strings(v: &serde_json::Value) -> Vec<String> {
     out
 }
 
+/// Extract column `n` (0-based) from each row of a multi-column JSON-LD result,
+/// keeping only string values, sorted.
+fn extract_nth_column(v: &serde_json::Value, n: usize) -> Vec<String> {
+    let mut out: Vec<String> = v
+        .as_array()
+        .expect("expected array")
+        .iter()
+        .filter_map(|row| row.as_array().and_then(|cols| cols.get(n)))
+        .filter_map(|c| c.as_str().map(str::to_string))
+        .collect();
+    out.sort();
+    out
+}
+
 // ============================================================================
 // Single-file import (streaming split)
 // ============================================================================
@@ -1085,4 +1099,369 @@ async fn import_nt_directory_then_query() {
     let names = extract_sorted_strings(&json);
 
     assert_eq!(names, vec!["Alice", "Bob"]);
+}
+
+// ============================================================================
+// TriG named-graph bulk import
+//
+// Verifies that named-graph (GRAPH block) data imported via the *bulk* path
+// (create().import(.trig)) is spooled into the Tier-2 index and is queryable
+// via the `#<graph-iri>` fragment — not just default-graph triples.
+// ============================================================================
+
+#[tokio::test]
+async fn import_trig_named_graph_is_queryable() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let trig = r#"@prefix ex: <http://example.org/> .
+@prefix schema: <http://schema.org/> .
+
+ex:alice schema:name "Alice" .
+
+GRAPH <http://example.org/graphs/audit> {
+    ex:event1 schema:description "User login" .
+    ex:event2 schema:description "User logout" .
+}
+"#;
+
+    let path = data_dir.path().join("data.trig");
+    {
+        let mut f = std::fs::File::create(&path).expect("create trig");
+        f.write_all(trig.as_bytes()).expect("write trig");
+    }
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/trig-named:main")
+        .import(&path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("trig import should succeed");
+    assert!(result.flake_count >= 3, "default + 2 named-graph flakes");
+
+    let ledger = fluree
+        .ledger("test/trig-named:main")
+        .await
+        .expect("load ledger");
+
+    // Default graph: broad triple scan must include Alice's name.
+    let q_default = json!({
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let qr = support::query_jsonld(&fluree, &ledger, &q_default)
+        .await
+        .expect("default-graph query");
+    let json_default = qr.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let default_objs = extract_nth_column(&json_default, 2);
+    assert!(
+        default_objs.contains(&"Alice".to_string()),
+        "default graph must contain Alice; got {json_default}"
+    );
+
+    // Named graph: the audit events are queryable via the #<iri> fragment.
+    // This is the behavior the fix enables — previously this errored with
+    // "Unknown named graph" because named-graph flakes never reached the index.
+    let named_alias = "test/trig-named:main#http://example.org/graphs/audit";
+    let q_named = json!({
+        "from": named_alias,
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let qr = fluree
+        .query_connection(&q_named)
+        .await
+        .expect("named-graph query should resolve and return data");
+    let json_named = qr.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let named_objs = extract_nth_column(&json_named, 2);
+    assert_eq!(
+        named_objs,
+        vec!["User login", "User logout"],
+        "named-graph data must be indexed and queryable after bulk import; got {json_named}"
+    );
+}
+
+// ============================================================================
+// N-Quads (.nq) import
+//
+// N-Quads is converted to TriG and dispatched through the named-graph-aware
+// TriG path. Default-graph quads and named-graph (4th-term) quads must both
+// import and be queryable.
+// ============================================================================
+
+#[tokio::test]
+async fn import_nquads_default_and_named_graph() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // N-Quads: 3-term lines = default graph; 4-term lines = named graph.
+    let nq = "\
+<http://example.org/alice> <http://schema.org/name> \"Alice\" .
+<http://example.org/event1> <http://schema.org/description> \"User login\" <http://example.org/graphs/audit> .
+<http://example.org/event2> <http://schema.org/description> \"User logout\" <http://example.org/graphs/audit> .
+";
+
+    let nq_path = write_data(data_dir.path(), "data.nq", nq);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/nq:main")
+        .import(&nq_path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("single .nq import should succeed");
+    assert!(result.flake_count >= 3, "1 default + 2 named-graph quads");
+
+    let ledger = fluree.ledger("test/nq:main").await.expect("load ledger");
+
+    // Default graph contains Alice.
+    let q_default = json!({
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let qr = support::query_jsonld(&fluree, &ledger, &q_default)
+        .await
+        .expect("default-graph query");
+    assert!(
+        extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2)
+            .contains(&"Alice".to_string()),
+        "default graph must contain Alice"
+    );
+
+    // Named graph (the 4th-term graph label) is queryable via the #<iri> fragment.
+    let named_alias = "test/nq:main#http://example.org/graphs/audit";
+    let q_named = json!({
+        "from": named_alias,
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let qr = fluree
+        .query_connection(&q_named)
+        .await
+        .expect("named-graph query should resolve and return data");
+    assert_eq!(
+        extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2),
+        vec!["User login", "User logout"],
+        "N-Quads named-graph data must be indexed and queryable"
+    );
+}
+
+// ============================================================================
+// Compressed inputs (.gz / .zst)
+//
+// Transparent decompression for `.ttl.gz`, `.nt.gz`, `.nq.gz`, `.ttl.zst`, etc.
+// The streaming-split path is exercised by the large-file test; small files
+// run through the `Files` single-chunk path.
+// ============================================================================
+
+fn write_gzipped(dir: &std::path::Path, name: &str, content: &[u8]) -> std::path::PathBuf {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    let path = dir.join(name);
+    let f = std::fs::File::create(&path).expect("create gz file");
+    let mut enc = GzEncoder::new(f, Compression::default());
+    std::io::Write::write_all(&mut enc, content).expect("gz encode");
+    enc.finish().expect("gz finish");
+    path
+}
+
+fn write_zstd(dir: &std::path::Path, name: &str, content: &[u8]) -> std::path::PathBuf {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).expect("create zst file");
+    zstd::stream::copy_encode(content, &mut f, 3).expect("zstd encode");
+    path
+}
+
+#[tokio::test]
+async fn import_gzipped_ttl_small_file() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let ttl = b"@prefix ex: <http://example.org/ns/> .\n\
+                @prefix schema: <http://schema.org/> .\n\
+                ex:alice schema:name \"Alice\" .\n\
+                ex:bob schema:name \"Bob\" .\n";
+
+    let gz_path = write_gzipped(data_dir.path(), "people.ttl.gz", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/ttl-gz:main")
+        .import(&gz_path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect(".ttl.gz import should succeed");
+    assert!(result.flake_count >= 2);
+
+    let ledger = fluree
+        .ledger("test/ttl-gz:main")
+        .await
+        .expect("load ledger");
+    let qr = support::query_jsonld(
+        &fluree,
+        &ledger,
+        &json!({"select": ["?s", "?p", "?o"], "where": {"@id": "?s", "?p": "?o"}}),
+    )
+    .await
+    .expect("query");
+    let objs = extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2);
+    assert!(objs.contains(&"Alice".to_string()));
+    assert!(objs.contains(&"Bob".to_string()));
+}
+
+#[tokio::test]
+async fn import_gzipped_nt_directory() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // Directory of `.nt.gz` files — discovery must accept the compressed
+    // extension via `effective_extension`.
+    write_gzipped(
+        data_dir.path(),
+        "a.nt.gz",
+        b"<http://example.org/alice> <http://schema.org/name> \"Alice\" .\n",
+    );
+    write_gzipped(
+        data_dir.path(),
+        "b.nt.gz",
+        b"<http://example.org/bob> <http://schema.org/name> \"Bob\" .\n",
+    );
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build");
+
+    let result = fluree
+        .create("test/nt-gz-dir:main")
+        .import(data_dir.path())
+        .threads(2)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("directory .nt.gz import should succeed");
+    assert_eq!(result.t, 2, "two .nt.gz files => t=2");
+
+    let ledger = fluree
+        .ledger("test/nt-gz-dir:main")
+        .await
+        .expect("load ledger");
+    let qr = support::query_jsonld(
+        &fluree,
+        &ledger,
+        &json!({"select": ["?s", "?p", "?o"], "where": {"@id": "?s", "?p": "?o"}}),
+    )
+    .await
+    .expect("query");
+    let objs = extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2);
+    assert!(objs.contains(&"Alice".to_string()) && objs.contains(&"Bob".to_string()));
+}
+
+#[tokio::test]
+async fn import_zstd_ttl_small_file() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let ttl = b"@prefix ex: <http://example.org/ns/> .\n\
+                @prefix schema: <http://schema.org/> .\n\
+                ex:carol schema:name \"Carol\" .\n";
+
+    let zst_path = write_zstd(data_dir.path(), "people.ttl.zst", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build");
+
+    let result = fluree
+        .create("test/ttl-zst:main")
+        .import(&zst_path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect(".ttl.zst import should succeed");
+    assert!(result.flake_count >= 1);
+
+    let ledger = fluree.ledger("test/ttl-zst:main").await.expect("load");
+    let qr = support::query_jsonld(
+        &fluree,
+        &ledger,
+        &json!({"select": ["?s", "?p", "?o"], "where": {"@id": "?s", "?p": "?o"}}),
+    )
+    .await
+    .expect("query");
+    let objs = extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2);
+    assert!(objs.contains(&"Carol".to_string()));
+}
+
+#[tokio::test]
+async fn import_gzipped_ttl_streaming_split() {
+    // Force the streaming (large-file) path: write enough TTL that the
+    // compressed file exceeds the chunk threshold so the splitter activates.
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let mut ttl = String::from(
+        "@prefix ex: <http://example.org/ns/> .\n\
+         @prefix schema: <http://schema.org/> .\n",
+    );
+    // ~5 MB of synthetic triples — comfortably above the 1 MB chunk threshold
+    // we configure below, even after compression.
+    for i in 0..40_000 {
+        use std::fmt::Write as _;
+        writeln!(ttl, "ex:s{i} schema:name \"name-{i}\" .").unwrap();
+    }
+    let gz_path = write_gzipped(data_dir.path(), "big.ttl.gz", ttl.as_bytes());
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build");
+
+    let result = fluree
+        .create("test/ttl-gz-stream:main")
+        .import(&gz_path)
+        .threads(2)
+        .chunk_size_mb(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("streaming .ttl.gz import should succeed");
+    assert!(result.flake_count as usize >= 40_000);
+
+    let ledger = fluree
+        .ledger("test/ttl-gz-stream:main")
+        .await
+        .expect("load");
+    let qr = support::query_jsonld(
+        &fluree,
+        &ledger,
+        &json!({"select": ["?s", "?p", "?o"], "where": {"@id": "?s", "?p": "?o"}}),
+    )
+    .await
+    .expect("query");
+    let objs = extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2);
+    // Spot-check a handful of values are queryable post-index.
+    assert!(objs.contains(&"name-0".to_string()));
+    assert!(objs.contains(&"name-39999".to_string()));
 }

--- a/fluree-db-api/tests/it_import_remote.rs
+++ b/fluree-db-api/tests/it_import_remote.rs
@@ -35,6 +35,19 @@ fn extract_sorted_strings(v: &serde_json::Value) -> Vec<String> {
     out
 }
 
+/// Extract column `n` (0-based) of each row, string values only, sorted.
+fn extract_nth_column(v: &serde_json::Value, n: usize) -> Vec<String> {
+    let mut out: Vec<String> = v
+        .as_array()
+        .expect("expected array")
+        .iter()
+        .filter_map(|row| row.as_array().and_then(|cols| cols.get(n)))
+        .filter_map(|c| c.as_str().map(str::to_string))
+        .collect();
+    out.sort();
+    out
+}
+
 const TTL_PREFIX: &str = "@prefix ex: <http://example.org/ns/> .\n\
 @prefix schema: <http://schema.org/> .\n\
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n";
@@ -327,20 +340,25 @@ async fn import_from_storage_jsonld_then_query() {
 }
 
 // ============================================================================
-// .trig rejection — assert the explicit error so we don't silently start
-// importing TriG into a half-broken state if the resolver changes.
+// .trig remote import — including named GRAPH blocks — is fully supported.
+// Default-graph and named-graph data both index and become queryable.
 // ============================================================================
-//
-// The underlying TriG-via-import path has a documented upstream limitation
-// (see `import_trig_commit` in fluree-db-transact/src/import.rs). Until that
-// is fixed, import_from_storage rejects .trig with an actionable error message.
 
 #[tokio::test]
-async fn import_from_storage_rejects_trig_with_upstream_explanation() {
+async fn import_from_storage_trig_named_graph_then_query() {
     let db_dir = tempfile::tempdir().unwrap();
     let storage = Arc::new(MemoryStorage::new());
+    let trig = r#"@prefix ex: <http://example.org/> .
+@prefix schema: <http://schema.org/> .
+
+ex:alice schema:name "Alice" .
+
+GRAPH <http://example.org/graphs/audit> {
+    ex:event1 schema:description "User login" .
+}
+"#;
     storage
-        .write_bytes("trig/data.trig", b"# trig data")
+        .write_bytes("trig/data.trig", trig.as_bytes())
         .await
         .unwrap();
 
@@ -349,7 +367,7 @@ async fn import_from_storage_rejects_trig_with_upstream_explanation() {
         .unwrap();
 
     let storage_dyn: Arc<dyn StorageRead> = storage;
-    let err = fluree
+    let result = fluree
         .create("test/remote-trig:main")
         .import_from_storage(
             storage_dyn,
@@ -360,12 +378,44 @@ async fn import_from_storage_rejects_trig_with_upstream_explanation() {
         .cleanup(false)
         .execute()
         .await
-        .expect_err(".trig should be rejected with an upstream-limitation error");
+        .expect("remote .trig import should succeed");
+    assert!(result.flake_count >= 2, "default + named-graph flakes");
 
-    let msg = err.to_string();
+    let ledger = fluree
+        .ledger("test/remote-trig:main")
+        .await
+        .expect("load ledger");
+
+    // Default graph: broad scan must include Alice's name. (Uses a broad
+    // triple scan rather than a prefixed-name pattern to avoid an unrelated
+    // pre-existing prefix-resolution quirk on the TriG default-graph path.)
+    let q_default = json!({
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let qr = support::query_jsonld(&fluree, &ledger, &q_default)
+        .await
+        .expect("default-graph query");
     assert!(
-        msg.contains(".trig") && msg.contains("not currently supported"),
-        "expected explicit not-supported message, got: {msg}"
+        extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2)
+            .contains(&"Alice".to_string()),
+        "default graph must contain Alice"
+    );
+
+    // Named graph: queryable via the #<iri> fragment — the behavior the fix enables.
+    let named_alias = "test/remote-trig:main#http://example.org/graphs/audit";
+    let q_named = json!({
+        "from": named_alias,
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let qr = fluree
+        .query_connection(&q_named)
+        .await
+        .expect("named-graph query should resolve and return data");
+    assert_eq!(
+        extract_nth_column(&qr.to_jsonld(&ledger.snapshot).unwrap(), 2),
+        vec!["User login"]
     );
 }
 

--- a/fluree-db-cli/Cargo.toml
+++ b/fluree-db-cli/Cargo.toml
@@ -107,6 +107,9 @@ parking_lot = "0.12"
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
+# Used by `create --from` integration tests to produce .gz / .zst fixtures inline.
+flate2 = { workspace = true }
+zstd = { workspace = true }
 
 [lints]
 workspace = true

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -207,8 +207,10 @@ pub enum Commands {
         ledger: String,
 
         /// Import data from a file or directory.
-        /// Accepts a single .ttl, .nt, .json, or .jsonld file, or a directory of
-        /// .ttl/.nt/.trig or .jsonld files (bulk import, bypasses novelty).
+        /// Accepts a single .ttl, .nt, .nq, .json, or .jsonld file, or a directory
+        /// of .ttl/.nt/.nq/.trig or .jsonld files (bulk import, bypasses novelty).
+        /// Any of these may carry a `.gz` or `.zst` suffix and is decoded
+        /// transparently (e.g. `data.ttl.gz`, `dump.nq.zst`).
         /// Files in a directory are processed in lexicographic order.
         #[arg(long)]
         from: Option<PathBuf>,

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -207,8 +207,8 @@ pub enum Commands {
         ledger: String,
 
         /// Import data from a file or directory.
-        /// Accepts a single .ttl, .json, or .jsonld file, or a directory of
-        /// .ttl/.trig or .jsonld files (bulk import, bypasses novelty).
+        /// Accepts a single .ttl, .nt, .json, or .jsonld file, or a directory of
+        /// .ttl/.nt/.trig or .jsonld files (bulk import, bypasses novelty).
         /// Files in a directory are processed in lexicographic order.
         #[arg(long)]
         from: Option<PathBuf>,

--- a/fluree-db-cli/src/commands/create.rs
+++ b/fluree-db-cli/src/commands/create.rs
@@ -721,23 +721,35 @@ fn is_import_path(path: &Path) -> CliResult<bool> {
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
     let name_lower = name.to_ascii_lowercase();
 
-    // Reject compressed Turtle with a clear message.
-    if name_lower.ends_with(".ttl.gz")
-        || name_lower.ends_with(".ttl.zst")
-        || name_lower.ends_with(".ttl.bz2")
-    {
+    // Bulk import handles every supported RDF format. Each may carry an outer
+    // `.gz` or `.zst` suffix — the bulk pipeline decompresses transparently
+    // (see `fluree-db-api::import::effective_extension`). `.bz2` is rejected
+    // explicitly because the import pipeline doesn't link a bzip2 decoder.
+    if name_lower.ends_with(".bz2") {
         return Err(CliError::Input(format!(
-            "compressed Turtle files are not yet supported; decompress first: {}",
+            "bzip2-compressed files are not supported; use .gz or .zst, or \
+             decompress first: {}",
             path.display()
         )));
     }
-
-    // Case-insensitive .ttl / .jsonld check.
-    if name_lower.ends_with(".ttl") || name_lower.ends_with(".jsonld") {
-        return Ok(true);
-    }
-
-    Ok(false)
+    const SUPPORTED: &[&str] = &[
+        ".ttl",
+        ".ttl.gz",
+        ".ttl.zst",
+        ".nt",
+        ".nt.gz",
+        ".nt.zst",
+        ".nq",
+        ".nq.gz",
+        ".nq.zst",
+        ".trig",
+        ".trig.gz",
+        ".trig.zst",
+        ".jsonld",
+        ".jsonld.gz",
+        ".jsonld.zst",
+    ];
+    Ok(SUPPORTED.iter().any(|suffix| name_lower.ends_with(suffix)))
 }
 
 /// Replace non-alphanumeric characters with underscores for safe filenames.

--- a/fluree-db-cli/src/commands/create.rs
+++ b/fluree-db-cli/src/commands/create.rs
@@ -339,13 +339,25 @@ async fn run_bulk_import(
                 total_bytes,
             } => {
                 is_streaming_scan.store(true, std::sync::atomic::Ordering::Relaxed);
-                sb.set_length(total_bytes);
-                sb.set_position(bytes_read);
                 let gb_read = bytes_read as f64 / (1024.0 * 1024.0 * 1024.0);
-                let gb_total = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
-                sb.set_message(format!("{gb_read:.1} / {gb_total:.1} GB"));
-                if bytes_read >= total_bytes {
-                    sb.finish_with_message(format!("{gb_total:.1} GB"));
+                if total_bytes > 0 {
+                    // Known total — normal percentage bar.
+                    sb.set_length(total_bytes);
+                    sb.set_position(bytes_read);
+                    let gb_total = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+                    sb.set_message(format!("{gb_read:.1} / {gb_total:.1} GB"));
+                    if bytes_read >= total_bytes {
+                        sb.finish_with_message(format!("{gb_total:.1} GB"));
+                    }
+                } else {
+                    // Unknown total (compressed source — uncompressed size
+                    // not known ahead of time). Show running bytes only; the
+                    // bar's length is left at a sentinel so it never renders
+                    // as complete, and the Committing handler will clear it
+                    // when reading is genuinely done.
+                    sb.set_length(u64::MAX);
+                    sb.set_position(bytes_read);
+                    sb.set_message(format!("{gb_read:.2} GB read"));
                 }
             }
             ImportPhase::Committing {
@@ -377,6 +389,13 @@ async fn run_bulk_import(
             }
             ImportPhase::PreparingIndex { stage } => {
                 cb.finish();
+                // Unknown-total streaming scan (compressed input) leaves the
+                // scan bar without a natural finish event from the reader.
+                // By PreparingIndex, parsing is fully done so reading must be
+                // too — lock the bar at its last reported byte count.
+                if !sb.is_finished() {
+                    sb.finish();
+                }
                 // Show activity immediately (avoid "Indexing 0%" during merge/remap).
                 ib.set_length(100);
                 ib.set_position(1);

--- a/fluree-db-cli/src/detect.rs
+++ b/fluree-db-cli/src/detect.rs
@@ -35,10 +35,26 @@ pub fn detect_data_format(
         };
     }
 
-    // File extension
+    // File extension. Strip an outer `.gz`/`.zst` so `.ttl.gz` / `.jsonld.zst`
+    // map to the same DataFormat as their plain counterparts (the bulk-import
+    // path decompresses transparently; the insert/upsert HTTP path does not
+    // yet, and will surface a UTF-8 error if a raw compressed file is sent).
     if let Some(p) = path {
-        if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
-            return match ext.to_lowercase().as_str() {
+        let outer = p
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_lowercase);
+        let inner = match outer.as_deref() {
+            Some("gz" | "zst" | "zstd") => p
+                .file_stem()
+                .map(std::path::Path::new)
+                .and_then(|s| s.extension())
+                .and_then(|e| e.to_str())
+                .map(str::to_lowercase),
+            _ => outer,
+        };
+        if let Some(ext) = inner {
+            return match ext.as_str() {
                 // `.nt` (N-Triples) is a Turtle subset — same parser.
                 "ttl" | "nt" => Ok(DataFormat::Turtle),
                 "json" | "jsonld" => Ok(DataFormat::JsonLd),

--- a/fluree-db-cli/src/detect.rs
+++ b/fluree-db-cli/src/detect.rs
@@ -39,7 +39,8 @@ pub fn detect_data_format(
     if let Some(p) = path {
         if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
             return match ext.to_lowercase().as_str() {
-                "ttl" => Ok(DataFormat::Turtle),
+                // `.nt` (N-Triples) is a Turtle subset — same parser.
+                "ttl" | "nt" => Ok(DataFormat::Turtle),
                 "json" | "jsonld" => Ok(DataFormat::JsonLd),
                 _ => sniff_data_format(content),
             };

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -441,6 +441,122 @@ fn create_from_file() {
         .stdout(predicate::str::contains("flakes"));
 }
 
+#[test]
+fn create_from_nt_file() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    let nt_path = tmp.path().join("seed.nt");
+    std::fs::write(
+        &nt_path,
+        "<http://example.org/seed> <http://example.org/val> \"seeded\" .\n",
+    )
+    .unwrap();
+
+    fluree_cmd(&tmp)
+        .args(["create", "ntdb", "--from", nt_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("About ledger 'ntdb'"))
+        .stdout(predicate::str::contains("flakes"));
+}
+
+#[test]
+fn create_from_nquads_file() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    let nq_path = tmp.path().join("seed.nq");
+    std::fs::write(
+        &nq_path,
+        "<http://example.org/seed> <http://example.org/val> \"seeded\" .\n",
+    )
+    .unwrap();
+
+    fluree_cmd(&tmp)
+        .args(["create", "nqdb", "--from", nq_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("About ledger 'nqdb'"))
+        .stdout(predicate::str::contains("flakes"));
+}
+
+/// Regression: `fluree create --from data.nt.gz` was failing with "stream did
+/// not contain valid UTF-8" because the CLI's `is_import_path` gate didn't
+/// recognize compressed RDF extensions and silently routed them through a
+/// fallback that did raw `fs::read_to_string`.
+#[test]
+fn create_from_gzipped_nt_file() {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    let gz_path = tmp.path().join("seed.nt.gz");
+    let f = std::fs::File::create(&gz_path).unwrap();
+    let mut enc = GzEncoder::new(f, Compression::default());
+    enc.write_all(b"<http://example.org/seed> <http://example.org/val> \"seeded\" .\n")
+        .unwrap();
+    enc.finish().unwrap();
+
+    fluree_cmd(&tmp)
+        .args(["create", "ntgzdb", "--from", gz_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("About ledger 'ntgzdb'"))
+        .stdout(predicate::str::contains("flakes"));
+}
+
+#[test]
+fn create_from_gzipped_ttl_file() {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    let gz_path = tmp.path().join("seed.ttl.gz");
+    let f = std::fs::File::create(&gz_path).unwrap();
+    let mut enc = GzEncoder::new(f, Compression::default());
+    enc.write_all(
+        b"@prefix ex: <http://example.org/> .\nex:seed a ex:Thing ; ex:val \"seeded\" .\n",
+    )
+    .unwrap();
+    enc.finish().unwrap();
+
+    fluree_cmd(&tmp)
+        .args(["create", "ttlgzdb", "--from", gz_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("About ledger 'ttlgzdb'"))
+        .stdout(predicate::str::contains("flakes"));
+}
+
+#[test]
+fn create_from_zstd_ttl_file() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    let zst_path = tmp.path().join("seed.ttl.zst");
+    let mut f = std::fs::File::create(&zst_path).unwrap();
+    zstd::stream::copy_encode(
+        &b"@prefix ex: <http://example.org/> .\nex:seed a ex:Thing ; ex:val \"seeded\" .\n"[..],
+        &mut f,
+        3,
+    )
+    .unwrap();
+
+    fluree_cmd(&tmp)
+        .args(["create", "ttlzstdb", "--from", zst_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("About ledger 'ttlzstdb'"))
+        .stdout(predicate::str::contains("flakes"));
+}
+
 // ============================================================================
 // v1.1 — Upsert tests
 // ============================================================================

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -794,7 +794,7 @@ where
 
             // ---- Pass 2: Streaming class stats via k-way merge ----
             //
-            // Build ClassBitsetTable from .types sidecars (global IDs), then
+            // Build ClassMembership from .types sidecars (global IDs), then
             // k-way merge .fsc files in cmp_v2_g_spot order with dedup. Feed
             // deduped winning assertions to SpotClassStatsCollector.
 
@@ -802,8 +802,8 @@ where
                 .iter()
                 .filter_map(|info| info.types_map_path.clone())
                 .collect();
-            let class_bitset =
-                crate::run_index::build::ClassBitsetTable::build_from_global_types(&types_paths)
+            let class_membership =
+                crate::run_index::build::ClassMembership::build_from_global_types(&types_paths)
                     .map_err(|e| IndexerError::StorageWrite(e.to_string()))?;
 
             let spot_class_stats = {
@@ -811,7 +811,7 @@ where
                 use crate::run_index::runs::spool::V1SpoolMergeAdapter;
                 use fluree_db_binary_index::format::run_record_v2::cmp_v2_g_spot;
 
-                let mut collector = SpotClassStatsCollector::new(rdf_type_p_id, class_bitset);
+                let mut collector = SpotClassStatsCollector::new(rdf_type_p_id, class_membership);
 
                 // Open V1 spool merge adapters for all .fsc files.
                 let registry = std::sync::Arc::new(registry);
@@ -883,7 +883,7 @@ where
                     &spot_class_stats,
                     &predicate_sids,
                     &language_tags,
-                    None, // rebuild path still uses cs.class_prop_refs (64-capped); separate follow-up.
+                    None, // uncapped: cs.class_prop_refs now uses ClassMembership (no 64-class cap).
                     &run_dir,
                     &shared.ns_prefixes,
                 )

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -95,6 +95,10 @@ pub struct BuildResult {
     pub build_elapsed: std::time::Duration,
 }
 
+/// Dense 64-class subject→class-mask table: one `u64` bitmask per subject
+/// (bit *i* set ⇒ the subject is a member of `bit_to_class[i]`). Compact and
+/// cache-friendly, but limited to 64 distinct classes — used as the fast path
+/// in [`ClassMembership`] when a ledger has ≤ 64 classes.
 pub struct ClassBitsetTable {
     pub bit_to_class: Vec<u64>,
     graph_bitsets: FxHashMap<u16, FxHashMap<u16, Vec<u64>>>,
@@ -110,15 +114,76 @@ impl ClassBitsetTable {
             .and_then(|v| v.as_slice().get(local_id).copied())
             .unwrap_or(0)
     }
+}
 
+/// Sparse subject→class membership: an explicit (sorted, deduped) class list
+/// per subject. Memory is flat in the number of distinct classes (~one entry
+/// per `(subject, class)` type assertion), so it scales to arbitrarily large
+/// ontologies where the dense [`ClassBitsetTable`] would not fit. Used as the
+/// fallback in [`ClassMembership`] once a ledger exceeds 64 distinct classes.
+pub struct SparseClassMembership {
+    /// `(g_id, subject_sid64)` → sorted, deduped global class sids.
+    membership: FxHashMap<(u16, u64), Box<[u64]>>,
+    /// Number of distinct classes (diagnostics only).
+    distinct_classes: usize,
+}
+
+impl SparseClassMembership {
+    #[inline]
+    fn classes_of(&self, g_id: u16, sid: u64) -> &[u64] {
+        self.membership
+            .get(&(g_id, sid))
+            .map(|b| &b[..])
+            .unwrap_or(&[])
+    }
+}
+
+/// Subject→class membership lookup used to attribute reference *targets* to
+/// their classes when building `class_prop_refs` stats.
+///
+/// Uses the compact 64-class [`ClassBitsetTable`] for the common case
+/// (≤ 64 classes) and transparently transitions to a [`SparseClassMembership`]
+/// above that — uncapped and memory-bounded (flat in class count) for large
+/// ontologies. The previous implementation hard-capped at 64 classes and
+/// silently truncated ref-class rollups; this never truncates on class count.
+pub enum ClassMembership {
+    Bitset(ClassBitsetTable),
+    Sparse(SparseClassMembership),
+}
+
+impl ClassMembership {
+    /// Append the classes of `(g_id, sid)` into `out` (cleared first).
+    /// No allocation once `out` has capacity.
+    #[inline]
+    fn collect_classes(&self, g_id: u16, sid: u64, out: &mut Vec<u64>) {
+        out.clear();
+        match self {
+            Self::Bitset(b) => {
+                let mut bits = b.get(g_id, sid);
+                while bits != 0 {
+                    let bit_idx = bits.trailing_zeros() as usize;
+                    out.push(b.bit_to_class[bit_idx]);
+                    bits &= bits - 1;
+                }
+            }
+            Self::Sparse(s) => out.extend_from_slice(s.classes_of(g_id, sid)),
+        }
+    }
+
+    /// Number of distinct classes tracked (across both representations).
+    fn distinct_class_count(&self) -> usize {
+        match self {
+            Self::Bitset(b) => b.bit_to_class.len(),
+            Self::Sparse(s) => s.distinct_classes,
+        }
+    }
+
+    /// Build from per-chunk `.types` sidecars whose IDs are chunk-local and are
+    /// remapped to global via each commit's `MmapSubjectRemap`. Import path.
     fn build_from_commits(commits: &[CommitInput]) -> io::Result<Option<Self>> {
         use std::io::{BufReader, Read};
 
-        let mut class_to_bit: FxHashMap<u64, u8> = FxHashMap::default();
-        let mut bit_to_class: Vec<u64> = Vec::new();
-        let mut graph_bitsets: FxHashMap<u16, FxHashMap<u16, Vec<u64>>> = FxHashMap::default();
-        let mut overflow_classes: FxHashSet<u64> = FxHashSet::default();
-        let mut overflow_entries = 0u64;
+        let mut builder = ClassMembershipBuilder::new();
         let mut saw_sidecar = false;
         let mut buf = [0u8; 18];
 
@@ -139,59 +204,14 @@ impl ClassBitsetTable {
                 let c_local = u64::from_le_bytes(buf[10..18].try_into().unwrap());
                 let s_global = remap.get(s_local as usize)?;
                 let c_global = remap.get(c_local as usize)?;
-
-                let bit_idx = if let Some(&idx) = class_to_bit.get(&c_global) {
-                    idx
-                } else if bit_to_class.len() < 64 {
-                    let idx = bit_to_class.len() as u8;
-                    class_to_bit.insert(c_global, idx);
-                    bit_to_class.push(c_global);
-                    idx
-                } else {
-                    overflow_classes.insert(c_global);
-                    overflow_entries += 1;
-                    continue;
-                };
-
-                let ns_code = (s_global >> 48) as u16;
-                let local_id = (s_global & 0x0000_FFFF_FFFF_FFFF) as usize;
-                let ns_map = graph_bitsets.entry(g_id).or_default();
-                let vec = ns_map.entry(ns_code).or_default();
-                if local_id >= vec.len() {
-                    vec.resize(local_id + 1, 0);
-                }
-                vec[local_id] |= 1u64 << bit_idx;
+                builder.add(g_id, s_global, c_global);
             }
         }
 
         if !saw_sidecar {
             return Ok(None);
         }
-
-        tracing::info!(
-            classes = bit_to_class.len(),
-            graphs = graph_bitsets.len(),
-            total_subjects = graph_bitsets
-                .values()
-                .flat_map(|ns| ns.values())
-                .map(std::vec::Vec::len)
-                .sum::<usize>(),
-            "class bitset table built"
-        );
-
-        if !overflow_classes.is_empty() {
-            tracing::warn!(
-                retained_classes = bit_to_class.len(),
-                skipped_classes = overflow_classes.len(),
-                skipped_type_assertions = overflow_entries,
-                "class ref stats truncated at 64 distinct classes; stats.classes[*].properties[*].ref-classes may be incomplete"
-            );
-        }
-
-        Ok(Some(Self {
-            bit_to_class,
-            graph_bitsets,
-        }))
+        Ok(Some(builder.finish()))
     }
 
     /// Build from `.types` sidecar files that already contain **global** IDs.
@@ -203,11 +223,7 @@ impl ClassBitsetTable {
     pub fn build_from_global_types(types_paths: &[PathBuf]) -> io::Result<Option<Self>> {
         use std::io::{BufReader, Read};
 
-        let mut class_to_bit: FxHashMap<u64, u8> = FxHashMap::default();
-        let mut bit_to_class: Vec<u64> = Vec::new();
-        let mut graph_bitsets: FxHashMap<u16, FxHashMap<u16, Vec<u64>>> = FxHashMap::default();
-        let mut overflow_classes: FxHashSet<u64> = FxHashSet::default();
-        let mut overflow_entries = 0u64;
+        let mut builder = ClassMembershipBuilder::new();
         let mut saw_sidecar = false;
         let mut buf = [0u8; 18];
 
@@ -225,61 +241,150 @@ impl ClassBitsetTable {
                 let g_id = u16::from_le_bytes([buf[0], buf[1]]);
                 let s_global = u64::from_le_bytes(buf[2..10].try_into().unwrap());
                 let c_global = u64::from_le_bytes(buf[10..18].try_into().unwrap());
-
-                let bit_idx = if let Some(&idx) = class_to_bit.get(&c_global) {
-                    idx
-                } else if bit_to_class.len() < 64 {
-                    let idx = bit_to_class.len() as u8;
-                    class_to_bit.insert(c_global, idx);
-                    bit_to_class.push(c_global);
-                    idx
-                } else {
-                    overflow_classes.insert(c_global);
-                    overflow_entries += 1;
-                    continue;
-                };
-
-                let ns_code = (s_global >> 48) as u16;
-                let local_id = (s_global & 0x0000_FFFF_FFFF_FFFF) as usize;
-                let ns_map = graph_bitsets.entry(g_id).or_default();
-                let vec = ns_map.entry(ns_code).or_default();
-                if local_id >= vec.len() {
-                    vec.resize(local_id + 1, 0);
-                }
-                vec[local_id] |= 1u64 << bit_idx;
+                builder.add(g_id, s_global, c_global);
             }
         }
 
         if !saw_sidecar {
             return Ok(None);
         }
-
-        tracing::info!(
-            classes = bit_to_class.len(),
-            graphs = graph_bitsets.len(),
-            total_subjects = graph_bitsets
-                .values()
-                .flat_map(|ns| ns.values())
-                .map(std::vec::Vec::len)
-                .sum::<usize>(),
-            "class bitset table built (from global types)"
-        );
-
-        if !overflow_classes.is_empty() {
-            tracing::warn!(
-                retained_classes = bit_to_class.len(),
-                skipped_classes = overflow_classes.len(),
-                skipped_type_assertions = overflow_entries,
-                "class ref stats truncated at 64 distinct classes; stats.classes[*].properties[*].ref-classes may be incomplete"
-            );
-        }
-
-        Ok(Some(Self {
-            bit_to_class,
-            graph_bitsets,
-        }))
+        Ok(Some(builder.finish()))
     }
 }
+
+/// Accumulates subject→class membership, starting on the compact 64-class
+/// bitset and transparently promoting to a sparse per-subject representation
+/// the moment a 65th distinct class appears. The common case (≤ 64 classes)
+/// pays exactly the old dense-bitset cost; only large ontologies allocate the
+/// sparse map.
+struct ClassMembershipBuilder {
+    class_to_bit: FxHashMap<u64, u8>,
+    bit_to_class: Vec<u64>,
+    graph_bitsets: FxHashMap<u16, FxHashMap<u16, Vec<u64>>>,
+    /// `Some` once promoted to sparse mode: `(g_id, s_global)` → class list.
+    sparse: Option<FxHashMap<(u16, u64), Vec<u64>>>,
+    /// Distinct classes seen after promotion (seeded from `bit_to_class`).
+    sparse_classes: FxHashSet<u64>,
+}
+
+impl ClassMembershipBuilder {
+    fn new() -> Self {
+        Self {
+            class_to_bit: FxHashMap::default(),
+            bit_to_class: Vec::new(),
+            graph_bitsets: FxHashMap::default(),
+            sparse: None,
+            sparse_classes: FxHashSet::default(),
+        }
+    }
+
+    #[inline]
+    fn add(&mut self, g_id: u16, s_global: u64, c_global: u64) {
+        if let Some(sparse) = self.sparse.as_mut() {
+            sparse.entry((g_id, s_global)).or_default().push(c_global);
+            self.sparse_classes.insert(c_global);
+            return;
+        }
+
+        let bit_idx = if let Some(&idx) = self.class_to_bit.get(&c_global) {
+            idx
+        } else if self.bit_to_class.len() < 64 {
+            let idx = self.bit_to_class.len() as u8;
+            self.class_to_bit.insert(c_global, idx);
+            self.bit_to_class.push(c_global);
+            idx
+        } else {
+            // 65th distinct class: promote to sparse, then re-route this entry.
+            self.promote_to_sparse();
+            self.add(g_id, s_global, c_global);
+            return;
+        };
+
+        let ns_code = (s_global >> 48) as u16;
+        let local_id = (s_global & 0x0000_FFFF_FFFF_FFFF) as usize;
+        let ns_map = self.graph_bitsets.entry(g_id).or_default();
+        let vec = ns_map.entry(ns_code).or_default();
+        if local_id >= vec.len() {
+            vec.resize(local_id + 1, 0);
+        }
+        vec[local_id] |= 1u64 << bit_idx;
+    }
+
+    /// Expand the dense bitset accumulated so far into the sparse map, then
+    /// switch into sparse mode. One-time O(subjects-seen) cost, paid only on
+    /// ledgers that exceed 64 classes.
+    fn promote_to_sparse(&mut self) {
+        let mut sparse: FxHashMap<(u16, u64), Vec<u64>> = FxHashMap::default();
+        for (&g_id, ns_map) in &self.graph_bitsets {
+            for (&ns_code, vec) in ns_map {
+                for (local_id, &bits) in vec.iter().enumerate() {
+                    if bits == 0 {
+                        continue;
+                    }
+                    let s_global = ((ns_code as u64) << 48) | (local_id as u64);
+                    let entry = sparse.entry((g_id, s_global)).or_default();
+                    let mut b = bits;
+                    while b != 0 {
+                        let bit_idx = b.trailing_zeros() as usize;
+                        entry.push(self.bit_to_class[bit_idx]);
+                        b &= b - 1;
+                    }
+                }
+            }
+        }
+        self.sparse_classes = self.bit_to_class.iter().copied().collect();
+        self.graph_bitsets = FxHashMap::default();
+        self.class_to_bit = FxHashMap::default();
+        self.sparse = Some(sparse);
+    }
+
+    fn finish(self) -> ClassMembership {
+        if let Some(sparse) = self.sparse {
+            let distinct_classes = self.sparse_classes.len();
+            let mut membership: FxHashMap<(u16, u64), Box<[u64]>> = FxHashMap::default();
+            membership.reserve(sparse.len());
+            for (key, mut classes) in sparse {
+                classes.sort_unstable();
+                classes.dedup();
+                membership.insert(key, classes.into_boxed_slice());
+            }
+            tracing::info!(
+                classes = distinct_classes,
+                subjects = membership.len(),
+                "class membership promoted to sparse (uncapped, > 64 classes)"
+            );
+            ClassMembership::Sparse(SparseClassMembership {
+                membership,
+                distinct_classes,
+            })
+        } else {
+            tracing::info!(
+                classes = self.bit_to_class.len(),
+                graphs = self.graph_bitsets.len(),
+                total_subjects = self
+                    .graph_bitsets
+                    .values()
+                    .flat_map(|ns| ns.values())
+                    .map(std::vec::Vec::len)
+                    .sum::<usize>(),
+                "class bitset table built"
+            );
+            ClassMembership::Bitset(ClassBitsetTable {
+                bit_to_class: self.bit_to_class,
+                graph_bitsets: self.graph_bitsets,
+            })
+        }
+    }
+}
+
+/// Upper bound on the number of distinct `(src_class, prop, target_class)` leaf
+/// entries `class_prop_refs` may hold for a single build. Reference-target stats
+/// are worst-case `O(classes² × predicates)`; on a pathological high-class,
+/// densely-connected ontology that product can explode. Past this budget the
+/// collector stops recording *new* class pairs (existing counts keep
+/// incrementing) and emits a truncation warning — degrade at the edge, never
+/// OOM. ~64M `u64` leaves ≈ a couple GB worst case.
+const MAX_CLASS_REF_LEAF_ENTRIES: usize = 64_000_000;
 
 pub struct SpotClassStatsCollector {
     rdf_type_p_id: u32,
@@ -289,12 +394,19 @@ pub struct SpotClassStatsCollector {
     prop_dts: FxHashMap<(u32, u16), u64>,
     prop_langs: FxHashMap<(u32, u16), u64>,
     ref_targets: Vec<(u32, u64)>,
-    class_bitset: Option<ClassBitsetTable>,
+    class_membership: Option<ClassMembership>,
+    /// Reusable scratch buffer for a ref target's class list (avoids a
+    /// per-subject allocation in the ref-join inner loop).
+    target_class_buf: Vec<u64>,
+    /// Distinct `(src_class, prop, target_class)` leaves recorded so far.
+    ref_leaf_entries: usize,
+    /// Set once `class_prop_refs` hit [`MAX_CLASS_REF_LEAF_ENTRIES`].
+    ref_truncated: bool,
     result: SpotClassStats,
 }
 
 impl SpotClassStatsCollector {
-    pub fn new(rdf_type_p_id: u32, class_bitset: Option<ClassBitsetTable>) -> Self {
+    pub fn new(rdf_type_p_id: u32, class_membership: Option<ClassMembership>) -> Self {
         Self {
             rdf_type_p_id,
             current_s_id: None,
@@ -303,7 +415,10 @@ impl SpotClassStatsCollector {
             prop_dts: FxHashMap::default(),
             prop_langs: FxHashMap::default(),
             ref_targets: Vec::new(),
-            class_bitset,
+            class_membership,
+            target_class_buf: Vec::new(),
+            ref_leaf_entries: 0,
+            ref_truncated: false,
             result: SpotClassStats::default(),
         }
     }
@@ -334,7 +449,7 @@ impl SpotClassStatsCollector {
             *self.prop_langs.entry((sr.p_id, sr.lang_id)).or_insert(0) += 1;
         }
 
-        if is_ref && self.class_bitset.is_some() {
+        if is_ref && self.class_membership.is_some() {
             self.ref_targets.push((sr.p_id, sr.o_key));
         }
     }
@@ -378,10 +493,13 @@ impl SpotClassStatsCollector {
             }
         }
 
-        if let Some(ref bitset) = self.class_bitset {
+        if let Some(membership) = self.class_membership.as_ref() {
+            // Detach the scratch buffer so it does not alias `self` while the
+            // membership (also a field of `self`) is borrowed immutably below.
+            let mut tbuf = std::mem::take(&mut self.target_class_buf);
             for &(p_id, target_sid) in &self.ref_targets {
-                let target_bits = bitset.get(g_id, target_sid);
-                if target_bits == 0 {
+                membership.collect_classes(g_id, target_sid, &mut tbuf);
+                if tbuf.is_empty() {
                     continue;
                 }
                 for &src_class in &self.classes {
@@ -392,15 +510,24 @@ impl SpotClassStatsCollector {
                         .or_default()
                         .entry(p_id)
                         .or_default();
-                    let mut bits = target_bits;
-                    while bits != 0 {
-                        let bit_idx = bits.trailing_zeros() as usize;
-                        let target_class = bitset.bit_to_class[bit_idx];
-                        *ref_entry.entry(target_class).or_insert(0) += 1;
-                        bits &= bits - 1;
+                    for &target_class in &tbuf {
+                        match ref_entry.entry(target_class) {
+                            std::collections::hash_map::Entry::Occupied(mut e) => {
+                                *e.get_mut() += 1;
+                            }
+                            std::collections::hash_map::Entry::Vacant(e) => {
+                                if self.ref_leaf_entries >= MAX_CLASS_REF_LEAF_ENTRIES {
+                                    self.ref_truncated = true;
+                                } else {
+                                    e.insert(1);
+                                    self.ref_leaf_entries += 1;
+                                }
+                            }
+                        }
                     }
                 }
             }
+            self.target_class_buf = tbuf;
         }
 
         self.classes.clear();
@@ -411,6 +538,14 @@ impl SpotClassStatsCollector {
 
     pub fn finish(mut self) -> SpotClassStats {
         self.flush_subject();
+        if self.ref_truncated {
+            tracing::warn!(
+                recorded_ref_entries = self.ref_leaf_entries,
+                budget = MAX_CLASS_REF_LEAF_ENTRIES,
+                "class ref-target stats hit the per-build entry budget and were truncated; \
+                 stats.classes[*].properties[*].ref-classes may omit the rarest class pairs"
+            );
+        }
         self.result
     }
 }
@@ -446,17 +581,24 @@ pub fn build_indexes_from_commits(
     let spot_commits = commits.to_vec();
     let spot_config = config.clone();
     let spot_rdf_type_p_id = stats_hook.as_ref().and_then(|hook| hook.rdf_type_p_id());
-    let spot_class_bitset = if spot_rdf_type_p_id.is_some() {
-        ClassBitsetTable::build_from_commits(commits)?
+    let spot_class_membership = if spot_rdf_type_p_id.is_some() {
+        ClassMembership::build_from_commits(commits)?
     } else {
         None
     };
+    if let Some(ref m) = spot_class_membership {
+        tracing::debug!(
+            classes = m.distinct_class_count(),
+            sparse = matches!(m, ClassMembership::Sparse(_)),
+            "class membership built for ref-target stats"
+        );
+    }
     let spot_handle = std::thread::spawn(move || {
         build_spot_index_from_commits(
             &spot_commits,
             &spot_config,
             spot_rdf_type_p_id,
-            spot_class_bitset,
+            spot_class_membership,
         )
     });
 
@@ -482,23 +624,19 @@ pub fn build_indexes_from_commits(
             let remap_progress = config.remap_progress.clone();
             let target_g_id = config.g_id;
             let collect_stats = stats_hook.is_some();
-            // Propagate rdf:type p_id so the worker hook can track per-subject
-            // class membership and ref history. Without this, `on_record`
-            // short-circuits at the `rdf_type_p_id` check and
-            // `subject_ref_history` stays empty even when
-            // `track_ref_targets` is true.
-            let worker_rdf_type_pid = spot_rdf_type_p_id;
+            // IMPORTANT: worker hooks intentionally do NOT set rdf:type p_id.
+            // Setting it makes `IdStatsHook::on_record` build per-subject class /
+            // ref / datatype maps for every distinct subject — tens of GB across
+            // workers and a >500s serial merge + finalize on large imports (and
+            // an OOM risk). Class and ref-class stats are instead produced —
+            // uncapped — by the `SpotClassStatsCollector` via `ClassMembership`.
+            // Worker hooks keep only the cheap per-property HLL / datatype /
+            // graph-flake aggregates.
 
             handles.push(scope.spawn(
                 move || -> io::Result<(u64, Option<crate::stats::IdStatsHook>)> {
                     let mut local_total = 0u64;
-                    let mut worker_hook = collect_stats.then(|| {
-                        let mut h = crate::stats::IdStatsHook::new();
-                        if let Some(pid) = worker_rdf_type_pid {
-                            h.set_rdf_type_p_id(pid);
-                        }
-                        h
-                    });
+                    let mut worker_hook = collect_stats.then(crate::stats::IdStatsHook::new);
                     loop {
                         let pos = next_chunk.fetch_add(1, Ordering::Relaxed);
                         if pos >= commits_ref.len() {
@@ -649,7 +787,7 @@ fn build_spot_index_from_commits(
     commits: &[CommitInput],
     config: &BuildConfig,
     rdf_type_p_id: Option<u32>,
-    class_bitset: Option<ClassBitsetTable>,
+    class_membership: Option<ClassMembership>,
 ) -> io::Result<(IndexBuildResult, Option<SpotClassStats>)> {
     let g_id = config.g_id;
     let index_dir = &config.index_dir;
@@ -702,7 +840,7 @@ fn build_spot_index_from_commits(
     let mut total_rows = 0u64;
     let mut progress_batch = 0u64;
     let mut class_stats_collector =
-        rdf_type_p_id.map(|p_id| SpotClassStatsCollector::new(p_id, class_bitset));
+        rdf_type_p_id.map(|p_id| SpotClassStatsCollector::new(p_id, class_membership));
     while let Some((record, op)) = merge.next_record()? {
         if op == 0 {
             continue;
@@ -988,91 +1126,127 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Helper: write `.types` sidecar entries (g_id: u16, s_id: u64, class_sid64: u64).
+    fn write_types_sidecar(path: &std::path::Path, entries: &[(u16, u64, u64)]) {
+        use std::io::Write;
+        let mut file = std::fs::File::create(path).unwrap();
+        for (g_id, s_id, c_id) in entries {
+            file.write_all(&g_id.to_le_bytes()).unwrap();
+            file.write_all(&s_id.to_le_bytes()).unwrap();
+            file.write_all(&c_id.to_le_bytes()).unwrap();
+        }
+    }
+
     #[test]
-    fn class_bitset_build_from_global_types() {
+    fn class_membership_bitset_for_few_classes() {
         let dir = tempfile::tempdir().unwrap();
         let types_path = dir.path().join("chunk_00000.types");
 
-        // Write .types sidecar entries: (g_id: u16, s_id: u64, class_sid64: u64)
-        // Subject 100 is class A (sid=1000), subject 200 is class A and class B (sid=2000).
+        // Subject 100 is class A (sid=1000); subject 200 is class A and class B (sid=2000).
         let class_a: u64 = 1000;
         let class_b: u64 = 2000;
-        let entries: Vec<(u16, u64, u64)> =
-            vec![(0, 100, class_a), (0, 200, class_a), (0, 200, class_b)];
+        write_types_sidecar(
+            &types_path,
+            &[(0, 100, class_a), (0, 200, class_a), (0, 200, class_b)],
+        );
 
-        {
-            let mut file = std::fs::File::create(&types_path).unwrap();
-            for (g_id, s_id, c_id) in &entries {
-                use std::io::Write;
-                file.write_all(&g_id.to_le_bytes()).unwrap();
-                file.write_all(&s_id.to_le_bytes()).unwrap();
-                file.write_all(&c_id.to_le_bytes()).unwrap();
-            }
-        }
-
-        let table = ClassBitsetTable::build_from_global_types(&[types_path])
+        let membership = ClassMembership::build_from_global_types(&[types_path])
             .unwrap()
-            .expect("should produce a table");
+            .expect("should produce membership");
 
-        // Both classes should be mapped.
-        assert_eq!(table.bit_to_class.len(), 2);
+        // ≤ 64 classes ⇒ dense bitset fast path.
+        let ClassMembership::Bitset(table) = &membership else {
+            panic!("expected bitset variant for ≤ 64 classes");
+        };
+        assert_eq!(membership.distinct_class_count(), 2);
         assert!(table.bit_to_class.contains(&class_a));
         assert!(table.bit_to_class.contains(&class_b));
 
+        let mut buf = Vec::new();
         // Subject 100: only class A.
-        let bits_100 = table.get(0, 100);
-        assert_ne!(bits_100, 0);
-        // Exactly one bit set.
-        assert_eq!(bits_100.count_ones(), 1);
-
-        // Subject 200: both class A and class B.
-        let bits_200 = table.get(0, 200);
-        assert_eq!(bits_200.count_ones(), 2);
-
-        // Unknown subject returns 0.
-        assert_eq!(table.get(0, 999), 0);
-        // Unknown graph returns 0.
-        assert_eq!(table.get(5, 100), 0);
+        membership.collect_classes(0, 100, &mut buf);
+        assert_eq!(buf, vec![class_a]);
+        // Subject 200: both classes (collect_classes order follows bit order).
+        membership.collect_classes(0, 200, &mut buf);
+        buf.sort_unstable();
+        assert_eq!(buf, vec![class_a, class_b]);
+        // Unknown subject / graph ⇒ empty.
+        membership.collect_classes(0, 999, &mut buf);
+        assert!(buf.is_empty());
+        membership.collect_classes(5, 100, &mut buf);
+        assert!(buf.is_empty());
     }
 
     #[test]
-    fn class_bitset_overflow_at_64_classes() {
+    fn class_membership_promotes_to_sparse_above_64() {
         let dir = tempfile::tempdir().unwrap();
         let types_path = dir.path().join("overflow.types");
 
-        // Write 65 distinct classes — the 65th should be silently dropped.
-        {
-            let mut file = std::fs::File::create(&types_path).unwrap();
-            for class_idx in 0u64..65 {
-                use std::io::Write;
-                let g_id: u16 = 0;
-                let s_id: u64 = class_idx + 1; // unique subject per class
-                let c_id: u64 = 10_000 + class_idx;
-                file.write_all(&g_id.to_le_bytes()).unwrap();
-                file.write_all(&s_id.to_le_bytes()).unwrap();
-                file.write_all(&c_id.to_le_bytes()).unwrap();
-            }
+        // 65 distinct classes, one unique subject each. The old bitset capped at
+        // 64 and dropped the 65th; the sparse promotion must retain ALL of them.
+        let mut entries: Vec<(u16, u64, u64)> = Vec::new();
+        for class_idx in 0u64..65 {
+            entries.push((0, class_idx + 1, 10_000 + class_idx));
         }
+        write_types_sidecar(&types_path, &entries);
 
-        let table = ClassBitsetTable::build_from_global_types(&[types_path])
+        let membership = ClassMembership::build_from_global_types(&[types_path])
             .unwrap()
-            .expect("should produce a table");
+            .expect("should produce membership");
 
-        // Only 64 classes should be retained.
-        assert_eq!(table.bit_to_class.len(), 64);
+        assert!(
+            matches!(membership, ClassMembership::Sparse(_)),
+            "should promote to sparse above 64 classes"
+        );
+        assert_eq!(membership.distinct_class_count(), 65);
 
-        // First 64 subjects should have a bit set.
-        for s_id in 1u64..=64 {
-            assert_ne!(table.get(0, s_id), 0, "subject {s_id} should be mapped");
+        // Every subject (including the 65th, which the old code truncated) maps
+        // to exactly its class.
+        let mut buf = Vec::new();
+        for class_idx in 0u64..65 {
+            let s_id = class_idx + 1;
+            let c_id = 10_000 + class_idx;
+            membership.collect_classes(0, s_id, &mut buf);
+            assert_eq!(buf, vec![c_id], "subject {s_id} should map to class {c_id}");
         }
-
-        // Subject 65 has the 65th class which overflowed — no bit set.
-        assert_eq!(table.get(0, 65), 0);
+        membership.collect_classes(0, 9999, &mut buf);
+        assert!(buf.is_empty());
     }
 
     #[test]
-    fn class_bitset_no_types_files_returns_none() {
-        let result = ClassBitsetTable::build_from_global_types(&[]).unwrap();
+    fn class_membership_promotion_carries_early_bitset_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let types_path = dir.path().join("carry.types");
+
+        // Subject 1 gets an early class (bitset mode), then 64 more distinct
+        // classes force promotion, then subject 1 gets another class (sparse
+        // mode). After promotion the early bitset bit must be carried over so
+        // subject 1 ends up with BOTH classes.
+        let mut entries: Vec<(u16, u64, u64)> = vec![(0, 1, 500)];
+        for class_idx in 0u64..64 {
+            entries.push((0, 1000 + class_idx, 20_000 + class_idx));
+        }
+        entries.push((0, 1, 999)); // subject 1's second class, added in sparse mode
+        write_types_sidecar(&types_path, &entries);
+
+        let membership = ClassMembership::build_from_global_types(&[types_path])
+            .unwrap()
+            .expect("should produce membership");
+        assert!(matches!(membership, ClassMembership::Sparse(_)));
+
+        let mut buf = Vec::new();
+        membership.collect_classes(0, 1, &mut buf);
+        buf.sort_unstable();
+        assert_eq!(
+            buf,
+            vec![500, 999],
+            "promotion must carry the early bitset class (500) plus the sparse-mode class (999)"
+        );
+    }
+
+    #[test]
+    fn class_membership_no_types_files_returns_none() {
+        let result = ClassMembership::build_from_global_types(&[]).unwrap();
         assert!(result.is_none());
     }
 }

--- a/fluree-db-indexer/src/run_index/build/mod.rs
+++ b/fluree-db-indexer/src/run_index/build/mod.rs
@@ -1,5 +1,5 @@
 pub mod build_from_commits;
-pub use build_from_commits::{ClassBitsetTable, SpotClassStatsCollector};
+pub use build_from_commits::{ClassMembership, SpotClassStatsCollector};
 pub mod incremental_branch;
 pub mod incremental_leaf;
 pub mod incremental_resolve;

--- a/fluree-db-indexer/src/stats/id_hook.rs
+++ b/fluree-db-indexer/src/stats/id_hook.rs
@@ -483,6 +483,27 @@ impl IdStatsHook {
             for (key, props) in other.subject_props {
                 self.subject_props.entry(key).or_default().extend(props);
             }
+            // Merge per-subject, per-property datatype/language deltas. (These
+            // were previously dropped here, leaving class→property→datatype/lang
+            // attribution empty after any multi-worker accumulation.)
+            for (key, per_prop) in other.subject_prop_dts {
+                let entry = self.subject_prop_dts.entry(key).or_default();
+                for (p_id, dts) in per_prop {
+                    let dt_entry = entry.entry(p_id).or_default();
+                    for (dt, delta) in dts {
+                        *dt_entry.entry(dt).or_insert(0) += delta;
+                    }
+                }
+            }
+            for (key, per_prop) in other.subject_prop_langs {
+                let entry = self.subject_prop_langs.entry(key).or_default();
+                for (p_id, langs) in per_prop {
+                    let lang_entry = entry.entry(p_id).or_default();
+                    for (lang, delta) in langs {
+                        *lang_entry.entry(lang).or_insert(0) += delta;
+                    }
+                }
+            }
         }
         // Merge per-subject ref history.
         if self.track_ref_targets && !self.hll_only {

--- a/fluree-db-memory/src/store.rs
+++ b/fluree-db-memory/src/store.rs
@@ -764,44 +764,6 @@ WHERE {{\n\
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fluree_db_api::FlureeBuilder;
-
-    #[tokio::test]
-    async fn is_initialized_finds_memory_ledger_by_normalized_id() {
-        let fluree = FlureeBuilder::memory().build_memory();
-        fluree
-            .create_ledger(MEMORY_LEDGER)
-            .await
-            .expect("create memory ledger");
-        let store = MemoryStore::new(fluree, None);
-
-        assert!(
-            store.is_initialized().await.expect("check initialized"),
-            "ledger_exists should accept the normalized __memory:main ledger id"
-        );
-    }
-
-    #[tokio::test]
-    async fn drop_and_reinit_drops_by_whole_ledger_name() {
-        let fluree = FlureeBuilder::memory().build_memory();
-        let store = MemoryStore::new(fluree, None);
-        store.initialize().await.expect("initialize memory store");
-
-        store
-            .drop_and_reinit()
-            .await
-            .expect("drop and reinitialize memory ledger");
-
-        assert!(
-            store.is_initialized().await.expect("check initialized"),
-            "memory ledger should exist after drop_and_reinit"
-        );
-    }
-}
-
 // ---------------------------------------------------------------------------
 // SPARQL result parsing helpers
 // ---------------------------------------------------------------------------
@@ -1094,5 +1056,43 @@ fn iri_to_kind(iri: &str) -> Option<MemoryKind> {
         // Backwards compat: map removed kinds to Fact
         "Preference" | "Artifact" => Some(MemoryKind::Fact),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_api::FlureeBuilder;
+
+    #[tokio::test]
+    async fn is_initialized_finds_memory_ledger_by_normalized_id() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        fluree
+            .create_ledger(MEMORY_LEDGER)
+            .await
+            .expect("create memory ledger");
+        let store = MemoryStore::new(fluree, None);
+
+        assert!(
+            store.is_initialized().await.expect("check initialized"),
+            "ledger_exists should accept the normalized __memory:main ledger id"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_and_reinit_drops_by_whole_ledger_name() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let store = MemoryStore::new(fluree, None);
+        store.initialize().await.expect("initialize memory store");
+
+        store
+            .drop_and_reinit()
+            .await
+            .expect("drop and reinitialize memory ledger");
+
+        assert!(
+            store.is_initialized().await.expect("check initialized"),
+            "memory ledger should exist after drop_and_reinit"
+        );
     }
 }

--- a/fluree-db-server/src/extract/credential.rs
+++ b/fluree-db-server/src/extract/credential.rs
@@ -65,9 +65,13 @@ fn mime_type_matches(content_type: &str, base: &str, x_prefix: Option<&str>) -> 
     false
 }
 
-/// Check if content-type indicates Turtle format
+/// Check if content-type indicates Turtle format.
+///
+/// N-Triples (`application/n-triples`) is a strict subset of Turtle and is
+/// parsed by the same Turtle parser, so it is accepted here as Turtle.
 fn is_turtle_content_type(content_type: &str) -> bool {
     mime_type_matches(content_type, "text/turtle", Some("application/x-turtle"))
+        || mime_type_matches(content_type, "application/n-triples", None)
 }
 
 /// Check if content-type indicates TriG format
@@ -401,6 +405,12 @@ mod tests {
 
         // Vendor extension
         assert!(is_turtle_content_type("application/x-turtle"));
+
+        // N-Triples is a Turtle subset — accepted as Turtle
+        assert!(is_turtle_content_type("application/n-triples"));
+        assert!(is_turtle_content_type(
+            "application/n-triples; charset=utf-8"
+        ));
 
         // Should not match
         assert!(!is_turtle_content_type("application/json"));

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -55,9 +55,11 @@ mod inner {
         /// Import start time (reused for all commits to avoid per-chunk Utc::now).
         pub import_time: String,
         /// Named graph IRI → g_id mapping (stable across chunks).
-        /// g_id 0 = default graph, g_id 1 = txn-meta, g_id 2+ = user-defined.
+        /// g_id 0 = default graph, 1 = txn-meta, 2 = config, 3+ = user-defined.
         pub graph_ids: HashMap<String, u16>,
-        /// Next available g_id for user-defined named graphs.
+        /// Next available g_id for user-defined named graphs. Only used by the
+        /// non-spooling fallback; the spooling path allocates from the shared
+        /// graph allocator instead (see `import_trig_commit`).
         pub next_gid: u16,
         /// Accumulated turtle @prefix short names: IRI → short prefix.
         /// Captured from `on_prefix()` calls across all chunks.
@@ -77,7 +79,10 @@ mod inner {
                 cumulative_flakes: 0,
                 import_time: chrono::Utc::now().to_rfc3339(),
                 graph_ids: HashMap::new(),
-                next_gid: 2, // 0=default, 1=txn-meta
+                // 0=default, 1=txn-meta, 2=config (reserved); user graphs start
+                // at FIRST_USER_GRAPH_ID. Matches the shared graph allocator's
+                // dict_id+1 convention so spooled and fallback g_ids agree.
+                next_gid: fluree_db_core::graph_registry::FIRST_USER_GRAPH_ID,
                 prefix_map: HashMap::new(),
             }
         }
@@ -448,15 +453,17 @@ mod inner {
         fluree_graph_turtle::parse(&phase1.turtle, &mut sink)
             .map_err(|e| TransactError::Parse(e.to_string()))?;
 
-        // 3. Retrieve writer for named graph flakes
-        // Note: spool only captures default-graph triples parsed above.
-        // Named graph flakes (pushed below) are NOT spooled — TriG import
-        // falls back to the serial resolver path for index generation.
-        let (mut writer, chunk_prefix_map, spool_ctx) = sink
+        // 3. Retrieve writer + spool context for named graph flakes.
+        //
+        // Default-graph triples were parsed (and spooled) above. Named-graph
+        // flakes are pushed below to BOTH the commit blob (`writer`) and the
+        // spool (`spool_ctx`), so they reach the Tier-2 index and the index
+        // root's `named_graphs` routing exactly like default-graph triples.
+        // The spool is finished only after the named-graph loop completes.
+        let (mut writer, chunk_prefix_map, mut spool_ctx) = sink
             .finish()
             .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
         state.prefix_map.extend(chunk_prefix_map);
-        let spool_result = spool_ctx.map(crate::import_sink::SpoolContext::finish_buffered);
         let mut op_count = writer.op_count();
 
         // 4. Process named graphs
@@ -465,13 +472,25 @@ mod inner {
         let mut graph_delta: HashMap<u16, String> = HashMap::new();
 
         for block in &phase1.named_graphs {
-            // Allocate or reuse g_id for this graph IRI from session state
+            // Allocate or reuse g_id for this graph IRI.
+            //
+            // When spooling (index build) is active, allocate from the shared
+            // graph allocator so the commit's `graph_delta` and the index's
+            // `graphs.dict` / query graph registry agree on the same g_id
+            // (allocator convention: dict_id + 1 = g_id). Without spooling
+            // (commit-only paths), fall back to the session counter.
             let g_id = if let Some(&existing) = state.graph_ids.get(&block.iri) {
                 existing
             } else {
-                // New graph IRI in this session — allocate and record in delta
-                let id = state.next_gid;
-                state.next_gid += 1;
+                // New graph IRI in this session — allocate and record in delta.
+                let id = match spool_ctx.as_mut() {
+                    Some(sc) => sc.graph_g_id_for_iri(&block.iri),
+                    None => {
+                        let id = state.next_gid;
+                        state.next_gid += 1;
+                        id
+                    }
+                };
                 state.graph_ids.insert(block.iri.clone(), id);
                 graph_delta.insert(id, block.iri.clone());
                 id
@@ -493,7 +512,13 @@ mod inner {
                     let (o, dt, lang) =
                         expand_object(obj, &block.prefixes, &mut state.ns_registry)?;
 
-                    let meta = lang.map(|l| FlakeMeta::with_lang(&l));
+                    // Spool the named-graph flake under its g_id (so it enters
+                    // the index), then encode it into the commit blob.
+                    if let Some(sc) = spool_ctx.as_mut() {
+                        sc.push_named_graph_record(g_id, &s, &p, &o, &dt, lang.as_deref(), new_t);
+                    }
+
+                    let meta = lang.as_deref().map(FlakeMeta::with_lang);
                     let flake = Flake::new_in_graph(
                         graph_sid.clone(),
                         s.clone(),
@@ -511,10 +536,10 @@ mod inner {
                     op_count += 1;
                 }
             }
-
-            // Suppress unused variable warning - g_id is used for stability tracking
-            let _ = g_id;
         }
+
+        // Named-graph flakes are now in the spool; finish it for the index.
+        let spool_result = spool_ctx.map(crate::import_sink::SpoolContext::finish_buffered);
         drop(_parse_span);
 
         // 5. Resolve txn-meta if present

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -130,9 +130,8 @@ mod inner {
         // Shared global allocators (no remap needed)
         predicates: DictWorkerCache,
         datatypes: DictWorkerCache,
-        // Kept for: TriG named graph support in parallel import.
-        // Use when: T2.13 orchestration enables TriG parallel parsing.
-        #[expect(dead_code)]
+        // Graph IRI → dict_id allocator (shared). Used by `graph_g_id_for_iri`
+        // to assign named-graph g_ids consistently with the index `graphs.dict`.
         graphs: DictWorkerCache,
         // Shared global pools (no remap needed)
         numbig_pool: Arc<SharedNumBigPool>,
@@ -438,6 +437,43 @@ mod inner {
             };
 
             self.records.push(record);
+        }
+
+        /// Allocate (or look up) the `g_id` for a named-graph IRI via the shared
+        /// graph allocator.
+        ///
+        /// Applies the allocator convention `dict_id + 1 = g_id` (default graph
+        /// is g_id 0 and not in the dict; txn-meta is dict_id 0 → g_id 1) so the
+        /// returned g_id matches the index's `graphs.dict` and the query-time
+        /// graph registry. Used by the TriG/N-Quads import path so the commit
+        /// envelope's `graph_delta` and the index agree on the same g_id.
+        pub fn graph_g_id_for_iri(&mut self, iri: &str) -> GraphId {
+            let dict_id = self.graphs.get_or_insert(iri);
+            (dict_id + 1) as GraphId
+        }
+
+        /// Spool one flake belonging to an explicit named graph (`g_id`).
+        ///
+        /// The default-graph fast path writes records under the per-chunk `g_id`
+        /// fixed at construction; named `GRAPH`-block flakes go through here so
+        /// they enter the Tier-2 index (and the `named_graphs` routing) exactly
+        /// like default-graph triples. Only invoked when an import contains named
+        /// graphs — the single-graph hot path never touches this.
+        #[allow(clippy::too_many_arguments)]
+        pub fn push_named_graph_record(
+            &mut self,
+            g_id: GraphId,
+            s: &Sid,
+            p: &Sid,
+            o: &FlakeValue,
+            dt: &Sid,
+            lang: Option<&str>,
+            t: i64,
+        ) {
+            let saved = self.g_id;
+            self.g_id = g_id;
+            self.write_record(s, p, o, dt, lang, None, t);
+            self.g_id = saved;
         }
     }
 

--- a/fluree-db-transact/src/parse/mod.rs
+++ b/fluree-db-transact/src/parse/mod.rs
@@ -4,10 +4,12 @@
 //! representations into the internal Transaction IR.
 
 pub mod jsonld;
+pub mod nquads;
 pub mod trig_meta;
 pub mod txn_meta;
 
 pub use jsonld::parse_transaction;
+pub use nquads::nquads_to_trig;
 pub use trig_meta::{
     extract_trig_txn_meta, parse_trig_phase1, resolve_trig_meta, NamedGraphBlock, RawObject,
     RawTerm, RawTrigMeta, RawTriple, TrigMetaResult, TrigPhase1Result, TXN_META_GRAPH_IRI,

--- a/fluree-db-transact/src/parse/nquads.rs
+++ b/fluree-db-transact/src/parse/nquads.rs
@@ -1,0 +1,209 @@
+//! N-Quads → TriG conversion.
+//!
+//! N-Quads (`.nq`) is N-Triples plus an optional 4th *graph label* term per
+//! statement: `<s> <p> <o> [<g>] .`. It is **not** a syntactic subset of TriG
+//! (which groups named graphs in `GRAPH <g> { ... }` blocks), so the
+//! Turtle/TriG parser cannot read it directly. This converter regroups quads
+//! into TriG so the existing TriG import path ([`crate::import_trig_commit`])
+//! handles them: default-graph triples stay bare, named-graph triples are
+//! wrapped in a `GRAPH <g> { ... }` block per distinct graph label.
+//!
+//! N-Quads uses only absolute IRIs (`<...>`), blank nodes (`_:b`), and literals
+//! — there are no `@prefix` declarations — so the conversion is a pure
+//! regrouping of byte spans from the original text (no term re-serialization,
+//! hence no escape/round-trip hazards).
+
+use crate::error::{Result, TransactError};
+use fluree_graph_turtle::{tokenize, Token, TokenKind};
+
+/// Convert an N-Quads document into equivalent TriG text.
+///
+/// Default-graph quads (3 terms) are emitted as bare triples; quads with a
+/// graph label (4 terms) are grouped under `GRAPH <label> { ... }`, preserving
+/// first-seen order of graph labels.
+pub fn nquads_to_trig(content: &str) -> Result<String> {
+    let tokens =
+        tokenize(content).map_err(|e| TransactError::Parse(format!("n-quads tokenize: {e}")))?;
+
+    let mut default_triples: Vec<&str> = Vec::new();
+    // (graph label text incl. delimiters, triples). Vec preserves first-seen order.
+    let mut named: Vec<(&str, Vec<&str>)> = Vec::new();
+
+    // Walk statements: accumulate term tokens until each `.`, then regroup.
+    let mut stmt: Vec<&Token> = Vec::new();
+    for tok in &tokens {
+        match tok.kind {
+            TokenKind::Eof => break,
+            TokenKind::Dot => {
+                if !stmt.is_empty() {
+                    classify_statement(content, &stmt, &mut default_triples, &mut named)?;
+                    stmt.clear();
+                }
+            }
+            _ => stmt.push(tok),
+        }
+    }
+    if !stmt.is_empty() {
+        return Err(TransactError::Parse(
+            "n-quads: trailing statement not terminated by '.'".to_string(),
+        ));
+    }
+
+    // Emit TriG.
+    let mut out = String::with_capacity(content.len() + named.len() * 16);
+    for triple in default_triples {
+        out.push_str(triple);
+        out.push_str(" .\n");
+    }
+    for (label, triples) in named {
+        out.push_str("GRAPH ");
+        out.push_str(label);
+        out.push_str(" {\n");
+        for triple in triples {
+            out.push_str(triple);
+            out.push_str(" .\n");
+        }
+        out.push_str("}\n");
+    }
+    Ok(out)
+}
+
+/// Split a statement's term tokens into "term groups" and route the triple
+/// portion to either the default graph or a named graph.
+fn classify_statement<'a>(
+    content: &'a str,
+    stmt: &[&Token],
+    default_triples: &mut Vec<&'a str>,
+    named: &mut Vec<(&'a str, Vec<&'a str>)>,
+) -> Result<()> {
+    let terms = group_terms(stmt)?;
+    // subject, predicate, object, [graph]
+    if terms.len() != 3 && terms.len() != 4 {
+        return Err(TransactError::Parse(format!(
+            "n-quads: expected 3 or 4 terms per statement, found {}",
+            terms.len()
+        )));
+    }
+
+    // Triple text spans from the subject's start to the object's end.
+    let (triple_start, _) = terms[0];
+    let (_, triple_end) = terms[2];
+    let triple = &content[triple_start..triple_end];
+
+    if terms.len() == 3 {
+        default_triples.push(triple);
+    } else {
+        // 4th term is the graph label; reuse its original text (`<iri>`).
+        let (g_start, g_end) = terms[3];
+        let label = &content[g_start..g_end];
+        // The TriG parser only accepts an IRI graph label, not a blank node.
+        // Blank-node graph labels are valid N-Quads but unsupported on import;
+        // reject with a clear error rather than emitting un-parseable TriG.
+        if label.starts_with("_:") {
+            return Err(TransactError::Parse(format!(
+                "n-quads: blank-node graph labels are not supported on import \
+                 (found `{label}`); use an IRI graph label"
+            )));
+        }
+        if let Some((_, triples)) = named.iter_mut().find(|(l, _)| *l == label) {
+            triples.push(triple);
+        } else {
+            named.push((label, vec![triple]));
+        }
+    }
+    Ok(())
+}
+
+/// Group a statement's tokens into term spans `(start_byte, end_byte)`.
+///
+/// Most terms are a single token; a string literal may be followed by a
+/// datatype (`^^ <iri>`) or a language tag (`@lang`), which are folded into the
+/// same term.
+fn group_terms(stmt: &[&Token]) -> Result<Vec<(usize, usize)>> {
+    let mut terms = Vec::with_capacity(4);
+    let mut i = 0;
+    while i < stmt.len() {
+        let start = stmt[i].start as usize;
+        let mut end = stmt[i].end as usize;
+        let is_string = matches!(stmt[i].kind, TokenKind::String | TokenKind::LongString);
+        i += 1;
+        if is_string && i < stmt.len() {
+            match stmt[i].kind {
+                TokenKind::DoubleCaret => {
+                    // datatype: ^^ <iri>
+                    i += 1;
+                    let dt = stmt.get(i).ok_or_else(|| {
+                        TransactError::Parse("n-quads: '^^' not followed by a datatype".to_string())
+                    })?;
+                    end = dt.end as usize;
+                    i += 1;
+                }
+                TokenKind::LangTag => {
+                    end = stmt[i].end as usize;
+                    i += 1;
+                }
+                _ => {}
+            }
+        }
+        terms.push((start, end));
+    }
+    Ok(terms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_graph_only_is_pass_through_triples() {
+        let nq = "<http://ex/a> <http://ex/p> <http://ex/b> .\n\
+                  <http://ex/a> <http://ex/name> \"Alice\" .\n";
+        let trig = nquads_to_trig(nq).unwrap();
+        assert!(trig.contains("<http://ex/a> <http://ex/p> <http://ex/b> ."));
+        assert!(trig.contains("<http://ex/a> <http://ex/name> \"Alice\" ."));
+        assert!(!trig.contains("GRAPH"));
+    }
+
+    #[test]
+    fn named_graph_quads_grouped() {
+        let nq = "<http://ex/a> <http://ex/name> \"Alice\" .\n\
+                  <http://ex/e1> <http://ex/desc> \"login\" <http://ex/g/audit> .\n\
+                  <http://ex/e2> <http://ex/desc> \"logout\" <http://ex/g/audit> .\n";
+        let trig = nquads_to_trig(nq).unwrap();
+        assert!(trig.contains("GRAPH <http://ex/g/audit> {"));
+        assert!(trig.contains("<http://ex/e1> <http://ex/desc> \"login\" ."));
+        assert!(trig.contains("<http://ex/e2> <http://ex/desc> \"logout\" ."));
+        // The default-graph triple stays outside the GRAPH block.
+        let graph_pos = trig.find("GRAPH").unwrap();
+        assert!(trig[..graph_pos].contains("\"Alice\" ."));
+    }
+
+    #[test]
+    fn typed_and_lang_literals_keep_their_suffix() {
+        let nq = "<http://ex/a> <http://ex/age> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer> <http://ex/g> .\n\
+                  <http://ex/a> <http://ex/label> \"hi\"@en <http://ex/g> .\n";
+        let trig = nquads_to_trig(nq).unwrap();
+        assert!(trig.contains("\"42\"^^<http://www.w3.org/2001/XMLSchema#integer> ."));
+        assert!(trig.contains("\"hi\"@en ."));
+        assert!(trig.contains("GRAPH <http://ex/g> {"));
+    }
+
+    #[test]
+    fn blank_node_graph_label_is_rejected() {
+        // Blank-node graph labels are valid N-Quads but the TriG parser only
+        // accepts IRI graph labels, so import rejects them with a clear error.
+        let nq = "<http://ex/a> <http://ex/p> <http://ex/b> _:g1 .\n";
+        let err = nquads_to_trig(nq).expect_err("blank-node graph label should be rejected");
+        assert!(
+            err.to_string()
+                .contains("blank-node graph labels are not supported"),
+            "expected a clear rejection message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unterminated_statement_errors() {
+        let nq = "<http://ex/a> <http://ex/p> <http://ex/b>\n";
+        assert!(nquads_to_trig(nq).is_err());
+    }
+}

--- a/fluree-graph-turtle/src/splitter.rs
+++ b/fluree-graph-turtle/src/splitter.rs
@@ -1300,9 +1300,17 @@ fn reader_thread_from_source(
         }
 
         // Report progress periodically.
+        //
+        // `file_size` may be 0 when the caller has no cheap way to know the
+        // uncompressed total (e.g. a gzip source). Use `saturating_sub` so the
+        // denominator stays 0 (the UI's contract for "unknown total") instead
+        // of underflowing u64 to a huge bogus value.
         if abs_pos >= next_progress {
             if let Some(ref cb) = progress {
-                cb(abs_pos - data_start, file_size - data_start);
+                cb(
+                    abs_pos.saturating_sub(data_start),
+                    file_size.saturating_sub(data_start),
+                );
             }
             next_progress = abs_pos + progress_interval;
         }
@@ -1404,9 +1412,14 @@ fn reader_thread_from_source(
         }
     }
 
-    // Final progress report.
+    // Final progress report. Skip when `file_size` is 0 (unknown total) —
+    // emitting (0, 0) would tell the UI "0 of 0 read" which it can't
+    // distinguish from a reset. The CLI handles unknown-total finalization
+    // from the next `Committing` phase event instead.
     if let Some(ref cb) = progress {
-        cb(file_size - data_start, file_size - data_start);
+        if file_size > 0 {
+            cb(file_size - data_start, file_size - data_start);
+        }
     }
 
     // If we never emitted chunk 0 (small file) or finished scanning windows late, publish now.

--- a/fluree-graph-turtle/src/splitter.rs
+++ b/fluree-graph-turtle/src/splitter.rs
@@ -20,7 +20,7 @@
 //!    document.
 
 use std::fs::File;
-use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -131,10 +131,36 @@ pub fn extract_prefix_block(path: &Path) -> Result<(String, u64), SplitError> {
     let mut buf = vec![0u8; scan_size];
     let mut reader = BufReader::new(file);
     reader.read_exact(&mut buf)?;
+    extract_prefix_block_from_bytes(&buf)
+}
 
+/// Variant of [`extract_prefix_block`] that reads from any `Read` source.
+///
+/// Used for compressed inputs (gzip, zstd) where the path-based variant can't
+/// `metadata()` for the uncompressed size and can't seek back. Reads up to
+/// `PREFIX_SCAN_SIZE` bytes from `reader` (consuming them) and returns the
+/// `(prefix_text, data_start_byte)` pair.
+pub fn extract_prefix_block_from_reader<R: Read>(
+    reader: &mut R,
+) -> Result<(String, u64), SplitError> {
+    let mut buf = vec![0u8; PREFIX_SCAN_SIZE];
+    let mut filled = 0;
+    while filled < buf.len() {
+        match reader.read(&mut buf[filled..])? {
+            0 => break,
+            n => filled += n,
+        }
+    }
+    buf.truncate(filled);
+    extract_prefix_block_from_bytes(&buf)
+}
+
+/// Shared scan logic — extract the prefix/base directive block from a buffer
+/// of leading bytes. Returns `(prefix_text, data_start_byte_within_buf)`.
+fn extract_prefix_block_from_bytes(buf: &[u8]) -> Result<(String, u64), SplitError> {
     // Tokenize the header region. If it ends mid-token, tokenize() may error;
     // we try to find a safe truncation point by scanning backwards for a newline.
-    let header_str = find_safe_header(&buf);
+    let header_str = find_safe_header(buf);
 
     let tokens = tokenize(header_str).map_err(|e| SplitError::Tokenize(e.to_string()))?;
 
@@ -1009,6 +1035,92 @@ impl StreamingTurtleReader {
         })
     }
 
+    /// Create a streaming reader from a non-seekable source (e.g. a streaming
+    /// decompressor over a `.ttl.gz` / `.ttl.zst` file).
+    ///
+    /// `open_reader` is called twice: once on the calling thread to extract the
+    /// prelude, and once on the spawned reader thread to stream the body. Each
+    /// call must return a freshly-positioned reader at byte 0. This avoids any
+    /// seek requirement on the underlying source.
+    ///
+    /// `total_bytes_hint` is the best-effort *uncompressed* size used only for
+    /// progress denominators. Pass `0` if unknown (gzip's footer is only
+    /// reliable for files under 4 GiB uncompressed); in that case
+    /// `estimated_chunks` is computed from the hint and may be 0.
+    ///
+    /// All other parameters match [`new`](Self::new).
+    pub fn new_from_factory<F>(
+        open_reader: F,
+        total_bytes_hint: u64,
+        chunk_size_bytes: u64,
+        channel_capacity: usize,
+        progress: Option<ScanProgressFn>,
+    ) -> Result<Self, SplitError>
+    where
+        F: Fn() -> io::Result<Box<dyn BufRead + Send>> + Send + Sync + 'static,
+    {
+        // Pass 1: open a reader, extract prelude (consumes the prelude bytes).
+        let mut prelude_reader = open_reader()?;
+        let (prefix_block, data_start) = extract_prefix_block_from_reader(&mut prelude_reader)?;
+        drop(prelude_reader);
+        let prelude = parse_prelude(&prefix_block)?;
+
+        // `file_size` here is the uncompressed total. For compressed sources
+        // the caller may not know it cheaply — in that case 0 means "unknown"
+        // and progress callbacks will receive 0 as the denominator.
+        let file_size = total_bytes_hint;
+        let data_len = file_size.saturating_sub(data_start);
+        let estimated_chunks = if data_len == 0 || chunk_size_bytes == 0 {
+            0
+        } else {
+            data_len.div_ceil(chunk_size_bytes) as usize
+        };
+
+        tracing::info!(
+            file_size_mb = file_size / (1024 * 1024),
+            chunk_size_mb = chunk_size_bytes / (1024 * 1024),
+            prefix_bytes = prefix_block.len(),
+            data_start,
+            estimated_chunks,
+            "streaming reader (factory): prefix extracted, spawning reader thread"
+        );
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(channel_capacity);
+        let ns_preflight: std::sync::Arc<std::sync::OnceLock<NamespacePreflight>> =
+            std::sync::Arc::new(std::sync::OnceLock::new());
+        let ns_preflight_thread = std::sync::Arc::clone(&ns_preflight);
+        let reader_handle = std::thread::Builder::new()
+            .name("ttl-reader".into())
+            .spawn(move || -> Result<usize, SplitError> {
+                // Pass 2: open a fresh reader, advance past the prelude, stream.
+                let body_reader = open_reader()?;
+                reader_thread_from_source(
+                    body_reader,
+                    data_start,
+                    file_size,
+                    chunk_size_bytes,
+                    tx,
+                    progress,
+                    ns_preflight_thread,
+                )
+            })
+            .map_err(|e| {
+                SplitError::Io(io::Error::other(format!(
+                    "failed to spawn reader thread: {e}"
+                )))
+            })?;
+
+        Ok(Self {
+            prefix_block,
+            prelude,
+            file_size,
+            estimated_chunks,
+            ns_preflight,
+            rx: Arc::new(std::sync::Mutex::new(rx)),
+            reader_handle: Some(reader_handle),
+        })
+    }
+
     /// Receive the next chunk from the reader thread.
     ///
     /// Returns `Ok(Some((index, raw_bytes)))` for each chunk, or `Ok(None)`
@@ -1100,8 +1212,40 @@ fn reader_thread(
     ns_preflight: std::sync::Arc<std::sync::OnceLock<NamespacePreflight>>,
 ) -> Result<usize, SplitError> {
     let file = File::open(path)?;
-    let mut reader = BufReader::with_capacity(SCAN_BUF_SIZE, file);
-    reader.seek(SeekFrom::Start(data_start))?;
+    let reader: Box<dyn BufRead + Send> = Box::new(BufReader::with_capacity(SCAN_BUF_SIZE, file));
+    reader_thread_from_source(
+        reader,
+        data_start,
+        file_size,
+        chunk_size_bytes,
+        tx,
+        progress,
+        ns_preflight,
+    )
+}
+
+/// Reader-thread variant that takes an already-opened `BufRead` source.
+///
+/// Used by [`StreamingTurtleReader::new_from_factory`] for compressed inputs
+/// (gzip, zstd) and other non-seekable sources. Advances the reader past
+/// `data_start` bytes via read-and-discard, then runs the shared chunk
+/// emission loop. `file_size` is the best-effort uncompressed total
+/// (0 means unknown — used only as the denominator in `progress` callbacks).
+fn reader_thread_from_source(
+    mut reader: Box<dyn BufRead + Send>,
+    data_start: u64,
+    file_size: u64,
+    chunk_size_bytes: u64,
+    tx: std::sync::mpsc::SyncSender<ChunkPayload>,
+    progress: Option<ScanProgressFn>,
+    ns_preflight: std::sync::Arc<std::sync::OnceLock<NamespacePreflight>>,
+) -> Result<usize, SplitError> {
+    // Advance past the prelude bytes without a seek (works for any reader).
+    // For seekable File readers the cost is one buffered read of the prelude,
+    // which is small (< 256 KiB by convention) — negligible vs the chunk loop.
+    if data_start > 0 {
+        io::copy(&mut reader.by_ref().take(data_start), &mut io::sink())?;
+    }
 
     let mut buf = vec![0u8; SCAN_BUF_SIZE];
 


### PR DESCRIPTION
Closes several gaps in the bulk-import pipeline (`fluree create --from`, `import_from_storage`) — without touching the optimized single-graph `.ttl` hot path:

- **N-Triples (`.nt`)** — parsed as Turtle (it's a strict subset). Pure dispatch-layer extension; the parser needed no changes.
- **N-Quads (`.nq`)** — converted to TriG and routed through the named-graph-aware TriG path.
- **TriG (`.trig`) named graphs are now queryable after bulk import.** Previously only default-graph TriG worked end-to-end; named-graph flakes were silently dropped by the spool/index pipeline. Remote `.trig` (`import_from_storage`) is re-enabled.
- **Transparent `.gz` and `.zst` decompression** for all five RDF input formats (`.ttl.gz`, `.nt.gz`, `.nq.gz`, `.trig.gz`, `.jsonld.gz`, plus the `.zst` variants).

## What changed and why

### 1. N-Triples (`.nt`)

N-Triples is a strict syntactic subset of Turtle (three full-IRI terms, then `.`), so the Turtle parser already accepts it. The only gap was dispatch: a single `.nt` file already worked via a fallback path, but directory discovery, large-file streaming-split, and remote-object acceptance all hard-coded `.ttl`/`.trig`/`.jsonld` allowlists and silently dropped `.nt`. Fixed by extending each allowlist site to treat `.nt` as Turtle.

### 2. TriG named-graph bulk import

`.trig` files were already accepted, but a deeper look revealed the existing wiring only worked for default-graph content. Named-graph data — the entire point of TriG — was:

- Written to the commit blob but **not spooled** for index generation.
- Never registered in `graphs.dict` / the query-time graph registry, so queries returned `Unknown named graph '#<iri>'`.

There were also two unreconciled graph-id allocators (the commit `state.next_gid` counter vs. the shared `graph_alloc` that feeds the index), creating a sharp edge where the same graph could end up with different IDs on the commit and index sides.

**Fix** spans three layers:

- `fluree-db-transact/src/import_sink.rs` — `SpoolContext::graph_g_id_for_iri` (allocates a graph's g_id via the shared allocator, honoring the `dict_id + 1 = g_id` convention) and `SpoolContext::push_named_graph_record` (spools a record under an explicit g_id by temporarily swapping the per-chunk `g_id` field).
- `fluree-db-transact/src/import.rs` — `import_trig_commit` now allocates named g_ids from the spool allocator when spooling (the source of truth for `graphs.dict`), spools each named-graph flake, and finishes the spool only after the named-graph loop. The non-spooling fallback's `ImportState::new()` was shifted to start at `FIRST_USER_GRAPH_ID` (3) so it honors the reserved range (`0=default, 1=txn-meta, 2=config, 3+=user`) even without a spool config.
- `fluree-db-api/src/import.rs` — `build_and_upload` now runs an extra `build_indexes_from_commits` pass per user-defined named graph (g_id ≥ `FIRST_USER_GRAPH_ID`), mirroring the existing g_id=1 (txn-meta) build and merging the resulting per-order results. The named-graph list is threaded through `ChunkImportResult.named_g_ids` → `IndexBuildInput.named_g_ids`. For single-graph imports the range is empty, so the loop is skipped entirely.

With the underlying limitation gone, `resolve_remote_objects` no longer rejects remote `.trig` — that error path and its now-stale "TriG is not currently supported" copy have been removed.

### 3. N-Quads (`.nq`)

Unlike N-Triples, N-Quads is **not** a TriG subset — TriG groups named graphs in `GRAPH <g> { ... }` blocks, while N-Quads carries an optional 4th *graph label* term on each statement. So the Turtle/TriG parser cannot read it directly.

Solution: `fluree-db-transact/src/parse/nquads.rs` — a small converter (`nquads_to_trig`) that walks Turtle tokens (typed-literal `^^` and language-tag `@lang` suffixes are folded into the preceding term), regroups quads by graph label, and emits equivalent TriG with `GRAPH <iri> { ... }` blocks. The output is **byte-span sliced from the original input** — no term re-serialization, so escape sequences round-trip safely.

`.nq` files force the serial path (`has_nquads()` joins `has_trig` / `has_jsonld` in the parallel-vs-serial gate) and dispatch via `is_nquads(idx) → nquads_to_trig() → import_trig_commit` in both local and remote serial arms. Blank-node graph labels (which the TriG parser doesn't accept) are rejected with a clear error rather than silently producing un-parseable TriG.

### 4. Transparent `.gz` and `.zst` decompression

Real-world RDF dumps (DBpedia, Wikidata, every LOD-cloud archive) ship compressed. Now any of the five RDF formats above can carry a `.gz` or `.zst` suffix and is decoded transparently.

- `fluree-db-api/src/import.rs` — new `Compression` enum + `effective_extension(path) -> (Option<String>, Compression)` helper strips an outer `.gz`/`.zst`/`.zstd` and returns the underlying RDF extension. Every dispatch site (`is_trig`, `is_nquads`, `is_jsonld`, `has_jsonld`, `has_nquads`, `scan_directory_format`, `discover_chunks`, `resolve_chunk_source`) now uses it. `open_decoded` wraps a file in `flate2::read::MultiGzDecoder` (handles concatenated streams from `pigz`/`bgzip`) or `zstd::stream::read::Decoder` as needed; `read_decoded_to_string` is the small-file path and falls back to plain `fs::read_to_string` for uncompressed inputs (zero overhead).
- `fluree-graph-turtle/src/splitter.rs` — `StreamingTurtleReader::new_from_factory(open_reader, total_bytes_hint, ...)` takes a closure that opens a fresh `Box<dyn BufRead + Send>`; called once on the main thread for prelude extraction (via the new `extract_prefix_block_from_reader`), once on the reader thread for body streaming. The reader thread replaces its lone `seek(data_start)` with `io::copy(reader.take(data_start), &mut sink)` so any source — not just seekable `File` — qualifies. The plain-file path keeps its original seek-backed fast path.
- `fluree-db-cli/src/detect.rs` — `detect_data_format` now looks at the inner extension so `.ttl.gz` / `.jsonld.zst` classify as their underlying format.

Performance footprint: the single-graph `.ttl` hot path is untouched. The streaming large-file reader's prelude advance is now `io::copy(take(N), sink)` rather than `seek`, but `N` is the prelude size (≤ 256 KiB) so the cost is negligible vs the chunk loop. Compressed inputs decode single-threaded (gzip and zstd are sequential), so on multi-GB compressed files the decoder will be the bottleneck — multi-stream (bgzip-style) parallel decode is a future optimization, not blocking.

### Deliberate scope cuts

- **Remote compressed objects** (e.g. `.ttl.gz` in S3 via `import_from_storage`): the local path covers the dominant use case (`fluree create mydb --from dbpedia.ttl.gz`). Wiring decompression into the producer/bridge thread is a natural follow-up.
- **HTTP `Content-Encoding: gzip` on `/insert`/`/upsert`**: a separate server-middleware change. The CLI's `detect_data_format` was updated to recognize inner extensions so the eventual end-to-end wiring is straightforward.
- **`.nq` over HTTP content-type**: the server's Turtle parser can't read raw N-Quads. `.nq` is bulk-import-only by design.

## New tests

- `it_import.rs::import_single_nt_file_then_query` and `import_nt_directory_then_query` — `.nt` round-trips for single-file and directory discovery.
- `it_import.rs::import_trig_named_graph_is_queryable` — TriG bulk import with a GRAPH block; asserts both default-graph and named-graph data are queryable post-index (the latter is the behavior the named-graph fix enables).
- `it_import.rs::import_nquads_default_and_named_graph` — `.nq` round-trip covering both 3-term default-graph lines and 4-term named-graph quads.
- `it_import_remote.rs::import_from_storage_trig_named_graph_then_query` — replaces the prior "reject `.trig` remotely" test with a positive round-trip that includes a named graph.
- `it_import.rs::import_gzipped_ttl_small_file`, `import_gzipped_nt_directory`, `import_zstd_ttl_small_file` — compressed-input round-trips covering both formats and both single-file and directory paths.
- `it_import.rs::import_gzipped_ttl_streaming_split` — ~40k synthetic triples gzipped, imported with `--chunk-size-mb 1` so the streaming-split factory path is exercised end-to-end; asserts spot-check values queryable post-index.
- `parse/nquads.rs` unit tests — default-graph pass-through, named-graph grouping, typed-literal and language-tag suffix preservation, unterminated-statement rejection, blank-node graph-label rejection.

## Dependencies

- `flate2 = "1"` added as a workspace dep (pure-Rust `miniz_oxide` backend, no system libz dependency, no new transitive crates of note).
- `zstd` was already a workspace dep.

## Docs touched

- `docs/cli/create.md` — `--from` accepts all five formats plus `.gz`/`.zst` variants; named-graph queryability via `#<graph-iri>` fragment.
- `docs/cli/insert.md` — extension detection includes `.nt`.
- `docs/api/endpoints.md` — `application/n-triples` content type on `/insert` and `/upsert`.
