### PR TITLE
perf: parallelize secondary index builds + memory-aware CPU model

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -37,8 +37,8 @@ fluree query 'SELECT ?name WHERE { ?s <http://example.org/name> ?name }'
 | `-q, --quiet` | Suppress non-essential output |
 | `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
 | `--config <PATH>` | Path to config file |
-| `--memory-budget-mb <MB>` | Memory budget in MB for bulk import (0 = auto: 75% of system RAM). Affects chunk size, concurrency, and run budget when creating a ledger with `--from`. |
-| `--parallelism <N>` | Number of parallel parse threads for bulk import (0 = auto: system cores, default cap 6). Used when creating a ledger with `--from`. |
+| `--memory-budget-mb <MB>` | Memory budget in MB for bulk import (0 = auto: 60% of system RAM). Affects chunk size, concurrency, and run budget when creating a ledger with `--from`. Set this to cap memory use; auto-detected thread count shrinks to fit it. |
+| `--parallelism <N>` | Number of parallel parse threads for bulk import (0 = auto: most logical cores, capped to fit the memory budget; explicit values honored as-is, floored at 1). Used when creating a ledger with `--from`. |
 | `-h, --help` | Print help |
 | `-V, --version` | Print version |
 

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -27,8 +27,8 @@ fluree create <LEDGER> [OPTIONS]
 
 **Global flags** that affect bulk import when using `--from` (see [CLI README](README.md#global-options)):
 
-- `--memory-budget-mb <MB>` — Memory budget in MB (0 = auto: 75% of system RAM). Drives chunk size, concurrency, and indexer run budget.
-- `--parallelism <N>` — Number of parallel parse threads (0 = auto: system cores, cap 6).
+- `--memory-budget-mb <MB>` — Memory budget in MB (0 = auto: 60% of system RAM). Drives chunk size, concurrency, and indexer run budget. Set this to cap how much memory the import uses; auto-detected thread count shrinks to fit it.
+- `--parallelism <N>` — Number of parallel parse threads (0 = auto: most logical cores, capped to fit the memory budget; explicit values honored as-is, floored at 1).
 
 ## Description
 

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -96,7 +96,10 @@ pub type ProgressFn = Arc<dyn Fn(ImportPhase) + Send + Sync>;
 /// Configuration for the bulk import pipeline.
 #[derive(Clone)]
 pub struct ImportConfig {
-    /// Number of parallel TTL parse threads. Default: available parallelism (capped at 6).
+    /// Number of parallel TTL parse threads. `0` = auto: the machine's logical
+    /// cores, capped so peak parse memory fits the budget (see
+    /// [`effective_parse_threads`](Self::effective_parse_threads)). Explicit
+    /// values are honored as-is (uncapped), with a hard floor of 1.
     pub parse_threads: usize,
     /// Whether to build multi-order indexes after runs. Default: true.
     pub build_index: bool,
@@ -184,11 +187,10 @@ impl std::fmt::Debug for ImportConfig {
 
 impl Default for ImportConfig {
     fn default() -> Self {
-        let threads = std::thread::available_parallelism()
-            .map(|n| n.get().min(6))
-            .unwrap_or(4);
         Self {
-            parse_threads: threads,
+            // 0 = auto: resolved by `effective_parse_threads()` to (most of) the
+            // machine's cores, memory-capped. Explicit values bypass the cap.
+            parse_threads: 0,
             build_index: true,
             publish: true,
             cleanup_local_files: true,
@@ -311,11 +313,48 @@ impl ImportConfig {
         raw.clamp(128, 768)
     }
 
+    /// Effective parse/worker thread count.
+    ///
+    /// Resolution order:
+    /// 1. `FLUREE_IMPORT_THREADS=<n>` env override (trusted, only floored at 1).
+    /// 2. Explicit `parse_threads > 0` from the builder/CLI (trusted, floored at 1).
+    /// 3. Auto (`parse_threads == 0`): use the machine's logical cores, then cap
+    ///    so the pipeline's peak memory stays within budget.
+    ///
+    /// The memory cap matters because each parse worker holds an in-flight chunk
+    /// plus its parse expansion, and each heavy/remap worker holds a run buffer
+    /// (`effective_run_budget_mb / workers`). Auto-detect therefore never returns
+    /// more threads than the memory budget can feed — but an explicit value is
+    /// honored as-is (the operator owns the trade-off), with a hard floor of 1 so
+    /// imports still run on a 1–2 core box (just slower).
+    pub fn effective_parse_threads(&self) -> usize {
+        if let Ok(v) = std::env::var("FLUREE_IMPORT_THREADS") {
+            if let Ok(n) = v.parse::<usize>() {
+                return n.max(1);
+            }
+        }
+        if self.parse_threads > 0 {
+            return self.parse_threads;
+        }
+        // Auto: start from logical cores.
+        let cores = std::thread::available_parallelism()
+            .map(std::num::NonZero::get)
+            .unwrap_or(4);
+        // Memory guard: peak parse-side memory ≈ threads × chunk_size × ~2.5
+        // (raw chunk + token/parse expansion). Keep that under ~half the budget
+        // so dict merge, run buffers, and OS cache have room. This bounds auto
+        // detection on small-RAM boxes without penalizing big ones.
+        let budget_mb = self.effective_memory_budget_mb();
+        let chunk_mb = self.effective_chunk_size_mb().max(1);
+        let mem_cap = ((budget_mb / 2) as f64 / (chunk_mb as f64 * 2.5)).floor() as usize;
+        cores.min(mem_cap.max(1)).max(1)
+    }
+
     /// Effective run budget in MB (always auto-derived from budget and parallelism).
     pub fn effective_run_budget_mb(&self) -> usize {
         let budget_mb = self.effective_memory_budget_mb();
         let chunk_size = self.effective_chunk_size_mb();
-        let threads = self.parse_threads.max(1);
+        let threads = self.effective_parse_threads();
         // IMPORTANT: In Tier 2, we have N independent run writers (one per remap worker),
         // so the *total* run budget must scale with parallelism. Otherwise each writer
         // gets a tiny slice and flushes many small run files, exploding disk I/O.
@@ -333,8 +372,9 @@ impl ImportConfig {
     /// These workers remap sorted-commit artifacts to per-order run files and
     /// then merge those runs into final index artifacts.
     /// Memory per worker is bounded by `per_thread_budget_bytes` (derived from
-    /// `effective_run_budget_mb() / worker_count`), so we can safely run as many workers as
-    /// we have parse threads (which is already capped at CPU count, max 6).
+    /// `effective_run_budget_mb() / worker_count`), so we can safely run as many
+    /// workers as we have parse threads. This count also bounds concurrent
+    /// secondary-order index builds (`BuildAllConfig::max_concurrency`).
     ///
     /// Override with `FLUREE_IMPORT_HEAVY_WORKERS=<n>`.
     pub fn effective_heavy_workers(&self) -> usize {
@@ -343,7 +383,7 @@ impl ImportConfig {
                 return n.max(1);
             }
         }
-        self.parse_threads.max(1)
+        self.effective_parse_threads()
     }
 
     /// Log all computed import settings.
@@ -352,7 +392,7 @@ impl ImportConfig {
         let chunk_size = self.effective_chunk_size_mb();
         let max_inflight = self.effective_max_inflight();
         let run_budget = self.effective_run_budget_mb();
-        let parallelism = self.parse_threads;
+        let parallelism = self.effective_parse_threads();
 
         tracing::info!(
             memory_budget_mb = budget,
@@ -369,7 +409,7 @@ impl ImportConfig {
     pub fn effective_import_settings(&self) -> EffectiveImportSettings {
         EffectiveImportSettings {
             memory_budget_mb: self.effective_memory_budget_mb(),
-            parallelism: self.parse_threads,
+            parallelism: self.effective_parse_threads(),
             chunk_size_mb: self.effective_chunk_size_mb(),
             max_inflight_chunks: self.effective_max_inflight(),
         }
@@ -389,7 +429,7 @@ impl ImportConfig {
 pub struct EffectiveImportSettings {
     /// Memory budget in MB (60% of system RAM when not set).
     pub memory_budget_mb: usize,
-    /// Number of parallel parse threads (system cores capped at 6 when not set).
+    /// Number of parallel parse threads (auto: logical cores, memory-capped, when not set).
     pub parallelism: usize,
     /// Chunk size in MB for large-file splitting (derived from budget when not set).
     pub chunk_size_mb: usize,
@@ -1516,7 +1556,9 @@ impl<'a> ImportBuilder<'a> {
         }
     }
 
-    /// Set the number of parallel TTL parse threads.
+    /// Set the number of parallel TTL parse threads. `0` = auto (use the
+    /// machine's logical cores, memory-capped). Explicit values are honored
+    /// as-is (not capped to core count) with a hard floor of 1.
     pub fn threads(mut self, n: usize) -> Self {
         self.config.parse_threads = n;
         self
@@ -1549,7 +1591,7 @@ impl<'a> ImportBuilder<'a> {
         self
     }
 
-    /// Set the parallelism (alias for `.threads()`).
+    /// Set the parallelism (alias for [`threads`](Self::threads)). `0` = auto.
     pub fn parallelism(mut self, n: usize) -> Self {
         self.config.parse_threads = n;
         self
@@ -2454,7 +2496,7 @@ where
     let is_channel_fed = is_streaming || is_remote_parallel || is_local_rechunk;
     let estimated_total = chunk_source.estimated_len();
     let compress = config.compress_commits;
-    let num_threads = config.parse_threads;
+    let num_threads = config.effective_parse_threads();
     let mut state = ImportState::new();
     let run_start = Instant::now();
 
@@ -5080,4 +5122,127 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod resource_model_tests {
+    use super::*;
+
+    /// Serializes env mutation across these tests (process-global env is shared
+    /// by all test threads) and guarantees the import override vars are unset for
+    /// the body — so a developer/CI environment that exports
+    /// `FLUREE_IMPORT_THREADS` / `FLUREE_IMPORT_HEAVY_WORKERS` cannot perturb the
+    /// resolution logic under test. Vars are restored on drop.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn clear_overrides() -> Self {
+            let lock = ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let vars = ["FLUREE_IMPORT_THREADS", "FLUREE_IMPORT_HEAVY_WORKERS"];
+            let saved = vars
+                .iter()
+                .map(|&k| (k, std::env::var(k).ok()))
+                .collect::<Vec<_>>();
+            for (k, _) in &saved {
+                std::env::remove_var(k);
+            }
+            Self { _lock: lock, saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    /// Build a config with an explicit memory budget + chunk size so the
+    /// memory-cap arithmetic in `effective_parse_threads` is deterministic
+    /// (independent of the host's RAM and core count for the explicit cases).
+    fn cfg(memory_budget_mb: usize, chunk_size_mb: usize, parse_threads: usize) -> ImportConfig {
+        ImportConfig {
+            parse_threads,
+            memory_budget_mb,
+            chunk_size_mb,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn explicit_thread_count_is_honored_uncapped() {
+        let _env = EnvGuard::clear_overrides();
+        // Explicit value must NOT be clamped to core count or the memory cap —
+        // the operator owns the trade-off.
+        let c = cfg(8192, 256, 64);
+        assert_eq!(c.effective_parse_threads(), 64);
+        // ...and heavy workers follow it.
+        assert_eq!(c.effective_heavy_workers(), 64);
+    }
+
+    #[test]
+    fn explicit_thread_count_floored_at_one() {
+        let _env = EnvGuard::clear_overrides();
+        // A 0 means "auto", but the floor guarantees auto never yields 0 either.
+        // An explicit 1 stays 1 (serial-ish, works on a 1-CPU box).
+        let c = cfg(8192, 256, 1);
+        assert_eq!(c.effective_parse_threads(), 1);
+    }
+
+    #[test]
+    fn auto_is_memory_capped_on_tiny_budget() {
+        let _env = EnvGuard::clear_overrides();
+        // Auto (parse_threads = 0) with a deliberately tiny budget must shrink
+        // to (near) 1 so a small-RAM box does not oversubscribe memory.
+        // budget/2 = 768 MB; chunk 512 MB * 2.5 = 1280 MB/thread => cap = 0 -> floored to 1.
+        let c = cfg(1536, 512, 0);
+        assert_eq!(
+            c.effective_parse_threads(),
+            1,
+            "tiny budget must cap auto threads to 1"
+        );
+        // A slightly larger budget allows exactly 2 (sanity on the cap formula):
+        // budget/2 = 1536 MB; chunk 256 * 2.5 = 640 => cap = 2.
+        let c2 = cfg(3072, 256, 0);
+        let cap2 = ((3072 / 2) as f64 / (256.0 * 2.5)).floor() as usize;
+        assert_eq!(cap2, 2);
+        assert!(c2.effective_parse_threads() <= 2);
+    }
+
+    #[test]
+    fn auto_never_returns_zero() {
+        let _env = EnvGuard::clear_overrides();
+        // Even with a budget so small the cap arithmetic floors out, the hard
+        // floor of 1 keeps the import runnable (just slow).
+        let c = cfg(1, 768, 0);
+        assert!(c.effective_parse_threads() >= 1);
+    }
+
+    #[test]
+    fn auto_allows_many_threads_on_large_budget() {
+        let _env = EnvGuard::clear_overrides();
+        // Large budget + small chunk: the memory cap should be generous enough
+        // that auto is bounded by cores, not memory. We can't assert the exact
+        // core count, but the cap must be well above a typical core count.
+        let c = cfg(256 * 1024, 128, 0);
+        let cap = ((256 * 1024 / 2) as f64 / (128.0 * 2.5)).floor() as usize;
+        assert!(
+            cap >= 64,
+            "large-budget memory cap should not bind below cores"
+        );
+        // Auto result is min(cores, cap); it must be >= 1 and <= cap.
+        let t = c.effective_parse_threads();
+        assert!((1..=cap).contains(&t));
+    }
 }

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -212,6 +212,21 @@ impl LeafWriter {
         self.sidecar_builder.push_entry(entry);
     }
 
+    /// Drain the leaves completed so far, transferring ownership to the caller
+    /// while preserving the internal buffer's allocation (so repeated draining
+    /// does not reallocate).
+    ///
+    /// A leaf is "completed" the moment `flush_leaf()` runs — i.e. when the
+    /// leaf-level row threshold is crossed during `push_record`. Callers that
+    /// want to bound memory (e.g. the indexer's `PersistingLeafWriter`) drain
+    /// after every `push_record` and stream each completed leaf's blob to disk,
+    /// instead of retaining every compressed leaf for the whole order. The
+    /// trailing leaf is only flushed by `finish()`, so a final drain of its
+    /// return value is still required.
+    pub fn drain_completed_leaves(&mut self) -> std::vec::Drain<'_, LeafInfo> {
+        self.completed_leaves.drain(..)
+    }
+
     /// Consume the writer, flushing any remaining data, and return all
     /// produced leaves.
     pub fn finish(mut self) -> io::Result<Vec<LeafInfo>> {

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -178,7 +178,8 @@ pub struct Cli {
     pub memory_budget_mb: usize,
 
     /// Number of parallel parse threads for bulk import.
-    /// 0 = auto (system cores, default cap 6). Explicit values are not capped.
+    /// 0 = auto (most logical cores, capped to fit the memory budget).
+    /// Explicit values are honored as-is (not capped), floored at 1.
     #[arg(long, global = true, default_value_t = 0)]
     pub parallelism: usize,
 
@@ -237,7 +238,8 @@ pub enum Commands {
         memory_budget_mb: usize,
 
         /// Number of parallel parse threads for bulk import.
-        /// 0 = auto (system cores, default cap 6). Explicit values are not capped.
+        /// 0 = auto (most logical cores, capped to fit the memory budget).
+        /// Explicit values are honored as-is (not capped), floored at 1.
         #[arg(long, default_value_t = 0)]
         parallelism: usize,
 

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -742,6 +742,11 @@ pub fn build_indexes_from_commits(
         skip_history: true, // Append-only: no time-travel data.
         g_id: config.g_id,
         progress: config.build_progress.clone(),
+        // Build the secondary orders (PSOT/POST/OPST) concurrently, bounded by
+        // the import core budget. SPOT already builds on its own thread above,
+        // so total concurrent build threads are ~1 (SPOT) + max_concurrency.
+        // build_all_indexes clamps this to the number of buildable orders.
+        max_concurrency: config.worker_count,
     };
 
     let mut order_results = build_all_indexes(&build_config).map_err(io::Error::other)?;
@@ -961,6 +966,9 @@ pub fn build_indexes_from_remapped_commits(
         skip_history: false, // Produce history sidecars for time-travel.
         g_id: config.g_id,
         progress: config.build_progress.clone(),
+        // Rebuild path builds all 4 orders here (no separate SPOT thread), so
+        // concurrency can cover all of them, bounded by the core budget.
+        max_concurrency: config.worker_count,
     };
 
     let order_results = build_all_indexes(&build_config).map_err(io::Error::other)?;

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -8,7 +8,7 @@
 //! module consumes those artifacts without a bulk-import-only V1 → V2 pass.
 
 use crate::run_index::build::index_build::{
-    build_all_indexes, finish_graph_v2, BuildAllConfig, IndexBuildResult,
+    build_all_indexes, BuildAllConfig, IndexBuildResult, PersistingLeafWriter,
 };
 use crate::run_index::build::merge::KWayMerge;
 use crate::run_index::runs::run_writer::{
@@ -19,7 +19,6 @@ use crate::run_index::runs::spool::{
     MmapStringRemap, MmapSubjectRemap, SortedCommitMergeReaderV2, SubjectRemap,
 };
 use crate::stats::{stats_record_from_v2, SpotClassStats, DT_REF_ID};
-use fluree_db_binary_index::format::leaf::LeafWriter;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::format::run_record_v2::cmp_v2_spot;
 use fluree_db_core::o_type::OType;
@@ -836,10 +835,18 @@ fn build_spot_index_from_commits(
 
     let mut merge = KWayMerge::new(streams, cmp_v2_spot)?;
     let order = RunSortOrder::Spot;
-    let order_name = order.dir_name();
-    std::fs::create_dir_all(index_dir.join(format!("graph_{g_id}/{order_name}")))?;
 
-    let mut writer = LeafWriter::new(order, leaflet_target_rows, leaf_target_rows, zstd_level);
+    // Streams each completed leaf to disk as produced (see PersistingLeafWriter)
+    // so the SPOT build — which overlaps the parallel secondary-order builds —
+    // does not retain its whole compressed leaf set in RAM.
+    let mut writer = PersistingLeafWriter::new(
+        g_id,
+        order,
+        index_dir,
+        leaflet_target_rows,
+        leaf_target_rows,
+        zstd_level,
+    )?;
     writer.set_skip_history(true);
 
     let mut total_rows = 0u64;
@@ -869,7 +876,7 @@ fn build_spot_index_from_commits(
         }
     }
 
-    let result = finish_graph_v2(g_id, order, writer, index_dir, order_name)?;
+    let result = writer.finish()?;
     tracing::info!(
         g_id,
         total_rows,

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -12,9 +12,10 @@
 use super::merge::KWayMerge;
 use crate::run_index::runs::streaming_reader::StreamingRunReader;
 use fluree_db_binary_index::format::branch::{build_branch_bytes, LeafEntry};
+use fluree_db_binary_index::format::history_sidecar::HistEntryV2;
 use fluree_db_binary_index::format::leaf::{LeafInfo, LeafWriter};
 use fluree_db_binary_index::format::run_record::RunSortOrder;
-use fluree_db_binary_index::format::run_record_v2::cmp_v2_for_order;
+use fluree_db_binary_index::format::run_record_v2::{cmp_v2_for_order, RunRecordV2};
 use fluree_db_core::ContentId;
 use fluree_db_core::GraphId;
 use std::io;
@@ -138,19 +139,22 @@ pub fn build_index(config: &IndexBuildConfig) -> Result<IndexBuildResult, IndexB
     let mut merge = KWayMerge::new(streams, cmp)?;
 
     let order = config.sort_order;
-    let order_name = order.dir_name();
 
     // V2 builds are graph-scoped: all records in the run directory belong
     // to config.g_id. No graph transition detection needed.
     let g_id = config.g_id;
-    create_graph_dir(&config.index_dir, g_id, order_name)?;
 
-    let mut writer = LeafWriter::new(
+    // Streams each completed leaf to disk as it is produced, so the build holds
+    // only the active leaf's working set plus O(#leaves) branch metadata in RAM
+    // — never the whole order's compressed FLI3/FHS1 blobs.
+    let mut writer = PersistingLeafWriter::new(
+        g_id,
         order,
+        &config.index_dir,
         config.leaflet_target_rows,
         config.leaf_target_rows,
         config.zstd_level,
-    );
+    )?;
     writer.set_skip_history(config.skip_history);
 
     let mut total_rows: u64 = 0;
@@ -238,7 +242,7 @@ pub fn build_index(config: &IndexBuildConfig) -> Result<IndexBuildResult, IndexB
         }
     }
 
-    let result = finish_graph_v2(g_id, order, writer, &config.index_dir, order_name)?;
+    let result = writer.finish()?;
     let graph_results = vec![result];
 
     Ok(IndexBuildResult {
@@ -259,65 +263,63 @@ fn create_graph_dir(index_dir: &Path, g_id: u16, order_name: &str) -> io::Result
     Ok(graph_dir)
 }
 
-pub(crate) fn finish_graph_v2(
+/// Persist a single completed leaf (and its history sidecar, if any) to disk
+/// as content-addressed files, returning only the metadata + paths. Dropping
+/// `leaf_bytes`/`sidecar_bytes` here is what keeps the build from retaining
+/// every compressed FLI3/FHS1 blob for the whole order.
+fn persist_leaf(graph_dir: &Path, info: LeafInfo) -> io::Result<PersistedLeafInfo> {
+    let LeafInfo {
+        leaf_cid,
+        leaf_bytes,
+        sidecar_cid,
+        sidecar_bytes,
+        total_rows,
+        first_key,
+        last_key,
+        re_encoded_leaflet_count,
+    } = info;
+
+    let leaf_path = graph_dir.join(leaf_cid.to_string());
+    std::fs::write(&leaf_path, &leaf_bytes)?;
+
+    let sidecar_path = match (&sidecar_cid, sidecar_bytes.as_ref()) {
+        (Some(sc_cid), Some(sc_bytes)) => {
+            let sc_path = graph_dir.join(sc_cid.to_string());
+            std::fs::write(&sc_path, sc_bytes)?;
+            Some(sc_path)
+        }
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(io::Error::other(
+                "leaf sidecar CID/bytes mismatch while persisting index artifact",
+            ));
+        }
+    };
+
+    Ok(PersistedLeafInfo {
+        leaf_cid,
+        leaf_path,
+        sidecar_cid,
+        sidecar_path,
+        total_rows,
+        first_key,
+        last_key,
+        re_encoded_leaflet_count,
+    })
+}
+
+/// Assemble the FBR3 branch manifest from the (already disk-persisted) leaf
+/// metadata and write it. Branch entries must stay in leaf-flush order — i.e.
+/// sorted by key range — so callers must preserve the order in which leaves
+/// were produced; only the blob writes (in `persist_leaf`) are order-independent.
+fn build_graph_index_result(
     g_id: GraphId,
     order: RunSortOrder,
-    writer: LeafWriter,
-    index_dir: &Path,
-    order_name: &str,
+    graph_dir: PathBuf,
+    persisted_leaf_infos: Vec<PersistedLeafInfo>,
 ) -> io::Result<GraphIndexResult> {
-    let graph_dir = index_dir.join(format!("graph_{g_id}/{order_name}"));
-    let leaf_infos = writer.finish()?;
+    let total_rows: u64 = persisted_leaf_infos.iter().map(|l| l.total_rows).sum();
 
-    let total_rows: u64 = leaf_infos.iter().map(|l| l.total_rows).sum();
-
-    // Write leaf + sidecar blobs to disk (content-addressed), then retain only
-    // metadata + paths so the import build doesn't keep all FLI3/FHS1 bytes in RAM.
-    let persisted_leaf_infos: Vec<PersistedLeafInfo> = leaf_infos
-        .into_iter()
-        .map(|info| -> io::Result<PersistedLeafInfo> {
-            let LeafInfo {
-                leaf_cid,
-                leaf_bytes,
-                sidecar_cid,
-                sidecar_bytes,
-                total_rows,
-                first_key,
-                last_key,
-                re_encoded_leaflet_count,
-            } = info;
-
-            let leaf_path = graph_dir.join(leaf_cid.to_string());
-            std::fs::write(&leaf_path, &leaf_bytes)?;
-
-            let sidecar_path = match (&sidecar_cid, sidecar_bytes.as_ref()) {
-                (Some(sc_cid), Some(sc_bytes)) => {
-                    let sc_path = graph_dir.join(sc_cid.to_string());
-                    std::fs::write(&sc_path, sc_bytes)?;
-                    Some(sc_path)
-                }
-                (None, None) => None,
-                (Some(_), None) | (None, Some(_)) => {
-                    return Err(io::Error::other(
-                        "leaf sidecar CID/bytes mismatch while persisting index artifact",
-                    ));
-                }
-            };
-
-            Ok(PersistedLeafInfo {
-                leaf_cid,
-                leaf_path,
-                sidecar_cid,
-                sidecar_path,
-                total_rows,
-                first_key,
-                last_key,
-                re_encoded_leaflet_count,
-            })
-        })
-        .collect::<io::Result<Vec<_>>>()?;
-
-    // Build branch manifest entries.
     let leaf_entries: Vec<LeafEntry> = persisted_leaf_infos
         .iter()
         .map(|info| LeafEntry {
@@ -350,6 +352,77 @@ pub(crate) fn finish_graph_v2(
         leaf_entries,
         graph_dir,
     })
+}
+
+/// Indexer-side wrapper around the pure [`LeafWriter`] that streams each
+/// completed leaf to disk as it is produced.
+///
+/// `LeafWriter` itself accumulates every completed leaf's compressed bytes in
+/// memory until `finish()`. For a full-order build that is the entire order's
+/// index — and the parallel secondary-order build can have several orders in
+/// flight at once. This wrapper drains the writer after every `push_record`
+/// and persists each completed leaf immediately, so retained memory is bounded
+/// by the active leaf's working set plus the O(#leaves) branch metadata
+/// (~100 bytes/leaf), not the order's full FLI3/FHS1 blob set.
+///
+/// Crate boundary: the `binary-index` crate stays pure (its `LeafWriter` still
+/// returns in-memory `LeafInfo`, as the incremental paths require); only this
+/// indexer-side wrapper touches the filesystem.
+pub(crate) struct PersistingLeafWriter {
+    inner: LeafWriter,
+    g_id: GraphId,
+    order: RunSortOrder,
+    graph_dir: PathBuf,
+    persisted: Vec<PersistedLeafInfo>,
+}
+
+impl PersistingLeafWriter {
+    pub(crate) fn new(
+        g_id: GraphId,
+        order: RunSortOrder,
+        index_dir: &Path,
+        leaflet_target_rows: usize,
+        leaf_target_rows: usize,
+        zstd_level: i32,
+    ) -> io::Result<Self> {
+        let graph_dir = create_graph_dir(index_dir, g_id, order.dir_name())?;
+        let inner = LeafWriter::new(order, leaflet_target_rows, leaf_target_rows, zstd_level);
+        Ok(Self {
+            inner,
+            g_id,
+            order,
+            graph_dir,
+            persisted: Vec::new(),
+        })
+    }
+
+    pub(crate) fn set_skip_history(&mut self, skip: bool) {
+        self.inner.set_skip_history(skip);
+    }
+
+    pub(crate) fn push_record(&mut self, record: RunRecordV2) -> io::Result<()> {
+        self.inner.push_record(record)?;
+        // A single push completes at most one leaf; drain + persist it now so
+        // its blob bytes are not retained for the rest of the order.
+        for info in self.inner.drain_completed_leaves() {
+            self.persisted.push(persist_leaf(&self.graph_dir, info)?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn push_history_entry(&mut self, entry: HistEntryV2) {
+        self.inner.push_history_entry(entry);
+    }
+
+    pub(crate) fn finish(mut self) -> io::Result<GraphIndexResult> {
+        // `finish()` flushes the trailing leaf into the completed-leaves buffer;
+        // persist that final batch (everything prior was drained per-push).
+        let final_batch = self.inner.finish()?;
+        for info in final_batch {
+            self.persisted.push(persist_leaf(&self.graph_dir, info)?);
+        }
+        build_graph_index_result(self.g_id, self.order, self.graph_dir, self.persisted)
+    }
 }
 
 /// Discover V2 run files in a directory (sorted by name).

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -413,23 +413,42 @@ pub struct BuildAllConfig {
     /// Graph ID — builds are graph-scoped (run files don't carry g_id).
     pub g_id: u16,
     pub progress: Option<Arc<AtomicU64>>,
+    /// Max number of orders to build concurrently. Each order is an independent
+    /// single-threaded k-way merge + leaf-encode pipeline over disjoint input
+    /// and output directories, so running them in parallel turns the per-order
+    /// build times from additive into `max()`. `0`/`1` preserves the legacy
+    /// serial build; callers size this from the effective import core budget.
+    pub max_concurrency: usize,
 }
 
 /// Build V2 indexes for all four orders from a base run directory.
 ///
 /// Expects per-order subdirectories: `base_run_dir/{spot,psot,post,opst}/`.
 /// Each subdirectory contains V2 run files sorted in that order.
+///
+/// Orders whose run directory exists are built concurrently, up to
+/// `config.max_concurrency` at a time (work-stealing). Each order is fully
+/// independent — disjoint run dirs in, disjoint `graph_{g}/{order}` dirs out,
+/// independent results — so the only shared state is the atomic progress
+/// counter. The import path drives SPOT separately on its own thread (its run
+/// dir does not exist here), so in practice this parallelizes PSOT/POST/OPST.
 pub fn build_all_indexes(
     config: &BuildAllConfig,
 ) -> Result<Vec<(RunSortOrder, IndexBuildResult)>, IndexBuildError> {
-    let orders = RunSortOrder::all_build_orders();
-    let mut results = Vec::with_capacity(orders.len());
+    // Collect the orders that actually have run files to build.
+    let buildable: Vec<RunSortOrder> = RunSortOrder::all_build_orders()
+        .iter()
+        .copied()
+        .filter(|order| config.base_run_dir.join(order.dir_name()).exists())
+        .collect();
 
-    for &order in orders {
+    if buildable.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Build one order: k-way merge its run files into FLI3/FBR3 artifacts.
+    let build_one = |order: RunSortOrder| -> Result<IndexBuildResult, IndexBuildError> {
         let run_dir = config.base_run_dir.join(order.dir_name());
-        if !run_dir.exists() {
-            continue;
-        }
         let order_start = Instant::now();
         let run_count = discover_run_files_v2(&run_dir)?.len();
         tracing::info!(
@@ -438,10 +457,6 @@ pub fn build_all_indexes(
             run_dir = %run_dir.display(),
             "starting order index build"
         );
-
-        // Import progress wants to reflect all order builds, not just a single
-        // representative order, so attach the shared counter to every build.
-        let order_progress = config.progress.clone();
 
         let order_config = IndexBuildConfig {
             run_dir,
@@ -453,7 +468,9 @@ pub fn build_all_indexes(
             skip_dedup: config.skip_dedup,
             skip_history: config.skip_history,
             g_id: config.g_id,
-            progress: order_progress,
+            // Import progress reflects all order builds, not just one
+            // representative order, so attach the shared counter to each.
+            progress: config.progress.clone(),
         };
 
         let result = build_index(&order_config)?;
@@ -464,9 +481,77 @@ pub fn build_all_indexes(
             elapsed_ms = order_start.elapsed().as_millis(),
             "completed order index build"
         );
-        results.push((order, result));
+        Ok(result)
+    };
+
+    let concurrency = config.max_concurrency.max(1).min(buildable.len());
+
+    // Serial fast path (single order, or concurrency disabled): no thread spawn.
+    if concurrency == 1 {
+        let mut results = Vec::with_capacity(buildable.len());
+        for order in buildable {
+            results.push((order, build_one(order)?));
+        }
+        return Ok(results);
     }
 
+    // Parallel path: work-stealing over the buildable orders, bounded to
+    // `concurrency` threads. Mirrors the secondary-run-generation pool in
+    // build_from_commits.rs. Workers push in completion order; we re-sort into
+    // canonical `all_build_orders()` order before returning so the result is
+    // deterministic regardless of thread scheduling. (The FIR6 encoder already
+    // sorts orders by wire-id before serializing, so the root CID does not
+    // depend on this — but a deterministic return contract avoids surprising
+    // any future consumer that iterates results positionally.)
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let collected: std::sync::Mutex<Vec<(RunSortOrder, IndexBuildResult)>> =
+        std::sync::Mutex::new(Vec::with_capacity(buildable.len()));
+
+    std::thread::scope(|scope| -> Result<(), IndexBuildError> {
+        let mut handles = Vec::with_capacity(concurrency);
+        for _ in 0..concurrency {
+            let next = &next;
+            let collected = &collected;
+            let buildable = &buildable;
+            let build_one = &build_one;
+            handles.push(scope.spawn(move || -> Result<(), IndexBuildError> {
+                loop {
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    if i >= buildable.len() {
+                        break;
+                    }
+                    let order = buildable[i];
+                    let result = build_one(order)?;
+                    collected.lock().unwrap().push((order, result));
+                }
+                Ok(())
+            }));
+        }
+        // Propagate the first worker error (others finish their current order).
+        let mut first_err = None;
+        for handle in handles {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
+                Ok(Err(_)) => {}
+                Err(_) => {
+                    if first_err.is_none() {
+                        first_err = Some(IndexBuildError::Io(io::Error::other(
+                            "order index build thread panicked",
+                        )));
+                    }
+                }
+            }
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    })?;
+
+    let mut results = collected.into_inner().unwrap();
+    // Deterministic order, independent of which thread finished first.
+    results.sort_by_key(|(order, _)| order.to_wire_id());
     Ok(results)
 }
 


### PR DESCRIPTION
Cuts bulk-import wall time ~40% (1,759s → 1,047s) on a 1.574-billion-flake corpus by removing two structural bottlenecks the import pipeline hit on multi-core machines: a serial secondary-index build, and a hard 6-thread cap on parsing. This is a follow-up to the byte-rechunk directory-import work already on `main`.

## Why

Phase-timing logs on a real import (16-core / 128 GB box) showed wall time was total-data-bound, not chunk-count-bound — halving the chunk count moved wall time ~0%. Two phases were pinned far below the machine's core count:

- **Index build** ran the secondary orders strictly serially (`PSOT → POST → OPST`), each a single-threaded k-way merge — ~595s at ~6% CPU while ~23 cores sat idle.
- **Parse** was hard-capped at `min(6)` threads regardless of available cores.

## What changed

### 1. Parallel secondary-order index builds

`build_all_indexes` now builds the buildable orders **concurrently** via a bounded work-stealing `thread::scope` (new `BuildAllConfig.max_concurrency`, sized from the heavy-worker count), instead of a serial `for` loop.

- Orders read and write **disjoint directories** and return independent results — the only shared state is the atomic progress counter, so the change is low-risk.
- Serial fast path preserved when concurrency is 1; the first worker error is propagated.
- Results are sorted into canonical order before returning, so output is **deterministic regardless of thread scheduling**. (The FIR6 encoder already sorts orders by wire-id before serializing, so the root CID never depended on this — the sort makes the return contract robust for any future positional consumer.)
- SPOT continues to build on its own thread and overlaps this phase.

### 2. Memory-aware CPU resource model

Replaces the fixed `min(6)` thread cap with an auto-detect / override / floor model:

- `parse_threads` defaults to `0` = **auto**: use the machine's logical cores, then cap so peak parse memory (`threads × chunk_size × ~2.5`) stays within half the memory budget. Many-core boxes scale up; small-RAM boxes don't oversubscribe.
- **Explicit values** (builder `.threads()`, `--parallelism`, `FLUREE_IMPORT_THREADS`) are honored as-is (uncapped), with a **hard floor of 1** so imports still run on a 1–2 core box (slower, won't blow up).
- `effective_heavy_workers` derives from the same effective thread count, which also bounds secondary-build concurrency.

### 3. Docs / comments / tests

- Corrected stale references (memory auto is 60% of RAM, not 75%; parse threads no longer capped at 6) in `docs/cli/`, CLI flag help, and config doc comments.
- Added env-isolated unit tests for the thread-resolution logic (a polluted environment cannot perturb them).

## Measured impact (same 1.574B-flake dataset, 128 GB box)

| Phase          | Before  | After   | Δ                          |
|----------------|---------|---------|----------------------------|
| Parse + commit | 936s    | 633s    | −32% (parallelism 6 → 16)  |
| Index build    | 712s    | 336s    | −53% (secondaries parallel)|
| **Total wall** | **1,759s** | **1,047s** | **−40%**                |

Index-build timestamps confirm the mechanism: `post` (218.7s), `opst` (219.8s), and `psot` (233.6s) now complete within ~15s of each other (genuinely concurrent), with SPOT (313s) overlapping. The build critical path collapsed from `remap + 595s sequential` to `remap(67s) + max(SPOT 313s, secondaries 233s) ≈ 336s`.

## Risk

- **Low.** Parallel order builds touch disjoint dirs with independent results; the serial path is preserved at concurrency 1. Root-CID determinism is unchanged (verified: the encoder sorts before serializing, and the return value is now also sorted).
- Memory is self-bounding: auto thread count shrinks to fit the budget, and per-worker run budget scales inversely with worker count. Explicit overrides are the operator's call, floored at 1.

## Tuning knobs (all optional; sensible auto defaults)

- `--parallelism` / `FLUREE_IMPORT_THREADS` — parse/worker threads (`0` = auto).
- `--memory-budget-mb` — caps memory; auto thread count shrinks to fit it.
- `FLUREE_IMPORT_HEAVY_WORKERS` — overrides heavy/index-build worker count.

## Testing

- End-to-end verified on the 1.574B-flake corpus (numbers above)

