### PR TITLE
fix: serve SPARQL CONSTRUCT/DESCRIBE as JSON-LD via content negotiation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -183,6 +183,7 @@
   - [Running with Docker](operations/docker.md)
   - [Storage modes (memory/file/AWS/IPFS)](operations/storage.md)
   - [Serverless storage choices](operations/serverless-storage.md)
+  - [Hardware sizing: CPU vs disk (benchmark)](operations/hardware-benchmarks.md)
   - [IPFS storage](operations/ipfs-storage.md)
   - [DynamoDB nameservice](operations/dynamodb-guide.md)
   - [Query peers and replication](operations/query-peers.md)

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -947,11 +947,43 @@ LIMIT 100
 }
 ```
 
+**SPARQL output negotiation (`Accept` header):**
+
+The full byte-format negotiation below is available on the **ledger-scoped**
+[`POST /query/{ledger}`](#post-queryledger) route. The **connection-scoped**
+`POST /query` route (SPARQL with `FROM <ledger>`) returns pre-formatted JSON only
+— it supports the JSON family (JSON-LD, SPARQL-results JSON, AgentJson) but not the
+byte formats; RDF/XML, SPARQL-results XML, and CSV/TSV require the ledger-scoped
+route (see the [connection-scoped note](#connection-scoped-sparql-output) below).
+
+| Query form | Default (no/`*/*`/`application/json`) | `application/ld+json` | `application/rdf+xml` | `application/sparql-results+json` | `text/csv` / `text/tab-separated-values` | `application/sparql-results+xml` | `application/vnd.fluree.agent+json` |
+|---|---|---|---|---|---|---|---|
+| `SELECT` / `ASK` | SPARQL-results JSON | JSON-LD | **406** | SPARQL-results JSON | CSV / TSV | SPARQL-results XML | AgentJson |
+| `CONSTRUCT` / `DESCRIBE` | **JSON-LD** | JSON-LD | RDF/XML | JSON-LD | **406** | **406** | **406** |
+
+A `CONSTRUCT` / `DESCRIBE` produces an RDF graph, which has no solution/binding-table
+form, so it is always returned as **JSON-LD** (`Content-Type: application/ld+json`)
+unless `application/rdf+xml` is explicitly requested; the solution-table formats
+(SPARQL-results XML, CSV/TSV, AgentJson) are rejected with `406`. A `SELECT` / `ASK`
+defaults to SPARQL-results JSON and only switches to JSON-LD when `application/ld+json`
+is requested explicitly — a bare `application/json` keeps the SPARQL-results-JSON
+shape — and RDF/XML (a graph format) is rejected with `406`.
+
+<a name="connection-scoped-sparql-output"></a>
+> **Connection-scoped `POST /query` (SPARQL):** this route returns pre-formatted
+> JSON only. The JSON-family columns above apply (CONSTRUCT/DESCRIBE → JSON-LD;
+> SELECT/ASK → SPARQL-results JSON, or JSON-LD with `Accept: application/ld+json`;
+> AgentJson via `application/vnd.fluree.agent+json`, rejected `406` for graph
+> queries). CSV/TSV are rejected with `406`, and `application/rdf+xml` /
+> `application/sparql-results+xml` are **not** negotiated here — use
+> `POST /query/{ledger}` for those byte formats.
+
 **Status Codes:**
 - `200 OK` - Query successful
 - `400 Bad Request` - Invalid query syntax
 - `401 Unauthorized` - Authentication required
 - `404 Not Found` - Ledger not found
+- `406 Not Acceptable` - Requested output format is not available for this query form (e.g. RDF/XML for a `SELECT`)
 - `413 Payload Too Large` - Query exceeds size limit
 - `500 Internal Server Error` - Server error
 - `503 Service Unavailable` - Query timeout or resource limit

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -40,6 +40,13 @@ Cloud/serverless storage placement guidance:
 - Expected transaction, query, and indexing latency ranges
 - Lambda disk cache and S3 concurrency tuning notes
 
+### [Hardware sizing: CPU vs disk (benchmark)](hardware-benchmarks.md)
+
+A worked benchmark (SPARQLoscope on ~574 M-triple DBLP) showing how hardware maps to performance:
+- Import is storage-bound — local NVMe imports faster even on slower CPUs
+- Query latency is CPU-bound — served from cache, tracks single-thread speed
+- Sizing guidance: when to prioritize disk vs core vs RAM
+
 ### [IPFS Storage](ipfs-storage.md)
 
 IPFS-specific setup and configuration:

--- a/docs/operations/hardware-benchmarks.md
+++ b/docs/operations/hardware-benchmarks.md
@@ -1,0 +1,76 @@
+# Hardware sizing: CPU vs disk (a worked benchmark)
+
+This guide is a concrete, reproducible example of how cloud hardware choices affect
+Fluree, using a large public dataset. The headline result is that **import speed and
+query speed respond to different levers**: bulk import is dominated by **storage
+throughput**, while steady-state query latency is dominated by **single-thread CPU
+performance**. Sizing a deployment well means knowing which one you are optimizing for.
+
+The numbers below come from the open Fluree benchmark suite:
+
+- **Repo:** <https://github.com/fluree/benchmark-db>
+- **Query set:** [SPARQLoscope](https://purl.org/ad-freiburg/sparqloscope) — a
+  105-query suite spanning joins, OPTIONAL/MINUS/EXISTS, UNION, aggregates, numeric
+  and date functions, string/REGEX, transitive paths, and result-size/export.
+- **Dataset:** DBLP-core (the standard DBLP bibliography), DROPS monthly archive
+  `2026-06-01` — **574.2 M** N-Triples lines (**561.5 M** distinct after dedup),
+  90 predicates, ~73.5 GB uncompressed. Fluree builds a **27 GB** inline-indexed
+  ledger from it.
+
+Method: `fluree create dblp --from dblp.ttl` for import; for queries, 1 warmup + 3
+timed runs per query, median per query, then aggregated across the 105 queries.
+Each machine has 16 cores and 64 GB RAM, differing in CPU family and disk.
+
+## Import: storage-bound
+
+| Instance | CPU | Disk | Import | Throughput | Peak RSS | Index |
+|---|---|---|--:|--:|--:|--:|
+| `m7a.4xlarge` | AMD EPYC Zen 4 (~3.7 GHz) | gp3 EBS (500 MB/s) | 504 s | 1.14 M tr/s | 21.9 GB | 27 GB |
+| `m7gd.4xlarge` | Graviton3 (~2.6 GHz) | local NVMe | 430 s | 1.33 M tr/s | 24.6 GB | 27 GB |
+| `m8gd.4xlarge` | Graviton4 (~2.8 GHz) | local NVMe | **382 s** | **1.50 M tr/s** | 24.4 GB | 27 GB |
+
+The two NVMe machines import **15–24% faster** than the EBS machine **even though
+their CPUs are slower per core**. That is the tell-tale sign that import is
+**I/O-bound, not CPU-bound**: a slower processor still finishes sooner once it is
+fed by a faster disk. During the dominant parse + sorted-commit phase the CPU sits
+around 25–30% busy on all three machines — the bottleneck is how fast triples can
+be streamed off disk and indexed onto disk. If your workload is ingest-heavy
+(large initial loads, frequent bulk imports), **prioritize local NVMe / high disk
+throughput** over raw core speed.
+
+## Query: CPU-bound
+
+After warmup the working set (the 27 GB index) is resident in the 64 GB page cache,
+so the disk barely participates and query latency tracks the **CPU**:
+
+| Instance | CPU | Average (mean) | Geo mean | Median |
+|---|---|--:|--:|--:|
+| `m7a.4xlarge` | AMD EPYC Zen 4 (~3.7 GHz) | **936 ms** | **119 ms** | **67 ms** |
+| `m8gd.4xlarge` | Graviton4 (~2.8 GHz) | 1,003 ms | 145 ms | 94 ms |
+| `m7gd.4xlarge` | Graviton3 (~2.6 GHz) | 1,153 ms | 167 ms | 110 ms |
+
+Here the ordering is the reverse of import: the highest-clock core (Zen 4) is
+fastest, and the ranking lines up with single-thread performance, not disk. The
+gap is widest on the cheapest queries — where fixed per-query overhead (planning,
+parsing, serialization) dominates and there is little parallel work to hide a
+slower core — and narrows on the heavy joins and aggregates. Newer cores help:
+Graviton4 is ~13% faster than Graviton3 on the same suite. If your workload is
+query-latency-sensitive (interactive APIs, many small reads), **prioritize a
+high-clock / high-IPC CPU** and ensure RAM comfortably holds the working index.
+
+## Putting it together
+
+| If you optimize for… | Choose… | Why |
+|---|---|---|
+| Bulk import / ingest throughput | local NVMe, high disk bandwidth | import is I/O-bound |
+| Query latency | fast single-thread CPU + enough RAM to cache the index | queries are CPU-bound and served from cache |
+| Mixed | a modern core **with** NVMe (e.g. Graviton4 + NVMe) | best balance of both |
+
+A practical rule of thumb: **size RAM to hold the active index** (so queries stay
+in cache), pick the **fastest core** you can for query latency, and reach for
+**local NVMe** when import time matters. The same-hardware effect is real — moving
+from network block storage to local NVMe shortens import with no change to the CPU
+— so storage class is a first-class sizing decision, not an afterthought.
+
+To reproduce these numbers or run the suite against your own hardware and datasets,
+see <https://github.com/fluree/benchmark-db>.

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -121,14 +121,13 @@ pub fn format_results(
 
     let compactor = IriCompactor::new(snapshot.namespaces(), context);
 
-    // CONSTRUCT queries have dedicated output format
+    // CONSTRUCT / DESCRIBE produce a graph, not a binding table, so the only
+    // sensible JSON rendering is JSON-LD. Any JSON-producing format request
+    // (including the SPARQL default `SparqlJson`) is coerced to JSON-LD rather
+    // than rejected — a graph has no SPARQL-results-JSON / TypedJson / AgentJson
+    // form. RDF/XML and the delimited formats never reach here: they are bytes
+    // formats handled (or rejected) earlier on the string path. See issue #1274.
     if result.output.construct_template().is_some() {
-        // Only JSON-LD makes sense for CONSTRUCT
-        if config.format != OutputFormat::JsonLd {
-            return Err(FormatError::InvalidBinding(
-                "CONSTRUCT queries only support JSON-LD output format".to_string(),
-            ));
-        }
         return construct::format(result, &compactor);
     }
 
@@ -265,13 +264,11 @@ pub async fn format_results_async(
 
     let compactor = IriCompactor::new(db.snapshot.namespaces(), context);
 
-    // CONSTRUCT queries have dedicated output format (sync, no DB access needed)
+    // CONSTRUCT / DESCRIBE produce a graph (sync, no DB access needed); coerce
+    // any JSON-producing format to JSON-LD rather than rejecting it. RDF/XML and
+    // delimited formats are handled on the string/bytes path and never reach
+    // here. See the sync `format_results` above and issue #1274.
     if result.output.construct_template().is_some() {
-        if config.format != OutputFormat::JsonLd {
-            return Err(FormatError::InvalidBinding(
-                "CONSTRUCT queries only support JSON-LD output format".to_string(),
-            ));
-        }
         return construct::format(result, &compactor);
     }
 

--- a/fluree-db-api/tests/it_query_construct.rs
+++ b/fluree-db-api/tests/it_query_construct.rs
@@ -368,3 +368,37 @@ async fn construct_value_metadata_displays() {
 
     assert_eq!(actual, expected);
 }
+
+/// Regression for issue #1274: a SPARQL CONSTRUCT executed through the default
+/// formatted path (no explicit `.format()`) must NOT error with "CONSTRUCT
+/// queries only support JSON-LD output format". The SPARQL default is
+/// SPARQL-results JSON, but a graph has no binding-table form, so the formatter
+/// coerces the result to JSON-LD instead of rejecting it.
+#[tokio::test]
+async fn sparql_construct_default_format_yields_jsonld_graph() {
+    let (fluree, ledger) = seed_people().await;
+    let db = support::graphdb_from_ledger(&ledger);
+
+    let sparql = "PREFIX person: <http://example.org/Person#> \
+                  CONSTRUCT { ?s person:fullName ?n } WHERE { ?s person:fullName ?n }";
+
+    // Default path — exactly what the server's no-Accept / application/json /
+    // application/ld+json branches drive.
+    let out = db
+        .query(&fluree)
+        .sparql(sparql)
+        .execute_formatted()
+        .await
+        .expect("CONSTRUCT default format must not 400");
+
+    // JSON-LD graph shape: an object carrying an @graph array of nodes.
+    let graph = out
+        .get("@graph")
+        .and_then(JsonValue::as_array)
+        .expect("CONSTRUCT output is a JSON-LD @graph object");
+    assert!(!graph.is_empty(), "expected constructed triples");
+    assert!(
+        graph.iter().all(|node| node.get("@id").is_some()),
+        "each constructed node carries an @id"
+    );
+}

--- a/fluree-db-server/src/extract/headers.rs
+++ b/fluree-db-server/src/extract/headers.rs
@@ -271,6 +271,23 @@ impl FlureeHeaders {
             .unwrap_or(false)
     }
 
+    /// Check if the client explicitly requests JSON-LD output via Accept header.
+    ///
+    /// Matches `application/ld+json` (case-insensitive) only. Bare
+    /// `application/json` is intentionally NOT matched: it is the most common
+    /// default Accept value, and treating it as a JSON-LD request would silently
+    /// flip every existing SELECT client from SPARQL-results-JSON to JSON-LD.
+    /// SPARQL CONSTRUCT/DESCRIBE already render as JSON-LD regardless of Accept
+    /// (the formatter coerces graph results — see issue #1274); this helper lets
+    /// a SELECT query *opt in* to JSON-LD via the unambiguous media type.
+    /// Does NOT match `*/*` — JSON-LD must be explicitly requested.
+    pub fn wants_jsonld(&self) -> bool {
+        self.accept
+            .as_ref()
+            .map(|a| a.to_ascii_lowercase().contains("application/ld+json"))
+            .unwrap_or(false)
+    }
+
     /// Check if this is a JWT/JWS based on Content-Type
     pub fn is_jwt(&self) -> bool {
         self.content_type

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -340,13 +340,30 @@ pub async fn query(
 
     // Handle SPARQL query
     if is_sparql_request(&headers, &credential, &params) {
-        // Connection-scoped SPARQL returns pre-formatted JSON — delimited not supported
+        // Connection-scoped SPARQL returns pre-formatted JSON only. The byte
+        // formats (delimited, RDF/XML, SPARQL-results XML) are not negotiated on
+        // this route — reject with 406 rather than silently downgrading to JSON,
+        // and point callers at the ledger-scoped route which does serve them.
         if let Some(fmt) = delimited {
             return Err(ServerError::not_acceptable(format!(
                 "{} format not supported for connection-scoped SPARQL queries. \
                      Use the /:ledger/query endpoint instead.",
                 fmt.name().to_uppercase()
             )));
+        }
+        if headers.wants_rdf_xml() {
+            return Err(ServerError::not_acceptable(
+                "RDF/XML is not supported for connection-scoped SPARQL queries. \
+                 Use the /:ledger/query endpoint instead."
+                    .to_string(),
+            ));
+        }
+        if headers.wants_sparql_results_xml() {
+            return Err(ServerError::not_acceptable(
+                "SPARQL Results XML is not supported for connection-scoped SPARQL queries. \
+                 Use the /:ledger/query endpoint instead."
+                    .to_string(),
+            ));
         }
 
         let sparql = resolve_sparql_text(&params, &credential)?;
@@ -377,6 +394,16 @@ pub async fn query(
         // AgentJson: connection-scoped SPARQL with agent-optimized envelope
         if headers.wants_agent_json() {
             let parsed = fluree_db_sparql::parse_sparql(&sparql);
+            // AgentJson is a solution-table envelope; a CONSTRUCT/DESCRIBE graph
+            // has no such form, so reject rather than mislabel a JSON-LD graph
+            // as AgentJson (issue #1274).
+            if is_graph_query(parsed.ast.as_ref()) {
+                return Err(ServerError::not_acceptable(
+                    "AgentJson is not available for SPARQL CONSTRUCT/DESCRIBE queries; \
+                     use the default (JSON-LD) or Accept: application/rdf+xml"
+                        .to_string(),
+                ));
+            }
             let from_count = parsed.ast.as_ref()
                 .and_then(|ast| match &ast.body {
                     fluree_db_sparql::ast::QueryBody::Select(q) => q.dataset.as_ref(),
@@ -494,14 +521,17 @@ pub async fn query(
             return Ok((resp_headers, Json(response)).into_response());
         }
 
-        match state.fluree.query_from().sparql(&sparql).execute_formatted().await {
+        let parsed = fluree_db_sparql::parse_sparql(&sparql);
+        let (fmt_config, content_type) =
+            sparql_json_response_format(parsed.ast.as_ref(), &headers);
+        match state.fluree.query_from().sparql(&sparql).format(fmt_config).execute_formatted().await {
             Ok(result) => {
                 tracing::info!(
                     status = "success",
                     query_kind = "sparql",
                     result_count = result.as_array().map(std::vec::Vec::len).unwrap_or(0)
                 );
-                Ok((HeaderMap::new(), Json(result)).into_response())
+                Ok(([(axum::http::header::CONTENT_TYPE, content_type)], Json(result)).into_response())
             }
             Err(e) => {
                 let server_error = ServerError::Api(e);
@@ -1070,6 +1100,48 @@ fn iri_to_string(iri: &fluree_db_sparql::ast::Iri) -> String {
     }
 }
 
+/// Whether a parsed SPARQL query is a graph query (CONSTRUCT / DESCRIBE), whose
+/// result is an RDF graph rather than a solution/binding table. Graph queries
+/// have no SPARQL-results-JSON / SPARQL-results-XML / AgentJson rendering; their
+/// only serializations are JSON-LD (default) and RDF/XML.
+fn is_graph_query(ast: Option<&fluree_db_sparql::ast::SparqlAst>) -> bool {
+    matches!(
+        ast.map(|a| &a.body),
+        Some(
+            fluree_db_sparql::ast::QueryBody::Construct(_)
+                | fluree_db_sparql::ast::QueryBody::Describe(_)
+        )
+    )
+}
+
+/// Pick the formatter config and response `Content-Type` for a SPARQL query that
+/// returns a JSON body (i.e. not RDF/XML, SPARQL-results XML, delimited, or
+/// AgentJson — those are negotiated on their own paths).
+///
+/// - CONSTRUCT / DESCRIBE produce a graph, which only has a JSON-LD rendering, so
+///   they are always formatted as JSON-LD and labelled `application/ld+json`. The
+///   formatter coerces graph results to JSON-LD regardless (issue #1274); forcing
+///   the config here keeps the chosen format and the `Content-Type` in agreement.
+/// - SELECT / ASK keep the SPARQL-results-JSON default unless the client opts into
+///   JSON-LD with `Accept: application/ld+json` (see [`FlureeHeaders::wants_jsonld`]).
+fn sparql_json_response_format(
+    ast: Option<&fluree_db_sparql::ast::SparqlAst>,
+    headers: &FlureeHeaders,
+) -> (fluree_db_api::FormatterConfig, &'static str) {
+    if is_graph_query(ast) || headers.wants_jsonld() {
+        (
+            fluree_db_api::FormatterConfig::jsonld(),
+            "application/ld+json; charset=utf-8",
+        )
+    } else {
+        // SPARQL-results JSON: the builder default for a SPARQL query.
+        (
+            fluree_db_api::FormatterConfig::sparql_json(),
+            "application/json",
+        )
+    }
+}
+
 fn split_graph_fragment(s: &str) -> (&str, Option<&str>) {
     match s.split_once('#') {
         Some((base, frag)) => (base, Some(frag)),
@@ -1537,6 +1609,13 @@ async fn execute_sparql_ledger(
             ));
         }
 
+        // Formatter config + Content-Type for the JSON response paths below.
+        // CONSTRUCT/DESCRIBE always render as JSON-LD; SELECT/ASK opt in via
+        // `Accept: application/ld+json` (issue #1274). XML / delimited / AgentJson
+        // are negotiated separately on their own branches and ignore this.
+        let (json_fmt_config, json_content_type) =
+            sparql_json_response_format(parsed.ast.as_ref(), headers);
+
         // In proxy mode, use the unified Fluree method (returns pre-formatted JSON)
         if state.config.is_proxy_storage_mode() && !has_dataset_clause {
             if wants_sparql_xml {
@@ -1563,6 +1642,7 @@ async fn execute_sparql_ledger(
                         .await?;
                 view.query(state.fluree.as_ref())
                     .sparql(sparql)
+                    .format(json_fmt_config.clone())
                     .execute_formatted()
                     .await
                     .inspect_err(|_| { set_span_error_code(&span, "error:QueryFailed"); })?
@@ -1577,13 +1657,18 @@ async fn execute_sparql_ledger(
                 })?;
                 view.query(state.fluree.as_ref())
                     .sparql(sparql)
+                    .format(json_fmt_config.clone())
                     .execute_formatted()
                     .await
                     .inspect_err(|_| {
                         set_span_error_code(&span, "error:QueryFailed");
                     })?
             };
-            return Ok((HeaderMap::new(), Json(result)).into_response());
+            return Ok((
+                [(axum::http::header::CONTENT_TYPE, json_content_type)],
+                Json(result),
+            )
+                .into_response());
         }
 
         // Policy-scoped queries (identity or explicit policy inputs) without a
@@ -1614,12 +1699,17 @@ async fn execute_sparql_ledger(
                 .await?;
             let result = view.query(state.fluree.as_ref())
                 .sparql(sparql)
+                .format(json_fmt_config.clone())
                 .execute_formatted()
                 .await
                 .inspect_err(|_| {
                     set_span_error_code(&span, "error:QueryFailed");
                 })?;
-            return Ok((HeaderMap::new(), Json(result)).into_response());
+            return Ok((
+                [(axum::http::header::CONTENT_TYPE, json_content_type)],
+                Json(result),
+            )
+                .into_response());
         }
 
         // Ledger-scoped SPARQL with dataset clauses (FROM/FROM NAMED): build a dataset
@@ -1797,6 +1887,17 @@ async fn execute_sparql_ledger(
 
             // SPARQL Results XML: execute and format as XML string (SELECT/ASK only)
             if wants_sparql_xml {
+                // SPARQL Results XML serializes a solution table, not a graph;
+                // reject CONSTRUCT/DESCRIBE here (406) instead of executing and
+                // surfacing the formatter's 400 (issue #1274).
+                if is_graph_query(parsed.ast.as_ref()) {
+                    return Err(ServerError::not_acceptable(
+                        "SPARQL Results XML is only available for SPARQL SELECT/ASK queries; \
+                         CONSTRUCT/DESCRIBE return a graph (use the default JSON-LD or \
+                         Accept: application/rdf+xml)"
+                            .to_string(),
+                    ));
+                }
                 let dataset = if qc_opts.has_any_policy_inputs() {
                     state.fluree.build_dataset_view_with_policy(&spec, &qc_opts).await
                 } else {
@@ -1820,12 +1921,7 @@ async fn execute_sparql_ledger(
 
             // RDF/XML: execute and format graph results (CONSTRUCT/DESCRIBE only)
             if wants_rdf_xml {
-                let is_graph_query = matches!(
-                    parsed.ast.as_ref().map(|a| &a.body),
-                    Some(fluree_db_sparql::ast::QueryBody::Construct(_) |
-fluree_db_sparql::ast::QueryBody::Describe(_))
-                );
-                if !is_graph_query {
+                if !is_graph_query(parsed.ast.as_ref()) {
                     return Err(ServerError::not_acceptable(
                         "RDF/XML is only available for SPARQL CONSTRUCT/DESCRIBE queries"
                             .to_string(),
@@ -1855,6 +1951,13 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
 
             // AgentJson: dataset query with agent-optimized envelope
             if headers.wants_agent_json() {
+                if is_graph_query(parsed.ast.as_ref()) {
+                    return Err(ServerError::not_acceptable(
+                        "AgentJson is not available for SPARQL CONSTRUCT/DESCRIBE queries; \
+                         use the default (JSON-LD) or Accept: application/rdf+xml"
+                            .to_string(),
+                    ));
+                }
                 let from_count = dc.default_graphs.len();
                 let agent_ctx = fluree_db_api::AgentJsonContext {
                     sparql_text: Some(sparql.to_string()),
@@ -1897,11 +2000,16 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
             let result = dataset
                 .query(state.fluree.as_ref())
                 .sparql(sparql)
+                .format(json_fmt_config.clone())
                 .execute_formatted()
                 .await
                 .map_err(ServerError::Api)?;
 
-            return Ok((HeaderMap::new(), Json(result)).into_response());
+            return Ok((
+                [(axum::http::header::CONTENT_TYPE, json_content_type)],
+                Json(result),
+            )
+                .into_response());
         }
 
         // Shared storage mode: use load_ledger_for_query with freshness checking
@@ -1977,6 +2085,17 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
 
         // Delimited fast path: execute raw query and format as TSV/CSV bytes
         if let Some(fmt) = delimited {
+            // CSV/TSV serialize a solution table; a CONSTRUCT/DESCRIBE graph has
+            // no such form, so reject with 406 rather than producing malformed
+            // rows or a 500 (issue #1274).
+            if is_graph_query(parsed.ast.as_ref()) {
+                return Err(ServerError::not_acceptable(format!(
+                    "{} is only available for SPARQL SELECT/ASK queries; \
+                     CONSTRUCT/DESCRIBE return a graph (use the default JSON-LD or \
+                     Accept: application/rdf+xml)",
+                    fmt.name().to_uppercase()
+                )));
+            }
             let result = graph
                 .query(fluree.as_ref())
                 .sparql(sparql)
@@ -2007,6 +2126,16 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
 
         // SPARQL Results XML: execute and format as XML string (SELECT/ASK only)
         if wants_sparql_xml {
+            // Graph queries have no solution-table XML form — reject with 406
+            // rather than executing into the formatter's 400 (issue #1274).
+            if is_graph_query(parsed.ast.as_ref()) {
+                return Err(ServerError::not_acceptable(
+                    "SPARQL Results XML is only available for SPARQL SELECT/ASK queries; \
+                     CONSTRUCT/DESCRIBE return a graph (use the default JSON-LD or \
+                     Accept: application/rdf+xml)"
+                        .to_string(),
+                ));
+            }
             let xml = graph
                 .query(fluree.as_ref())
                 .sparql(sparql)
@@ -2027,12 +2156,7 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
 
         // RDF/XML: execute and format graph results (CONSTRUCT/DESCRIBE only)
         if wants_rdf_xml {
-            let is_graph_query = matches!(
-                parsed.ast.as_ref().map(|a| &a.body),
-                Some(fluree_db_sparql::ast::QueryBody::Construct(_) |
-fluree_db_sparql::ast::QueryBody::Describe(_))
-            );
-            if !is_graph_query {
+            if !is_graph_query(parsed.ast.as_ref()) {
                 return Err(ServerError::not_acceptable(
                     "RDF/XML is only available for SPARQL CONSTRUCT/DESCRIBE queries".to_string(),
                 ));
@@ -2058,6 +2182,13 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
 
         // AgentJson: execute with agent-optimized envelope format
         if headers.wants_agent_json() {
+            if is_graph_query(parsed.ast.as_ref()) {
+                return Err(ServerError::not_acceptable(
+                    "AgentJson is not available for SPARQL CONSTRUCT/DESCRIBE queries; \
+                     use the default (JSON-LD) or Accept: application/rdf+xml"
+                        .to_string(),
+                ));
+            }
             let from_count = dataset_clause
                 .map(|d| d.default_graphs.len())
                 .unwrap_or(0);
@@ -2093,12 +2224,17 @@ fluree_db_sparql::ast::QueryBody::Describe(_))
         let result = graph
             .query(fluree.as_ref())
             .sparql(sparql)
+            .format(json_fmt_config)
             .execute_formatted()
             .await
             .inspect_err(|_| {
                 set_span_error_code(&span, "error:QueryFailed");
             })?;
-        Ok((HeaderMap::new(), Json(result)).into_response())
+        Ok((
+            [(axum::http::header::CONTENT_TYPE, json_content_type)],
+            Json(result),
+        )
+            .into_response())
     }
     .instrument(span)
     .await

--- a/fluree-db-server/tests/sparql_construct_jsonld_accept.rs
+++ b/fluree-db-server/tests/sparql_construct_jsonld_accept.rs
@@ -1,0 +1,368 @@
+//! HTTP-layer regression coverage for issue #1274: a SPARQL CONSTRUCT served
+//! through `POST /v1/fluree/query/<ledger>` must return the constructed graph as
+//! JSON-LD for the default (no `Accept`), `application/ld+json`, and
+//! `application/json` cases — not a self-contradictory
+//! `400 "CONSTRUCT queries only support JSON-LD output format"`. The explicit
+//! `application/rdf+xml` path must keep working as the graph alternative.
+
+use axum::body::Body;
+use fluree_db_server::routes::build_router;
+use fluree_db_server::{AppState, ServerConfig, TelemetryConfig};
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value as JsonValue};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+async fn server_state() -> (TempDir, Arc<AppState>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = ServerConfig {
+        cors_enabled: false,
+        indexing_enabled: false,
+        storage_path: Some(tmp.path().to_path_buf()),
+        ..Default::default()
+    };
+    let telemetry = TelemetryConfig::with_server_config(&cfg);
+    let state = Arc::new(AppState::new(cfg, telemetry).await.expect("AppState"));
+    (tmp, state)
+}
+
+async fn create_ledger(state: &Arc<AppState>, ledger: &str) {
+    let resp = build_router(Arc::clone(state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "ledger": ledger }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED, "create {ledger}");
+}
+
+async fn insert(state: &Arc<AppState>, ledger: &str, body: JsonValue) {
+    let resp = build_router(Arc::clone(state))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/insert/{ledger}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "insert into {ledger}");
+}
+
+async fn seed(state: &Arc<AppState>, ledger: &str) {
+    create_ledger(state, ledger).await;
+    insert(
+        state,
+        ledger,
+        json!({
+            "@context": {"schema": "http://schema.org/", "id": "@id", "type": "@type"},
+            "@graph": [{"@id": "http://ex.org/alice", "@type": "schema:Person", "schema:name": "Alice"}]
+        }),
+    )
+    .await;
+}
+
+/// POST a raw SPARQL query to the ledger-scoped route with an optional `Accept`.
+/// Returns `(status, content_type, raw_body_bytes)`.
+async fn post_sparql(
+    state: &Arc<AppState>,
+    ledger: &str,
+    sparql: &str,
+    accept: Option<&str>,
+) -> (StatusCode, String, Vec<u8>) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/fluree/query/{ledger}"))
+        .header("content-type", "application/sparql-query");
+    if let Some(a) = accept {
+        builder = builder.header("accept", a);
+    }
+    let resp = build_router(Arc::clone(state))
+        .oneshot(builder.body(Body::from(sparql.to_string())).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, content_type, bytes)
+}
+
+/// POST a raw SPARQL query to the connection-scoped route (`/v1/fluree/query`,
+/// no path ledger) with an optional `Accept`. Returns `(status, content_type)`.
+async fn post_connection_sparql(
+    state: &Arc<AppState>,
+    sparql: &str,
+    accept: Option<&str>,
+) -> (StatusCode, String, Vec<u8>) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/fluree/query")
+        .header("content-type", "application/sparql-query");
+    if let Some(a) = accept {
+        builder = builder.header("accept", a);
+    }
+    let resp = build_router(Arc::clone(state))
+        .oneshot(builder.body(Body::from(sparql.to_string())).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, content_type, bytes)
+}
+
+const CONSTRUCT: &str = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 3";
+
+/// Assert the body is a JSON-LD graph object (`{ "@graph": [ { "@id": ... } ] }`).
+fn assert_jsonld_graph(bytes: &[u8]) {
+    let body: JsonValue = serde_json::from_slice(bytes).expect("JSON body");
+    let graph = body
+        .get("@graph")
+        .and_then(JsonValue::as_array)
+        .unwrap_or_else(|| panic!("expected @graph array, got: {body}"));
+    assert!(!graph.is_empty(), "expected constructed triples: {body}");
+    assert!(
+        graph.iter().all(|n| n.get("@id").is_some()),
+        "each node carries an @id: {body}"
+    );
+}
+
+#[tokio::test]
+async fn construct_no_accept_returns_jsonld() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, content_type, body) = post_sparql(&state, ledger, CONSTRUCT, None).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "no-Accept CONSTRUCT must not 400: {}",
+        String::from_utf8_lossy(&body)
+    );
+    assert!(
+        content_type.contains("application/ld+json"),
+        "graph response labelled JSON-LD, got: {content_type}"
+    );
+    assert_jsonld_graph(&body);
+}
+
+#[tokio::test]
+async fn construct_accept_ld_json_returns_jsonld() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, content_type, body) =
+        post_sparql(&state, ledger, CONSTRUCT, Some("application/ld+json")).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "application/ld+json CONSTRUCT must succeed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    assert!(
+        content_type.contains("application/ld+json"),
+        "{content_type}"
+    );
+    assert_jsonld_graph(&body);
+}
+
+#[tokio::test]
+async fn construct_accept_plain_json_returns_jsonld() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, _content_type, body) =
+        post_sparql(&state, ledger, CONSTRUCT, Some("application/json")).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "application/json CONSTRUCT must succeed (graph coerced to JSON-LD): {}",
+        String::from_utf8_lossy(&body)
+    );
+    assert_jsonld_graph(&body);
+}
+
+#[tokio::test]
+async fn construct_accept_rdf_xml_still_works() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, content_type, body) =
+        post_sparql(&state, ledger, CONSTRUCT, Some("application/rdf+xml")).await;
+    assert_eq!(status, StatusCode::OK, "rdf+xml CONSTRUCT must still work");
+    assert!(
+        content_type.contains("application/rdf+xml"),
+        "{content_type}"
+    );
+    let xml = String::from_utf8_lossy(&body);
+    assert!(
+        xml.contains("<rdf:RDF") || xml.contains("rdf:RDF"),
+        "RDF/XML body: {xml}"
+    );
+}
+
+/// A SELECT must NOT be flipped to JSON-LD by a bare `application/json` Accept;
+/// only `application/ld+json` opts a SELECT into JSON-LD. Bare json keeps the
+/// SPARQL-results-JSON shape (`{ "head": ..., "results": ... }`).
+#[tokio::test]
+async fn select_plain_json_stays_sparql_results_json() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let select = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 3";
+    let (status, _ct, body) = post_sparql(&state, ledger, select, Some("application/json")).await;
+    assert_eq!(status, StatusCode::OK);
+    let json: JsonValue = serde_json::from_slice(&body).expect("JSON body");
+    assert!(
+        json.get("head").is_some() && json.get("results").is_some(),
+        "SELECT under application/json stays SPARQL-results JSON, got: {json}"
+    );
+}
+
+/// A graph query under `Accept: application/sparql-results+xml` has no
+/// solution-table form — the route must reject it with `406 Not Acceptable`
+/// (matching the documented negotiation matrix), not execute into a 400.
+#[tokio::test]
+async fn construct_accept_sparql_results_xml_is_406() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, _ct, _body) = post_sparql(
+        &state,
+        ledger,
+        CONSTRUCT,
+        Some("application/sparql-results+xml"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_ACCEPTABLE,
+        "CONSTRUCT + SPARQL Results XML must be 406, not a format 400"
+    );
+}
+
+/// CSV/TSV serialize a solution table; a graph query must be rejected with `406`,
+/// not executed into a malformed body or a 500.
+#[tokio::test]
+async fn construct_accept_csv_is_406() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, _ct, _body) = post_sparql(&state, ledger, CONSTRUCT, Some("text/csv")).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_ACCEPTABLE,
+        "CONSTRUCT + CSV must be 406"
+    );
+}
+
+/// AgentJson is a solution-table envelope; a graph query must be rejected with
+/// `406`, not served as raw JSON-LD mislabelled `application/vnd.fluree.agent+json`.
+#[tokio::test]
+async fn construct_accept_agent_json_is_406() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let (status, _ct, _body) = post_sparql(
+        &state,
+        ledger,
+        CONSTRUCT,
+        Some("application/vnd.fluree.agent+json"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_ACCEPTABLE,
+        "CONSTRUCT + AgentJson must be 406, not a mislabelled JSON-LD graph"
+    );
+}
+
+/// Connection-scoped `/v1/fluree/query` (SPARQL with FROM): CONSTRUCT still
+/// returns a JSON-LD graph (the JSON-family columns of the matrix apply here).
+#[tokio::test]
+async fn connection_construct_returns_jsonld() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let sparql = format!("CONSTRUCT {{ ?s ?p ?o }} FROM <{ledger}> WHERE {{ ?s ?p ?o }}");
+    let (status, content_type, body) = post_connection_sparql(&state, &sparql, None).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "connection CONSTRUCT must not 400: {}",
+        String::from_utf8_lossy(&body)
+    );
+    assert!(
+        content_type.contains("application/ld+json"),
+        "graph response labelled JSON-LD, got: {content_type}"
+    );
+    assert_jsonld_graph(&body);
+}
+
+/// Connection-scoped route does not negotiate byte formats — RDF/XML and
+/// SPARQL-results XML are rejected with 406 (not silently downgraded to JSON),
+/// pointing callers at the ledger-scoped route.
+#[tokio::test]
+async fn connection_byte_formats_are_406() {
+    let (_tmp, state) = server_state().await;
+    let ledger = "test/construct:main";
+    seed(&state, ledger).await;
+
+    let construct = format!("CONSTRUCT {{ ?s ?p ?o }} FROM <{ledger}> WHERE {{ ?s ?p ?o }}");
+    let (status, _ct, _body) =
+        post_connection_sparql(&state, &construct, Some("application/rdf+xml")).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_ACCEPTABLE,
+        "connection CONSTRUCT + rdf+xml must be 406 (use ledger-scoped route)"
+    );
+
+    let select = format!("SELECT ?s ?p ?o FROM <{ledger}> WHERE {{ ?s ?p ?o }}");
+    let (status, _ct, _body) =
+        post_connection_sparql(&state, &select, Some("application/sparql-results+xml")).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_ACCEPTABLE,
+        "connection SELECT + sparql-results+xml must be 406 (use ledger-scoped route)"
+    );
+}


### PR DESCRIPTION
Closes #1274.

A SPARQL `CONSTRUCT`/`DESCRIBE` through `/v1/fluree/query[/{ledger}]` returned a self-contradictory `400 "CONSTRUCT queries only support JSON-LD output format"` for every `Accept` except `application/rdf+xml`. The SPARQL default output is SPARQL-results JSON, which the formatter then rejected for a graph result, so no header actually produced JSON-LD.

## Fix

**Formatter (root cause).** A graph has no binding-table rendering, so `format_results` / `format_results_async` now render `CONSTRUCT`/`DESCRIBE` as JSON-LD for any JSON-producing format instead of erroring. RDF/XML and the delimited formats are bytes formats handled earlier on the string path, so `application/rdf+xml` is unaffected. This one change fixes the server (all paths), the CLI, and library callers.

**Server content negotiation.** Graph JSON responses are now labelled `Content-Type: application/ld+json`, and a new `wants_jsonld()` helper lets `SELECT`/`ASK` opt into JSON-LD via the unambiguous `application/ld+json` type. A bare `application/json` intentionally does **not** flip `SELECT` off SPARQL-results JSON (it is the common default `Accept`).

**406 for mismatched formats.** A shared `is_graph_query()` guards the solution-table branches (SPARQL-results XML, CSV/TSV, AgentJson) so a graph query returns `406` instead of executing into a format `400`/`500` or a JSON-LD body mislabelled as AgentJson.

**Connection-scoped `/query`.** This route returns pre-formatted JSON only; the JSON family works (`CONSTRUCT` → JSON-LD, `SELECT` → results-JSON/JSON-LD, AgentJson), and the byte formats it does not negotiate (RDF/XML, SPARQL-results XML) now return `406` pointing at the ledger-scoped route rather than silently downgrading to JSON.

## Negotiation matrix (ledger-scoped `/query/{ledger}`)

| Query form | default / `application/json` | `application/ld+json` | `application/rdf+xml` | `sparql-results+json` | `csv` / `tsv` | `sparql-results+xml` | `agent+json` |
|---|---|---|---|---|---|---|---|
| `SELECT` / `ASK` | results JSON | JSON-LD | 406 | results JSON | CSV / TSV | results XML | AgentJson |
| `CONSTRUCT` / `DESCRIBE` | **JSON-LD** | JSON-LD | RDF/XML | JSON-LD | 406 | 406 | 406 |

## Tests & docs

New end-to-end server coverage in `sparql_construct_jsonld_accept.rs` (ledger- and connection-scoped: JSON-LD coercion, RDF/XML still works, `SELECT`+json stays results-JSON, mismatched formats → 406) plus an API-level CONSTRUCT default-path test. `docs/api/endpoints.md` documents the matrix and scopes byte-format negotiation to the ledger-scoped route. Also includes a hardware-sizing benchmark doc (CPU vs disk).

Based on the #1267 branch since it touches the same formatter/route files.