### PR TITLE
release v4.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,7 +2287,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "cid",
@@ -2995,14 +2995,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3144,14 +3144,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.4"
+version = "4.0.5"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 exclude = ["testsuite-sparql"]
 
 [workspace.package]
-version = "4.0.4"
+version = "4.0.5"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"


### PR DESCRIPTION
Bumps the workspace version from 4.0.4 → 4.0.5 in preparation for the v4.0.5 release.

- `[workspace.package].version` → `4.0.5`
- `cargo update --workspace` to refresh member entries in `Cargo.lock` (no external dependency changes)

Per `docs/contributing/releasing.md`, once this merges to `main` the `v4.0.5` tag will be pushed against the merge commit to trigger the cargo-dist release workflow.