### PR TITLE
fix: multi-ledger JSON-LD queries through `/v1/fluree/query` (dispatcher + formatter)

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -893,6 +893,18 @@ Accept: application/sparql-results+json
 }
 ```
 
+**Multi-ledger / dataset queries:** The connection-scoped `/query` route (no
+`{ledger}` in the path) accepts the full dataset `from` surface, not just a
+single ledger string:
+
+- `"from": ["a:main", "b:main"]` — union the listed ledgers as the default graph.
+- `"from": { "@id": "a:main@t:5" }` — a single source with time-travel / graph selectors.
+- `"fromNamed": { "alias": { "@id": "b:main" } }` — named graphs addressed by a
+  GRAPH pattern in the `where` (a query may use `fromNamed` with no `from`).
+
+The query is authorized against the first resolvable source for the bearer
+scope; per-ledger policy is then applied to each source during execution.
+
 **Request Body (SPARQL):**
 
 ```sparql

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -323,6 +323,54 @@ impl RootRef {
     }
 }
 
+/// Merge two JSON-LD objects describing the **same subject** seen through
+/// different default-graph ledgers (RDF merge of the union). Predicates present
+/// in only one are kept; predicates in both have their values unioned and
+/// de-duplicated (so identical triples, including `@id` / `@type`, collapse).
+fn merge_subject_objects(a: JsonValue, b: JsonValue) -> JsonValue {
+    let (JsonValue::Object(mut am), JsonValue::Object(bm)) = (a, b) else {
+        // Both are always objects in practice; if not, prefer the first.
+        return JsonValue::Null;
+    };
+    for (k, bv) in bm {
+        match am.remove(&k) {
+            None => {
+                am.insert(k, bv);
+            }
+            Some(av) => {
+                am.insert(k, merge_values(av, bv));
+            }
+        }
+    }
+    JsonValue::Object(am)
+}
+
+/// Union two property values into a de-duplicated value: a single survivor is
+/// returned bare, multiple as an array. Arrays on either side are flattened.
+fn merge_values(a: JsonValue, b: JsonValue) -> JsonValue {
+    let mut items: Vec<JsonValue> = Vec::new();
+    collect_values(a, &mut items);
+    collect_values(b, &mut items);
+    let mut out: Vec<JsonValue> = Vec::with_capacity(items.len());
+    for it in items {
+        if !out.contains(&it) {
+            out.push(it);
+        }
+    }
+    if out.len() == 1 {
+        out.into_iter().next().unwrap()
+    } else {
+        JsonValue::Array(out)
+    }
+}
+
+fn collect_values(v: JsonValue, out: &mut Vec<JsonValue>) {
+    match v {
+        JsonValue::Array(arr) => out.extend(arr),
+        other => out.push(other),
+    }
+}
+
 /// Format one hydration column for one solution row.
 ///
 /// Resolves the column's root (variable or IRI constant) into a `Sid` and
@@ -437,57 +485,111 @@ pub async fn format_async_dataset(
         ));
     }
 
-    // All dataset views — default graphs first, then named. Owned per-view
-    // compactors / policies live in parallel vecs that outlive the
-    // borrowed-state formatters.
-    let graph_views: Vec<&crate::view::GraphDb> = dataset
-        .default
-        .iter()
-        .chain(dataset.named.values())
-        .collect();
-    let compactors: Vec<IriCompactor> = graph_views
-        .iter()
-        .map(|g| IriCompactor::new(g.snapshot.namespaces(), context))
-        .collect();
-    let policies: Vec<Option<PolicyContext>> =
-        graph_views.iter().map(|g| g.policy().cloned()).collect();
-
-    let mut formatters: Vec<HydrationFormatter> = Vec::with_capacity(graph_views.len());
-    // Keyed by `GraphDb::ledger_id`, which is exactly what `IriMatch.ledger_alias`
-    // carries (set from the runtime `GraphRef.ledger_id`) — so root routing
-    // looks up the correct view.
-    let mut by_ledger: HashMap<Arc<str>, usize> = HashMap::new();
-    for (i, g) in graph_views.iter().enumerate() {
-        let mut view_db = g.as_graph_db_ref();
-        if let Some(t) = tracker {
-            view_db = view_db.with_tracker(t);
-        }
-        let formatter = HydrationFormatter::new(
-            view_db,
-            &compactors[i],
-            Arc::clone(&g.ledger_id),
-            config,
-            policies[i].as_ref(),
-            tracker,
-        );
-        // First occurrence wins (a ledger may appear as both default and named).
-        by_ledger.entry(Arc::clone(&g.ledger_id)).or_insert(i);
-        formatters.push(formatter);
-    }
-
-    // Primary = the dataset's primary view (first default, else first named),
-    // used for flat columns and as the fallback for unrouted roots.
-    let primary = dataset
-        .primary()
-        .and_then(|p| by_ledger.get(&p.ledger_id).copied())
-        .unwrap_or(0);
-
+    let ctx = DatasetCtx::build(dataset, context, config, tracker);
+    let formatters: Vec<HydrationFormatter> =
+        (0..ctx.views.len()).map(|i| ctx.formatter_for(i)).collect();
     let set = FormatterSet {
         formatters,
-        by_ledger,
-        primary,
+        by_ledger: ctx.by_ledger.clone(),
+        primary: ctx.primary,
     };
     run_hydration_rows(&set, result).await
+}
+
+/// One ledger's hydration view: its db, namespace-aware compactor, policy, and
+/// ledger id. Owned by [`DatasetCtx`]; formatters borrow from it.
+struct LedgerView<'a> {
+    db: GraphDbRef<'a>,
+    compactor: IriCompactor,
+    policy: Option<PolicyContext>,
+    ledger_id: Arc<str>,
+}
+
+/// Owns every dataset ledger's [`LedgerView`] and the routing metadata that
+/// cross-ledger hydration needs: which views back the default-graph union and
+/// which ledger maps to which view. Formatters borrow from this; it must
+/// outlive them.
+struct DatasetCtx<'a> {
+    views: Vec<LedgerView<'a>>,
+    /// `GraphDb::ledger_id` → index into `views` (matches `IriMatch.ledger_alias`).
+    by_ledger: HashMap<Arc<str>, usize>,
+    /// Indices of the default-graph views — the union scope for default-graph refs.
+    default_indices: Vec<usize>,
+    /// Primary view index (flat columns + unrouted-root fallback).
+    primary: usize,
+    typed: bool,
+    normalize_arrays: bool,
+    tracker: Option<&'a Tracker>,
+}
+
+impl<'a> DatasetCtx<'a> {
+    fn build(
+        dataset: &'a crate::view::DataSetDb,
+        context: &crate::ParsedContext,
+        config: &FormatterConfig,
+        tracker: Option<&'a Tracker>,
+    ) -> Self {
+        // Default graphs first (their indices form the union scope), then named.
+        let graph_views: Vec<&crate::view::GraphDb> = dataset
+            .default
+            .iter()
+            .chain(dataset.named.values())
+            .collect();
+        let default_count = dataset.default.len();
+
+        let mut views: Vec<LedgerView<'a>> = Vec::with_capacity(graph_views.len());
+        let mut by_ledger: HashMap<Arc<str>, usize> = HashMap::new();
+        let mut default_indices: Vec<usize> = Vec::with_capacity(default_count);
+        for (i, g) in graph_views.iter().enumerate() {
+            let mut view_db = g.as_graph_db_ref();
+            if let Some(t) = tracker {
+                view_db = view_db.with_tracker(t);
+            }
+            views.push(LedgerView {
+                db: view_db,
+                compactor: IriCompactor::new(g.snapshot.namespaces(), context),
+                policy: g.policy().cloned(),
+                ledger_id: Arc::clone(&g.ledger_id),
+            });
+            // First occurrence wins (a ledger may appear as both default and named).
+            by_ledger.entry(Arc::clone(&g.ledger_id)).or_insert(i);
+            if i < default_count {
+                default_indices.push(i);
+            }
+        }
+
+        let primary = dataset
+            .primary()
+            .and_then(|p| by_ledger.get(&p.ledger_id).copied())
+            .unwrap_or(0);
+
+        DatasetCtx {
+            views,
+            by_ledger,
+            default_indices,
+            primary,
+            typed: config.format == OutputFormat::TypedJson,
+            normalize_arrays: config.normalize_arrays,
+            tracker,
+        }
+    }
+
+    /// Build a formatter bound to one view, wired back to this context so it can
+    /// resolve cross-ledger refs.
+    fn formatter_for(&'a self, idx: usize) -> HydrationFormatter<'a> {
+        let view = &self.views[idx];
+        HydrationFormatter {
+            db: view.db,
+            compactor: &view.compactor,
+            active_ledger: Arc::clone(&view.ledger_id),
+            typed: self.typed,
+            normalize_arrays: self.normalize_arrays,
+            policy: view.policy.as_ref(),
+            tracker: self.tracker,
+            dataset: Some(self),
+            active_idx: idx,
+        }
+    }
 }
 
 /// A collection of per-ledger hydration formatters with root-routing.
@@ -628,6 +730,15 @@ struct HydrationFormatter<'a> {
     policy: Option<&'a PolicyContext>,
     /// Optional execution tracker for fuel/policy tracking.
     tracker: Option<&'a Tracker>,
+    /// Dataset context for cross-ledger reference resolution.
+    ///
+    /// `None` in single-ledger mode (refs stay within `db`). `Some` in dataset
+    /// mode: when expansion follows a ref into another ledger, the ref's SID is
+    /// decoded to its canonical IRI here, then re-encoded and expanded in the
+    /// target ledger's view (issue #1259).
+    dataset: Option<&'a DatasetCtx<'a>>,
+    /// This formatter's index into [`DatasetCtx::views`] (0 in single-ledger mode).
+    active_idx: usize,
 }
 
 impl<'a> HydrationFormatter<'a> {
@@ -647,6 +758,8 @@ impl<'a> HydrationFormatter<'a> {
             normalize_arrays: config.normalize_arrays,
             policy,
             tracker,
+            dataset: None,
+            active_idx: 0,
         }
     }
 
@@ -833,6 +946,72 @@ impl<'a> HydrationFormatter<'a> {
         .boxed()
     }
 
+    /// Expand a referenced subject, routing across ledgers when needed.
+    ///
+    /// In single-ledger mode this is just `format_subject` against the current
+    /// view. In dataset mode the ref's SID is decoded (via the current view) to
+    /// its canonical IRI, then re-encoded and expanded in the target ledger(s):
+    /// a ref inside a default-graph view resolves across the **whole
+    /// default-graph union** (merging each contributing ledger's view of the
+    /// subject under that ledger's own policy); a ref inside a named graph stays
+    /// in that graph. This is what makes a ref that points into another ledger
+    /// hydrate its properties instead of rendering as a bare `{"@id": ...}`
+    /// (issue #1259).
+    fn expand_ref<'b>(
+        &'b self,
+        ref_sid: &'b Sid,
+        level: &'b NestedSelectSpec,
+        depth: DepthBudget,
+        visited: &'b mut HashSet<Sid>,
+        cache: &'b mut HashMap<CacheKey, JsonValue>,
+    ) -> BoxFuture<'b, Result<JsonValue>> {
+        async move {
+            let Some(ctx) = self.dataset else {
+                // Single-ledger: stay in the current view.
+                return self
+                    .format_subject(ref_sid, None, level, depth, visited, cache)
+                    .await;
+            };
+
+            // Decode against the CURRENT view (where the flake lives) to recover
+            // the canonical IRI, then resolve it in the target ledger(s).
+            let iri: Arc<str> = Arc::from(self.compactor.decode_sid(ref_sid)?.as_str());
+
+            // Scope: default-graph refs resolve across the default-graph union;
+            // a named-graph ref stays within its graph.
+            let targets: Vec<usize> = if ctx.default_indices.contains(&self.active_idx) {
+                ctx.default_indices.clone()
+            } else {
+                vec![self.active_idx]
+            };
+
+            let mut merged: Option<JsonValue> = None;
+            for tidx in targets {
+                let tview = &ctx.views[tidx];
+                // Only a view whose namespace dict can encode the IRI can hold
+                // the subject — skip the rest (no scan, no error).
+                let Some(tsid) = tview.db.snapshot.encode_iri_strict(&iri) else {
+                    continue;
+                };
+                let tfmt = ctx.formatter_for(tidx);
+                let obj = tfmt
+                    .format_subject(&tsid, Some(Arc::clone(&iri)), level, depth, visited, cache)
+                    .await?;
+                merged = Some(match merged {
+                    None => obj,
+                    Some(acc) => merge_subject_objects(acc, obj),
+                });
+            }
+
+            // No view could resolve the subject → bare canonical @id.
+            match merged {
+                Some(v) => Ok(v),
+                None => Ok(json!({ "@id": self.compactor.compact_iri(&iri)? })),
+            }
+        }
+        .boxed()
+    }
+
     /// Whether this compact key should always be represented as an array.
     ///
     /// JSON-LD `@container` semantics:
@@ -887,33 +1066,17 @@ impl<'a> HydrationFormatter<'a> {
                         // 1. If explicit sub-selection exists → expand with that spec
                         // 2. Else if budget permits → auto-expand with FULL parent level
                         // 3. Else → just return {"@id": ...}
-                        if let Some(nested) = pred_ctx.explicit_sub_spec {
-                            values.push(
-                                self.format_subject(
-                                    ref_sid,
-                                    None,
-                                    nested,
-                                    depth.descend(),
-                                    visited,
-                                    cache,
-                                )
-                                .await?,
-                            );
-                        } else if depth.can_expand() {
-                            values.push(
-                                self.format_subject(
-                                    ref_sid,
-                                    None,
-                                    parent_level,
-                                    depth.descend(),
-                                    visited,
-                                    cache,
-                                )
-                                .await?,
-                            );
-                        } else {
-                            // Max depth reached, just @id
-                            values.push(json!({ "@id": self.compactor.compact_sid(ref_sid)? }));
+                        let sub_level = pred_ctx
+                            .explicit_sub_spec
+                            .or_else(|| depth.can_expand().then_some(parent_level));
+                        match sub_level {
+                            Some(level) => values.push(
+                                self.expand_ref(ref_sid, level, depth.descend(), visited, cache)
+                                    .await?,
+                            ),
+                            None => {
+                                values.push(json!({ "@id": self.compactor.compact_sid(ref_sid)? }));
+                            }
                         }
                     }
                 }
