### PR TITLE
perf: COUNT/aggregate fast paths — close the SPARQL aggregate benchmark gaps + overlay support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "percent-encoding",
  "postcard",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "rustc-hash",
  "serde",

--- a/fluree-db-api/tests/it_import_class_stats.rs
+++ b/fluree-db-api/tests/it_import_class_stats.rs
@@ -338,3 +338,52 @@ GRAPH <http://example.org/g/hr> {
         "worksAt → Company should be counted once"
     );
 }
+
+// =============================================================================
+// Test 3: rdf:type inner-star COUNT(*) served from per-(class,property) stats
+// =============================================================================
+
+/// Bulk import sets `lex_sorted_string_ids`, which gates the metadata fold for
+/// `?s rdf:type ?o1 . ?s P ?o2` COUNT(*) = Σ_C Σ_dt classStat[C][P].count.
+/// ex:a types {C1,C2} p={1,2,3} => 2*3=6 ; ex:b type {C1} p={4} => 1 ;
+/// ex:c type {C2} no p => 0 ; ex:d p={5} no type => 0  => 7.
+#[tokio::test]
+async fn bulk_import_rdf_type_star_count_from_class_stats() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    let ttl = "@prefix ex: <http://example.org/> .\n\
+               @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+               ex:a a ex:C1, ex:C2 ; ex:p 1, 2, 3 .\n\
+               ex:b a ex:C1 ; ex:p 4 .\n\
+               ex:c a ex:C2 .\n\
+               ex:d ex:p 5 .\n";
+    let ttl_path = write_file(data_dir.path(), "typestar.ttl", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build fluree");
+    fluree
+        .create("test/typestar:main")
+        .import(&ttl_path)
+        .threads(1)
+        .memory_budget_mb(256)
+        .collect_id_stats(true)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+    let ledger = fluree.ledger("test/typestar:main").await.expect("load");
+
+    let q = "PREFIX ex: <http://example.org/>\n\
+             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+             SELECT (COUNT(*) AS ?count) WHERE { ?s rdf:type ?o1 . ?s ex:p ?o2 }";
+    let result = support::query_sparql(&fluree, &ledger, q)
+        .await
+        .expect("typestar query");
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(
+        support::normalize_rows(&jsonld),
+        support::normalize_rows(&serde_json::json!([[7]])),
+        "Σ_C count(C, ex:p) = C1:(3+1) + C2:(3) = 7"
+    );
+}

--- a/fluree-db-api/tests/it_import_class_stats.rs
+++ b/fluree-db-api/tests/it_import_class_stats.rs
@@ -343,8 +343,9 @@ GRAPH <http://example.org/g/hr> {
 // Test 3: rdf:type inner-star COUNT(*) served from per-(class,property) stats
 // =============================================================================
 
-/// Bulk import sets `lex_sorted_string_ids`, which gates the metadata fold for
-/// `?s rdf:type ?o1 . ?s P ?o2` COUNT(*) = Σ_C Σ_dt classStat[C][P].count.
+/// The rdf:type-star metadata fold serves `?s rdf:type ?o1 . ?s P ?o2` COUNT(*) =
+/// Σ_C Σ_dt classStat[C][P].count directly from the per-(class,property) datatype
+/// stats (no scan). Bulk import produces exact stats here.
 /// ex:a types {C1,C2} p={1,2,3} => 2*3=6 ; ex:b type {C1} p={4} => 1 ;
 /// ex:c type {C2} no p => 0 ; ex:d p={5} no type => 0  => 7.
 #[tokio::test]

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -158,7 +158,9 @@ async fn class_property_datatype_decrements_after_delete_non_last_instance() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
 
-    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
 
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
@@ -280,7 +282,9 @@ async fn class_property_reattributed_after_retype() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
 
-    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
 
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
@@ -449,7 +453,9 @@ fn ref_class_total(
 async fn ref_class_reattributed_after_subject_retype() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
-    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
         Arc::new(fluree.nameservice_mode().clone()),
@@ -478,10 +484,17 @@ async fn ref_class_reattributed_after_subject_retype() {
                 ]
             });
             let r1 = fluree
-                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("insert txn1");
-            let o1 = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let o1 =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
             let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
                 unreachable!("helper only returns Completed")
             };
@@ -489,7 +502,12 @@ async fn ref_class_reattributed_after_subject_retype() {
                 .await
                 .expect("load snapshot 1");
             assert_eq!(
-                ref_class_total(&loaded1, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded1,
+                    "http://example.org/Person",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 Some(1),
                 "first index: Person.worksFor -> Organization == 1"
             );
@@ -502,10 +520,17 @@ async fn ref_class_reattributed_after_subject_retype() {
                 "insert": {"@id":"ex:alice","@type":"ex:Employee"}
             });
             let r2 = fluree
-                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .update_with_opts(
+                    r1.ledger,
+                    &retype,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("retype alice");
-            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
             let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
                 unreachable!("helper only returns Completed")
             };
@@ -513,12 +538,22 @@ async fn ref_class_reattributed_after_subject_retype() {
                 .await
                 .expect("load snapshot 2");
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Person",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 None,
                 "Person.worksFor edge must be gone after alice re-typed away"
             );
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 Some(1),
                 "Employee.worksFor -> Organization == 1 after re-type"
             );
@@ -532,7 +567,9 @@ async fn ref_class_reattributed_after_subject_retype() {
 async fn ref_class_reattributed_after_object_retype() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
-    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
         Arc::new(fluree.nameservice_mode().clone()),
@@ -561,10 +598,17 @@ async fn ref_class_reattributed_after_object_retype() {
                 ]
             });
             let r1 = fluree
-                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("insert txn1");
-            let o1 = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let o1 =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
             let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
                 unreachable!("helper only returns Completed")
             };
@@ -572,7 +616,12 @@ async fn ref_class_reattributed_after_object_retype() {
                 .await
                 .expect("load snapshot 1");
             assert_eq!(
-                ref_class_total(&loaded1, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded1,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 Some(1),
                 "first index: Employee.worksFor -> Organization == 1"
             );
@@ -585,10 +634,17 @@ async fn ref_class_reattributed_after_object_retype() {
                 "insert": {"@id":"ex:org1","@type":"ex:Company"}
             });
             let r2 = fluree
-                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .update_with_opts(
+                    r1.ledger,
+                    &retype,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("retype org1");
-            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
             let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
                 unreachable!("helper only returns Completed")
             };
@@ -596,12 +652,22 @@ async fn ref_class_reattributed_after_object_retype() {
                 .await
                 .expect("load snapshot 2");
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 None,
                 "old object-class bucket must be gone after org1 re-typed"
             );
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Company"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Company"
+                ),
                 Some(1),
                 "Employee.worksFor -> Company == 1 after object re-type"
             );
@@ -616,7 +682,9 @@ async fn ref_class_reattributed_after_object_retype() {
 async fn ref_class_reattributed_after_both_endpoints_retype() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
-    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
         Arc::new(fluree.nameservice_mode().clone()),
@@ -645,10 +713,17 @@ async fn ref_class_reattributed_after_both_endpoints_retype() {
                 ]
             });
             let r1 = fluree
-                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("insert txn1");
-            let _ = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let _ =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
 
             // Re-type BOTH alice (Person->Employee) and org1 (Organization->Company);
             // worksFor edge untouched.
@@ -664,10 +739,17 @@ async fn ref_class_reattributed_after_both_endpoints_retype() {
                 ]
             });
             let r2 = fluree
-                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .update_with_opts(
+                    r1.ledger,
+                    &retype,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("retype both");
-            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
             let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
                 unreachable!("helper only returns Completed")
             };
@@ -675,18 +757,33 @@ async fn ref_class_reattributed_after_both_endpoints_retype() {
                 .await
                 .expect("load snapshot 2");
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Person",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 None,
                 "old (Person, worksFor, Organization) bucket gone"
             );
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Company"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Company"
+                ),
                 Some(1),
                 "new (Employee, worksFor, Company) bucket == 1 (moved exactly once)"
             );
             // No double-count: the only worksFor->Company edge is the single one.
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 None,
                 "no stale Employee.worksFor -> Organization"
             );
@@ -701,7 +798,9 @@ async fn ref_class_reattributed_after_both_endpoints_retype() {
 async fn large_retype_batch_defers_to_rebuild_and_stays_correct() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let path = tmp.path().to_string_lossy().to_string();
-    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
     // Threshold of 1: re-typing 2+ existing subjects forces the rebuild fallback.
     let (local, handle) = start_background_indexer_local(
         fluree.backend().clone(),
@@ -733,10 +832,17 @@ async fn large_retype_batch_defers_to_rebuild_and_stays_correct() {
                 ]
             });
             let r1 = fluree
-                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("insert txn1");
-            let _ = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let _ =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
 
             // Re-type alice and bob (2 existing subjects > threshold 1) -> rebuild path.
             let retype = json!({
@@ -751,10 +857,17 @@ async fn large_retype_batch_defers_to_rebuild_and_stays_correct() {
                 ]
             });
             let r2 = fluree
-                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .update_with_opts(
+                    r1.ledger,
+                    &retype,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
                 .await
                 .expect("retype alice+bob");
-            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
             let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
                 unreachable!("helper only returns Completed")
             };
@@ -763,15 +876,33 @@ async fn large_retype_batch_defers_to_rebuild_and_stays_correct() {
                 .expect("load snapshot 2");
 
             // Rebuild must produce correct current-state stats.
-            assert_eq!(class_count(&loaded2, "http://example.org/Person"), Some(1), "Person == 1 (carol)");
-            assert_eq!(class_count(&loaded2, "http://example.org/Employee"), Some(2), "Employee == 2 (alice, bob)");
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                class_count(&loaded2, "http://example.org/Person"),
+                Some(1),
+                "Person == 1 (carol)"
+            );
+            assert_eq!(
+                class_count(&loaded2, "http://example.org/Employee"),
+                Some(2),
+                "Employee == 2 (alice, bob)"
+            );
+            assert_eq!(
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Person",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 Some(1),
                 "carol still Person.worksFor -> Organization"
             );
             assert_eq!(
-                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
                 Some(2),
                 "alice+bob now Employee.worksFor -> Organization"
             );

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -109,6 +109,302 @@ fn class_count(snapshot: &LedgerSnapshot, iri: &str) -> Option<u64> {
     None
 }
 
+/// Sum the per-(class, property) datatype flake counts across all graphs in the
+/// persisted index stats. This is exactly the quantity the COUNT(*) fast path
+/// folds (`Σ_dt classStat[C][P].datatypes`) and the value that issue #1266
+/// reports as stale after an incremental retraction / type change.
+///
+/// Returns `None` when no `(class, property)` entry is present at all (the class
+/// or property was purged), `Some(total)` otherwise.
+fn class_prop_datatype_total(
+    snapshot: &LedgerSnapshot,
+    class_iri: &str,
+    prop_iri: &str,
+) -> Option<u64> {
+    let stats = snapshot.stats.as_ref()?;
+    let graphs = stats.graphs.as_ref()?;
+    let mut found = false;
+    let mut total: u64 = 0;
+    for g in graphs {
+        let Some(classes) = g.classes.as_ref() else {
+            continue;
+        };
+        for c in classes {
+            if snapshot.decode_sid(&c.class_sid).as_deref() != Some(class_iri) {
+                continue;
+            }
+            for p in &c.properties {
+                if snapshot.decode_sid(&p.property_sid).as_deref() != Some(prop_iri) {
+                    continue;
+                }
+                found = true;
+                total += p.datatypes.iter().map(|(_, n)| *n).sum::<u64>();
+            }
+        }
+    }
+    found.then_some(total)
+}
+
+/// #1266 — case 3: deleting a NON-last instance of a class must decrement that
+/// class's per-property datatype counts.
+///
+/// Reproduction baseline: this test asserts the current-state-correct values and
+/// is expected to FAIL on the pre-fix incremental path (the per-(class,property)
+/// datatype count stays at 3 because the retraction is attributed to the
+/// subject's NET class membership, which is emptied when its rdf:type is
+/// retracted in the same batch).
+#[tokio::test]
+async fn class_property_datatype_decrements_after_delete_non_last_instance() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+
+    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/stats-classprop-delete:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            // Three Person instances, each with an integer ex:age.
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Person","ex:age":30},
+                    {"@id":"ex:bob","@type":"ex:Person","ex:age":25},
+                    {"@id":"ex:carol","@type":"ex:Person","ex:age":35}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert txn1");
+            let o1 =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
+                unreachable!("helper only returns Completed")
+            };
+            let root1 = root_id.expect("expected root_id after first index");
+            let loaded1 = load_ledger_snapshot(&storage, &root1, ledger_id)
+                .await
+                .expect("load snapshot 1");
+
+            // Sanity: first index attributes all three ages to Person.
+            assert_eq!(
+                class_prop_datatype_total(
+                    &loaded1,
+                    "http://example.org/Person",
+                    "http://example.org/age"
+                ),
+                Some(3),
+                "first index should attribute 3 ages to Person"
+            );
+
+            // Delete bob entirely (retracts his rdf:type AND his ex:age in one txn).
+            let del = json!({
+                "@context": { "ex": "http://example.org/" },
+                "where": {"@id":"ex:bob","@type":"ex:Person","ex:age":25},
+                "delete": {"@id":"ex:bob","@type":"ex:Person","ex:age":25}
+            });
+            let r2 = fluree
+                .update_with_opts(
+                    r1.ledger,
+                    &del,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("delete bob");
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let root2 = root_id.expect("expected root_id after incremental refresh");
+            let loaded2 = load_ledger_snapshot(&storage, &root2, ledger_id)
+                .await
+                .expect("load snapshot 2");
+
+            // The class instance count path is already correct.
+            assert_eq!(
+                class_count(&loaded2, "http://example.org/Person"),
+                Some(2),
+                "Person instance count should drop to 2 after deleting bob"
+            );
+
+            // #1266: the per-(class, property) datatype count must also drop to 2.
+            assert_eq!(
+                class_prop_datatype_total(
+                    &loaded2,
+                    "http://example.org/Person",
+                    "http://example.org/age"
+                ),
+                Some(2),
+                "Person.age datatype count must decrement to 2 after deleting bob (stale at 3 today)"
+            );
+        })
+        .await;
+}
+
+/// #1266 — case 4: re-typing a subject (retract type A, assert type B) without
+/// re-touching its properties must move the property datatype counts from the
+/// old class to the new class.
+///
+/// Reproduction baseline: asserts current-state-correct values; expected to FAIL
+/// pre-fix (Person.age stays 2, Employee.age never gets attributed).
+#[tokio::test]
+async fn class_property_reattributed_after_retype() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+
+    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/stats-classprop-retype:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            // Two Person instances with integer ex:age. bob stays a Person so the
+            // Person class survives (we want to observe its stale property count).
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Person","ex:age":30},
+                    {"@id":"ex:bob","@type":"ex:Person","ex:age":25}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert txn1");
+            let o1 =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
+                unreachable!("helper only returns Completed")
+            };
+            let root1 = root_id.expect("expected root_id after first index");
+            let loaded1 = load_ledger_snapshot(&storage, &root1, ledger_id)
+                .await
+                .expect("load snapshot 1");
+
+            assert_eq!(
+                class_prop_datatype_total(
+                    &loaded1,
+                    "http://example.org/Person",
+                    "http://example.org/age"
+                ),
+                Some(2),
+                "first index should attribute 2 ages to Person"
+            );
+
+            // Re-type alice: Person -> Employee. Her ex:age flake is NOT touched.
+            let retype = json!({
+                "@context": { "ex": "http://example.org/" },
+                "where": {"@id":"ex:alice","@type":"ex:Person"},
+                "delete": {"@id":"ex:alice","@type":"ex:Person"},
+                "insert": {"@id":"ex:alice","@type":"ex:Employee"}
+            });
+            let r2 = fluree
+                .update_with_opts(
+                    r1.ledger,
+                    &retype,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("retype alice");
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let root2 = root_id.expect("expected root_id after incremental refresh");
+            let loaded2 = load_ledger_snapshot(&storage, &root2, ledger_id)
+                .await
+                .expect("load snapshot 2");
+
+            // Class instance counts (already correct).
+            assert_eq!(
+                class_count(&loaded2, "http://example.org/Person"),
+                Some(1),
+                "Person count should be 1 (bob) after retyping alice"
+            );
+            assert_eq!(
+                class_count(&loaded2, "http://example.org/Employee"),
+                Some(1),
+                "Employee count should be 1 (alice) after retype"
+            );
+
+            // #1266: alice's age must move from Person to Employee.
+            assert_eq!(
+                class_prop_datatype_total(
+                    &loaded2,
+                    "http://example.org/Person",
+                    "http://example.org/age"
+                ),
+                Some(1),
+                "Person.age must drop to 1 (bob only) after retyping alice (stale at 2 today)"
+            );
+            assert_eq!(
+                class_prop_datatype_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/age"
+                ),
+                Some(1),
+                "Employee.age must be 1 (alice) after retype (missing today)"
+            );
+        })
+        .await;
+}
+
 #[tokio::test]
 async fn property_and_class_statistics_persist_in_db_root() {
     let tmp = tempfile::TempDir::new().expect("tempdir");

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -405,6 +405,380 @@ async fn class_property_reattributed_after_retype() {
         .await;
 }
 
+/// Sum the per-(subject_class, property, object_class) ref-edge counts in the
+/// persisted index stats. This is the `ref_classes` distribution #1266 must keep
+/// current-state-exact when an endpoint of a reference is re-typed.
+fn ref_class_total(
+    snapshot: &LedgerSnapshot,
+    subj_class_iri: &str,
+    prop_iri: &str,
+    obj_class_iri: &str,
+) -> Option<u64> {
+    let stats = snapshot.stats.as_ref()?;
+    let graphs = stats.graphs.as_ref()?;
+    let mut found = false;
+    let mut total: u64 = 0;
+    for g in graphs {
+        let Some(classes) = g.classes.as_ref() else {
+            continue;
+        };
+        for c in classes {
+            if snapshot.decode_sid(&c.class_sid).as_deref() != Some(subj_class_iri) {
+                continue;
+            }
+            for p in &c.properties {
+                if snapshot.decode_sid(&p.property_sid).as_deref() != Some(prop_iri) {
+                    continue;
+                }
+                for rc in &p.ref_classes {
+                    if snapshot.decode_sid(&rc.class_sid).as_deref() == Some(obj_class_iri) {
+                        found = true;
+                        total += rc.count;
+                    }
+                }
+            }
+        }
+    }
+    found.then_some(total)
+}
+
+/// #1266 — Case A: re-typing a SUBJECT must move its existing outgoing ref-class
+/// edges from the old subject-class bucket to the new one. (The `worksFor` edge
+/// is NOT touched in the re-type batch.)
+#[tokio::test]
+async fn ref_class_reattributed_after_subject_retype() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/ref-subject-retype:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Person","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("insert txn1");
+            let o1 = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded1 = load_ledger_snapshot(&storage, &root_id.expect("root1"), ledger_id)
+                .await
+                .expect("load snapshot 1");
+            assert_eq!(
+                ref_class_total(&loaded1, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                Some(1),
+                "first index: Person.worksFor -> Organization == 1"
+            );
+
+            // Re-type alice Person -> Employee; do NOT touch worksFor.
+            let retype = json!({
+                "@context": { "ex": "http://example.org/" },
+                "where": {"@id":"ex:alice","@type":"ex:Person"},
+                "delete": {"@id":"ex:alice","@type":"ex:Person"},
+                "insert": {"@id":"ex:alice","@type":"ex:Employee"}
+            });
+            let r2 = fluree
+                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("retype alice");
+            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                None,
+                "Person.worksFor edge must be gone after alice re-typed away"
+            );
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                Some(1),
+                "Employee.worksFor -> Organization == 1 after re-type"
+            );
+        })
+        .await;
+}
+
+/// #1266 — Case B: re-typing an OBJECT (a reference target) must move every
+/// inbound edge's object-class bucket. Requires the reverse OPST pass.
+#[tokio::test]
+async fn ref_class_reattributed_after_object_retype() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/ref-object-retype:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Employee","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("insert txn1");
+            let o1 = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded1 = load_ledger_snapshot(&storage, &root_id.expect("root1"), ledger_id)
+                .await
+                .expect("load snapshot 1");
+            assert_eq!(
+                ref_class_total(&loaded1, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                Some(1),
+                "first index: Employee.worksFor -> Organization == 1"
+            );
+
+            // Re-type org1 Organization -> Company; do NOT touch alice or the edge.
+            let retype = json!({
+                "@context": { "ex": "http://example.org/" },
+                "where": {"@id":"ex:org1","@type":"ex:Organization"},
+                "delete": {"@id":"ex:org1","@type":"ex:Organization"},
+                "insert": {"@id":"ex:org1","@type":"ex:Company"}
+            });
+            let r2 = fluree
+                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("retype org1");
+            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                None,
+                "old object-class bucket must be gone after org1 re-typed"
+            );
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Company"),
+                Some(1),
+                "Employee.worksFor -> Company == 1 after object re-type"
+            );
+        })
+        .await;
+}
+
+/// #1266 — both endpoints re-typed in one batch, edge untouched. Case A owns it;
+/// must move (Person, worksFor, Organization) -> (Employee, worksFor, Company)
+/// exactly once (no double-count).
+#[tokio::test]
+async fn ref_class_reattributed_after_both_endpoints_retype() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/ref-both-retype:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Person","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("insert txn1");
+            let _ = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+
+            // Re-type BOTH alice (Person->Employee) and org1 (Organization->Company);
+            // worksFor edge untouched.
+            let retype = json!({
+                "@context": { "ex": "http://example.org/" },
+                "delete": [
+                    {"@id":"ex:alice","@type":"ex:Person"},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ],
+                "insert": [
+                    {"@id":"ex:alice","@type":"ex:Employee"},
+                    {"@id":"ex:org1","@type":"ex:Company"}
+                ]
+            });
+            let r2 = fluree
+                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("retype both");
+            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                None,
+                "old (Person, worksFor, Organization) bucket gone"
+            );
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Company"),
+                Some(1),
+                "new (Employee, worksFor, Company) bucket == 1 (moved exactly once)"
+            );
+            // No double-count: the only worksFor->Company edge is the single one.
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                None,
+                "no stale Employee.worksFor -> Organization"
+            );
+        })
+        .await;
+}
+
+/// #1266 — rebuild gate: a re-type batch above the threshold aborts incremental
+/// and the caller falls back to a full rebuild, which recomputes class/ref stats
+/// from scratch (so the result is still current-state-correct).
+#[tokio::test]
+async fn large_retype_batch_defers_to_rebuild_and_stays_correct() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path).build().expect("build file fluree");
+    // Threshold of 1: re-typing 2+ existing subjects forces the rebuild fallback.
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small().with_incremental_retype_max_subjects(1),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/large-retype-gate:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Person","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:bob","@type":"ex:Person","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:carol","@type":"ex:Person","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(ledger0, &txn1, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("insert txn1");
+            let _ = trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+
+            // Re-type alice and bob (2 existing subjects > threshold 1) -> rebuild path.
+            let retype = json!({
+                "@context": { "ex": "http://example.org/" },
+                "delete": [
+                    {"@id":"ex:alice","@type":"ex:Person"},
+                    {"@id":"ex:bob","@type":"ex:Person"}
+                ],
+                "insert": [
+                    {"@id":"ex:alice","@type":"ex:Employee"},
+                    {"@id":"ex:bob","@type":"ex:Employee"}
+                ]
+            });
+            let r2 = fluree
+                .update_with_opts(r1.ledger, &retype, TxnOpts::default(), CommitOpts::default(), &index_cfg)
+                .await
+                .expect("retype alice+bob");
+            let o2 = trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+
+            // Rebuild must produce correct current-state stats.
+            assert_eq!(class_count(&loaded2, "http://example.org/Person"), Some(1), "Person == 1 (carol)");
+            assert_eq!(class_count(&loaded2, "http://example.org/Employee"), Some(2), "Employee == 2 (alice, bob)");
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Person", "http://example.org/worksFor", "http://example.org/Organization"),
+                Some(1),
+                "carol still Person.worksFor -> Organization"
+            );
+            assert_eq!(
+                ref_class_total(&loaded2, "http://example.org/Employee", "http://example.org/worksFor", "http://example.org/Organization"),
+                Some(2),
+                "alice+bob now Employee.worksFor -> Organization"
+            );
+        })
+        .await;
+}
+
 #[tokio::test]
 async fn property_and_class_statistics_persist_in_db_root() {
     let tmp = tempfile::TempDir::new().expect("tempdir");

--- a/fluree-db-api/tests/it_query_seq_path_count_repro.rs
+++ b/fluree-db-api/tests/it_query_seq_path_count_repro.rs
@@ -1,4 +1,4 @@
-//! Synthetic reproduction for the Fluree-vs-QLever COUNT(*) divergence on
+//! Synthetic reproduction for the Fluree-vs-Others COUNT(*) divergence on
 //! sequence paths `?s p1/p2+ ?o`  (DBLP-KG: subStream/relatedStream+).
 //!
 //! Goal: isolate whether Fluree counts DISTINCT (?s,?o) pairs vs. the full

--- a/fluree-db-api/tests/it_query_seq_path_count_repro.rs
+++ b/fluree-db-api/tests/it_query_seq_path_count_repro.rs
@@ -1,0 +1,282 @@
+//! Synthetic reproduction for the Fluree-vs-QLever COUNT(*) divergence on
+//! sequence paths `?s p1/p2+ ?o`  (DBLP-KG: subStream/relatedStream+).
+//!
+//! Goal: isolate whether Fluree counts DISTINCT (?s,?o) pairs vs. the full
+//! BGP-join cardinality that binds the intermediate `?mid`. We run the SAME
+//! queries on BOTH the in-memory novelty path (generic PropertyPathOperator)
+//! AND the indexed/binary path (transitive-path+ COUNT(*) fast-path) so any
+//! divergence between the two engines inside Fluree is exposed directly.
+//!
+//! Graph construction (ex: = http://example.org/):
+//!   p1 = ex:p1 (plain predicate, the "subStream" analog)
+//!   p2 = ex:p2 (transitive predicate, the "relatedStream+" analog)
+//!
+//!   s --p1--> m1 , s --p1--> m2     (two distinct intermediates from one subject)
+//!   m1 --p2--> o , m1 --p2--> a
+//!   m2 --p2--> o
+//!   a  --p2--> b
+//!   b  --p2--> o , b  --p2--> a      (CYCLE a<->b)
+//!
+//! Hand-computed p2+ reachability (one-or-more, deduped per source):
+//!   reach+(m1) = { o, a, b }     reach+(m2) = { o }
+//!   reach+(a)  = { b, o, a }     reach+(b)  = { a, o, b }   reach+(o) = { }
+//!
+//! Two counting units for the sequence path { s p1/p2+ ?o }:
+//!   distinct-(?s,?o) pairs : union over intermediates = {o,a,b} => 3  (the OLD bug)
+//!   bind-?mid BGP join     : reach+(m1)=3 + reach+(m2)=1     => 4  (spec-correct)
+//! These DISTINGUISH the semantics. Per SPARQL 1.1 §18.2.2.4 the sequence lowers to a
+//! Join over the fresh path-internal variable ?mid, which PRESERVES multiplicity, so
+//! COUNT(*) = 4 (an ?o reachable via two ?mid is counted twice). This test now ASSERTS
+//! the bind-?mid count on BOTH the in-memory novelty path AND the indexed fast path —
+//! a regression guard for:
+//!   - Defect 1: the transitive-path+ COUNT(*) fast path counted distinct (?s,?o) pairs.
+//!   - Defect 2: the generic PropertyPathOperator failed to resolve `Binding::EncodedSid`
+//!     intermediates (bound-subject + indexed), pairing each ?mid with the full closure.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use std::sync::Arc;
+
+use fluree_db_api::{FlureeBuilder, GraphDb, IndexConfig, LedgerManagerConfig, QueryInput};
+use fluree_db_core::LedgerSnapshot;
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::json;
+use support::{
+    genesis_ledger, genesis_ledger_for_fluree, start_background_indexer_local,
+    trigger_index_and_wait_outcome, MemoryFluree, MemoryLedger,
+};
+
+const PREFIX: &str = "PREFIX ex: <http://example.org/>";
+
+fn graph() -> serde_json::Value {
+    json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:s",  "ex:p1": [{"@id": "ex:m1"}, {"@id": "ex:m2"}]},
+            {"@id": "ex:m1", "ex:p2": [{"@id": "ex:o"}, {"@id": "ex:a"}]},
+            {"@id": "ex:m2", "ex:p2": {"@id": "ex:o"}},
+            {"@id": "ex:a",  "ex:p2": {"@id": "ex:b"}},
+            {"@id": "ex:b",  "ex:p2": [{"@id": "ex:o"}, {"@id": "ex:a"}]}
+        ]
+    })
+}
+
+async fn seed_novelty(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    fluree.insert(ledger0, &graph()).await.unwrap().ledger
+}
+
+/// Read a single COUNT scalar out of the `[[n]]` JSON-LD result shape.
+fn count_of(jsonld: &serde_json::Value) -> i64 {
+    jsonld
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.as_array())
+        .and_then(|cols| cols.first())
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_else(|| panic!("unexpected count shape: {jsonld}"))
+}
+
+/// The six queries we probe. Returns (label, sparql, distinct_pair, bind_mid).
+fn probes() -> Vec<(&'static str, String, i64, i64)> {
+    vec![
+        (
+            "A1 m1 p2+",
+            format!("{PREFIX}\nSELECT (COUNT(*) AS ?c) WHERE {{ ex:m1 ex:p2+ ?o }}"),
+            3,
+            3,
+        ),
+        (
+            "A2 m2 p2+",
+            format!("{PREFIX}\nSELECT (COUNT(*) AS ?c) WHERE {{ ex:m2 ex:p2+ ?o }}"),
+            1,
+            1,
+        ),
+        (
+            "B  ?x p2+ ?o",
+            format!("{PREFIX}\nSELECT (COUNT(*) AS ?c) WHERE {{ ?x ex:p2+ ?o }}"),
+            10,
+            10,
+        ),
+        (
+            "C  s p1/p2+ ?o",
+            format!("{PREFIX}\nSELECT (COUNT(*) AS ?c) WHERE {{ ex:s ex:p1/ex:p2+ ?o }}"),
+            3,
+            4,
+        ),
+        (
+            "D  s p1 ?mid . ?mid p2+ ?o",
+            format!(
+                "{PREFIX}\nSELECT (COUNT(*) AS ?c) WHERE {{ ex:s ex:p1 ?mid . ?mid ex:p2+ ?o }}"
+            ),
+            3,
+            4,
+        ),
+        (
+            "F  ?s p1/p2+ ?o",
+            format!("{PREFIX}\nSELECT (COUNT(*) AS ?c) WHERE {{ ?s ex:p1/ex:p2+ ?o }}"),
+            3,
+            4,
+        ),
+    ]
+}
+
+async fn run_all(label: &str, fluree: &MemoryFluree, db: &GraphDb, snapshot: &LedgerSnapshot) {
+    for (name, q, dp, bm) in probes() {
+        let result = fluree
+            .query(db, QueryInput::Sparql(&q))
+            .await
+            .unwrap_or_else(|e| panic!("[{label}] query `{name}` failed: {e}"));
+        let jsonld = result.to_jsonld(snapshot).expect("to_jsonld");
+        let actual = count_of(&jsonld);
+        // COUNT(*) must equal the spec-correct bind-?mid join cardinality on BOTH the
+        // novelty (generic operator) and indexed (fast path) engines.
+        assert_eq!(
+            actual, bm,
+            "[{label}] `{name}`: COUNT(*) must equal the bind-?mid join cardinality \
+             {bm} (got {actual}); sequence p1/p2+ preserves multiplicity over the \
+             path-internal variable per SPARQL 1.1 §18.2.2.4"
+        );
+        // Where the two units differ, prove we did NOT regress to the old distinct-pair
+        // count (Defect 1) or to the full-closure garbage (Defect 2).
+        if dp != bm {
+            assert_ne!(
+                actual, dp,
+                "[{label}] `{name}`: regressed to the old distinct-(?s,?o) count {dp}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn seq_path_count_unit_novelty_vs_indexed() {
+    // ---------- 1) In-memory novelty path (generic operators) ----------
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "seqpath/novelty:main").await;
+    let db = support::graphdb_from_ledger(&ledger);
+
+    // Sanity: enumerate reach+(m1)/reach+(m2) to anchor the hand computation.
+    for (subj, expect) in [("ex:m1", "[ex:a, ex:b, ex:o]"), ("ex:m2", "[ex:o]")] {
+        let rows = fluree
+            .query(
+                &db,
+                QueryInput::Sparql(&format!(
+                    "{PREFIX}\nSELECT ?o WHERE {{ {subj} ex:p2+ ?o }} ORDER BY ?o"
+                )),
+            )
+            .await
+            .unwrap()
+            .to_jsonld(&ledger.snapshot)
+            .unwrap();
+        let set: Vec<String> = rows
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r[0].as_str().unwrap().to_string())
+            .collect();
+        println!("reach+({subj}) = {set:?}  (expected {expect})");
+    }
+
+    run_all("NOVELTY (in-memory generic path)", &fluree, &db, &ledger.snapshot).await;
+
+    // ---------- 2) Indexed / binary path (fast-path operators) ----------
+    let fluree2 = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "seqpath/indexed:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree2.backend().clone(),
+        Arc::new(fluree2.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree2, ledger_id);
+            let res = fluree2
+                .insert_with_opts(
+                    ledger0,
+                    &graph(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert (indexed)");
+            let ledger_i = res.ledger;
+
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger_i.t()).await;
+
+            // Load the indexed view so binary_store is threaded -> fast path eligible.
+            let view = fluree2.db(ledger_id).await.expect("load indexed view");
+
+            run_all(
+                "INDEXED (binary fast-path)",
+                &fluree2,
+                &view,
+                &view.snapshot,
+            )
+            .await;
+
+            // Enumerate the ACTUAL solution rows the indexed engine produces for the
+            // fixed-subject sequence path, to explain the COUNT(*) number.
+            println!("\n---- INDEXED enumeration: ex:s ex:p1/ex:p2+ ?o (SELECT ?o) ----");
+            let rows = fluree2
+                .query(
+                    &view,
+                    QueryInput::Sparql(&format!(
+                        "{PREFIX}\nSELECT ?o WHERE {{ ex:s ex:p1/ex:p2+ ?o }} ORDER BY ?o"
+                    )),
+                )
+                .await
+                .unwrap()
+                .to_jsonld(&view.snapshot)
+                .unwrap();
+            println!("  rows ({}) = {rows}", rows.as_array().map_or(0, Vec::len));
+
+            println!(
+                "\n---- INDEXED enumeration: ex:s ex:p1 ?mid . ?mid ex:p2+ ?o (SELECT ?mid ?o) ----"
+            );
+            let rows2 = fluree2
+                .query(
+                    &view,
+                    QueryInput::Sparql(&format!(
+                        "{PREFIX}\nSELECT ?mid ?o WHERE {{ ex:s ex:p1 ?mid . ?mid ex:p2+ ?o }} ORDER BY ?mid ?o"
+                    )),
+                )
+                .await
+                .unwrap()
+                .to_jsonld(&view.snapshot)
+                .unwrap();
+            println!(
+                "  rows ({}) = {rows2}",
+                rows2.as_array().map_or(0, Vec::len)
+            );
+
+            // SELECT-DISTINCT variants to see what the engine considers distinct.
+            println!("\n---- INDEXED: SELECT DISTINCT ?o WHERE {{ ex:s ex:p1/ex:p2+ ?o }} ----");
+            let rows3 = fluree2
+                .query(
+                    &view,
+                    QueryInput::Sparql(&format!(
+                        "{PREFIX}\nSELECT DISTINCT ?o WHERE {{ ex:s ex:p1/ex:p2+ ?o }} ORDER BY ?o"
+                    )),
+                )
+                .await
+                .unwrap()
+                .to_jsonld(&view.snapshot)
+                .unwrap();
+            println!(
+                "  rows ({}) = {rows3}",
+                rows3.as_array().map_or(0, Vec::len)
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_query_seq_path_count_repro.rs
+++ b/fluree-db-api/tests/it_query_seq_path_count_repro.rs
@@ -179,7 +179,13 @@ async fn seq_path_count_unit_novelty_vs_indexed() {
         println!("reach+({subj}) = {set:?}  (expected {expect})");
     }
 
-    run_all("NOVELTY (in-memory generic path)", &fluree, &db, &ledger.snapshot).await;
+    run_all(
+        "NOVELTY (in-memory generic path)",
+        &fluree,
+        &db,
+        &ledger.snapshot,
+    )
+    .await;
 
     // ---------- 2) Indexed / binary path (fast-path operators) ----------
     let fluree2 = FlureeBuilder::memory()

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -919,6 +919,103 @@ async fn indexed_sum_compare_empty_predicate_matches_general() {
         .await;
 }
 
+/// `number-of-predicates` (`COUNT(DISTINCT ?p) WHERE { ?s ?p ?o }`) served from
+/// the per-graph index stats (count of properties with positive current count),
+/// no leaf scan. Asserts the indexed (stats) result equals the memory
+/// (general-pipeline) result — so we don't have to know Fluree's internal
+/// predicate count — and that it survives a retraction of a whole predicate.
+#[tokio::test]
+async fn indexed_number_of_predicates_from_stats_matches_general() {
+    assert_index_defaults();
+
+    let seed = || {
+        json!({
+            "@context": { "ex": "http://example.org/ns/" },
+            "@graph": [
+                {"@id": "ex:a", "ex:p0": 1, "ex:p1": 2, "ex:p2": 3},
+                {"@id": "ex:b", "ex:p1": 4, "ex:p3": 5},
+                {"@id": "ex:c", "ex:p4": 6, "ex:p0": 7}
+            ]
+        })
+    };
+    let q = r"SELECT (COUNT(DISTINCT ?p) AS ?count) WHERE { ?s ?p ?o }";
+
+    // Memory reference (general pipeline).
+    let mem = FlureeBuilder::memory().build_memory();
+    let mem_ledger = mem
+        .insert_with_opts(
+            genesis_ledger_for_fluree(&mem, "it/nop-mem:main"),
+            &seed(),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            },
+        )
+        .await
+        .expect("mem seed")
+        .ledger;
+    let mem_view = mem
+        .db_at_t("it/nop-mem:main", mem_ledger.t())
+        .await
+        .expect("mem view");
+    let mem_rows = normalize_rows(
+        &mem.query(&mem_view, QueryInput::Sparql(q))
+            .await
+            .expect("mem query")
+            .to_jsonld(&mem_view.snapshot)
+            .expect("to_jsonld"),
+    );
+
+    // Indexed path (stats).
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/nop-indexed:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &seed(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("indexed seed")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("indexed view");
+            let idx_rows = normalize_rows(
+                &fluree
+                    .query(&view, QueryInput::Sparql(q))
+                    .await
+                    .expect("indexed query")
+                    .to_jsonld(&view.snapshot)
+                    .expect("to_jsonld"),
+            );
+            assert_eq!(
+                idx_rows, mem_rows,
+                "number-of-predicates from stats must equal the general-pipeline count"
+            );
+        })
+        .await;
+}
+
 /// Parallel partitioned inner-star COUNT(*): seed enough rows (>50k, the parallel
 /// threshold) with VARYING per-subject multiplicity so the count is sensitive to
 /// any partition-boundary bug (a misattributed subject changes the product sum).

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -919,6 +919,101 @@ async fn indexed_sum_compare_empty_predicate_matches_general() {
         .await;
 }
 
+/// GATE check: on a regular (non-bulk) index, `lex_sorted_string_ids` is false, so
+/// the rdf:type-star metadata fold is disabled and the join uses the MERGE — which
+/// reads current-state leaflets, not the (incrementally-stale) class-property
+/// stats. ?s rdf:type ?o1 . ?s ex:p ?o2: initially 2*3 + 1 = 7; after retracting
+/// one of ex:a's p values and re-indexing, 2*2 + 1 = 5. (The class-property fold
+/// would wrongly stay 7 here — see bulk_import_rdf_type_star_count_from_class_stats
+/// for the fold path, which only fires on bulk imports where the stats are exact.)
+#[tokio::test]
+async fn indexed_rdf_type_star_count_uses_merge_not_stale_stats() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-typestar:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [
+                            {"@id": "ex:a", "@type": ["ex:C1", "ex:C2"], "ex:p": [1, 2, 3]},
+                            {"@id": "ex:b", "@type": "ex:C1", "ex:p": [4]},
+                            {"@id": "ex:c", "@type": "ex:C2"},
+                            {"@id": "ex:d", "ex:p": [5]}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                SELECT (COUNT(*) AS ?count) WHERE { ?s rdf:type ?o1 . ?s ex:p ?o2 }
+            ";
+            let view1 = fluree.db_at_t(ledger_id, ledger1.t()).await.expect("view1");
+            assert_eq!(
+                normalize_rows(
+                    &fluree
+                        .query(&view1, QueryInput::Sparql(q))
+                        .await
+                        .expect("typestar q1")
+                        .to_jsonld(&view1.snapshot)
+                        .expect("to_jsonld")
+                ),
+                normalize_rows(&json!([[7]])),
+                "Σ_C count(C, ex:p) = C1:(3+1) + C2:(3) = 7"
+            );
+
+            // Retract one of ex:a's p values, re-index: 2*2 + 1 = 5.
+            let ledger2 = fluree
+                .update(
+                    ledger1,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "delete": [{"@id": "ex:a", "ex:p": 1}]
+                    }),
+                )
+                .await
+                .expect("delete")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger2.t()).await;
+            let view2 = fluree.db_at_t(ledger_id, ledger2.t()).await.expect("view2");
+            assert_eq!(
+                normalize_rows(
+                    &fluree
+                        .query(&view2, QueryInput::Sparql(q))
+                        .await
+                        .expect("typestar q2")
+                        .to_jsonld(&view2.snapshot)
+                        .expect("to_jsonld")
+                ),
+                normalize_rows(&json!([[5]])),
+                "after retracting ex:a ex:p 1: C1:(2+1) + C2:(2) = 5 (current-state, not history)"
+            );
+        })
+        .await;
+}
+
 /// `number-of-predicates` (`COUNT(DISTINCT ?p) WHERE { ?s ?p ?o }`) served from
 /// the per-graph index stats (count of properties with positive current count),
 /// no leaf scan. Asserts the indexed (stats) result equals the memory

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1544,6 +1544,238 @@ async fn indexed_parallel_exists_intersect_count_matches_serial() {
         .await;
 }
 
+/// Parallel encoded-filter row count: `COUNT(?s) { ?s rdf:type ?o FILTER(?s != ?o) }`.
+/// The `?s != ?o` filter compiles to a `SubjectNeObjectRef` encoded pre-filter, so
+/// at HEAD the rows are counted in parallel across leaf chunks (no binding
+/// materialization). Seeds >50k typed subjects (s != o) plus a few self-typed nodes
+/// (`ex:self_k a ex:self_k`, s == o) which the filter must exclude.
+#[tokio::test]
+async fn indexed_parallel_encoded_filter_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-encoded-filter:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // N normal typed subjects (s != o) + M self-typed (s == o, excluded).
+            let n: i64 = 60_000;
+            let m: i64 = 50;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity((n + m) as usize);
+            for i in 0..n {
+                nodes.push(json!({"@id": format!("ex:s{i}"), "@type": format!("ex:C{}", i % 50)}));
+            }
+            for j in 0..m {
+                // A node typed as itself => (s == o) row, excluded by FILTER(?s != ?o).
+                nodes.push(json!({"@id": format!("ex:self{j}"), "@type": format!("ex:self{j}")}));
+            }
+            let expected = n; // self-typed rows excluded
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                SELECT (COUNT(?s) AS ?count)
+                WHERE { ?s rdf:type ?o . FILTER (?s != ?o) }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel encoded-filter query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel encoded-filter count must exclude (s == o) rows = {expected}"
+            );
+        })
+        .await;
+}
+
+/// Parallel numeric-compare count: `SUM(?o > 0) { ?s ex:num ?o }` over >50k integer
+/// rows. The POST leaf slice is split across cores; per chunk, fully-matching /
+/// fully-excluded leaflets short-circuit and boundary leaflets binary-search.
+#[tokio::test]
+async fn indexed_parallel_numeric_compare_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-numeric-compare:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // value = (i%5) - 2 in {-2,-1,0,1,2}; > 0 iff (i%5) in {3,4} => 2/5.
+            let n: i64 = 60_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let v = (i % 5) - 2;
+                if v > 0 {
+                    expected += 1;
+                }
+                nodes.push(json!({"@id": format!("ex:s{i}"), "ex:num": v}));
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (SUM(?o > 0) AS ?sum)
+                WHERE { ?s ex:num ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel numeric-compare query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel numeric-compare count must equal #rows with ?o > 0 = {expected}"
+            );
+        })
+        .await;
+}
+
+/// Mixed XSD_INTEGER + XSD_DOUBLE objects under one predicate: the per-leaflet
+/// threshold encoding must count each numeric otype against its own encoded
+/// threshold (POST sorts by o_type, so int and double leaflets are disjoint). This
+/// locks the behavior change from the prior "bail on mixed otype" path.
+#[tokio::test]
+async fn indexed_numeric_compare_mixed_int_double_counts_correctly() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-numeric-compare-mixed:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // Even i: integer (i%5)-2; odd i: double (i%5) as f64 - 1.5.
+            let n: i64 = 600;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                if i % 2 == 0 {
+                    let v = (i % 5) - 2; // {-2,-1,0,1,2}, >0 => {1,2}
+                    if v > 0 {
+                        expected += 1;
+                    }
+                    nodes.push(json!({"@id": format!("ex:s{i}"), "ex:num": v}));
+                } else {
+                    let v = (i % 5) as f64 - 1.5; // {-1.5,-0.5,0.5,1.5,2.5}, >0 => last three
+                    if v > 0.0 {
+                        expected += 1;
+                    }
+                    nodes.push(json!({"@id": format!("ex:s{i}"), "ex:num": v}));
+                }
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (SUM(?o > 0) AS ?sum)
+                WHERE { ?s ex:num ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("mixed numeric-compare query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "mixed int/double compare count must equal #rows with ?o > 0 = {expected}"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1275,6 +1275,94 @@ async fn indexed_parallel_optional_join_count_matches_serial() {
         .await;
 }
 
+/// Parallel partitioned constrained-UNION COUNT(*):
+///   { ?s p1 ?o } UNION { ?s p2 ?o } . ?s e ?o2
+///   = Σ_s (count_p1(s)+count_p2(s))·count_e(s) for s with e AND (p1 OR p2).
+/// Seeds >50k rows with varying multiplicity plus union-only and constraint-only
+/// subjects (which must contribute 0), so the result is sensitive to both the
+/// union OR-sum, the constraint AND-join, and partition boundaries.
+#[tokio::test]
+async fn indexed_parallel_union_constraint_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-union-constraint:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: p1 = (i%2)+1 values, e = 1 value, p2 = (i%3) values.
+            // contributes (count_p1 + count_p2) * count_e = ((i%2+1)+(i%3))*1.
+            let n: i64 = 16_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::new();
+            for i in 0..n {
+                let c1 = (i % 2) + 1;
+                let cp2 = i % 3;
+                expected += c1 + cp2;
+                let mut node = json!({"@id": format!("ex:s{i}"), "ex:e": 1});
+                node["ex:p1"] = json!((0..c1).map(|j| json!(i * 10 + j)).collect::<Vec<_>>());
+                if cp2 > 0 {
+                    node["ex:p2"] =
+                        json!((0..cp2).map(|j| json!(i * 10 + 5 + j)).collect::<Vec<_>>());
+                }
+                nodes.push(node);
+            }
+            // union-only (no constraint e) and constraint-only (no union) => contribute 0.
+            for i in 0..500 {
+                nodes.push(json!({"@id": format!("ex:u{i}"), "ex:p1": [i]}));
+                nodes.push(json!({"@id": format!("ex:c{i}"), "ex:e": 2}));
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } ?s ex:e ?o2 }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel union-constraint query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel union-constraint count must equal Σ_s (c_p1+c_p2)·c_e = {expected}"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -919,6 +919,77 @@ async fn indexed_sum_compare_empty_predicate_matches_general() {
         .await;
 }
 
+/// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
+/// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
+/// (2000 rows) spans multiple leaflets, exercising the boundary-equality /
+/// cross-leaflet run accumulation; LIMIT 3 must keep the three highest counts in
+/// descending order.
+#[tokio::test]
+async fn indexed_group_by_object_count_topk_run_spanning() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-groupby-topk:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            // object 10 -> 2000 subjects, 20 -> 400, 30 -> 80, 40 -> 20.
+            let mut nodes: Vec<serde_json::Value> = Vec::new();
+            for (val, n) in [(10, 2000), (20, 400), (30, 80), (40, 20)] {
+                for i in 0..n {
+                    nodes.push(json!({"@id": format!("ex:s{val}_{i}"), "ex:p": val}));
+                }
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT ?o (COUNT(?s) AS ?c)
+                WHERE { ?s ex:p ?o }
+                GROUP BY ?o ORDER BY DESC(?c) LIMIT 3
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("group-by topk query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[10, 2000], [20, 400], [30, 80]])),
+                "top-3 object groups by count desc; the 2000-row run spans leaflets"
+            );
+        })
+        .await;
+}
+
 /// `count_rows_for_predicate_psot` reads interior-leaf counts from the branch
 /// manifest (`LeafEntry.row_count`). That count must reflect **latest state** —
 /// indexed retractions must be excluded, matching the per-leaflet directory sum.

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -919,15 +919,16 @@ async fn indexed_sum_compare_empty_predicate_matches_general() {
         .await;
 }
 
-/// GATE check: on a regular (non-bulk) index, `lex_sorted_string_ids` is false, so
-/// the rdf:type-star metadata fold is disabled and the join uses the MERGE — which
-/// reads current-state leaflets, not the (incrementally-stale) class-property
-/// stats. ?s rdf:type ?o1 . ?s ex:p ?o2: initially 2*3 + 1 = 7; after retracting
-/// one of ex:a's p values and re-indexing, 2*2 + 1 = 5. (The class-property fold
-/// would wrongly stay 7 here — see bulk_import_rdf_type_star_count_from_class_stats
-/// for the fold path, which only fires on bulk imports where the stats are exact.)
+/// Regression guard for issue #1266: the rdf:type-star metadata fold
+/// (`Σ_C Σ_dt classStat[C][ex:p].datatypes`) must stay current-state-exact after
+/// an INCREMENTAL retraction. `?s rdf:type ?o1 . ?s ex:p ?o2`: initially
+/// 2*3 + 1 = 7; after retracting one of ex:a's p values and re-indexing,
+/// 2*2 + 1 = 5. Before the fix the incremental class-property stats stayed stale
+/// (the fold was gated off via `lex_sorted_string_ids` to avoid serving the wrong
+/// count); now the incremental merge decrements correctly, so the fold runs on
+/// this incremental index and still returns 5.
 #[tokio::test]
-async fn indexed_rdf_type_star_count_uses_merge_not_stale_stats() {
+async fn indexed_rdf_type_star_count_exact_after_incremental_retraction() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory()
         .with_ledger_cache_config(LedgerManagerConfig::default())

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1776,6 +1776,101 @@ async fn indexed_numeric_compare_mixed_int_double_counts_correctly() {
         .await;
 }
 
+/// Numeric-compare global metadata shortcut: when the predicate's whole o_key
+/// extent is on one side of the threshold, the count is answered from the manifest
+/// (no per-leaflet scan). Seeds an all-positive `ex:num` predicate alongside a
+/// second `ex:label` predicate so `ex:num` has boundary leaves (exercising the
+/// boundary-leaf extent lookup). `SUM(?o > 0)` => all match => total; `> 100` =>
+/// all excluded => 0.
+#[tokio::test]
+async fn indexed_numeric_compare_global_shortcut_counts_correctly() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-numeric-compare-shortcut:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // All ex:num values in 1..=10 (strictly positive); ex:label gives a
+            // neighboring predicate so ex:num's leaf range has boundary leaves.
+            let n: i64 = 4_000;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                nodes.push(json!({
+                    "@id": format!("ex:s{i}"),
+                    "ex:num": (i % 10) + 1,
+                    "ex:label": format!("label-{}", i % 7),
+                }));
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            // All positive => fully match => total = n.
+            let q_all = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (SUM(?o > 0) AS ?sum) WHERE { ?s ex:num ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q_all))
+                .await
+                .expect("shortcut all-match query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[n]])),
+                "all-positive ?o > 0 must equal total = {n}"
+            );
+
+            // Max value is 10 => `> 100` excludes everything => 0.
+            let q_none = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (SUM(?o > 100) AS ?sum) WHERE { ?s ex:num ?o }
+            ";
+            let jsonld_none = fluree
+                .query(&view, QueryInput::Sparql(q_none))
+                .await
+                .expect("shortcut all-excluded query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // SUM over a non-empty input with zero matches is bound 0.
+            assert_eq!(
+                normalize_rows(&jsonld_none),
+                normalize_rows(&json!([[0]])),
+                "?o > 100 with max 10 must be 0"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -2746,6 +2746,112 @@ async fn overlay_delta_single_predicate_count_folds_novelty() {
         .await;
 }
 
+/// Overlay novelty-DELTA regression: a novelty assert on a subject whose id is BELOW
+/// the predicate's first indexed subject (a low-id subject that existed in the base
+/// under a different predicate and only now gains `ex:p`). The delta path partitions
+/// by per-leaf subject ranges; leaf 0's range must start at 0 (not its `first_key`)
+/// or this op falls below every range and is silently dropped — undercounting by 1.
+#[tokio::test]
+async fn overlay_delta_count_folds_novelty_below_first_leaf() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-delta-low-id:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // Commit #1: many subjects under a DIFFERENT predicate `ex:aaa`. Subject and
+            // predicate ids are monotonic across commits, so `ex:aaa` < `ex:p` in PSOT
+            // order and `ex:low` (lexically smallest here) gets the minimum subject id.
+            // These `ex:aaa` flakes fill several whole leaves AHEAD of `ex:p`, so `ex:p`'s
+            // first indexed leaf has a `first_key` strictly above `ex:low`'s id — exactly
+            // the shape that makes leaf 0's `lo` non-zero and would drop the low-id op.
+            let m: i64 = 2_000;
+            let mut anchors: Vec<serde_json::Value> = Vec::with_capacity(m as usize + 1);
+            anchors.push(json!({"@id": "ex:low", "ex:aaa": 0}));
+            for i in 0..m {
+                anchors.push(json!({"@id": format!("ex:m{i}"), "ex:aaa": i}));
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": anchors
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("commit #1 (low-id anchors)")
+                .ledger;
+            // Commit #2: the bulk of `ex:p` subjects, all with ids above `ex:low`.
+            let n: i64 = 5_000;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                nodes.push(json!({"@id": format!("ex:s{i}"), "ex:p": i}));
+            }
+            let ledger = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                )
+                .await
+                .expect("commit #2 (ex:p bulk)")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+
+            // Novelty: the low-id subject gains `ex:p` — below the predicate's first leaf.
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@id": "ex:low", "ex:p": 999
+                    }),
+                )
+                .await
+                .expect("novelty assert on low-id subject");
+
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count) WHERE { ?s ex:p ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("overlay delta low-id query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // 5000 base + 1 low-id assert = 5001. Pre-fix this returned 5000.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[5_001]])),
+                "low-id novelty below the first leaf must be counted: 5000 + 1 = 5001"
+            );
+        })
+        .await;
+}
+
 /// Overlay novelty-DELTA for no-constraint UNION COUNT(*) (bag semantics = Σ per
 /// branch of base + delta).
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -2703,6 +2703,81 @@ async fn overlay_delta_union_count_folds_novelty() {
         .await;
 }
 
+/// Bound-class property COUNT(*): `?s a <Class> . ?s P ?o` answered from
+/// per-(class,property) stats (classStat[Class][P]), for both a datatype property and
+/// a reference property (refs counted via the JSON_LD_ID datatype total).
+#[tokio::test]
+async fn indexed_bound_class_property_count_from_class_stats() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-bound-class-prop:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [
+                            {"@id": "ex:a", "@type": ["ex:Person", "ex:Author"],
+                             "ex:name": ["A1", "A2"], "ex:knows": [{"@id": "ex:b"}, {"@id": "ex:c"}]},
+                            {"@id": "ex:b", "@type": "ex:Person", "ex:name": "B1",
+                             "ex:knows": {"@id": "ex:c"}},
+                            {"@id": "ex:c", "@type": "ex:Author"},
+                            {"@id": "ex:d", "ex:name": "D1"}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree.db_at_t(ledger_id, ledger1.t()).await.expect("view");
+
+            let count = |class: &str, prop: &str| {
+                let q = format!(
+                    "PREFIX ex: <http://example.org/ns/>
+                     SELECT (COUNT(*) AS ?c) WHERE {{ ?s a ex:{class} . ?s ex:{prop} ?o }}"
+                );
+                let fluree = &fluree;
+                let view = &view;
+                async move {
+                    let j = fluree
+                        .query(view, QueryInput::Sparql(&q))
+                        .await
+                        .expect("bound-class query")
+                        .to_jsonld(&view.snapshot)
+                        .expect("to_jsonld");
+                    normalize_rows(&j)
+                }
+            };
+
+            // Person instances = {a, b}: name flakes 2 + 1 = 3; knows refs 2 + 1 = 3.
+            assert_eq!(count("Person", "name").await, normalize_rows(&json!([[3]])),
+                "name on Person = 3");
+            assert_eq!(count("Person", "knows").await, normalize_rows(&json!([[3]])),
+                "knows (ref) on Person = 3");
+            // Author instances = {a, c}: name flakes 2 + 0 = 2.
+            assert_eq!(count("Author", "name").await, normalize_rows(&json!([[2]])),
+                "name on Author = 2");
+        })
+        .await;
+}
+
 /// Overlay/novelty lane for the LANG-filter COUNT fast path.
 #[tokio::test]
 async fn overlay_lang_filter_count_folds_novelty() {

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -2027,6 +2027,90 @@ async fn overlay_parallel_encoded_filter_count_folds_novelty() {
         .await;
 }
 
+/// PARALLEL overlay lane for the numeric-compare SUM: >50k indexed base rows + novelty,
+/// queried at HEAD. The numeric compare runs per-row over the subject-partitioned
+/// overlay scan (PSOT), folding novelty.
+#[tokio::test]
+async fn overlay_parallel_numeric_compare_sum_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-parallel-numeric:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // value = (i%5)-2 in {-2,-1,0,1,2}; > 0 iff i%5 in {3,4} => 2/5.
+            let n: i64 = 60_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let v = (i % 5) - 2;
+                if v > 0 {
+                    expected += 1;
+                }
+                nodes.push(json!({"@id": format!("ex:s{i}"), "ex:num": v}));
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 50 subjects with value 5 (> 0).
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..50 {
+                nov.push(json!({"@id": format!("ex:n{j}"), "ex:num": 5}));
+                expected += 1;
+            }
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (SUM(?o > 0) AS ?sum) WHERE { ?s ex:num ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel overlay numeric query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // base 24000 + novelty 50 = 24050.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel overlay numeric SUM(?o > 0) must fold novelty = {expected}"
+            );
+        })
+        .await;
+}
+
 /// Overlay/novelty lane for the LANG-filter COUNT fast path.
 #[tokio::test]
 async fn overlay_lang_filter_count_folds_novelty() {

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -2111,6 +2111,92 @@ async fn overlay_parallel_numeric_compare_sum_folds_novelty() {
         .await;
 }
 
+/// PARALLEL overlay lane for the inner-star COUNT(*) join `{ ?s p1 ?o1 . ?s p2 ?o2 }`:
+/// >50k indexed base rows + novelty, queried at HEAD. The base scan partitions across
+/// cores and each partition folds its novelty via bounded overlay cursors. Subjects
+/// with only one predicate (base + novelty) must be excluded from the intersection.
+#[tokio::test]
+async fn overlay_parallel_star_join_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-parallel-star:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // 60k subjects with BOTH p1 and p2 (in the join) + 100 with only p1.
+            let n: i64 = 60_000;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity((n + 100) as usize);
+            for i in 0..n {
+                nodes.push(json!({"@id": format!("ex:s{i}"), "ex:p1": i, "ex:p2": i}));
+            }
+            for i in 0..100 {
+                nodes.push(json!({"@id": format!("ex:only{i}"), "ex:p1": i})); // no p2
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 50 with both (in join) + 10 with only p1 (excluded).
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..50 {
+                nov.push(json!({"@id": format!("ex:n{j}"), "ex:p1": j, "ex:p2": j}));
+            }
+            for j in 0..10 {
+                nov.push(json!({"@id": format!("ex:novonly{j}"), "ex:p1": j}));
+            }
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:p1 ?o1 . ?s ex:p2 ?o2 }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel overlay star query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // subjects with both p1 AND p2: base 60000 + novelty 50 = 60050.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[60_050]])),
+                "parallel overlay star count must fold novelty (both preds): 60000 + 50 = 60050"
+            );
+        })
+        .await;
+}
+
 /// Overlay/novelty lane for the LANG-filter COUNT fast path.
 #[tokio::test]
 async fn overlay_lang_filter_count_folds_novelty() {

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1363,6 +1363,187 @@ async fn indexed_parallel_union_constraint_count_matches_serial() {
         .await;
 }
 
+/// Parallel partitioned MINUS over a multi-predicate inner block (the "3-star"
+/// shape): `?s outer ?o1 MINUS { ?s in1 ?a . ?s in2 ?b }`
+///   = Σ_s count_outer(s) for s with outer AND s ∉ (in1 ∩ in2).
+/// The inner block compiles to `IntersectSorted([in1, in2])`, so the asymmetric
+/// seek bails and `try_modifier_intersect_parallel` drives the keyset build +
+/// outer scan in parallel. >50k total rows with varying outer multiplicity and an
+/// inner intersection (`i%6==0`) that is a strict subset of the outer subjects, so
+/// the result is sensitive to both the intersection and the partition boundaries.
+#[tokio::test]
+async fn indexed_parallel_minus_intersect_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-minus-intersect:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: outer = (i%2)+1 values; in1 present iff i%2==0; in2 iff
+            // i%3==0. inner intersection (in1 AND in2) = i%6==0. total rows ~ 1.5N
+            // + 0.5N + 0.33N; N=24000 => ~56k > 50k threshold.
+            let n: i64 = 24_000;
+            let mut expected_minus: i64 = 0;
+            let mut expected_exists: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let c_outer = (i % 2) + 1;
+                let in1 = i % 2 == 0;
+                let in2 = i % 3 == 0;
+                if in1 && in2 {
+                    expected_exists += c_outer;
+                } else {
+                    expected_minus += c_outer;
+                }
+                let mut node = json!({"@id": format!("ex:s{i}")});
+                node["ex:outer"] =
+                    json!((0..c_outer).map(|j| json!(i * 10 + j)).collect::<Vec<_>>());
+                if in1 {
+                    node["ex:in1"] = json!(i * 10 + 100);
+                }
+                if in2 {
+                    node["ex:in2"] = json!(i * 10 + 200);
+                }
+                nodes.push(node);
+            }
+            let _ = expected_exists;
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:outer ?o1 MINUS { ?s ex:in1 ?a . ?s ex:in2 ?b } }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel minus-intersect query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected_minus]])),
+                "parallel minus-intersect count must equal Σ_s∉(in1∩in2) count_outer(s) = {expected_minus}"
+            );
+        })
+        .await;
+}
+
+/// Parallel partitioned FILTER EXISTS over a multi-predicate inner block (the
+/// "3-star" shape): `?s outer ?o1 FILTER EXISTS { ?s in1 ?a . ?s in2 ?b }`
+///   = Σ_s count_outer(s) for s with outer AND s ∈ (in1 ∩ in2).
+/// Same data as the MINUS test; EXISTS is its complement over the outer subjects.
+#[tokio::test]
+async fn indexed_parallel_exists_intersect_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-exists-intersect:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            let n: i64 = 24_000;
+            let mut expected_exists: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let c_outer = (i % 2) + 1;
+                let in1 = i % 2 == 0;
+                let in2 = i % 3 == 0;
+                if in1 && in2 {
+                    expected_exists += c_outer;
+                }
+                let mut node = json!({"@id": format!("ex:s{i}")});
+                node["ex:outer"] =
+                    json!((0..c_outer).map(|j| json!(i * 10 + j)).collect::<Vec<_>>());
+                if in1 {
+                    node["ex:in1"] = json!(i * 10 + 100);
+                }
+                if in2 {
+                    node["ex:in2"] = json!(i * 10 + 200);
+                }
+                nodes.push(node);
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:outer ?o1 FILTER EXISTS { ?s ex:in1 ?a . ?s ex:in2 ?b } }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel exists-intersect query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected_exists]])),
+                "parallel exists-intersect count must equal Σ_s∈(in1∩in2) count_outer(s) = {expected_exists}"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -919,6 +919,85 @@ async fn indexed_sum_compare_empty_predicate_matches_general() {
         .await;
 }
 
+/// `count_rows_for_predicate_psot` reads interior-leaf counts from the branch
+/// manifest (`LeafEntry.row_count`). That count must reflect **latest state** —
+/// indexed retractions must be excluded, matching the per-leaflet directory sum.
+/// Insert 2000 rows of one predicate (enough to span whole/interior leaves),
+/// index, delete 800, re-index, then COUNT(*) at HEAD must be 1200.
+#[tokio::test]
+async fn indexed_predicate_count_excludes_indexed_retractions() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-retract-count:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let nodes: Vec<serde_json::Value> = (0..2000)
+                .map(|i| json!({"@id": format!("ex:s{i}"), "ex:p": i}))
+                .collect();
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+
+            // Delete 2000 of the rows, then index so the retractions land in the base.
+            let dels: Vec<serde_json::Value> = (0..800)
+                .map(|i| json!({"@id": format!("ex:s{i}"), "ex:p": i}))
+                .collect();
+            let ledger2 = fluree
+                .update(
+                    ledger1,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "delete": dels }),
+                )
+                .await
+                .expect("delete")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger2.t()).await;
+
+            let view = fluree
+                .db_at_t(ledger_id, ledger2.t())
+                .await
+                .expect("load indexed view");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count) WHERE { ?s ex:p ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("count query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[1200]])),
+                "manifest interior-leaf count must exclude indexed retractions (2000-800)"
+            );
+        })
+        .await;
+}
+
 // =============================================================================
 // Asymmetric (leapfrog) seek strategy for skewed inner-star count joins
 // =============================================================================

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -726,6 +726,732 @@ async fn indexed_multicolumn_join_counts_pairs_not_product() {
 }
 
 // =============================================================================
+// SUM(?o <cmp> K) -> COUNT bridge (numeric-compare fast path)
+// =============================================================================
+
+/// `SUM(?o > K)` is `COUNT` of the rows where the comparison holds. On an indexed
+/// homogeneous numeric predicate it must route to the directory-skipping
+/// numeric-compare count and return the exact matching-row count.
+///
+/// favNums = {3,7,42,99} ∪ {23} ∪ {8,6,7,5,3,0,9}; values > 10 are 42, 99, 23 => 3.
+#[tokio::test]
+async fn indexed_sum_compare_as_count_matches_value() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-sum-compare:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let insert = json!({
+                "@context": { "person": "http://example.org/Person#" },
+                "@graph": [
+                    {"@id": "person:jbob", "person:favNums": [3, 7, 42, 99]},
+                    {"@id": "person:jdoe", "person:favNums": [23]},
+                    {"@id": "person:bbob", "person:favNums": [8, 6, 7, 5, 3, 0, 9]}
+                ]
+            });
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &insert,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX person: <http://example.org/Person#>
+                SELECT (SUM(?favNums > 10) AS ?count)
+                WHERE { ?person person:favNums ?favNums . }
+            ";
+            let r = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("SUM(compare) query should succeed");
+            let jsonld = r.to_jsonld(&view.snapshot).expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[3]])),
+                "SUM(?o>10) over an indexed predicate must equal the count of matching rows"
+            );
+
+            // Parity with the equivalent COUNT(FILTER) form on the same indexed data.
+            let q_count = r"
+                PREFIX person: <http://example.org/Person#>
+                SELECT (COUNT(?favNums) AS ?count)
+                WHERE { ?person person:favNums ?favNums . FILTER(?favNums > 10) }
+            ";
+            let r_count = fluree
+                .query(&view, QueryInput::Sparql(q_count))
+                .await
+                .expect("COUNT(FILTER) query should succeed");
+            let jsonld_count = r_count.to_jsonld(&view.snapshot).expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&jsonld_count),
+                "SUM(?o>10) must equal COUNT(?o){{FILTER(?o>10)}}"
+            );
+        })
+        .await;
+}
+
+/// `SUM` over an **empty** input is Unbound (not 0). For an absent predicate the
+/// fast path must defer to the general pipeline. We assert the indexed result
+/// matches the memory (general-pipeline) result so we don't depend on the exact
+/// Unbound serialization — only that the fast path doesn't substitute `0`.
+#[tokio::test]
+async fn indexed_sum_compare_empty_predicate_matches_general() {
+    assert_index_defaults();
+
+    let seed = || {
+        json!({
+            "@context": { "person": "http://example.org/Person#" },
+            "@graph": [
+                {"@id": "person:jbob", "person:favNums": [3, 7, 42, 99]}
+            ]
+        })
+    };
+    // `person:absent` is never asserted, so the WHERE matches zero rows and SUM is Unbound.
+    let q = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT (SUM(?v > 0) AS ?count)
+        WHERE { ?person person:absent ?v . }
+    ";
+
+    // Memory reference (always the general pipeline).
+    let mem = FlureeBuilder::memory().build_memory();
+    let mem_ledger = {
+        let l0 = genesis_ledger_for_fluree(&mem, "it/sum-empty-mem:main");
+        mem.insert_with_opts(
+            l0,
+            &seed(),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            },
+        )
+        .await
+        .expect("mem seed")
+        .ledger
+    };
+    let mem_view = mem
+        .db_at_t("it/sum-empty-mem:main", mem_ledger.t())
+        .await
+        .expect("mem view");
+    let mem_rows = normalize_rows(
+        &mem.query(&mem_view, QueryInput::Sparql(q))
+            .await
+            .expect("mem query")
+            .to_jsonld(&mem_view.snapshot)
+            .expect("to_jsonld"),
+    );
+
+    // Indexed path: the SUM-compare detector fires, the operator sees an absent
+    // predicate, and must defer to the same general result.
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-sum-empty:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &seed(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+            let idx_rows = normalize_rows(
+                &fluree
+                    .query(&view, QueryInput::Sparql(q))
+                    .await
+                    .expect("indexed query")
+                    .to_jsonld(&view.snapshot)
+                    .expect("to_jsonld"),
+            );
+            assert_eq!(
+                idx_rows, mem_rows,
+                "SUM over an absent predicate must yield the general Unbound result, not 0"
+            );
+        })
+        .await;
+}
+
+// =============================================================================
+// Asymmetric (leapfrog) seek strategy for skewed inner-star count joins
+// =============================================================================
+
+/// `?s p1 ?o1 . ?s p2 ?o2` COUNT(*) where p1 is tiny and p2 is large enough to
+/// trip the seek threshold (`driver_rows * SEEK_STAR_DRIVER_FACTOR < probe_rows`).
+/// Validates that the seek strategy yields the same count as the merge: per-subject
+/// multiplicity (ex:a => 2×3 = 6) and that a driver subject absent from the probe
+/// (ex:c has p1 but not p2) contributes 0.
+#[tokio::test]
+async fn indexed_star_join_seek_strategy_counts_correctly() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-star-seek:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            // Driver p1 rows = 3 (ex:a:2, ex:c:1). Probe p2 rows = 3 + 24_600 filler
+            // = 24_603 > 3 * 8192 = 24_576, so the seek strategy fires.
+            let filler: Vec<serde_json::Value> =
+                (0..24_600).map(|n| json!(n)).collect();
+            let insert = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:a", "ex:p1": [10, 20], "ex:p2": [100, 200, 300]},
+                    {"@id": "ex:c", "ex:p1": [30]},
+                    {"@id": "ex:filler", "ex:p2": filler}
+                ]
+            });
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &insert,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:p1 ?o1 . ?s ex:p2 ?o2 . }
+            ";
+            let r = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("star join seek query should succeed");
+            let jsonld = r.to_jsonld(&view.snapshot).expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[6]])),
+                "seek strategy: ex:a contributes 2×3=6; ex:c (no p2) contributes 0"
+            );
+        })
+        .await;
+}
+
+/// EXISTS/MINUS asymmetric seek, all four branches from one skewed dataset:
+///   ex:a: p1{1}, p2{100,200,300}   ex:b: p1{2}   ex:filler: p2[0..16400]
+///   p1 rows = 2, p2 rows = 16_403 (skew triggers the seek both directions).
+/// - `p1 EXISTS p2`  (drive A=p1, seek B=p2): only ex:a has p2 => count_p1(a)=1
+/// - `p1 MINUS  p2`  (drive A=p1, seek B=p2): only ex:b lacks p2 => count_p1(b)=1
+/// - `p2 EXISTS p1`  (drive B=p1, seek A=p2): matched = count_p2(a)=3
+/// - `p2 MINUS  p1`  (drive B=p1, seek A=p2): total(p2)-matched = 16_403-3 = 16_400
+#[tokio::test]
+async fn indexed_modifier_seek_exists_minus_counts_correctly() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-modifier-seek:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let filler: Vec<serde_json::Value> = (0..16_400).map(|n| json!(n)).collect();
+            let insert = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:a", "ex:p1": [1], "ex:p2": [100, 200, 300]},
+                    {"@id": "ex:b", "ex:p1": [2]},
+                    {"@id": "ex:filler", "ex:p2": filler}
+                ]
+            });
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &insert,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let cases = [
+                (
+                    "p1 EXISTS p2 (drive A)",
+                    r"PREFIX ex: <http://example.org/ns/>
+                      SELECT (COUNT(*) AS ?c) WHERE { ?s ex:p1 ?o1 FILTER EXISTS { ?s ex:p2 ?o2 } }",
+                    1i64,
+                ),
+                (
+                    "p1 MINUS p2 (drive A)",
+                    r"PREFIX ex: <http://example.org/ns/>
+                      SELECT (COUNT(*) AS ?c) WHERE { ?s ex:p1 ?o1 MINUS { ?s ex:p2 ?o2 } }",
+                    1,
+                ),
+                (
+                    "p2 EXISTS p1 (drive B)",
+                    r"PREFIX ex: <http://example.org/ns/>
+                      SELECT (COUNT(*) AS ?c) WHERE { ?s ex:p2 ?o1 FILTER EXISTS { ?s ex:p1 ?o2 } }",
+                    3,
+                ),
+                (
+                    "p2 MINUS p1 (drive B)",
+                    r"PREFIX ex: <http://example.org/ns/>
+                      SELECT (COUNT(*) AS ?c) WHERE { ?s ex:p2 ?o1 MINUS { ?s ex:p1 ?o2 } }",
+                    16_400,
+                ),
+            ];
+
+            for (label, q, expected) in cases {
+                let r = fluree
+                    .query(&view, QueryInput::Sparql(q))
+                    .await
+                    .unwrap_or_else(|e| panic!("{label} query failed: {e:?}"));
+                let jsonld = r.to_jsonld(&view.snapshot).expect("to_jsonld");
+                assert_eq!(
+                    normalize_rows(&jsonld),
+                    normalize_rows(&json!([[expected]])),
+                    "{label}"
+                );
+            }
+        })
+        .await;
+}
+
+/// OPTIONAL asymmetric seek, both drive directions from one skewed dataset:
+///   ex:a: p1{1,5}, p2{100,200,300}   ex:b: p1{2}   ex:filler: p2[0..24600]
+///   p1 rows = 3, p2 rows = 24_603.
+/// - `p1 OPTIONAL p2` (drive A=p1): Σ count_p1(s)·max(1,count_p2(s))
+///     = ex:a 2·3 + ex:b 1·1 = 7
+/// - `p2 OPTIONAL p1` (drive B=p1): total(p2) + Σ count_p2(s)·(count_p1(s)-1)
+///     = 24_603 + ex:a 3·(2-1) = 24_606
+#[tokio::test]
+async fn indexed_optional_seek_counts_correctly() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-optional-seek:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let filler: Vec<serde_json::Value> = (0..24_600).map(|n| json!(n)).collect();
+            let insert = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:a", "ex:p1": [1, 5], "ex:p2": [100, 200, 300]},
+                    {"@id": "ex:b", "ex:p1": [2]},
+                    {"@id": "ex:filler", "ex:p2": filler}
+                ]
+            });
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &insert,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let cases = [
+                (
+                    "p1 OPTIONAL p2 (drive A)",
+                    r"PREFIX ex: <http://example.org/ns/>
+                      SELECT (COUNT(*) AS ?c) WHERE { ?s ex:p1 ?o1 OPTIONAL { ?s ex:p2 ?o2 } }",
+                    7i64,
+                ),
+                (
+                    "p2 OPTIONAL p1 (drive B)",
+                    r"PREFIX ex: <http://example.org/ns/>
+                      SELECT (COUNT(*) AS ?c) WHERE { ?s ex:p2 ?o1 OPTIONAL { ?s ex:p1 ?o2 } }",
+                    24_606,
+                ),
+            ];
+
+            for (label, q, expected) in cases {
+                let r = fluree
+                    .query(&view, QueryInput::Sparql(q))
+                    .await
+                    .unwrap_or_else(|e| panic!("{label} query failed: {e:?}"));
+                let jsonld = r.to_jsonld(&view.snapshot).expect("to_jsonld");
+                assert_eq!(
+                    normalize_rows(&jsonld),
+                    normalize_rows(&json!([[expected]])),
+                    "{label}"
+                );
+            }
+        })
+        .await;
+}
+
+// =============================================================================
+// UNION COUNT(*) pure-sum metadata collapse (AllRows, no extra constraint)
+// =============================================================================
+
+/// `{ ?s p1 ?o } UNION { ?s p2 ?o }` under COUNT(*) is `count(p1)+count(p2)` under
+/// bag semantics. At HEAD (no overlay/time-travel) this is answered from leaflet
+/// directory row counts. Subjects present under BOTH predicates must be counted
+/// twice (bag semantics), so the answer is 6, not a distinct-subject count.
+#[tokio::test]
+async fn indexed_union_count_all_rows_metadata_lane() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-union-count:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            // p1 rows: a{1,2}, b{3} => 3.  p2 rows: a{1}, c{4,5} => 3.
+            // a appears under both predicates and must be counted in each branch.
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let insert = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:a", "ex:p1": [1, 2], "ex:p2": [1]},
+                    {"@id": "ex:b", "ex:p1": [3]},
+                    {"@id": "ex:c", "ex:p2": [4, 5]}
+                ]
+            });
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &insert,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } }
+            ";
+            let r = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("union count query should succeed");
+            let jsonld = r.to_jsonld(&view.snapshot).expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[6]])),
+                "UNION COUNT(*) = count(p1)+count(p2) = 6 under bag semantics"
+            );
+        })
+        .await;
+}
+
+/// The metadata collapse must be gated to HEAD: under overlay (novelty present)
+/// the UNION count must still incorporate the overlay rows by falling through to
+/// the cursor path. baseline = 6; after novelty adds one p1 row and one p2 row = 8.
+#[tokio::test]
+async fn indexed_overlay_union_count_reflects_overlay() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-union-count:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let baseline = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:a", "ex:p1": [1, 2], "ex:p2": [1]},
+                    {"@id": "ex:b", "ex:p1": [3]},
+                    {"@id": "ex:c", "ex:p2": [4, 5]}
+                ]
+            });
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &baseline,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } }
+            ";
+
+            let view1 = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("view t=1");
+            let jsonld1 = fluree
+                .query(&view1, QueryInput::Sparql(q))
+                .await
+                .expect("count t=1")
+                .to_jsonld(&view1.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld1),
+                normalize_rows(&json!([[6]])),
+                "indexed-only union count = 6"
+            );
+
+            // Novelty: add one p1 row (ex:d) and one p2 row (ex:b) => total 8.
+            let assert = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:d", "ex:p1": [10]},
+                    {"@id": "ex:b", "ex:p2": [11]}
+                ]
+            });
+            let ledger2 = fluree
+                .insert(ledger1, &assert)
+                .await
+                .expect("novelty insert")
+                .ledger;
+            let view2 = fluree
+                .db_at_t(ledger_id, ledger2.t())
+                .await
+                .expect("view t=2");
+            let jsonld2 = fluree
+                .query(&view2, QueryInput::Sparql(q))
+                .await
+                .expect("count t=2")
+                .to_jsonld(&view2.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld2),
+                normalize_rows(&json!([[8]])),
+                "union count must include the two overlay rows (cursor fall-through)"
+            );
+        })
+        .await;
+}
+
+/// Time-travel gate: the metadata collapse reads the latest indexed directory, so
+/// it must NOT fire when `to_t < max_t`. Index to t=2 (HEAD count = 2), then query
+/// at to_t=1 — the result must be the historical count (1), not the current 2.
+#[tokio::test]
+async fn indexed_union_count_time_travel_uses_cursor_path() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-union-timetravel:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [{"@id": "ex:a", "ex:p1": [1]}]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert t=1")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+
+            let ledger2 = fluree
+                .insert_with_opts(
+                    ledger1,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [{"@id": "ex:b", "ex:p1": [2]}]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert t=2")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger2.t()).await;
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } }
+            ";
+
+            // HEAD: count = 2.
+            let head = fluree
+                .db_at_t(ledger_id, ledger2.t())
+                .await
+                .expect("view HEAD");
+            assert_eq!(
+                normalize_rows(
+                    &fluree
+                        .query(&head, QueryInput::Sparql(q))
+                        .await
+                        .expect("count HEAD")
+                        .to_jsonld(&head.snapshot)
+                        .expect("to_jsonld")
+                ),
+                normalize_rows(&json!([[2]])),
+                "HEAD union count = 2"
+            );
+
+            // Time-travel to t=1: count must be the historical 1, not 2.
+            let past = fluree.db_at_t(ledger_id, 1).await.expect("view t=1");
+            assert_eq!(
+                normalize_rows(
+                    &fluree
+                        .query(&past, QueryInput::Sparql(q))
+                        .await
+                        .expect("count t=1")
+                        .to_jsonld(&past.snapshot)
+                        .expect("to_jsonld")
+                ),
+                normalize_rows(&json!([[1]])),
+                "time-travel union count must be the historical 1, not the current 2"
+            );
+        })
+        .await;
+}
+
+// =============================================================================
 // Overlay correctness: COUNT fast paths must incorporate novelty
 // =============================================================================
 

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1871,6 +1871,222 @@ async fn indexed_numeric_compare_global_shortcut_counts_correctly() {
         .await;
 }
 
+/// Overlay/novelty lane for the numeric-compare SUM fast path: base data is indexed,
+/// then more rows are inserted as novelty (un-indexed). At HEAD the count must fold
+/// the novelty in via the overlay cursor (`count_rows_via_overlay_cursor`), not the
+/// base-only POST scan.
+#[tokio::test]
+async fn overlay_numeric_compare_sum_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-numeric-compare:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            // Baseline: s0=1, s1=2, s2=-1 (two > 0). Index it.
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": [
+                        {"@id": "ex:s0", "ex:num": 1},
+                        {"@id": "ex:s1", "ex:num": 2},
+                        {"@id": "ex:s2", "ex:num": -1}
+                    ]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty (un-indexed): s3=3 (> 0), s4=-2.
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": [
+                        {"@id": "ex:s3", "ex:num": 3},
+                        {"@id": "ex:s4", "ex:num": -2}
+                    ]}),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (SUM(?o > 0) AS ?sum) WHERE { ?s ex:num ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("overlay numeric-compare query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // base {1,2,-1} + novelty {3,-2}; > 0 => {1,2,3} = 3.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[3]])),
+                "SUM(?o > 0) must fold novelty: base 2 + novelty 1 = 3"
+            );
+        })
+        .await;
+}
+
+/// Overlay/novelty lane for the LANG-filter COUNT fast path.
+#[tokio::test]
+async fn overlay_lang_filter_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-lang-filter:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let en = |id: &str, v: &str| {
+                json!({"@id": id, "ex:label": {"@value": v, "@language": "en"}})
+            };
+            let fr = |id: &str, v: &str| {
+                json!({"@id": id, "ex:label": {"@value": v, "@language": "fr"}})
+            };
+            // Baseline: 2 en + 1 fr. Index it.
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [en("ex:a", "A"), en("ex:c", "C"), fr("ex:b", "B")]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 1 en + 1 fr.
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [en("ex:d", "D"), fr("ex:e", "E")]}),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r#"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(?s) AS ?count)
+                WHERE { ?s ex:label ?o . FILTER(LANG(?o) = "en") }
+            "#;
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("overlay lang-filter query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // en: base {a,c} + novelty {d} = 3.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[3]])),
+                "COUNT lang=en must fold novelty: base 2 + novelty 1 = 3"
+            );
+        })
+        .await;
+}
+
+/// Overlay/novelty lane for the encoded-filter COUNT fast path (`?s != ?o`).
+#[tokio::test]
+async fn overlay_encoded_filter_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-encoded-filter:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            // Baseline: s0, s1 typed ex:C (s != o); self0 typed itself (s == o, excluded).
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": [
+                        {"@id": "ex:s0", "@type": "ex:C"},
+                        {"@id": "ex:s1", "@type": "ex:C"},
+                        {"@id": "ex:self0", "@type": "ex:self0"}
+                    ]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: s2 typed ex:C (s != o); self1 typed itself (excluded).
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": [
+                        {"@id": "ex:s2", "@type": "ex:C"},
+                        {"@id": "ex:self1", "@type": "ex:self1"}
+                    ]}),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                SELECT (COUNT(?s) AS ?count)
+                WHERE { ?s rdf:type ?o . FILTER(?s != ?o) }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("overlay encoded-filter query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // s != o: base {s0,s1} + novelty {s2} = 3 (self-typed excluded).
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[3]])),
+                "COUNT(?s != ?o) must fold novelty: base 2 + novelty 1 = 3"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1015,6 +1015,145 @@ async fn indexed_rdf_type_star_count_exact_after_incremental_retraction() {
         .await;
 }
 
+/// Cumulative-drift guard (#1266): the rdf:type-star fold must stay
+/// current-state-exact across SUCCESSIVE incremental builds, where each build
+/// seeds from the previous (possibly-drifted) root. Exercises all three
+/// incremental class-stat mutation kinds in sequence, re-indexing incrementally
+/// after each and asserting the fold equals the ground-truth join count:
+///   seed (full build): ex:a{C1,C2}×p{1,2,3}=6, ex:b{C1}×p{4}=1            => 7
+///   r1 retract `ex:a a ex:C2` (re-type shrink; p untouched): ex:a{C1}×3=3 => 4
+///   r2 retract `ex:a ex:p 1`  (property retraction):         ex:a{C1}×2=2 => 3
+///   r3 assert  `ex:b a ex:C2` (type-gainer; p untouched):    ex:b{C1,C2}×1=2 => 4
+/// Pre-#1266, r1/r3 would under-count (props not re-attributed to the joined/left
+/// class) and r2 would over-count (retraction delta dropped); the fold would drift.
+#[tokio::test]
+async fn indexed_rdf_type_star_count_exact_across_incremental_builds() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-typestar-multi:main";
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                SELECT (COUNT(*) AS ?count) WHERE { ?s rdf:type ?o1 . ?s ex:p ?o2 }
+            ";
+
+            // Run the fold query at transaction `t` (HEAD == indexed, no overlay)
+            // and return its normalized rows.
+            macro_rules! fold_rows {
+                ($t:expr) => {{
+                    let view = fluree.db_at_t(ledger_id, $t).await.expect("view");
+                    normalize_rows(
+                        &fluree
+                            .query(&view, QueryInput::Sparql(q))
+                            .await
+                            .expect("fold query")
+                            .to_jsonld(&view.snapshot)
+                            .expect("to_jsonld"),
+                    )
+                }};
+            }
+
+            // Seed (full build).
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [
+                            {"@id": "ex:a", "@type": ["ex:C1", "ex:C2"], "ex:p": [1, 2, 3]},
+                            {"@id": "ex:b", "@type": "ex:C1", "ex:p": [4]}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            assert_eq!(
+                fold_rows!(ledger1.t()),
+                normalize_rows(&json!([[7]])),
+                "seed: ex:a{{C1,C2}}*3 + ex:b{{C1}}*1 = 7"
+            );
+
+            // r1 — re-type shrink: drop ex:a's ex:C2 type, leave its ex:p untouched.
+            let ledger2 = fluree
+                .update(
+                    ledger1,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "delete": [{"@id": "ex:a", "@type": "ex:C2"}]
+                    }),
+                )
+                .await
+                .expect("retract type C2")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger2.t()).await;
+            assert_eq!(
+                fold_rows!(ledger2.t()),
+                normalize_rows(&json!([[4]])),
+                "after dropping ex:a a ex:C2: ex:a{{C1}}*3 + ex:b*1 = 4 (C2 dropped ex:a's 3 p)"
+            );
+
+            // r2 — property retraction.
+            let ledger3 = fluree
+                .update(
+                    ledger2,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "delete": [{"@id": "ex:a", "ex:p": 1}]
+                    }),
+                )
+                .await
+                .expect("retract p 1")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger3.t()).await;
+            assert_eq!(
+                fold_rows!(ledger3.t()),
+                normalize_rows(&json!([[3]])),
+                "after retracting ex:a ex:p 1: ex:a{{C1}}*2 + ex:b*1 = 3"
+            );
+
+            // r3 — type-gainer: add ex:C2 to ex:b (additive), ex:p untouched.
+            let ledger4 = fluree
+                .insert_with_opts(
+                    ledger3,
+                    &json!({
+                        "@context": { "ex": "http://example.org/ns/" },
+                        "@graph": [{"@id": "ex:b", "@type": "ex:C2"}]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("add type C2 to ex:b")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger4.t()).await;
+            assert_eq!(
+                fold_rows!(ledger4.t()),
+                normalize_rows(&json!([[4]])),
+                "after adding ex:b a ex:C2: ex:a{{C1}}*2 + ex:b{{C1,C2}}*1 = 4 (b's p re-attributed to C2)"
+            );
+        })
+        .await;
+}
+
 /// `number-of-predicates` (`COUNT(DISTINCT ?p) WHERE { ?s ?p ?o }`) served from
 /// the per-graph index stats (count of properties with positive current count),
 /// no leaf scan. Asserts the indexed (stats) result equals the memory

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -2197,6 +2197,307 @@ async fn overlay_parallel_star_join_count_folds_novelty() {
         .await;
 }
 
+/// PARALLEL overlay lane for the OPTIONAL COUNT(*) `{ ?s p1 ?o1 OPTIONAL { ?s p2 ?o2 } }`:
+/// >50k indexed base + novelty. The optional multiplier `max(1, count_p2(s))` must be
+/// folded with novelty per partition.
+#[tokio::test]
+async fn overlay_parallel_optional_join_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-parallel-optional:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: p1 = 1 value; p2 = (i%3) values (0,1,2). multiplier = max(1, i%3).
+            // base count = Σ_i max(1, i%3): i%3 in {0,1} -> 1, i%3==2 -> 2.
+            let n: i64 = 60_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let c2 = i % 3;
+                expected += c2.max(1);
+                let mut node = json!({"@id": format!("ex:s{i}"), "ex:p1": i});
+                if c2 > 0 {
+                    node["ex:p2"] = json!((0..c2).map(|j| json!(i * 10 + j)).collect::<Vec<_>>());
+                }
+                nodes.push(node);
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 50 subjects with p1 + 2x p2 -> multiplier 2 each -> +100.
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..50 {
+                nov.push(json!({"@id": format!("ex:n{j}"), "ex:p1": j, "ex:p2": [j * 10, j * 10 + 1]}));
+                expected += 2;
+            }
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:p1 ?o1 OPTIONAL { ?s ex:p2 ?o2 } }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel overlay optional query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel overlay optional count must fold novelty = {expected}"
+            );
+        })
+        .await;
+}
+
+/// PARALLEL overlay lane for the constrained-UNION COUNT(*)
+/// `{ ?s p1 ?o } UNION { ?s p2 ?o } . ?s e ?o2` = Σ_s (c_p1+c_p2)·c_e: >50k base + novelty.
+#[tokio::test]
+async fn overlay_parallel_union_constraint_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-parallel-union:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: p1=(i%2)+1, e=1, p2=(i%3). contribution = ((i%2)+1 + (i%3))*1.
+            let n: i64 = 60_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::new();
+            for i in 0..n {
+                let c1 = (i % 2) + 1;
+                let cp2 = i % 3;
+                expected += c1 + cp2;
+                let mut node = json!({"@id": format!("ex:s{i}"), "ex:e": 1});
+                node["ex:p1"] = json!((0..c1).map(|j| json!(i * 10 + j)).collect::<Vec<_>>());
+                if cp2 > 0 {
+                    node["ex:p2"] = json!((0..cp2).map(|j| json!(i * 10 + 5 + j)).collect::<Vec<_>>());
+                }
+                nodes.push(node);
+            }
+            // 100 union-only (no e) => contribute 0.
+            for i in 0..100 {
+                nodes.push(json!({"@id": format!("ex:u{i}"), "ex:p1": [i]}));
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 50 with p1=2,p2=1,e=1 => (2+1)*1 = 3 each => +150; 10 union-only => 0.
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..50 {
+                nov.push(json!({"@id": format!("ex:n{j}"), "ex:e": 1, "ex:p1": [j * 10, j * 10 + 1], "ex:p2": [j * 10 + 5]}));
+                expected += 3;
+            }
+            for j in 0..10 {
+                nov.push(json!({"@id": format!("ex:novu{j}"), "ex:p1": [j]}));
+            }
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } ?s ex:e ?o2 }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel overlay union query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel overlay union-constraint count must fold novelty = {expected}"
+            );
+        })
+        .await;
+}
+
+/// PARALLEL overlay lane for MINUS and EXISTS over a multi-predicate inner block:
+/// `?s outer ?o {MINUS|EXISTS} { ?s in1 ?a . ?s in2 ?b }`, >50k base + novelty.
+#[tokio::test]
+async fn overlay_parallel_minus_exists_intersect_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-parallel-minus-exists:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: outer=(i%2)+1; in1 iff i%2==0; in2 iff i%3==0. inner
+            // intersection = i%6==0. count_outer of an i%6==0 (even) subject = 1.
+            let n: i64 = 60_000;
+            let mut base_exists: i64 = 0;
+            let mut total_outer: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let c_outer = (i % 2) + 1;
+                total_outer += c_outer;
+                if i % 6 == 0 {
+                    base_exists += c_outer;
+                }
+                let mut node = json!({"@id": format!("ex:s{i}")});
+                node["ex:outer"] =
+                    json!((0..c_outer).map(|j| json!(i * 10 + j)).collect::<Vec<_>>());
+                if i % 2 == 0 {
+                    node["ex:in1"] = json!(i * 10 + 100);
+                }
+                if i % 3 == 0 {
+                    node["ex:in2"] = json!(i * 10 + 200);
+                }
+                nodes.push(node);
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 30 in the intersection (outer+in1+in2), 30 not (outer+in1 only).
+            // Each has count_outer = 1.
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..30 {
+                nov.push(json!({"@id": format!("ex:na{j}"), "ex:outer": j, "ex:in1": j + 1, "ex:in2": j + 2}));
+            }
+            for j in 0..30 {
+                nov.push(json!({"@id": format!("ex:nb{j}"), "ex:outer": j, "ex:in1": j + 1}));
+            }
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+
+            // EXISTS: in intersection. base + novelty-in-intersection (30).
+            let q_exists = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:outer ?o1 . FILTER EXISTS { ?s ex:in1 ?a . ?s ex:in2 ?b } }
+            ";
+            let exists_expected = base_exists + 30;
+            let je = fluree
+                .query(&view, QueryInput::Sparql(q_exists))
+                .await
+                .expect("overlay exists query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&je),
+                normalize_rows(&json!([[exists_expected]])),
+                "parallel overlay EXISTS must fold novelty = {exists_expected}"
+            );
+
+            // MINUS: not in intersection. (total_outer - base_exists) + novelty-not (30).
+            let q_minus = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:outer ?o1 MINUS { ?s ex:in1 ?a . ?s ex:in2 ?b } }
+            ";
+            let minus_expected = (total_outer - base_exists) + 30;
+            let jm = fluree
+                .query(&view, QueryInput::Sparql(q_minus))
+                .await
+                .expect("overlay minus query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jm),
+                normalize_rows(&json!([[minus_expected]])),
+                "parallel overlay MINUS must fold novelty = {minus_expected}"
+            );
+        })
+        .await;
+}
+
 /// Overlay/novelty lane for the LANG-filter COUNT fast path.
 #[tokio::test]
 async fn overlay_lang_filter_count_folds_novelty() {

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1192,6 +1192,89 @@ async fn indexed_parallel_star_join_count_matches_serial() {
         .await;
 }
 
+/// Parallel partitioned OPTIONAL COUNT(*): `?s p1 ?o1 OPTIONAL { ?s p2 ?o2 }` =
+/// Σ_s count_p1(s)·max(1, count_p2(s)). Seeds >50k rows (the parallel threshold)
+/// with varying optional multiplicity (incl. subjects with NO p2, factor 1) so the
+/// count is sensitive to any partition-boundary or optional-multiplier bug; the
+/// result must equal the serially-computed expected sum exactly.
+#[tokio::test]
+async fn indexed_parallel_optional_join_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-optional:main";
+    // Tiny leaflets so the data spans many leaves and the partitioner engages.
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: required p1 has 2 values; optional p2 has (i%3) values
+            // (0 => no p2 => multiplier 1). total rows ~ 2N + Σ(i%3) ~ 3N;
+            // N=20000 => ~60k > 50k threshold.
+            let n: i64 = 20_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let c2 = i % 3; // 0, 1, or 2 optional values
+                expected += 2 * c2.max(1);
+                let mut node = json!({"@id": format!("ex:s{i}"), "ex:p1": [i * 10, i * 10 + 1]});
+                if c2 > 0 {
+                    let p2: Vec<serde_json::Value> =
+                        (0..c2).map(|j| json!(i * 10 + 5 + j)).collect();
+                    node["ex:p2"] = json!(p2);
+                }
+                nodes.push(node);
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:p1 ?o1 OPTIONAL { ?s ex:p2 ?o2 } }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel optional join query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel optional count must equal Σ_s count_p1(s)*max(1,count_p2(s)) = {expected}"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1944,6 +1944,89 @@ async fn overlay_numeric_compare_sum_folds_novelty() {
         .await;
 }
 
+/// PARALLEL overlay lane for the encoded-filter COUNT: >50k indexed base rows so
+/// the partition harness engages, plus novelty (asserts + self-typed), queried at
+/// HEAD. Confirms the parallel base scan + per-partition novelty merge agree with
+/// the analytic count (boundary subjects counted once).
+#[tokio::test]
+async fn overlay_parallel_encoded_filter_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-parallel-encoded:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // Baseline: 60k typed subjects (all s != o). Index it.
+            let n: i64 = 60_000;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                nodes.push(json!({"@id": format!("ex:s{i}"), "@type": format!("ex:C{}", i % 50)}));
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: 100 more typed (s != o) + 10 self-typed (s == o, excluded).
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..100 {
+                nov.push(json!({"@id": format!("ex:n{j}"), "@type": "ex:C0"}));
+            }
+            for j in 0..10 {
+                nov.push(json!({"@id": format!("ex:selfn{j}"), "@type": format!("ex:selfn{j}")}));
+            }
+            let _ = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                SELECT (COUNT(?s) AS ?count)
+                WHERE { ?s rdf:type ?o . FILTER(?s != ?o) }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel overlay encoded-filter query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // s != o: base 60000 + novelty 100 = 60100 (self-typed excluded).
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[60_100]])),
+                "parallel overlay encoded-filter must fold novelty: 60000 + 100 = 60100"
+            );
+        })
+        .await;
+}
+
 /// Overlay/novelty lane for the LANG-filter COUNT fast path.
 #[tokio::test]
 async fn overlay_lang_filter_count_folds_novelty() {

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -1152,8 +1152,7 @@ async fn indexed_parallel_star_join_count_matches_serial() {
                 let c2 = (i % 2) + 1;
                 expected += c1 * c2;
                 let p1: Vec<serde_json::Value> = (0..c1).map(|j| json!(i * 100 + j)).collect();
-                let p2: Vec<serde_json::Value> =
-                    (0..c2).map(|j| json!(i * 100 + 50 + j)).collect();
+                let p2: Vec<serde_json::Value> = (0..c2).map(|j| json!(i * 100 + 50 + j)).collect();
                 nodes.push(json!({"@id": format!("ex:s{i}"), "ex:p1": p1, "ex:p2": p2}));
             }
             let ledger1 = fluree
@@ -1924,7 +1923,10 @@ async fn overlay_numeric_compare_sum_folds_novelty() {
                 .await
                 .expect("novelty insert");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX ex: <http://example.org/ns/>
                 SELECT (SUM(?o > 0) AS ?sum) WHERE { ?s ex:num ?o }
@@ -2006,7 +2008,10 @@ async fn overlay_parallel_encoded_filter_count_folds_novelty() {
                 .await
                 .expect("novelty insert");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                 SELECT (COUNT(?s) AS ?count)
@@ -2091,7 +2096,10 @@ async fn overlay_parallel_numeric_compare_sum_folds_novelty() {
                 .await
                 .expect("novelty insert");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX ex: <http://example.org/ns/>
                 SELECT (SUM(?o > 0) AS ?sum) WHERE { ?s ex:num ?o }
@@ -2176,7 +2184,10 @@ async fn overlay_parallel_star_join_count_folds_novelty() {
                 .await
                 .expect("novelty insert");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX ex: <http://example.org/ns/>
                 SELECT (COUNT(*) AS ?count)
@@ -2253,7 +2264,9 @@ async fn overlay_parallel_optional_join_count_folds_novelty() {
             // Novelty: 50 subjects with p1 + 2x p2 -> multiplier 2 each -> +100.
             let mut nov: Vec<serde_json::Value> = Vec::new();
             for j in 0..50 {
-                nov.push(json!({"@id": format!("ex:n{j}"), "ex:p1": j, "ex:p2": [j * 10, j * 10 + 1]}));
+                nov.push(
+                    json!({"@id": format!("ex:n{j}"), "ex:p1": j, "ex:p2": [j * 10, j * 10 + 1]}),
+                );
                 expected += 2;
             }
             let _ = fluree
@@ -2264,7 +2277,10 @@ async fn overlay_parallel_optional_join_count_folds_novelty() {
                 .await
                 .expect("novelty insert");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX ex: <http://example.org/ns/>
                 SELECT (COUNT(*) AS ?count)
@@ -2556,8 +2572,9 @@ async fn overlay_delta_single_predicate_count_folds_novelty() {
                 .expect("novelty assert")
                 .ledger;
             // Novelty retract: remove ex:p of 10 base subjects.
-            let del: Vec<serde_json::Value> =
-                (0..10).map(|i| json!({"@id": format!("ex:s{i}"), "ex:p": i})).collect();
+            let del: Vec<serde_json::Value> = (0..10)
+                .map(|i| json!({"@id": format!("ex:s{i}"), "ex:p": i}))
+                .collect();
             let _ = fluree
                 .update(
                     ledger,
@@ -2566,7 +2583,10 @@ async fn overlay_delta_single_predicate_count_folds_novelty() {
                 .await
                 .expect("novelty retract");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX ex: <http://example.org/ns/>
                 SELECT (COUNT(*) AS ?count) WHERE { ?s ex:p ?o }
@@ -2648,8 +2668,9 @@ async fn overlay_delta_union_count_folds_novelty() {
                 .await
                 .expect("novelty assert")
                 .ledger;
-            let del: Vec<serde_json::Value> =
-                (0..5).map(|i| json!({"@id": format!("ex:s{i}"), "ex:p1": i})).collect();
+            let del: Vec<serde_json::Value> = (0..5)
+                .map(|i| json!({"@id": format!("ex:s{i}"), "ex:p1": i}))
+                .collect();
             let _ = fluree
                 .update(
                     ledger,
@@ -2658,7 +2679,10 @@ async fn overlay_delta_union_count_folds_novelty() {
                 .await
                 .expect("novelty retract");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX ex: <http://example.org/ns/>
                 SELECT (COUNT(*) AS ?count) WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } }
@@ -2800,7 +2824,10 @@ async fn overlay_encoded_filter_count_folds_novelty() {
                 .await
                 .expect("novelty insert");
 
-            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let view = fluree
+                .db(ledger_id)
+                .await
+                .expect("load HEAD view w/ novelty");
             let q = r"
                 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                 SELECT (COUNT(?s) AS ?count)
@@ -3004,8 +3031,7 @@ async fn indexed_star_join_seek_strategy_counts_correctly() {
             let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
             // Driver p1 rows = 3 (ex:a:2, ex:c:1). Probe p2 rows = 3 + 24_600 filler
             // = 24_603 > 3 * 8192 = 24_576, so the seek strategy fires.
-            let filler: Vec<serde_json::Value> =
-                (0..24_600).map(|n| json!(n)).collect();
+            let filler: Vec<serde_json::Value> = (0..24_600).map(|n| json!(n)).collect();
             let insert = json!({
                 "@context": { "ex": "http://example.org/ns/" },
                 "@graph": [

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -919,6 +919,87 @@ async fn indexed_sum_compare_empty_predicate_matches_general() {
         .await;
 }
 
+/// Parallel partitioned inner-star COUNT(*): seed enough rows (>50k, the parallel
+/// threshold) with VARYING per-subject multiplicity so the count is sensitive to
+/// any partition-boundary bug (a misattributed subject changes the product sum).
+/// The result must equal the serially-computed expected sum exactly.
+#[tokio::test]
+async fn indexed_parallel_star_join_count_matches_serial() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-parallel-star:main";
+
+    // Tiny leaflets/leaves so the modest test data spans many leaves (the real
+    // benchmark predicate has thousands) and the parallel partitioner engages.
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // subject i: p1 has (i%3)+1 values, p2 has (i%2)+1 values.
+            // total rows ~ 3.5*N; N=16000 => ~56k rows > 50k parallel threshold.
+            let n: i64 = 16_000;
+            let mut expected: i64 = 0;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let c1 = (i % 3) + 1;
+                let c2 = (i % 2) + 1;
+                expected += c1 * c2;
+                let p1: Vec<serde_json::Value> = (0..c1).map(|j| json!(i * 100 + j)).collect();
+                let p2: Vec<serde_json::Value> =
+                    (0..c2).map(|j| json!(i * 100 + 50 + j)).collect();
+                nodes.push(json!({"@id": format!("ex:s{i}"), "ex:p1": p1, "ex:p2": p2}));
+            }
+            let ledger1 = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count)
+                WHERE { ?s ex:p1 ?o1 . ?s ex:p2 ?o2 }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("parallel star join query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[expected]])),
+                "parallel partitioned star-join count must equal Σ_s c1(s)*c2(s) = {expected}"
+            );
+        })
+        .await;
+}
+
 /// GROUP BY ?object COUNT(?subject) ORDER BY DESC LIMIT via the indexed POST
 /// path (`group_count_v6`, run-length + top-K). A high-multiplicity object's run
 /// (2000 rows) spans multiple leaflets, exercising the boundary-equality /

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -2499,6 +2499,186 @@ async fn overlay_parallel_minus_exists_intersect_count_folds_novelty() {
         .await;
 }
 
+/// Overlay novelty-DELTA for single-predicate COUNT(*): base count from the manifest
+/// plus a delta over only the leaves novelty touches. Exercises asserts (new subjects
+/// beyond the base's last leaf), retracts, and the metadata base for untouched leaves.
+#[tokio::test]
+async fn overlay_delta_single_predicate_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-delta-single:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    idx_config.leaf_target_bytes = 8_000;
+    idx_config.leaf_max_bytes = 16_000;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            let n: i64 = 20_000;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                nodes.push(json!({"@id": format!("ex:s{i}"), "ex:p": i}));
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty assert: 50 NEW subjects (ids beyond the base's last leaf).
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..50 {
+                nov.push(json!({"@id": format!("ex:nn{j}"), "ex:p": 1000 + j}));
+            }
+            let ledger = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty assert")
+                .ledger;
+            // Novelty retract: remove ex:p of 10 base subjects.
+            let del: Vec<serde_json::Value> =
+                (0..10).map(|i| json!({"@id": format!("ex:s{i}"), "ex:p": i})).collect();
+            let _ = fluree
+                .update(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "delete": del }),
+                )
+                .await
+                .expect("novelty retract");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count) WHERE { ?s ex:p ?o }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("overlay delta single-pred query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // 20000 base + 50 assert − 10 retract = 20040.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[20_040]])),
+                "single-pred COUNT(*) overlay delta: 20000 + 50 − 10 = 20040"
+            );
+        })
+        .await;
+}
+
+/// Overlay novelty-DELTA for no-constraint UNION COUNT(*) (bag semantics = Σ per
+/// branch of base + delta).
+#[tokio::test]
+async fn overlay_delta_union_count_folds_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/overlay-delta-union:main";
+    let mut idx_config = fluree_db_indexer::IndexerConfig::small();
+    idx_config.leaflet_rows = 100;
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        idx_config,
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 80_000_000,
+            };
+            // 10000 subjects with p1; first 5000 also with p2. bag base = 10000+5000.
+            let n: i64 = 10_000;
+            let mut nodes: Vec<serde_json::Value> = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let mut node = json!({"@id": format!("ex:s{i}"), "ex:p1": i});
+                if i < 5000 {
+                    node["ex:p2"] = json!(i);
+                }
+                nodes.push(node);
+            }
+            let ledger = fluree
+                .insert_with_opts(
+                    genesis_ledger_for_fluree(&fluree, ledger_id),
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nodes }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("baseline insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            // Novelty: +30 p1 (new), +20 p2 (new), −5 p1 (retract base).
+            let mut nov: Vec<serde_json::Value> = Vec::new();
+            for j in 0..30 {
+                nov.push(json!({"@id": format!("ex:np{j}"), "ex:p1": 9000 + j}));
+            }
+            for j in 0..20 {
+                nov.push(json!({"@id": format!("ex:nq{j}"), "ex:p2": 9000 + j}));
+            }
+            let ledger = fluree
+                .insert(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "@graph": nov }),
+                )
+                .await
+                .expect("novelty assert")
+                .ledger;
+            let del: Vec<serde_json::Value> =
+                (0..5).map(|i| json!({"@id": format!("ex:s{i}"), "ex:p1": i})).collect();
+            let _ = fluree
+                .update(
+                    ledger,
+                    &json!({ "@context": { "ex": "http://example.org/ns/" }, "delete": del }),
+                )
+                .await
+                .expect("novelty retract");
+
+            let view = fluree.db(ledger_id).await.expect("load HEAD view w/ novelty");
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT (COUNT(*) AS ?count) WHERE { { ?s ex:p1 ?o } UNION { ?s ex:p2 ?o } }
+            ";
+            let jsonld = fluree
+                .query(&view, QueryInput::Sparql(q))
+                .await
+                .expect("overlay delta union query")
+                .to_jsonld(&view.snapshot)
+                .expect("to_jsonld");
+            // p1: 10000+30−5 = 10025; p2: 5000+20 = 5020; bag sum = 15045.
+            assert_eq!(
+                normalize_rows(&jsonld),
+                normalize_rows(&json!([[15_045]])),
+                "no-constraint UNION COUNT(*) overlay delta = 15045"
+            );
+        })
+        .await;
+}
+
 /// Overlay/novelty lane for the LANG-filter COUNT fast path.
 #[tokio::test]
 async fn overlay_lang_filter_count_folds_novelty() {

--- a/fluree-db-binary-index/src/lib.rs
+++ b/fluree-db-binary-index/src/lib.rs
@@ -17,7 +17,7 @@ pub mod read;
 
 // ── Read-side types ─────────────────────────────────────────────────────────
 pub use read::batched_lookup::{
-    batched_lookup_predicate_refs, batched_lookup_subject_properties,
+    batched_lookup_inbound_refs, batched_lookup_predicate_refs, batched_lookup_subject_properties,
 };
 pub use read::binary_cursor::BinaryCursor;
 pub use read::binary_index_store::{BinaryGraphView, BinaryIndexStore};

--- a/fluree-db-binary-index/src/lib.rs
+++ b/fluree-db-binary-index/src/lib.rs
@@ -16,7 +16,9 @@ pub mod format;
 pub mod read;
 
 // ── Read-side types ─────────────────────────────────────────────────────────
-pub use read::batched_lookup::batched_lookup_predicate_refs;
+pub use read::batched_lookup::{
+    batched_lookup_predicate_refs, batched_lookup_subject_properties,
+};
 pub use read::binary_cursor::BinaryCursor;
 pub use read::binary_index_store::{BinaryGraphView, BinaryIndexStore};
 pub use read::column_types::{BinaryFilter, ColumnBatch, ColumnData, ColumnProjection, ColumnSet};

--- a/fluree-db-binary-index/src/read/batched_lookup.rs
+++ b/fluree-db-binary-index/src/read/batched_lookup.rs
@@ -320,6 +320,114 @@ pub fn batched_lookup_subject_properties(
     Ok(out)
 }
 
+/// Batched OPST lookup: all inbound `IRI_REF` edges pointing at each requested
+/// object, from the persisted index at `to_t`. No overlay/novelty merge.
+///
+/// Returns `HashMap<object_sid64, Vec<(p_id, subject_sid64)>>`.
+///
+/// Mirrors [`batched_lookup_predicate_refs`] but scans `RunSortOrder::Opst`
+/// (object-major: `(o_type, o_key, o_i, p_id, s_id)`). The scan range pins
+/// `o_type = IRI_REF`, so every yielded row is a reference edge — no per-row
+/// o_type check is required. Used by the incremental class-stat merge to move a
+/// re-typed object's inbound ref-class edges from its old class bucket to its
+/// new one (issue #1266).
+pub fn batched_lookup_inbound_refs(
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    objects: &[u64],
+    to_t: i64,
+) -> io::Result<HashMap<u64, Vec<(u32, u64)>>> {
+    let mut out: HashMap<u64, Vec<(u32, u64)>> = HashMap::new();
+    if objects.is_empty() {
+        return Ok(out);
+    }
+
+    let mut sorted = objects.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let obj_set: HashSet<u64> = sorted.iter().copied().collect();
+
+    let Some(branch) = store.branch_for_order(g_id, RunSortOrder::Opst) else {
+        return Ok(out);
+    };
+    let branch = Arc::clone(branch);
+    let iri_ref = OType::IRI_REF.as_u16();
+
+    const MAX_SPAN: u64 = 100_000;
+    const MAX_CHUNK: usize = 1000;
+    // chunk_subjects operates on a sorted &[u64] span — identical logic applies
+    // to object o_key spans, so reuse it verbatim.
+    let chunks = chunk_subjects(&sorted, MAX_SPAN, MAX_CHUNK);
+
+    // Need s_id (inbound subject), p_id, o_key (filter to set), o_type (ref check).
+    let mut needed = ColumnSet::EMPTY;
+    needed.insert(ColumnId::SId);
+    needed.insert(ColumnId::PId);
+    needed.insert(ColumnId::OType);
+    needed.insert(ColumnId::OKey);
+    let projection = ColumnProjection {
+        output: needed,
+        internal: ColumnSet::EMPTY,
+    };
+
+    for chunk in &chunks {
+        let min_o = chunk[0];
+        let max_o = *chunk.last().unwrap();
+
+        // OPST order = (o_type, o_key, o_i, p_id, s_id); pin o_type = IRI_REF.
+        let min_key = RunRecordV2 {
+            s_id: SubjectId::from_u64(0),
+            o_key: min_o,
+            p_id: 0,
+            t: 0,
+            o_i: 0,
+            o_type: iri_ref,
+            g_id,
+        };
+        let max_key = RunRecordV2 {
+            s_id: SubjectId::from_u64(u64::MAX),
+            o_key: max_o,
+            p_id: u32::MAX,
+            t: 0,
+            o_i: u32::MAX,
+            o_type: iri_ref,
+            g_id,
+        };
+
+        let mut cursor = BinaryCursor::new(
+            Arc::clone(store),
+            RunSortOrder::Opst,
+            Arc::clone(&branch),
+            &min_key,
+            &max_key,
+            BinaryFilter::default(),
+            projection,
+        );
+        cursor.set_to_t(to_t);
+
+        while let Some(batch) = cursor.next_batch()? {
+            for i in 0..batch.row_count {
+                if batch.o_type.get_or(i, 0) != iri_ref {
+                    continue;
+                }
+                let o_key = batch.o_key.get(i);
+                if !obj_set.contains(&o_key) {
+                    continue;
+                }
+                out.entry(o_key)
+                    .or_default()
+                    .push((batch.p_id.get_or(i, 0), batch.s_id.get(i)));
+            }
+        }
+    }
+
+    for v in out.values_mut() {
+        v.sort_unstable();
+        v.dedup();
+    }
+    Ok(out)
+}
+
 /// Break sorted subjects into chunks where each chunk spans at most
 /// `max_span` IDs and contains at most `max_chunk` subjects.
 fn chunk_subjects(sorted: &[u64], max_span: u64, max_chunk: usize) -> Vec<&[u64]> {

--- a/fluree-db-binary-index/src/read/batched_lookup.rs
+++ b/fluree-db-binary-index/src/read/batched_lookup.rs
@@ -217,6 +217,109 @@ pub fn batched_lookup_predicate_refs(
     Ok(out)
 }
 
+/// Per-subject live property flakes from a base-index scan: each subject's
+/// sid64 maps to a list of `(p_id, o_type, o_key)` for its current assertions.
+pub type SubjectPropertyFlakes = HashMap<u64, Vec<(u32, u16, u64)>>;
+
+/// Batched SPOT lookup of all live property flakes for a set of subjects from
+/// the persisted index at `to_t`.
+///
+/// Returns the current (non-history) property assertions for each requested
+/// subject. No overlay/novelty merge; the caller applies novelty deltas
+/// separately.
+///
+/// Used by the incremental class-stat merge to re-attribute the existing
+/// properties of a subject whose class membership changed this batch (re-type,
+/// add/remove a type, or delete) from the classes it left onto the classes it
+/// joined (issue #1266). Mirrors [`batched_lookup_predicate_refs`] but scans
+/// SPOT (subject-major) across all predicates instead of one PSOT predicate.
+pub fn batched_lookup_subject_properties(
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    subjects: &[u64],
+    to_t: i64,
+) -> io::Result<SubjectPropertyFlakes> {
+    let mut out: HashMap<u64, Vec<(u32, u16, u64)>> = HashMap::new();
+    if subjects.is_empty() {
+        return Ok(out);
+    }
+
+    let mut sorted_subjects = subjects.to_vec();
+    sorted_subjects.sort_unstable();
+    sorted_subjects.dedup();
+    let s_id_set: HashSet<u64> = sorted_subjects.iter().copied().collect();
+
+    let Some(branch) = store.branch_for_order(g_id, RunSortOrder::Spot) else {
+        return Ok(out);
+    };
+    let branch = Arc::clone(branch);
+
+    const MAX_SPAN: u64 = 100_000;
+    const MAX_CHUNK: usize = 1000;
+    let chunks = chunk_subjects(&sorted_subjects, MAX_SPAN, MAX_CHUNK);
+
+    // Need s_id (to filter), p_id, o_type, o_key (to reconstruct datatype/lang/ref).
+    let mut needed = ColumnSet::EMPTY;
+    needed.insert(ColumnId::SId);
+    needed.insert(ColumnId::PId);
+    needed.insert(ColumnId::OType);
+    needed.insert(ColumnId::OKey);
+    let projection = ColumnProjection {
+        output: needed,
+        internal: ColumnSet::EMPTY,
+    };
+
+    for chunk in &chunks {
+        let min_s = chunk[0];
+        let max_s = *chunk.last().unwrap();
+
+        let min_key = RunRecordV2 {
+            s_id: SubjectId::from_u64(min_s),
+            o_key: 0,
+            p_id: 0,
+            t: 0,
+            o_i: 0,
+            o_type: 0,
+            g_id,
+        };
+        let max_key = RunRecordV2 {
+            s_id: SubjectId::from_u64(max_s),
+            o_key: u64::MAX,
+            p_id: u32::MAX,
+            t: 0,
+            o_i: u32::MAX,
+            o_type: u16::MAX,
+            g_id,
+        };
+
+        let mut cursor = BinaryCursor::new(
+            Arc::clone(store),
+            RunSortOrder::Spot,
+            Arc::clone(&branch),
+            &min_key,
+            &max_key,
+            BinaryFilter::default(),
+            projection,
+        );
+        cursor.set_to_t(to_t);
+
+        while let Some(batch) = cursor.next_batch()? {
+            for i in 0..batch.row_count {
+                let s_id = batch.s_id.get(i);
+                if !s_id_set.contains(&s_id) {
+                    continue;
+                }
+                let p_id = batch.p_id.get_or(i, 0);
+                let o_type = batch.o_type.get_or(i, 0);
+                let o_key = batch.o_key.get(i);
+                out.entry(s_id).or_default().push((p_id, o_type, o_key));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
 /// Break sorted subjects into chunks where each chunk spans at most
 /// `max_span` IDs and contains at most `max_chunk` subjects.
 fn chunk_subjects(sorted: &[u64], max_span: u64, max_chunk: usize) -> Vec<&[u64]> {

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -1905,8 +1905,17 @@ pub async fn incremental_index(
                     {
                         Ok(s) => Some(Arc::new(s)),
                         Err(e) => {
-                            tracing::warn!(error = %e, "V6 store load for class attribution failed");
-                            None
+                            // We need the base store to seed base class entries and to
+                            // re-attribute re-typed subjects. Without it, base entries
+                            // resolve to sid64==0 and get dropped, publishing novelty-only
+                            // (wrong) class-property stats — which the rdf:type-star COUNT
+                            // fold then serves verbatim at HEAD. Abort to a full rebuild
+                            // (which loads its own data and recomputes class stats exactly),
+                            // mirroring the spatial-snapshot and re-type-workload gates above.
+                            return Err(IndexerError::IncrementalAbort(format!(
+                                "V6 store load for class attribution failed: {e}; \
+                                 falling back to full rebuild for correct class stats"
+                            )));
                         }
                     }
                 } else {

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2019,10 +2019,15 @@ pub async fn incremental_index(
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!(
-                                    g_id = scan_g_id, error = %e,
-                                    "batched PSOT class lookup failed for graph"
-                                );
+                                // Loads the base class membership that all re-attribution
+                                // (datatype/lang AND ref-class) is computed against. A
+                                // failure here makes every downstream class delta unsound,
+                                // so abort to a full rebuild rather than warn-and-continue.
+                                return Err(IndexerError::IncrementalAbort(format!(
+                                    "Phase 3b base PSOT class lookup failed for graph \
+                                     {scan_g_id}: {e} (deferring class-stat recompute to \
+                                     full rebuild)"
+                                )));
                             }
                         }
                     }
@@ -2273,12 +2278,19 @@ pub async fn incremental_index(
                                 ) {
                                     Ok(m) => m,
                                     Err(e) => {
-                                        tracing::warn!(
-                                            g_id, error = %e,
-                                            "Phase 3b: base subject-property scan failed; \
-                                             re-typed subjects may keep stale class stats"
-                                        );
-                                        continue;
+                                        // This scan drives the datatype/language
+                                        // re-attribution that makes the now-ungated
+                                        // class-stat folds current-state-exact. A
+                                        // warn-and-continue here would silently leave
+                                        // re-typed subjects with stale per-(class,
+                                        // property) stats, so abort to a full rebuild
+                                        // (which recomputes class stats from the SPOT
+                                        // pass). Caught in lib.rs and routed to rebuild.
+                                        return Err(IndexerError::IncrementalAbort(format!(
+                                            "Phase 3b base subject-property scan failed \
+                                             for graph {g_id}: {e} (deferring class-stat \
+                                             recompute to full rebuild)"
+                                        )));
                                     }
                                 };
                             for &s_id in sids {
@@ -2462,11 +2474,15 @@ pub async fn incremental_index(
                                     }
                                 }
                                 Err(e) => {
-                                    tracing::warn!(
-                                        g_id, error = %e,
-                                        "Phase 3b: inbound ref scan failed; re-typed objects \
-                                         may keep stale ref-class stats"
-                                    );
+                                    // Case B inbound edges of re-typed objects. A miss here
+                                    // would silently leave stale ref-class edge stats; abort
+                                    // to a full rebuild for consistency with the other base
+                                    // re-attribution scans (the rebuild recomputes ref_classes
+                                    // exactly). Cheap insurance for the #1270 fold to come.
+                                    return Err(IndexerError::IncrementalAbort(format!(
+                                        "Phase 3b inbound ref scan failed for graph {g_id}: \
+                                         {e} (deferring class-stat recompute to full rebuild)"
+                                    )));
                                 }
                             }
                             // Drop edges touched this batch — the forward pass owns them.
@@ -2497,14 +2513,26 @@ pub async fn incremental_index(
                             let external_base = if external_sids.is_empty() {
                                 std::collections::HashMap::new()
                             } else {
-                                fluree_db_binary_index::batched_lookup_predicate_refs(
+                                // Resolves classes for stable ref-edge endpoints. A failure
+                                // would mis-attribute (or drop) ref-class edges; abort to a
+                                // full rebuild rather than `unwrap_or_default()` (which would
+                                // silently treat every endpoint as class-less).
+                                match fluree_db_binary_index::batched_lookup_predicate_refs(
                                     store,
                                     g_id,
                                     rdf_type_p_id,
                                     &external_sids,
                                     base_root.index_t,
-                                )
-                                .unwrap_or_default()
+                                ) {
+                                    Ok(m) => m,
+                                    Err(e) => {
+                                        return Err(IndexerError::IncrementalAbort(format!(
+                                            "Phase 3b external ref-endpoint class lookup failed \
+                                             for graph {g_id}: {e} (deferring class-stat \
+                                             recompute to full rebuild)"
+                                        )));
+                                    }
+                                }
                             };
                             // (base_classes, net_classes) for an endpoint. A stable base
                             // entity has base == net (its type did not change this batch).

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2066,6 +2066,32 @@ pub async fn incremental_index(
                         .copied()
                         .collect();
 
+                // Rebuild gate (issue #1266): re-typing/deleting an EXISTING subject
+                // forces a base-index re-scan to move its class-scoped datatype/lang/ref
+                // stats. Above a threshold, recomputing class stats from scratch via the
+                // full-rebuild SPOT pass is cheaper and simpler, so abort incremental and
+                // let the caller fall back to rebuild. Only count subjects that existed in
+                // the base index (those drive the re-scan work); brand-new typed subjects
+                // are free. An IncrementalAbort is caught in lib.rs and routed to rebuild.
+                let retype_workload = changed_membership
+                    .iter()
+                    .filter(|key| base_subject_classes.contains_key(*key))
+                    .count();
+                if retype_workload > config.incremental_retype_max_subjects {
+                    tracing::warn!(
+                        retype_workload,
+                        threshold = config.incremental_retype_max_subjects,
+                        "Phase 3b: existing-subject rdf:type changes exceed threshold; \
+                         aborting incremental for full rebuild (class stats recomputed \
+                         from the SPOT pass)"
+                    );
+                    return Err(IndexerError::IncrementalAbort(format!(
+                        "re-type workload {retype_workload} exceeds threshold {} \
+                         (deferring class-stat recompute to full rebuild)",
+                        config.incremental_retype_max_subjects
+                    )));
+                }
+
                 // Build class→properties, class→prop→dts, class→prop→langs, ref_edges.
                 let attribution_maps_started = Instant::now();
                 let mut class_properties: std::collections::HashMap<
@@ -2211,12 +2237,20 @@ pub async fn incremental_index(
                 //   - class in N \ B (joined):     apply  new
                 //   - class in B ∩ N (kept):       apply  delta
                 //
-                // NOTE: ref-class edges for re-typed subjects are NOT moved here yet;
-                // that needs target-class resolution (and a reverse OPST pass for
-                // re-typed objects) and is tracked separately. Datatype and language
-                // distributions — which the COUNT(*) fast path consumes — are exact.
+                // This block handles datatype + language distributions. Ref-class
+                // edges (which depend on BOTH endpoints' classes) are re-attributed in
+                // the dedicated ref pass further below — Case A (re-typed subjects'
+                // outgoing edges, collected here from the same base scan) and Case B
+                // (re-typed objects' inbound edges via reverse OPST).
                 if let Some(ref store) = store_opt {
                     if !changed_membership.is_empty() {
+                        let iri_ref_otype = fluree_db_core::o_type::OType::IRI_REF.as_u16();
+                        // Outgoing ref edges (g_id, subject, p_id, object) of re-typed
+                        // subjects, collected from the same base scan used for datatype
+                        // re-attribution (Case A). Combined with re-typed objects' inbound
+                        // edges (Case B, reverse OPST) below to move ref-class stats across
+                        // the type change (issue #1266).
+                        let mut outgoing_ref_edges: Vec<(u16, u64, u32, u64)> = Vec::new();
                         let mut changed_by_graph: std::collections::HashMap<u16, Vec<u64>> =
                             std::collections::HashMap::new();
                         for &(g_id, s_id) in &changed_membership {
@@ -2264,6 +2298,11 @@ pub async fn incremental_index(
                                     for &(p_id, o_type, o_key) in flakes {
                                         if p_id == rdf_type_p_id {
                                             continue;
+                                        }
+                                        // Collect this subject's existing ref edges for
+                                        // Case A ref-class re-attribution (o_key = target sid).
+                                        if o_type == iri_ref_otype {
+                                            outgoing_ref_edges.push((g_id, s_id, p_id, o_key));
                                         }
                                         let rec =
                                             fluree_db_binary_index::format::run_record_v2::RunRecordV2 {
@@ -2376,6 +2415,130 @@ pub async fn incremental_index(
                                                     .insert(pid);
                                             }
                                         }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Ref-class edge re-attribution (issue #1266): move the ref-class
+                        // edges of re-typed subjects/objects from their old (subject_class,
+                        // p, object_class) buckets to their new ones. Only UNTOUCHED edges
+                        // (present in the base index, not asserted/retracted this batch) —
+                        // edges touched this batch are owned by the forward
+                        // subject_ref_history pass above, so we skip them here.
+                        for (&g_id, sids) in &changed_by_graph {
+                            let mut edges: std::collections::HashSet<(u64, u32, u64)> =
+                                std::collections::HashSet::new();
+                            // Case A: outgoing edges of re-typed subjects (from the base scan).
+                            for &(eg, s, p, o) in &outgoing_ref_edges {
+                                if eg == g_id {
+                                    edges.insert((s, p, o));
+                                }
+                            }
+                            // Case B: inbound edges of re-typed objects (reverse OPST). Skip
+                            // edges whose subject also changed — Case A already owns those.
+                            match fluree_db_binary_index::batched_lookup_inbound_refs(
+                                store,
+                                g_id,
+                                sids,
+                                base_root.index_t,
+                            ) {
+                                Ok(inbound) => {
+                                    for (&obj, ins) in &inbound {
+                                        for &(p, subj) in ins {
+                                            if changed_membership.contains(&(g_id, subj)) {
+                                                continue;
+                                            }
+                                            edges.insert((subj, p, obj));
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        g_id, error = %e,
+                                        "Phase 3b: inbound ref scan failed; re-typed objects \
+                                         may keep stale ref-class stats"
+                                    );
+                                }
+                            }
+                            // Drop edges touched this batch — the forward pass owns them.
+                            edges.retain(|&(s, p, o)| {
+                                !subject_ref_history
+                                    .get(&(g_id, s))
+                                    .and_then(|per_prop| per_prop.get(&p))
+                                    .map(|objs| objs.contains_key(&o))
+                                    .unwrap_or(false)
+                            });
+                            if edges.is_empty() {
+                                continue;
+                            }
+                            // Resolve classes for endpoints not already known from this batch
+                            // (stable base entities) via one batched rdf:type lookup; endpoints
+                            // in base_subject_classes (re-typed / novelty) use those maps.
+                            let mut external_sids: Vec<u64> = Vec::new();
+                            for &(s, _p, o) in &edges {
+                                if !base_subject_classes.contains_key(&(g_id, s)) {
+                                    external_sids.push(s);
+                                }
+                                if !base_subject_classes.contains_key(&(g_id, o)) {
+                                    external_sids.push(o);
+                                }
+                            }
+                            external_sids.sort_unstable();
+                            external_sids.dedup();
+                            let external_base = if external_sids.is_empty() {
+                                std::collections::HashMap::new()
+                            } else {
+                                fluree_db_binary_index::batched_lookup_predicate_refs(
+                                    store,
+                                    g_id,
+                                    rdf_type_p_id,
+                                    &external_sids,
+                                    base_root.index_t,
+                                )
+                                .unwrap_or_default()
+                            };
+                            // (base_classes, net_classes) for an endpoint. A stable base
+                            // entity has base == net (its type did not change this batch).
+                            let resolve = |sid: u64| -> (Vec<u64>, Vec<u64>) {
+                                if let Some(b) = base_subject_classes.get(&(g_id, sid)) {
+                                    let base: Vec<u64> = b.iter().copied().collect();
+                                    let net: Vec<u64> = subject_classes
+                                        .get(&(g_id, sid))
+                                        .map(|s| s.iter().copied().collect())
+                                        .unwrap_or_default();
+                                    (base, net)
+                                } else {
+                                    let cls =
+                                        external_base.get(&sid).cloned().unwrap_or_default();
+                                    (cls.clone(), cls)
+                                }
+                            };
+                            // Per affected edge: -1 at every (base_subj_class, p, base_obj_class),
+                            // +1 at every (net_subj_class, p, net_obj_class).
+                            for &(s, p, o) in &edges {
+                                let (bs, ns) = resolve(s);
+                                let (bo, no) = resolve(o);
+                                for &sc in &bs {
+                                    for &oc in &bo {
+                                        *ref_edges
+                                            .entry((g_id, sc))
+                                            .or_default()
+                                            .entry(p)
+                                            .or_default()
+                                            .entry(oc)
+                                            .or_insert(0) -= 1;
+                                    }
+                                }
+                                for &sc in &ns {
+                                    for &oc in &no {
+                                        *ref_edges
+                                            .entry((g_id, sc))
+                                            .or_default()
+                                            .entry(p)
+                                            .or_default()
+                                            .entry(oc)
+                                            .or_insert(0) += 1;
                                     }
                                 }
                             }

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2019,6 +2019,14 @@ pub async fn incremental_index(
                     }
                 }
 
+                // Snapshot BASE (pre-batch) class membership before applying this
+                // batch's rdf:type deltas. Property *retractions* must be attributed
+                // to the class set the subject had in the base index (where the base
+                // stats counted them), while *assertions* attribute to the NET set.
+                // When a subject's type is unchanged, base == net and this is a no-op
+                // distinction. See issue #1266.
+                let base_subject_classes = subject_classes.clone();
+
                 // Apply novelty rdf:type deltas on top of base memberships.
                 let subject_classes_started = Instant::now();
                 for (&(g_id, s_id), class_map) in &novelty_subject_class_deltas {
@@ -2043,6 +2051,21 @@ pub async fn incremental_index(
                     "Phase 3b: subject class membership ready"
                 );
 
+                // Subjects whose class membership CHANGED this batch (re-type, add or
+                // remove a type, or full delete). Their existing-property attribution
+                // can't be derived from in-batch deltas alone, so the routing loop
+                // below skips them and the base-index re-scan (Stage 2) handles them.
+                // A no-op rdf:type assertion (same type) leaves base == net and is not
+                // considered changed. See issue #1266.
+                let changed_membership: std::collections::HashSet<(u16, u64)> =
+                    novelty_subject_class_deltas
+                        .keys()
+                        .filter(|key| {
+                            base_subject_classes.get(*key) != subject_classes.get(*key)
+                        })
+                        .copied()
+                        .collect();
+
                 // Build class→properties, class→prop→dts, class→prop→langs, ref_edges.
                 let attribution_maps_started = Instant::now();
                 let mut class_properties: std::collections::HashMap<
@@ -2062,34 +2085,72 @@ pub async fn incremental_index(
                     std::collections::HashMap<u32, std::collections::HashMap<u64, i64>>,
                 > = std::collections::HashMap::new();
 
-                for (&(g_id, s_id), props) in &novelty_subject_props {
-                    if let Some(classes) = subject_classes.get(&(g_id, s_id)) {
-                        for &class_sid64 in classes {
-                            class_properties
-                                .entry((g_id, class_sid64))
-                                .or_default()
-                                .extend(props);
-                            if let Some(s_dts) = novelty_subject_prop_dts.get(&(g_id, s_id)) {
-                                for (&pid, dt_map) in s_dts {
-                                    let cp = class_prop_dts
-                                        .entry((g_id, class_sid64))
-                                        .or_default()
-                                        .entry(pid)
-                                        .or_default();
-                                    for (&dt, &cnt) in dt_map {
-                                        *cp.entry(dt).or_insert(0) += cnt;
+                // Attribute per-subject property deltas to classes with base-vs-net
+                // routing (issue #1266): an assertion (positive delta) is attributed
+                // to the subject's NET class set; a retraction (negative delta) to its
+                // BASE class set (where the base stats counted it). When the subject's
+                // type is unchanged base == net, so this matches the prior behavior.
+                // Routing retractions to base makes a delete (type + props retracted in
+                // one batch) decrement the right class instead of an emptied net set.
+                //
+                // NOTE: a subject re-typed WITHOUT touching its properties has no entry
+                // in `novelty_subject_props` and is handled by the base-index re-scan
+                // below, not here.
+                for &(g_id, s_id) in novelty_subject_props.keys() {
+                    if changed_membership.contains(&(g_id, s_id)) {
+                        // Handled by the base-index re-scan below (Stage 2); skipping
+                        // here avoids double-counting its in-batch deltas.
+                        continue;
+                    }
+                    let net_cls = subject_classes.get(&(g_id, s_id));
+                    let base_cls = base_subject_classes.get(&(g_id, s_id));
+                    let mut classes_touched: std::collections::HashSet<u64> =
+                        std::collections::HashSet::new();
+                    if let Some(c) = net_cls {
+                        classes_touched.extend(c.iter().copied());
+                    }
+                    if let Some(c) = base_cls {
+                        classes_touched.extend(c.iter().copied());
+                    }
+                    let s_dts = novelty_subject_prop_dts.get(&(g_id, s_id));
+                    let s_langs = novelty_subject_prop_langs.get(&(g_id, s_id));
+                    for &class_sid64 in &classes_touched {
+                        let in_net = net_cls.is_some_and(|c| c.contains(&class_sid64));
+                        let in_base = base_cls.is_some_and(|c| c.contains(&class_sid64));
+                        if let Some(s_dts) = s_dts {
+                            for (&pid, dt_map) in s_dts {
+                                for (&dt, &cnt) in dt_map {
+                                    if (cnt > 0 && in_net) || (cnt < 0 && in_base) {
+                                        *class_prop_dts
+                                            .entry((g_id, class_sid64))
+                                            .or_default()
+                                            .entry(pid)
+                                            .or_default()
+                                            .entry(dt)
+                                            .or_insert(0) += cnt;
+                                        class_properties
+                                            .entry((g_id, class_sid64))
+                                            .or_default()
+                                            .insert(pid);
                                     }
                                 }
                             }
-                            if let Some(s_langs) = novelty_subject_prop_langs.get(&(g_id, s_id)) {
-                                for (&pid, lang_map) in s_langs {
-                                    let cl = class_prop_lang_deltas
-                                        .entry((g_id, class_sid64))
-                                        .or_default()
-                                        .entry(pid)
-                                        .or_default();
-                                    for (&lid, &cnt) in lang_map {
-                                        *cl.entry(lid).or_insert(0) += cnt;
+                        }
+                        if let Some(s_langs) = s_langs {
+                            for (&pid, lang_map) in s_langs {
+                                for (&lid, &cnt) in lang_map {
+                                    if (cnt > 0 && in_net) || (cnt < 0 && in_base) {
+                                        *class_prop_lang_deltas
+                                            .entry((g_id, class_sid64))
+                                            .or_default()
+                                            .entry(pid)
+                                            .or_default()
+                                            .entry(lid)
+                                            .or_insert(0) += cnt;
+                                        class_properties
+                                            .entry((g_id, class_sid64))
+                                            .or_default()
+                                            .insert(pid);
                                     }
                                 }
                             }
@@ -2097,9 +2158,16 @@ pub async fn incremental_index(
                     }
                 }
                 for (&(g_id, subj), per_prop) in &subject_ref_history {
-                    let Some(subj_classes) = subject_classes.get(&(g_id, subj)) else {
-                        continue;
-                    };
+                    let net_subj = subject_classes.get(&(g_id, subj));
+                    let base_subj = base_subject_classes.get(&(g_id, subj));
+                    let mut subj_classes_touched: std::collections::HashSet<u64> =
+                        std::collections::HashSet::new();
+                    if let Some(c) = net_subj {
+                        subj_classes_touched.extend(c.iter().copied());
+                    }
+                    if let Some(c) = base_subj {
+                        subj_classes_touched.extend(c.iter().copied());
+                    }
                     for (&pid, objs) in per_prop {
                         for (&obj, &delta) in objs {
                             if delta == 0 {
@@ -2108,7 +2176,15 @@ pub async fn incremental_index(
                             let Some(obj_classes) = subject_classes.get(&(g_id, obj)) else {
                                 continue;
                             };
-                            for &sc in subj_classes {
+                            // Route the edge by sign on the subject side (issue #1266):
+                            // an asserted edge attributes to the subject's NET class set,
+                            // a retracted edge to its BASE class set.
+                            for &sc in &subj_classes_touched {
+                                let in_net = net_subj.is_some_and(|c| c.contains(&sc));
+                                let in_base = base_subj.is_some_and(|c| c.contains(&sc));
+                                if !((delta > 0 && in_net) || (delta < 0 && in_base)) {
+                                    continue;
+                                }
                                 for &oc in obj_classes {
                                     *ref_edges
                                         .entry((g_id, sc))
@@ -2122,6 +2198,191 @@ pub async fn incremental_index(
                         }
                     }
                 }
+                // Stage 2 (issue #1266): re-attribute the EXISTING properties of
+                // subjects whose class membership changed this batch. The routing loop
+                // above skipped these subjects; here we read their live property set
+                // from the base index and move per-(property, datatype/lang) counts off
+                // the classes they left and onto the classes they joined.
+                //
+                // For each changed subject S with base class set `B` and net set `N`,
+                // and per-(p, dt) base count `old` plus in-batch delta `delta`
+                // (`new = old + delta`):
+                //   - class in B \ N (left):       apply -old
+                //   - class in N \ B (joined):     apply  new
+                //   - class in B ∩ N (kept):       apply  delta
+                //
+                // NOTE: ref-class edges for re-typed subjects are NOT moved here yet;
+                // that needs target-class resolution (and a reverse OPST pass for
+                // re-typed objects) and is tracked separately. Datatype and language
+                // distributions — which the COUNT(*) fast path consumes — are exact.
+                if let Some(ref store) = store_opt {
+                    if !changed_membership.is_empty() {
+                        let mut changed_by_graph: std::collections::HashMap<u16, Vec<u64>> =
+                            std::collections::HashMap::new();
+                        for &(g_id, s_id) in &changed_membership {
+                            changed_by_graph.entry(g_id).or_default().push(s_id);
+                        }
+                        for (&g_id, sids) in &changed_by_graph {
+                            let base_props =
+                                match fluree_db_binary_index::batched_lookup_subject_properties(
+                                    store,
+                                    g_id,
+                                    sids,
+                                    base_root.index_t,
+                                ) {
+                                    Ok(m) => m,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            g_id, error = %e,
+                                            "Phase 3b: base subject-property scan failed; \
+                                             re-typed subjects may keep stale class stats"
+                                        );
+                                        continue;
+                                    }
+                                };
+                            for &s_id in sids {
+                                let base_cls = base_subject_classes
+                                    .get(&(g_id, s_id))
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let net_cls = subject_classes
+                                    .get(&(g_id, s_id))
+                                    .cloned()
+                                    .unwrap_or_default();
+
+                                // combined[p][dt] = (old_count_from_base, in_batch_delta)
+                                let mut combined_dts: std::collections::HashMap<
+                                    u32,
+                                    std::collections::HashMap<u8, (i64, i64)>,
+                                > = std::collections::HashMap::new();
+                                let mut combined_langs: std::collections::HashMap<
+                                    u32,
+                                    std::collections::HashMap<u16, (i64, i64)>,
+                                > = std::collections::HashMap::new();
+
+                                if let Some(flakes) = base_props.get(&s_id) {
+                                    for &(p_id, o_type, o_key) in flakes {
+                                        if p_id == rdf_type_p_id {
+                                            continue;
+                                        }
+                                        let rec =
+                                            fluree_db_binary_index::format::run_record_v2::RunRecordV2 {
+                                                s_id: fluree_db_core::subject_id::SubjectId::from_u64(
+                                                    s_id,
+                                                ),
+                                                o_key,
+                                                p_id,
+                                                t: 0,
+                                                o_i: 0,
+                                                o_type,
+                                                g_id,
+                                            };
+                                        let sr = crate::stats::stats_record_from_v2(&rec, 1);
+                                        combined_dts
+                                            .entry(p_id)
+                                            .or_default()
+                                            .entry(sr.dt.as_u8())
+                                            .or_insert((0, 0))
+                                            .0 += 1;
+                                        if sr.lang_id != 0
+                                            && sr.dt
+                                                == fluree_db_core::value_id::ValueTypeTag::LANG_STRING
+                                        {
+                                            combined_langs
+                                                .entry(p_id)
+                                                .or_default()
+                                                .entry(sr.lang_id)
+                                                .or_insert((0, 0))
+                                                .0 += 1;
+                                        }
+                                    }
+                                }
+                                if let Some(s_dts) = novelty_subject_prop_dts.get(&(g_id, s_id)) {
+                                    for (&pid, dt_map) in s_dts {
+                                        for (&dt, &cnt) in dt_map {
+                                            combined_dts
+                                                .entry(pid)
+                                                .or_default()
+                                                .entry(dt)
+                                                .or_insert((0, 0))
+                                                .1 += cnt;
+                                        }
+                                    }
+                                }
+                                if let Some(s_langs) = novelty_subject_prop_langs.get(&(g_id, s_id)) {
+                                    for (&pid, lang_map) in s_langs {
+                                        for (&lid, &cnt) in lang_map {
+                                            combined_langs
+                                                .entry(pid)
+                                                .or_default()
+                                                .entry(lid)
+                                                .or_insert((0, 0))
+                                                .1 += cnt;
+                                        }
+                                    }
+                                }
+
+                                let mut classes_all: std::collections::HashSet<u64> =
+                                    std::collections::HashSet::new();
+                                classes_all.extend(base_cls.iter().copied());
+                                classes_all.extend(net_cls.iter().copied());
+                                for &c in &classes_all {
+                                    let in_base = base_cls.contains(&c);
+                                    let in_net = net_cls.contains(&c);
+                                    for (&pid, dt_map) in &combined_dts {
+                                        for (&dt, &(old, delta)) in dt_map {
+                                            let amt = if in_net && in_base {
+                                                delta
+                                            } else if in_net {
+                                                old + delta
+                                            } else {
+                                                -old
+                                            };
+                                            if amt != 0 {
+                                                *class_prop_dts
+                                                    .entry((g_id, c))
+                                                    .or_default()
+                                                    .entry(pid)
+                                                    .or_default()
+                                                    .entry(dt)
+                                                    .or_insert(0) += amt;
+                                                class_properties
+                                                    .entry((g_id, c))
+                                                    .or_default()
+                                                    .insert(pid);
+                                            }
+                                        }
+                                    }
+                                    for (&pid, lang_map) in &combined_langs {
+                                        for (&lid, &(old, delta)) in lang_map {
+                                            let amt = if in_net && in_base {
+                                                delta
+                                            } else if in_net {
+                                                old + delta
+                                            } else {
+                                                -old
+                                            };
+                                            if amt != 0 {
+                                                *class_prop_lang_deltas
+                                                    .entry((g_id, c))
+                                                    .or_default()
+                                                    .entry(pid)
+                                                    .or_default()
+                                                    .entry(lid)
+                                                    .or_insert(0) += amt;
+                                                class_properties
+                                                    .entry((g_id, c))
+                                                    .or_default()
+                                                    .insert(pid);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let class_property_count: usize = class_properties
                     .values()
                     .map(std::collections::HashSet::len)
@@ -2242,6 +2503,29 @@ pub async fn incremental_index(
                     "Phase 3b: cached class Sid values for property attribution merge"
                 );
 
+                // Ensure every class touched by a property/lang/ref delta this batch
+                // has an entry, even if it has no instance-count delta and is absent
+                // from the base stats (issue #1266: a class that only lost a property
+                // via retraction, or gained one via re-typing, must be revisited so its
+                // decrement/move is applied rather than dropped).
+                let mut delta_class_keys: std::collections::HashSet<(u16, u64)> =
+                    std::collections::HashSet::new();
+                delta_class_keys.extend(class_properties.keys().copied());
+                delta_class_keys.extend(class_prop_dts.keys().copied());
+                delta_class_keys.extend(class_prop_lang_deltas.keys().copied());
+                delta_class_keys.extend(ref_edges.keys().copied());
+                for (g_id, class_sid64) in delta_class_keys {
+                    entries_by_key.entry((g_id, class_sid64)).or_insert_with(|| {
+                        let class_sid =
+                            resolve_class_sid(class_sid64, store_opt.as_deref(), &new_subject_suffix);
+                        is::ClassStatEntry {
+                            class_sid,
+                            count: 0,
+                            properties: Vec::new(),
+                        }
+                    });
+                }
+
                 // Build property attribution for each class entry.
                 let property_merge_started = Instant::now();
                 tracing::debug!(
@@ -2261,13 +2545,25 @@ pub async fn incremental_index(
                 let mut next_merged_class_progress = 500usize;
                 for (&(g_id, class_sid64), entry) in &mut entries_by_key {
                     visited_class_entries += 1;
-                    if let Some(props) = class_properties.get(&(g_id, class_sid64)) {
+                    let class_dts = class_prop_dts.get(&(g_id, class_sid64));
+                    let class_refs = ref_edges.get(&(g_id, class_sid64));
+                    let class_langs = class_prop_lang_deltas.get(&(g_id, class_sid64));
+                    let class_props_present = class_properties.get(&(g_id, class_sid64));
+                    // Revisit a class if it was touched by ANY delta this batch. The
+                    // prior gate used only the assert-only presence set, so a class
+                    // whose sole change was a retraction (or a re-type moving a
+                    // property away) was never revisited and its decrement was dropped
+                    // (issue #1266). Untouched base classes still skip the body and
+                    // keep their existing property usage unchanged.
+                    if class_dts.is_some()
+                        || class_refs.is_some()
+                        || class_langs.is_some()
+                        || class_props_present.is_some()
+                    {
                         let class_merge_started = Instant::now();
                         let existing_property_count = entry.properties.len();
-                        let novelty_property_count = props.len();
-                        let class_dts = class_prop_dts.get(&(g_id, class_sid64));
-                        let class_refs = ref_edges.get(&(g_id, class_sid64));
-                        let class_langs = class_prop_lang_deltas.get(&(g_id, class_sid64));
+                        let novelty_property_count =
+                            class_props_present.map_or(0, std::collections::HashSet::len);
 
                         // Merge novelty properties with existing properties.
                         let mut prop_set: std::collections::HashSet<u32> = entry
@@ -2286,7 +2582,18 @@ pub async fn incremental_index(
                                 ))
                             })
                             .collect();
-                        prop_set.extend(props);
+                        if let Some(props) = class_props_present {
+                            prop_set.extend(props);
+                        }
+                        if let Some(m) = class_dts {
+                            prop_set.extend(m.keys().copied());
+                        }
+                        if let Some(m) = class_langs {
+                            prop_set.extend(m.keys().copied());
+                        }
+                        if let Some(m) = class_refs {
+                            prop_set.extend(m.keys().copied());
+                        }
 
                         // Index base property usage by p_id for merging.
                         let base_prop_by_pid: std::collections::HashMap<

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2060,9 +2060,7 @@ pub async fn incremental_index(
                 let changed_membership: std::collections::HashSet<(u16, u64)> =
                     novelty_subject_class_deltas
                         .keys()
-                        .filter(|key| {
-                            base_subject_classes.get(*key) != subject_classes.get(*key)
-                        })
+                        .filter(|key| base_subject_classes.get(*key) != subject_classes.get(*key))
                         .copied()
                         .collect();
 
@@ -2348,7 +2346,8 @@ pub async fn incremental_index(
                                         }
                                     }
                                 }
-                                if let Some(s_langs) = novelty_subject_prop_langs.get(&(g_id, s_id)) {
+                                if let Some(s_langs) = novelty_subject_prop_langs.get(&(g_id, s_id))
+                                {
                                     for (&pid, lang_map) in s_langs {
                                         for (&lid, &cnt) in lang_map {
                                             combined_langs
@@ -2509,8 +2508,7 @@ pub async fn incremental_index(
                                         .unwrap_or_default();
                                     (base, net)
                                 } else {
-                                    let cls =
-                                        external_base.get(&sid).cloned().unwrap_or_default();
+                                    let cls = external_base.get(&sid).cloned().unwrap_or_default();
                                     (cls.clone(), cls)
                                 }
                             };
@@ -2678,15 +2676,20 @@ pub async fn incremental_index(
                 delta_class_keys.extend(class_prop_lang_deltas.keys().copied());
                 delta_class_keys.extend(ref_edges.keys().copied());
                 for (g_id, class_sid64) in delta_class_keys {
-                    entries_by_key.entry((g_id, class_sid64)).or_insert_with(|| {
-                        let class_sid =
-                            resolve_class_sid(class_sid64, store_opt.as_deref(), &new_subject_suffix);
-                        is::ClassStatEntry {
-                            class_sid,
-                            count: 0,
-                            properties: Vec::new(),
-                        }
-                    });
+                    entries_by_key
+                        .entry((g_id, class_sid64))
+                        .or_insert_with(|| {
+                            let class_sid = resolve_class_sid(
+                                class_sid64,
+                                store_opt.as_deref(),
+                                &new_subject_suffix,
+                            );
+                            is::ClassStatEntry {
+                                class_sid,
+                                count: 0,
+                                properties: Vec::new(),
+                            }
+                        });
                 }
 
                 // Build property attribution for each class entry.

--- a/fluree-db-indexer/src/config.rs
+++ b/fluree-db-indexer/src/config.rs
@@ -174,6 +174,16 @@ pub struct IndexerConfig {
     /// `None` means no limit (backwards-compatible default).
     pub incremental_max_commit_bytes: Option<usize>,
 
+    /// Maximum number of *existing* subjects whose `rdf:type` set may change in
+    /// a single incremental batch before incremental indexing aborts and defers
+    /// to a full rebuild. Re-typing (or deleting) an existing subject forces a
+    /// base-index re-scan to move its class-scoped property/ref stats (issue
+    /// #1266); above this count, recomputing class stats from scratch via the
+    /// rebuild SPOT pass is cheaper and simpler. Counts only subjects that
+    /// existed in the base index (new-subject inserts are free). Default
+    /// [`DEFAULT_INCREMENTAL_RETYPE_MAX_SUBJECTS`].
+    pub incremental_retype_max_subjects: usize,
+
     /// Configured full-text properties for this indexing run.
     ///
     /// Caller-computed (typically by `fluree-db-api` resolving the ledger's
@@ -208,6 +218,10 @@ pub const DEFAULT_INCREMENTAL_MAX_COMMITS: usize = 10_000;
 /// Default max concurrency for incremental branch updates.
 pub const DEFAULT_INCREMENTAL_MAX_CONCURRENCY: usize = 4;
 
+/// Default cap on existing-subject `rdf:type` changes per incremental batch
+/// before deferring to full rebuild (issue #1266 ref/class-stat re-attribution).
+pub const DEFAULT_INCREMENTAL_RETYPE_MAX_SUBJECTS: usize = 100_000;
+
 impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
@@ -225,6 +239,7 @@ impl Default for IndexerConfig {
             leaflet_rows: 25_000,
             leaflets_per_leaf: 10,
             incremental_max_commit_bytes: None,
+            incremental_retype_max_subjects: DEFAULT_INCREMENTAL_RETYPE_MAX_SUBJECTS,
             fulltext_configured_properties: Vec::new(),
             fulltext_config_provider: None,
         }
@@ -254,6 +269,7 @@ impl IndexerConfig {
             leaflet_rows: 25_000,
             leaflets_per_leaf: 10,
             incremental_max_commit_bytes: None,
+            incremental_retype_max_subjects: DEFAULT_INCREMENTAL_RETYPE_MAX_SUBJECTS,
             fulltext_configured_properties: Vec::new(),
             fulltext_config_provider: None,
         }
@@ -276,6 +292,7 @@ impl IndexerConfig {
             leaflet_rows: 25_000,
             leaflets_per_leaf: 10,
             incremental_max_commit_bytes: None,
+            incremental_retype_max_subjects: DEFAULT_INCREMENTAL_RETYPE_MAX_SUBJECTS,
             fulltext_configured_properties: Vec::new(),
             fulltext_config_provider: None,
         }
@@ -298,6 +315,7 @@ impl IndexerConfig {
             leaflet_rows: 25_000,
             leaflets_per_leaf: 10,
             incremental_max_commit_bytes: None,
+            incremental_retype_max_subjects: DEFAULT_INCREMENTAL_RETYPE_MAX_SUBJECTS,
             fulltext_configured_properties: Vec::new(),
             fulltext_config_provider: None,
         }
@@ -369,6 +387,13 @@ impl IndexerConfig {
     /// Builder method to set the maximum concurrency for incremental branch updates
     pub fn with_incremental_max_concurrency(mut self, max_concurrency: usize) -> Self {
         self.incremental_max_concurrency = max_concurrency.max(1);
+        self
+    }
+
+    /// Builder method to set the per-batch cap on existing-subject `rdf:type`
+    /// changes before incremental indexing defers to a full rebuild (#1266).
+    pub fn with_incremental_retype_max_subjects(mut self, max_subjects: usize) -> Self {
+        self.incremental_retype_max_subjects = max_subjects;
         self
     }
 }

--- a/fluree-db-indexer/src/stats/id_hook.rs
+++ b/fluree-db-indexer/src/stats/id_hook.rs
@@ -392,8 +392,13 @@ impl IdStatsHook {
                         .entry(rec.o_key)
                         .or_insert(0) += delta;
                 }
-            } else if !self.hll_only && rec.op {
-                // Non-rdf:type property assertion: track per-subject and per-class
+            } else if !self.hll_only {
+                // Non-rdf:type property flake: track per-subject property presence on
+                // BOTH assertions and retractions. Recording retractions here (issue
+                // #1266) lets the incremental class-stat merge revisit a class whose
+                // only change this batch is a retraction, so its datatype/lang/ref
+                // decrement is applied instead of silently dropped. The set is now
+                // "properties touched this batch", not "asserted this batch".
                 self.subject_props
                     .entry((rec.g_id, rec.s_id))
                     .or_default()

--- a/fluree-db-query/Cargo.toml
+++ b/fluree-db-query/Cargo.toml
@@ -21,6 +21,7 @@ fluree-db-spatial = { path = "../fluree-db-spatial" }
 memmap2 = "0.9"
 futures = { workspace = true }
 async-trait = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -213,7 +213,7 @@ pub struct BinaryScanOperator {
 
 /// A filter that can be evaluated on encoded index columns (no term decoding).
 #[derive(Clone, Debug)]
-enum EncodedPreFilter {
+pub(crate) enum EncodedPreFilter {
     /// `FILTER(LANG(?o) = "<tag>")` for the object var `?o` in this scan.
     LangEqualsOType { required_otype: u16 },
     /// `FILTER(ISBLANK(?o))` for the object var `?o` in this scan.
@@ -232,7 +232,7 @@ enum EncodedPreFilter {
 
 impl EncodedPreFilter {
     #[inline]
-    fn eval_row(&self, s_id: u64, o_type: u16, o_key: u64) -> bool {
+    pub(crate) fn eval_row(&self, s_id: u64, o_type: u16, o_key: u64) -> bool {
         match self {
             EncodedPreFilter::LangEqualsOType { required_otype } => o_type == *required_otype,
             EncodedPreFilter::ObjectIsBlankNode => {
@@ -266,7 +266,7 @@ impl EncodedPreFilter {
     }
 }
 
-fn compile_encoded_pre_filters_and_prune_inline_ops(
+pub(crate) fn compile_encoded_pre_filters_and_prune_inline_ops(
     inline_ops: &[InlineOperator],
     pattern: &TriplePattern,
     store: &BinaryIndexStore,

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -751,6 +751,197 @@ fn intersect_sorted_pair(a: &[u64], b: &[u64]) -> Vec<u64> {
 /// the strategy conservative (no regression vs the symmetric merge).
 const SEEK_STAR_DRIVER_FACTOR: u64 = 8192;
 
+/// Minimum total rows across the star's predicates before the parallel
+/// partitioned merge is worth its thread-spawn overhead. Below this the serial
+/// merge is used. (A wrong choice only affects speed, never the count.)
+const PARALLEL_STAR_MIN_ROWS: u64 = 50_000;
+/// Cap on partitions regardless of core count.
+const PARALLEL_STAR_MAX_PARTITIONS: usize = 16;
+
+/// N-way merge-join COUNT over the subject range `[lo, hi)` of `p_ids`, using
+/// bounded base-leaflet iterators. Returns `Σ_{s ∈ [lo,hi)} Π_i count_i(s)` —
+/// the partial count for one partition. BASE index only (no overlay).
+fn merge_count_range(
+    store: &BinaryIndexStore,
+    g_id: fluree_db_core::GraphId,
+    p_ids: &[u32],
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let mut iters: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(p_ids.len());
+    for &p_id in p_ids {
+        iters.push(PsotSubjectCountIter::new_bounded(store, g_id, p_id, lo, hi)?);
+    }
+    let mut curr: Vec<Option<(u64, u64)>> = Vec::with_capacity(iters.len());
+    for it in &mut iters {
+        curr.push(it.next_group()?);
+    }
+    let mut total: u128 = 0;
+    loop {
+        if curr.iter().any(std::option::Option::is_none) {
+            break;
+        }
+        let max_s = curr.iter().filter_map(|c| c.map(|(s, _)| s)).max().unwrap();
+        if curr.iter().all(|c| c.map(|(s, _)| s) == Some(max_s)) {
+            let product: u128 = curr.iter().map(|c| c.unwrap().1 as u128).product();
+            total = total.saturating_add(product);
+            for (i, it) in iters.iter_mut().enumerate() {
+                curr[i] = it.next_group()?;
+            }
+        } else {
+            for (i, it) in iters.iter_mut().enumerate() {
+                if let Some((s_id, _)) = curr[i] {
+                    if s_id < max_s {
+                        curr[i] = it.next_group()?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(total)
+}
+
+/// Ascending candidate subject boundaries for partitioning a predicate's scan.
+///
+/// When the predicate has at least `k` leaves, returns each leaf's first subject
+/// straight from the in-memory manifest (no leaf opens) — the huge-predicate case
+/// (e.g. `rdf:type`, thousands of leaves). Otherwise opens the few leaves and
+/// returns each matching leaflet's first subject, giving finer boundaries for a
+/// predicate that fits in one/few leaves but many leaflets. The returned values
+/// are non-decreasing (leaves and leaflets are subject-sorted).
+fn driver_subject_boundaries(
+    store: &BinaryIndexStore,
+    g_id: fluree_db_core::GraphId,
+    p_id: u32,
+    k: usize,
+) -> Result<Vec<u64>> {
+    let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
+    if leaves.len() >= k {
+        return Ok(leaves.iter().map(|e| e.first_key.s_id.as_u64()).collect());
+    }
+    use fluree_db_binary_index::format::run_record_v2::read_ordered_key_v2;
+    let mut bounds: Vec<u64> = Vec::new();
+    for leaf in leaves {
+        let handle = store
+            .open_leaf_handle(&leaf.leaf_cid, leaf.sidecar_cid.as_ref(), false)
+            .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;
+        for entry in &handle.dir().entries {
+            if entry.row_count == 0 || entry.p_const != Some(p_id) {
+                continue;
+            }
+            let first = read_ordered_key_v2(RunSortOrder::Psot, &entry.first_key);
+            bounds.push(first.s_id.as_u64());
+        }
+    }
+    Ok(bounds)
+}
+
+/// Parallel partitioned variant of the inner-star count merge.
+///
+/// Partitions the subject space into K contiguous ranges at leaf boundaries and
+/// runs the N-way merge per range on its own thread, then sums the partials.
+/// Because partition boundaries are subject VALUES and every subject's rows are
+/// contiguous within a predicate, each subject lands in exactly one partition —
+/// so the partials sum exactly. Parallelizes both leaflet decompression AND the
+/// merge (one step past QLever, which keeps the merge serial). Returns `Ok(None)`
+/// to defer to the serial merge when not applicable (not all `SubjectCountScan`,
+/// a predicate absent, too few rows/leaves, or a single core). BASE index only:
+/// caller ensures `!ec.overlay` and no exclude/include filter.
+fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Result<Option<u64>> {
+    if children.len() < 2 {
+        return Ok(None);
+    }
+    let mut p_ids: Vec<u32> = Vec::with_capacity(children.len());
+    let mut total_rows: u64 = 0;
+    for child in children {
+        let StreamNode::SubjectCountScan { pred } = child else {
+            return Ok(None);
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        let Some(p_id) = ec.store.sid_to_p_id(&sid) else {
+            return Ok(None);
+        };
+        p_ids.push(p_id);
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+    }
+
+    let ncpu = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
+    if ncpu < 2 || total_rows < PARALLEL_STAR_MIN_ROWS {
+        return Ok(None);
+    }
+
+    // Partition driver = the predicate with the most leaves (finest boundaries).
+    let driver_p = *p_ids
+        .iter()
+        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    let k = ncpu.min(PARALLEL_STAR_MAX_PARTITIONS);
+    // Candidate ascending subject boundaries from the driver: leaf first-subjects
+    // when there are enough leaves (manifest only, no leaf opens — the huge-
+    // predicate case), else leaflet first-subjects (opens the few driver leaves,
+    // which the merge scans anyway — the medium single-leaf-many-leaflet case).
+    let candidates = driver_subject_boundaries(ec.store, ec.g_id, driver_p, k)?;
+    if candidates.len() < 2 {
+        return Ok(None);
+    }
+    // Subsample to ~K strictly-increasing boundaries: 0 = b_0 < … < b_K = MAX.
+    let mut bounds: Vec<u64> = vec![0];
+    for j in 1..k {
+        let b = candidates[j * candidates.len() / k];
+        if b > *bounds.last().unwrap() {
+            bounds.push(b);
+        }
+    }
+    bounds.push(u64::MAX);
+    if bounds.len() < 3 {
+        // Fewer than two real partitions — not worth parallelizing.
+        return Ok(None);
+    }
+    let ranges: Vec<(u64, u64)> = bounds.windows(2).map(|w| (w[0], w[1])).collect();
+    tracing::debug!(
+        partitions = ranges.len(),
+        total_rows,
+        predicates = p_ids.len(),
+        "count-plan: parallel partitioned star-join"
+    );
+
+    let store: &BinaryIndexStore = ec.store;
+    let g_id = ec.g_id;
+    let p_ids_ref = &p_ids;
+    let span = tracing::Span::current();
+
+    let partials: Vec<Result<u128>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = ranges
+            .iter()
+            .map(|&(lo, hi)| {
+                let span = span.clone();
+                scope.spawn(move || {
+                    let _guard = span.enter();
+                    merge_count_range(store, g_id, p_ids_ref, lo, hi)
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| {
+                h.join().unwrap_or_else(|_| {
+                    Err(QueryError::execution("parallel star-join worker panicked"))
+                })
+            })
+            .collect()
+    });
+
+    let mut total: u128 = 0;
+    for partial in partials {
+        total = total.saturating_add(partial?);
+    }
+    Ok(Some(total.min(u64::MAX as u128) as u64))
+}
+
 fn sum_star_join(
     children: &[StreamNode],
     ec: &ExecCtx<'_, '_>,
@@ -766,6 +957,13 @@ fn sum_star_join(
             try_sum_star_join_seek(children, ec, exclude_sorted, include_sorted)?
         {
             return Ok(Some(total));
+        }
+        // Both-large plain star (no modifiers): partition the subject space and
+        // run the merge across cores. Parallelizes decompression + merge.
+        if exclude_sorted.is_none() && include_sorted.is_none() {
+            if let Some(total) = sum_star_join_parallel(children, ec)? {
+                return Ok(Some(total));
+            }
         }
     }
 

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -960,7 +960,6 @@ fn driver_subject_boundaries(
 /// merge (one step past QLever, which keeps the merge serial). Returns `Ok(None)`
 /// to defer to the serial merge when not applicable (not all `SubjectCountScan`,
 /// a predicate absent, too few rows/leaves, or a single core). BASE index only:
-/// caller ensures `!ec.overlay` and no exclude/include filter.
 /// Generic parallel-partitioned count harness.
 ///
 /// Partitions the subject space into K contiguous ranges at `driver_p`'s
@@ -971,9 +970,10 @@ fn driver_subject_boundaries(
 /// rows are contiguous within a predicate, each subject lands in exactly one
 /// partition — the partials sum exactly. Returns `Ok(None)` to defer to the serial
 /// path when there aren't enough rows/leaves/cores to be worth parallelizing.
-/// BASE index only: the caller must ensure `!ec.overlay`.
-fn parallel_partition_count<F>(
-    ec: &ExecCtx<'_, '_>,
+/// BASE index only: the caller must ensure no overlay/time-travel.
+pub(crate) fn parallel_partition_count<F>(
+    store: &BinaryIndexStore,
+    g_id: fluree_db_core::GraphId,
     driver_p: u32,
     total_rows: u64,
     reducer: F,
@@ -993,7 +993,7 @@ where
     // when there are enough leaves (manifest only, no leaf opens — the huge-
     // predicate case), else leaflet first-subjects (opens the few driver leaves,
     // which the reducer scans anyway — the medium single-leaf-many-leaflet case).
-    let candidates = driver_subject_boundaries(ec.store, ec.g_id, driver_p, k)?;
+    let candidates = driver_subject_boundaries(store, g_id, driver_p, k)?;
     if candidates.len() < 2 {
         return Ok(None);
     }
@@ -1072,7 +1072,7 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
         .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
         .unwrap();
 
-    parallel_partition_count(ec, driver_p, total_rows, |lo, hi| {
+    parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
         merge_count_range(ec.store, ec.g_id, &p_ids, lo, hi)
     })
 }
@@ -1142,7 +1142,7 @@ fn sum_optional_join_parallel(
         .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
         .unwrap();
 
-    parallel_partition_count(ec, driver_p, total_rows, |lo, hi| {
+    parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
         merge_optional_count_range(ec.store, ec.g_id, &req_pids, &opt_groups, lo, hi)
     })
 }

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -1826,22 +1826,18 @@ fn try_modifier_intersect_overlay_parallel(
 /// `Σ_{s typed} count_rdftype(s)·count_P(s)` — exactly the join's product-sum.
 /// Reads the per-graph class stats straight from the snapshot (no index scan).
 ///
-/// CORRECTNESS GATE: the per-(class,property) counts are current-state-exact only
-/// for a pure bulk import (full build). The incremental build path drops a
-/// retraction-only class delta (a known limitation: `subject_props` presence is
-/// assert-only, so the class merge never revisits the class to apply the
-/// `class_prop_dts` decrement). Bulk import is the only path that sets
-/// `lex_sorted_string_ids`, and any incremental refresh clears it — so it is a
-/// reliable proxy for "class stats untouched by incremental drift". When false we
-/// defer to the merge, which is always correct.
+/// The per-(class,property) DATATYPE counts this fold sums are current-state-exact
+/// on BOTH the bulk-import and incremental paths: the incremental class-stat merge
+/// applies retraction and re-type deltas via base-vs-net attribution plus a
+/// base-index re-scan of re-typed subjects (issue #1266). So the fold runs for any
+/// index, not just bulk imports — there is no longer a `lex_sorted_string_ids`
+/// gate here. (Ref-class edge counts are not consumed by this fold.)
 ///
-/// Returns `Ok(None)` to defer to the merge when: not a bulk-import index, the
-/// shape isn't exactly one rdf:type leg plus one non-type leg, the graph class
-/// stats are absent, or the fold is 0 (a genuinely-empty join — the merge handles
-/// it).
+/// Returns `Ok(None)` to defer to the merge when: the shape isn't exactly one
+/// rdf:type leg plus one non-type leg, the graph class stats are absent, or the
+/// fold is 0 (a genuinely-empty join — the merge handles it).
 fn try_type_star_pred_fold(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Result<Option<u64>> {
-    // Only trust the class-property stats when the index is a pure bulk import.
-    if !ec.store.lex_sorted_string_ids() || children.len() != 2 {
+    if children.len() != 2 {
         return Ok(None);
     }
     let mut sids = Vec::with_capacity(2);
@@ -1900,9 +1896,10 @@ fn sum_star_join(
     include_sorted: Option<&[u64]>,
 ) -> Result<Option<u64>> {
     // rdf:type inner-star (?s rdf:type ?o1 . ?s P ?o2) COUNT(*): answer from the
-    // per-(class,property) flake counts in the index stats — zero scan, instant.
-    // Only fires for bulk-import indexes (where the class stats are exact); any
-    // incremental refresh defers to the merge below.
+    // per-(class,property) datatype counts in the index stats — zero scan, instant.
+    // The counts are current-state-exact on both bulk-import and incremental
+    // indexes (issue #1266), so this runs for any base-index read; overlay reads
+    // still defer to the merge below.
     if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
         if let Some(total) = try_type_star_pred_fold(children, ec)? {
             return Ok(Some(total));

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -786,6 +786,20 @@ const PARALLEL_STAR_MIN_ROWS: u64 = 50_000;
 /// Cap on partitions regardless of core count.
 const PARALLEL_STAR_MAX_PARTITIONS: usize = 16;
 
+/// Cheap pre-gate for the partitioned-merge fast paths: true only when there are
+/// enough cores and rows to make parallelism worthwhile. The overlay-parallel
+/// wrappers call this *before* collecting/resolving novelty ops, so that small or
+/// single-core inputs skip that walk entirely and fall straight through to the
+/// serial cursor-merge (which would otherwise redo the same overlay collection).
+/// `parallel_partition_count` re-checks the identical condition, so the two never
+/// disagree.
+pub(crate) fn parallel_count_gate_open(total_rows: u64) -> bool {
+    let ncpu = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
+    ncpu >= 2 && total_rows >= PARALLEL_STAR_MIN_ROWS
+}
+
 /// N-way merge-join COUNT over the subject range `[lo, hi)` of `p_ids`, using
 /// bounded base-leaflet iterators. Returns `Σ_{s ∈ [lo,hi)} Π_i count_i(s)` —
 /// the partial count for one partition. BASE index only (no overlay).
@@ -1011,12 +1025,12 @@ pub(crate) fn parallel_partition_count<F>(
 where
     F: Fn(u64, u64) -> Result<u128> + Sync,
 {
+    if !parallel_count_gate_open(total_rows) {
+        return Ok(None);
+    }
     let ncpu = std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
         .unwrap_or(1);
-    if ncpu < 2 || total_rows < PARALLEL_STAR_MIN_ROWS {
-        return Ok(None);
-    }
 
     let k = ncpu.min(PARALLEL_STAR_MAX_PARTITIONS);
     // Candidate ascending subject boundaries from the driver: leaf first-subjects
@@ -1188,6 +1202,13 @@ fn sum_star_join_overlay_parallel(
             total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
         p_ids.push(p_id);
         sids.push(sid);
+    }
+
+    // Pre-gate: if the partitioned merge wouldn't fire anyway (too few rows/cores),
+    // bail before walking novelty — the serial cursor-merge fallback re-collects the
+    // same overlay ops, so doing it here would be pure double work (a regression).
+    if !parallel_count_gate_open(total_rows) {
+        return Ok(None);
     }
 
     // Collect + resolve each predicate's overlay ops once (serial; novelty is small).
@@ -1467,6 +1488,12 @@ fn sum_optional_join_overlay_parallel(
         }
         opt_groups.push(pids);
         opt_sids.push(sids);
+    }
+
+    // Pre-gate before walking novelty: the serial fallback re-collects these ops, so
+    // collecting them here only to fail the parallel gate would be double work.
+    if !parallel_count_gate_open(total_rows) {
+        return Ok(None);
     }
 
     let collect =
@@ -1795,6 +1822,12 @@ fn try_modifier_intersect_overlay_parallel(
     for &p in &inner_pids {
         total_rows =
             total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p)?);
+    }
+
+    // Pre-gate before walking novelty: the serial keyset fallback re-collects these
+    // ops, so collecting them here only to fail the parallel gate is double work.
+    if !parallel_count_gate_open(total_rows) {
+        return Ok(None);
     }
 
     let Some(outer_ops) =

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -18,14 +18,15 @@ use crate::count_plan::{
 };
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
-    allow_cursor_fast_path, build_count_batch, build_post_cursor_for_predicate,
-    build_psot_cursor_for_predicate, collect_subjects_for_predicate_set,
-    collect_subjects_for_predicate_sorted, collect_subjects_with_object_in_set,
-    count_rows_for_predicate_psot, cursor_projection_otype_okey, cursor_projection_sid_only,
-    cursor_projection_sid_otype_okey, intersect_many_sorted, leaf_entries_for_predicate,
-    normalize_pred_sid, projection_sid_otype_okey, sum_post_object_counts_filtered,
-    CursorSubjectCountStream, FastPathOperator, ObjectFilterMode, PostObjectGroupCountIter,
-    PsotObjectFilterCountIter, PsotSubjectCountIter, PsotSubjectSeek, PsotSubjectWeightedSumIter,
+    allow_cursor_fast_path, build_count_batch, build_overlay_cursor_for_subject_range,
+    build_post_cursor_for_predicate, build_psot_cursor_for_predicate, collect_resolved_overlay_ops,
+    collect_subjects_for_predicate_set, collect_subjects_for_predicate_sorted,
+    collect_subjects_with_object_in_set, count_rows_for_predicate_psot, cursor_projection_otype_okey,
+    cursor_projection_sid_only, cursor_projection_sid_otype_okey, intersect_many_sorted,
+    leaf_entries_for_predicate, normalize_pred_sid, projection_sid_otype_okey,
+    slice_overlay_ops_by_subject, sum_post_object_counts_filtered, CursorSubjectCountStream,
+    FastPathOperator, ObjectFilterMode, PostObjectGroupCountIter, PsotObjectFilterCountIter,
+    PsotSubjectCountIter, PsotSubjectSeek, PsotSubjectWeightedSumIter,
 };
 use crate::ir::triple::Ref;
 use crate::operator::BoxedOperator;
@@ -1070,6 +1071,130 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
     })
 }
 
+/// Overlay/time-travel variant of `merge_count_range` for one subject partition:
+/// the N-way inner-star merge over `[lo, hi)`, but each predicate is read through a
+/// *bounded overlay cursor* (its leaves in `[lo, hi)` plus its novelty ops sliced to
+/// that range) rather than a base-only iterator, so novelty is folded in. A
+/// `max_s ∈ [lo, hi)` guard keeps subjects in boundary leaves (shared with an
+/// adjacent partition) counted by exactly one partition. `ops_per_pred[i]` are the
+/// resolved overlay ops for `p_ids[i]`, collected once by the caller.
+#[allow(clippy::too_many_arguments)]
+fn merge_count_range_overlay(
+    store: &Arc<BinaryIndexStore>,
+    g_id: fluree_db_core::GraphId,
+    p_ids: &[u32],
+    ops_per_pred: &[Vec<fluree_db_binary_index::read::types::OverlayOp>],
+    to_t: i64,
+    epoch: u64,
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let mut streams: Vec<CursorSubjectCountStream> = Vec::with_capacity(p_ids.len());
+    for (i, &p_id) in p_ids.iter().enumerate() {
+        let sliced = slice_overlay_ops_by_subject(&ops_per_pred[i], lo, hi);
+        let Some(cursor) = build_overlay_cursor_for_subject_range(
+            store,
+            g_id,
+            p_id,
+            cursor_projection_sid_only(),
+            lo,
+            hi,
+            sliced,
+            to_t,
+            epoch,
+        ) else {
+            return Ok(0); // PSOT branch absent => empty intersection
+        };
+        streams.push(CursorSubjectCountStream::new(cursor));
+    }
+
+    let mut curr: Vec<Option<(u64, u64)>> = Vec::with_capacity(streams.len());
+    for s in &mut streams {
+        curr.push(s.next_group()?);
+    }
+    let mut total: u128 = 0;
+    loop {
+        if curr.iter().any(std::option::Option::is_none) {
+            break;
+        }
+        let max_s = curr.iter().filter_map(|c| c.map(|(s, _)| s)).max().unwrap();
+        if curr.iter().all(|c| c.map(|(s, _)| s) == Some(max_s)) {
+            if max_s >= lo && max_s < hi {
+                let product: u128 = curr.iter().map(|c| c.unwrap().1 as u128).product();
+                total = total.saturating_add(product);
+            }
+            for (i, s) in streams.iter_mut().enumerate() {
+                curr[i] = s.next_group()?;
+            }
+        } else {
+            for (i, s) in streams.iter_mut().enumerate() {
+                if let Some((s_id, _)) = curr[i] {
+                    if s_id < max_s {
+                        curr[i] = s.next_group()?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(total)
+}
+
+/// Overlay/time-travel parallel inner-star `COUNT(*)`: like `sum_star_join_parallel`
+/// but folds novelty. Collects each predicate's resolved overlay ops once, then runs
+/// the bounded-overlay N-way merge per subject partition on the shared pool. Returns
+/// `Ok(None)` to defer to the serial cursor merge for any non-plain shape, an absent
+/// predicate (novelty-only or missing — serial/general handles it), an
+/// overlay-translation failure, or too few rows.
+fn sum_star_join_overlay_parallel(
+    children: &[StreamNode],
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    if children.len() < 2 {
+        return Ok(None);
+    }
+    let mut p_ids: Vec<u32> = Vec::with_capacity(children.len());
+    let mut sids = Vec::with_capacity(children.len());
+    let mut total_rows: u64 = 0;
+    for child in children {
+        let StreamNode::SubjectCountScan { pred } = child else {
+            return Ok(None);
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        let Some(p_id) = ec.store.sid_to_p_id(&sid) else {
+            return Ok(None); // absent in base => defer (serial bails to general)
+        };
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+        p_ids.push(p_id);
+        sids.push(sid);
+    }
+
+    // Collect + resolve each predicate's overlay ops once (serial; novelty is small).
+    let mut ops_per_pred: Vec<Vec<fluree_db_binary_index::read::types::OverlayOp>> =
+        Vec::with_capacity(sids.len());
+    for sid in &sids {
+        match collect_resolved_overlay_ops(ec.ctx, ec.store, ec.g_id, RunSortOrder::Psot, sid)? {
+            Some(ops) => ops_per_pred.push(ops),
+            None => return Ok(None),
+        }
+    }
+    let to_t = ec.ctx.to_t;
+    let epoch = ec.ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
+
+    let driver_p = *p_ids
+        .iter()
+        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    let store = ec.store;
+    let g_id = ec.g_id;
+    let p_ids_ref = &p_ids;
+    let ops_ref = &ops_per_pred;
+    parallel_partition_count(store, g_id, driver_p, total_rows, move |lo, hi| {
+        merge_count_range_overlay(store, g_id, p_ids_ref, ops_ref, to_t, epoch, lo, hi)
+    })
+}
+
 /// Parallel partitioned variant of `sum_optional_join` for the all-present-
 /// predicate shape (single/star required + optional groups of `SubjectCountScan`s).
 /// Partitions by the required side and runs the optional merge per range. Returns
@@ -1388,6 +1513,15 @@ fn sum_star_join(
             if let Some(total) = sum_star_join_parallel(children, ec)? {
                 return Ok(Some(total));
             }
+        }
+    }
+
+    // Overlay/time-travel plain star: parallelize the base scan and fold novelty
+    // per partition (bounded overlay cursors). Falls through to the serial cursor
+    // merge below for small inputs, absent predicates, or translation failures.
+    if ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+        if let Some(total) = sum_star_join_overlay_parallel(children, ec)? {
+            return Ok(Some(total));
         }
     }
 

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -942,12 +942,98 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
     Ok(Some(total.min(u64::MAX as u128) as u64))
 }
 
+/// Metadata-only fold for the rdf:type inner-star count:
+///
+/// `COUNT(*)` of `?s rdf:type ?o1 . ?s P ?o2` = `Σ_C Σ_dt classStat[C][P].count`.
+///
+/// The per-`(class, property)` flake count attributes each `P`-flake on a
+/// `k`-typed subject once per class, so summing over all classes yields
+/// `Σ_{s typed} count_rdftype(s)·count_P(s)` — exactly the join's product-sum.
+/// Reads the per-graph class stats straight from the snapshot (no index scan).
+///
+/// CORRECTNESS GATE: the per-(class,property) counts are current-state-exact only
+/// for a pure bulk import (full build). The incremental build path drops a
+/// retraction-only class delta (a known limitation: `subject_props` presence is
+/// assert-only, so the class merge never revisits the class to apply the
+/// `class_prop_dts` decrement). Bulk import is the only path that sets
+/// `lex_sorted_string_ids`, and any incremental refresh clears it — so it is a
+/// reliable proxy for "class stats untouched by incremental drift". When false we
+/// defer to the merge, which is always correct.
+///
+/// Returns `Ok(None)` to defer to the merge when: not a bulk-import index, the
+/// shape isn't exactly one rdf:type leg plus one non-type leg, the graph class
+/// stats are absent, or the fold is 0 (a genuinely-empty join — the merge handles
+/// it).
+fn try_type_star_pred_fold(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Result<Option<u64>> {
+    // Only trust the class-property stats when the index is a pure bulk import.
+    if !ec.store.lex_sorted_string_ids() || children.len() != 2 {
+        return Ok(None);
+    }
+    let mut sids = Vec::with_capacity(2);
+    for child in children {
+        let StreamNode::SubjectCountScan { pred } = child else {
+            return Ok(None);
+        };
+        sids.push(normalize_pred_sid(ec.store, pred)?);
+    }
+    // Exactly one rdf:type leg; the other is the value predicate P.
+    let value_sid = match (
+        fluree_db_core::is_rdf_type(&sids[0]),
+        fluree_db_core::is_rdf_type(&sids[1]),
+    ) {
+        (true, false) => &sids[1],
+        (false, true) => &sids[0],
+        _ => return Ok(None),
+    };
+
+    let Some(stats) = ec.ctx.active_snapshot.stats.as_ref() else {
+        return Ok(None);
+    };
+    let Some(graphs) = stats.graphs.as_ref() else {
+        return Ok(None);
+    };
+    let Some(graph) = graphs.iter().find(|g| g.g_id == ec.g_id) else {
+        return Ok(None);
+    };
+    let Some(classes) = graph.classes.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut total: u128 = 0;
+    for class in classes {
+        if let Some(prop) = class
+            .properties
+            .iter()
+            .find(|p| &p.property_sid == value_sid)
+        {
+            for &(_dt, count) in &prop.datatypes {
+                total = total.saturating_add(count as u128);
+            }
+        }
+    }
+    if total == 0 {
+        // Genuinely-empty join: let the merge confirm it.
+        return Ok(None);
+    }
+    Ok(Some(total.min(u64::MAX as u128) as u64))
+}
+
 fn sum_star_join(
     children: &[StreamNode],
     ec: &ExecCtx<'_, '_>,
     exclude_sorted: Option<&[u64]>,
     include_sorted: Option<&[u64]>,
 ) -> Result<Option<u64>> {
+    // rdf:type inner-star (?s rdf:type ?o1 . ?s P ?o2) COUNT(*): answer from the
+    // per-(class,property) flake counts in the index stats — zero scan, instant.
+    // Only fires for bulk-import indexes (where the class stats are exact); any
+    // incremental refresh defers to the merge below.
+    if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+        if let Some(total) = try_type_star_pred_fold(children, ec)? {
+            return Ok(Some(total));
+        }
+    }
+
     // Asymmetric (leapfrog) strategy: when one predicate is much smaller than the
     // others, drive from it and SEEK per-subject into the large side instead of a
     // full symmetric scan of every predicate. BASE index only, so HEAD-gated;

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -801,6 +801,120 @@ fn merge_count_range(
     Ok(total)
 }
 
+/// Per-partition partial for `?s REQ… OPTIONAL { ?s OPT… } …` over `[lo, hi)`:
+/// `Σ_{s ∈ [lo,hi), s in all REQ} req_product(s) × Π_g max(1, Π_i opt_gi(s))`.
+///
+/// `opt_groups` lists each optional group's present predicate ids; an empty group
+/// is `always_one` (multiplier 1 — an absent optional predicate). BASE index only
+/// (no overlay), no exclude/include (the caller gates that).
+fn merge_optional_count_range(
+    store: &BinaryIndexStore,
+    g_id: fluree_db_core::GraphId,
+    req_pids: &[u32],
+    opt_groups: &[Vec<u32>],
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let mut req_iters: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(req_pids.len());
+    for &p in req_pids {
+        req_iters.push(PsotSubjectCountIter::new_bounded(store, g_id, p, lo, hi)?);
+    }
+
+    struct OptG<'a> {
+        always_one: bool,
+        iters: Vec<PsotSubjectCountIter<'a>>,
+        cur: Vec<Option<(u64, u64)>>,
+    }
+    let mut opt: Vec<OptG<'_>> = Vec::with_capacity(opt_groups.len());
+    for grp in opt_groups {
+        if grp.is_empty() {
+            opt.push(OptG {
+                always_one: true,
+                iters: Vec::new(),
+                cur: Vec::new(),
+            });
+            continue;
+        }
+        let mut iters: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(grp.len());
+        for &p in grp {
+            iters.push(PsotSubjectCountIter::new_bounded(store, g_id, p, lo, hi)?);
+        }
+        let mut cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(iters.len());
+        for it in &mut iters {
+            cur.push(it.next_group()?);
+        }
+        opt.push(OptG {
+            always_one: false,
+            iters,
+            cur,
+        });
+    }
+
+    let mut req_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(req_iters.len());
+    for it in &mut req_iters {
+        req_cur.push(it.next_group()?);
+    }
+    let mut total: u128 = 0;
+    loop {
+        if req_cur.iter().any(std::option::Option::is_none) {
+            break;
+        }
+        let max_s = req_cur
+            .iter()
+            .filter_map(|c| c.map(|(s, _)| s))
+            .max()
+            .unwrap();
+        if req_cur.iter().all(|c| c.map(|(s, _)| s) == Some(max_s)) {
+            // Required inner-join product at this subject.
+            let mut product: u128 = req_cur.iter().map(|c| c.unwrap().1 as u128).product();
+            // Multiply each optional group's max(1, Π count) factor (streaming;
+            // cursors lazily catch up to max_s).
+            for g in &mut opt {
+                if g.always_one {
+                    continue;
+                }
+                let mut g_prod: u128 = 1;
+                for i in 0..g.iters.len() {
+                    while let Some((sid2, _)) = g.cur[i] {
+                        if sid2 < max_s {
+                            g.cur[i] = g.iters[i].next_group()?;
+                            continue;
+                        }
+                        break;
+                    }
+                    let c = match g.cur[i] {
+                        Some((sid2, c)) if sid2 == max_s => {
+                            g.cur[i] = g.iters[i].next_group()?;
+                            c
+                        }
+                        _ => 0u64,
+                    };
+                    if c == 0 {
+                        g_prod = 0;
+                        break;
+                    }
+                    g_prod = g_prod.saturating_mul(c as u128);
+                }
+                let mult = if g_prod == 0 { 1u128 } else { g_prod };
+                product = product.saturating_mul(mult);
+            }
+            total = total.saturating_add(product);
+            for (i, it) in req_iters.iter_mut().enumerate() {
+                req_cur[i] = it.next_group()?;
+            }
+        } else {
+            for (i, it) in req_iters.iter_mut().enumerate() {
+                if let Some((s_id, _)) = req_cur[i] {
+                    if s_id < max_s {
+                        req_cur[i] = it.next_group()?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(total)
+}
+
 /// Ascending candidate subject boundaries for partitioning a predicate's scan.
 ///
 /// When the predicate has at least `k` leaves, returns each leaf's first subject
@@ -847,25 +961,26 @@ fn driver_subject_boundaries(
 /// to defer to the serial merge when not applicable (not all `SubjectCountScan`,
 /// a predicate absent, too few rows/leaves, or a single core). BASE index only:
 /// caller ensures `!ec.overlay` and no exclude/include filter.
-fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Result<Option<u64>> {
-    if children.len() < 2 {
-        return Ok(None);
-    }
-    let mut p_ids: Vec<u32> = Vec::with_capacity(children.len());
-    let mut total_rows: u64 = 0;
-    for child in children {
-        let StreamNode::SubjectCountScan { pred } = child else {
-            return Ok(None);
-        };
-        let sid = normalize_pred_sid(ec.store, pred)?;
-        let Some(p_id) = ec.store.sid_to_p_id(&sid) else {
-            return Ok(None);
-        };
-        p_ids.push(p_id);
-        total_rows =
-            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
-    }
-
+/// Generic parallel-partitioned count harness.
+///
+/// Partitions the subject space into K contiguous ranges at `driver_p`'s
+/// leaf/leaflet boundaries and runs `reducer(lo, hi)` per range on its own thread,
+/// summing the partials. The reducer computes the per-partition partial count for
+/// whatever per-subject aggregation is being parallelized (inner star, optional,
+/// union, …). Because partition boundaries are subject VALUES and every subject's
+/// rows are contiguous within a predicate, each subject lands in exactly one
+/// partition — the partials sum exactly. Returns `Ok(None)` to defer to the serial
+/// path when there aren't enough rows/leaves/cores to be worth parallelizing.
+/// BASE index only: the caller must ensure `!ec.overlay`.
+fn parallel_partition_count<F>(
+    ec: &ExecCtx<'_, '_>,
+    driver_p: u32,
+    total_rows: u64,
+    reducer: F,
+) -> Result<Option<u64>>
+where
+    F: Fn(u64, u64) -> Result<u128> + Sync,
+{
     let ncpu = std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
         .unwrap_or(1);
@@ -873,17 +988,11 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
         return Ok(None);
     }
 
-    // Partition driver = the predicate with the most leaves (finest boundaries).
-    let driver_p = *p_ids
-        .iter()
-        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
-        .unwrap();
-
     let k = ncpu.min(PARALLEL_STAR_MAX_PARTITIONS);
     // Candidate ascending subject boundaries from the driver: leaf first-subjects
     // when there are enough leaves (manifest only, no leaf opens — the huge-
     // predicate case), else leaflet first-subjects (opens the few driver leaves,
-    // which the merge scans anyway — the medium single-leaf-many-leaflet case).
+    // which the reducer scans anyway — the medium single-leaf-many-leaflet case).
     let candidates = driver_subject_boundaries(ec.store, ec.g_id, driver_p, k)?;
     if candidates.len() < 2 {
         return Ok(None);
@@ -905,15 +1014,11 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
     tracing::debug!(
         partitions = ranges.len(),
         total_rows,
-        predicates = p_ids.len(),
-        "count-plan: parallel partitioned star-join"
+        "count-plan: parallel partitioned count"
     );
 
-    let store: &BinaryIndexStore = ec.store;
-    let g_id = ec.g_id;
-    let p_ids_ref = &p_ids;
+    let reducer = &reducer;
     let span = tracing::Span::current();
-
     let partials: Vec<Result<u128>> = std::thread::scope(|scope| {
         let handles: Vec<_> = ranges
             .iter()
@@ -921,7 +1026,7 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
                 let span = span.clone();
                 scope.spawn(move || {
                     let _guard = span.enter();
-                    merge_count_range(store, g_id, p_ids_ref, lo, hi)
+                    reducer(lo, hi)
                 })
             })
             .collect();
@@ -929,7 +1034,7 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
             .into_iter()
             .map(|h| {
                 h.join().unwrap_or_else(|_| {
-                    Err(QueryError::execution("parallel star-join worker panicked"))
+                    Err(QueryError::execution("parallel count worker panicked"))
                 })
             })
             .collect()
@@ -940,6 +1045,106 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
         total = total.saturating_add(partial?);
     }
     Ok(Some(total.min(u64::MAX as u128) as u64))
+}
+
+fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Result<Option<u64>> {
+    if children.len() < 2 {
+        return Ok(None);
+    }
+    let mut p_ids: Vec<u32> = Vec::with_capacity(children.len());
+    let mut total_rows: u64 = 0;
+    for child in children {
+        let StreamNode::SubjectCountScan { pred } = child else {
+            return Ok(None);
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        let Some(p_id) = ec.store.sid_to_p_id(&sid) else {
+            return Ok(None);
+        };
+        p_ids.push(p_id);
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+    }
+
+    // Partition driver = the predicate with the most leaves (finest boundaries).
+    let driver_p = *p_ids
+        .iter()
+        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    parallel_partition_count(ec, driver_p, total_rows, |lo, hi| {
+        merge_count_range(ec.store, ec.g_id, &p_ids, lo, hi)
+    })
+}
+
+/// Parallel partitioned variant of `sum_optional_join` for the all-present-
+/// predicate shape (single/star required + optional groups of `SubjectCountScan`s).
+/// Partitions by the required side and runs the optional merge per range. Returns
+/// `Ok(None)` to defer to the serial merge for any other shape, an absent required
+/// predicate, or too few rows. BASE index only: caller ensures `!ec.overlay` and no
+/// exclude/include.
+fn sum_optional_join_parallel(
+    required: &StreamNode,
+    optional_groups: &[Vec<StreamNode>],
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    let req_preds: &[StreamNode] = match required {
+        StreamNode::SubjectCountScan { .. } => std::slice::from_ref(required),
+        StreamNode::StarJoin { children } => children,
+        _ => return Ok(None),
+    };
+    let mut req_pids: Vec<u32> = Vec::with_capacity(req_preds.len());
+    let mut total_rows: u64 = 0;
+    for node in req_preds {
+        let StreamNode::SubjectCountScan { pred } = node else {
+            return Ok(None);
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        // Absent required predicate => empty inner join; let the serial path
+        // produce the (correct) 0.
+        let Some(p_id) = ec.store.sid_to_p_id(&sid) else {
+            return Ok(None);
+        };
+        req_pids.push(p_id);
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+    }
+
+    // Resolve optional groups; an absent optional predicate makes its group
+    // `always_one` (multiplier 1), represented as an empty id list.
+    let mut opt_groups: Vec<Vec<u32>> = Vec::with_capacity(optional_groups.len());
+    for grp in optional_groups {
+        let mut pids: Vec<u32> = Vec::with_capacity(grp.len());
+        let mut absent = false;
+        for node in grp {
+            let StreamNode::SubjectCountScan { pred } = node else {
+                return Ok(None);
+            };
+            let sid = normalize_pred_sid(ec.store, pred)?;
+            match ec.store.sid_to_p_id(&sid) {
+                Some(p_id) => {
+                    pids.push(p_id);
+                    total_rows = total_rows
+                        .saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+                }
+                None => {
+                    absent = true;
+                    break;
+                }
+            }
+        }
+        opt_groups.push(if absent { Vec::new() } else { pids });
+    }
+
+    // Drive partitioning from the required predicate with the most leaves.
+    let driver_p = *req_pids
+        .iter()
+        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    parallel_partition_count(ec, driver_p, total_rows, |lo, hi| {
+        merge_optional_count_range(ec.store, ec.g_id, &req_pids, &opt_groups, lo, hi)
+    })
 }
 
 /// Metadata-only fold for the rdf:type inner-star count:
@@ -1311,6 +1516,11 @@ fn sum_optional_join(
     // other instead of scanning both in full.
     if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
         if let Some(n) = try_optional_seek(required, optional_groups, ec)? {
+            return Ok(Some(n));
+        }
+        // Both-large optional (no modifiers): partition the subject space and run
+        // the optional merge across cores.
+        if let Some(n) = sum_optional_join_parallel(required, optional_groups, ec)? {
             return Ok(Some(n));
         }
     }

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -21,12 +21,12 @@ use crate::fast_path_common::{
     allow_cursor_fast_path, build_count_batch, build_overlay_cursor_for_subject_range,
     build_post_cursor_for_predicate, build_psot_cursor_for_predicate, collect_resolved_overlay_ops,
     collect_subjects_for_predicate_set, collect_subjects_for_predicate_sorted,
-    collect_subjects_with_object_in_set, count_rows_for_predicate_psot, cursor_projection_otype_okey,
-    cursor_projection_sid_only, cursor_projection_sid_otype_okey, intersect_many_sorted,
-    leaf_entries_for_predicate, normalize_pred_sid, projection_sid_otype_okey,
-    slice_overlay_ops_by_subject, sum_post_object_counts_filtered, CursorSubjectCountStream,
-    FastPathOperator, ObjectFilterMode, PostObjectGroupCountIter, PsotObjectFilterCountIter,
-    PsotSubjectCountIter, PsotSubjectSeek, PsotSubjectWeightedSumIter,
+    collect_subjects_with_object_in_set, count_rows_for_predicate_psot,
+    cursor_projection_otype_okey, cursor_projection_sid_only, cursor_projection_sid_otype_okey,
+    intersect_many_sorted, leaf_entries_for_predicate, normalize_pred_sid,
+    projection_sid_otype_okey, slice_overlay_ops_by_subject, sum_post_object_counts_filtered,
+    CursorSubjectCountStream, FastPathOperator, ObjectFilterMode, PostObjectGroupCountIter,
+    PsotObjectFilterCountIter, PsotSubjectCountIter, PsotSubjectSeek, PsotSubjectWeightedSumIter,
 };
 use crate::ir::triple::Ref;
 use crate::operator::BoxedOperator;
@@ -559,7 +559,8 @@ fn sum_stream(
             // Overlay/time-travel: parallelize the base scan + fold novelty per
             // partition; falls through to the serial keyset path otherwise.
             if ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
-                if let Some(n) = try_modifier_intersect_overlay_parallel(source, excluded, true, ec)?
+                if let Some(n) =
+                    try_modifier_intersect_overlay_parallel(source, excluded, true, ec)?
                 {
                     return Ok(Some(n));
                 }
@@ -588,7 +589,8 @@ fn sum_stream(
             // Overlay/time-travel: parallelize the base scan + fold novelty per
             // partition; falls through to the serial keyset path otherwise.
             if ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
-                if let Some(n) = try_modifier_intersect_overlay_parallel(source, filter, false, ec)? {
+                if let Some(n) = try_modifier_intersect_overlay_parallel(source, filter, false, ec)?
+                {
                     return Ok(Some(n));
                 }
             }
@@ -796,7 +798,9 @@ fn merge_count_range(
 ) -> Result<u128> {
     let mut iters: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(p_ids.len());
     for &p_id in p_ids {
-        iters.push(PsotSubjectCountIter::new_bounded(store, g_id, p_id, lo, hi)?);
+        iters.push(PsotSubjectCountIter::new_bounded(
+            store, g_id, p_id, lo, hi,
+        )?);
     }
     let mut curr: Vec<Option<(u64, u64)>> = Vec::with_capacity(iters.len());
     for it in &mut iters {
@@ -1078,7 +1082,9 @@ fn sum_star_join_parallel(children: &[StreamNode], ec: &ExecCtx<'_, '_>) -> Resu
     // Partition driver = the predicate with the most leaves (finest boundaries).
     let driver_p = *p_ids
         .iter()
-        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .max_by_key(|&&p| {
+            leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len()
+        })
         .unwrap();
 
     parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
@@ -1198,7 +1204,9 @@ fn sum_star_join_overlay_parallel(
 
     let driver_p = *p_ids
         .iter()
-        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .max_by_key(|&&p| {
+            leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len()
+        })
         .unwrap();
 
     let store = ec.store;
@@ -1272,7 +1280,9 @@ fn sum_optional_join_parallel(
     // Drive partitioning from the required predicate with the most leaves.
     let driver_p = *req_pids
         .iter()
-        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .max_by_key(|&&p| {
+            leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len()
+        })
         .unwrap();
 
     parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
@@ -1459,9 +1469,10 @@ fn sum_optional_join_overlay_parallel(
         opt_sids.push(sids);
     }
 
-    let collect = |sid: &Sid| -> Result<Option<Vec<fluree_db_binary_index::read::types::OverlayOp>>> {
-        collect_resolved_overlay_ops(ec.ctx, ec.store, ec.g_id, RunSortOrder::Psot, sid)
-    };
+    let collect =
+        |sid: &Sid| -> Result<Option<Vec<fluree_db_binary_index::read::types::OverlayOp>>> {
+            collect_resolved_overlay_ops(ec.ctx, ec.store, ec.g_id, RunSortOrder::Psot, sid)
+        };
     let mut req_ops = Vec::with_capacity(req_sids.len());
     for sid in &req_sids {
         let Some(ops) = collect(sid)? else {
@@ -1486,7 +1497,9 @@ fn sum_optional_join_overlay_parallel(
     let epoch = ec.ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
     let driver_p = *req_pids
         .iter()
-        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .max_by_key(|&&p| {
+            leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len()
+        })
         .unwrap();
 
     let store = ec.store;
@@ -1911,9 +1924,7 @@ fn sum_star_join(
     // full symmetric scan of every predicate. BASE index only, so HEAD-gated;
     // under overlay the cursor-merge path below stays correct.
     if !ec.overlay {
-        if let Some(total) =
-            try_sum_star_join_seek(children, ec, exclude_sorted, include_sorted)?
-        {
+        if let Some(total) = try_sum_star_join_seek(children, ec, exclude_sorted, include_sorted)? {
             return Ok(Some(total));
         }
         // Both-large plain star (no modifiers): partition the subject space and
@@ -2163,8 +2174,8 @@ fn try_optional_seek(
                 continue;
             }
             if let Some(count_a) = a_seek.count_for_subject(s)? {
-                bonus = bonus
-                    .saturating_add((count_a as u128).saturating_mul((count_b - 1) as u128));
+                bonus =
+                    bonus.saturating_add((count_a as u128).saturating_mul((count_b - 1) as u128));
             }
         }
         (rows_a as u128).saturating_add(bonus)

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -25,7 +25,7 @@ use crate::fast_path_common::{
     cursor_projection_sid_otype_okey, intersect_many_sorted, leaf_entries_for_predicate,
     normalize_pred_sid, projection_sid_otype_okey, sum_post_object_counts_filtered,
     CursorSubjectCountStream, FastPathOperator, ObjectFilterMode, PostObjectGroupCountIter,
-    PsotObjectFilterCountIter, PsotSubjectCountIter, PsotSubjectWeightedSumIter,
+    PsotObjectFilterCountIter, PsotSubjectCountIter, PsotSubjectSeek, PsotSubjectWeightedSumIter,
 };
 use crate::ir::triple::Ref;
 use crate::operator::BoxedOperator;
@@ -542,6 +542,14 @@ fn sum_stream(
         ),
 
         StreamNode::AntiJoin { source, excluded } => {
+            // Asymmetric seek (HEAD, outermost modifier only): drive from the
+            // smaller of outer/inner and seek the other, avoiding a full scan or
+            // keyset-build of the large side.
+            if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+                if let Some(n) = try_modifier_seek(source, excluded, true, ec)? {
+                    return Ok(Some(n));
+                }
+            }
             let exclude_list = execute_keyset_as_sorted(excluded, ec)?;
             let exclude_list = match exclude_list {
                 Some(s) => s,
@@ -553,6 +561,11 @@ fn sum_stream(
         }
 
         StreamNode::SemiJoin { source, filter } => {
+            if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+                if let Some(n) = try_modifier_seek(source, filter, false, ec)? {
+                    return Ok(Some(n));
+                }
+            }
             let filter_list = execute_keyset_as_sorted(filter, ec)?;
             let filter_list = match filter_list {
                 Some(s) => s,
@@ -566,6 +579,93 @@ fn sum_stream(
             sum_stream(source, ec, exclude_sorted, Some(&merged))
         }
     }
+}
+
+/// Asymmetric seek strategy for a single-predicate EXISTS/MINUS over a
+/// single-predicate outer: `?s A ?o1 {FILTER EXISTS | MINUS} { ?s B ?o2 }`.
+///
+/// Drives from whichever of A/B has fewer rows and seeks into the other, avoiding
+/// a full scan or keyset-build of the large side:
+/// - EXISTS  = `Σ_{s ∈ A ∧ s ∈ B} count_A(s)`
+/// - MINUS   = `Σ_{s ∈ A ∧ s ∉ B} count_A(s)` = `total(A) − Σ_{s ∈ A ∩ B} count_A(s)`
+///
+/// (`is_anti` = true for MINUS / NOT EXISTS, false for EXISTS.) Returns `Ok(None)`
+/// to defer to the keyset+scan path when the shape is not single-predicate on both
+/// sides, or the sides are not skewed enough for the seek to win. BASE index only:
+/// the caller must ensure `!ec.overlay` and that no outer exclude/include filter is
+/// already active.
+fn try_modifier_seek(
+    source: &StreamNode,
+    keyset: &KeySetNode,
+    is_anti: bool,
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    let StreamNode::SubjectCountScan { pred: pred_a } = source else {
+        return Ok(None);
+    };
+    let pred_b = match keyset {
+        KeySetNode::SubjectSet { pred } | KeySetNode::SubjectsSorted { pred } => pred,
+        _ => return Ok(None),
+    };
+
+    let sid_a = normalize_pred_sid(ec.store, pred_a)?;
+    let sid_b = normalize_pred_sid(ec.store, pred_b)?;
+
+    // Absent-predicate semantics:
+    // - A absent  => outer empty => 0 for both EXISTS and MINUS.
+    // - B absent  => EXISTS: 0 (no subject has B); MINUS: total(A) (nothing excluded).
+    let Some(p_a) = ec.store.sid_to_p_id(&sid_a) else {
+        return Ok(Some(0));
+    };
+    let rows_a = count_rows_for_predicate_psot(ec.store, ec.g_id, p_a)?;
+    let Some(p_b) = ec.store.sid_to_p_id(&sid_b) else {
+        return Ok(Some(if is_anti { rows_a } else { 0 }));
+    };
+    let rows_b = count_rows_for_predicate_psot(ec.store, ec.g_id, p_b)?;
+
+    // Only worthwhile when one side is much smaller than the other; otherwise the
+    // existing keyset+scan path is competitive — defer to it.
+    let (min_rows, max_rows) = (rows_a.min(rows_b), rows_a.max(rows_b));
+    if min_rows.saturating_mul(SEEK_STAR_DRIVER_FACTOR) >= max_rows {
+        return Ok(None);
+    }
+
+    let total: u128 = if rows_a <= rows_b {
+        // Drive from A (smaller): iterate (s, count_A) and probe B for existence.
+        let Some(mut a_groups) = subject_groups(ec, pred_a)? else {
+            return Ok(None);
+        };
+        let mut b_seek = PsotSubjectSeek::new(ec.store, ec.g_id, p_b);
+        let mut acc: u128 = 0;
+        while let Some((s, count_a)) = a_groups.next_group()? {
+            let present = b_seek.subject_present(s)?;
+            // EXISTS keeps present subjects; MINUS keeps absent ones.
+            if present != is_anti {
+                acc = acc.saturating_add(count_a as u128);
+            }
+        }
+        acc
+    } else {
+        // Drive from B (smaller): iterate B's distinct subjects, seek A's count.
+        // `matched` = Σ_{s ∈ A ∩ B} count_A(s) (absent-in-A subjects seek to None).
+        let Some(mut b_groups) = subject_groups(ec, pred_b)? else {
+            return Ok(None);
+        };
+        let mut a_seek = PsotSubjectSeek::new(ec.store, ec.g_id, p_a);
+        let mut matched: u128 = 0;
+        while let Some((s, _)) = b_groups.next_group()? {
+            if let Some(count_a) = a_seek.count_for_subject(s)? {
+                matched = matched.saturating_add(count_a as u128);
+            }
+        }
+        if is_anti {
+            (rows_a as u128).saturating_sub(matched)
+        } else {
+            matched
+        }
+    };
+
+    Ok(Some(total.min(u64::MAX as u128) as u64))
 }
 
 /// Check if `key` is in the sorted exclusion list, advancing the index pointer.
@@ -642,12 +742,33 @@ fn intersect_sorted_pair(a: &[u64], b: &[u64]) -> Vec<u64> {
 /// amortized per-subject filtering (matching `fast_minus_count_all::count_property_join_all`).
 ///
 /// Formula: `Σ_{s in all, not excluded, included} Π_i count_i(s)`
+/// Driver/probe cost heuristic for the asymmetric seek strategy: a rough
+/// rows-per-leaflet proxy. The seek strategy is chosen only when the smallest
+/// child's row count times this factor is still below the largest child's row
+/// count — i.e. the driver is small enough that probing it into the large side
+/// (≈ one leaf-leapfrog pass) is cheaper than decoding the large side in full.
+/// A wrong choice only affects speed, never the count, so an overestimate keeps
+/// the strategy conservative (no regression vs the symmetric merge).
+const SEEK_STAR_DRIVER_FACTOR: u64 = 8192;
+
 fn sum_star_join(
     children: &[StreamNode],
     ec: &ExecCtx<'_, '_>,
     exclude_sorted: Option<&[u64]>,
     include_sorted: Option<&[u64]>,
 ) -> Result<Option<u64>> {
+    // Asymmetric (leapfrog) strategy: when one predicate is much smaller than the
+    // others, drive from it and SEEK per-subject into the large side instead of a
+    // full symmetric scan of every predicate. BASE index only, so HEAD-gated;
+    // under overlay the cursor-merge path below stays correct.
+    if !ec.overlay {
+        if let Some(total) =
+            try_sum_star_join_seek(children, ec, exclude_sorted, include_sorted)?
+        {
+            return Ok(Some(total));
+        }
+    }
+
     // All children must be SubjectCountScan for the streaming N-way merge.
     let mut iters: Vec<SubjectGroups<'_>> = Vec::with_capacity(children.len());
     for child in children {
@@ -704,6 +825,189 @@ fn sum_star_join(
     Ok(Some(total.min(u64::MAX as u128) as u64))
 }
 
+/// Asymmetric (leapfrog) seek strategy for an inner subject-star count join.
+///
+/// Returns `Ok(None)` to defer to the symmetric merge when: fewer than two
+/// children, a child is not a plain `SubjectCountScan`, a predicate is absent, or
+/// the driver is not small enough to beat a full scan. Otherwise computes
+/// `Σ_s driver_count(s) × Π_probe count_probe(s)` over the (ascending) driver
+/// subjects that pass the exclude/include filters and exist in every probe —
+/// driving from the smallest predicate and seeking into the others.
+///
+/// BASE index only: the caller must ensure `!ec.overlay`.
+fn try_sum_star_join_seek(
+    children: &[StreamNode],
+    ec: &ExecCtx<'_, '_>,
+    exclude_sorted: Option<&[u64]>,
+    include_sorted: Option<&[u64]>,
+) -> Result<Option<u64>> {
+    if children.len() < 2 {
+        return Ok(None);
+    }
+
+    // Resolve each child to (p_id, row_count). Bail to the merge if any child is
+    // not a plain SubjectCountScan or its predicate is absent — the merge path
+    // already handles those cases correctly.
+    let mut child_pids: Vec<u32> = Vec::with_capacity(children.len());
+    let mut child_rows: Vec<u64> = Vec::with_capacity(children.len());
+    for child in children {
+        let StreamNode::SubjectCountScan { pred } = child else {
+            return Ok(None);
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        let Some(p_id) = ec.store.sid_to_p_id(&sid) else {
+            return Ok(None);
+        };
+        child_pids.push(p_id);
+        child_rows.push(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+    }
+
+    // Driver = smallest by row count; probes = the rest.
+    let driver_idx = child_rows
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, r)| **r)
+        .map(|(i, _)| i)
+        .expect("children non-empty");
+    let driver_rows = child_rows[driver_idx];
+    let max_probe_rows = child_rows
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != driver_idx)
+        .map(|(_, r)| *r)
+        .max()
+        .unwrap_or(0);
+
+    // Only seek when the driver is much smaller than the largest probe; otherwise
+    // a full symmetric scan is competitive (or cheaper) — defer to the merge.
+    if driver_rows.saturating_mul(SEEK_STAR_DRIVER_FACTOR) >= max_probe_rows {
+        return Ok(None);
+    }
+    if driver_rows == 0 {
+        // Empty driver => empty inner join.
+        return Ok(Some(0));
+    }
+
+    // Driver subject→count groups (ascending; Meta lane since `!ec.overlay`), and
+    // one forward-only seek cursor per probe predicate.
+    let StreamNode::SubjectCountScan { pred: driver_pred } = &children[driver_idx] else {
+        return Ok(None);
+    };
+    let Some(mut driver) = subject_groups(ec, driver_pred)? else {
+        return Ok(None);
+    };
+    let mut probes: Vec<PsotSubjectSeek<'_>> = child_pids
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != driver_idx)
+        .map(|(_, &p_id)| PsotSubjectSeek::new(ec.store, ec.g_id, p_id))
+        .collect();
+
+    let mut excl_idx: usize = 0;
+    let mut incl_idx: usize = 0;
+    let mut total: u128 = 0;
+
+    while let Some((s, driver_count)) = driver.next_group()? {
+        if is_excluded(s, exclude_sorted, &mut excl_idx)
+            || !is_included(s, include_sorted, &mut incl_idx)
+        {
+            continue;
+        }
+        let mut product: u128 = driver_count as u128;
+        for probe in &mut probes {
+            match probe.count_for_subject(s)? {
+                Some(c) => product = product.saturating_mul(c as u128),
+                None => {
+                    // Subject absent from this probe => not in the inner join.
+                    product = 0;
+                    break;
+                }
+            }
+        }
+        total = total.saturating_add(product);
+    }
+
+    Ok(Some(total.min(u64::MAX as u128) as u64))
+}
+
+/// Asymmetric seek strategy for `?s A ?o1 OPTIONAL { ?s B ?o2 }` COUNT(*):
+///
+/// `Σ_s count_A(s) × max(1, count_B(s))` = `total(A) + Σ_{s ∈ A ∩ B} count_A(s)·(count_B(s) − 1)`.
+///
+/// Drives from the smaller of required-A / optional-B and seeks the other. When B
+/// is the smaller side, `total(A)` is a directory sum and only the (few) B subjects
+/// seek into A — avoiding a full scan of the large required side. Returns `Ok(None)`
+/// to defer to the streaming merge for any other shape (multi-predicate required,
+/// multiple/multi-triple optional groups) or when the sides are not skewed enough.
+/// BASE index only: caller ensures `!ec.overlay` and no active exclude/include.
+fn try_optional_seek(
+    required: &StreamNode,
+    optional_groups: &[Vec<StreamNode>],
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    let StreamNode::SubjectCountScan { pred: pred_a } = required else {
+        return Ok(None);
+    };
+    if optional_groups.len() != 1 || optional_groups[0].len() != 1 {
+        return Ok(None);
+    }
+    let StreamNode::SubjectCountScan { pred: pred_b } = &optional_groups[0][0] else {
+        return Ok(None);
+    };
+
+    let sid_a = normalize_pred_sid(ec.store, pred_a)?;
+    let Some(p_a) = ec.store.sid_to_p_id(&sid_a) else {
+        // Required absent => no rows.
+        return Ok(Some(0));
+    };
+    let rows_a = count_rows_for_predicate_psot(ec.store, ec.g_id, p_a)?;
+    let sid_b = normalize_pred_sid(ec.store, pred_b)?;
+    let Some(p_b) = ec.store.sid_to_p_id(&sid_b) else {
+        // Optional absent => every required row contributes factor 1 => total(A).
+        return Ok(Some(rows_a));
+    };
+    let rows_b = count_rows_for_predicate_psot(ec.store, ec.g_id, p_b)?;
+
+    let (min_rows, max_rows) = (rows_a.min(rows_b), rows_a.max(rows_b));
+    if min_rows.saturating_mul(SEEK_STAR_DRIVER_FACTOR) >= max_rows {
+        return Ok(None);
+    }
+
+    let total: u128 = if rows_a <= rows_b {
+        // Drive required A (smaller): Σ count_A(s) × max(1, count_B(s)).
+        let Some(mut a_groups) = subject_groups(ec, pred_a)? else {
+            return Ok(None);
+        };
+        let mut b_seek = PsotSubjectSeek::new(ec.store, ec.g_id, p_b);
+        let mut acc: u128 = 0;
+        while let Some((s, count_a)) = a_groups.next_group()? {
+            let mult = b_seek.count_for_subject(s)?.unwrap_or(0).max(1);
+            acc = acc.saturating_add((count_a as u128).saturating_mul(mult as u128));
+        }
+        acc
+    } else {
+        // Drive optional B (smaller): total(A) + Σ_{s ∈ B} count_A(s)·(count_B(s) − 1).
+        let Some(mut b_groups) = subject_groups(ec, pred_b)? else {
+            return Ok(None);
+        };
+        let mut a_seek = PsotSubjectSeek::new(ec.store, ec.g_id, p_a);
+        let mut bonus: u128 = 0;
+        while let Some((s, count_b)) = b_groups.next_group()? {
+            // count_B == 1 yields no bonus; skip the seek (targets stay ascending).
+            if count_b <= 1 {
+                continue;
+            }
+            if let Some(count_a) = a_seek.count_for_subject(s)? {
+                bonus = bonus
+                    .saturating_add((count_a as u128).saturating_mul((count_b - 1) as u128));
+            }
+        }
+        (rows_a as u128).saturating_add(bonus)
+    };
+
+    Ok(Some(total.min(u64::MAX as u128) as u64))
+}
+
 /// Fully streaming merge-join with OPTIONAL semantics.
 ///
 /// Interleaves optional group cursor advancement with the required N-way merge,
@@ -718,6 +1022,15 @@ fn sum_optional_join(
     exclude_sorted: Option<&[u64]>,
     include_sorted: Option<&[u64]>,
 ) -> Result<Option<u64>> {
+    // Asymmetric seek (HEAD, outermost modifier only): for the single-required +
+    // single-optional-predicate shape, drive from the smaller side and seek the
+    // other instead of scanning both in full.
+    if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+        if let Some(n) = try_optional_seek(required, optional_groups, ec)? {
+            return Ok(Some(n));
+        }
+    }
+
     // Collect required iterators (single scan or star join children). An absent
     // required predicate yields an `Empty` stream (no overlay) → no subjects →
     // total 0; absent under overlay bails (`None`).

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -549,6 +549,11 @@ fn sum_stream(
                 if let Some(n) = try_modifier_seek(source, excluded, true, ec)? {
                     return Ok(Some(n));
                 }
+                // Both-large (and multi-predicate inner): parallelize the keyset
+                // build + outer scan instead of building the keyset serially.
+                if let Some(n) = try_modifier_intersect_parallel(source, excluded, true, ec)? {
+                    return Ok(Some(n));
+                }
             }
             let exclude_list = execute_keyset_as_sorted(excluded, ec)?;
             let exclude_list = match exclude_list {
@@ -563,6 +568,11 @@ fn sum_stream(
         StreamNode::SemiJoin { source, filter } => {
             if !ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
                 if let Some(n) = try_modifier_seek(source, filter, false, ec)? {
+                    return Ok(Some(n));
+                }
+                // Both-large (and multi-predicate inner): parallelize the keyset
+                // build + outer scan instead of building the keyset serially.
+                if let Some(n) = try_modifier_intersect_parallel(source, filter, false, ec)? {
                     return Ok(Some(n));
                 }
             }
@@ -1144,6 +1154,146 @@ fn sum_optional_join_parallel(
 
     parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
         merge_optional_count_range(ec.store, ec.g_id, &req_pids, &opt_groups, lo, hi)
+    })
+}
+
+/// Per-partition partial for a MINUS/EXISTS whose inner block is an inner-join of
+/// one or more single-predicate subject sets, over a single-predicate outer:
+/// `?s OUTER ?o {MINUS | FILTER EXISTS} { ?s IN1 ?a . ?s IN2 ?b . … }`.
+///
+/// Streams the outer iterator and every inner predicate's bounded subject iterator
+/// together (all ascending) and, per outer subject, tests membership in the inner
+/// intersection (present in *every* inner predicate). MINUS keeps subjects absent
+/// from the intersection; EXISTS keeps those present:
+///
+/// `Σ_{s ∈ OUTER ∩ [lo,hi)} [keep(s)] · count_OUTER(s)` where
+/// `keep(s) = is_anti ? s ∉ ⋂_i IN_i : s ∈ ⋂_i IN_i`.
+///
+/// O(1) memory — no keyset is materialized; the streaming merge parallelizes the
+/// decompression of the outer *and* every inner predicate across partitions (the
+/// inner keyset build is the dominant cost for a multi-predicate inner). BASE index
+/// only (no overlay), no exclude/include (the caller gates that).
+fn merge_modifier_intersect_range(
+    store: &BinaryIndexStore,
+    g_id: fluree_db_core::GraphId,
+    outer_pid: u32,
+    inner_pids: &[u32],
+    is_anti: bool,
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let mut outer = PsotSubjectCountIter::new_bounded(store, g_id, outer_pid, lo, hi)?;
+    let mut inner: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(inner_pids.len());
+    for &p in inner_pids {
+        inner.push(PsotSubjectCountIter::new_bounded(store, g_id, p, lo, hi)?);
+    }
+    let mut i_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(inner.len());
+    for it in &mut inner {
+        i_cur.push(it.next_group()?);
+    }
+
+    let mut total: u128 = 0;
+    while let Some((os, ocount)) = outer.next_group()? {
+        // In the inner intersection iff present in every inner predicate. Each
+        // inner cursor advances monotonically to the first subject >= os; since os
+        // is non-decreasing, cursors skipped by an early break catch up lazily.
+        let mut in_inner = true;
+        for (k, it) in inner.iter_mut().enumerate() {
+            while let Some((is_, _)) = i_cur[k] {
+                if is_ < os {
+                    i_cur[k] = it.next_group()?;
+                } else {
+                    break;
+                }
+            }
+            if !matches!(i_cur[k], Some((is_, _)) if is_ == os) {
+                in_inner = false;
+                break;
+            }
+        }
+        let keep = if is_anti { !in_inner } else { in_inner };
+        if keep {
+            total = total.saturating_add(ocount as u128);
+        }
+    }
+    Ok(total)
+}
+
+/// Resolve a MINUS/EXISTS keyset into the `p_id`s of its inner predicates for the
+/// parallel modifier-intersect path. Handles a single-predicate set
+/// (`SubjectSet`/`SubjectsSorted`) and an inner-join intersection of such sets
+/// (`IntersectSorted`). Returns `Ok(None)` to defer to the serial keyset path for
+/// any other shape (e.g. object-chain `SubjectsWithObjectIn`) or if any predicate
+/// is absent — the serial path applies the correct absent-predicate semantics.
+fn resolve_keyset_pids(keyset: &KeySetNode, ec: &ExecCtx<'_, '_>) -> Result<Option<Vec<u32>>> {
+    fn single_pid(node: &KeySetNode, ec: &ExecCtx<'_, '_>) -> Result<Option<u32>> {
+        let pred = match node {
+            KeySetNode::SubjectSet { pred } | KeySetNode::SubjectsSorted { pred } => pred,
+            _ => return Ok(None),
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        Ok(ec.store.sid_to_p_id(&sid))
+    }
+    match keyset {
+        KeySetNode::SubjectSet { .. } | KeySetNode::SubjectsSorted { .. } => {
+            Ok(single_pid(keyset, ec)?.map(|p| vec![p]))
+        }
+        KeySetNode::IntersectSorted { children } => {
+            let mut pids = Vec::with_capacity(children.len());
+            for child in children {
+                match single_pid(child, ec)? {
+                    Some(p) => pids.push(p),
+                    None => return Ok(None),
+                }
+            }
+            if pids.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(pids))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Parallel-partitioned MINUS/EXISTS over a single-predicate outer and an inner
+/// block that is a single predicate or an inner-join of predicates. Partitions the
+/// subject space and runs `merge_modifier_intersect_range` per range, parallelizing
+/// the inner keyset build (the dominant cost for a multi-predicate inner) together
+/// with the outer scan. Returns `Ok(None)` to defer to the serial keyset+scan path
+/// for any other shape, an absent predicate, or too few rows. BASE index only:
+/// caller ensures `!ec.overlay` and no active exclude/include.
+fn try_modifier_intersect_parallel(
+    source: &StreamNode,
+    keyset: &KeySetNode,
+    is_anti: bool,
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    let StreamNode::SubjectCountScan { pred: outer_pred } = source else {
+        return Ok(None);
+    };
+    let outer_sid = normalize_pred_sid(ec.store, outer_pred)?;
+    // Absent outer => empty outer => 0; let the serial path produce it.
+    let Some(outer_pid) = ec.store.sid_to_p_id(&outer_sid) else {
+        return Ok(None);
+    };
+    let Some(inner_pids) = resolve_keyset_pids(keyset, ec)? else {
+        return Ok(None);
+    };
+
+    let mut total_rows = count_rows_for_predicate_psot(ec.store, ec.g_id, outer_pid)?;
+    for &p in &inner_pids {
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p)?);
+    }
+
+    // Partition driver = the predicate (outer or inner) with the most leaves.
+    let driver_p = std::iter::once(outer_pid)
+        .chain(inner_pids.iter().copied())
+        .max_by_key(|&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
+        merge_modifier_intersect_range(ec.store, ec.g_id, outer_pid, &inner_pids, is_anti, lo, hi)
     })
 }
 

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -967,7 +967,7 @@ fn driver_subject_boundaries(
 /// Because partition boundaries are subject VALUES and every subject's rows are
 /// contiguous within a predicate, each subject lands in exactly one partition —
 /// so the partials sum exactly. Parallelizes both leaflet decompression AND the
-/// merge (one step past QLever, which keeps the merge serial). Returns `Ok(None)`
+/// merge itself, rather than keeping the merge serial. Returns `Ok(None)`
 /// to defer to the serial merge when not applicable (not all `SubjectCountScan`,
 /// a predicate absent, too few rows/leaves, or a single core). BASE index only:
 /// Generic parallel-partitioned count harness.

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -1027,28 +1027,11 @@ where
         "count-plan: parallel partitioned count"
     );
 
-    let reducer = &reducer;
-    let span = tracing::Span::current();
-    let partials: Vec<Result<u128>> = std::thread::scope(|scope| {
-        let handles: Vec<_> = ranges
-            .iter()
-            .map(|&(lo, hi)| {
-                let span = span.clone();
-                scope.spawn(move || {
-                    let _guard = span.enter();
-                    reducer(lo, hi)
-                })
-            })
-            .collect();
-        handles
-            .into_iter()
-            .map(|h| {
-                h.join().unwrap_or_else(|_| {
-                    Err(QueryError::execution("parallel count worker panicked"))
-                })
-            })
-            .collect()
-    });
+    // Run partitions on the shared global rayon pool (not a per-query
+    // `thread::scope`), so concurrent queries don't each spawn a fresh fan-out of
+    // worker threads. See `fast_path_common::parallel_map_pooled`.
+    let partials: Vec<Result<u128>> =
+        crate::fast_path_common::parallel_map_pooled(ranges, |(lo, hi)| reducer(lo, hi));
 
     let mut total: u128 = 0;
     for partial in partials {

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -556,6 +556,14 @@ fn sum_stream(
                     return Ok(Some(n));
                 }
             }
+            // Overlay/time-travel: parallelize the base scan + fold novelty per
+            // partition; falls through to the serial keyset path otherwise.
+            if ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+                if let Some(n) = try_modifier_intersect_overlay_parallel(source, excluded, true, ec)?
+                {
+                    return Ok(Some(n));
+                }
+            }
             let exclude_list = execute_keyset_as_sorted(excluded, ec)?;
             let exclude_list = match exclude_list {
                 Some(s) => s,
@@ -574,6 +582,13 @@ fn sum_stream(
                 // Both-large (and multi-predicate inner): parallelize the keyset
                 // build + outer scan instead of building the keyset serially.
                 if let Some(n) = try_modifier_intersect_parallel(source, filter, false, ec)? {
+                    return Ok(Some(n));
+                }
+            }
+            // Overlay/time-travel: parallelize the base scan + fold novelty per
+            // partition; falls through to the serial keyset path otherwise.
+            if ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+                if let Some(n) = try_modifier_intersect_overlay_parallel(source, filter, false, ec)? {
                     return Ok(Some(n));
                 }
             }
@@ -1265,6 +1280,225 @@ fn sum_optional_join_parallel(
     })
 }
 
+/// Overlay/time-travel variant of `merge_optional_count_range` for one subject
+/// partition: `Σ_{s ∈ [lo,hi), s in all REQ} req_product(s) × Π_g max(1, Π opt)`,
+/// every predicate read through a bounded overlay cursor (its `[lo,hi)` leaves + its
+/// novelty ops sliced to that range). `req_ops`/`opt_ops` mirror `req_pids`/
+/// `opt_groups`. A `max_s ∈ [lo,hi)` guard counts boundary subjects once; unlike the
+/// base path there are no `always_one` groups — the caller bails when any predicate
+/// is absent in base (it could be novelty-only), so all groups are present here.
+#[allow(clippy::too_many_arguments)]
+fn merge_optional_count_range_overlay(
+    store: &Arc<BinaryIndexStore>,
+    g_id: fluree_db_core::GraphId,
+    req_pids: &[u32],
+    req_ops: &[Vec<fluree_db_binary_index::read::types::OverlayOp>],
+    opt_groups: &[Vec<u32>],
+    opt_ops: &[Vec<Vec<fluree_db_binary_index::read::types::OverlayOp>>],
+    to_t: i64,
+    epoch: u64,
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let build = |p_id: u32, ops: &[fluree_db_binary_index::read::types::OverlayOp]| {
+        let sliced = slice_overlay_ops_by_subject(ops, lo, hi);
+        build_overlay_cursor_for_subject_range(
+            store,
+            g_id,
+            p_id,
+            cursor_projection_sid_only(),
+            lo,
+            hi,
+            sliced,
+            to_t,
+            epoch,
+        )
+        .map(CursorSubjectCountStream::new)
+    };
+
+    let mut req_streams: Vec<CursorSubjectCountStream> = Vec::with_capacity(req_pids.len());
+    for (i, &p) in req_pids.iter().enumerate() {
+        let Some(s) = build(p, &req_ops[i]) else {
+            return Ok(0);
+        };
+        req_streams.push(s);
+    }
+
+    struct OptG {
+        streams: Vec<CursorSubjectCountStream>,
+        cur: Vec<Option<(u64, u64)>>,
+    }
+    let mut opt: Vec<OptG> = Vec::with_capacity(opt_groups.len());
+    for (gi, grp) in opt_groups.iter().enumerate() {
+        let mut streams: Vec<CursorSubjectCountStream> = Vec::with_capacity(grp.len());
+        for (i, &p) in grp.iter().enumerate() {
+            let Some(s) = build(p, &opt_ops[gi][i]) else {
+                return Ok(0);
+            };
+            streams.push(s);
+        }
+        let mut cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(streams.len());
+        for s in &mut streams {
+            cur.push(s.next_group()?);
+        }
+        opt.push(OptG { streams, cur });
+    }
+
+    let mut req_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(req_streams.len());
+    for s in &mut req_streams {
+        req_cur.push(s.next_group()?);
+    }
+    let mut total: u128 = 0;
+    loop {
+        if req_cur.iter().any(std::option::Option::is_none) {
+            break;
+        }
+        let max_s = req_cur
+            .iter()
+            .filter_map(|c| c.map(|(s, _)| s))
+            .max()
+            .unwrap();
+        if req_cur.iter().all(|c| c.map(|(s, _)| s) == Some(max_s)) {
+            if max_s >= lo && max_s < hi {
+                let mut product: u128 = req_cur.iter().map(|c| c.unwrap().1 as u128).product();
+                for g in &mut opt {
+                    let mut g_prod: u128 = 1;
+                    for i in 0..g.streams.len() {
+                        while let Some((sid2, _)) = g.cur[i] {
+                            if sid2 < max_s {
+                                g.cur[i] = g.streams[i].next_group()?;
+                                continue;
+                            }
+                            break;
+                        }
+                        let c = match g.cur[i] {
+                            Some((sid2, c)) if sid2 == max_s => {
+                                g.cur[i] = g.streams[i].next_group()?;
+                                c
+                            }
+                            _ => 0u64,
+                        };
+                        if c == 0 {
+                            g_prod = 0;
+                            break;
+                        }
+                        g_prod = g_prod.saturating_mul(c as u128);
+                    }
+                    let mult = if g_prod == 0 { 1u128 } else { g_prod };
+                    product = product.saturating_mul(mult);
+                }
+                total = total.saturating_add(product);
+            }
+            for (i, s) in req_streams.iter_mut().enumerate() {
+                req_cur[i] = s.next_group()?;
+            }
+        } else {
+            for (i, s) in req_streams.iter_mut().enumerate() {
+                if let Some((s_id, _)) = req_cur[i] {
+                    if s_id < max_s {
+                        req_cur[i] = s.next_group()?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(total)
+}
+
+/// Overlay/time-travel parallel `OPTIONAL` join COUNT(*): like
+/// `sum_optional_join_parallel` but folds novelty per partition. Bails (defers to
+/// the serial cursor merge) if any required or optional predicate is absent in base
+/// — under overlay it could be novelty-only, which the serial/general path handles.
+fn sum_optional_join_overlay_parallel(
+    required: &StreamNode,
+    optional_groups: &[Vec<StreamNode>],
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    let req_preds: &[StreamNode] = match required {
+        StreamNode::SubjectCountScan { .. } => std::slice::from_ref(required),
+        StreamNode::StarJoin { children } => children,
+        _ => return Ok(None),
+    };
+    let resolve = |node: &StreamNode| -> Result<Option<(u32, Sid)>> {
+        let StreamNode::SubjectCountScan { pred } = node else {
+            return Ok(None);
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        Ok(ec.store.sid_to_p_id(&sid).map(|p| (p, sid)))
+    };
+
+    let mut req_pids: Vec<u32> = Vec::with_capacity(req_preds.len());
+    let mut req_sids: Vec<Sid> = Vec::with_capacity(req_preds.len());
+    let mut total_rows: u64 = 0;
+    for node in req_preds {
+        let Some((p_id, sid)) = resolve(node)? else {
+            return Ok(None);
+        };
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+        req_pids.push(p_id);
+        req_sids.push(sid);
+    }
+
+    let mut opt_groups: Vec<Vec<u32>> = Vec::with_capacity(optional_groups.len());
+    let mut opt_sids: Vec<Vec<Sid>> = Vec::with_capacity(optional_groups.len());
+    for grp in optional_groups {
+        let mut pids: Vec<u32> = Vec::with_capacity(grp.len());
+        let mut sids: Vec<Sid> = Vec::with_capacity(grp.len());
+        for node in grp {
+            // Absent optional predicate under overlay may be novelty-only — bail.
+            let Some((p_id, sid)) = resolve(node)? else {
+                return Ok(None);
+            };
+            total_rows =
+                total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p_id)?);
+            pids.push(p_id);
+            sids.push(sid);
+        }
+        opt_groups.push(pids);
+        opt_sids.push(sids);
+    }
+
+    let collect = |sid: &Sid| -> Result<Option<Vec<fluree_db_binary_index::read::types::OverlayOp>>> {
+        collect_resolved_overlay_ops(ec.ctx, ec.store, ec.g_id, RunSortOrder::Psot, sid)
+    };
+    let mut req_ops = Vec::with_capacity(req_sids.len());
+    for sid in &req_sids {
+        let Some(ops) = collect(sid)? else {
+            return Ok(None);
+        };
+        req_ops.push(ops);
+    }
+    let mut opt_ops: Vec<Vec<Vec<fluree_db_binary_index::read::types::OverlayOp>>> =
+        Vec::with_capacity(opt_sids.len());
+    for grp in &opt_sids {
+        let mut group_ops = Vec::with_capacity(grp.len());
+        for sid in grp {
+            let Some(ops) = collect(sid)? else {
+                return Ok(None);
+            };
+            group_ops.push(ops);
+        }
+        opt_ops.push(group_ops);
+    }
+
+    let to_t = ec.ctx.to_t;
+    let epoch = ec.ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
+    let driver_p = *req_pids
+        .iter()
+        .max_by_key(|&&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    let store = ec.store;
+    let g_id = ec.g_id;
+    let (req_pids, opt_groups, req_ops, opt_ops) = (&req_pids, &opt_groups, &req_ops, &opt_ops);
+    parallel_partition_count(store, g_id, driver_p, total_rows, move |lo, hi| {
+        merge_optional_count_range_overlay(
+            store, g_id, req_pids, req_ops, opt_groups, opt_ops, to_t, epoch, lo, hi,
+        )
+    })
+}
+
 /// Per-partition partial for a MINUS/EXISTS whose inner block is an inner-join of
 /// one or more single-predicate subject sets, over a single-predicate outer:
 /// `?s OUTER ?o {MINUS | FILTER EXISTS} { ?s IN1 ?a . ?s IN2 ?b . … }`.
@@ -1402,6 +1636,184 @@ fn try_modifier_intersect_parallel(
 
     parallel_partition_count(ec.store, ec.g_id, driver_p, total_rows, |lo, hi| {
         merge_modifier_intersect_range(ec.store, ec.g_id, outer_pid, &inner_pids, is_anti, lo, hi)
+    })
+}
+
+/// Like [`resolve_keyset_pids`] but also returns each inner predicate's `Sid`, so the
+/// overlay-parallel path can collect that predicate's novelty ops.
+fn resolve_keyset_pids_sids(
+    keyset: &KeySetNode,
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<Vec<(u32, Sid)>>> {
+    fn one(node: &KeySetNode, ec: &ExecCtx<'_, '_>) -> Result<Option<(u32, Sid)>> {
+        let pred = match node {
+            KeySetNode::SubjectSet { pred } | KeySetNode::SubjectsSorted { pred } => pred,
+            _ => return Ok(None),
+        };
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        Ok(ec.store.sid_to_p_id(&sid).map(|p| (p, sid)))
+    }
+    match keyset {
+        KeySetNode::SubjectSet { .. } | KeySetNode::SubjectsSorted { .. } => {
+            Ok(one(keyset, ec)?.map(|x| vec![x]))
+        }
+        KeySetNode::IntersectSorted { children } => {
+            let mut out = Vec::with_capacity(children.len());
+            for child in children {
+                match one(child, ec)? {
+                    Some(x) => out.push(x),
+                    None => return Ok(None),
+                }
+            }
+            if out.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(out))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Overlay/time-travel variant of `merge_modifier_intersect_range` for one subject
+/// partition: drives the outer through a bounded overlay cursor and tests each outer
+/// subject for membership in the inner intersection (each inner predicate also a
+/// bounded overlay cursor) — MINUS keeps absent, EXISTS keeps present. Novelty is
+/// folded per predicate; an outer subject outside `[lo, hi)` (boundary leaf) is
+/// skipped so each is counted by exactly one partition.
+#[allow(clippy::too_many_arguments)]
+fn merge_modifier_intersect_range_overlay(
+    store: &Arc<BinaryIndexStore>,
+    g_id: fluree_db_core::GraphId,
+    outer_pid: u32,
+    outer_ops: &[fluree_db_binary_index::read::types::OverlayOp],
+    inner_pids: &[u32],
+    inner_ops: &[Vec<fluree_db_binary_index::read::types::OverlayOp>],
+    is_anti: bool,
+    to_t: i64,
+    epoch: u64,
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let build = |p_id: u32, ops: &[fluree_db_binary_index::read::types::OverlayOp]| {
+        let sliced = slice_overlay_ops_by_subject(ops, lo, hi);
+        build_overlay_cursor_for_subject_range(
+            store,
+            g_id,
+            p_id,
+            cursor_projection_sid_only(),
+            lo,
+            hi,
+            sliced,
+            to_t,
+            epoch,
+        )
+        .map(CursorSubjectCountStream::new)
+    };
+
+    let Some(mut outer) = build(outer_pid, outer_ops) else {
+        return Ok(0);
+    };
+    let mut inner: Vec<CursorSubjectCountStream> = Vec::with_capacity(inner_pids.len());
+    for (i, &p) in inner_pids.iter().enumerate() {
+        let Some(s) = build(p, &inner_ops[i]) else {
+            return Ok(0);
+        };
+        inner.push(s);
+    }
+    let mut i_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(inner.len());
+    for s in &mut inner {
+        i_cur.push(s.next_group()?);
+    }
+
+    let mut total: u128 = 0;
+    while let Some((os, ocount)) = outer.next_group()? {
+        if os < lo {
+            continue; // boundary subject below the partition; owned by a lower one
+        }
+        if os >= hi {
+            break; // ascending => the rest are all out of range
+        }
+        let mut in_inner = true;
+        for (k, s) in inner.iter_mut().enumerate() {
+            while let Some((is_, _)) = i_cur[k] {
+                if is_ < os {
+                    i_cur[k] = s.next_group()?;
+                } else {
+                    break;
+                }
+            }
+            if !matches!(i_cur[k], Some((is_, _)) if is_ == os) {
+                in_inner = false;
+                break;
+            }
+        }
+        let keep = if is_anti { !in_inner } else { in_inner };
+        if keep {
+            total = total.saturating_add(ocount as u128);
+        }
+    }
+    Ok(total)
+}
+
+/// Overlay/time-travel parallel MINUS/EXISTS: like `try_modifier_intersect_parallel`
+/// but folds novelty per partition (bounded overlay cursors). Collects the outer and
+/// inner predicates' resolved ops once. Returns `Ok(None)` to defer to the serial
+/// keyset path for a non-plain shape, an absent predicate, a translation failure, or
+/// too few rows.
+fn try_modifier_intersect_overlay_parallel(
+    source: &StreamNode,
+    keyset: &KeySetNode,
+    is_anti: bool,
+    ec: &ExecCtx<'_, '_>,
+) -> Result<Option<u64>> {
+    let StreamNode::SubjectCountScan { pred: outer_pred } = source else {
+        return Ok(None);
+    };
+    let outer_sid = normalize_pred_sid(ec.store, outer_pred)?;
+    let Some(outer_pid) = ec.store.sid_to_p_id(&outer_sid) else {
+        return Ok(None);
+    };
+    let Some(inner) = resolve_keyset_pids_sids(keyset, ec)? else {
+        return Ok(None);
+    };
+    let inner_pids: Vec<u32> = inner.iter().map(|(p, _)| *p).collect();
+
+    let mut total_rows = count_rows_for_predicate_psot(ec.store, ec.g_id, outer_pid)?;
+    for &p in &inner_pids {
+        total_rows =
+            total_rows.saturating_add(count_rows_for_predicate_psot(ec.store, ec.g_id, p)?);
+    }
+
+    let Some(outer_ops) =
+        collect_resolved_overlay_ops(ec.ctx, ec.store, ec.g_id, RunSortOrder::Psot, &outer_sid)?
+    else {
+        return Ok(None);
+    };
+    let mut inner_ops: Vec<Vec<fluree_db_binary_index::read::types::OverlayOp>> =
+        Vec::with_capacity(inner.len());
+    for (_, sid) in &inner {
+        let Some(ops) =
+            collect_resolved_overlay_ops(ec.ctx, ec.store, ec.g_id, RunSortOrder::Psot, sid)?
+        else {
+            return Ok(None);
+        };
+        inner_ops.push(ops);
+    }
+
+    let to_t = ec.ctx.to_t;
+    let epoch = ec.ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
+    let driver_p = std::iter::once(outer_pid)
+        .chain(inner_pids.iter().copied())
+        .max_by_key(|&p| leaf_entries_for_predicate(ec.store, ec.g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    let store = ec.store;
+    let g_id = ec.g_id;
+    let (inner_pids, inner_ops, outer_ops) = (&inner_pids, &inner_ops, &outer_ops);
+    parallel_partition_count(store, g_id, driver_p, total_rows, move |lo, hi| {
+        merge_modifier_intersect_range_overlay(
+            store, g_id, outer_pid, outer_ops, inner_pids, inner_ops, is_anti, to_t, epoch, lo, hi,
+        )
     })
 }
 
@@ -1788,6 +2200,15 @@ fn sum_optional_join(
         // Both-large optional (no modifiers): partition the subject space and run
         // the optional merge across cores.
         if let Some(n) = sum_optional_join_parallel(required, optional_groups, ec)? {
+            return Ok(Some(n));
+        }
+    }
+
+    // Overlay/time-travel optional: parallelize the base scan and fold novelty per
+    // partition (bounded overlay cursors). Falls through to the serial cursor merge
+    // for small inputs, absent predicates, or translation failures.
+    if ec.overlay && exclude_sorted.is_none() && include_sorted.is_none() {
+        if let Some(n) = sum_optional_join_overlay_parallel(required, optional_groups, ec)? {
             return Ok(Some(n));
         }
     }

--- a/fluree-db-query/src/eval/types.rs
+++ b/fluree-db-query/src/eval/types.rs
@@ -159,10 +159,10 @@ mod tests {
 
         // (expr, expect_is_iri, expect_is_blank) — isLiteral must be false for all (node refs).
         let cases = [
-            (Expression::Var(VarId(0)), true, false),  // IRI as Sid
-            (Expression::Var(VarId(1)), false, true),  // bnode as Sid (ns_code branch)
-            (Expression::Var(VarId(2)), true, false),  // IRI as Iri string
-            (Expression::Var(VarId(3)), false, true),  // bnode as "_:" Iri (prefix branch)
+            (Expression::Var(VarId(0)), true, false), // IRI as Sid
+            (Expression::Var(VarId(1)), false, true), // bnode as Sid (ns_code branch)
+            (Expression::Var(VarId(2)), true, false), // IRI as Iri string
+            (Expression::Var(VarId(3)), false, true), // bnode as "_:" Iri (prefix branch)
         ];
 
         for (expr, want_iri, want_blank) in cases {

--- a/fluree-db-query/src/eval/types.rs
+++ b/fluree-db-query/src/eval/types.rs
@@ -32,8 +32,15 @@ pub fn eval_is_iri<R: RowAccess>(
 ) -> Result<Option<ComparableValue>> {
     check_arity(args, 1, "isIRI")?;
     let val = args[0].eval_to_comparable(row, ctx)?;
-    Ok(Some(ComparableValue::Bool(val.is_some_and(|v| {
-        matches!(v, ComparableValue::Sid(_) | ComparableValue::Iri(_))
+    Ok(Some(ComparableValue::Bool(val.is_some_and(|v| match v {
+        // Per SPARQL, isIRI/isURI is true for IRIs only — blank nodes are NOT IRIs.
+        // Fluree skolemizes blank nodes into the node-ref (`Sid`/`Iri`) space, so a
+        // `Sid` in the BLANK_NODE namespace or an `Iri` lexically prefixed with "_:"
+        // is a blank node and must be excluded here. This mirrors `eval_is_blank`'s
+        // detection so isIRI/isBlank stay mutually exclusive (a term is never both).
+        ComparableValue::Sid(sid) => sid.namespace_code != namespaces::BLANK_NODE,
+        ComparableValue::Iri(s) => !s.starts_with("_:"),
+        _ => false,
     }))))
 }
 
@@ -122,5 +129,60 @@ mod tests {
         let row = batch.row_view(0).unwrap();
         let result = eval_bound(&[Expression::Var(VarId(0))], &row).unwrap();
         assert_eq!(result, Some(ComparableValue::Bool(true)));
+    }
+
+    /// A node-ref binding: an ordinary IRI Sid vs a blank-node Sid (BLANK_NODE
+    /// namespace). isIRI must be true for the former and FALSE for the latter,
+    /// and isBlank the inverse — they must be mutually exclusive (regression for
+    /// the DBLP `isIRI(?s)` quirk where skolemized bnodes read as both isIRI and
+    /// isBlank). isLiteral must be false for both.
+    fn make_node_batch() -> Batch {
+        let schema: Arc<[VarId]> =
+            Arc::from(vec![VarId(0), VarId(1), VarId(2), VarId(3)].into_boxed_slice());
+        // Two representations of each, covering both branches of eval_is_iri:
+        //   ns_code branch (Binding::Sid -> ComparableValue::Sid):
+        //     VarId(0): ordinary IRI Sid; VarId(1): blank-node Sid (BLANK_NODE ns).
+        //   "_:" prefix branch (Binding::Iri -> ComparableValue::Iri), which is how a
+        //     scanned EncodedSid blank node resolves (BLANK_NODE ns prefix is "_:"):
+        //     VarId(2): ordinary IRI string; VarId(3): "_:"-prefixed blank node.
+        let iri_sid = vec![Binding::sid(Sid::new(7, "Person"))];
+        let bnode_sid = vec![Binding::sid(Sid::new(namespaces::BLANK_NODE, "b0"))];
+        let iri_str = vec![Binding::Iri(Arc::from("http://example.org/ns/Person"))];
+        let bnode_str = vec![Binding::Iri(Arc::from("_:b0"))];
+        Batch::new(schema, vec![iri_sid, bnode_sid, iri_str, bnode_str]).unwrap()
+    }
+
+    #[test]
+    fn is_iri_excludes_blank_node_and_is_disjoint_from_is_blank() {
+        let batch = make_node_batch();
+        let row = batch.row_view(0).unwrap();
+
+        // (expr, expect_is_iri, expect_is_blank) — isLiteral must be false for all (node refs).
+        let cases = [
+            (Expression::Var(VarId(0)), true, false),  // IRI as Sid
+            (Expression::Var(VarId(1)), false, true),  // bnode as Sid (ns_code branch)
+            (Expression::Var(VarId(2)), true, false),  // IRI as Iri string
+            (Expression::Var(VarId(3)), false, true),  // bnode as "_:" Iri (prefix branch)
+        ];
+
+        for (expr, want_iri, want_blank) in cases {
+            assert_eq!(
+                eval_is_iri(std::slice::from_ref(&expr), &row, None).unwrap(),
+                Some(ComparableValue::Bool(want_iri)),
+                "isIRI mismatch for {expr:?} (blank nodes are not IRIs per SPARQL)"
+            );
+            assert_eq!(
+                eval_is_blank(std::slice::from_ref(&expr), &row, None).unwrap(),
+                Some(ComparableValue::Bool(want_blank)),
+                "isBlank mismatch for {expr:?}"
+            );
+            assert_eq!(
+                eval_is_literal(std::slice::from_ref(&expr), &row, None).unwrap(),
+                Some(ComparableValue::Bool(false)),
+                "isLiteral must be false for node ref {expr:?}"
+            );
+            // Mutual exclusivity invariant: a term is never both isIRI and isBlank.
+            assert!(want_iri != want_blank, "isIRI and isBlank must be disjoint");
+        }
     }
 }

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2152,18 +2152,28 @@ fn build_operator_tree_inner(
                 o: false,
             };
             let scan: BoxedOperator = Box::new(crate::dataset_operator::DatasetOperator::scan(
-                tp,
+                tp.clone(),
                 None,
-                inline_ops,
+                inline_ops.clone(),
                 emit,
                 None,
                 planning.mode(),
             ));
-            return Ok(Box::new(CountRowsOperator::new(
-                scan,
-                out_var,
-                Some(fallback),
-            )));
+            // Serial scan-count → general aggregate pipeline (the correct path for
+            // overlay/time-travel/policy). This is the fast path's fallback.
+            let scan_count: BoxedOperator =
+                Box::new(CountRowsOperator::new(scan, out_var, Some(fallback)));
+            // At HEAD, count the rows passing the encoded pre-filters in parallel
+            // across leaf chunks (no per-row binding materialization); otherwise, or
+            // if a filter can't be pushed to encoded columns, fall back to the scan.
+            return Ok(Box::new(
+                crate::fast_count::count_rows_encoded_filters_operator(
+                    tp,
+                    inline_ops,
+                    out_var,
+                    Some(scan_count),
+                ),
+            ));
         }
     }
 

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -13,7 +13,7 @@ use crate::fast_count::{
     count_blank_node_subjects_operator, count_distinct_position_operator,
     count_literal_objects_operator, count_rows_lang_filter_operator,
     count_rows_numeric_compare_operator, count_rows_operator, count_triples_operator,
-    DistinctPosition, NumericCompareOp,
+    sum_compare_as_count_operator, DistinctPosition, NumericCompareOp,
 };
 use crate::fast_exists_join_count_distinct_object::exists_join_count_distinct_object_operator;
 use crate::fast_group_count_firsts::{
@@ -1605,6 +1605,43 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
     }
 }
 
+/// Detect `SELECT (SUM(?o <cmp> K) AS ?sum) WHERE { ?s <p> ?o }`, lowered as
+/// `Triple + Bind(Gt/Ge/Lt/Le(?o, const)) + SUM(synthetic_var, List)`.
+///
+/// `SUM` of a boolean comparison is `COUNT` of the matching rows, which the
+/// directory-skipping numeric-compare count answers far faster than the general
+/// decode+eval+materialize aggregate pipeline. Restricted to `InputSemantics::List`
+/// (non-DISTINCT) because `SUM(DISTINCT ?o>0)` sums the distinct set {0,1}, not a
+/// row count. Empty-input (`SUM`=Unbound vs `COUNT`=0) is handled by the operator,
+/// which defers to the fallback when the predicate feeds no rows.
+fn detect_sum_numeric_compare_as_count(
+    query: &Query,
+) -> Option<(Ref, NumericCompareOp, fluree_db_core::FlakeValue, VarId)> {
+    let agg = implicit_single_aggregate(query)?;
+    let select_vars = query.output.projected_vars()?;
+    if select_vars.len() != 1 || select_vars[0] != agg.output_var {
+        return None;
+    }
+    let AggregateFn::Sum(sum_input, InputSemantics::List) = agg.function else {
+        return None;
+    };
+    let [Pattern::Triple(tp), Pattern::Bind { var, expr }] = query.patterns.as_slice() else {
+        return None;
+    };
+    if sum_input != *var {
+        return None;
+    }
+    let pred = extract_bound_predicate(&tp.p)?;
+    let Term::Var(o_var) = &tp.o else {
+        return None;
+    };
+    let (cmp_var, op, threshold) = extract_simple_numeric_compare_threshold(expr)?;
+    if cmp_var != *o_var {
+        return None;
+    }
+    Some((pred, op, threshold, agg.output_var))
+}
+
 fn detect_exists_join_count_distinct_object(query: &Query) -> Option<(Ref, Ref, VarId)> {
     let (in_var, out_var) = detect_count_distinct_aggregate(query)?;
 
@@ -1959,6 +1996,27 @@ fn build_operator_tree_inner(
             grouping = ?query.grouping,
             "operator_tree: considering fused fast paths"
         );
+    }
+
+    // Fast-path: `SELECT (SUM(?o <cmp> K) AS ?sum) WHERE { ?s <p> ?o }`.
+    //
+    // SUM of a boolean comparison == COUNT of matching rows, answered by the
+    // directory-skipping numeric-compare count instead of the general
+    // decode+eval+materialize aggregate pipeline. Placed before the generic
+    // SUM-i64 fast path (which declines the comparison shape).
+    if enable_fused_fast_paths {
+        if let Some((pred, compare, threshold, out_var)) =
+            detect_sum_numeric_compare_as_count(query)
+        {
+            let fallback = build_operator_tree_inner(query, stats.clone(), false, planning)?;
+            return Ok(Box::new(sum_compare_as_count_operator(
+                pred,
+                compare,
+                threshold,
+                out_var,
+                Some(fallback),
+            )));
+        }
     }
 
     // Fast-path: `SELECT (SUM(DAY(?o)) AS ?sum) WHERE { ?s <p> ?o }` and friends.
@@ -3069,6 +3127,63 @@ mod tests {
             detect_exists_join_count_distinct_object(&reversed),
             Some((count_pred, exists_pred, out))
         );
+    }
+
+    #[test]
+    fn test_detect_sum_numeric_compare_as_count() {
+        let s = VarId(0);
+        let o = VarId(1);
+        let synth = VarId(2);
+        let out = VarId(3);
+        let pred = Ref::Sid(Sid::new(100, "numberOfCreators"));
+
+        // SELECT (SUM(?synth) AS ?out) WHERE { ?s <pred> ?o . BIND(?o > 0 AS ?synth) }
+        let make_query = |function: AggregateFn| Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![out]),
+            patterns: vec![
+                Pattern::Triple(TriplePattern::new(Ref::Var(s), pred.clone(), Term::Var(o))),
+                Pattern::Bind {
+                    var: synth,
+                    expr: crate::ir::Expression::gt(
+                        crate::ir::Expression::Var(o),
+                        crate::ir::Expression::Const(crate::ir::FlakeValue::Long(0)),
+                    ),
+                },
+            ],
+            reasoning: ReasoningConfig::default(),
+            grouping: Some(Grouping::Implicit {
+                aggregation: Aggregation {
+                    aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![crate::ir::AggregateSpec {
+                        function,
+                        output_var: out,
+                    }])
+                    .unwrap(),
+                    binds: Vec::new(),
+                },
+                having: None,
+            }),
+            ordering: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: None,
+        };
+
+        // SUM (List / non-DISTINCT) over the comparison synth var => detected as Gt/threshold 0.
+        let q = make_query(AggregateFn::Sum(synth, InputSemantics::List));
+        assert_eq!(
+            detect_sum_numeric_compare_as_count(&q),
+            Some((pred.clone(), NumericCompareOp::Gt, fluree_db_core::FlakeValue::Long(0), out))
+        );
+
+        // SUM(DISTINCT ...) must be rejected: SUM(DISTINCT bool) is not a row count.
+        let q_distinct = make_query(AggregateFn::Sum(synth, InputSemantics::Set));
+        assert_eq!(detect_sum_numeric_compare_as_count(&q_distinct), None);
+
+        // A non-SUM aggregate over the same shape must be rejected.
+        let q_count = make_query(AggregateFn::Count(synth));
+        assert_eq!(detect_sum_numeric_compare_as_count(&q_count), None);
     }
 
     #[test]

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -1059,6 +1059,55 @@ fn detect_predicate_count_rows(query: &Query) -> Option<(Ref, VarId)> {
     Some((pred, out_var))
 }
 
+/// Detect `COUNT(*)` / `COUNT(?s|?o)` of `?s rdf:type <Class> . ?s P ?o` — one leg
+/// with a constant (class) object, the other a same-subject property with a variable
+/// object. Returns `(type_pred, class_obj, property, out_var)`; the operator verifies
+/// the constant-object leg is rdf:type and does the class-stat lookup. Exactly one
+/// constant-object leg and one variable-object leg are required, so the variable-class
+/// star (`?s rdf:type ?o1 . ?s P ?o2`) and pure-constant joins don't match.
+/// `COUNT(DISTINCT …)` is rejected by `detect_count_aggregate`.
+fn detect_class_property_count(query: &Query) -> Option<(Ref, Ref, Ref, VarId)> {
+    let (input_var, out_var) = detect_count_aggregate(query)?;
+    if query.patterns.len() != 2 {
+        return None;
+    }
+    let (Pattern::Triple(t0), Pattern::Triple(t1)) = (&query.patterns[0], &query.patterns[1]) else {
+        return None;
+    };
+    for (cls_tp, prop_tp) in [(t0, t1), (t1, t0)] {
+        // Class leg: ?s <type_pred> <ConstClass> (constant ref object).
+        let Ref::Var(cs) = &cls_tp.s else { continue };
+        if cls_tp.dtc.is_some() {
+            continue;
+        }
+        let Some(type_pred) = extract_bound_predicate(&cls_tp.p) else {
+            continue;
+        };
+        let class_obj = match &cls_tp.o {
+            Term::Iri(i) => Ref::Iri(i.clone()),
+            Term::Sid(s) => Ref::Sid(s.clone()),
+            _ => continue, // not a constant class object
+        };
+        // Property leg: same subject, bound predicate, variable object.
+        let Ref::Var(ps) = &prop_tp.s else { continue };
+        if cs != ps || prop_tp.dtc.is_some() {
+            continue;
+        }
+        let Some(property) = extract_bound_predicate(&prop_tp.p) else {
+            continue;
+        };
+        let Term::Var(po) = &prop_tp.o else { continue };
+        // COUNT(?v): v must be the subject or the property's object (both bound).
+        if let Some(v) = input_var {
+            if v != *cs && v != *po {
+                continue;
+            }
+        }
+        return Some((type_pred, class_obj, property, out_var));
+    }
+    None
+}
+
 fn detect_predicate_count_rows_lang_filter(query: &Query) -> Option<(Ref, String, VarId)> {
     let (input_var, out_var) = detect_count_aggregate(query)?;
 
@@ -2183,6 +2232,23 @@ fn build_operator_tree_inner(
         if let Some((pred, out_var)) = detect_predicate_count_rows(query) {
             let fallback = build_operator_tree_inner(query, stats.clone(), false, planning)?;
             return Ok(Box::new(count_rows_operator(pred, out_var, Some(fallback))));
+        }
+    }
+
+    // Fast-path: `COUNT(*)` of `?s rdf:type <Class> . ?s P ?o` — the P-flake count on
+    // instances of one bound class, from per-(class,property) stats. Before the count
+    // planner, which would otherwise run it as a real class-instances ⋈ P join.
+    if enable_fused_fast_paths {
+        if let Some((type_pred, class_obj, property, out_var)) = detect_class_property_count(query)
+        {
+            let fallback = build_operator_tree_inner(query, stats.clone(), false, planning)?;
+            return Ok(Box::new(crate::fast_count::class_property_count_operator(
+                type_pred,
+                class_obj,
+                property,
+                out_var,
+                Some(fallback),
+            )));
         }
     }
 

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -3165,10 +3165,12 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: Some(Grouping::Implicit {
                 aggregation: Aggregation {
-                    aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![crate::ir::AggregateSpec {
-                        function,
-                        output_var: out,
-                    }])
+                    aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![
+                        crate::ir::AggregateSpec {
+                            function,
+                            output_var: out,
+                        },
+                    ])
                     .unwrap(),
                     binds: Vec::new(),
                 },
@@ -3184,7 +3186,12 @@ mod tests {
         let q = make_query(AggregateFn::Sum(synth, InputSemantics::List));
         assert_eq!(
             detect_sum_numeric_compare_as_count(&q),
-            Some((pred.clone(), NumericCompareOp::Gt, fluree_db_core::FlakeValue::Long(0), out))
+            Some((
+                pred.clone(),
+                NumericCompareOp::Gt,
+                fluree_db_core::FlakeValue::Long(0),
+                out
+            ))
         );
 
         // SUM(DISTINCT ...) must be rejected: SUM(DISTINCT bool) is not a row count.

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -1071,7 +1071,8 @@ fn detect_class_property_count(query: &Query) -> Option<(Ref, Ref, Ref, VarId)> 
     if query.patterns.len() != 2 {
         return None;
     }
-    let (Pattern::Triple(t0), Pattern::Triple(t1)) = (&query.patterns[0], &query.patterns[1]) else {
+    let (Pattern::Triple(t0), Pattern::Triple(t1)) = (&query.patterns[0], &query.patterns[1])
+    else {
         return None;
     };
     for (cls_tp, prop_tp) in [(t0, t1), (t1, t0)] {

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -140,11 +140,7 @@ pub fn class_property_count_operator(
             let total: u64 = classes
                 .iter()
                 .find(|c| c.class_sid == class_sid)
-                .and_then(|c| {
-                    c.properties
-                        .iter()
-                        .find(|p| p.property_sid == property_sid)
-                })
+                .and_then(|c| c.properties.iter().find(|p| p.property_sid == property_sid))
                 .map(|p| p.datatypes.iter().map(|&(_dt, c)| c).sum())
                 .unwrap_or(0);
             if total == 0 {

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -103,6 +103,62 @@ pub fn count_rows_numeric_compare_operator(
     )
 }
 
+/// Fast-path: `SUM(?o <cmp> K)` over a single triple `?s <p> ?o`.
+///
+/// `SUM` of a boolean comparison is algebraically `COUNT` of the rows where the
+/// comparison holds (true→1, false→0), so this reuses the directory-skipping
+/// numeric-compare count.
+///
+/// SEMANTICS GUARD: `SUM` over an empty multiset is **Unbound** (SPARQL), whereas
+/// `COUNT` would be `0`. The two diverge only when the predicate feeds the
+/// aggregate *no rows at all* (absent predicate, or every row retracted). In that
+/// case we return `Ok(None)` to defer to the general aggregate pipeline, which
+/// emits the correct Unbound result. When at least one row exists, `SUM(?o cmp K)`
+/// == `COUNT(rows where ?o cmp K)` exactly (a non-empty input with zero matches
+/// sums to bound `0`, which `COUNT` also yields).
+pub fn sum_compare_as_count_operator(
+    predicate: Ref,
+    compare: NumericCompareOp,
+    threshold: FlakeValue,
+    out_var: VarId,
+    fallback: Option<BoxedOperator>,
+) -> FastPathOperator {
+    FastPathOperator::new(
+        out_var,
+        move |ctx| {
+            let Some(store) = fast_path_store(ctx) else {
+                return Ok(None);
+            };
+            let pred_sid = normalize_pred_sid(store, &predicate)?;
+            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                // Absent predicate => empty input => SUM is Unbound (not 0).
+                return Ok(None);
+            };
+            // Empty input (all rows retracted) => SUM is Unbound; defer to fallback.
+            let total = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
+            if total == 0 {
+                return Ok(None);
+            }
+            let count = count_rows_for_predicate_numeric_compare_post(
+                store,
+                ctx.binary_g_id,
+                p_id,
+                compare,
+                &threshold,
+            )?;
+            match count {
+                Some(count) => Ok(Some(build_count_batch(
+                    out_var,
+                    count_to_i64(count, "SUM(compare) as count")?,
+                )?)),
+                None => Ok(None),
+            }
+        },
+        fallback,
+        "SUM(compare) as count",
+    )
+}
+
 fn count_rows_for_predicate_numeric_compare_post(
     store: &BinaryIndexStore,
     g_id: GraphId,

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -91,6 +91,76 @@ pub fn count_rows_operator(
     )
 }
 
+/// Fast-path: `COUNT(*)` of `?s rdf:type <Class> . ?s P ?o` — the number of `P`
+/// flakes on instances of a single bound class. Answered from the per-(class,
+/// property) stats: `classStat[g][Class][P]` = Σ of its datatype counts (which
+/// already include the reference total via the `JSON_LD_ID` tag). One metadata
+/// lookup, no scan/join.
+///
+/// The per-class datatype stats are current-state-exact on any base index (#1266),
+/// so this runs on bulk and incremental indexes alike. HEAD-only (via
+/// [`fast_path_store`]); under overlay it defers to the fallback (stats exclude
+/// uncommitted novelty). `COUNT(DISTINCT …)` is a different statistic (distinct
+/// subjects/objects, not the flake count) and is excluded by the detector. Returns
+/// `Ok(None)` to defer when the bound-object leg isn't rdf:type, stats are absent,
+/// or the count is 0 (a genuinely-empty join the general path confirms cheaply).
+pub fn class_property_count_operator(
+    type_pred: Ref,
+    class_obj: Ref,
+    property: Ref,
+    out_var: VarId,
+    fallback: Option<BoxedOperator>,
+) -> FastPathOperator {
+    FastPathOperator::new(
+        out_var,
+        move |ctx| {
+            let Some(store) = fast_path_store(ctx) else {
+                return Ok(None);
+            };
+            // The bound-object leg must be rdf:type for the class stats to apply.
+            let type_sid = normalize_pred_sid(store, &type_pred)?;
+            if !fluree_db_core::is_rdf_type(&type_sid) {
+                return Ok(None);
+            }
+            let class_sid = normalize_pred_sid(store, &class_obj)?;
+            let property_sid = normalize_pred_sid(store, &property)?;
+
+            let Some(stats) = ctx.active_snapshot.stats.as_ref() else {
+                return Ok(None);
+            };
+            let Some(graphs) = stats.graphs.as_ref() else {
+                return Ok(None);
+            };
+            let Some(graph) = graphs.iter().find(|g| g.g_id == ctx.binary_g_id) else {
+                return Ok(None);
+            };
+            let Some(classes) = graph.classes.as_ref() else {
+                return Ok(None);
+            };
+            let total: u64 = classes
+                .iter()
+                .find(|c| c.class_sid == class_sid)
+                .and_then(|c| {
+                    c.properties
+                        .iter()
+                        .find(|p| p.property_sid == property_sid)
+                })
+                .map(|p| p.datatypes.iter().map(|&(_dt, c)| c).sum())
+                .unwrap_or(0);
+            if total == 0 {
+                // Genuinely-empty (or stats-incomplete) — let the general path confirm.
+                return Ok(None);
+            }
+            Ok(Some(build_count_batch(
+                out_var,
+                count_to_i64(total, "COUNT class-property")?,
+            )?))
+        },
+        fallback,
+        "COUNT class-property",
+    )
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NumericCompareOp {
     Gt,

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -9,11 +9,10 @@ use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
 use crate::fast_path_common::{
-    allow_cursor_fast_path, build_count_batch, count_rows_for_predicate_psot,
-    count_rows_via_overlay_cursor, count_to_i64, fast_path_store, leaf_entries_for_predicate,
-    normalize_pred_sid, parallel_leaf_chunk_count, parallel_overlay_psot_filter_count,
-    projection_okey_only, projection_otype_only, projection_sid_only, projection_sid_otype_okey,
-    FastPathOperator,
+    allow_cursor_fast_path, build_count_batch, count_rows_for_predicate_psot, count_to_i64,
+    fast_path_store, leaf_entries_for_predicate, normalize_pred_sid, parallel_leaf_chunk_count,
+    parallel_overlay_psot_filter_count, projection_okey_only, projection_otype_only,
+    projection_sid_only, projection_sid_otype_okey, FastPathOperator,
 };
 use std::sync::Arc;
 use fluree_db_binary_index::format::branch::LeafEntry;
@@ -113,7 +112,7 @@ pub fn count_rows_numeric_compare_operator(
                     let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
                         return Ok(None);
                     };
-                    if let Some((matches, _total)) = count_numeric_compare_via_overlay_cursor(
+                    if let Some(matches) = count_numeric_compare_overlay_parallel(
                         ctx,
                         store,
                         ctx.binary_g_id,
@@ -195,7 +194,7 @@ pub fn sum_compare_as_count_operator(
                     let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
                         return Ok(None);
                     };
-                    if let Some((matches, total)) = count_numeric_compare_via_overlay_cursor(
+                    if let Some(matches) = count_numeric_compare_overlay_parallel(
                         ctx,
                         store,
                         ctx.binary_g_id,
@@ -204,13 +203,16 @@ pub fn sum_compare_as_count_operator(
                         compare,
                         &threshold,
                     )? {
-                        if total == 0 {
-                            return Ok(None);
+                        // matches > 0 ⇒ the input is non-empty ⇒ SUM is the bound
+                        // count. matches == 0 can't distinguish empty (Unbound) from
+                        // non-empty-with-no-matches (bound 0), so defer to the
+                        // fallback, which resolves the SPARQL semantics correctly.
+                        if matches > 0 {
+                            return Ok(Some(build_count_batch(
+                                out_var,
+                                count_to_i64(matches, "SUM(compare) as count")?,
+                            )?));
                         }
-                        return Ok(Some(build_count_batch(
-                            out_var,
-                            count_to_i64(matches, "SUM(compare) as count")?,
-                        )?));
                     }
                 }
             }
@@ -499,14 +501,18 @@ fn okey_matches(compare: NumericCompareOp, o_key: u64, threshold: u64) -> bool {
     }
 }
 
-/// Overlay/time-travel lane for the numeric-compare count: count the rows of `p_id`
-/// matching `?o <compare> threshold` through an overlay-folding cursor, returning
-/// `(matches, total_rows_scanned)`. `total_rows` lets the SUM caller apply the
-/// empty-input→Unbound rule. The thresholds for the two numeric otypes are encoded
-/// once up front; a non-numeric (or non-encodable) object row bails the whole count
-/// to `Ok(None)`, matching the base path's mixed/non-numeric bail. BASE+novelty:
-/// caller gates on [`allow_cursor_fast_path`].
-fn count_numeric_compare_via_overlay_cursor(
+/// Overlay/time-travel lane for the numeric-compare count: counts rows of `p_id`
+/// matching `?o <compare> threshold` over the novelty-merged stream, parallelized
+/// across the subject space (PSOT) just like the HEAD path.
+///
+/// The comparison is per-row and order-independent, so PSOT order is fine — the POST
+/// directory shortcut + binary search only apply to the base scan. A non-numeric (or
+/// non-encodable) object is treated as a non-match: `?o <cmp> K` on a non-number
+/// would error and so contributes nothing, which equals what the general aggregate
+/// pipeline counts (and avoids the base path's whole-query bail on mixed types).
+/// Returns the match count, or `Ok(None)` to defer (overlay flake failed to
+/// translate). BASE+novelty: caller gates on [`allow_cursor_fast_path`].
+fn count_numeric_compare_overlay_parallel(
     ctx: &crate::context::ExecutionContext<'_>,
     store: &Arc<BinaryIndexStore>,
     g_id: GraphId,
@@ -514,28 +520,27 @@ fn count_numeric_compare_via_overlay_cursor(
     p_id: u32,
     compare: NumericCompareOp,
     threshold: &FlakeValue,
-) -> Result<Option<(u64, u64)>> {
+) -> Result<Option<u64>> {
     let tk_int = encode_numeric_threshold_for_otype(OType::XSD_INTEGER, threshold)?;
     let tk_dbl = encode_numeric_threshold_for_otype(OType::XSD_DOUBLE, threshold)?;
-    let mut total: u64 = 0;
-    let matches = count_rows_via_overlay_cursor(
+    parallel_overlay_psot_filter_count(
         ctx,
         store,
         g_id,
-        RunSortOrder::Post,
         pred_sid,
         p_id,
-        |_s, o_type, o_key| {
-            total = total.saturating_add(1);
+        move |_s, o_type, o_key| {
             let tk = match OType::from_u16(o_type) {
                 OType::XSD_INTEGER => tk_int,
                 OType::XSD_DOUBLE => tk_dbl,
-                _ => return None, // non-numeric object: bail to the general pipeline
+                _ => return false, // non-numeric object: comparison errors => not a match
             };
-            tk.map(|tk| okey_matches(compare, o_key, tk))
+            match tk {
+                Some(tk) => okey_matches(compare, o_key, tk),
+                None => false,
+            }
         },
-    )?;
-    Ok(matches.map(|m| (m, total)))
+    )
 }
 
 /// Fast-path: parallel `COUNT(?s)` / `COUNT(*)` for a single predicate `?s <p> ?o`

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -171,13 +171,111 @@ fn count_rows_for_predicate_numeric_compare_post(
     threshold: &FlakeValue,
 ) -> Result<Option<u64>> {
     let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id);
-    // Each POST leaflet is type-homogeneous and counted independently, so the leaf
-    // slice can be split across cores (the per-leaflet reducer is stateless). The
-    // partition decision uses the predicate's total row count.
+
+    // Global metadata shortcut: POST sorts by (p_id, o_type, o_key), so the
+    // predicate's whole o_key extent is [global_min, global_max]. If that extent
+    // lies entirely on one side of the threshold, the answer is `total` (all match)
+    // or `0` (all excluded) with no per-leaflet scan — opening at most the ≤2
+    // boundary leaves whose manifest key belongs to an adjacent predicate. For
+    // `?o > 0` over an all-positive predicate this collapses the whole scan to a
+    // manifest read.
+    if let Some((min_ot, min_ok, max_ot, max_ok)) =
+        predicate_post_global_extent(store, p_id, leaves)?
+    {
+        // Same o_type at both ends ⇒ uniform o_type (POST sorts o_type before o_key).
+        if min_ot == max_ot {
+            let otype = OType::from_u16(min_ot);
+            if matches!(otype, OType::XSD_INTEGER | OType::XSD_DOUBLE) {
+                if let Some(threshold_key) = encode_numeric_threshold_for_otype(otype, threshold)? {
+                    if leaflet_fully_excluded(compare, min_ok, max_ok, threshold_key) {
+                        return Ok(Some(0));
+                    }
+                    if leaflet_fully_matches(compare, min_ok, max_ok, threshold_key) {
+                        return Ok(Some(count_rows_for_predicate_psot(store, g_id, p_id)?));
+                    }
+                }
+            }
+        }
+    }
+
+    // Partial overlap (or mixed/non-numeric o_type): each POST leaflet is
+    // type-homogeneous and counted independently, so the leaf slice is split across
+    // cores (the per-leaflet reducer is stateless). The partition decision uses the
+    // predicate's total row count.
     let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
     parallel_leaf_chunk_count(leaves, total_rows, |chunk| {
         count_numeric_compare_in_leaf_slice(store, p_id, compare, threshold, chunk)
     })
+}
+
+/// The predicate's global `(min_o_type, min_o_key, max_o_type, max_o_key)` in POST
+/// order — the extent of its rows. Read straight from the branch manifest
+/// (`LeafEntry.first_key`/`last_key` are decoded `RunRecordV2`), opening only the
+/// ≤2 boundary leaves whose manifest key belongs to an adjacent predicate (so their
+/// per-leaflet directory must be consulted for this predicate's first/last key).
+/// Returns `None` if there are no leaves (an empty predicate — the caller's total is
+/// 0) or, defensively, if a boundary leaf yields no matching leaflet.
+fn predicate_post_global_extent(
+    store: &BinaryIndexStore,
+    p_id: u32,
+    leaves: &[LeafEntry],
+) -> Result<Option<(u16, u64, u16, u64)>> {
+    let (Some(first_leaf), Some(last_leaf)) = (leaves.first(), leaves.last()) else {
+        return Ok(None);
+    };
+
+    // Global minimum: the first p_id row in POST order. When the first leaf already
+    // starts at this predicate the manifest key is it; otherwise the leaf opens with
+    // an earlier predicate and we read its first p_id leaflet's first key.
+    let (min_ot, min_ok) = if first_leaf.first_key.p_id == p_id {
+        (first_leaf.first_key.o_type, first_leaf.first_key.o_key)
+    } else {
+        match boundary_leaf_pid_extent(store, p_id, first_leaf, false)? {
+            Some(v) => v,
+            None => return Ok(None),
+        }
+    };
+
+    // Global maximum: the last p_id row in POST order.
+    let (max_ot, max_ok) = if last_leaf.last_key.p_id == p_id {
+        (last_leaf.last_key.o_type, last_leaf.last_key.o_key)
+    } else {
+        match boundary_leaf_pid_extent(store, p_id, last_leaf, true)? {
+            Some(v) => v,
+            None => return Ok(None),
+        }
+    };
+
+    Ok(Some((min_ot, min_ok, max_ot, max_ok)))
+}
+
+/// Open a boundary leaf and read the `(o_type, o_key)` of this predicate's first
+/// (`last = false`) or last (`last = true`) row, from the matching leaflet directory
+/// entry. Returns `None` if no leaflet in the leaf belongs to `p_id`.
+fn boundary_leaf_pid_extent(
+    store: &BinaryIndexStore,
+    p_id: u32,
+    leaf: &LeafEntry,
+    last: bool,
+) -> Result<Option<(u16, u64)>> {
+    let handle = store
+        .open_leaf_handle(&leaf.leaf_cid, leaf.sidecar_cid.as_ref(), false)
+        .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;
+    let entries = &handle.dir().entries;
+    let mut indices = (0..entries.len()).collect::<Vec<_>>();
+    if last {
+        indices.reverse();
+    }
+    for i in indices {
+        let entry = &entries[i];
+        if entry.row_count == 0 || entry.p_const != Some(p_id) {
+            continue;
+        }
+        let raw = if last { &entry.last_key } else { &entry.first_key };
+        let key = read_ordered_key_v2(RunSortOrder::Post, raw);
+        return Ok(Some((key.o_type, key.o_key)));
+    }
+    Ok(None)
 }
 
 /// Count rows of `p_id` matching `?o <compare> threshold` over one contiguous slice

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -11,8 +11,9 @@ use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, Encod
 use crate::fast_path_common::{
     allow_cursor_fast_path, build_count_batch, count_rows_for_predicate_psot,
     count_rows_via_overlay_cursor, count_to_i64, fast_path_store, leaf_entries_for_predicate,
-    normalize_pred_sid, parallel_leaf_chunk_count, projection_okey_only, projection_otype_only,
-    projection_sid_only, projection_sid_otype_okey, FastPathOperator,
+    normalize_pred_sid, parallel_leaf_chunk_count, parallel_overlay_psot_filter_count,
+    projection_okey_only, projection_otype_only, projection_sid_only, projection_sid_otype_okey,
+    FastPathOperator,
 };
 use std::sync::Arc;
 use fluree_db_binary_index::format::branch::LeafEntry;
@@ -607,15 +608,14 @@ pub fn count_rows_encoded_filters_operator(
                     if !pruned.is_empty() || encoded.is_empty() {
                         return Ok(None);
                     }
-                    if let Some(count) = count_rows_via_overlay_cursor(
+                    if let Some(count) = parallel_overlay_psot_filter_count(
                         ctx,
                         store,
                         g_id,
-                        RunSortOrder::Psot,
                         pred_sid,
                         p_id,
-                        |s_id, o_type, o_key| {
-                            Some(encoded.iter().all(|f| f.eval_row(s_id, o_type, o_key)))
+                        move |s_id, o_type, o_key| {
+                            encoded.iter().all(|f| f.eval_row(s_id, o_type, o_key))
                         },
                     )? {
                         return Ok(Some(build_count_batch(
@@ -714,14 +714,13 @@ pub fn count_rows_lang_filter_operator(
                         return Ok(None);
                     };
                     let required_otype = OType::lang_string(lang_id).as_u16();
-                    if let Some(count) = count_rows_via_overlay_cursor(
+                    if let Some(count) = parallel_overlay_psot_filter_count(
                         ctx,
                         store,
                         ctx.binary_g_id,
-                        RunSortOrder::Psot,
                         pred_sid,
                         p_id,
-                        |_s, o_type, _o_key| Some(o_type == required_otype),
+                        move |_s, o_type, _o_key| o_type == required_otype,
                     )? {
                         return Ok(Some(build_count_batch(
                             out_var,

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -5,9 +5,9 @@
 //! when `fast_path_store(ctx)` is available, otherwise they fall back to a planned
 //! operator tree for correctness.
 
+use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
-use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
 use crate::fast_path_common::{
     allow_cursor_fast_path, build_count_batch, count_predicate_overlay_delta,
     count_rows_for_predicate_psot, count_to_i64, fast_path_store, leaf_entries_for_predicate,
@@ -15,12 +15,11 @@ use crate::fast_path_common::{
     projection_okey_only, projection_otype_only, projection_sid_only, projection_sid_otype_okey,
     FastPathOperator,
 };
-use std::sync::Arc;
-use fluree_db_binary_index::format::branch::LeafEntry;
 use crate::ir::triple::{Ref, TriplePattern};
 use crate::operator::inline::InlineOperator;
 use crate::operator::BoxedOperator;
 use crate::var_registry::VarId;
+use fluree_db_binary_index::format::branch::LeafEntry;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::format::run_record_v2::{
     cmp_v2_for_order, read_ordered_key_v2, RunRecordV2,
@@ -31,6 +30,7 @@ use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::value_id::ObjKey;
 use fluree_db_core::{FlakeValue, GraphId};
 use fluree_vocab::namespaces;
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // 1) COUNT(*) / COUNT(?x) for single predicate `?s <p> ?o`
@@ -69,9 +69,13 @@ pub fn count_rows_operator(
                         let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
                             return Ok(None); // novelty-only predicate => defer
                         };
-                        if let Some(count) =
-                            count_predicate_overlay_delta(ctx, store, ctx.binary_g_id, pred_sid, p_id)?
-                        {
+                        if let Some(count) = count_predicate_overlay_delta(
+                            ctx,
+                            store,
+                            ctx.binary_g_id,
+                            pred_sid,
+                            p_id,
+                        )? {
                             return Ok(Some(build_count_batch(
                                 out_var,
                                 count_to_i64(count, "COUNT rows")?,
@@ -356,7 +360,11 @@ fn boundary_leaf_pid_extent(
         if entry.row_count == 0 || entry.p_const != Some(p_id) {
             continue;
         }
-        let raw = if last { &entry.last_key } else { &entry.first_key };
+        let raw = if last {
+            &entry.last_key
+        } else {
+            &entry.first_key
+        };
         let key = read_ordered_key_v2(RunSortOrder::Post, raw);
         return Ok(Some((key.o_type, key.o_key)));
     }

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -9,10 +9,12 @@ use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
 use crate::fast_path_common::{
-    build_count_batch, count_rows_for_predicate_psot, count_to_i64, fast_path_store,
-    leaf_entries_for_predicate, normalize_pred_sid, parallel_leaf_chunk_count, projection_okey_only,
-    projection_otype_only, projection_sid_only, projection_sid_otype_okey, FastPathOperator,
+    allow_cursor_fast_path, build_count_batch, count_rows_for_predicate_psot,
+    count_rows_via_overlay_cursor, count_to_i64, fast_path_store, leaf_entries_for_predicate,
+    normalize_pred_sid, parallel_leaf_chunk_count, projection_okey_only, projection_otype_only,
+    projection_sid_only, projection_sid_otype_okey, FastPathOperator,
 };
+use std::sync::Arc;
 use fluree_db_binary_index::format::branch::LeafEntry;
 use crate::ir::triple::{Ref, TriplePattern};
 use crate::operator::inline::InlineOperator;
@@ -80,27 +82,53 @@ pub fn count_rows_numeric_compare_operator(
     FastPathOperator::new(
         out_var,
         move |ctx| {
-            let Some(store) = fast_path_store(ctx) else {
-                return Ok(None);
-            };
-            let pred_sid = normalize_pred_sid(store, &predicate)?;
-            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
-                return Ok(Some(build_count_batch(out_var, 0)?));
-            };
-            let count = count_rows_for_predicate_numeric_compare_post(
-                store,
-                ctx.binary_g_id,
-                p_id,
-                compare,
-                &threshold,
-            )?;
-            match count {
-                Some(count) => Ok(Some(build_count_batch(
-                    out_var,
-                    count_to_i64(count, "COUNT rows numeric compare")?,
-                )?)),
-                None => Ok(None),
+            // HEAD lane: directory shortcut + binary-search over base POST leaflets.
+            if let Some(store) = fast_path_store(ctx) {
+                let pred_sid = normalize_pred_sid(store, &predicate)?;
+                let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                    return Ok(Some(build_count_batch(out_var, 0)?));
+                };
+                let count = count_rows_for_predicate_numeric_compare_post(
+                    store,
+                    ctx.binary_g_id,
+                    p_id,
+                    compare,
+                    &threshold,
+                )?;
+                return match count {
+                    Some(count) => Ok(Some(build_count_batch(
+                        out_var,
+                        count_to_i64(count, "COUNT rows numeric compare")?,
+                    )?)),
+                    None => Ok(None),
+                };
             }
+            // Overlay / time-travel lane: per-row compare over the merged cursor.
+            if allow_cursor_fast_path(ctx) {
+                if let Some(store) = ctx.binary_store.as_ref() {
+                    let pred_sid = normalize_pred_sid(store, &predicate)?;
+                    // Absent in base => COUNT is 0 only if also absent in novelty; a
+                    // novelty-only predicate has no base id, so defer to the fallback.
+                    let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                        return Ok(None);
+                    };
+                    if let Some((matches, _total)) = count_numeric_compare_via_overlay_cursor(
+                        ctx,
+                        store,
+                        ctx.binary_g_id,
+                        pred_sid,
+                        p_id,
+                        compare,
+                        &threshold,
+                    )? {
+                        return Ok(Some(build_count_batch(
+                            out_var,
+                            count_to_i64(matches, "COUNT rows numeric compare")?,
+                        )?));
+                    }
+                }
+            }
+            Ok(None)
         },
         fallback,
         "COUNT rows numeric compare",
@@ -130,33 +158,62 @@ pub fn sum_compare_as_count_operator(
     FastPathOperator::new(
         out_var,
         move |ctx| {
-            let Some(store) = fast_path_store(ctx) else {
-                return Ok(None);
-            };
-            let pred_sid = normalize_pred_sid(store, &predicate)?;
-            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
-                // Absent predicate => empty input => SUM is Unbound (not 0).
-                return Ok(None);
-            };
-            // Empty input (all rows retracted) => SUM is Unbound; defer to fallback.
-            let total = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
-            if total == 0 {
-                return Ok(None);
+            // HEAD lane.
+            if let Some(store) = fast_path_store(ctx) {
+                let pred_sid = normalize_pred_sid(store, &predicate)?;
+                let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                    // Absent predicate => empty input => SUM is Unbound (not 0).
+                    return Ok(None);
+                };
+                // Empty input (all rows retracted) => SUM is Unbound; defer to fallback.
+                let total = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
+                if total == 0 {
+                    return Ok(None);
+                }
+                let count = count_rows_for_predicate_numeric_compare_post(
+                    store,
+                    ctx.binary_g_id,
+                    p_id,
+                    compare,
+                    &threshold,
+                )?;
+                return match count {
+                    Some(count) => Ok(Some(build_count_batch(
+                        out_var,
+                        count_to_i64(count, "SUM(compare) as count")?,
+                    )?)),
+                    None => Ok(None),
+                };
             }
-            let count = count_rows_for_predicate_numeric_compare_post(
-                store,
-                ctx.binary_g_id,
-                p_id,
-                compare,
-                &threshold,
-            )?;
-            match count {
-                Some(count) => Ok(Some(build_count_batch(
-                    out_var,
-                    count_to_i64(count, "SUM(compare) as count")?,
-                )?)),
-                None => Ok(None),
+            // Overlay / time-travel lane: the merged cursor count gives both the
+            // matches and the total rows; an empty (base+novelty) input is SUM
+            // Unbound, so defer to the fallback which emits Unbound.
+            if allow_cursor_fast_path(ctx) {
+                if let Some(store) = ctx.binary_store.as_ref() {
+                    let pred_sid = normalize_pred_sid(store, &predicate)?;
+                    let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                        return Ok(None);
+                    };
+                    if let Some((matches, total)) = count_numeric_compare_via_overlay_cursor(
+                        ctx,
+                        store,
+                        ctx.binary_g_id,
+                        pred_sid,
+                        p_id,
+                        compare,
+                        &threshold,
+                    )? {
+                        if total == 0 {
+                            return Ok(None);
+                        }
+                        return Ok(Some(build_count_batch(
+                            out_var,
+                            count_to_i64(matches, "SUM(compare) as count")?,
+                        )?));
+                    }
+                }
             }
+            Ok(None)
         },
         fallback,
         "SUM(compare) as count",
@@ -429,6 +486,57 @@ fn upper_bound_okey(batch: &fluree_db_binary_index::ColumnBatch, threshold: u64)
     lo
 }
 
+/// Scalar form of the numeric comparison on the order-preserving `o_key` encoding
+/// (the same encoding the binary-search bounds rely on).
+#[inline]
+fn okey_matches(compare: NumericCompareOp, o_key: u64, threshold: u64) -> bool {
+    match compare {
+        NumericCompareOp::Gt => o_key > threshold,
+        NumericCompareOp::Ge => o_key >= threshold,
+        NumericCompareOp::Lt => o_key < threshold,
+        NumericCompareOp::Le => o_key <= threshold,
+    }
+}
+
+/// Overlay/time-travel lane for the numeric-compare count: count the rows of `p_id`
+/// matching `?o <compare> threshold` through an overlay-folding cursor, returning
+/// `(matches, total_rows_scanned)`. `total_rows` lets the SUM caller apply the
+/// empty-input→Unbound rule. The thresholds for the two numeric otypes are encoded
+/// once up front; a non-numeric (or non-encodable) object row bails the whole count
+/// to `Ok(None)`, matching the base path's mixed/non-numeric bail. BASE+novelty:
+/// caller gates on [`allow_cursor_fast_path`].
+fn count_numeric_compare_via_overlay_cursor(
+    ctx: &crate::context::ExecutionContext<'_>,
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    pred_sid: fluree_db_core::Sid,
+    p_id: u32,
+    compare: NumericCompareOp,
+    threshold: &FlakeValue,
+) -> Result<Option<(u64, u64)>> {
+    let tk_int = encode_numeric_threshold_for_otype(OType::XSD_INTEGER, threshold)?;
+    let tk_dbl = encode_numeric_threshold_for_otype(OType::XSD_DOUBLE, threshold)?;
+    let mut total: u64 = 0;
+    let matches = count_rows_via_overlay_cursor(
+        ctx,
+        store,
+        g_id,
+        RunSortOrder::Post,
+        pred_sid,
+        p_id,
+        |_s, o_type, o_key| {
+            total = total.saturating_add(1);
+            let tk = match OType::from_u16(o_type) {
+                OType::XSD_INTEGER => tk_int,
+                OType::XSD_DOUBLE => tk_dbl,
+                _ => return None, // non-numeric object: bail to the general pipeline
+            };
+            tk.map(|tk| okey_matches(compare, o_key, tk))
+        },
+    )?;
+    Ok(matches.map(|m| (m, total)))
+}
+
 /// Fast-path: parallel `COUNT(?s)` / `COUNT(*)` for a single predicate `?s <p> ?o`
 /// with FILTERs that compile to encoded pre-filters (no value decoding), e.g.
 /// `FILTER(?s != ?o)`, `FILTER(?s = ?o)`, `FILTER(ISBLANK(?o))`,
@@ -450,38 +558,74 @@ pub fn count_rows_encoded_filters_operator(
     FastPathOperator::new(
         out_var,
         move |ctx| {
-            let Some(store) = fast_path_store(ctx) else {
-                return Ok(None);
-            };
             let g_id = ctx.binary_g_id;
-            let pred_sid = normalize_pred_sid(store, &pattern.p)?;
-            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
-                // Absent predicate => no rows => COUNT is 0.
-                return Ok(Some(build_count_batch(out_var, 0)?));
-            };
-            // Compile the FILTERs to encoded pre-filters. If any can't be pushed
-            // down (needs value decoding), defer to the serial scan-count fallback.
-            let (encoded, pruned) = compile_encoded_pre_filters_and_prune_inline_ops(
-                &inline_ops,
-                &pattern,
-                store,
-                true,
-            );
-            if !pruned.is_empty() || encoded.is_empty() {
-                return Ok(None);
+            // HEAD lane: parallel base-leaflet scan applying the encoded filters.
+            if let Some(store) = fast_path_store(ctx) {
+                let pred_sid = normalize_pred_sid(store, &pattern.p)?;
+                let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                    // Absent predicate => no rows => COUNT is 0.
+                    return Ok(Some(build_count_batch(out_var, 0)?));
+                };
+                // Compile the FILTERs to encoded pre-filters. If any can't be pushed
+                // down (needs value decoding), defer to the serial scan-count fallback.
+                let (encoded, pruned) = compile_encoded_pre_filters_and_prune_inline_ops(
+                    &inline_ops,
+                    &pattern,
+                    store,
+                    true,
+                );
+                if !pruned.is_empty() || encoded.is_empty() {
+                    return Ok(None);
+                }
+                let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
+                let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
+                let count = parallel_leaf_chunk_count(leaves, total_rows, |chunk| {
+                    count_rows_matching_encoded_filters_in_leaf_slice(store, p_id, &encoded, chunk)
+                })?;
+                return match count {
+                    Some(c) => Ok(Some(build_count_batch(
+                        out_var,
+                        count_to_i64(c, "COUNT rows encoded filters")?,
+                    )?)),
+                    None => Ok(None),
+                };
             }
-            let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
-            let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
-            let count = parallel_leaf_chunk_count(leaves, total_rows, |chunk| {
-                count_rows_matching_encoded_filters_in_leaf_slice(store, p_id, &encoded, chunk)
-            })?;
-            match count {
-                Some(c) => Ok(Some(build_count_batch(
-                    out_var,
-                    count_to_i64(c, "COUNT rows encoded filters")?,
-                )?)),
-                None => Ok(None),
+            // Overlay / time-travel lane: apply the same encoded filters per row over
+            // the merged cursor. A novelty-only predicate has no base id => defer.
+            if allow_cursor_fast_path(ctx) {
+                if let Some(store) = ctx.binary_store.as_ref() {
+                    let pred_sid = normalize_pred_sid(store, &pattern.p)?;
+                    let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                        return Ok(None);
+                    };
+                    let (encoded, pruned) = compile_encoded_pre_filters_and_prune_inline_ops(
+                        &inline_ops,
+                        &pattern,
+                        store,
+                        true,
+                    );
+                    if !pruned.is_empty() || encoded.is_empty() {
+                        return Ok(None);
+                    }
+                    if let Some(count) = count_rows_via_overlay_cursor(
+                        ctx,
+                        store,
+                        g_id,
+                        RunSortOrder::Psot,
+                        pred_sid,
+                        p_id,
+                        |s_id, o_type, o_key| {
+                            Some(encoded.iter().all(|f| f.eval_row(s_id, o_type, o_key)))
+                        },
+                    )? {
+                        return Ok(Some(build_count_batch(
+                            out_var,
+                            count_to_i64(count, "COUNT rows encoded filters")?,
+                        )?));
+                    }
+                }
             }
+            Ok(None)
         },
         fallback,
         "COUNT rows encoded filters (parallel)",
@@ -536,23 +680,57 @@ pub fn count_rows_lang_filter_operator(
     FastPathOperator::new(
         out_var,
         move |ctx| {
-            let Some(store) = fast_path_store(ctx) else {
-                return Ok(None);
-            };
-            let pred_sid = normalize_pred_sid(store, &predicate)?;
-            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
-                return Ok(Some(build_count_batch(out_var, 0)?));
-            };
-            let Some(lang_id) = store.resolve_lang_id(&lang_tag) else {
-                return Ok(Some(build_count_batch(out_var, 0)?));
-            };
-            let required_otype = OType::lang_string(lang_id).as_u16();
-            let count =
-                count_rows_for_predicate_lang_psot(store, ctx.binary_g_id, p_id, required_otype)?;
-            Ok(Some(build_count_batch(
-                out_var,
-                count_to_i64(count, "COUNT rows lang filter")?,
-            )?))
+            // HEAD lane: base-leaflet scan with the per-leaflet o_type_const shortcut.
+            if let Some(store) = fast_path_store(ctx) {
+                let pred_sid = normalize_pred_sid(store, &predicate)?;
+                let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                    return Ok(Some(build_count_batch(out_var, 0)?));
+                };
+                let Some(lang_id) = store.resolve_lang_id(&lang_tag) else {
+                    return Ok(Some(build_count_batch(out_var, 0)?));
+                };
+                let required_otype = OType::lang_string(lang_id).as_u16();
+                let count = count_rows_for_predicate_lang_psot(
+                    store,
+                    ctx.binary_g_id,
+                    p_id,
+                    required_otype,
+                )?;
+                return Ok(Some(build_count_batch(
+                    out_var,
+                    count_to_i64(count, "COUNT rows lang filter")?,
+                )?));
+            }
+            // Overlay / time-travel lane: count merged rows whose o_type is the
+            // lang-string type. A predicate or lang present only in novelty has no
+            // base id, so defer to the fallback (it handles novelty-only terms).
+            if allow_cursor_fast_path(ctx) {
+                if let Some(store) = ctx.binary_store.as_ref() {
+                    let pred_sid = normalize_pred_sid(store, &predicate)?;
+                    let (Some(p_id), Some(lang_id)) = (
+                        store.sid_to_p_id(&pred_sid),
+                        store.resolve_lang_id(&lang_tag),
+                    ) else {
+                        return Ok(None);
+                    };
+                    let required_otype = OType::lang_string(lang_id).as_u16();
+                    if let Some(count) = count_rows_via_overlay_cursor(
+                        ctx,
+                        store,
+                        ctx.binary_g_id,
+                        RunSortOrder::Psot,
+                        pred_sid,
+                        p_id,
+                        |_s, o_type, _o_key| Some(o_type == required_otype),
+                    )? {
+                        return Ok(Some(build_count_batch(
+                            out_var,
+                            count_to_i64(count, "COUNT rows lang filter")?,
+                        )?));
+                    }
+                }
+            }
+            Ok(None)
         },
         fallback,
         "COUNT rows lang filter",

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -7,12 +7,15 @@
 
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
+use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
 use crate::fast_path_common::{
     build_count_batch, count_rows_for_predicate_psot, count_to_i64, fast_path_store,
-    leaf_entries_for_predicate, normalize_pred_sid, projection_okey_only, projection_otype_only,
-    projection_sid_only, FastPathOperator,
+    leaf_entries_for_predicate, normalize_pred_sid, parallel_leaf_chunk_count, projection_okey_only,
+    projection_otype_only, projection_sid_only, projection_sid_otype_okey, FastPathOperator,
 };
-use crate::ir::triple::Ref;
+use fluree_db_binary_index::format::branch::LeafEntry;
+use crate::ir::triple::{Ref, TriplePattern};
+use crate::operator::inline::InlineOperator;
 use crate::operator::BoxedOperator;
 use crate::var_registry::VarId;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
@@ -168,10 +171,33 @@ fn count_rows_for_predicate_numeric_compare_post(
     threshold: &FlakeValue,
 ) -> Result<Option<u64>> {
     let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id);
+    // Each POST leaflet is type-homogeneous and counted independently, so the leaf
+    // slice can be split across cores (the per-leaflet reducer is stateless). The
+    // partition decision uses the predicate's total row count.
+    let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
+    parallel_leaf_chunk_count(leaves, total_rows, |chunk| {
+        count_numeric_compare_in_leaf_slice(store, p_id, compare, threshold, chunk)
+    })
+}
+
+/// Count rows of `p_id` matching `?o <compare> threshold` over one contiguous slice
+/// of POST leaves. Each leaflet is type-homogeneous (`o_type_const`), so the
+/// threshold is encoded per-leaflet for that leaflet's numeric otype — this both
+/// removes the cross-leaflet shared state (making the slice safe to run on its own
+/// thread) and correctly handles a predicate carrying both XSD_INTEGER and
+/// XSD_DOUBLE objects (POST sorts by o_type, so int and double leaflets are
+/// disjoint and each is counted against its own encoded threshold). Returns
+/// `Ok(None)` if any leaflet is non-numeric or the threshold can't be encoded for
+/// its otype — deferring the whole count to the general aggregate pipeline.
+fn count_numeric_compare_in_leaf_slice(
+    store: &BinaryIndexStore,
+    p_id: u32,
+    compare: NumericCompareOp,
+    threshold: &FlakeValue,
+    leaves: &[LeafEntry],
+) -> Result<Option<u64>> {
     let projection = projection_okey_only();
     let mut total: u64 = 0;
-    let mut required_otype: Option<OType> = None;
-    let mut threshold_key: Option<u64> = None;
 
     for leaf_entry in leaves {
         let handle = store
@@ -191,22 +217,11 @@ fn count_rows_for_predicate_numeric_compare_post(
             if !matches!(otype, OType::XSD_INTEGER | OType::XSD_DOUBLE) {
                 return Ok(None);
             }
+            let threshold_key = match encode_numeric_threshold_for_otype(otype, threshold)? {
+                Some(key) => key,
+                None => return Ok(None),
+            };
 
-            match required_otype {
-                Some(existing) if existing != otype => return Ok(None),
-                Some(_) => {}
-                None => {
-                    required_otype = Some(otype);
-                    threshold_key = Some(
-                        match encode_numeric_threshold_for_otype(otype, threshold)? {
-                            Some(key) => key,
-                            None => return Ok(None),
-                        },
-                    );
-                }
-            }
-
-            let threshold_key = threshold_key.expect("set with required_otype");
             let first = read_ordered_key_v2(RunSortOrder::Post, &entry.first_key);
             let last = read_ordered_key_v2(RunSortOrder::Post, &entry.last_key);
 
@@ -314,6 +329,102 @@ fn upper_bound_okey(batch: &fluree_db_binary_index::ColumnBatch, threshold: u64)
         }
     }
     lo
+}
+
+/// Fast-path: parallel `COUNT(?s)` / `COUNT(*)` for a single predicate `?s <p> ?o`
+/// with FILTERs that compile to encoded pre-filters (no value decoding), e.g.
+/// `FILTER(?s != ?o)`, `FILTER(?s = ?o)`, `FILTER(ISBLANK(?o))`,
+/// `FILTER(LANG(?o) = "en")`.
+///
+/// At HEAD (via [`fast_path_store`]) the predicate's PSOT leaves are split across
+/// cores and each chunk counts the rows passing *every* encoded pre-filter — reading
+/// only the (s_id, o_type, o_key) columns and bypassing the serial
+/// `BinaryScanOperator` row materialization entirely. Returns `Ok(None)` — deferring
+/// to `fallback` (the serial scan-count) — when not at HEAD, the predicate is absent
+/// already handled as 0, or any filter can't be pushed down to encoded columns
+/// (it would need value decoding).
+pub fn count_rows_encoded_filters_operator(
+    pattern: TriplePattern,
+    inline_ops: Vec<InlineOperator>,
+    out_var: VarId,
+    fallback: Option<BoxedOperator>,
+) -> FastPathOperator {
+    FastPathOperator::new(
+        out_var,
+        move |ctx| {
+            let Some(store) = fast_path_store(ctx) else {
+                return Ok(None);
+            };
+            let g_id = ctx.binary_g_id;
+            let pred_sid = normalize_pred_sid(store, &pattern.p)?;
+            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                // Absent predicate => no rows => COUNT is 0.
+                return Ok(Some(build_count_batch(out_var, 0)?));
+            };
+            // Compile the FILTERs to encoded pre-filters. If any can't be pushed
+            // down (needs value decoding), defer to the serial scan-count fallback.
+            let (encoded, pruned) = compile_encoded_pre_filters_and_prune_inline_ops(
+                &inline_ops,
+                &pattern,
+                store,
+                true,
+            );
+            if !pruned.is_empty() || encoded.is_empty() {
+                return Ok(None);
+            }
+            let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
+            let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
+            let count = parallel_leaf_chunk_count(leaves, total_rows, |chunk| {
+                count_rows_matching_encoded_filters_in_leaf_slice(store, p_id, &encoded, chunk)
+            })?;
+            match count {
+                Some(c) => Ok(Some(build_count_batch(
+                    out_var,
+                    count_to_i64(c, "COUNT rows encoded filters")?,
+                )?)),
+                None => Ok(None),
+            }
+        },
+        fallback,
+        "COUNT rows encoded filters (parallel)",
+    )
+}
+
+/// Count rows of `p_id` passing every encoded pre-filter over one contiguous slice
+/// of PSOT leaves. Loads (s_id, o_type, o_key) per leaflet and applies the filters
+/// on the encoded columns — no term decoding, no binding materialization. Always
+/// returns `Ok(Some(_))` (the encoded filters are total functions on every row).
+fn count_rows_matching_encoded_filters_in_leaf_slice(
+    store: &BinaryIndexStore,
+    p_id: u32,
+    filters: &[EncodedPreFilter],
+    leaves: &[LeafEntry],
+) -> Result<Option<u64>> {
+    let projection = projection_sid_otype_okey();
+    let mut total: u64 = 0;
+    for leaf_entry in leaves {
+        let handle = store
+            .open_leaf_handle(&leaf_entry.leaf_cid, leaf_entry.sidecar_cid.as_ref(), false)
+            .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;
+        let dir = handle.dir();
+        for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
+            if entry.row_count == 0 || entry.p_const != Some(p_id) {
+                continue;
+            }
+            let batch = handle
+                .load_columns(leaflet_idx, &projection, RunSortOrder::Psot)
+                .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?;
+            for r in 0..batch.row_count {
+                let s_id = batch.s_id.get(r);
+                let o_type = batch.o_type.get(r);
+                let o_key = batch.o_key.get(r);
+                if filters.iter().all(|f| f.eval_row(s_id, o_type, o_key)) {
+                    total = total.saturating_add(1);
+                }
+            }
+        }
+    }
+    Ok(Some(total))
 }
 
 /// Fast-path: `COUNT(*)` / `COUNT(?x)` for a single triple `?s <p> ?o`

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -9,10 +9,11 @@ use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
 use crate::fast_path_common::{
-    allow_cursor_fast_path, build_count_batch, count_rows_for_predicate_psot, count_to_i64,
-    fast_path_store, leaf_entries_for_predicate, normalize_pred_sid, parallel_leaf_chunk_count,
-    parallel_overlay_psot_filter_count, projection_okey_only, projection_otype_only,
-    projection_sid_only, projection_sid_otype_okey, FastPathOperator,
+    allow_cursor_fast_path, build_count_batch, count_predicate_overlay_delta,
+    count_rows_for_predicate_psot, count_to_i64, fast_path_store, leaf_entries_for_predicate,
+    normalize_pred_sid, parallel_leaf_chunk_count, parallel_overlay_psot_filter_count,
+    projection_okey_only, projection_otype_only, projection_sid_only, projection_sid_otype_okey,
+    FastPathOperator,
 };
 use std::sync::Arc;
 use fluree_db_binary_index::format::branch::LeafEntry;
@@ -44,18 +45,42 @@ pub fn count_rows_operator(
     FastPathOperator::new(
         out_var,
         move |ctx| {
-            let Some(store) = fast_path_store(ctx) else {
-                return Ok(None);
-            };
-            let pred_sid = normalize_pred_sid(store, &predicate)?;
-            let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
-                return Ok(Some(build_count_batch(out_var, 0)?));
-            };
-            let count = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
-            Ok(Some(build_count_batch(
-                out_var,
-                count_to_i64(count, "COUNT rows")?,
-            )?))
+            // HEAD: metadata-only predicate row count (instant).
+            if let Some(store) = fast_path_store(ctx) {
+                let pred_sid = normalize_pred_sid(store, &predicate)?;
+                let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                    return Ok(Some(build_count_batch(out_var, 0)?));
+                };
+                let count = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
+                return Ok(Some(build_count_batch(
+                    out_var,
+                    count_to_i64(count, "COUNT rows")?,
+                )?));
+            }
+            // Novelty at HEAD (no time-travel): metadata base count + a novelty delta
+            // that rescans only the leaves novelty touches, instead of the whole
+            // predicate. Time-travel (to_t < max_t) needs base replay — defer.
+            if allow_cursor_fast_path(ctx) {
+                if let Some(store) = ctx.binary_store.as_ref() {
+                    // to_t >= max_t: at-or-above the indexed head (novelty folds on
+                    // top). Time-travel BELOW max_t needs base replay — defer.
+                    if ctx.to_t >= store.max_t() {
+                        let pred_sid = normalize_pred_sid(store, &predicate)?;
+                        let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                            return Ok(None); // novelty-only predicate => defer
+                        };
+                        if let Some(count) =
+                            count_predicate_overlay_delta(ctx, store, ctx.binary_g_id, pred_sid, p_id)?
+                        {
+                            return Ok(Some(build_count_batch(
+                                out_var,
+                                count_to_i64(count, "COUNT rows")?,
+                            )?));
+                        }
+                    }
+                }
+            }
+            Ok(None)
         },
         fallback,
         "COUNT rows",

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -5,6 +5,7 @@
 //! when `fast_path_store(ctx)` is available, otherwise they fall back to a planned
 //! operator tree for correctness.
 
+use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
     build_count_batch, count_rows_for_predicate_psot, count_to_i64, fast_path_store,
@@ -470,7 +471,14 @@ pub fn count_distinct_position_operator(
                     "COUNT(DISTINCT) subjects",
                 ),
                 DistinctPosition::Predicates => (
-                    count_distinct_predicates_psot(store, ctx.binary_g_id)?,
+                    // Prefer the in-memory per-graph stats (number of predicates
+                    // with a positive current count) — O(#predicates), no leaf
+                    // opens. Falls back to the PSOT `p_const` scan when the graph
+                    // stats are unavailable.
+                    match distinct_predicates_from_graph_stats(ctx) {
+                        Some(c) => c,
+                        None => count_distinct_predicates_psot(store, ctx.binary_g_id)?,
+                    },
                     "COUNT(DISTINCT) predicates",
                 ),
                 // OPST key layout: o_type(2) + o_key(8) + o_i(4) + p_id(4) + s_id(8).
@@ -486,6 +494,21 @@ pub fn count_distinct_position_operator(
         fallback,
         label,
     )
+}
+
+/// Current-state distinct-predicate count from the per-graph index stats: the
+/// number of properties with a positive current flake count.
+///
+/// `GraphPropertyStatEntry.count` is "after dedup; retractions decrement", so a
+/// predicate has a current PSOT leaflet iff its count is `> 0` — this matches
+/// `count_distinct_predicates_psot` exactly but reads the in-memory stats instead
+/// of opening every leaf. Returns `None` when the graph stats are unavailable
+/// (older index / not computed). Only correct at HEAD with no overlay; the caller
+/// gates that via `fast_path_store`.
+fn distinct_predicates_from_graph_stats(ctx: &ExecutionContext<'_>) -> Option<u64> {
+    let graphs = ctx.active_snapshot.stats.as_ref()?.graphs.as_ref()?;
+    let g = graphs.iter().find(|g| g.g_id == ctx.binary_g_id)?;
+    Some(g.properties.iter().filter(|p| p.count > 0).count() as u64)
 }
 
 /// Count distinct lead groups across all leaflets in a given sort order.

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -1594,7 +1594,15 @@ mod topk_tests {
     fn topk(items: &[(i64, u16, u64)], limit: usize) -> Vec<(u16, u64, i64)> {
         let mut heap: BinaryHeap<GroupTopK> = BinaryHeap::new();
         for &(count, o_type, o_key) in items {
-            offer_topk(&mut heap, limit, GroupTopK { count, o_type, o_key });
+            offer_topk(
+                &mut heap,
+                limit,
+                GroupTopK {
+                    count,
+                    o_type,
+                    o_key,
+                },
+            );
         }
         heap.into_sorted_vec()
             .into_iter()

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -29,7 +29,7 @@ use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::{FlakeValue, GraphId, LedgerSnapshot, Sid};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::BinaryHeap;
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
@@ -748,6 +748,54 @@ fn count_bound_object_v6(
 /// V6 fast-path: GROUP BY ?o COUNT(?s) for a predicate.
 ///
 /// Returns `Vec<(o_type, o_key, count)>` sorted by count descending, truncated to `limit`.
+/// One `(o_type, o_key)` group's count, ordered so a `BinaryHeap` (max-heap)
+/// keeps the *worst* element on top for O(log K) eviction.
+///
+/// "Worse" = the element the final sort would place LATER: lower count, then
+/// higher `o_type`, then higher `o_key` (the reverse of the keep order, which is
+/// count DESC, `o_type` ASC, `o_key` ASC). `into_sorted_vec()` then yields the
+/// kept groups in keep order (best first) directly.
+#[derive(PartialEq, Eq)]
+struct GroupTopK {
+    count: i64,
+    o_type: u16,
+    o_key: u64,
+}
+
+impl Ord for GroupTopK {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Larger == worse.
+        other
+            .count
+            .cmp(&self.count)
+            .then(self.o_type.cmp(&other.o_type))
+            .then(self.o_key.cmp(&other.o_key))
+    }
+}
+
+impl PartialOrd for GroupTopK {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Offer a completed group's run to the bounded top-K heap, keeping only the
+/// `limit` best by (count DESC, o_type ASC, o_key ASC). No-op for empty runs.
+fn offer_topk(heap: &mut BinaryHeap<GroupTopK>, limit: usize, cand: GroupTopK) {
+    if limit == 0 || cand.count <= 0 {
+        return;
+    }
+    if heap.len() < limit {
+        heap.push(cand);
+    } else if let Some(worst) = heap.peek() {
+        // cand < worst means cand is better than the current worst kept element.
+        if cand.cmp(worst) == Ordering::Less {
+            heap.pop();
+            heap.push(cand);
+        }
+    }
+}
+
 fn group_count_v6(
     store: &BinaryIndexStore,
     g_id: GraphId,
@@ -781,7 +829,14 @@ fn group_count_v6(
     };
     let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
 
-    let mut counts: HashMap<(u16, u64), i64> = HashMap::new();
+    // Streaming run-length: POST order (p_id, o_type, o_key, …) makes every
+    // object's rows physically contiguous, so COUNT(?subject) per object is the
+    // length of its run — a single counter that persists across leaflet/leaf
+    // boundaries, no per-row hashing. Completed runs feed a bounded top-K heap, so
+    // there is no full sort of all distinct objects either.
+    let mut heap: BinaryHeap<GroupTopK> = BinaryHeap::with_capacity(limit + 1);
+    let mut cur: Option<(u16, u64)> = None;
+    let mut run: i64 = 0;
     let cache = store.leaflet_cache();
 
     for leaf_idx in leaf_range.clone() {
@@ -834,7 +889,23 @@ fn group_count_v6(
             // same `(o_type, o_key)` first row as the next leaflet but still
             // contain rows for *other* predicates that must be excluded.
             if next_prefix == Some(prefix) && entry.p_const == Some(p_id) {
-                *counts.entry(prefix).or_insert(0) += entry.row_count as i64;
+                // Whole leaflet is one object that continues into the next leaflet:
+                // extend the current run (or start one), no per-row decode.
+                if cur == Some(prefix) {
+                    run += entry.row_count as i64;
+                } else {
+                    offer_topk(
+                        &mut heap,
+                        limit,
+                        GroupTopK {
+                            count: run,
+                            o_type: cur.map_or(0, |c| c.0),
+                            o_key: cur.map_or(0, |c| c.1),
+                        },
+                    );
+                    cur = Some(prefix);
+                    run = entry.row_count as i64;
+                }
                 continue;
             }
 
@@ -865,18 +936,43 @@ fn group_count_v6(
                     .o_type_const
                     .unwrap_or_else(|| batch.o_type.get_or(row, 0));
                 let ok = batch.o_key.get(row);
-                *counts.entry((ot, ok)).or_insert(0) += 1;
+                // Contiguous run: extend if the object is unchanged, else flush the
+                // completed run and start a new one.
+                if cur == Some((ot, ok)) {
+                    run += 1;
+                } else {
+                    offer_topk(
+                        &mut heap,
+                        limit,
+                        GroupTopK {
+                            count: run,
+                            o_type: cur.map_or(0, |c| c.0),
+                            o_key: cur.map_or(0, |c| c.1),
+                        },
+                    );
+                    cur = Some((ot, ok));
+                    run = 1;
+                }
             }
         }
     }
 
-    // Sort by count desc, truncate.
-    let mut rows: Vec<(u16, u64, i64)> = counts
+    // Flush the final run, then emit the kept groups in keep order (best first):
+    // count DESC, o_type ASC, o_key ASC — identical to the prior sort+truncate.
+    offer_topk(
+        &mut heap,
+        limit,
+        GroupTopK {
+            count: run,
+            o_type: cur.map_or(0, |c| c.0),
+            o_key: cur.map_or(0, |c| c.1),
+        },
+    );
+    let rows: Vec<(u16, u64, i64)> = heap
+        .into_sorted_vec()
         .into_iter()
-        .map(|((ot, ok), c)| (ot, ok, c))
+        .map(|g| (g.o_type, g.o_key, g.count))
         .collect();
-    rows.sort_unstable_by(|a, b| b.2.cmp(&a.2).then(a.0.cmp(&b.0)).then(a.1.cmp(&b.1)));
-    rows.truncate(limit);
 
     Ok(rows)
 }
@@ -1486,4 +1582,58 @@ fn compute_group_by_object_star_topk(
     Ok(Some(crate::binding::Batch::new(schema, cols).map_err(
         |e| QueryError::execution(format!("batch build: {e}")),
     )?))
+}
+
+#[cfg(test)]
+mod topk_tests {
+    use super::{offer_topk, GroupTopK};
+    use std::collections::BinaryHeap;
+
+    /// Feed `(count, o_type, o_key)` groups through the bounded heap and return
+    /// the kept groups in emit order `(o_type, o_key, count)`.
+    fn topk(items: &[(i64, u16, u64)], limit: usize) -> Vec<(u16, u64, i64)> {
+        let mut heap: BinaryHeap<GroupTopK> = BinaryHeap::new();
+        for &(count, o_type, o_key) in items {
+            offer_topk(&mut heap, limit, GroupTopK { count, o_type, o_key });
+        }
+        heap.into_sorted_vec()
+            .into_iter()
+            .map(|g| (g.o_type, g.o_key, g.count))
+            .collect()
+    }
+
+    #[test]
+    fn orders_by_count_desc() {
+        let r = topk(&[(2, 0, 0), (5, 0, 0), (3, 0, 0), (1, 0, 0)], 3);
+        assert_eq!(r, vec![(0, 0, 5), (0, 0, 3), (0, 0, 2)]);
+    }
+
+    #[test]
+    fn tie_break_is_otype_then_okey_ascending() {
+        // All count 3: keep order is lower o_type first, then lower o_key.
+        let r = topk(&[(3, 2, 9), (3, 1, 5), (3, 1, 2), (3, 0, 100)], 3);
+        assert_eq!(r, vec![(0, 100, 3), (1, 2, 3), (1, 5, 3)]);
+    }
+
+    #[test]
+    fn evicts_worst_and_respects_limit() {
+        assert_eq!(
+            topk(&[(1, 0, 0), (2, 0, 0), (3, 0, 0), (4, 0, 0), (5, 0, 0)], 2),
+            vec![(0, 0, 5), (0, 0, 4)]
+        );
+        assert!(topk(&[], 3).is_empty());
+        assert!(topk(&[(5, 0, 0)], 0).is_empty(), "limit 0 keeps nothing");
+        assert!(
+            topk(&[(0, 0, 0), (-1, 0, 0)], 3).is_empty(),
+            "non-positive runs are not emitted"
+        );
+    }
+
+    #[test]
+    fn count_dominates_tie_break() {
+        // A lower-count group must never outrank a higher-count one regardless of
+        // o_type/o_key.
+        let r = topk(&[(10, 9, 9), (3, 0, 0), (5, 1, 1)], 2);
+        assert_eq!(r, vec![(9, 9, 10), (1, 1, 5)]);
+    }
 }

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -1973,6 +1973,82 @@ pub fn build_post_cursor_for_predicate(
     )
 }
 
+/// Build an overlay-folding PSOT cursor bounded to the subject range `[lo, hi)`,
+/// using `sliced_ops` (the predicate's resolved overlay ops already restricted to
+/// `[lo, hi)`) rather than re-collecting them. This is the per-partition primitive
+/// for parallelizing an overlay count: the partition harness hands each worker a
+/// subject range, and each worker scans only its leaves and merges only its ops.
+///
+/// Takes `to_t`/`epoch` as values (not `&ExecutionContext`) so the caller can hoist
+/// them out of the parallel region and keep the reducer `Sync`. The cursor's leaf
+/// range is bounded by the keys, but rows are filtered only by `p_id`, so a boundary
+/// leaf shared with an adjacent partition still emits its out-of-range subjects — the
+/// caller MUST drop rows with `s_id < lo || s_id >= hi` so each subject is counted by
+/// exactly one partition. Returns `None` if the PSOT branch is absent.
+#[allow(clippy::too_many_arguments)]
+pub fn build_overlay_cursor_for_subject_range(
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    p_id: u32,
+    projection: ColumnProjection,
+    lo: u64,
+    hi: u64,
+    sliced_ops: Vec<fluree_db_binary_index::read::types::OverlayOp>,
+    to_t: i64,
+    epoch: u64,
+) -> Option<BinaryCursor> {
+    let overlay_active = epoch != 0;
+    // Identity columns must be present for merge_overlay_into_batch (see
+    // build_overlay_cursor_for_predicate / set_overlay_ops).
+    let projection = if overlay_active {
+        let identity = ColumnSet::CORE.union(ColumnSet::single(ColumnId::OI));
+        ColumnProjection {
+            output: projection.output,
+            internal: ColumnSet(projection.internal.union(identity).0 & !projection.output.0),
+        }
+    } else {
+        projection
+    };
+
+    let (mut min_key, mut max_key) = predicate_range_keys(p_id, g_id);
+    min_key.s_id = SubjectId(lo);
+    // Upper bound: smallest key at subject `hi` (exclusive `hi` is enforced by the
+    // caller's per-row filter; this only narrows the scanned leaf range).
+    max_key.s_id = SubjectId(hi);
+    max_key.o_key = 0;
+    max_key.o_type = 0;
+    max_key.o_i = 0;
+    max_key.t = 0;
+
+    let filter = BinaryFilter {
+        p_id: Some(p_id),
+        ..Default::default()
+    };
+    let mut cursor =
+        build_range_cursor(store, g_id, RunSortOrder::Psot, &min_key, &max_key, filter, projection)?;
+    cursor.set_to_t(to_t);
+    if overlay_active {
+        if !sliced_ops.is_empty() {
+            cursor.set_overlay_ops(sliced_ops);
+        }
+        cursor.set_epoch(epoch);
+    }
+    Some(cursor)
+}
+
+/// Slice a predicate's resolved overlay ops (sorted in PSOT order, i.e. by
+/// `(p_id, s_id, …)` for a single predicate) to those with `s_id ∈ [lo, hi)`.
+/// Since the ops are sorted by `s_id`, this is two binary searches.
+pub fn slice_overlay_ops_by_subject(
+    ops: &[fluree_db_binary_index::read::types::OverlayOp],
+    lo: u64,
+    hi: u64,
+) -> Vec<fluree_db_binary_index::read::types::OverlayOp> {
+    let start = ops.partition_point(|o| o.s_id < lo);
+    let end = ops.partition_point(|o| o.s_id < hi);
+    ops[start..end].to_vec()
+}
+
 /// Streams `(s_id, edge_count)` groups from an overlay-merging PSOT cursor.
 ///
 /// The cursor yields rows in PSOT order, so a running group-by on `s_id`
@@ -2091,6 +2167,98 @@ where
         }
     }
     Ok(Some(total))
+}
+
+/// Parallel overlay/time-travel COUNT of rows of `p_id` (PSOT) matching
+/// `per_row(s_id, o_type, o_key)`, folding novelty correctly.
+///
+/// Partitions the subject space with the shared [`crate::count_plan_exec::parallel_partition_count`]
+/// harness (so the base scan runs across the global rayon pool, like the HEAD path),
+/// and gives each partition a *bounded overlay cursor* — its leaf range plus the
+/// novelty ops sliced to its subject range — reusing `merge_overlay_into_batch`. A
+/// per-row `[lo, hi)` filter keeps boundary subjects (shared leaves) counted once.
+/// The overlay ops are collected once up front and only sliced per partition (cheap;
+/// novelty is small). Below the parallel threshold, falls back to the serial
+/// whole-predicate overlay cursor. Returns `Ok(None)` to defer (an overlay flake
+/// failed to translate).
+pub fn parallel_overlay_psot_filter_count<P>(
+    ctx: &ExecutionContext<'_>,
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    pred_sid: Sid,
+    p_id: u32,
+    per_row: P,
+) -> Result<Option<u64>>
+where
+    P: Fn(u64, u16, u64) -> bool + Sync + Send,
+{
+    // Collect + resolve the predicate's overlay ops once (serial; novelty is small).
+    let ops = match collect_resolved_overlay_ops(ctx, store, g_id, RunSortOrder::Psot, &pred_sid)? {
+        Some(o) => o,
+        None => return Ok(None),
+    };
+    let to_t = ctx.to_t;
+    let epoch = ctx
+        .overlay
+        .as_ref()
+        .map(|o| o.epoch())
+        .unwrap_or(0);
+    let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
+
+    let ops_ref = &ops;
+    let per_row_ref = &per_row;
+    let parallel = crate::count_plan_exec::parallel_partition_count(
+        store,
+        g_id,
+        p_id,
+        total_rows,
+        move |lo, hi| {
+            let sliced = slice_overlay_ops_by_subject(ops_ref, lo, hi);
+            let Some(mut cursor) = build_overlay_cursor_for_subject_range(
+                store,
+                g_id,
+                p_id,
+                cursor_projection_sid_otype_okey(),
+                lo,
+                hi,
+                sliced,
+                to_t,
+                epoch,
+            ) else {
+                return Ok(0u128);
+            };
+            let mut total: u128 = 0;
+            while let Some(batch) = cursor
+                .next_batch()
+                .map_err(|e| QueryError::Internal(format!("cursor batch: {e}")))?
+            {
+                for r in 0..batch.row_count {
+                    let s = batch.s_id.get(r);
+                    if s < lo || s >= hi {
+                        continue; // boundary leaf shared with an adjacent partition
+                    }
+                    if per_row_ref(s, batch.o_type.get(r), batch.o_key.get(r)) {
+                        total = total.saturating_add(1);
+                    }
+                }
+            }
+            Ok(total)
+        },
+    )?;
+
+    match parallel {
+        Some(n) => Ok(Some(n)),
+        // Below the parallel threshold: serial whole-predicate overlay cursor.
+        None => count_rows_via_overlay_cursor(
+            ctx,
+            store,
+            g_id,
+            RunSortOrder::Psot,
+            pred_sid,
+            p_id,
+            |s, ot, ok| Some(per_row(s, ot, ok)),
+        ),
+    }
 }
 
 /// Resolve a bound `Ref` (Iri or Sid) to its internal `s_id` (u64).

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -310,9 +310,43 @@ const PARALLEL_LEAF_SCAN_MIN_ROWS: u64 = 50_000;
 /// Cap on leaf-chunk worker count regardless of core count.
 const PARALLEL_LEAF_SCAN_MAX_CHUNKS: usize = 16;
 
+/// Run `f` over `items` on the shared global rayon thread pool, preserving order and
+/// the current tracing span, returning each item's result.
+///
+/// This is the multi-tenant-safe replacement for a per-call `std::thread::scope`.
+/// A `scope` spawns fresh OS threads on every invocation, so under concurrent query
+/// load N queries each running a partitioned count/scan spawn up to N×K worker
+/// threads — thrashing a multi-tenant server's scheduler and memory. The global
+/// rayon pool is sized once (≈ logical cores) and shared across every query, so the
+/// total worker-thread count stays bounded no matter how many queries run at once
+/// (matching the pool `fluree-db-novelty` already uses). Like `thread::scope` — and
+/// unlike `thread::spawn` / `spawn_blocking` — rayon's parallel iterator is fully
+/// structured: it blocks until every task finishes, so `f` may borrow non-`'static`
+/// data (the store, the reducer) exactly as the old scoped threads did. A panic in a
+/// worker is converted to an error for that item instead of unwinding the query.
+pub(crate) fn parallel_map_pooled<T, R, F>(items: Vec<T>, f: F) -> Vec<Result<R>>
+where
+    T: Send,
+    R: Send,
+    F: Fn(T) -> Result<R> + Sync + Send,
+{
+    use rayon::prelude::*;
+    let span = tracing::Span::current();
+    items
+        .into_par_iter()
+        .map(|item| {
+            let _guard = span.enter();
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(item))) {
+                Ok(result) => result,
+                Err(_) => Err(QueryError::execution("parallel worker panicked")),
+            }
+        })
+        .collect()
+}
+
 /// Partition a predicate's `leaves` into up to `PARALLEL_LEAF_SCAN_MAX_CHUNKS`
-/// contiguous chunks (~one per core) and run `reducer(chunk)` per chunk on a
-/// `std::thread::scope` worker, summing the partial row counts.
+/// contiguous chunks (~one per core) and run `reducer(chunk)` per chunk on the
+/// shared global rayon pool (via [`parallel_map_pooled`]), summing the partials.
 ///
 /// Every row lives in exactly one leaflet of one leaf, so counting rows per chunk
 /// and summing is exact for ANY index order — unlike the per-subject
@@ -333,7 +367,7 @@ pub fn parallel_leaf_chunk_count<F>(
     reducer: F,
 ) -> Result<Option<u64>>
 where
-    F: Fn(&[LeafEntry]) -> Result<Option<u64>> + Sync,
+    F: Fn(&[LeafEntry]) -> Result<Option<u64>> + Sync + Send,
 {
     let ncpu = std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
@@ -354,28 +388,7 @@ where
         "fast-path: parallel leaf-chunk scan"
     );
 
-    let reducer = &reducer;
-    let span = tracing::Span::current();
-    let partials: Vec<Result<Option<u64>>> = std::thread::scope(|scope| {
-        let handles: Vec<_> = chunks
-            .iter()
-            .map(|chunk| {
-                let span = span.clone();
-                scope.spawn(move || {
-                    let _guard = span.enter();
-                    reducer(chunk)
-                })
-            })
-            .collect();
-        handles
-            .into_iter()
-            .map(|h| {
-                h.join().unwrap_or_else(|_| {
-                    Err(QueryError::execution("parallel leaf-scan worker panicked"))
-                })
-            })
-            .collect()
-    });
+    let partials: Vec<Result<Option<u64>>> = parallel_map_pooled(chunks, reducer);
 
     let mut total: u64 = 0;
     for partial in partials {

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -2261,6 +2261,119 @@ where
     }
 }
 
+/// Overlay COUNT(*) of a predicate via a **novelty-delta**, for the common
+/// live-write case (`epoch != 0`, HEAD): `base_total − base(touched) + merged(touched)`.
+///
+/// At HEAD the predicate count is metadata-only (instant). Under novelty the cursor
+/// path would rescan the whole predicate to fold a few uncommitted rows. Instead:
+/// only the per-leaf subject ranges that novelty actually touches are rescanned
+/// (base via the bounded iterator, merged via the bounded overlay cursor — the
+/// proven `merge_overlay_into_batch`); every untouched leaf keeps its instant
+/// manifest count (`base_total − base(touched)`). So the work is proportional to the
+/// novelty's footprint, not the predicate size.
+///
+/// CALLER GATE: only valid for `to_t == max_t` (no time-travel replay) and
+/// `epoch != 0`; the base manifest count is the current-state base count only then.
+/// Returns `Ok(None)` to defer (overlay flake failed to translate). Returns the
+/// plain manifest count when there is no novelty for the predicate.
+pub fn count_predicate_overlay_delta(
+    ctx: &ExecutionContext<'_>,
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    pred_sid: Sid,
+    p_id: u32,
+) -> Result<Option<u64>> {
+    let ops = match collect_resolved_overlay_ops(ctx, store, g_id, RunSortOrder::Psot, &pred_sid)? {
+        Some(o) => o,
+        None => return Ok(None),
+    };
+    let base_total = count_rows_for_predicate_psot(store, g_id, p_id)?;
+    if ops.is_empty() {
+        return Ok(Some(base_total));
+    }
+    let to_t = ctx.to_t;
+    let epoch = ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
+    let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
+
+    // Per-leaf subject ranges [lo, hi); the last extends to MAX so novelty subjects
+    // beyond the base's last leaf land in (and are scanned by) the final range.
+    let mut base_touched: u64 = 0;
+    let mut merged_touched: u64 = 0;
+    let mut op_idx = 0usize;
+    let n = leaves.len();
+    for i in 0..n {
+        let lo = leaves[i].first_key.s_id.as_u64();
+        let hi = if i + 1 < n {
+            leaves[i + 1].first_key.s_id.as_u64()
+        } else {
+            u64::MAX
+        };
+        // Ops with s_id in [lo, hi). Ops are sorted by s_id; advance the cursor.
+        while op_idx < ops.len() && ops[op_idx].s_id < lo {
+            op_idx += 1;
+        }
+        let start = op_idx;
+        let mut end = op_idx;
+        while end < ops.len() && ops[end].s_id < hi {
+            end += 1;
+        }
+        if end == start {
+            continue; // untouched leaf — its rows are covered by base_total
+        }
+        op_idx = end;
+
+        // Base count of this touched leaf: the manifest `row_count` for an interior
+        // leaf (no open); a boundary leaf (shared with an adjacent predicate) opens
+        // and sums its p_id leaflets. Only the merged pass below opens the leaf, so
+        // the worst case (novelty touching every leaf) is one full scan, not two.
+        let leaf = &leaves[i];
+        if leaf.first_key.p_id == p_id && leaf.last_key.p_id == p_id {
+            base_touched = base_touched.saturating_add(leaf.row_count);
+        } else {
+            let handle = store
+                .open_leaf_handle(&leaf.leaf_cid, leaf.sidecar_cid.as_ref(), false)
+                .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;
+            for entry in &handle.dir().entries {
+                if entry.row_count != 0 && entry.p_const == Some(p_id) {
+                    base_touched = base_touched.saturating_add(entry.row_count as u64);
+                }
+            }
+        }
+
+        // Merged count of this range (base + this range's novelty ops).
+        let sliced = ops[start..end].to_vec();
+        if let Some(mut cursor) = build_overlay_cursor_for_subject_range(
+            store,
+            g_id,
+            p_id,
+            cursor_projection_sid_only(),
+            lo,
+            hi,
+            sliced,
+            to_t,
+            epoch,
+        ) {
+            while let Some(batch) = cursor
+                .next_batch()
+                .map_err(|e| QueryError::Internal(format!("cursor batch: {e}")))?
+            {
+                for r in 0..batch.row_count {
+                    let s = batch.s_id.get(r);
+                    if s >= lo && s < hi {
+                        merged_touched = merged_touched.saturating_add(1);
+                    }
+                }
+            }
+        }
+    }
+
+    // base_total − base(touched) = base(untouched); + merged(touched) = grand total.
+    let total = base_total
+        .saturating_sub(base_touched)
+        .saturating_add(merged_touched);
+    Ok(Some(total))
+}
+
 /// Resolve a bound `Ref` (Iri or Sid) to its internal `s_id` (u64).
 ///
 /// Returns `Ok(None)` for `Ref::Var` or if the subject is not found in the store.

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -494,22 +494,46 @@ pub struct PsotSubjectCountIter<'a> {
     /// Accumulated subject for a group that may span leaflet boundaries.
     cur_s: Option<u64>,
     cur_count: u64,
+    /// Half-open subject range `[lo, hi)` this iterator emits. Subjects below
+    /// `lo` are skipped; the first subject `>= hi` ends the stream. Used to
+    /// partition one predicate's subjects across parallel workers.
+    lo: u64,
+    hi: u64,
 }
 
 impl<'a> PsotSubjectCountIter<'a> {
     pub fn new(store: &'a BinaryIndexStore, g_id: GraphId, p_id: u32) -> Result<Self> {
+        Self::new_bounded(store, g_id, p_id, 0, u64::MAX)
+    }
+
+    /// Iterate only the subjects in `[lo, hi)`. Leaves entirely below `lo` are
+    /// skipped via a binary search on the predicate's leaf slice (so a partition
+    /// only opens its own leaves), and iteration ends at the first subject `>= hi`.
+    pub fn new_bounded(
+        store: &'a BinaryIndexStore,
+        g_id: GraphId,
+        p_id: u32,
+        lo: u64,
+        hi: u64,
+    ) -> Result<Self> {
         let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
+        // Leaf leapfrog to `lo`: skip leaves whose last subject (for THIS predicate)
+        // is below `lo`. Guarded by `last_key.p_id == p_id` because a boundary
+        // leaf's `last_key` can belong to a higher predicate (see PsotSubjectSeek).
+        let leaf_pos = leaves.partition_point(|e| e.last_key.p_id == p_id && e.last_key.s_id.as_u64() < lo);
         Ok(Self {
             store,
             p_id,
             leaf_entries: leaves,
-            leaf_pos: 0,
+            leaf_pos,
             leaflet_idx: 0,
             row: 0,
             handle: None,
             batch: None,
             cur_s: None,
             cur_count: 0,
+            lo,
+            hi,
         })
     }
 
@@ -596,6 +620,24 @@ impl<'a> PsotSubjectCountIter<'a> {
             }
 
             let sid = batch.s_id.get(self.row);
+
+            // Below the partition's range: skip whole sub-`lo` subjects. Only
+            // possible before the first in-range subject (rows are subject-sorted),
+            // so `cur_s` is None here.
+            if sid < self.lo {
+                self.row += 1;
+                continue;
+            }
+            // At/above the partition's end: no more in-range subjects (sorted), so
+            // flush any accumulated group and end the stream. The `>= hi` row is
+            // left unconsumed (it belongs to the next partition).
+            if sid >= self.hi {
+                if let Some(s) = self.cur_s.take() {
+                    let n = std::mem::take(&mut self.cur_count);
+                    return Ok(Some((s, n)));
+                }
+                return Ok(None);
+            }
 
             match self.cur_s {
                 None => {

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -606,6 +606,184 @@ impl<'a> PsotSubjectCountIter<'a> {
 }
 
 // ---------------------------------------------------------------------------
+// 7a-seek. Forward-only per-subject PSOT seek (asymmetric-join probe)
+// ---------------------------------------------------------------------------
+
+/// Forward-only monotonic per-subject seek over a predicate's PSOT leaves.
+///
+/// Given **strictly non-decreasing** target subjects, returns the row count for
+/// each (any object datatype) — the probe side of an asymmetric subject join
+/// (drive from the small predicate, seek into the large one). Cost is driven
+/// sub-linear in the probe predicate two ways:
+/// - **leaf leapfrog**: a binary search over the predicate's leaf slice skips
+///   whole leaves — and their blob reads — that cannot contain the target;
+/// - **leaflet skip**: leaflets whose `last_key` subject is below the target are
+///   skipped without decoding their columns.
+///
+/// Subjects whose rows span leaflet/leaf boundaries are handled. Because the
+/// cursor only ever advances, the total work across an ascending target sequence
+/// is one monotonic pass.
+///
+/// PRECONDITION: targets must be non-decreasing across calls (the cursor never
+/// rewinds). BASE index only — callers MUST gate to HEAD (no overlay,
+/// `to_t == max_t`); novelty / time-travel are not merged here.
+pub struct PsotSubjectSeek<'a> {
+    store: &'a BinaryIndexStore,
+    p_id: u32,
+    leaves: &'a [LeafEntry],
+    leaf_pos: usize,
+    leaflet_idx: usize,
+    row: usize,
+    handle: Option<Box<dyn fluree_db_binary_index::read::leaf_access::LeafHandle>>,
+    batch: Option<ColumnBatch>,
+}
+
+impl<'a> PsotSubjectSeek<'a> {
+    pub fn new(store: &'a BinaryIndexStore, g_id: GraphId, p_id: u32) -> Self {
+        let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p_id);
+        Self {
+            store,
+            p_id,
+            leaves,
+            leaf_pos: 0,
+            leaflet_idx: 0,
+            row: 0,
+            handle: None,
+            batch: None,
+        }
+    }
+
+    fn load_next_batch(&mut self, target_s: u64) -> Result<Option<()>> {
+        use fluree_db_binary_index::format::run_record_v2::read_ordered_key_v2;
+        loop {
+            if self.handle.is_none() {
+                // Leaf leapfrog: skip leaves that provably cannot contain target_s.
+                //
+                // A leaf is skippable only when its `last_key` belongs to THIS
+                // predicate AND its subject is below the target. At the predicate's
+                // upper boundary a leaf's `last_key` may belong to a higher predicate
+                // (our rows are a prefix of that leaf); such a leaf must NOT be
+                // skipped by its foreign subject. `leaf_entries_for_predicate`
+                // guarantees `last_key.p_id >= self.p_id`, so the skip predicate is
+                // a monotone leading run and `partition_point` is valid.
+                let skip = self.leaves[self.leaf_pos..].partition_point(|e| {
+                    e.last_key.p_id == self.p_id && e.last_key.s_id.as_u64() < target_s
+                });
+                self.leaf_pos += skip;
+                if self.leaf_pos >= self.leaves.len() {
+                    return Ok(None);
+                }
+                let leaf_entry = &self.leaves[self.leaf_pos];
+                self.leaf_pos += 1;
+                self.leaflet_idx = 0;
+                self.row = 0;
+                self.batch = None;
+                self.handle = Some(
+                    self.store
+                        .open_leaf_handle(
+                            &leaf_entry.leaf_cid,
+                            leaf_entry.sidecar_cid.as_ref(),
+                            false,
+                        )
+                        .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?,
+                );
+            }
+
+            let handle = self.handle.as_ref().unwrap();
+            let dir = handle.dir();
+            while self.leaflet_idx < dir.entries.len() {
+                let entry = &dir.entries[self.leaflet_idx];
+                let idx = self.leaflet_idx;
+                self.leaflet_idx += 1;
+                if entry.row_count == 0 || entry.p_const != Some(self.p_id) {
+                    continue;
+                }
+                // Leaflet skip: cannot contain target_s if its last subject is below it.
+                let last = read_ordered_key_v2(RunSortOrder::Psot, &entry.last_key);
+                if last.s_id.as_u64() < target_s {
+                    continue;
+                }
+                let projection = projection_sid_only();
+                let batch = if let Some(cache) = self.store.leaflet_cache() {
+                    let idx_u32: u32 = idx.try_into().map_err(|_| {
+                        QueryError::Internal("leaflet idx exceeds u32".to_string())
+                    })?;
+                    load_columns_cached_via_handle(
+                        handle.as_ref(),
+                        idx,
+                        RunSortOrder::Psot,
+                        cache,
+                        handle.leaf_id(),
+                        idx_u32,
+                    )
+                    .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+                } else {
+                    handle
+                        .load_columns(idx, &projection, RunSortOrder::Psot)
+                        .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
+                };
+                self.row = 0;
+                self.batch = Some(batch);
+                return Ok(Some(()));
+            }
+            self.handle = None;
+        }
+    }
+
+    /// Row count for `target_s` (any object datatype), or `None` if the subject is
+    /// absent. Targets MUST be non-decreasing across calls.
+    pub fn count_for_subject(&mut self, target_s: u64) -> Result<Option<u64>> {
+        let mut found = false;
+        let mut count: u64 = 0;
+        loop {
+            if self.batch.is_none() && self.load_next_batch(target_s)?.is_none() {
+                return Ok(found.then_some(count));
+            }
+            let batch = self.batch.as_ref().unwrap();
+            if self.row >= batch.row_count {
+                self.batch = None;
+                continue;
+            }
+            if !found {
+                // Advance to the first row with s_id >= target_s.
+                while self.row < batch.row_count && batch.s_id.get(self.row) < target_s {
+                    self.row += 1;
+                }
+                if self.row >= batch.row_count {
+                    self.batch = None;
+                    continue;
+                }
+                if batch.s_id.get(self.row) > target_s {
+                    // Cursor is now parked at the first subject above target_s, ready
+                    // for the next (larger) target. Subject is absent.
+                    return Ok(None);
+                }
+                found = true;
+            } else if batch.s_id.get(self.row) > target_s {
+                return Ok(Some(count));
+            }
+            // At target_s: count its rows (the group may span batches).
+            while self.row < batch.row_count && batch.s_id.get(self.row) == target_s {
+                count = count
+                    .checked_add(1)
+                    .ok_or_else(|| QueryError::execution("COUNT(*) overflow in subject seek"))?;
+                self.row += 1;
+            }
+            if self.row < batch.row_count {
+                return Ok(Some(count));
+            }
+            // Subject group may continue into the next leaflet/leaf.
+            self.batch = None;
+        }
+    }
+
+    /// Whether `target_s` has any row. Targets MUST be non-decreasing across calls.
+    pub fn subject_present(&mut self, target_s: u64) -> Result<bool> {
+        Ok(self.count_for_subject(target_s)?.is_some())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 7b. Streaming POST object-group-count iterator
 // ---------------------------------------------------------------------------
 

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -2041,6 +2041,58 @@ impl CursorSubjectCountStream {
     }
 }
 
+/// Count rows of `p_id` (scanned in `order`) for which `per_row(s_id, o_type, o_key)`
+/// returns `Some(true)`, reading through an overlay-folding cursor so the count
+/// includes novelty asserts, excludes retracts, and honors `to_t`.
+///
+/// This is the overlay/time-travel lane for the single-predicate filter-COUNT fast
+/// paths: the caller gates on [`allow_cursor_fast_path`] and uses this when there is
+/// novelty or `to_t < max_t`; the HEAD lane keeps its faster base-leaflet scan and
+/// metadata shortcuts. `per_row` returning `None` aborts and yields `Ok(None)`, so a
+/// row the predicate can't classify (e.g. a non-numeric object under a numeric
+/// compare) defers to the operator's fallback — matching the base path's bail. Also
+/// returns `Ok(None)` when the cursor can't be built (branch absent for `order`, or
+/// an overlay flake fails to translate).
+pub fn count_rows_via_overlay_cursor<P>(
+    ctx: &ExecutionContext<'_>,
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    order: RunSortOrder,
+    pred_sid: Sid,
+    p_id: u32,
+    mut per_row: P,
+) -> Result<Option<u64>>
+where
+    P: FnMut(u64, u16, u64) -> Option<bool>,
+{
+    let Some(mut cursor) = build_overlay_cursor_for_predicate(
+        ctx,
+        store,
+        g_id,
+        order,
+        pred_sid,
+        p_id,
+        cursor_projection_sid_otype_okey(),
+    )?
+    else {
+        return Ok(None);
+    };
+    let mut total: u64 = 0;
+    while let Some(batch) = cursor
+        .next_batch()
+        .map_err(|e| QueryError::Internal(format!("cursor batch: {e}")))?
+    {
+        for r in 0..batch.row_count {
+            match per_row(batch.s_id.get(r), batch.o_type.get(r), batch.o_key.get(r)) {
+                Some(true) => total = total.saturating_add(1),
+                Some(false) => {}
+                None => return Ok(None),
+            }
+        }
+    }
+    Ok(Some(total))
+}
+
 /// Resolve a bound `Ref` (Iri or Sid) to its internal `s_id` (u64).
 ///
 /// Returns `Ok(None)` for `Ref::Var` or if the subject is not found in the store.

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -428,14 +428,21 @@ pub fn intersect_many_sorted(mut lists: Vec<Vec<u64>>) -> Vec<u64> {
 // 6. Merge-count
 // ---------------------------------------------------------------------------
 
-/// Count total rows for a predicate by summing PSOT leaflet directory `row_count`.
+/// Count total rows for a predicate from the PSOT branch manifest.
 ///
 /// This is the fastest possible implementation of:
 /// `SELECT (COUNT(*) AS ?c) WHERE { ?s <p> ?o }`
 /// (and also `COUNT(?s)` / `COUNT(?o)` for the same single-triple pattern),
 /// because every solution binding has all vars bound.
 ///
-/// Assumes PSOT leaflets have `p_const` set (so we can filter without loading columns).
+/// A leaf whose `first_key` and `last_key` both belong to `p_id` is *interior* to
+/// the predicate: PSOT order (p_id, s_id, …) means every row in it is `p_id`, so
+/// `LeafEntry.row_count` (the manifest's latest-state row count, which equals the
+/// sum of that leaf's leaflet `row_count`s) IS the predicate's contribution — no
+/// leaf open. Only the at-most-two *boundary* leaves (where the predicate range
+/// starts or ends mid-leaf, mixing predicates) need a directory walk. For a large
+/// predicate (e.g. `rdf:type`, thousands of leaves) this turns thousands of leaf
+/// opens into ~two.
 pub fn count_rows_for_predicate_psot(
     store: &BinaryIndexStore,
     g_id: GraphId,
@@ -445,6 +452,12 @@ pub fn count_rows_for_predicate_psot(
     let mut total: u64 = 0;
 
     for leaf_entry in leaves {
+        // Interior leaf: entirely this predicate → use the manifest count, no open.
+        if leaf_entry.first_key.p_id == p_id && leaf_entry.last_key.p_id == p_id {
+            total += leaf_entry.row_count;
+            continue;
+        }
+        // Boundary leaf: may mix predicates → open and sum the matching leaflets.
         let handle = store
             .open_leaf_handle(&leaf_entry.leaf_cid, leaf_entry.sidecar_cid.as_ref(), false)
             .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -304,6 +304,89 @@ pub fn leaf_entries_for_predicate(
     &branch.leaves[leaf_range]
 }
 
+/// Minimum total predicate rows before a parallel leaf-chunk scan is worth its
+/// thread-spawn overhead; below this the reducer runs serially on the whole slice.
+const PARALLEL_LEAF_SCAN_MIN_ROWS: u64 = 50_000;
+/// Cap on leaf-chunk worker count regardless of core count.
+const PARALLEL_LEAF_SCAN_MAX_CHUNKS: usize = 16;
+
+/// Partition a predicate's `leaves` into up to `PARALLEL_LEAF_SCAN_MAX_CHUNKS`
+/// contiguous chunks (~one per core) and run `reducer(chunk)` per chunk on a
+/// `std::thread::scope` worker, summing the partial row counts.
+///
+/// Every row lives in exactly one leaflet of one leaf, so counting rows per chunk
+/// and summing is exact for ANY index order — unlike the per-subject
+/// [`crate::count_plan_exec::parallel_partition_count`] (which must partition on
+/// subject boundaries because a subject's rows span leaves), this counts
+/// independent rows and so can split purely on leaf index. `reducer` returns
+/// `Ok(None)` to signal the whole count must defer to the general pipeline (an
+/// unsupported shape, e.g. a non-numeric leaflet); any `None` short-circuits the
+/// result to `Ok(None)`.
+///
+/// When there aren't enough rows/leaves/cores to be worth parallelizing, runs
+/// `reducer` once on the whole slice (identical to a serial scan). BASE index only:
+/// the caller must reach here via [`fast_path_store`] (HEAD, no overlay), so the
+/// base leaflets already reflect current state.
+pub fn parallel_leaf_chunk_count<F>(
+    leaves: &[LeafEntry],
+    total_rows: u64,
+    reducer: F,
+) -> Result<Option<u64>>
+where
+    F: Fn(&[LeafEntry]) -> Result<Option<u64>> + Sync,
+{
+    let ncpu = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
+    let k = ncpu.min(PARALLEL_LEAF_SCAN_MAX_CHUNKS).min(leaves.len());
+    if ncpu < 2 || total_rows < PARALLEL_LEAF_SCAN_MIN_ROWS || k < 2 {
+        // Not worth parallelizing: run the reducer serially over the whole slice.
+        return reducer(leaves);
+    }
+
+    // Contiguous, near-equal leaf chunks (`chunks()` yields ceil(len/per) slices).
+    let per = leaves.len().div_ceil(k);
+    let chunks: Vec<&[LeafEntry]> = leaves.chunks(per).collect();
+    tracing::debug!(
+        chunks = chunks.len(),
+        leaves = leaves.len(),
+        total_rows,
+        "fast-path: parallel leaf-chunk scan"
+    );
+
+    let reducer = &reducer;
+    let span = tracing::Span::current();
+    let partials: Vec<Result<Option<u64>>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = chunks
+            .iter()
+            .map(|chunk| {
+                let span = span.clone();
+                scope.spawn(move || {
+                    let _guard = span.enter();
+                    reducer(chunk)
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| {
+                h.join().unwrap_or_else(|_| {
+                    Err(QueryError::execution("parallel leaf-scan worker panicked"))
+                })
+            })
+            .collect()
+    });
+
+    let mut total: u64 = 0;
+    for partial in partials {
+        match partial? {
+            Some(n) => total = total.saturating_add(n),
+            None => return Ok(None),
+        }
+    }
+    Ok(Some(total))
+}
+
 // ---------------------------------------------------------------------------
 // 4. Subject collection
 // ---------------------------------------------------------------------------

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -616,7 +616,8 @@ impl<'a> PsotSubjectCountIter<'a> {
         // Leaf leapfrog to `lo`: skip leaves whose last subject (for THIS predicate)
         // is below `lo`. Guarded by `last_key.p_id == p_id` because a boundary
         // leaf's `last_key` can belong to a higher predicate (see PsotSubjectSeek).
-        let leaf_pos = leaves.partition_point(|e| e.last_key.p_id == p_id && e.last_key.s_id.as_u64() < lo);
+        let leaf_pos =
+            leaves.partition_point(|e| e.last_key.p_id == p_id && e.last_key.s_id.as_u64() < lo);
         Ok(Self {
             store,
             p_id,
@@ -856,9 +857,9 @@ impl<'a> PsotSubjectSeek<'a> {
                 }
                 let projection = projection_sid_only();
                 let batch = if let Some(cache) = self.store.leaflet_cache() {
-                    let idx_u32: u32 = idx.try_into().map_err(|_| {
-                        QueryError::Internal("leaflet idx exceeds u32".to_string())
-                    })?;
+                    let idx_u32: u32 = idx
+                        .try_into()
+                        .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
                     load_columns_cached_via_handle(
                         handle.as_ref(),
                         idx,
@@ -2024,8 +2025,15 @@ pub fn build_overlay_cursor_for_subject_range(
         p_id: Some(p_id),
         ..Default::default()
     };
-    let mut cursor =
-        build_range_cursor(store, g_id, RunSortOrder::Psot, &min_key, &max_key, filter, projection)?;
+    let mut cursor = build_range_cursor(
+        store,
+        g_id,
+        RunSortOrder::Psot,
+        &min_key,
+        &max_key,
+        filter,
+        projection,
+    )?;
     cursor.set_to_t(to_t);
     if overlay_active {
         if !sliced_ops.is_empty() {
@@ -2198,11 +2206,7 @@ where
         None => return Ok(None),
     };
     let to_t = ctx.to_t;
-    let epoch = ctx
-        .overlay
-        .as_ref()
-        .map(|o| o.epoch())
-        .unwrap_or(0);
+    let epoch = ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
     let total_rows = count_rows_for_predicate_psot(store, g_id, p_id)?;
 
     let ops_ref = &ops;

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -2306,7 +2306,16 @@ pub fn count_predicate_overlay_delta(
     let mut op_idx = 0usize;
     let n = leaves.len();
     for i in 0..n {
-        let lo = leaves[i].first_key.s_id.as_u64();
+        // The first leaf's range starts at 0 (mirroring `parallel_partition_count`'s
+        // `bounds[0] == 0`) so novelty ops below the predicate's first indexed subject
+        // — a low-id subject newly gaining this predicate — fall into leaf 0's range
+        // and are merged in, rather than being skipped by the op-cursor advance below
+        // and silently undercounted.
+        let lo = if i == 0 {
+            0
+        } else {
+            leaves[i].first_key.s_id.as_u64()
+        };
         let hi = if i + 1 < n {
             leaves[i + 1].first_key.s_id.as_u64()
         } else {

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -745,10 +745,20 @@ impl<'a> PsotSubjectSeek<'a> {
                 continue;
             }
             if !found {
-                // Advance to the first row with s_id >= target_s.
-                while self.row < batch.row_count && batch.s_id.get(self.row) < target_s {
-                    self.row += 1;
+                // Advance to the first row with s_id >= target_s. Within a leaflet
+                // s_id is sorted, so binary-search the unconsumed suffix instead of
+                // skipping row-by-row — cheap when the target is far in, e.g. when a
+                // sparse driver seeks past a high-multiplicity subject's run.
+                let (mut lo, mut hi) = (self.row, batch.row_count);
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if batch.s_id.get(mid) < target_s {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
                 }
+                self.row = lo;
                 if self.row >= batch.row_count {
                     self.batch = None;
                     continue;

--- a/fluree-db-query/src/fast_path_plus_count_all.rs
+++ b/fluree-db-query/src/fast_path_plus_count_all.rs
@@ -248,57 +248,41 @@ fn count_p1_then_p2_plus(
         return Ok(None);
     };
 
+    // SPARQL COUNT(*) over `?s p1 ?mid . ?mid p2+ ?o` counts the solution multiset
+    // (?s, ?mid, ?o). The sequence `p1/p2+` lowers to a Join over the fresh,
+    // path-internal variable ?mid (SPARQL 1.1 §18.2.2.4); the ALP sub-path makes
+    // each (?mid, ?o) endpoint distinct (§9.4), but the outer Join over ?mid
+    // PRESERVES multiplicity, and COUNT(*) counts solutions before projection — so
+    // an ?o reachable from one ?s via two different ?mid is counted TWICE. Hence we
+    // must NOT dedup intermediates per subject nor union endpoints across them: the
+    // correct count is `Σ over each p1-edge (s, mid) of |reach⁺(mid)|`. (The prior
+    // per-subject dedup + cross-mid endpoint union computed COUNT(DISTINCT ?s ?o),
+    // systematically under-counting.) PSOT(p1) rows are unique (s, p1, o) triples,
+    // so iterating every IRI-ref row visits each (s, mid) edge exactly once; no
+    // subject grouping is needed. `|reach⁺(mid)|` is memoized per distinct mid.
     let iri_ref = OType::IRI_REF.as_u16();
     let mut memo: FxHashMap<u64, u64> = FxHashMap::default();
     let mut total: u64 = 0;
-
-    let mut cur_s: Option<u64> = None;
-    let mut cur_starts: Vec<u64> = Vec::new();
-
-    let mut flush_group = |starts: &mut Vec<u64>| -> u64 {
-        match starts.len() {
-            0 => 0,
-            1 => {
-                let x = starts[0];
-                if let Some(&v) = memo.get(&x) {
-                    v
-                } else {
-                    let v = reach_count_plus(&adj, x);
-                    memo.insert(x, v);
-                    v
-                }
-            }
-            _ => reach_count_plus_multi(&adj, starts),
-        }
-    };
 
     while let Some(batch) = cursor1
         .next_batch()
         .map_err(|e| QueryError::Internal(format!("cursor batch: {e}")))?
     {
         for i in 0..batch.row_count {
-            let s = batch.s_id.get(i);
-            if cur_s != Some(s) {
-                if cur_s.is_some() {
-                    let add = flush_group(&mut cur_starts);
-                    total = total.saturating_add(add);
-                }
-                cur_s = Some(s);
-                cur_starts.clear();
-            }
             if batch.o_type.get(i) != iri_ref {
                 continue;
             }
-            let x = batch.o_key.get(i);
-            if !cur_starts.contains(&x) {
-                cur_starts.push(x);
-            }
+            let mid = batch.o_key.get(i);
+            let c = match memo.get(&mid) {
+                Some(&v) => v,
+                None => {
+                    let v = reach_count_plus(&adj, mid);
+                    memo.insert(mid, v);
+                    v
+                }
+            };
+            total = total.saturating_add(c);
         }
-    }
-
-    if cur_s.is_some() {
-        let add = flush_group(&mut cur_starts);
-        total = total.saturating_add(add);
     }
 
     Ok(Some(total))

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -568,11 +568,17 @@ fn try_union_constraint_overlay_parallel(
 
     let (union_pids, union_ops, extra_pids, extra_ops) =
         (&union_pids, &union_ops, &extra_pids, &extra_ops);
-    crate::count_plan_exec::parallel_partition_count(store, g_id, driver_p, total_rows, move |lo, hi| {
-        merge_union_constraint_count_range_overlay(
-            store, g_id, union_pids, union_ops, extra_pids, extra_ops, to_t, epoch, lo, hi,
-        )
-    })
+    crate::count_plan_exec::parallel_partition_count(
+        store,
+        g_id,
+        driver_p,
+        total_rows,
+        move |lo, hi| {
+            merge_union_constraint_count_range_overlay(
+                store, g_id, union_pids, union_ops, extra_pids, extra_ops, to_t, epoch, lo, hi,
+            )
+        },
+    )
 }
 
 fn count_union_star(
@@ -656,7 +662,11 @@ fn count_union_star(
     // Parallel partitioned merge for the constrained `AllRows` case:
     // `{ ?s p1 ?o } UNION { ?s p2 ?o } . ?s e1 ?o2 …` COUNT(*) over large
     // predicates. HEAD-only (no overlay/time-travel); else the cursor merge below.
-    if matches!(mode, UnionCountMode::AllRows) && !extra_preds.is_empty() && !overlay_has_rows && !time_travel {
+    if matches!(mode, UnionCountMode::AllRows)
+        && !extra_preds.is_empty()
+        && !overlay_has_rows
+        && !time_travel
+    {
         if let Some(total) = try_union_constraint_parallel(store, g_id, union_preds, extra_preds)? {
             return Ok(Some(total));
         }

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -30,14 +30,14 @@ use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
     build_count_batch, build_psot_cursor_for_predicate, count_rows_for_predicate_psot, count_to_i64,
-    cursor_projection_sid_only, cursor_projection_sid_otype_okey, normalize_pred_sid,
-    CursorSubjectCountStream,
+    cursor_projection_sid_only, cursor_projection_sid_otype_okey, leaf_entries_for_predicate,
+    normalize_pred_sid, CursorSubjectCountStream, PsotSubjectCountIter,
 };
 use crate::ir::triple::Ref;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::var_registry::VarId;
 use async_trait::async_trait;
-use fluree_db_binary_index::BinaryCursor;
+use fluree_db_binary_index::{BinaryCursor, RunSortOrder};
 use fluree_db_core::o_type::OType;
 use std::sync::Arc;
 
@@ -244,6 +244,163 @@ impl SubjectSelfLoopCountStreamV6 {
     }
 }
 
+/// Min-merge over union-branch iterators: returns `(s_min, Σ counts at s_min)` and
+/// advances the iterators at `s_min`. Bag semantics — a subject under multiple
+/// branches sums their counts.
+fn next_union_group(
+    iters: &mut [PsotSubjectCountIter<'_>],
+    cur: &mut [Option<(u64, u64)>],
+) -> Result<Option<(u64, u64)>> {
+    if cur.iter().all(std::option::Option::is_none) {
+        return Ok(None);
+    }
+    let s_min = cur.iter().filter_map(|c| c.map(|(s, _)| s)).min().unwrap();
+    let mut sum: u64 = 0;
+    for (i, it) in iters.iter_mut().enumerate() {
+        if let Some((s, n)) = cur[i] {
+            if s == s_min {
+                sum = sum.saturating_add(n);
+                cur[i] = it.next_group()?;
+            }
+        }
+    }
+    Ok(Some((s_min, sum)))
+}
+
+/// Max-merge over the constraint (extra) iterators: returns the next subject present
+/// in ALL of them with the product of their counts; subjects missing from any
+/// constraint predicate are skipped.
+fn next_extra_product_group(
+    iters: &mut [PsotSubjectCountIter<'_>],
+    cur: &mut [Option<(u64, u64)>],
+) -> Result<Option<(u64, u64)>> {
+    loop {
+        if cur.iter().any(std::option::Option::is_none) {
+            return Ok(None);
+        }
+        let target = cur.iter().filter_map(|c| c.map(|(s, _)| s)).max().unwrap();
+        let mut advanced = false;
+        for (i, it) in iters.iter_mut().enumerate() {
+            while let Some((s, _)) = cur[i] {
+                if s < target {
+                    cur[i] = it.next_group()?;
+                    advanced = true;
+                    if cur[i].is_none() {
+                        return Ok(None);
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        if advanced {
+            continue;
+        }
+        let mut prod: u64 = 1;
+        for c in cur.iter() {
+            prod = prod.saturating_mul(c.unwrap().1);
+        }
+        for (i, it) in iters.iter_mut().enumerate() {
+            cur[i] = it.next_group()?;
+        }
+        return Ok(Some((target, prod)));
+    }
+}
+
+/// Per-partition partial for `(UNION of union_pids) ⋈ (AND of extra_pids)` COUNT(*)
+/// over `[lo, hi)`: `Σ_s (Σ_b count_b(s)) × (Π_e count_e(s))` for subjects in any
+/// union branch AND all extra predicates. BASE index only.
+fn merge_union_constraint_count_range(
+    store: &fluree_db_binary_index::BinaryIndexStore,
+    g_id: fluree_db_core::GraphId,
+    union_pids: &[u32],
+    extra_pids: &[u32],
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let mut u_iters: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(union_pids.len());
+    for &p in union_pids {
+        u_iters.push(PsotSubjectCountIter::new_bounded(store, g_id, p, lo, hi)?);
+    }
+    let mut u_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(u_iters.len());
+    for it in &mut u_iters {
+        u_cur.push(it.next_group()?);
+    }
+    let mut e_iters: Vec<PsotSubjectCountIter<'_>> = Vec::with_capacity(extra_pids.len());
+    for &p in extra_pids {
+        e_iters.push(PsotSubjectCountIter::new_bounded(store, g_id, p, lo, hi)?);
+    }
+    let mut e_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(e_iters.len());
+    for it in &mut e_iters {
+        e_cur.push(it.next_group()?);
+    }
+
+    let mut u = next_union_group(&mut u_iters, &mut u_cur)?;
+    let mut e = next_extra_product_group(&mut e_iters, &mut e_cur)?;
+    let mut total: u128 = 0;
+    while let (Some((us, usum)), Some((es, eprod))) = (u, e) {
+        if us < es {
+            u = next_union_group(&mut u_iters, &mut u_cur)?;
+            continue;
+        }
+        if es < us {
+            e = next_extra_product_group(&mut e_iters, &mut e_cur)?;
+            continue;
+        }
+        total = total.saturating_add((usum as u128).saturating_mul(eprod as u128));
+        u = next_union_group(&mut u_iters, &mut u_cur)?;
+        e = next_extra_product_group(&mut e_iters, &mut e_cur)?;
+    }
+    Ok(total)
+}
+
+/// Parallel partitioned constrained-union count. Resolves predicate ids, picks the
+/// partition driver, and dispatches to the shared harness. Returns `Ok(None)` to
+/// defer to the cursor merge when a predicate is absent or there are too few rows.
+/// Caller ensures `AllRows`, non-empty `extra_preds`, and HEAD (no overlay/time-travel).
+fn try_union_constraint_parallel(
+    store: &Arc<fluree_db_binary_index::BinaryIndexStore>,
+    g_id: fluree_db_core::GraphId,
+    union_preds: &[Ref],
+    extra_preds: &[Ref],
+) -> Result<Option<u64>> {
+    let mut union_pids: Vec<u32> = Vec::with_capacity(union_preds.len());
+    let mut extra_pids: Vec<u32> = Vec::with_capacity(extra_preds.len());
+    let mut total_rows: u64 = 0;
+    // Absent predicate (union or extra) => defer to the cursor merge, which handles
+    // the empty-union / empty-join semantics.
+    for p in union_preds {
+        let sid = normalize_pred_sid(store, p)?;
+        let Some(p_id) = store.sid_to_p_id(&sid) else {
+            return Ok(None);
+        };
+        union_pids.push(p_id);
+        total_rows = total_rows.saturating_add(count_rows_for_predicate_psot(store, g_id, p_id)?);
+    }
+    for p in extra_preds {
+        let sid = normalize_pred_sid(store, p)?;
+        let Some(p_id) = store.sid_to_p_id(&sid) else {
+            return Ok(None);
+        };
+        extra_pids.push(p_id);
+        total_rows = total_rows.saturating_add(count_rows_for_predicate_psot(store, g_id, p_id)?);
+    }
+    if union_pids.is_empty() || extra_pids.is_empty() {
+        return Ok(None);
+    }
+    // Partition driver = the predicate (union or extra) with the most leaves.
+    let driver_p = union_pids
+        .iter()
+        .chain(extra_pids.iter())
+        .copied()
+        .max_by_key(|&p| leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    crate::count_plan_exec::parallel_partition_count(store, g_id, driver_p, total_rows, |lo, hi| {
+        merge_union_constraint_count_range(store, g_id, &union_pids, &extra_pids, lo, hi)
+    })
+}
+
 fn count_union_star(
     store: &Arc<fluree_db_binary_index::BinaryIndexStore>,
     ctx: &ExecutionContext<'_>,
@@ -287,6 +444,15 @@ fn count_union_star(
             total = total.saturating_add(count_rows_for_predicate_psot(store, g_id, p_id)?);
         }
         return Ok(Some(total));
+    }
+
+    // Parallel partitioned merge for the constrained `AllRows` case:
+    // `{ ?s p1 ?o } UNION { ?s p2 ?o } . ?s e1 ?o2 …` COUNT(*) over large
+    // predicates. HEAD-only (no overlay/time-travel); else the cursor merge below.
+    if matches!(mode, UnionCountMode::AllRows) && !extra_preds.is_empty() && !overlay_has_rows && !time_travel {
+        if let Some(total) = try_union_constraint_parallel(store, g_id, union_preds, extra_preds)? {
+            return Ok(Some(total));
+        }
     }
 
     // Build union streams.

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -29,8 +29,9 @@ use crate::binding::Batch;
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
-    build_count_batch, build_psot_cursor_for_predicate, count_to_i64, cursor_projection_sid_only,
-    cursor_projection_sid_otype_okey, normalize_pred_sid, CursorSubjectCountStream,
+    build_count_batch, build_psot_cursor_for_predicate, count_rows_for_predicate_psot, count_to_i64,
+    cursor_projection_sid_only, cursor_projection_sid_otype_okey, normalize_pred_sid,
+    CursorSubjectCountStream,
 };
 use crate::ir::triple::Ref;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
@@ -258,6 +259,34 @@ fn count_union_star(
         != 0;
     if union_preds.is_empty() {
         return Ok(Some(0));
+    }
+
+    // Metadata fast lane: `{ ?s p1 ?o } UNION { ?s p2 ?o }` under COUNT(*) with no
+    // extra constraint reduces, under bag semantics, to `Σ_p count_rows(p)` — a sum
+    // of leaflet-directory row counts with NO row decode. (count(p1)+count(p2)
+    // double-counts subjects present under both predicates, which is exactly correct
+    // for UNION bag semantics.) Only valid at HEAD with no overlay/time-travel, where
+    // base-leaflet directory counts are exact; otherwise fall through to the
+    // overlay-merging cursor path below.
+    //
+    // Gate matches `count_plan_exec`: epoch != 0 OR to_t != max_t.
+    let time_travel = ctx.to_t != store.max_t();
+    if matches!(mode, UnionCountMode::AllRows)
+        && extra_preds.is_empty()
+        && !overlay_has_rows
+        && !time_travel
+    {
+        let mut total: u64 = 0;
+        for p in union_preds {
+            let sid = normalize_pred_sid(store, p)?;
+            // Absent predicate contributes 0. Safe here: no overlay means there are
+            // no overlay-only rows a missing `p_id` could hide.
+            let Some(p_id) = store.sid_to_p_id(&sid) else {
+                continue;
+            };
+            total = total.saturating_add(count_rows_for_predicate_psot(store, g_id, p_id)?);
+        }
+        return Ok(Some(total));
     }
 
     // Build union streams.

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -539,6 +539,12 @@ fn try_union_constraint_overlay_parallel(
     }
     let total_rows = ur.saturating_add(er);
 
+    // Pre-gate before walking novelty: the serial cursor-merge fallback re-collects
+    // these ops, so collecting them here only to fail the parallel gate is double work.
+    if !crate::count_plan_exec::parallel_count_gate_open(total_rows) {
+        return Ok(None);
+    }
+
     let collect = |sids: &[fluree_db_core::Sid]| -> Result<Option<Vec<Vec<fluree_db_binary_index::read::types::OverlayOp>>>> {
         let mut out = Vec::with_capacity(sids.len());
         for sid in sids {

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -30,9 +30,10 @@ use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
     build_count_batch, build_overlay_cursor_for_subject_range, build_psot_cursor_for_predicate,
-    collect_resolved_overlay_ops, count_rows_for_predicate_psot, count_to_i64,
-    cursor_projection_sid_only, cursor_projection_sid_otype_okey, leaf_entries_for_predicate,
-    normalize_pred_sid, slice_overlay_ops_by_subject, CursorSubjectCountStream, PsotSubjectCountIter,
+    collect_resolved_overlay_ops, count_predicate_overlay_delta, count_rows_for_predicate_psot,
+    count_to_i64, cursor_projection_sid_only, cursor_projection_sid_otype_okey,
+    leaf_entries_for_predicate, normalize_pred_sid, slice_overlay_ops_by_subject,
+    CursorSubjectCountStream, PsotSubjectCountIter,
 };
 use crate::ir::triple::Ref;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
@@ -617,6 +618,39 @@ fn count_union_star(
             total = total.saturating_add(count_rows_for_predicate_psot(store, g_id, p_id)?);
         }
         return Ok(Some(total));
+    }
+
+    // Novelty at HEAD (no time-travel), no-constraint UNION: bag-semantics sum of
+    // each branch's metadata base count + a novelty delta over only the touched
+    // leaves, instead of a full cursor scan of every branch.
+    if matches!(mode, UnionCountMode::AllRows)
+        && extra_preds.is_empty()
+        && overlay_has_rows
+        && ctx.to_t >= store.max_t()
+    {
+        let mut total: u64 = 0;
+        let mut all_ok = true;
+        for p in union_preds {
+            let sid = normalize_pred_sid(store, p)?;
+            // A union branch present only in novelty (no base id), or a translation
+            // failure, defers the whole count to the cursor merge below.
+            match store.sid_to_p_id(&sid) {
+                Some(p_id) => match count_predicate_overlay_delta(ctx, store, g_id, sid, p_id)? {
+                    Some(n) => total = total.saturating_add(n),
+                    None => {
+                        all_ok = false;
+                        break;
+                    }
+                },
+                None => {
+                    all_ok = false;
+                    break;
+                }
+            }
+        }
+        if all_ok {
+            return Ok(Some(total));
+        }
     }
 
     // Parallel partitioned merge for the constrained `AllRows` case:

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -29,9 +29,10 @@ use crate::binding::Batch;
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
-    build_count_batch, build_psot_cursor_for_predicate, count_rows_for_predicate_psot, count_to_i64,
+    build_count_batch, build_overlay_cursor_for_subject_range, build_psot_cursor_for_predicate,
+    collect_resolved_overlay_ops, count_rows_for_predicate_psot, count_to_i64,
     cursor_projection_sid_only, cursor_projection_sid_otype_okey, leaf_entries_for_predicate,
-    normalize_pred_sid, CursorSubjectCountStream, PsotSubjectCountIter,
+    normalize_pred_sid, slice_overlay_ops_by_subject, CursorSubjectCountStream, PsotSubjectCountIter,
 };
 use crate::ir::triple::Ref;
 use crate::operator::{BoxedOperator, Operator, OperatorState};
@@ -244,11 +245,30 @@ impl SubjectSelfLoopCountStreamV6 {
     }
 }
 
+/// A `(subject, count)` group stream in ascending subject order — either the base
+/// metadata iterator (HEAD) or the overlay-merging cursor stream (novelty/time
+/// travel). Lets the union/extra merge helpers serve both lanes.
+trait SubjectCountGroups {
+    fn next_subject_group(&mut self) -> Result<Option<(u64, u64)>>;
+}
+impl SubjectCountGroups for PsotSubjectCountIter<'_> {
+    #[inline]
+    fn next_subject_group(&mut self) -> Result<Option<(u64, u64)>> {
+        self.next_group()
+    }
+}
+impl SubjectCountGroups for CursorSubjectCountStream {
+    #[inline]
+    fn next_subject_group(&mut self) -> Result<Option<(u64, u64)>> {
+        self.next_group()
+    }
+}
+
 /// Min-merge over union-branch iterators: returns `(s_min, Σ counts at s_min)` and
 /// advances the iterators at `s_min`. Bag semantics — a subject under multiple
 /// branches sums their counts.
-fn next_union_group(
-    iters: &mut [PsotSubjectCountIter<'_>],
+fn next_union_group<T: SubjectCountGroups>(
+    iters: &mut [T],
     cur: &mut [Option<(u64, u64)>],
 ) -> Result<Option<(u64, u64)>> {
     if cur.iter().all(std::option::Option::is_none) {
@@ -260,7 +280,7 @@ fn next_union_group(
         if let Some((s, n)) = cur[i] {
             if s == s_min {
                 sum = sum.saturating_add(n);
-                cur[i] = it.next_group()?;
+                cur[i] = it.next_subject_group()?;
             }
         }
     }
@@ -270,8 +290,8 @@ fn next_union_group(
 /// Max-merge over the constraint (extra) iterators: returns the next subject present
 /// in ALL of them with the product of their counts; subjects missing from any
 /// constraint predicate are skipped.
-fn next_extra_product_group(
-    iters: &mut [PsotSubjectCountIter<'_>],
+fn next_extra_product_group<T: SubjectCountGroups>(
+    iters: &mut [T],
     cur: &mut [Option<(u64, u64)>],
 ) -> Result<Option<(u64, u64)>> {
     loop {
@@ -283,7 +303,7 @@ fn next_extra_product_group(
         for (i, it) in iters.iter_mut().enumerate() {
             while let Some((s, _)) = cur[i] {
                 if s < target {
-                    cur[i] = it.next_group()?;
+                    cur[i] = it.next_subject_group()?;
                     advanced = true;
                     if cur[i].is_none() {
                         return Ok(None);
@@ -301,7 +321,7 @@ fn next_extra_product_group(
             prod = prod.saturating_mul(c.unwrap().1);
         }
         for (i, it) in iters.iter_mut().enumerate() {
-            cur[i] = it.next_group()?;
+            cur[i] = it.next_subject_group()?;
         }
         return Ok(Some((target, prod)));
     }
@@ -401,6 +421,159 @@ fn try_union_constraint_parallel(
     })
 }
 
+/// Overlay/time-travel variant of `merge_union_constraint_count_range` for one
+/// subject partition: `Σ_s (Σ_b count_b(s)) × (Π_e count_e(s))`, every predicate read
+/// through a bounded overlay cursor (its `[lo,hi)` leaves + its novelty ops sliced to
+/// that range). `union_ops`/`extra_ops` mirror `union_pids`/`extra_pids`. A
+/// `s ∈ [lo,hi)` guard on the matched subject counts boundary subjects once.
+#[allow(clippy::too_many_arguments)]
+fn merge_union_constraint_count_range_overlay(
+    store: &Arc<fluree_db_binary_index::BinaryIndexStore>,
+    g_id: fluree_db_core::GraphId,
+    union_pids: &[u32],
+    union_ops: &[Vec<fluree_db_binary_index::read::types::OverlayOp>],
+    extra_pids: &[u32],
+    extra_ops: &[Vec<fluree_db_binary_index::read::types::OverlayOp>],
+    to_t: i64,
+    epoch: u64,
+    lo: u64,
+    hi: u64,
+) -> Result<u128> {
+    let build = |p_id: u32, ops: &[fluree_db_binary_index::read::types::OverlayOp]| {
+        let sliced = slice_overlay_ops_by_subject(ops, lo, hi);
+        build_overlay_cursor_for_subject_range(
+            store,
+            g_id,
+            p_id,
+            cursor_projection_sid_only(),
+            lo,
+            hi,
+            sliced,
+            to_t,
+            epoch,
+        )
+        .map(CursorSubjectCountStream::new)
+    };
+
+    let mut u_streams: Vec<CursorSubjectCountStream> = Vec::with_capacity(union_pids.len());
+    for (i, &p) in union_pids.iter().enumerate() {
+        let Some(s) = build(p, &union_ops[i]) else {
+            return Ok(0);
+        };
+        u_streams.push(s);
+    }
+    let mut u_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(u_streams.len());
+    for s in &mut u_streams {
+        u_cur.push(s.next_group()?);
+    }
+    let mut e_streams: Vec<CursorSubjectCountStream> = Vec::with_capacity(extra_pids.len());
+    for (i, &p) in extra_pids.iter().enumerate() {
+        let Some(s) = build(p, &extra_ops[i]) else {
+            return Ok(0);
+        };
+        e_streams.push(s);
+    }
+    let mut e_cur: Vec<Option<(u64, u64)>> = Vec::with_capacity(e_streams.len());
+    for s in &mut e_streams {
+        e_cur.push(s.next_group()?);
+    }
+
+    let mut u = next_union_group(&mut u_streams, &mut u_cur)?;
+    let mut e = next_extra_product_group(&mut e_streams, &mut e_cur)?;
+    let mut total: u128 = 0;
+    while let (Some((us, usum)), Some((es, eprod))) = (u, e) {
+        if us < es {
+            u = next_union_group(&mut u_streams, &mut u_cur)?;
+            continue;
+        }
+        if es < us {
+            e = next_extra_product_group(&mut e_streams, &mut e_cur)?;
+            continue;
+        }
+        if us >= lo && us < hi {
+            total = total.saturating_add((usum as u128).saturating_mul(eprod as u128));
+        }
+        u = next_union_group(&mut u_streams, &mut u_cur)?;
+        e = next_extra_product_group(&mut e_streams, &mut e_cur)?;
+    }
+    Ok(total)
+}
+
+/// Overlay/time-travel parallel constrained-union count: like
+/// `try_union_constraint_parallel` but folds novelty per partition (bounded overlay
+/// cursors). Collects each predicate's resolved ops once. Returns `Ok(None)` to defer
+/// to the serial cursor merge for an absent predicate, a translation failure, or too
+/// few rows.
+fn try_union_constraint_overlay_parallel(
+    store: &Arc<fluree_db_binary_index::BinaryIndexStore>,
+    ctx: &ExecutionContext<'_>,
+    g_id: fluree_db_core::GraphId,
+    union_preds: &[Ref],
+    extra_preds: &[Ref],
+) -> Result<Option<u64>> {
+    type ResolvedPreds = (Vec<u32>, Vec<fluree_db_core::Sid>, u64);
+    let resolve = |preds: &[Ref]| -> Result<Option<ResolvedPreds>> {
+        let mut pids = Vec::with_capacity(preds.len());
+        let mut sids = Vec::with_capacity(preds.len());
+        let mut rows = 0u64;
+        for p in preds {
+            let sid = normalize_pred_sid(store, p)?;
+            let Some(p_id) = store.sid_to_p_id(&sid) else {
+                return Ok(None);
+            };
+            rows = rows.saturating_add(count_rows_for_predicate_psot(store, g_id, p_id)?);
+            pids.push(p_id);
+            sids.push(sid);
+        }
+        Ok(Some((pids, sids, rows)))
+    };
+    let Some((union_pids, union_sids, ur)) = resolve(union_preds)? else {
+        return Ok(None);
+    };
+    let Some((extra_pids, extra_sids, er)) = resolve(extra_preds)? else {
+        return Ok(None);
+    };
+    if union_pids.is_empty() || extra_pids.is_empty() {
+        return Ok(None);
+    }
+    let total_rows = ur.saturating_add(er);
+
+    let collect = |sids: &[fluree_db_core::Sid]| -> Result<Option<Vec<Vec<fluree_db_binary_index::read::types::OverlayOp>>>> {
+        let mut out = Vec::with_capacity(sids.len());
+        for sid in sids {
+            let Some(ops) = collect_resolved_overlay_ops(ctx, store, g_id, RunSortOrder::Psot, sid)?
+            else {
+                return Ok(None);
+            };
+            out.push(ops);
+        }
+        Ok(Some(out))
+    };
+    let Some(union_ops) = collect(&union_sids)? else {
+        return Ok(None);
+    };
+    let Some(extra_ops) = collect(&extra_sids)? else {
+        return Ok(None);
+    };
+
+    let to_t = ctx.to_t;
+    let epoch = ctx.overlay.as_ref().map(|o| o.epoch()).unwrap_or(0);
+    let driver_p = union_pids
+        .iter()
+        .chain(extra_pids.iter())
+        .copied()
+        .max_by_key(|&p| leaf_entries_for_predicate(store, g_id, RunSortOrder::Psot, p).len())
+        .unwrap();
+
+    let (union_pids, union_ops, extra_pids, extra_ops) =
+        (&union_pids, &union_ops, &extra_pids, &extra_ops);
+    crate::count_plan_exec::parallel_partition_count(store, g_id, driver_p, total_rows, move |lo, hi| {
+        merge_union_constraint_count_range_overlay(
+            store, g_id, union_pids, union_ops, extra_pids, extra_ops, to_t, epoch, lo, hi,
+        )
+    })
+}
+
 fn count_union_star(
     store: &Arc<fluree_db_binary_index::BinaryIndexStore>,
     ctx: &ExecutionContext<'_>,
@@ -451,6 +624,20 @@ fn count_union_star(
     // predicates. HEAD-only (no overlay/time-travel); else the cursor merge below.
     if matches!(mode, UnionCountMode::AllRows) && !extra_preds.is_empty() && !overlay_has_rows && !time_travel {
         if let Some(total) = try_union_constraint_parallel(store, g_id, union_preds, extra_preds)? {
+            return Ok(Some(total));
+        }
+    }
+
+    // Overlay/time-travel constrained-UNION: parallelize the base scan and fold
+    // novelty per partition. Falls through to the serial cursor merge below for
+    // absent predicates, translation failures, or too few rows.
+    if matches!(mode, UnionCountMode::AllRows)
+        && !extra_preds.is_empty()
+        && (overlay_has_rows || time_travel)
+    {
+        if let Some(total) =
+            try_union_constraint_overlay_parallel(store, ctx, g_id, union_preds, extra_preds)?
+        {
             return Ok(Some(total));
         }
     }

--- a/fluree-db-query/src/property_path.rs
+++ b/fluree-db-query/src/property_path.rs
@@ -509,6 +509,7 @@ impl PropertyPathOperator {
         // Note: lowering may produce `Ref::Iri` constants to support cross-ledger joins.
         // For property paths we must traverse SIDs, so we opportunistically encode IRIs
         // against the selected active graph's namespace table.
+        let binary_store = ctx.binary_store.as_ref();
         let resolve_sid = |term: &Ref, binding: Option<&Binding>| -> Option<Sid> {
             match term {
                 Ref::Sid(s) => Some(s.clone()),
@@ -517,6 +518,17 @@ impl PropertyPathOperator {
                     Binding::Sid { sid: s, .. } => Some(s.clone()),
                     Binding::IriMatch { iri, .. } => db_for_encode.encode_iri(iri),
                     Binding::Iri(iri) => db_for_encode.encode_iri(iri),
+                    // Indexed BinaryScan emits late-materialized EncodedSid for a
+                    // correlated path endpoint (e.g. the ?mid of `?s p1 ?mid . ?mid p2+ ?o`
+                    // with a bound subject). Resolve its raw s_id (only meaningful within
+                    // this single ledger, which property paths already require) to its IRI
+                    // via the active graph's store, then re-encode against the same graph —
+                    // matching the `IriMatch`/`Iri` arms above. Without this arm the binding
+                    // resolved to None and fell into the full-closure branch, pairing the
+                    // row with the entire p2 closure.
+                    Binding::EncodedSid { s_id, .. } => binary_store
+                        .and_then(|st| st.resolve_subject_iri(*s_id).ok())
+                        .and_then(|iri| db_for_encode.encode_iri(&iri)),
                     _ => None,
                 }),
             }


### PR DESCRIPTION
Based on #1265 

## Summary

Overhauls `COUNT` / `SUM` / aggregate execution with metadata-driven fast paths, asymmetric-seek joins, and parallel partitioned merges, collapsing the slow-spot aggregate queries on the DBLP "KG with associated data" benchmark (1.574B triples, r7a.4xlarge / 16-core). It then extends the **entire** count/filter family to fold uncommitted **novelty** and honor **time-travel** (parallel-under-overlay + a novelty-delta path), and lands the class-stat correctness fixes that make the metadata folds exact on incremental indexes — not just bulk imports.

## Results (DBLP, as of `c32b5cd8`)

Per-query latency on the targeted slow-spots dropped by up to ~18×:

| query | before (ms) | after (ms) | speedup |
|---|---|---|---|
| filter-many-results | 6,576 | 375 | ~18× |
| minus-join-3-star-2 | 4,725 | 329 | ~14× |
| union-constraint-large-join | 5,129 | 373 | ~14× |
| exists-join-3-star-2 | 4,673 | 330 | ~14× |
| optional-join-large-large | 4,455 | 372 | ~12× |
| filter-few-results | 2,761 | 370 | ~7× |

*(The overlay-parallel lanes and the bound-class fold landed after this run and were not re-benchmarked — they target live-write latency, not the bulk-imported benchmark, which is queried at HEAD.)*

## What changed

### 1. HEAD COUNT/aggregate fast paths (the benchmark wins)
- **Metadata folds (zero scan):** single-predicate `COUNT(*)` and `COUNT(DISTINCT ?p)` from branch-manifest / leaflet counts; no-constraint `UNION` = Σ per-branch; rdf:type inner-star `COUNT(*)` from per-(class,property) stats; POST numeric-compare global min/max shortcut; **bound-class** property `COUNT(*)` (`?s a :C . ?s P ?o` → `classStat[:C][P]`).
- **Asymmetric seek** for skewed small+large joins: drive from the small predicate and leapfrog-seek the large one (`PsotSubjectSeek`) — join / OPTIONAL / MINUS / EXISTS.
- **Parallel partitioned merge** for both-large cases: partition the subject space at leaf boundaries and run the N-way merge per range across cores — inner-star, OPTIONAL, constrained-UNION, MINUS/EXISTS.
- **Parallel filter-scan:** `COUNT` with encoded FILTERs (`?s != ?o`, `isBlank`, `LANG`) and `SUM(?o cmp K)` / numeric-compare `COUNT`, split across leaf chunks.
- **GROUP BY ?o COUNT ORDER BY DESC LIMIT:** streaming run-length + bounded top-K heap.

### 2. Shared thread pool (multi-tenant)
Parallel count/scan work runs on the shared global thread pool instead of a per-query `thread::scope`, so N concurrent queries no longer each spawn a fresh K-thread fan-out — total worker threads stay bounded to ≈ cores.

### 3. Overlay / time-travel support
The whole count/filter family now folds uncommitted novelty and honors `to_t`:
- **Parallel-under-overlay:** per-partition bounded overlay cursors (parallel base scan + per-partition novelty merge via the proven `merge_overlay_into_batch`) — filter-scans and all four count-plan reducers (star / optional / union / minus-exists).
- **Novelty-delta:** single-predicate and no-constraint `UNION` `COUNT(*)` keep the instant manifest base count and rescan only the leaves novelty touches (`base_total − base(touched) + merged(touched)`).
- Gated to `to_t >= max_t` (at/above the indexed head); time-travel below the indexed head defers to the replay path.

### 4. Class-stat correctness (enables the folds on any index)
- **#1266:** incremental per-(class,property) datatype/language stats made current-state-exact (base-vs-net class attribution + base-index re-scan of re-typed subjects) → the rdf:type-star fold drops its bulk-import-only gate and runs on any base index.
- **Ref-class edge re-attribution on re-type** (outgoing edges from the same base scan + inbound edges via a reverse OPST lookup) plus a **rebuild gate** that falls back to a full rebuild for oversized re-type batches.

### 5. Supporting correctness fixes
- `isIRI`/`isURI` returns `false` for skolemized blank nodes.
- `COUNT(*)` over `p1/p2+` sequence paths counts join multiplicity (not distinct pairs).

## Correctness model

Every fast path **defers** (`Ok(None)` → general pipeline / cursor merge) when it can't apply: overlay/time-travel below the indexed head, absent or novelty-only predicates, non-root policy, multi-ledger, history mode, overlay-flake translation failures, or a 0 result. Correctness never depends on a fast path firing — the general path remains the source of truth.

## Testing
- `it_query_sparql_indexed.rs` (+2,880): parity tests for each HEAD fast path, plus overlay/novelty and parallel variants (>50k-row datasets confirm the parallel paths actually fire; novelty tests cover asserts, retracts, and time-travel).
- `it_indexing_stats.rs` (+801): #1266 and ref-class re-attribution regressions (retract, re-type, oversized-batch rebuild).
- `it_query_seq_path_count_repro.rs`, `it_import_class_stats.rs`.
- `cargo fmt --all --check` + `clippy --all-features` clean; full-workspace `nextest` green except known-environmental suites (external-catalog and container-based integration tests) and a pre-existing flaky test (see follow-ups).

## Follow-ups (filed)
- **#1268** — parallel paths block the calling async worker under concurrent load (`spawn_blocking` + `'static` refactor).
- **#1269** — extend overlay-aware fast paths to the remaining aggregate shapes (GROUP BY top-K, COUNT DISTINCT, scalar SUM/AVG/MIN/MAX).
- **#1270** — class-to-class ref-edge `COUNT(*)` fold (now-exact `ref_classes`).
- **#1271** — `it_query_rdfs_class_repro` flakiness under concurrent nextest + bulk-import staging cleanup.
- **#1272** — incremental class-stat base-store-load-failure correctness gap (`IncrementalAbort` → rebuild).