@@ -947,27 +1110,16 @@ impl<'a> HydrationFormatter<'a> {
             // For reverse lookup, subject is the entity that points to our object
             let subject_sid = &flake.s;
 
-            if let Some(nested) = nested_spec {
-                values.push(
-                    self.format_subject(subject_sid, None, nested, depth.descend(), visited, cache)
+            let sub_level = nested_spec.or_else(|| depth.can_expand().then_some(parent_level));
+            match sub_level {
+                Some(level) => values.push(
+                    self.expand_ref(subject_sid, level, depth.descend(), visited, cache)
                         .await?,
-                );
-            } else if depth.can_expand() {
-                // Auto-expand reverse refs with FULL parent level
-                values.push(
-                    self.format_subject(
-                        subject_sid,
-                        None,
-                        parent_level,
-                        depth.descend(),
-                        visited,
-                        cache,
-                    )
-                    .await?,
-                );
-            } else {
-                // No expansion - just @id
-                values.push(json!({ "@id": self.compactor.compact_sid(subject_sid)? }));
+                ),
+                None => {
+                    // No expansion - just @id
+                    values.push(json!({ "@id": self.compactor.compact_sid(subject_sid)? }));
+                }
             }
         }
         Ok(values)

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -1138,14 +1138,8 @@ impl<'a> HydrationFormatter<'a> {
             let sub_level = nested_spec.or_else(|| depth.can_expand().then_some(parent_level));
             match sub_level {
                 Some(level) => values.push(
-                    self.expand_or_format_ref(
-                        subject_sid,
-                        level,
-                        depth.descend(),
-                        visited,
-                        cache,
-                    )
-                    .await?,
+                    self.expand_or_format_ref(subject_sid, level, depth.descend(), visited, cache)
+                        .await?,
                 ),
                 None => {
                     // No expansion - just @id

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -70,12 +70,13 @@ use std::sync::Arc;
 ///   the same Sid with structurally identical levels, and stay separated
 ///   when their levels differ.
 ///
-/// The trailing `Option<Arc<str>>` is the root subject's canonical IRI (present
-/// only for multi-ledger `IriMatch` roots). It participates in the key because
-/// two different ledgers can mint the same `(namespace_code, name)` SID for
-/// *different* IRIs — without it, a cross-ledger query could serve one ledger's
-/// rendering for another ledger's subject (issue #1259).
-type CacheKey = (Sid, u64, usize, Option<Arc<str>>);
+/// The leading `Arc<str>` is the active ledger (the view the `Sid` was scanned
+/// in): a `Sid` is view-local, so the same bytes can name different subjects
+/// across ledgers. The trailing `Option<Arc<str>>` is the root subject's
+/// canonical IRI (present only for multi-ledger `IriMatch` roots). Both
+/// participate so a cross-ledger query can never serve one ledger's rendering
+/// for another ledger's subject (issue #1259).
+type CacheKey = (Arc<str>, Sid, u64, usize, Option<Arc<str>>);
 
 /// Depth bookkeeping for one hydration call.
 ///
@@ -255,22 +256,30 @@ fn hash_reverse<H: std::hash::Hasher>(
 fn resolve_root_sid_from_binding(
     result: &QueryResult,
     binding: Option<&Binding>,
-) -> Result<Option<(Sid, Option<Arc<str>>)>> {
+) -> Result<Option<RootRef>> {
     match binding {
         Some(b) if b.is_encoded() => {
             let materialized = super::materialize::materialize_binding(result, b)?;
             Ok(match materialized {
-                Binding::Sid { sid, .. } => Some((sid, None)),
+                Binding::Sid { sid, .. } => Some(RootRef::local(sid)),
                 Binding::IriMatch {
-                    primary_sid, iri, ..
-                } => Some((primary_sid, Some(iri))),
+                    primary_sid,
+                    iri,
+                    ledger_alias,
+                } => Some(RootRef::cross_ledger(primary_sid, iri, ledger_alias)),
                 _ => None,
             })
         }
-        Some(Binding::Sid { sid, .. }) => Ok(Some((sid.clone(), None))),
+        Some(Binding::Sid { sid, .. }) => Ok(Some(RootRef::local(sid.clone()))),
         Some(Binding::IriMatch {
-            primary_sid, iri, ..
-        }) => Ok(Some((primary_sid.clone(), Some(iri.clone())))),
+            primary_sid,
+            iri,
+            ledger_alias,
+        }) => Ok(Some(RootRef::cross_ledger(
+            primary_sid.clone(),
+            iri.clone(),
+            ledger_alias.clone(),
+        ))),
         Some(Binding::Unbound | Binding::Poisoned) | None => Ok(None),
         Some(
             Binding::Lit { .. }
@@ -283,6 +292,37 @@ fn resolve_root_sid_from_binding(
     }
 }
 
+/// A resolved hydration-root reference.
+///
+/// `sid` is the subject's SID in its originating ledger. For multi-ledger
+/// (`IriMatch`) roots, `iri` is the canonical IRI (used for the `@id` and to
+/// re-resolve the subject in its home ledger) and `ledger_alias` names that
+/// home ledger so the formatter can route expansion to the correct view
+/// (issue #1259). Single-ledger (`Sid`) roots carry neither.
+struct RootRef {
+    sid: Sid,
+    iri: Option<Arc<str>>,
+    ledger_alias: Option<Arc<str>>,
+}
+
+impl RootRef {
+    fn local(sid: Sid) -> Self {
+        Self {
+            sid,
+            iri: None,
+            ledger_alias: None,
+        }
+    }
+
+    fn cross_ledger(sid: Sid, iri: Arc<str>, ledger_alias: Arc<str>) -> Self {
+        Self {
+            sid,
+            iri: Some(iri),
+            ledger_alias: Some(ledger_alias),
+        }
+    }
+}
+
 /// Format one hydration column for one solution row.
 ///
 /// Resolves the column's root (variable or IRI constant) into a `Sid` and
@@ -290,19 +330,19 @@ fn resolve_root_sid_from_binding(
 /// own level and depth budget. A variable root that's unbound for this row
 /// renders as `null` rather than skipping the row entirely.
 async fn format_hydration_column(
-    formatter: &HydrationFormatter<'_>,
+    set: &FormatterSet<'_>,
     spec: &HydrationSpec,
     result: &QueryResult,
     batch: &fluree_db_query::Batch,
     row_idx: usize,
     cache: &mut HashMap<CacheKey, JsonValue>,
 ) -> Result<JsonValue> {
-    // `root_iri` is the canonical IRI when the root came from a multi-ledger
-    // `IriMatch` binding; it lets `format_subject` emit the root `@id` from the
-    // ledger-correct IRI instead of decoding a foreign SID against the
-    // formatter's single-snapshot dict (issue #1259).
-    let (root_sid, root_iri): (Sid, Option<Arc<str>>) = match &spec.root {
-        Root::Sid(sid) => (sid.clone(), None),
+    // Resolve the root. For an `IriMatch` root, `iri` is the ledger-correct
+    // canonical IRI (used for the `@id`) and `ledger_alias` names its home
+    // ledger so we route expansion to that view rather than decoding/scanning
+    // a foreign SID against the primary view (issue #1259).
+    let root = match &spec.root {
+        Root::Sid(sid) => RootRef::local(sid.clone()),
         Root::Var(var_id) => {
             let Some(resolved) =
                 resolve_root_sid_from_binding(result, batch.get(row_idx, *var_id))?
@@ -313,11 +353,12 @@ async fn format_hydration_column(
         }
     };
 
+    let formatter = set.pick(root.ledger_alias.as_ref());
     let mut visited = HashSet::new();
     formatter
         .format_subject(
-            &root_sid,
-            root_iri,
+            &root.sid,
+            root.iri,
             &spec.level,
             DepthBudget::root(spec.depth),
             &mut visited,
@@ -348,10 +389,6 @@ pub async fn format_async(
             "Hydration format called without any hydration columns".into(),
         ));
     }
-    let columns = result.output.columns().ok_or_else(|| {
-        FormatError::InvalidBinding("Hydration format called on non-Select output".into())
-    })?;
-
     // Attach the tracker to the GraphDbRef so db.range calls inside the
     // formatter charge per-leaflet + per-dict-touch fuel through the
     // BinaryGraphView/BinaryCursor wiring (not just the per-flake baseline).
@@ -360,12 +397,146 @@ pub async fn format_async(
         None => db,
     };
 
-    let formatter = HydrationFormatter::new(db, compactor, config, policy, tracker);
+    // Single-view (single-ledger) hydration: one formatter, no cross-ledger
+    // routing. `FormatterSet::pick` always falls back to this primary.
+    let active_ledger: Arc<str> = Arc::from(db.snapshot.ledger_id.as_str());
+    let formatter = HydrationFormatter::new(db, compactor, active_ledger, config, policy, tracker);
+    let set = FormatterSet {
+        formatters: vec![formatter],
+        by_ledger: HashMap::new(),
+        primary: 0,
+    };
+    run_hydration_rows(&set, result).await
+}
+
+/// Dataset-aware hydration entry point (multi-ledger).
+///
+/// Unlike [`format_async`], each ledger in the dataset gets its own
+/// `(GraphDbRef, IriCompactor, policy)` view, and a hydration column's root is
+/// routed to its **home** ledger (via the `IriMatch` provenance carried on the
+/// root binding) so the subject's properties and `@id` decode against the
+/// ledger that actually stores them — not the primary view's namespace dict
+/// (issue #1259).
+///
+/// Per-ledger policy is preserved: a foreign subject is read under *its own*
+/// view's policy enforcer, never the primary's.
+///
+/// NOTE (staged): this slice routes the **root** subject. Nested cross-ledger
+/// refs still expand within the root's view (correct only when the two ledgers
+/// allocated matching namespace codes) until the union-resolution slice lands.
+pub async fn format_async_dataset(
+    result: &QueryResult,
+    dataset: &crate::view::DataSetDb,
+    context: &crate::ParsedContext,
+    config: &FormatterConfig,
+    tracker: Option<&Tracker>,
+) -> Result<JsonValue> {
+    if !result.output.has_hydration() {
+        return Err(FormatError::InvalidBinding(
+            "Hydration format called without any hydration columns".into(),
+        ));
+    }
+
+    // All dataset views — default graphs first, then named. Owned per-view
+    // compactors / policies live in parallel vecs that outlive the
+    // borrowed-state formatters.
+    let graph_views: Vec<&crate::view::GraphDb> = dataset
+        .default
+        .iter()
+        .chain(dataset.named.values())
+        .collect();
+    let compactors: Vec<IriCompactor> = graph_views
+        .iter()
+        .map(|g| IriCompactor::new(g.snapshot.namespaces(), context))
+        .collect();
+    let policies: Vec<Option<PolicyContext>> =
+        graph_views.iter().map(|g| g.policy().cloned()).collect();
+
+    let mut formatters: Vec<HydrationFormatter> = Vec::with_capacity(graph_views.len());
+    // Keyed by `GraphDb::ledger_id`, which is exactly what `IriMatch.ledger_alias`
+    // carries (set from the runtime `GraphRef.ledger_id`) — so root routing
+    // looks up the correct view.
+    let mut by_ledger: HashMap<Arc<str>, usize> = HashMap::new();
+    for (i, g) in graph_views.iter().enumerate() {
+        let mut view_db = g.as_graph_db_ref();
+        if let Some(t) = tracker {
+            view_db = view_db.with_tracker(t);
+        }
+        let formatter = HydrationFormatter::new(
+            view_db,
+            &compactors[i],
+            Arc::clone(&g.ledger_id),
+            config,
+            policies[i].as_ref(),
+            tracker,
+        );
+        // First occurrence wins (a ledger may appear as both default and named).
+        by_ledger.entry(Arc::clone(&g.ledger_id)).or_insert(i);
+        formatters.push(formatter);
+    }
+
+    // Primary = the dataset's primary view (first default, else first named),
+    // used for flat columns and as the fallback for unrouted roots.
+    let primary = dataset
+        .primary()
+        .and_then(|p| by_ledger.get(&p.ledger_id).copied())
+        .unwrap_or(0);
+
+    let set = FormatterSet {
+        formatters,
+        by_ledger,
+        primary,
+    };
+    run_hydration_rows(&set, result).await
+}
+
+/// A collection of per-ledger hydration formatters with root-routing.
+///
+/// In single-ledger mode this holds exactly one formatter and every lookup
+/// falls back to it. In dataset mode it holds one formatter per ledger view,
+/// and [`FormatterSet::pick`] routes a hydration root to its home ledger.
+struct FormatterSet<'a> {
+    formatters: Vec<HydrationFormatter<'a>>,
+    /// `GraphDb::ledger_id` → index into `formatters`.
+    by_ledger: HashMap<Arc<str>, usize>,
+    /// Index of the primary formatter (flat columns + unrouted-root fallback).
+    primary: usize,
+}
+
+impl<'a> FormatterSet<'a> {
+    fn primary(&self) -> &HydrationFormatter<'a> {
+        &self.formatters[self.primary]
+    }
+
+    /// Select the formatter for a root's home ledger, falling back to the
+    /// primary when there is no provenance (single-ledger `Sid` roots,
+    /// constant-IRI roots) or the ledger isn't in the dataset.
+    fn pick(&self, ledger_alias: Option<&Arc<str>>) -> &HydrationFormatter<'a> {
+        ledger_alias
+            .and_then(|a| self.by_ledger.get(a))
+            .map(|&i| &self.formatters[i])
+            .unwrap_or_else(|| self.primary())
+    }
+}
+
+/// Shared row loop for single-view and dataset hydration.
+///
+/// Flat (`Column::Var`) columns are formatted with the primary view's
+/// compactor — they carry `IriMatch.iri` for cross-ledger references, so the
+/// dict is irrelevant. Hydration columns route to their home-ledger formatter.
+async fn run_hydration_rows(set: &FormatterSet<'_>, result: &QueryResult) -> Result<JsonValue> {
+    let columns = result.output.columns().ok_or_else(|| {
+        FormatError::InvalidBinding("Hydration format called on non-Select output".into())
+    })?;
+
+    let primary = set.primary();
+    let primary_compactor = primary.compactor;
+    let typed = primary.typed;
 
     // Shared cache across all rows and all hydration columns. The cache key
-    // includes a hash of the current `NestedSelectSpec`, so columns with
-    // structurally identical levels share entries; columns with different
-    // levels do not collide.
+    // includes the active ledger + a hash of the current `NestedSelectSpec`, so
+    // columns with structurally identical levels share entries while different
+    // levels (and different ledgers) stay separate.
     let mut cache: HashMap<CacheKey, JsonValue> = HashMap::new();
     let mut rows: Vec<JsonValue> = Vec::new();
 
@@ -397,19 +568,21 @@ pub async fn format_async(
             for column in columns {
                 let value = match column {
                     Column::Var(v) => match batch.get(row_idx, *v) {
-                        Some(binding) if formatter.typed => {
-                            super::typed::format_binding_with_result(result, binding, compactor)?
-                        }
-                        Some(binding) => {
-                            super::jsonld::format_binding_with_result(result, binding, compactor)?
-                        }
+                        Some(binding) if typed => super::typed::format_binding_with_result(
+                            result,
+                            binding,
+                            primary_compactor,
+                        )?,
+                        Some(binding) => super::jsonld::format_binding_with_result(
+                            result,
+                            binding,
+                            primary_compactor,
+                        )?,
                         None => JsonValue::Null,
                     },
                     Column::Hydration(spec) => {
-                        format_hydration_column(
-                            &formatter, spec, result, batch, row_idx, &mut cache,
-                        )
-                        .await?
+                        format_hydration_column(set, spec, result, batch, row_idx, &mut cache)
+                            .await?
                     }
                 };
                 row_values.push(value);
@@ -438,6 +611,14 @@ pub async fn format_async(
 struct HydrationFormatter<'a> {
     db: GraphDbRef<'a>,
     compactor: &'a IriCompactor,
+    /// Ledger this formatter's view belongs to.
+    ///
+    /// Distinguishes per-ledger entries in the shared expansion cache: a
+    /// `Sid`'s `(namespace_code, name)` is view-local, so the same bytes can
+    /// name different subjects across ledgers. Including the ledger in the
+    /// cache key prevents one ledger's hydration from being served for
+    /// another's (issue #1259, multi-ledger formatting).
+    active_ledger: Arc<str>,
     /// Whether to emit typed JSON (`{"@value": ..., "@type": ...}`) for all literals.
     typed: bool,
     /// Whether to always wrap property values in arrays (even single-valued).
@@ -453,6 +634,7 @@ impl<'a> HydrationFormatter<'a> {
     fn new(
         db: GraphDbRef<'a>,
         compactor: &'a IriCompactor,
+        active_ledger: Arc<str>,
         config: &FormatterConfig,
         policy: Option<&'a PolicyContext>,
         tracker: Option<&'a Tracker>,
@@ -460,6 +642,7 @@ impl<'a> HydrationFormatter<'a> {
         Self {
             db,
             compactor,
+            active_ledger,
             typed: config.format == OutputFormat::TypedJson,
             normalize_arrays: config.normalize_arrays,
             policy,
@@ -488,6 +671,7 @@ impl<'a> HydrationFormatter<'a> {
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
             let cache_key = (
+                Arc::clone(&self.active_ledger),
                 sid.clone(),
                 compute_level_hash(level),
                 depth.remaining(),
@@ -1290,13 +1474,22 @@ mod tests {
     fn test_cache_key_different_depths() {
         let sid = Sid::new(100, "alice");
         let spec_hash = 12345u64;
+        let ledger: Arc<str> = Arc::from("a:main");
 
-        let key1: CacheKey = (sid.clone(), spec_hash, 0, None);
-        let key2: CacheKey = (sid.clone(), spec_hash, 1, None);
-        let key3: CacheKey = (sid.clone(), spec_hash, 0, None);
+        let key1: CacheKey = (Arc::clone(&ledger), sid.clone(), spec_hash, 0, None);
+        let key2: CacheKey = (Arc::clone(&ledger), sid.clone(), spec_hash, 1, None);
+        let key3: CacheKey = (Arc::clone(&ledger), sid.clone(), spec_hash, 0, None);
         // Same SID + spec + depth but a different canonical IRI (cross-ledger
         // collision) must NOT share a cache entry.
-        let key4: CacheKey = (sid, spec_hash, 0, Some(Arc::from("http://other.example/x")));
+        let key4: CacheKey = (
+            Arc::clone(&ledger),
+            sid.clone(),
+            spec_hash,
+            0,
+            Some(Arc::from("http://other.example/x")),
+        );
+        // Same SID + spec + depth in a DIFFERENT ledger must NOT share an entry.
+        let key5: CacheKey = (Arc::from("b:main"), sid, spec_hash, 0, None);
 
         // Different depths should produce different keys
         assert_ne!(key1, key2);
@@ -1304,6 +1497,8 @@ mod tests {
         assert_eq!(key1, key3);
         // Different canonical IRI → different key
         assert_ne!(key1, key4);
+        // Different active ledger → different key
+        assert_ne!(key1, key5);
     }
 
     fn explicit(forward: Vec<ForwardItem>) -> NestedSelectSpec {

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -70,13 +70,16 @@ use std::sync::Arc;
 ///   the same Sid with structurally identical levels, and stay separated
 ///   when their levels differ.
 ///
-/// The leading `Arc<str>` is the active ledger (the view the `Sid` was scanned
-/// in): a `Sid` is view-local, so the same bytes can name different subjects
-/// across ledgers. The trailing `Option<Arc<str>>` is the root subject's
-/// canonical IRI (present only for multi-ledger `IriMatch` roots). Both
-/// participate so a cross-ledger query can never serve one ledger's rendering
-/// for another ledger's subject (issue #1259).
-type CacheKey = (Arc<str>, Sid, u64, usize, Option<Arc<str>>);
+/// The leading `usize` is the active view index (`HydrationFormatter::active_idx`):
+/// a `Sid` is view-local, so the same bytes can name different subjects across
+/// ledgers, and the index uniquely identifies the view within a single
+/// hydration's shared cache. It replaces the active ledger `Arc<str>` to avoid
+/// hashing and `Arc`-cloning a string on every `format_subject` call. The
+/// trailing `Option<Arc<str>>` is the root subject's canonical IRI (present
+/// only for multi-ledger `IriMatch` roots). Both participate so a cross-ledger
+/// query can never serve one ledger's rendering for another ledger's subject
+/// (issue #1259).
+type CacheKey = (usize, Sid, u64, usize, Option<Arc<str>>);
 
 /// Depth bookkeeping for one hydration call.
 ///
@@ -447,8 +450,7 @@ pub async fn format_async(
 
     // Single-view (single-ledger) hydration: one formatter, no cross-ledger
     // routing. `FormatterSet::pick` always falls back to this primary.
-    let active_ledger: Arc<str> = Arc::from(db.snapshot.ledger_id.as_str());
-    let formatter = HydrationFormatter::new(db, compactor, active_ledger, config, policy, tracker);
+    let formatter = HydrationFormatter::new(db, compactor, config, policy, tracker);
     let set = FormatterSet {
         formatters: vec![formatter],
         by_ledger: HashMap::new(),
@@ -496,13 +498,13 @@ pub async fn format_async_dataset(
     run_hydration_rows(&set, result).await
 }
 
-/// One ledger's hydration view: its db, namespace-aware compactor, policy, and
-/// ledger id. Owned by [`DatasetCtx`]; formatters borrow from it.
+/// One ledger's hydration view: its db, namespace-aware compactor, and policy.
+/// Owned by [`DatasetCtx`]; formatters borrow from it. (Ledger identity is
+/// tracked by view index via [`DatasetCtx::by_ledger`], not stored per view.)
 struct LedgerView<'a> {
     db: GraphDbRef<'a>,
     compactor: IriCompactor,
     policy: Option<PolicyContext>,
-    ledger_id: Arc<str>,
 }
 
 /// Owns every dataset ledger's [`LedgerView`] and the routing metadata that
@@ -549,7 +551,6 @@ impl<'a> DatasetCtx<'a> {
                 db: view_db,
                 compactor: IriCompactor::new(g.snapshot.namespaces(), context),
                 policy: g.policy().cloned(),
-                ledger_id: Arc::clone(&g.ledger_id),
             });
             // First occurrence wins (a ledger may appear as both default and named).
             by_ledger.entry(Arc::clone(&g.ledger_id)).or_insert(i);
@@ -581,7 +582,6 @@ impl<'a> DatasetCtx<'a> {
         HydrationFormatter {
             db: view.db,
             compactor: &view.compactor,
-            active_ledger: Arc::clone(&view.ledger_id),
             typed: self.typed,
             normalize_arrays: self.normalize_arrays,
             policy: view.policy.as_ref(),
@@ -713,14 +713,6 @@ async fn run_hydration_rows(set: &FormatterSet<'_>, result: &QueryResult) -> Res
 struct HydrationFormatter<'a> {
     db: GraphDbRef<'a>,
     compactor: &'a IriCompactor,
-    /// Ledger this formatter's view belongs to.
-    ///
-    /// Distinguishes per-ledger entries in the shared expansion cache: a
-    /// `Sid`'s `(namespace_code, name)` is view-local, so the same bytes can
-    /// name different subjects across ledgers. Including the ledger in the
-    /// cache key prevents one ledger's hydration from being served for
-    /// another's (issue #1259, multi-ledger formatting).
-    active_ledger: Arc<str>,
     /// Whether to emit typed JSON (`{"@value": ..., "@type": ...}`) for all literals.
     typed: bool,
     /// Whether to always wrap property values in arrays (even single-valued).
@@ -738,6 +730,11 @@ struct HydrationFormatter<'a> {
     /// target ledger's view (issue #1259).
     dataset: Option<&'a DatasetCtx<'a>>,
     /// This formatter's index into [`DatasetCtx::views`] (0 in single-ledger mode).
+    ///
+    /// Also the leading component of [`CacheKey`]: a `Sid` is view-local, so the
+    /// same bytes can name different subjects across ledgers. The index uniquely
+    /// identifies the view within a hydration's shared cache, so one ledger's
+    /// rendering is never served for another's (issue #1259).
     active_idx: usize,
 }
 
@@ -745,7 +742,6 @@ impl<'a> HydrationFormatter<'a> {
     fn new(
         db: GraphDbRef<'a>,
         compactor: &'a IriCompactor,
-        active_ledger: Arc<str>,
         config: &FormatterConfig,
         policy: Option<&'a PolicyContext>,
         tracker: Option<&'a Tracker>,
@@ -753,7 +749,6 @@ impl<'a> HydrationFormatter<'a> {
         Self {
             db,
             compactor,
-            active_ledger,
             typed: config.format == OutputFormat::TypedJson,
             normalize_arrays: config.normalize_arrays,
             policy,
@@ -784,7 +779,7 @@ impl<'a> HydrationFormatter<'a> {
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
             let cache_key = (
-                Arc::clone(&self.active_ledger),
+                self.active_idx,
                 sid.clone(),
                 compute_level_hash(level),
                 depth.remaining(),
@@ -1012,6 +1007,30 @@ impl<'a> HydrationFormatter<'a> {
         .boxed()
     }
 
+    /// Hydrate a referenced subject, dispatching cross-ledger only when needed.
+    ///
+    /// `expand_ref` is the cross-ledger path: it returns its own boxed future
+    /// and then awaits `format_subject`'s boxed future, so a single-ledger ref
+    /// crawl would allocate two boxed futures per ref. Single-ledger refs stay
+    /// in the current view, so route them straight to `format_subject` (one
+    /// boxed future). This helper is a plain `async fn`, so it folds into the
+    /// caller's state machine and adds no allocation of its own.
+    async fn expand_or_format_ref<'b>(
+        &'b self,
+        ref_sid: &'b Sid,
+        level: &'b NestedSelectSpec,
+        depth: DepthBudget,
+        visited: &'b mut HashSet<Sid>,
+        cache: &'b mut HashMap<CacheKey, JsonValue>,
+    ) -> Result<JsonValue> {
+        if self.dataset.is_some() {
+            self.expand_ref(ref_sid, level, depth, visited, cache).await
+        } else {
+            self.format_subject(ref_sid, None, level, depth, visited, cache)
+                .await
+        }
+    }
+
     /// Whether this compact key should always be represented as an array.
     ///
     /// JSON-LD `@container` semantics:
@@ -1071,8 +1090,14 @@ impl<'a> HydrationFormatter<'a> {
                             .or_else(|| depth.can_expand().then_some(parent_level));
                         match sub_level {
                             Some(level) => values.push(
-                                self.expand_ref(ref_sid, level, depth.descend(), visited, cache)
-                                    .await?,
+                                self.expand_or_format_ref(
+                                    ref_sid,
+                                    level,
+                                    depth.descend(),
+                                    visited,
+                                    cache,
+                                )
+                                .await?,
                             ),
                             None => {
                                 values.push(json!({ "@id": self.compactor.compact_sid(ref_sid)? }));
@@ -1113,8 +1138,14 @@ impl<'a> HydrationFormatter<'a> {
             let sub_level = nested_spec.or_else(|| depth.can_expand().then_some(parent_level));
             match sub_level {
                 Some(level) => values.push(
-                    self.expand_ref(subject_sid, level, depth.descend(), visited, cache)
-                        .await?,
+                    self.expand_or_format_ref(
+                        subject_sid,
+                        level,
+                        depth.descend(),
+                        visited,
+                        cache,
+                    )
+                    .await?,
                 ),
                 None => {
                     // No expansion - just @id
@@ -1626,22 +1657,22 @@ mod tests {
     fn test_cache_key_different_depths() {
         let sid = Sid::new(100, "alice");
         let spec_hash = 12345u64;
-        let ledger: Arc<str> = Arc::from("a:main");
+        let view_a = 0usize;
 
-        let key1: CacheKey = (Arc::clone(&ledger), sid.clone(), spec_hash, 0, None);
-        let key2: CacheKey = (Arc::clone(&ledger), sid.clone(), spec_hash, 1, None);
-        let key3: CacheKey = (Arc::clone(&ledger), sid.clone(), spec_hash, 0, None);
+        let key1: CacheKey = (view_a, sid.clone(), spec_hash, 0, None);
+        let key2: CacheKey = (view_a, sid.clone(), spec_hash, 1, None);
+        let key3: CacheKey = (view_a, sid.clone(), spec_hash, 0, None);
         // Same SID + spec + depth but a different canonical IRI (cross-ledger
         // collision) must NOT share a cache entry.
         let key4: CacheKey = (
-            Arc::clone(&ledger),
+            view_a,
             sid.clone(),
             spec_hash,
             0,
             Some(Arc::from("http://other.example/x")),
         );
-        // Same SID + spec + depth in a DIFFERENT ledger must NOT share an entry.
-        let key5: CacheKey = (Arc::from("b:main"), sid, spec_hash, 0, None);
+        // Same SID + spec + depth in a DIFFERENT view (ledger) must NOT share an entry.
+        let key5: CacheKey = (1usize, sid, spec_hash, 0, None);
 
         // Different depths should produce different keys
         assert_ne!(key1, key2);
@@ -1649,7 +1680,7 @@ mod tests {
         assert_eq!(key1, key3);
         // Different canonical IRI → different key
         assert_ne!(key1, key4);
-        // Different active ledger → different key
+        // Different active view → different key
         assert_ne!(key1, key5);
     }
 

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -61,15 +61,21 @@ use serde_json::{json, Value as JsonValue};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
-/// Cache key: (Sid, local_spec_hash, depth_remaining)
+/// Cache key: `(Sid, local_spec_hash, depth_remaining, root_canonical_iri)`.
 ///
-/// The local_spec_hash is computed from the current `NestedSelectSpec`,
+/// The `local_spec_hash` is computed from the current `NestedSelectSpec`,
 /// NOT any top-level spec. This serves two purposes:
 /// - Different nested hydrations of the same Sid produce different entries.
 /// - Multiple top-level hydration columns share entries when they land on
 ///   the same Sid with structurally identical levels, and stay separated
 ///   when their levels differ.
-type CacheKey = (Sid, u64, usize);
+///
+/// The trailing `Option<Arc<str>>` is the root subject's canonical IRI (present
+/// only for multi-ledger `IriMatch` roots). It participates in the key because
+/// two different ledgers can mint the same `(namespace_code, name)` SID for
+/// *different* IRIs — without it, a cross-ledger query could serve one ledger's
+/// rendering for another ledger's subject (issue #1259).
+type CacheKey = (Sid, u64, usize, Option<Arc<str>>);
 
 /// Depth bookkeeping for one hydration call.
 ///
@@ -232,7 +238,16 @@ fn hash_reverse<H: std::hash::Hasher>(
     }
 }
 
-/// Resolve a hydration root variable's binding into a `Sid` for a single row.
+/// Resolve a hydration root variable's binding into a `Sid` plus its canonical
+/// IRI (when known) for a single row.
+///
+/// The optional `Arc<str>` is the canonical IRI carried by a multi-ledger
+/// `Binding::IriMatch`. It MUST be preferred over decoding the returned SID
+/// against the formatter's single-snapshot namespace dict: the SID is encoded
+/// in its *originating* ledger, which may differ from the ledger backing the
+/// formatter, so decoding it here would silently produce the wrong IRI
+/// (issue #1259). Single-ledger bindings (`Binding::Sid`) carry no canonical
+/// IRI and are decoded normally.
 ///
 /// Returns `Ok(None)` when the binding is unbound, poisoned, missing, or not
 /// subject-shaped (literals, IRIs that didn't match a known subject, etc.).
@@ -240,18 +255,22 @@ fn hash_reverse<H: std::hash::Hasher>(
 fn resolve_root_sid_from_binding(
     result: &QueryResult,
     binding: Option<&Binding>,
-) -> Result<Option<Sid>> {
+) -> Result<Option<(Sid, Option<Arc<str>>)>> {
     match binding {
         Some(b) if b.is_encoded() => {
             let materialized = super::materialize::materialize_binding(result, b)?;
             Ok(match materialized {
-                Binding::Sid { sid, .. } => Some(sid),
-                Binding::IriMatch { primary_sid, .. } => Some(primary_sid),
+                Binding::Sid { sid, .. } => Some((sid, None)),
+                Binding::IriMatch {
+                    primary_sid, iri, ..
+                } => Some((primary_sid, Some(iri))),
                 _ => None,
             })
         }
-        Some(Binding::Sid { sid, .. }) => Ok(Some(sid.clone())),
-        Some(Binding::IriMatch { primary_sid, .. }) => Ok(Some(primary_sid.clone())),
+        Some(Binding::Sid { sid, .. }) => Ok(Some((sid.clone(), None))),
+        Some(Binding::IriMatch {
+            primary_sid, iri, ..
+        }) => Ok(Some((primary_sid.clone(), Some(iri.clone())))),
         Some(Binding::Unbound | Binding::Poisoned) | None => Ok(None),
         Some(
             Binding::Lit { .. }
@@ -278,14 +297,19 @@ async fn format_hydration_column(
     row_idx: usize,
     cache: &mut HashMap<CacheKey, JsonValue>,
 ) -> Result<JsonValue> {
-    let root_sid: Sid = match &spec.root {
-        Root::Sid(sid) => sid.clone(),
+    // `root_iri` is the canonical IRI when the root came from a multi-ledger
+    // `IriMatch` binding; it lets `format_subject` emit the root `@id` from the
+    // ledger-correct IRI instead of decoding a foreign SID against the
+    // formatter's single-snapshot dict (issue #1259).
+    let (root_sid, root_iri): (Sid, Option<Arc<str>>) = match &spec.root {
+        Root::Sid(sid) => (sid.clone(), None),
         Root::Var(var_id) => {
-            let Some(sid) = resolve_root_sid_from_binding(result, batch.get(row_idx, *var_id))?
+            let Some(resolved) =
+                resolve_root_sid_from_binding(result, batch.get(row_idx, *var_id))?
             else {
                 return Ok(JsonValue::Null);
             };
-            sid
+            resolved
         }
     };
 
@@ -293,6 +317,7 @@ async fn format_hydration_column(
     formatter
         .format_subject(
             &root_sid,
+            root_iri,
             &spec.level,
             DepthBudget::root(spec.depth),
             &mut visited,
@@ -455,22 +480,43 @@ impl<'a> HydrationFormatter<'a> {
     fn format_subject<'b>(
         &'b self,
         sid: &'b Sid,
+        root_iri: Option<Arc<str>>,
         level: &'b NestedSelectSpec,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
         cache: &'b mut HashMap<CacheKey, JsonValue>,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
-            let cache_key = (sid.clone(), compute_level_hash(level), depth.remaining());
+            let cache_key = (
+                sid.clone(),
+                compute_level_hash(level),
+                depth.remaining(),
+                root_iri.clone(),
+            );
 
             // Check cache first (same Sid + spec + depth = same result)
             if let Some(cached) = cache.get(&cache_key) {
                 return Ok(cached.clone());
             }
 
+            // The `@id` of THIS subject: prefer the canonical IRI from a
+            // multi-ledger `IriMatch` root over decoding the SID against this
+            // formatter's single-snapshot dict, which would mis-decode a SID
+            // that originated in a different ledger (issue #1259). `compact_iri`
+            // is a pure context operation, independent of the namespace dict.
+            // `root_iri` is only ever set for the root subject; nested refs
+            // (recursive calls below) pass `None` and decode their SID against
+            // the ledger whose flakes produced them.
+            let id_json = |compactor: &IriCompactor| -> Result<JsonValue> {
+                Ok(json!(match root_iri.as_deref() {
+                    Some(iri) => compactor.compact_iri(iri)?,
+                    None => compactor.compact_sid(sid)?,
+                }))
+            };
+
             // Cycle detection - if already in current path, return just @id
             if !visited.insert(sid.clone()) {
-                return Ok(json!({ "@id": self.compactor.compact_sid(sid)? }));
+                return Ok(json!({ "@id": id_json(self.compactor)? }));
             }
 
             // Build object with sorted keys for determinism (BTreeMap)
@@ -480,7 +526,7 @@ impl<'a> HydrationFormatter<'a> {
             // - Always include for nested hydrations (identity of an expanded ref)
             // - Otherwise include when wildcard or explicit @id selection
             if depth.current > 0 || level.includes_id() {
-                obj.insert("@id".to_string(), json!(self.compactor.compact_sid(sid)?));
+                obj.insert("@id".to_string(), id_json(self.compactor)?);
             }
 
             // Fetch forward properties. For Explicit projections we hand the
@@ -661,6 +707,7 @@ impl<'a> HydrationFormatter<'a> {
                             values.push(
                                 self.format_subject(
                                     ref_sid,
+                                    None,
                                     nested,
                                     depth.descend(),
                                     visited,
@@ -672,6 +719,7 @@ impl<'a> HydrationFormatter<'a> {
                             values.push(
                                 self.format_subject(
                                     ref_sid,
+                                    None,
                                     parent_level,
                                     depth.descend(),
                                     visited,
@@ -717,14 +765,21 @@ impl<'a> HydrationFormatter<'a> {
 
             if let Some(nested) = nested_spec {
                 values.push(
-                    self.format_subject(subject_sid, nested, depth.descend(), visited, cache)
+                    self.format_subject(subject_sid, None, nested, depth.descend(), visited, cache)
                         .await?,
                 );
             } else if depth.can_expand() {
                 // Auto-expand reverse refs with FULL parent level
                 values.push(
-                    self.format_subject(subject_sid, parent_level, depth.descend(), visited, cache)
-                        .await?,
+                    self.format_subject(
+                        subject_sid,
+                        None,
+                        parent_level,
+                        depth.descend(),
+                        visited,
+                        cache,
+                    )
+                    .await?,
                 );
             } else {
                 // No expansion - just @id
@@ -1236,14 +1291,19 @@ mod tests {
         let sid = Sid::new(100, "alice");
         let spec_hash = 12345u64;
 
-        let key1: CacheKey = (sid.clone(), spec_hash, 0);
-        let key2: CacheKey = (sid.clone(), spec_hash, 1);
-        let key3: CacheKey = (sid, spec_hash, 0);
+        let key1: CacheKey = (sid.clone(), spec_hash, 0, None);
+        let key2: CacheKey = (sid.clone(), spec_hash, 1, None);
+        let key3: CacheKey = (sid.clone(), spec_hash, 0, None);
+        // Same SID + spec + depth but a different canonical IRI (cross-ledger
+        // collision) must NOT share a cache entry.
+        let key4: CacheKey = (sid, spec_hash, 0, Some(Arc::from("http://other.example/x")));
 
         // Different depths should produce different keys
         assert_ne!(key1, key2);
         // Same Sid + spec + depth should be equal
         assert_eq!(key1, key3);
+        // Different canonical IRI → different key
+        assert_ne!(key1, key4);
     }
 
     fn explicit(forward: Vec<ForwardItem>) -> NestedSelectSpec {

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -337,6 +337,67 @@ pub async fn format_results_async(
     }
 }
 
+/// Dataset-aware async formatting (multi-ledger).
+///
+/// Like [`format_results_async`], but for queries that span multiple ledgers:
+/// **hydration** expansion routes each subject to its home-ledger view so
+/// properties and `@id`s decode against the ledger that stores them, under that
+/// ledger's own policy (issue #1259). Non-hydration output (flat SELECT,
+/// CONSTRUCT, ASK) is dict-independent for cross-ledger IRIs — those carry
+/// `IriMatch.iri` — so it formats against the dataset's primary view exactly as
+/// before.
+pub async fn format_results_async_dataset(
+    result: &QueryResult,
+    context: &ParsedContext,
+    dataset: &crate::view::DataSetDb,
+    config: &FormatterConfig,
+    tracker: Option<&Tracker>,
+) -> Result<JsonValue> {
+    if matches!(config.format, OutputFormat::Tsv | OutputFormat::Csv) {
+        return Err(FormatError::InvalidBinding(format!(
+            "{:?} format produces bytes/String, not JsonValue. \
+             Use format_results_string() or QueryResult::to_tsv()/to_csv() instead.",
+            config.format
+        )));
+    }
+
+    if result.output.has_hydration() {
+        if !matches!(
+            config.format,
+            OutputFormat::JsonLd | OutputFormat::TypedJson
+        ) {
+            return Err(FormatError::InvalidBinding(
+                "Hydration only supports JSON-LD and TypedJson output formats".to_string(),
+            ));
+        }
+        let v = hydration::format_async_dataset(result, dataset, context, config, tracker).await?;
+        return if result.output.is_select_one() {
+            match v {
+                JsonValue::Array(mut rows) => Ok(rows.drain(..).next().unwrap_or(JsonValue::Null)),
+                other => Ok(other),
+            }
+        } else {
+            Ok(v)
+        };
+    }
+
+    // Non-hydration: format against the primary view. Cross-ledger subject/ref
+    // IRIs in flat SELECT / CONSTRUCT come from `IriMatch.iri` (dict-independent),
+    // so the single primary dict is sufficient.
+    let primary = dataset.primary().ok_or_else(|| {
+        FormatError::InvalidBinding("dataset has no graphs for formatting".to_string())
+    })?;
+    format_results_async(
+        result,
+        context,
+        primary.as_graph_db_ref(),
+        config,
+        None,
+        tracker,
+    )
+    .await
+}
+
 /// Format query results to a JSON string using async database access
 ///
 /// Async convenience function that formats and serializes in one step.
@@ -371,6 +432,45 @@ pub async fn format_results_string_async(
     }
 
     let value = format_results_async(result, context, db, config, policy, None).await?;
+
+    if config.pretty {
+        Ok(serde_json::to_string_pretty(&value)?)
+    } else {
+        Ok(serde_json::to_string(&value)?)
+    }
+}
+
+/// Dataset-aware string formatting (multi-ledger), mirroring
+/// [`format_results_string_async`]. Delimited / XML output is dict-independent
+/// for cross-ledger IRIs (carried as `IriMatch.iri`), so it formats against the
+/// primary view; JSON output (incl. hydration) goes through the dataset-aware
+/// path so cross-ledger subjects decode against their home ledger (issue #1259).
+pub async fn format_results_string_async_dataset(
+    result: &QueryResult,
+    context: &ParsedContext,
+    dataset: &crate::view::DataSetDb,
+    config: &FormatterConfig,
+    tracker: Option<&Tracker>,
+) -> Result<String> {
+    let primary = dataset.primary().ok_or_else(|| {
+        FormatError::InvalidBinding("dataset has no graphs for formatting".to_string())
+    })?;
+    let primary_db = primary.as_graph_db_ref();
+    match config.format {
+        OutputFormat::Tsv => return delimited::format_tsv(result, primary_db.snapshot),
+        OutputFormat::Csv => return delimited::format_csv(result, primary_db.snapshot),
+        OutputFormat::SparqlXml => {
+            let compactor = IriCompactor::new(primary_db.snapshot.namespaces(), context);
+            return sparql_xml::format(result, &compactor, config);
+        }
+        OutputFormat::RdfXml => {
+            let compactor = IriCompactor::new(primary_db.snapshot.namespaces(), context);
+            return rdf_xml::format(result, &compactor, config);
+        }
+        _ => {}
+    }
+
+    let value = format_results_async_dataset(result, context, dataset, config, tracker).await?;
 
     if config.pretty {
         Ok(serde_json::to_string_pretty(&value)?)

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -914,49 +914,36 @@ impl<'a> FromQueryBuilder<'a> {
         }
         match input {
             QueryInput::JsonLd(json) => {
-                let result = match &self.policy {
-                    Some(policy) => match r2rml.as_ref() {
-                        Some((provider, table_provider)) => {
-                            self.fluree
-                                .query_connection_with_policy_and_r2rml(
-                                    json,
-                                    policy,
-                                    provider.as_ref(),
-                                    table_provider.as_ref(),
-                                )
-                                .await?
-                        }
-                        None => {
-                            self.fluree
-                                .query_connection_with_policy(json, policy)
-                                .await?
-                        }
-                    },
-                    None => match r2rml.as_ref() {
-                        Some((provider, table_provider)) => {
-                            self.fluree
-                                .query_connection_jsonld_with_r2rml(
-                                    json,
-                                    provider.as_ref(),
-                                    table_provider.as_ref(),
-                                )
-                                .await?
-                        }
-                        None => self.fluree.query_connection(json).await?,
-                    },
-                };
-                let (spec, _) = parse_dataset_spec(json)?;
-                if let Some(alias) = spec
-                    .default_graphs
-                    .first()
-                    .or_else(|| spec.named_graphs.first())
-                {
-                    let view = self.fluree.db(alias.identifier.as_str()).await?;
-                    Ok(result
-                        .format_async(view.as_graph_db_ref(), &format_config)
-                        .await?)
-                } else {
-                    Err(ApiError::query("No graph specified for formatting"))
+                let policy = self.policy.as_deref();
+                let r2rml_pair = r2rml.as_ref().map(|(p, t)| (p.as_ref(), t.as_ref()));
+                let (result, dataset) = self
+                    .fluree
+                    .query_connection_jsonld_returning_dataset(json, policy, r2rml_pair)
+                    .await?;
+                match dataset {
+                    // Multi-ledger: format hydration per home-ledger view so
+                    // cross-graph IRIs/properties decode correctly (issue #1259).
+                    Some(dataset) => Ok(crate::format::format_results_async_dataset(
+                        &result,
+                        &result.context,
+                        &dataset,
+                        &format_config,
+                        None,
+                    )
+                    .await?),
+                    // Single-ledger: format against the sole view (today's path).
+                    None => {
+                        let (spec, _) = parse_dataset_spec(json)?;
+                        let alias = spec
+                            .default_graphs
+                            .first()
+                            .or_else(|| spec.named_graphs.first())
+                            .ok_or_else(|| ApiError::query("No graph specified for formatting"))?;
+                        let view = self.fluree.db(alias.identifier.as_str()).await?;
+                        Ok(result
+                            .format_async(view.as_graph_db_ref(), &format_config)
+                            .await?)
+                    }
                 }
             }
             QueryInput::Sparql(sparql) => {
@@ -1058,55 +1045,42 @@ impl<'a> FromQueryBuilder<'a> {
         }
         match input {
             QueryInput::JsonLd(json) => {
-                let result = match &self.policy {
-                    Some(policy) => match r2rml.as_ref() {
-                        Some((provider, table_provider)) => {
-                            self.fluree
-                                .query_connection_with_policy_and_r2rml(
-                                    json,
-                                    policy,
-                                    provider.as_ref(),
-                                    table_provider.as_ref(),
-                                )
-                                .await?
-                        }
-                        None => {
-                            self.fluree
-                                .query_connection_with_policy(json, policy)
-                                .await?
-                        }
-                    },
-                    None => match r2rml.as_ref() {
-                        Some((provider, table_provider)) => {
-                            self.fluree
-                                .query_connection_jsonld_with_r2rml(
-                                    json,
-                                    provider.as_ref(),
-                                    table_provider.as_ref(),
-                                )
-                                .await?
-                        }
-                        None => self.fluree.query_connection(json).await?,
-                    },
-                };
-                let (spec, _) = parse_dataset_spec(json)?;
-                if let Some(alias) = spec
-                    .default_graphs
-                    .first()
-                    .or_else(|| spec.named_graphs.first())
-                {
-                    let view = self.fluree.db(alias.identifier.as_str()).await?;
-                    crate::format::format_results_string_async(
+                let policy = self.policy.as_deref();
+                let r2rml_pair = r2rml.as_ref().map(|(p, t)| (p.as_ref(), t.as_ref()));
+                let (result, dataset) = self
+                    .fluree
+                    .query_connection_jsonld_returning_dataset(json, policy, r2rml_pair)
+                    .await?;
+                match dataset {
+                    // Multi-ledger: dataset-aware string formatting (issue #1259).
+                    Some(dataset) => crate::format::format_results_string_async_dataset(
                         &result,
                         &result.context,
-                        view.as_graph_db_ref(),
+                        &dataset,
                         &format_config,
                         None,
                     )
                     .await
-                    .map_err(ApiError::from)
-                } else {
-                    Err(ApiError::query("No graph specified for formatting"))
+                    .map_err(ApiError::from),
+                    // Single-ledger: format against the sole view (today's path).
+                    None => {
+                        let (spec, _) = parse_dataset_spec(json)?;
+                        let alias = spec
+                            .default_graphs
+                            .first()
+                            .or_else(|| spec.named_graphs.first())
+                            .ok_or_else(|| ApiError::query("No graph specified for formatting"))?;
+                        let view = self.fluree.db(alias.identifier.as_str()).await?;
+                        crate::format::format_results_string_async(
+                            &result,
+                            &result.context,
+                            view.as_graph_db_ref(),
+                            &format_config,
+                            None,
+                        )
+                        .await
+                        .map_err(ApiError::from)
+                    }
                 }
             }
             QueryInput::Sparql(sparql) => {

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -899,13 +899,17 @@ impl<'a> FromQueryBuilder<'a> {
                 .await?;
             let ast = crate::query::helpers::parse_and_validate_sparql(sparql)?;
             let spec = crate::query::helpers::extract_sparql_dataset_spec(&ast)?;
-            return if let Some(alias) = spec.default_graphs.first() {
+            return if let Some(alias) = spec
+                .default_graphs
+                .first()
+                .or_else(|| spec.named_graphs.first())
+            {
                 let view = self.fluree.db(alias.identifier.as_str()).await?;
                 Ok(result
                     .format_async(view.as_graph_db_ref(), &format_config)
                     .await?)
             } else {
-                Err(ApiError::query("No default graph for formatting"))
+                Err(ApiError::query("No graph specified for formatting"))
             };
         }
         match input {
@@ -942,13 +946,17 @@ impl<'a> FromQueryBuilder<'a> {
                     },
                 };
                 let (spec, _) = parse_dataset_spec(json)?;
-                if let Some(alias) = spec.default_graphs.first() {
+                if let Some(alias) = spec
+                    .default_graphs
+                    .first()
+                    .or_else(|| spec.named_graphs.first())
+                {
                     let view = self.fluree.db(alias.identifier.as_str()).await?;
                     Ok(result
                         .format_async(view.as_graph_db_ref(), &format_config)
                         .await?)
                 } else {
-                    Err(ApiError::query("No default graph for formatting"))
+                    Err(ApiError::query("No graph specified for formatting"))
                 }
             }
             QueryInput::Sparql(sparql) => {
@@ -985,13 +993,17 @@ impl<'a> FromQueryBuilder<'a> {
                 };
                 let ast = crate::query::helpers::parse_and_validate_sparql(sparql)?;
                 let spec = crate::query::helpers::extract_sparql_dataset_spec(&ast)?;
-                if let Some(alias) = spec.default_graphs.first() {
+                if let Some(alias) = spec
+                    .default_graphs
+                    .first()
+                    .or_else(|| spec.named_graphs.first())
+                {
                     let view = self.fluree.db(alias.identifier.as_str()).await?;
                     Ok(result
                         .format_async(view.as_graph_db_ref(), &format_config)
                         .await?)
                 } else {
-                    Err(ApiError::query("No default graph for formatting"))
+                    Err(ApiError::query("No graph specified for formatting"))
                 }
             }
         }
@@ -1025,7 +1037,11 @@ impl<'a> FromQueryBuilder<'a> {
                 .await?;
             let ast = crate::query::helpers::parse_and_validate_sparql(sparql)?;
             let spec = crate::query::helpers::extract_sparql_dataset_spec(&ast)?;
-            return if let Some(alias) = spec.default_graphs.first() {
+            return if let Some(alias) = spec
+                .default_graphs
+                .first()
+                .or_else(|| spec.named_graphs.first())
+            {
                 let view = self.fluree.db(alias.identifier.as_str()).await?;
                 crate::format::format_results_string_async(
                     &result,
@@ -1037,7 +1053,7 @@ impl<'a> FromQueryBuilder<'a> {
                 .await
                 .map_err(ApiError::from)
             } else {
-                Err(ApiError::query("No default graph for formatting"))
+                Err(ApiError::query("No graph specified for formatting"))
             };
         }
         match input {
@@ -1074,7 +1090,11 @@ impl<'a> FromQueryBuilder<'a> {
                     },
                 };
                 let (spec, _) = parse_dataset_spec(json)?;
-                if let Some(alias) = spec.default_graphs.first() {
+                if let Some(alias) = spec
+                    .default_graphs
+                    .first()
+                    .or_else(|| spec.named_graphs.first())
+                {
                     let view = self.fluree.db(alias.identifier.as_str()).await?;
                     crate::format::format_results_string_async(
                         &result,
@@ -1086,7 +1106,7 @@ impl<'a> FromQueryBuilder<'a> {
                     .await
                     .map_err(ApiError::from)
                 } else {
-                    Err(ApiError::query("No default graph for formatting"))
+                    Err(ApiError::query("No graph specified for formatting"))
                 }
             }
             QueryInput::Sparql(sparql) => {
@@ -1123,7 +1143,11 @@ impl<'a> FromQueryBuilder<'a> {
                 };
                 let ast = crate::query::helpers::parse_and_validate_sparql(sparql)?;
                 let spec = crate::query::helpers::extract_sparql_dataset_spec(&ast)?;
-                if let Some(alias) = spec.default_graphs.first() {
+                if let Some(alias) = spec
+                    .default_graphs
+                    .first()
+                    .or_else(|| spec.named_graphs.first())
+                {
                     let view = self.fluree.db(alias.identifier.as_str()).await?;
                     crate::format::format_results_string_async(
                         &result,
@@ -1135,7 +1159,7 @@ impl<'a> FromQueryBuilder<'a> {
                     .await
                     .map_err(ApiError::from)
                 } else {
-                    Err(ApiError::query("No default graph for formatting"))
+                    Err(ApiError::query("No graph specified for formatting"))
                 }
             }
         }

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -123,6 +123,68 @@ impl Fluree {
         self.query_dataset(&dataset, query_json).await
     }
 
+    /// Execute a JSON-LD connection query and, for the multi-ledger case,
+    /// return the `DataSetDb` alongside the result so the caller can format
+    /// hydration output against each ledger's own view (issue #1259).
+    ///
+    /// Mirrors the policy/r2rml combinations of [`Self::query_connection`],
+    /// [`Self::query_connection_with_policy`],
+    /// [`Self::query_connection_jsonld_with_r2rml`], and
+    /// [`Self::query_connection_with_policy_and_r2rml`] in one place. Returns
+    /// `None` for the single-ledger fast path (formatting is correct against
+    /// the sole view) and `Some(dataset)` for genuine multi-ledger queries.
+    pub(crate) async fn query_connection_jsonld_returning_dataset(
+        &self,
+        query_json: &JsonValue,
+        policy: Option<&PolicyContext>,
+        r2rml: Option<(&dyn R2rmlProvider, &dyn R2rmlTableProvider)>,
+    ) -> Result<(QueryResult, Option<DataSetDb>)> {
+        let (spec, qc_opts) = parse_dataset_spec(query_json)?;
+
+        if spec.is_empty() {
+            return Err(ApiError::query(
+                "Missing ledger specification in connection query",
+            ));
+        }
+
+        // Single-ledger fast path — no dataset needed for formatting.
+        let single = match policy {
+            Some(p) => {
+                self.prepare_single_view_for_connection_with_policy(&spec, p)
+                    .await?
+            }
+            None => {
+                self.prepare_single_view_for_connection(&spec, &qc_opts)
+                    .await?
+            }
+        };
+        if let Some(view) = single {
+            let result = match r2rml {
+                Some((rp, rtp)) => {
+                    self.query_view_with_r2rml(&view, query_json, rp, rtp)
+                        .await?
+                }
+                None => self.query(&view, query_json).await?,
+            };
+            return Ok((result, None));
+        }
+
+        // Multi-ledger: build the DataSetDb (with per-view policy) and keep it
+        // alive so the formatter can route hydration per ledger.
+        let dataset = match policy {
+            Some(p) => apply_policy_to_dataset(self.build_dataset_view(&spec).await?, p),
+            None => self.build_dataset_for_connection(&spec, &qc_opts).await?,
+        };
+        let result = match r2rml {
+            Some((rp, rtp)) => {
+                self.query_dataset_with_r2rml(&dataset, query_json, rp, rtp)
+                    .await?
+            }
+            None => self.query_dataset(&dataset, query_json).await?,
+        };
+        Ok((result, Some(dataset)))
+    }
+
     /// Execute a JSON-LD connection query with explicit R2RML providers.
     ///
     /// Uses graph source fallback for alias resolution: if a source in the

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -1,0 +1,310 @@
+//! Multi-ledger JSON-LD query formatting (API/engine level).
+//!
+//! These tests exercise the connection-scoped builder path
+//! (`Fluree::query_from().jsonld(..).execute_formatted()`) — the same path the
+//! HTTP `/v1/fluree/query` route reaches via `run_jsonld_subquery`.
+//!
+//! Unlike the `it_query_connection.rs` tests, these do NOT hand-pick a
+//! formatting view (`query_connection(..)` + `to_jsonld_async(picked_ledger)`).
+//! They go through `execute_formatted`, which auto-selects the formatting view
+//! from `spec.default_graphs.first()`. That auto-selection is where the
+//! multi-ledger formatter bugs live:
+//!   - cross-graph IRIs decoded against the wrong ledger's namespace dict
+//!   - `fromNamed`-only queries erroring with "No default graph for formatting"
+//!
+//! See GitHub issue #1259.
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::{genesis_ledger, MemoryFluree};
+
+/// Seed three federated ledgers with *divergent* entity vocabularies.
+///
+/// Mirrors the structure of the passing
+/// `query_connection_from_combined_datasets_selecting_subgraphs_depth_3` test
+/// (movie → isBasedOn → book → author → person), but each ledger uses its own
+/// entity prefix instead of a shared `wikidata.org`:
+///   - movies under `http://movie.example/`
+///   - books  under `http://book.example/`
+///   - authors under `http://author.example/`
+///
+/// User namespaces are allocated per-ledger from code 13 in first-appearance
+/// order, so the same numeric code maps to different prefixes across ledgers.
+/// The movies ledger never references an `author.example` IRI directly, so its
+/// dict either lacks that namespace or maps the colliding code to a different
+/// prefix — which is exactly what trips the single-snapshot formatter.
+async fn seed_divergent_ledgers(fluree: &MemoryFluree) {
+    // Authors — entity prefix `author`.
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/authors:main"),
+            &json!({
+                "@context": {
+                    "author": "http://author.example/",
+                    "schema": "http://schema.org/",
+                    "id": "@id",
+                    "type": "@type",
+                },
+                "@graph": [
+                    {"@id": "author:a1", "@type": "schema:Person", "schema:name": "Margaret Mitchell"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert authors");
+
+    // Books — entity prefix `book`; author ref points into `author` namespace.
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/books:main"),
+            &json!({
+                "@context": {
+                    "book": "http://book.example/",
+                    "author": "http://author.example/",
+                    "schema": "http://schema.org/",
+                    "id": "@id",
+                    "type": "@type",
+                },
+                "@graph": [
+                    {
+                        "@id": "book:b1",
+                        "@type": "schema:Book",
+                        "schema:name": "Gone with the Wind",
+                        "schema:isbn": "0-582-41805-4",
+                        "schema:author": {"@id": "author:a1"}
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("insert books");
+
+    // Movies — entity prefix `movie`; isBasedOn ref points into `book`
+    // namespace. NOTE: movies never references an `author` IRI, so the movies
+    // dict has no `http://author.example/` entry (or a colliding code).
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/movies:main"),
+            &json!({
+                "@context": {
+                    "movie": "http://movie.example/",
+                    "book": "http://book.example/",
+                    "schema": "http://schema.org/",
+                    "id": "@id",
+                    "type": "@type",
+                },
+                "@graph": [
+                    {
+                        "@id": "movie:m1",
+                        "@type": "schema:Movie",
+                        "schema:name": "Gone with the Wind",
+                        "schema:isBasedOn": {"@id": "book:b1"}
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("insert movies");
+}
+
+/// Issue 2 — a result subject sourced from one ledger is decoded against a
+/// different ledger's namespace dict, silently returning the wrong `@id`.
+#[tokio::test]
+async fn cross_graph_projection_iri_decode() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_ledgers(&fluree).await;
+
+    // movies is FIRST in `from`, so `execute_formatted` auto-picks the movies
+    // dict as the single formatting snapshot. But the only matching subject —
+    // a schema:Person — lives in the authors ledger and is SID-encoded against
+    // the authors dict. Decoding that SID against the movies dict is the bug:
+    // the movies dict has no `http://author.example/` (or a colliding code).
+    let q = json!({
+        "@context": {
+            "movie": "http://movie.example/",
+            "author": "http://author.example/",
+            "schema": "http://schema.org/",
+            "id": "@id",
+            "type": "@type",
+        },
+        "from": ["test/movies:main", "test/authors:main"],
+        "select": { "?person": ["*"] },
+        "where": { "@id": "?person", "type": "schema:Person" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    // The person's @id MUST decode to `http://author.example/a1` (compacted via
+    // the query @context to `author:a1`).
+    //
+    // BUG (issue #1259, Issue 2): the formatter decodes every result SID
+    // against `spec.default_graphs.first()` = the movies dict. The authors-dict
+    // code for `http://author.example/` collides with the movies-dict code for
+    // `http://movie.example/`, so the @id silently comes back as `movie:a1`.
+    let person = value
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one person");
+    let person_id = person.get("@id").and_then(|v| v.as_str());
+    assert_eq!(
+        person_id,
+        Some("author:a1"),
+        "cross-graph @id decoded against the wrong ledger's namespace dict: {value:#}"
+    );
+}
+
+/// Issue 3 layer 2 — a `fromNamed`-only query (no default graph) must still
+/// format. The sibling `DatasetQueryBuilder::execute_formatted` handles this
+/// via `dataset.primary()` (which falls back to the first named graph);
+/// `FromQueryBuilder::execute_formatted` lacks that fallback and instead errors
+/// "No default graph for formatting".
+#[tokio::test]
+async fn from_named_only_formats() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "author": "http://author.example/",
+            "schema": "http://schema.org/",
+            "id": "@id",
+            "type": "@type",
+        },
+        "fromNamed": ["test/authors:main"],
+        "select": { "?author": ["*"] },
+        "where": [
+            ["graph", "test/authors:main",
+                { "@id": "?author", "type": "schema:Person" }
+            ]
+        ]
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("fromNamed-only query should format, not error");
+
+    let person = value
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one person");
+    assert_eq!(
+        person.get("@id").and_then(|v| v.as_str()),
+        Some("author:a1"),
+    );
+    assert_eq!(
+        person.get("schema:name").and_then(|v| v.as_str()),
+        Some("Margaret Mitchell"),
+    );
+}
+
+/// Flat select (no hydration) goes through the `Binding::IriMatch` path
+/// (jsonld.rs:82), which already decodes the cross-ledger @id correctly via the
+/// canonical IRI. This guards that path against regressions and documents the
+/// contrast with the hydration path fixed for issue #1259.
+#[tokio::test]
+async fn flat_select_cross_graph_iri_decode() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "movie": "http://movie.example/",
+            "author": "http://author.example/",
+            "schema": "http://schema.org/",
+            "id": "@id",
+            "type": "@type",
+        },
+        "from": ["test/movies:main", "test/authors:main"],
+        "select": ["?person"],
+        "where": { "@id": "?person", "type": "schema:Person" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("flat select should format");
+
+    // Flat projection rows are arrays of bound values; the single column is the
+    // person IRI, which must compact to `author:a1` (decoded against the authors
+    // ledger via the IriMatch canonical IRI, not the movies primary dict).
+    let row = value.as_array().and_then(|a| a.first()).expect("one row");
+    let person_id = row
+        .as_array()
+        .and_then(|cols| cols.first())
+        .and_then(|v| v.as_str());
+    assert_eq!(
+        person_id,
+        Some("author:a1"),
+        "flat select result: {value:#}"
+    );
+}
+
+/// KNOWN LIMITATION (out of scope for issue #1259) — cross-ledger hydration
+/// *expansion* with divergent vocabularies.
+///
+/// The #1259 fix makes the cross-graph `@id` correct, but it does NOT make a
+/// foreign subject's *properties* expand when ledgers encode the shared IRIs
+/// under different namespace codes. Hydration follows a ref by its ledger-local
+/// SID and looks it up in the composite overlay, which is keyed by raw
+/// `(namespace_code, name)`. A ref minted in the movies ledger (movies' code for
+/// `http://book.example/`) cannot find the book subject stored under the books
+/// ledger's divergent code, so `isBasedOn` renders as a bare `{"@id": ...}`
+/// instead of a nested object.
+///
+/// The existing `query_connection_from_combined_datasets_selecting_subgraphs_depth_3`
+/// test only passes because its ledgers share schema.org/wikidata.org codes.
+///
+/// Fixing this requires SID re-encoding at ledger boundaries during hydration
+/// (decode under the source ledger, re-encode under the target snapshot) or a
+/// provenance-carrying composite overlay. Tracked as a follow-up. This test is
+/// `#[ignore]`d until then; when it starts passing, the limitation is resolved.
+#[tokio::test]
+#[ignore = "cross-ledger hydration expansion under divergent vocab — follow-up to #1259"]
+async fn cross_graph_hydration_expansion_divergent_vocab() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "movie": "http://movie.example/",
+            "book": "http://book.example/",
+            "author": "http://author.example/",
+            "schema": "http://schema.org/",
+            "id": "@id",
+            "type": "@type",
+        },
+        "from": ["test/movies:main", "test/books:main", "test/authors:main"],
+        "select": { "?movie": ["*"] },
+        "depth": 3,
+        "where": { "@id": "?movie", "type": "schema:Movie" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let movie = value.as_array().and_then(|a| a.first()).expect("one movie");
+    let book = movie.get("schema:isBasedOn").expect("isBasedOn present");
+    // The book ref must expand into a nested object with its real properties.
+    assert_eq!(book.get("@id").and_then(|v| v.as_str()), Some("book:b1"));
+    assert_eq!(
+        book.get("schema:name").and_then(|v| v.as_str()),
+        Some("Gone with the Wind"),
+        "cross-ledger ref should hydrate its properties: {value:#}"
+    );
+}

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -251,6 +251,100 @@ async fn flat_select_cross_graph_iri_decode() {
     );
 }
 
+/// Seed a primary "catalog" ledger and a "people" ledger whose person uses a
+/// divergent *predicate* vocabulary (`p:` = http://people.example/). The
+/// shared `schema:` type lets the BGP match across both; the divergent
+/// `p:fullName` predicate is what exercises home-ledger decoding.
+async fn seed_divergent_predicate_ledgers(fluree: &MemoryFluree) {
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/catalog:main"),
+            &json!({
+                "@context": {
+                    "schema": "http://schema.org/",
+                    "cat": "http://catalog.example/",
+                    "id": "@id",
+                    "type": "@type",
+                },
+                "@graph": [
+                    {"@id": "cat:item1", "@type": "schema:Product", "cat:sku": "X-1"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert catalog");
+
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/people:main"),
+            &json!({
+                "@context": {
+                    "schema": "http://schema.org/",
+                    "p": "http://people.example/",
+                    "id": "@id",
+                    "type": "@type",
+                },
+                "@graph": [
+                    {"@id": "p:ada", "@type": "schema:Person", "p:fullName": "Ada"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert people");
+}
+
+/// Commit 1 — a hydration root that lives in a NON-primary ledger must have its
+/// own properties decoded against its HOME ledger's namespace dict.
+///
+/// `catalog` is the primary (first default graph). The matching `schema:Person`
+/// lives in `people` and carries `p:fullName` (the `people` ledger's own
+/// vocabulary). Before the dataset-aware fix the property predicate was decoded
+/// against the catalog dict — where the colliding code maps to `cat:`, silently
+/// renaming `p:fullName` to `cat:fullName`. Routing the root to its home ledger
+/// fixes it.
+#[tokio::test]
+async fn cross_graph_root_properties_decode_in_home_ledger() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_predicate_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "schema": "http://schema.org/",
+            "cat": "http://catalog.example/",
+            "p": "http://people.example/",
+            "id": "@id",
+            "type": "@type",
+        },
+        "from": ["test/catalog:main", "test/people:main"],
+        "select": { "?person": ["*"] },
+        "where": { "@id": "?person", "type": "schema:Person" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let person = value
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one person");
+    assert_eq!(person.get("@id").and_then(|v| v.as_str()), Some("p:ada"));
+    // The property MUST be decoded against the people ledger's dict.
+    assert_eq!(
+        person.get("p:fullName").and_then(|v| v.as_str()),
+        Some("Ada"),
+        "root property decoded against the wrong ledger's dict: {value:#}"
+    );
+    // And must NOT have been mis-decoded under the catalog vocabulary.
+    assert!(
+        person.get("cat:fullName").is_none(),
+        "property mis-decoded against the primary (catalog) dict: {value:#}"
+    );
+}
+
 /// KNOWN LIMITATION (out of scope for issue #1259) — cross-ledger hydration
 /// *expansion* with divergent vocabularies.
 ///

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -477,10 +477,7 @@ async fn dataset_nested_projection_cross_graph_iri_resolution_via_connection() {
         .await
         .expect("nested cross-graph projection should succeed");
 
-    let list = result
-        .as_array()
-        .and_then(|a| a.first())
-        .expect("one list");
+    let list = result.as_array().and_then(|a| a.first()).expect("one list");
 
     // The list lives in the named (lists) ledger; its @id must decode against
     // that ledger's namespace dict, not the primary (catalog) view's.

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -413,3 +413,86 @@ async fn cross_graph_hydration_expansion_divergent_vocab() {
         "second cross-ledger hop (author) must hydrate too: {value:#}"
     );
 }
+
+/// Repro for the open issue on PR #1267 (Jack's comment): the canonical
+/// documented multi-ledger shape `fromNamed: {alias: {"@id": ...}}` +
+/// `["graph", "<alias>", ...]`. The inner GRAPH scope runs against a single
+/// active graph, so no provenance is stamped, bindings are plain `Binding::Sid`,
+/// and the formatter falls back to the primary (catalog) view — decoding the
+/// `lists` SID against catalog's namespace dict.
+#[tokio::test]
+async fn dataset_nested_projection_cross_graph_iri_resolution_via_connection() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    fluree
+        .insert(
+            genesis_ledger(&fluree, "catalog:main"),
+            &json!({
+                "@context": {"@vocab": "http://example.org/catalog/"},
+                "@graph": [
+                    {"@id": "http://example.org/items/q1", "@type": "Item",
+                     "name": "Item One", "isbn": "0001"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert catalog");
+
+    fluree
+        .insert(
+            genesis_ledger(&fluree, "lists:main"),
+            &json!({
+                "@context": {"@vocab": "http://example.org/lists/"},
+                "@graph": [
+                    {"@id": "http://example.org/lists/summer", "@type": "List",
+                     "name": "Summer",
+                     "contains": [{"@id": "http://example.org/items/q1"}]}
+                ]
+            }),
+        )
+        .await
+        .expect("insert lists");
+
+    // Explicit prefixes (no `@vocab`) so the cross-graph @id compacts to
+    // `lists:summer` — unambiguously proving it decoded against the lists
+    // namespace, not catalog's (whose colliding code maps to
+    // `http://example.org/items/`, the pre-fix symptom).
+    let query = json!({
+        "from": "catalog:main",
+        "fromNamed": { "lists_g": { "@id": "lists:main" } },
+        "@context": {
+            "lists": "http://example.org/lists/",
+            "catalog": "http://example.org/catalog/"
+        },
+        "select": {"?list": ["@id", "lists:name",
+            {"lists:contains": ["@id", "catalog:name", "catalog:isbn"]}
+        ]},
+        "where": [["graph", "lists_g", {"@id": "?list", "@type": "lists:List"}]]
+    });
+
+    let result = fluree
+        .query_from()
+        .jsonld(&query)
+        .execute_formatted()
+        .await
+        .expect("nested cross-graph projection should succeed");
+
+    let list = result
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one list");
+
+    // The list lives in the named (lists) ledger; its @id must decode against
+    // that ledger's namespace dict, not the primary (catalog) view's.
+    assert_eq!(
+        list.get("@id").and_then(|v| v.as_str()),
+        Some("lists:summer"),
+        "cross-graph @id decoded against the wrong ledger's namespace dict: {result:#}"
+    );
+
+    let s = result.to_string();
+    assert!(
+        !s.contains("http://example.org/items/summer") && !s.contains("catalog:summer"),
+        "the mis-decoded (catalog-namespace) @id must not appear: {s}"
+    );
+}

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -345,27 +345,16 @@ async fn cross_graph_root_properties_decode_in_home_ledger() {
     );
 }
 
-/// KNOWN LIMITATION (out of scope for issue #1259) — cross-ledger hydration
-/// *expansion* with divergent vocabularies.
+/// Cross-ledger hydration *expansion* with divergent vocabularies.
 ///
-/// The #1259 fix makes the cross-graph `@id` correct, but it does NOT make a
-/// foreign subject's *properties* expand when ledgers encode the shared IRIs
-/// under different namespace codes. Hydration follows a ref by its ledger-local
-/// SID and looks it up in the composite overlay, which is keyed by raw
-/// `(namespace_code, name)`. A ref minted in the movies ledger (movies' code for
-/// `http://book.example/`) cannot find the book subject stored under the books
-/// ledger's divergent code, so `isBasedOn` renders as a bare `{"@id": ...}`
-/// instead of a nested object.
-///
-/// The existing `query_connection_from_combined_datasets_selecting_subgraphs_depth_3`
-/// test only passes because its ledgers share schema.org/wikidata.org codes.
-///
-/// Fixing this requires SID re-encoding at ledger boundaries during hydration
-/// (decode under the source ledger, re-encode under the target snapshot) or a
-/// provenance-carrying composite overlay. Tracked as a follow-up. This test is
-/// `#[ignore]`d until then; when it starts passing, the limitation is resolved.
+/// `movie → isBasedOn → book → author` spans three ledgers, each using its own
+/// entity prefix (so the shared-vocab coincidence the older
+/// `query_connection_from_combined_datasets_selecting_subgraphs_depth_3` test
+/// relies on does NOT apply). Each ref is decoded to its canonical IRI in the
+/// source ledger, then re-encoded and expanded in the ledger that actually
+/// stores the subject — so the nested objects hydrate fully instead of
+/// collapsing to bare `{"@id": ...}` (issue #1259, dataset-aware hydration).
 #[tokio::test]
-#[ignore = "cross-ledger hydration expansion under divergent vocab — follow-up to #1259"]
 async fn cross_graph_hydration_expansion_divergent_vocab() {
     let fluree = FlureeBuilder::memory().build_memory();
     seed_divergent_ledgers(&fluree).await;
@@ -393,12 +382,34 @@ async fn cross_graph_hydration_expansion_divergent_vocab() {
         .expect("execute_formatted should not error");
 
     let movie = value.as_array().and_then(|a| a.first()).expect("one movie");
+    assert_eq!(movie.get("@id").and_then(|v| v.as_str()), Some("movie:m1"));
+
+    // Hop 1: movie (movies ledger) → isBasedOn → book (books ledger).
     let book = movie.get("schema:isBasedOn").expect("isBasedOn present");
-    // The book ref must expand into a nested object with its real properties.
-    assert_eq!(book.get("@id").and_then(|v| v.as_str()), Some("book:b1"));
+    assert_eq!(
+        book.get("@id").and_then(|v| v.as_str()),
+        Some("book:b1"),
+        "isBasedOn should hydrate, not collapse to a bare @id: {value:#}"
+    );
     assert_eq!(
         book.get("schema:name").and_then(|v| v.as_str()),
         Some("Gone with the Wind"),
-        "cross-ledger ref should hydrate its properties: {value:#}"
+        "book (foreign ledger) properties must hydrate: {value:#}"
+    );
+    assert_eq!(
+        book.get("schema:isbn").and_then(|v| v.as_str()),
+        Some("0-582-41805-4")
+    );
+
+    // Hop 2: book (books ledger) → author → person (authors ledger), at depth 3.
+    let author = book.get("schema:author").expect("author present");
+    assert_eq!(
+        author.get("@id").and_then(|v| v.as_str()),
+        Some("author:a1")
+    );
+    assert_eq!(
+        author.get("schema:name").and_then(|v| v.as_str()),
+        Some("Margaret Mitchell"),
+        "second cross-ledger hop (author) must hydrate too: {value:#}"
     );
 }

--- a/fluree-db-query/src/dataset.rs
+++ b/fluree-db-query/src/dataset.rs
@@ -253,11 +253,7 @@ impl<'a> DataSet<'a> {
     /// SIDs against the correct namespace table.
     pub fn spans_multiple_ledgers(&self) -> bool {
         let mut first: Option<&str> = None;
-        for graph in self
-            .default_graphs
-            .iter()
-            .chain(self.named_graphs.values())
-        {
+        for graph in self.default_graphs.iter().chain(self.named_graphs.values()) {
             match first {
                 None => first = Some(graph.ledger_id.as_ref()),
                 Some(f) if f != graph.ledger_id.as_ref() => return true,

--- a/fluree-db-query/src/dataset.rs
+++ b/fluree-db-query/src/dataset.rs
@@ -241,6 +241,32 @@ impl<'a> DataSet<'a> {
         self.named_graphs.iter()
     }
 
+    /// True when the dataset's graphs (default + named) span more than one
+    /// distinct ledger ID.
+    ///
+    /// Used to decide whether GRAPH-pattern results need cross-ledger
+    /// provenance stamping: inside a `GRAPH <iri> { .. }` scope only one
+    /// graph is active, so the per-scan multi-ledger check (which compares
+    /// the *active* graphs) is always false even when the surrounding
+    /// dataset is multi-ledger. This dataset-wide check lets `GraphOperator`
+    /// stamp inner results with their home ledger so the formatter decodes
+    /// SIDs against the correct namespace table.
+    pub fn spans_multiple_ledgers(&self) -> bool {
+        let mut first: Option<&str> = None;
+        for graph in self
+            .default_graphs
+            .iter()
+            .chain(self.named_graphs.values())
+        {
+            match first {
+                None => first = Some(graph.ledger_id.as_ref()),
+                Some(f) if f != graph.ledger_id.as_ref() => return true,
+                _ => {}
+            }
+        }
+        false
+    }
+
     /// Find a graph by ledger ID (searching both default and named graphs)
     ///
     /// Returns the first graph whose `ledger_id` matches the given address.

--- a/fluree-db-query/src/dataset_operator.rs
+++ b/fluree-db-query/src/dataset_operator.rs
@@ -209,7 +209,7 @@ impl DatasetOperator {
 /// - `Binding::IriMatch` → passed through unchanged (supports nested
 ///   `DatasetOperator` composition).
 /// - All other binding types → unchanged.
-fn stamp_provenance(
+pub(crate) fn stamp_provenance(
     batch: Batch,
     ledger_id: &Arc<str>,
     ctx: &ExecutionContext<'_>,

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -144,7 +144,33 @@ impl GraphOperator {
         bind_graph_var: Option<VarId>,
     ) -> Result<()> {
         // Switch to the named graph context
-        let graph_ctx = ctx.with_active_graph(graph_iri.clone());
+        let mut graph_ctx = ctx.with_active_graph(graph_iri.clone());
+
+        // Cross-ledger provenance for GRAPH patterns.
+        //
+        // Inside a `GRAPH <iri> { .. }` scope only one graph is active, so the
+        // inner `DatasetOperator`'s multi-ledger check (which compares the
+        // *active* graphs) is always false and it never stamps. The inner scan
+        // therefore emits plain `Binding::Sid` values encoded against this
+        // graph's namespace table. If the surrounding dataset spans multiple
+        // ledgers, those SIDs would later be decoded against the formatter's
+        // primary view (a different ledger), silently mis-decoding the IRI.
+        //
+        // When the dataset is multi-ledger, stamp inner results with this
+        // graph's home ledger so they carry `Binding::IriMatch` provenance —
+        // matching what `DatasetOperator` produces for the union (non-GRAPH)
+        // path. Forcing eager materialization makes the inner scan resolve
+        // `Binding::Sid` rather than late-materialized `Binding::EncodedSid`,
+        // which `stamp_provenance` cannot decode without the binary store.
+        let stamp_ledger_id: Option<Arc<str>> = match &ctx.dataset {
+            Some(ds) if ds.spans_multiple_ledgers() => ds
+                .named_graph(graph_iri.as_ref())
+                .map(|g| Arc::clone(&g.ledger_id)),
+            _ => None,
+        };
+        if stamp_ledger_id.is_some() {
+            graph_ctx.eager_materialization = true;
+        }
 
         // Check if this graph is backed by an R2RML mapping.
         // Prefer the precomputed set (populated in runner.rs for dataset queries),
@@ -197,6 +223,15 @@ impl GraphOperator {
         inner.open(&graph_ctx).await?;
 
         while let Some(batch) = inner.next_batch(&graph_ctx).await? {
+            // Stamp cross-ledger provenance before merging so the formatter
+            // decodes SIDs against this graph's home ledger (see above).
+            let batch = match &stamp_ledger_id {
+                Some(ledger_id) => {
+                    crate::dataset_operator::stamp_provenance(batch, ledger_id, &graph_ctx)?
+                }
+                None => batch,
+            };
+
             // Merge each inner result with parent row
             for inner_row_idx in 0..batch.len() {
                 let mut merged_row = Vec::with_capacity(self.schema.len());

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -177,6 +177,84 @@ fn first_ledger_identifier(value: &JsonValue) -> Option<String> {
     }
 }
 
+/// Collect **every** concrete ledger identifier a `from` / `fromNamed` value
+/// references, across all supported shapes.
+///
+/// Unlike [`first_ledger_identifier`] (which returns a single representative
+/// id for span recording), this enumerates all of them so the bearer
+/// ledger-scope check can authorize every ledger a multi-default-graph or
+/// named-graph query will actually read — not just the first. Mirrors the
+/// shape handling of `first_ledger_identifier`: an object with `@id` is a
+/// single source; otherwise its values are sources (`fromNamed` map form).
+fn collect_ledger_identifiers(value: &JsonValue, out: &mut Vec<String>) {
+    match value {
+        JsonValue::String(s) => out.push(s.clone()),
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_ledger_identifiers(item, out);
+            }
+        }
+        JsonValue::Object(map) => {
+            if let Some(id) = map.get("@id").and_then(JsonValue::as_str) {
+                out.push(id.to_string());
+            } else {
+                for v in map.values() {
+                    collect_ledger_identifiers(v, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Enforce bearer ledger-scope over **all** ledgers a query's `from` /
+/// `fromNamed` references, not just the representative one.
+///
+/// Unsigned bearer tokens may be scoped to a subset of ledgers. A
+/// multi-default-graph (`from: ["a","b"]`) or named-graph (`fromNamed`) query
+/// must be rejected if it touches any ledger outside that scope — otherwise a
+/// token scoped to `a` could read `b` by piggy-backing it onto the dataset.
+/// Rejected with 404 (not 403) to avoid leaking ledger existence, matching the
+/// single-query and multi-query-envelope responses.
+///
+/// No-op for signed requests and unauthenticated (no-bearer) requests; those
+/// are handled by the surrounding data-auth gate and per-ledger policy.
+fn enforce_bearer_dataset_scope(
+    query_json: &JsonValue,
+    bearer: &MaybeDataBearer,
+    is_signed: bool,
+    span: &tracing::Span,
+) -> Result<()> {
+    let Some(principal) = bearer.0.as_ref() else {
+        return Ok(());
+    };
+    if is_signed {
+        return Ok(());
+    }
+
+    let mut ids: Vec<String> = Vec::new();
+    if let Some(from) = query_json.get("from") {
+        collect_ledger_identifiers(from, &mut ids);
+    }
+    if let Some(named) = query_json
+        .get("fromNamed")
+        .or_else(|| query_json.get("from-named"))
+    {
+        collect_ledger_identifiers(named, &mut ids);
+    }
+
+    for raw in ids {
+        // Strip any `@t:` / `#graph` suffix so a scoped read token still
+        // authorizes time-travel / graph-fragment reads of an in-scope ledger.
+        let base = base_ledger_id(&raw)?;
+        if !principal.can_read(&base) {
+            set_span_error_code(span, "error:Forbidden");
+            return Err(ServerError::not_found("Ledger not found"));
+        }
+    }
+    Ok(())
+}
+
 /// Helper to extract ledger ID from request (for JSON-LD queries)
 fn get_ledger_id(
     path_ledger: Option<&str>,
@@ -545,6 +623,10 @@ pub async fn query(
                 return Err(ServerError::not_found("Ledger not found"));
             }
         }
+        // ...and over every additional ledger a multi-default-graph / named-graph
+        // `from`/`fromNamed` references (the single check above only covers the
+        // representative id). Parity with the multi-query envelope path.
+        enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
 
         // Apply bearer identity + server-default policy-class to opts, honoring
         // the root-identity impersonation semantic (see routes::policy_auth).
@@ -711,6 +793,10 @@ pub async fn query_ledger(
             return Err(ServerError::not_found("Ledger not found"));
         }
     }
+    // ...and over every additional ledger a `fromNamed` (or normalized `from`)
+    // references — a scoped token must not reach an out-of-scope ledger via a
+    // named graph even on the ledger-scoped endpoint.
+    enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
 
     // Apply bearer identity + server-default policy-class to opts, honoring
     // the root-identity impersonation semantic (see routes::policy_auth).

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -149,13 +149,41 @@ fn has_policy_opts(query_json: &JsonValue) -> bool {
         || opts.get("policy").is_some()
 }
 
+/// Extract a representative ledger identifier from a `from` / `fromNamed`
+/// value of any supported shape.
+///
+/// Shapes handled (see `requires_dataset_features` and `parse_dataset_spec`):
+/// - string: `"ledger:main"` (optionally with an `@t:` / `#graph` suffix)
+/// - array: `["a:main", "b:main"]` or `[{"@id": "a"}, ...]` — first element
+/// - object `from`: `{"@id": "ledger:main@t:5", ...}` — the `@id`
+/// - object `fromNamed`: `{"alias": <source>, ...}` — first map value
+///
+/// Returns the first concrete ledger string found, or `None` if the value
+/// carries no resolvable identifier. This is used only to pick a ledger for
+/// auth scoping and span recording; the full multi-graph dataset is resolved
+/// later by `parse_dataset_spec` in the dataset execution path.
+fn first_ledger_identifier(value: &JsonValue) -> Option<String> {
+    match value {
+        JsonValue::String(s) => Some(s.clone()),
+        JsonValue::Array(items) => items.iter().find_map(first_ledger_identifier),
+        JsonValue::Object(map) => map
+            .get("@id")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string)
+            // `fromNamed` map form: { alias -> source }. No `@id`, so fall
+            // back to the first source value that yields an identifier.
+            .or_else(|| map.values().find_map(first_ledger_identifier)),
+        _ => None,
+    }
+}
+
 /// Helper to extract ledger ID from request (for JSON-LD queries)
 fn get_ledger_id(
     path_ledger: Option<&str>,
     headers: &FlureeHeaders,
     body: &JsonValue,
 ) -> Result<String> {
-    // Priority: path > header > body.from
+    // Priority: path > header > body.from > body.fromNamed
     if let Some(ledger) = path_ledger {
         return Ok(ledger.to_string());
     }
@@ -164,8 +192,25 @@ fn get_ledger_id(
         return Ok(ledger.clone());
     }
 
-    if let Some(from) = body.get("from").and_then(|v| v.as_str()) {
-        return Ok(from.to_string());
+    // Accept every `from` shape the engine supports — string, array of
+    // sources (multi-default-graph union), or structured object (time travel
+    // / graph fragment). Earlier this only matched a bare string, so array /
+    // object `from` (and `fromNamed`-only) queries were rejected with
+    // `MissingLedger` before the dataset path could run (issue #1259).
+    //
+    // The extracted id is used only for the conservative bearer scope check
+    // and span recording; per-ledger policy and routing are applied later in
+    // `execute_dataset_query` via `parse_dataset_spec`, which sees the full
+    // dataset spec. Strip any `@t:` / `#graph` suffix so auth scopes to the
+    // base ledger.
+    let from_id = body.get("from").and_then(first_ledger_identifier);
+    let named_id = || {
+        body.get("fromNamed")
+            .or_else(|| body.get("from-named"))
+            .and_then(first_ledger_identifier)
+    };
+    if let Some(raw) = from_id.or_else(named_id) {
+        return base_ledger_id(&raw);
     }
 
     Err(ServerError::MissingLedger)

--- a/fluree-db-server/tests/connection_dataset_query_auth.rs
+++ b/fluree-db-server/tests/connection_dataset_query_auth.rs
@@ -199,7 +199,11 @@ async fn connection_from_array_inside_scope_succeeds() {
         "where":  { "@id": "?s", "ex:name": "?name" }
     });
     let (status, body) = post_query(&app, &query, &read_both).await;
-    assert_eq!(status, StatusCode::OK, "in-scope union should succeed: {body}");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "in-scope union should succeed: {body}"
+    );
 }
 
 /// Same gap via a `fromNamed` map: the out-of-scope ledger is reachable only

--- a/fluree-db-server/tests/connection_dataset_query_auth.rs
+++ b/fluree-db-server/tests/connection_dataset_query_auth.rs
@@ -1,0 +1,232 @@
+//! Bearer-scope enforcement for connection-scoped **dataset** JSON-LD queries
+//! (`POST /v1/fluree/query` with a multi-default-graph `from: [array]` or a
+//! `fromNamed` map).
+//!
+//! Review finding (PR #1267): the single-query handler derived one
+//! representative ledger from `from`/`fromNamed` and only scope-checked that
+//! one. A `from: ["a", "b"]` union therefore let a token scoped to `a` read
+//! `b` by piggy-backing it onto the dataset. These tests assert the handler
+//! now rejects the whole request (404, existence-leak-avoiding) when any
+//! referenced ledger is outside the token's read scope — parity with the
+//! multi-query envelope path in `multi_query_auth_integration.rs`.
+
+use axum::body::Body;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use ed25519_dalek::{Signer, SigningKey};
+use fluree_db_server::{routes::build_router, AppState, ServerConfig, TelemetryConfig};
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value as JsonValue};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+async fn data_auth_state() -> (TempDir, Arc<AppState>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = ServerConfig {
+        cors_enabled: false,
+        indexing_enabled: false,
+        storage_path: Some(tmp.path().to_path_buf()),
+        data_auth_mode: fluree_db_server::config::DataAuthMode::Required,
+        data_auth_insecure_accept_any_issuer: true,
+        ..Default::default()
+    };
+    let telemetry = TelemetryConfig::with_server_config(&cfg);
+    let state = Arc::new(AppState::new(cfg, telemetry).await.expect("AppState::new"));
+    (tmp, state)
+}
+
+fn now_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn create_jws(claims: &JsonValue, signing_key: &SigningKey) -> String {
+    let pubkey = signing_key.verifying_key().to_bytes();
+    let pubkey_b64 = URL_SAFE_NO_PAD.encode(pubkey);
+    let header = json!({
+        "alg": "EdDSA",
+        "jwk": { "kty": "OKP", "crv": "Ed25519", "x": pubkey_b64 }
+    });
+    let header_b64 = URL_SAFE_NO_PAD.encode(header.to_string().as_bytes());
+    let payload_b64 = URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let signature = signing_key.sign(signing_input.as_bytes());
+    let sig_b64 = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+    format!("{header_b64}.{payload_b64}.{sig_b64}")
+}
+
+async fn json_body(resp: http::Response<Body>) -> (StatusCode, JsonValue) {
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let json: JsonValue = serde_json::from_slice(&bytes).unwrap_or(JsonValue::Null);
+    (status, json)
+}
+
+async fn create_ledger(app: &axum::Router, ledger: &str) {
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"ledger":"{ledger}"}}"#)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED, "create {ledger}");
+}
+
+async fn insert_one(app: &axum::Router, ledger: &str, id: &str, name: &str, token: &str) {
+    let body = json!({
+        "@context": { "ex": "http://example.org/" },
+        "insert":   { "@id": id, "ex:name": name }
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/insert/{ledger}"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "insert into {ledger}");
+}
+
+fn write_scoped_token(ledgers: &[&str], secret_seed: u8) -> String {
+    let signing_key = SigningKey::from_bytes(&[secret_seed; 32]);
+    let claims = json!({
+        "iss": fluree_db_credential::did_from_pubkey(&signing_key.verifying_key().to_bytes()),
+        "exp": now_secs() + 3600,
+        "iat": now_secs(),
+        "fluree.ledger.read.ledgers":  ledgers,
+        "fluree.ledger.write.ledgers": ledgers
+    });
+    create_jws(&claims, &signing_key)
+}
+
+fn read_scoped_token(ledgers: &[&str], secret_seed: u8) -> String {
+    let signing_key = SigningKey::from_bytes(&[secret_seed; 32]);
+    let claims = json!({
+        "iss": fluree_db_credential::did_from_pubkey(&signing_key.verifying_key().to_bytes()),
+        "exp": now_secs() + 3600,
+        "iat": now_secs(),
+        "fluree.ledger.read.ledgers": ledgers
+    });
+    create_jws(&claims, &signing_key)
+}
+
+async fn post_query(app: &axum::Router, query: &JsonValue, token: &str) -> (StatusCode, JsonValue) {
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/query")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(query.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    json_body(resp).await
+}
+
+/// A `from: [in-scope, out-of-scope]` union must be rejected wholesale (404),
+/// not silently allowed because the *first* ledger is in scope.
+#[tokio::test]
+async fn connection_from_array_outside_scope_returns_404() {
+    let (_tmp, state) = data_auth_state().await;
+    let app = build_router(state);
+    create_ledger(&app, "dca:a").await;
+    create_ledger(&app, "dca:b").await;
+    let write_a = write_scoped_token(&["dca:a"], 31);
+    insert_one(&app, "dca:a", "ex:p", "P", &write_a).await;
+    let write_b = write_scoped_token(&["dca:b"], 32);
+    insert_one(&app, "dca:b", "ex:q", "Q", &write_b).await;
+
+    // Read token scoped to dca:a ONLY. dca:a is first in `from`, so the old
+    // single-ledger check passed and dca:b leaked into the union.
+    let read_a_only = read_scoped_token(&["dca:a"], 33);
+    let query = json!({
+        "@context": { "ex": "http://example.org/" },
+        "from":   ["dca:a", "dca:b"],
+        "select": ["?name"],
+        "where":  { "@id": "?s", "ex:name": "?name" }
+    });
+    let (status, _body) = post_query(&app, &query, &read_a_only).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "out-of-scope ledger in a `from` union must 404"
+    );
+}
+
+/// A token scoped to BOTH union ledgers succeeds — the check rejects only
+/// genuinely out-of-scope ledgers, not every multi-ledger query.
+#[tokio::test]
+async fn connection_from_array_inside_scope_succeeds() {
+    let (_tmp, state) = data_auth_state().await;
+    let app = build_router(state);
+    create_ledger(&app, "dca:c").await;
+    create_ledger(&app, "dca:d").await;
+    let write_c = write_scoped_token(&["dca:c"], 41);
+    insert_one(&app, "dca:c", "ex:p", "P", &write_c).await;
+    let write_d = write_scoped_token(&["dca:d"], 42);
+    insert_one(&app, "dca:d", "ex:q", "Q", &write_d).await;
+
+    let read_both = read_scoped_token(&["dca:c", "dca:d"], 43);
+    let query = json!({
+        "@context": { "ex": "http://example.org/" },
+        "from":   ["dca:c", "dca:d"],
+        "select": ["?name"],
+        "where":  { "@id": "?s", "ex:name": "?name" }
+    });
+    let (status, body) = post_query(&app, &query, &read_both).await;
+    assert_eq!(status, StatusCode::OK, "in-scope union should succeed: {body}");
+}
+
+/// Same gap via a `fromNamed` map: the out-of-scope ledger is reachable only
+/// through a named-graph alias, never as the representative `from` id.
+#[tokio::test]
+async fn connection_from_named_outside_scope_returns_404() {
+    let (_tmp, state) = data_auth_state().await;
+    let app = build_router(state);
+    create_ledger(&app, "dca:e").await;
+    create_ledger(&app, "dca:f").await;
+    let write_e = write_scoped_token(&["dca:e"], 51);
+    insert_one(&app, "dca:e", "ex:p", "P", &write_e).await;
+    let write_f = write_scoped_token(&["dca:f"], 52);
+    insert_one(&app, "dca:f", "ex:q", "Q", &write_f).await;
+
+    let read_e_only = read_scoped_token(&["dca:e"], 53);
+    let query = json!({
+        "@context": { "ex": "http://example.org/" },
+        "from":      "dca:e",
+        "fromNamed": { "other": { "@id": "dca:f" } },
+        "select":    ["?name"],
+        "where":     ["graph", "other", { "@id": "?s", "ex:name": "?name" }]
+    });
+    let (status, _body) = post_query(&app, &query, &read_e_only).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "out-of-scope ledger behind a fromNamed alias must 404"
+    );
+}

--- a/fluree-db-server/tests/multi_ledger_query_dispatch.rs
+++ b/fluree-db-server/tests/multi_ledger_query_dispatch.rs
@@ -1,0 +1,200 @@
+//! HTTP-layer integration tests for connection-scoped multi-ledger JSON-LD
+//! queries (`POST /v1/fluree/query`, no path ledger).
+//!
+//! Regression coverage for issue #1259, Issue 1 + Issue 3 layer 1: the
+//! dispatcher's `get_ledger_id` only accepted a bare string `from`, so a
+//! `from: [array]` (multi-default-graph union) or a `fromNamed`-only query was
+//! rejected with `400 MissingLedger` before `requires_dataset_features` could
+//! route it to the dataset execution path — even though the engine accepts
+//! both. These tests drive the real Axum router end to end.
+
+use axum::body::Body;
+use fluree_db_server::routes::build_router;
+use fluree_db_server::{AppState, ServerConfig, TelemetryConfig};
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value as JsonValue};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+async fn json_body(resp: http::Response<Body>) -> (StatusCode, JsonValue) {
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let json: JsonValue = serde_json::from_slice(&bytes).unwrap_or(JsonValue::Null);
+    (status, json)
+}
+
+async fn server_state() -> (TempDir, Arc<AppState>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = ServerConfig {
+        cors_enabled: false,
+        indexing_enabled: false,
+        storage_path: Some(tmp.path().to_path_buf()),
+        ..Default::default()
+    };
+    let telemetry = TelemetryConfig::with_server_config(&cfg);
+    let state = Arc::new(AppState::new(cfg, telemetry).await.expect("AppState"));
+    (tmp, state)
+}
+
+async fn create_ledger(state: &Arc<AppState>, ledger: &str) {
+    let resp = build_router(Arc::clone(state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "ledger": ledger }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED, "create {ledger}");
+}
+
+async fn insert(state: &Arc<AppState>, ledger: &str, body: JsonValue) {
+    let resp = build_router(Arc::clone(state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/insert/{ledger}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, json) = json_body(resp).await;
+    assert!(status.is_success(), "insert into {ledger}: {status} {json}");
+}
+
+/// Seed two independent ledgers, each with one typed subject.
+async fn seed_two_ledgers(state: &Arc<AppState>) {
+    create_ledger(state, "test/people-a:main").await;
+    create_ledger(state, "test/people-b:main").await;
+
+    insert(
+        state,
+        "test/people-a:main",
+        json!({
+            "@context": {"schema": "http://schema.org/", "id": "@id", "type": "@type"},
+            "@graph": [{"@id": "http://ex.org/alice", "@type": "schema:Person", "schema:name": "Alice"}]
+        }),
+    )
+    .await;
+    insert(
+        state,
+        "test/people-b:main",
+        json!({
+            "@context": {"schema": "http://schema.org/", "id": "@id", "type": "@type"},
+            "@graph": [{"@id": "http://ex.org/bob", "@type": "schema:Person", "schema:name": "Bob"}]
+        }),
+    )
+    .await;
+}
+
+async fn post_connection_query(state: &Arc<AppState>, query: JsonValue) -> (StatusCode, JsonValue) {
+    let resp = build_router(Arc::clone(state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/query")
+                .header("content-type", "application/json")
+                .body(Body::from(query.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    json_body(resp).await
+}
+
+/// Issue 1 — `from: [array]` (multi-default-graph union) over the
+/// connection-scoped route must return both ledgers' subjects, not 400.
+#[tokio::test]
+async fn connection_query_from_array_unions_default_graphs() {
+    let (_tmp, state) = server_state().await;
+    seed_two_ledgers(&state).await;
+
+    let (status, body) = post_connection_query(
+        &state,
+        json!({
+            "@context": {"schema": "http://schema.org/", "id": "@id", "type": "@type"},
+            "from": ["test/people-a:main", "test/people-b:main"],
+            "select": {"?p": ["schema:name"]},
+            "where": {"@id": "?p", "type": "schema:Person"}
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "from-array query body: {body}");
+    let names: Vec<&str> = body
+        .as_array()
+        .expect("array result")
+        .iter()
+        .filter_map(|row| row.get("schema:name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(names.contains(&"Alice"), "expected Alice in {body}");
+    assert!(names.contains(&"Bob"), "expected Bob in {body}");
+}
+
+/// Issue 3 layer 1 — a `fromNamed`-only query over the connection-scoped route
+/// must execute (not 400) and return the named graph's data via a GRAPH
+/// pattern.
+#[tokio::test]
+async fn connection_query_from_named_only_executes() {
+    let (_tmp, state) = server_state().await;
+    seed_two_ledgers(&state).await;
+
+    let (status, body) = post_connection_query(
+        &state,
+        json!({
+            "@context": {"schema": "http://schema.org/", "id": "@id", "type": "@type"},
+            "fromNamed": {"a": {"@id": "test/people-a:main"}},
+            "select": {"?p": ["schema:name"]},
+            "where": [["graph", "a", {"@id": "?p", "type": "schema:Person"}]]
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "fromNamed-only must not be rejected with MissingLedger; body: {body}"
+    );
+    let names: Vec<&str> = body
+        .as_array()
+        .expect("array result")
+        .iter()
+        .filter_map(|row| row.get("schema:name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(
+        names.contains(&"Alice"),
+        "expected Alice from named graph: {body}"
+    );
+}
+
+/// A request with no `from`, `fromNamed`, header, or path ledger is still a
+/// `400` — the relaxation must not swallow genuinely under-specified queries.
+#[tokio::test]
+async fn connection_query_without_any_ledger_still_400() {
+    let (_tmp, state) = server_state().await;
+    seed_two_ledgers(&state).await;
+
+    let (status, _body) = post_connection_query(
+        &state,
+        json!({
+            "@context": {"schema": "http://schema.org/", "id": "@id", "type": "@type"},
+            "select": {"?p": ["schema:name"]},
+            "where": {"@id": "?p", "type": "schema:Person"}
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float_extras"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +641,7 @@ dependencies = [
  "base64",
  "chrono",
  "dirs",
+ "flate2",
  "fluree-db-binary-index",
  "fluree-db-connection",
  "fluree-db-core",
@@ -647,6 +664,7 @@ dependencies = [
  "fluree-vocab",
  "futures",
  "hex",
+ "indexmap",
  "itoa",
  "moka",
  "rustc-hash",
@@ -658,6 +676,7 @@ dependencies = [
  "tokio",
  "tracing",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]
@@ -858,6 +877,7 @@ dependencies = [
  "fluree-vocab",
  "futures",
  "thiserror 1.0.69",
+ "tracing",
  "uuid",
 ]
 
@@ -1613,6 +1633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2193,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"


### PR DESCRIPTION
Closes #1259.

## Summary

Multi-ledger JSON-LD queries did not work correctly through the connection-scoped
`/v1/fluree/query` route. The reported issue covered three bugs; investigating it
surfaced a fourth, deeper one (cross-ledger hydration **expansion**). This PR fixes
all four, end to end, and adds regression coverage that reproduces each against
ledgers with **divergent** namespace vocabularies (the condition the existing tests
never exercised).

The work is split into four reviewable commits, smallest → largest:

| Commit | Fixes | Layer |
|--------|-------|-------|
| `correct multi-ledger JSON-LD query formatting` | Issue 2 (root @id), Issue 3-layer-2 | `fluree-db-api` formatter |
| `accept array/object from and fromNamed-only in query dispatcher` | Issue 1, Issue 3-layer-1 | `fluree-db-server` route |
| `route hydration roots to their home ledger` | cross-ledger expansion, slice 1 | `fluree-db-api` formatter |
| `expand cross-ledger refs against their home ledger` | cross-ledger expansion, slice 2 | `fluree-db-api` formatter |

## Background — why it broke

The connection path was built around single-ledger queries with a string `from`.
Multi-ledger support (`from` array, `fromNamed`, GRAPH alias) was wired into the
engine and `parse_dataset_spec` — where it works — but neither the HTTP route's
`get_ledger_id` nor the result **formatter** were updated to match. The formatter,
in particular, threw away the multi-view `DataSetDb` after execution and reloaded a
**single** ledger view, so every result IRI was decoded against one ledger's
namespace dictionary. Because each ledger numbers its namespaces independently, a
SID from another ledger silently decoded to the wrong prefix — or its properties
didn't resolve at all. The existing multi-ledger tests only passed because they
shared `schema.org`/`wikidata.org` across every ledger, so the colliding codes
happened to line up.

## What changed

### 1. Formatter — wrong cross-graph `@id` (Issue 2, silent data corruption)

Multi-ledger queries already stamp result bindings as `Binding::IriMatch`, which
carries the canonical IRI decoded against the **source** ledger. The flat SELECT /
CONSTRUCT formatters use it; the **hydration** formatter discarded it and re-decoded
the foreign SID against the primary dict. Hydration now emits the root `@id` from
the canonical IRI (`compact_iri`, which is namespace-dict-independent), and the
expansion cache key gained the active ledger so a view-local SID can't collide
across ledgers.

### 2. Formatter — `fromNamed`-only formatting error (Issue 3-layer-2)

`FromQueryBuilder::execute_formatted` errored `"No default graph for formatting"`
when a query had only named graphs. It now falls back to the first named graph
(`default_graphs.first().or_else(|| named_graphs.first())`), matching the
default-then-named precedence the sibling `DatasetQueryBuilder` already used.

### 3. HTTP dispatcher — array/object `from` and `fromNamed`-only rejected (Issues 1 & 3-layer-1)

`get_ledger_id` only matched a bare string `from`, so array `from` (multi-default-graph
union), object `from` (time travel / graph selectors), and `fromNamed`-only queries
were rejected with `400 MissingLedger` before the dataset path could run. A new
`first_ledger_identifier` extracts a representative source from any supported shape;
it is used only for the conservative bearer scope check and span recording, while
per-ledger policy and routing are resolved downstream by `parse_dataset_spec`. A
request with no path/header/`from`/`fromNamed` is still `400`.

### 4. Formatter — cross-ledger hydration **expansion** (the deeper bug)

Fixing #2 made the cross-graph `@id` correct but did **not** make a foreign
subject's nested properties expand: hydration scanned only the primary snapshot
(plus a composite novelty overlay keyed by raw ledger-local SID), so a ref into
another ledger collapsed to a bare `{"@id": ...}` — and indexed foreign data was
unreachable entirely. The formatter is now **dataset-aware**:

- It keeps the `DataSetDb` alive (`query_connection_jsonld_returning_dataset`) and
  builds one `(GraphDbRef, IriCompactor, policy)` view per ledger.
- A hydration **root** is routed to its home ledger via the `IriMatch.ledger_alias`
  provenance, so its properties, predicate keys, and `@id` decode against the ledger
  that stores them — under that ledger's own policy enforcer, never the primary's.
- A **nested ref** is decoded to its canonical IRI in the current view, then
  re-encoded (`encode_iri_strict`) and expanded in the target ledger(s). A ref inside
  the default-graph union resolves across **all** default views, merging each
  contributing ledger's view of the subject (RDF merge, de-duplicating identical
  triples) under that ledger's own policy; a ref inside a named graph stays in that
  graph. Views whose namespace dict can't encode the IRI contribute nothing and are
  skipped without a scan.

Single-ledger queries are unchanged: one view, every lookup falls back to it. Flat
SELECT / CONSTRUCT / SPARQL already carry `IriMatch.iri` and stay on the primary
view.

## Design decisions

- **Per-ledger policy is preserved.** A foreign subject is read under its own view's
  policy enforcer — reusing the primary's would be both semantically wrong and a
  plausible leak path (policy checks and class caches are SID-local).
- **Default-graph union semantics.** A `from: [A, B]` default graph is a union, so a
  subject visible in both is merged from both (each under its own policy), rather
  than taking the first match (order-dependent, hides data) or guessing ownership
  from vocabulary.
- **Identity is the canonical IRI.** A `Sid` is view-local; cache and routing keys
  incorporate the active ledger / canonical IRI so one ledger's rendering can never
  be served for another's.

## Testing

New `fluree-db-api/tests/it_multi_ledger_formatting.rs` reproduces every issue
against ledgers with **divergent** entity/predicate vocabularies:

- `cross_graph_projection_iri_decode` — foreign-ledger root `@id` (Issue 2)
- `flat_select_cross_graph_iri_decode` — guards the already-correct flat path
- `from_named_only_formats` — `fromNamed`-only formats (Issue 3-layer-2)
- `cross_graph_root_properties_decode_in_home_ledger` — foreign root's divergent
  predicate decodes in its home ledger
- `cross_graph_hydration_expansion_divergent_vocab` — full depth-3
  `movie → book → author` chain across three ledgers that share **no** entity
  vocabulary

New `fluree-db-server/tests/multi_ledger_query_dispatch.rs` drives the Axum router
end to end for `from: [array]`, `fromNamed`-only, and the still-rejected no-ledger
case.

No regressions across `it_query_connection` (including the shared-vocab depth-3
hydration test), `it_query_dataset`, `it_named_graphs`, all `it_query_jsonld*` /
hydration / reverse / construct / typed / sparql suites, the format unit tests, and
server `integration` / `cross_ledger_http_integration` / `data_auth_integration`.

## Compatibility & risk

- Single-ledger and shared-vocab multi-ledger behavior is unchanged.
- Path- and header-scoped query routes are unaffected (path/header take priority
  before `from` is consulted).
- No `QueryResult` schema change, no core/index changes; the dataset-aware work is
  contained in `fluree-db-api`'s formatter + connection builder, plus the
  server dispatcher relaxation.
- Docs: `docs/api/endpoints.md` now documents the dataset `from` / `fromNamed` forms
  on the connection route.

## Out of scope / follow-ups

- An **indexed-data** integration variant (background-indexer harness per ledger):
  the cross-ledger routing path is identical for indexed vs novelty data (both go
  through `encode_iri_strict` + the target view's `db.range`), so the divergent-vocab
  test already exercises the logic; a dedicated indexed test is belt-and-suspenders.
- Cross-ledger cycle detection currently relies on the per-column depth budget; it
  cannot loop infinitely, but a pathological cross-ledger cycle within budget could
  re-expand rather than collapse. Tightening `visited` to canonical-IRI keying is a
  possible hardening follow-up.
