### PR TITLE
fix: SPARQL 1.1 numeric arithmetic and expression ORDER BY correctness

### DIFF
--- a/fluree-db-api/tests/it_query_jsonld.rs
+++ b/fluree-db-api/tests/it_query_jsonld.rs
@@ -1882,6 +1882,77 @@ async fn jsonld_bind_arithmetic_in_select() {
     );
 }
 
+/// JSON-LD parity for SPARQL `sparql_integer_division_yields_decimal`.
+/// Per XPath op:numeric-divide, xsd:integer / xsd:integer yields xsd:decimal
+/// (10 / 4 = 2.5), not a truncated integer.
+#[tokio::test]
+async fn jsonld_integer_division_yields_decimal() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "parity/int-div:main");
+    let ctx = context_ex_schema();
+
+    let insert = json!({
+        "@context": ctx,
+        "@graph": [{"@id": "ex:s1", "ex:p": 1}]
+    });
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert")
+        .ledger;
+
+    let query = json!({
+        "@context": ctx,
+        "select": "?r",
+        "where": [
+            {"@id": "?s", "ex:p": "?o"},
+            ["bind", "?r", ["expr", ["/", 10, 4]]]
+        ]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    // xsd:decimal renders as a string to preserve exactness; value is 2.5, not 2.
+    assert_eq!(normalize_rows(&json_rows), normalize_rows(&json!(["2.5"])));
+}
+
+/// JSON-LD parity for SPARQL `sparql_float_divided_by_integer_promotes`.
+/// Mixed numeric arithmetic xsd:float(...) / xsd:integer must promote (not error).
+#[tokio::test]
+async fn jsonld_float_divided_by_integer_promotes() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "parity/float-div-int:main");
+    let ctx = context_ex_schema();
+
+    let insert = json!({
+        "@context": ctx,
+        "@graph": [{"@id": "ex:s1", "ex:p": 1}]
+    });
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert")
+        .ledger;
+
+    let query = json!({
+        "@context": ctx,
+        "select": "?r",
+        "where": [
+            {"@id": "?s", "ex:p": "?o"},
+            ["bind", "?r", ["expr", ["/", ["xsd:float", 10], 4]]]
+        ]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    // xsd:double renders as a JSON number: 10.0 / 4 = 2.5.
+    assert_eq!(normalize_rows(&json_rows), normalize_rows(&json!([2.5])));
+}
+
 /// Parity for W3C bind02: chained BINDs.
 /// SPARQL: SELECT ?o ?z ?z2 WHERE { ?s ex:p ?o . BIND(?o+10 AS ?z) BIND(?o+100 AS ?z2) }
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -635,6 +635,110 @@ async fn sparql_order_by_expression_dedup_only_group_by() {
 }
 
 #[tokio::test]
+async fn sparql_order_by_inline_aggregate_shared_with_select_alias() {
+    // `ORDER BY DESC(COUNT(?x))` with an explicit GROUP BY. The inline aggregate
+    // is hoisted and deduped against the SELECT alias `?c`, so it sorts by the
+    // same count without recomputing it.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle (COUNT(?favNum) AS ?c)
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        GROUP BY ?handle
+        ORDER BY DESC(COUNT(?favNum))
+        LIMIT 10
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(jsonld, json!([["jbob", 7], ["jdoe", 4], ["bbob", 1]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_inline_aggregate_not_selected() {
+    // `ORDER BY DESC(COUNT(?favNum))` where the aggregate is NOT in the SELECT.
+    // It must be hoisted into the grouping with its own synthetic output var so
+    // the rows order by a count that never appears in the output.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        GROUP BY ?handle
+        ORDER BY DESC(COUNT(?favNum))
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Counts: jbob 7, jdoe 4, bbob 1 → handles in that order, count not projected.
+    assert_eq!(jsonld, json!([["jbob"], ["jdoe"], ["bbob"]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_inline_aggregate_implicit_single_group() {
+    // No explicit GROUP BY: the aggregate in ORDER BY triggers implicit
+    // single-group aggregation (must not error).
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT (COUNT(?favNum) AS ?c)
+        WHERE { ?person person:favNums ?favNum }
+        ORDER BY DESC(COUNT(?favNum))
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Total favNums across all people = 4 + 1 + 7 = 12 (single group).
+    assert_eq!(jsonld, json!([[12]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_inline_aggregate_in_compound_expression() {
+    // Aggregate nested inside a compound order expression: `DESC(COUNT(?x) * 2)`.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle (COUNT(?favNum) AS ?c)
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        GROUP BY ?handle
+        ORDER BY DESC(COUNT(?favNum) * 2)
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(jsonld, json!([["jbob", 7], ["jdoe", 4], ["bbob", 1]]));
+}
+
+#[tokio::test]
 async fn sparql_order_by_expression_count_by_predicate_not_dropped() {
     // Regression: the `?s ?p ?o` / GROUP BY ?p / COUNT(?s) shape can match the
     // stats (and predicate-object) count fast paths, which sort on

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -3001,6 +3001,49 @@ async fn sparql_xsd_cast_double_from_integer() {
 }
 
 #[tokio::test]
+async fn sparql_integer_division_yields_decimal() {
+    // Per XPath op:numeric-divide, xsd:integer / xsd:integer yields xsd:decimal:
+    // 10 / 4 = 2.5, NOT a truncated integer 2.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_builtin_fn_data(&fluree, "arith:int-div").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT (10 / 4 AS ?r)
+        WHERE { ex:sushi ex:label ?label }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("integer division query");
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // xsd:decimal renders as a string to preserve exactness (see the
+    // xsd:double note elsewhere in this file); the value is 2.5, not 2.
+    assert_eq!(jsonld, json!([["2.5"]]));
+}
+
+#[tokio::test]
+async fn sparql_float_divided_by_integer_promotes() {
+    // Mixed numeric arithmetic: xsd:float(...) / xsd:integer must promote (not
+    // error with a type mismatch). 10.0 / 4 = 2.5.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_builtin_fn_data(&fluree, "arith:float-div-int").await;
+
+    let query = r"
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        PREFIX ex: <http://example.org/ns/>
+        SELECT (xsd:float(10) / 4 AS ?r)
+        WHERE { ex:sushi ex:label ?label }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("float / integer query");
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(jsonld, json!([[2.5]]));
+}
+
+#[tokio::test]
 async fn sparql_xsd_cast_string_from_integer() {
     // xsd:string(42) should return "42"
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -495,6 +495,236 @@ async fn sparql_count_distinct_with_group_by_and_order_by() {
 }
 
 #[tokio::test]
+async fn sparql_order_by_expression_no_aggregation() {
+    // Bug 1: expression-based ORDER BY (no aggregation). `(0 - ?favNum)`
+    // ascending must produce DESCENDING ?favNum, proving the expression is
+    // evaluated per-solution (a bare `ORDER BY ?favNum` would yield the
+    // opposite order).
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?favNum
+        WHERE { ex:jdoe person:favNums ?favNum }
+        ORDER BY (0 - ?favNum)
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // jdoe favNums [3,7,42,99]; ascending by (0 - favNum) => 99,42,7,3.
+    assert_eq!(jsonld, json!([[99], [42], [7], [3]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_expression_over_aggregate_with_limit() {
+    // Bug 1 + top-k: expression ORDER BY over an aggregate output is evaluated
+    // AFTER grouping (dedicated post-grouping stage). `(0 - ?c)` ascending =>
+    // descending count; LIMIT exercises top-k on the synthetic sort key.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle (COUNT(?favNum) AS ?c)
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        GROUP BY ?handle
+        ORDER BY (0 - ?c)
+        LIMIT 2
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Counts: jbob 7, jdoe 4, bbob 1; descending by count, top 2.
+    assert_eq!(jsonld, json!([["jbob", 7], ["jdoe", 4]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_desc_expression_with_tiebreak() {
+    // BSBM-shaped `ORDER BY DESC(expr) ?tiebreak`: descending computed key then
+    // a bare variable tiebreaker, with LIMIT.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?favNum
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        ORDER BY DESC(?favNum * 1) ?handle
+        LIMIT 3
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Highest favNums: 99 (jdoe), 42 (jdoe), 23 (bbob).
+    assert_eq!(jsonld, json!([["jdoe", 99], ["jdoe", 42], ["bbob", 23]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_float_ratio_expression() {
+    // BSBM BI Q5 shape: `ORDER BY DESC(xsd:float(?count) / N)`. Exercises
+    // expression ORDER BY (Bug 1) together with mixed float/int arithmetic in
+    // the sort key. Must neither reject at parse/lowering nor error at eval.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle (COUNT(?favNum) AS ?c)
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        GROUP BY ?handle
+        ORDER BY DESC(xsd:float(?c) / 2)
+        LIMIT 10
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // xsd:float(count)/2: jbob 3.5, jdoe 2.0, bbob 0.5 => descending.
+    assert_eq!(jsonld, json!([["jbob", 7], ["jdoe", 4], ["bbob", 1]]));
+}
+
+#[tokio::test]
+async fn sparql_order_by_expression_dedup_only_group_by() {
+    // Regression (P1a): expression ORDER BY over a *dedup-only* GROUP BY (no
+    // aggregates) must work. The order key is computed by the dedicated
+    // post-grouping stage; the group key ?favNum survives grouping as a scalar.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?favNum
+        WHERE { ?person person:favNums ?favNum }
+        GROUP BY ?favNum
+        ORDER BY (0 - ?favNum)
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Distinct favNums across all people, descending.
+    assert_eq!(
+        jsonld,
+        json!([[99], [42], [23], [9], [8], [7], [6], [5], [3], [0]])
+    );
+}
+
+#[tokio::test]
+async fn sparql_order_by_expression_count_by_predicate_not_dropped() {
+    // Regression: the `?s ?p ?o` / GROUP BY ?p / COUNT(?s) shape can match the
+    // stats (and predicate-object) count fast paths, which sort on
+    // `query.ordering` directly. With an expression ORDER BY the sort var is
+    // synthetic, so a fast path that skips the order-bind stage would silently
+    // drop the sort. The result counts must come back strictly grouped and
+    // descending here.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        SELECT ?p (COUNT(?s) AS ?c)
+        WHERE { ?s ?p ?o }
+        GROUP BY ?p
+        ORDER BY (0 - ?c)
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    let rows = jsonld.as_array().expect("array of rows");
+    let counts: Vec<i64> = rows
+        .iter()
+        .map(|row| row[1].as_i64().expect("count is an integer"))
+        .collect();
+    assert!(
+        counts.len() >= 2,
+        "expected multiple predicate groups, got: {counts:?}"
+    );
+    assert!(
+        counts.windows(2).all(|w| w[0] >= w[1]),
+        "ORDER BY (0 - ?c) must yield descending counts, got: {counts:?}"
+    );
+}
+
+#[tokio::test]
+async fn sparql_order_by_expression_over_grouped_var_errors_cleanly() {
+    // Regression (P1b): an aggregating query whose ORDER BY expression reads a
+    // variable that is neither a GROUP BY key nor an aggregate output must be
+    // rejected with a clean error — NOT panic on a Grouped binding.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle (COUNT(?favNum) AS ?c)
+        WHERE {
+          ?person person:handle ?handle ;
+                  person:favNums ?favNum .
+        }
+        GROUP BY ?handle
+        ORDER BY (?favNum + 1)
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query).await;
+    assert!(
+        result.is_err(),
+        "ORDER BY over a non-grouped variable should error, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn sparql_subquery_expression_order_by_errors_cleanly() {
+    // Regression (P2): expression ORDER BY inside a subquery must be rejected
+    // rather than silently mis-sorting by a grabbed variable. (Bare-variable
+    // subquery ORDER BY still works.)
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?favNum
+        WHERE {
+          { SELECT ?favNum WHERE { ?person person:favNums ?favNum }
+            ORDER BY (0 - ?favNum) }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query).await;
+    assert!(
+        result.is_err(),
+        "expression ORDER BY in a subquery should error, got: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn sparql_delete_data_removes_specified_triples() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_transact_conditional.rs
+++ b/fluree-db-api/tests/it_transact_conditional.rs
@@ -762,10 +762,13 @@ async fn batch_conditional_salary_raise() {
     let emp2 = query_entity(&fluree, &updated.ledger, "ex:emp2").await;
     let emp3 = query_entity(&fluree, &updated.ledger, "ex:emp3").await;
 
-    // Engineering employees get 10% raise: 100→110, 200→220
-    assert_eq!(emp1.get("ex:salary"), Some(&json!(110)));
-    assert_eq!(emp2.get("ex:salary"), Some(&json!(220)));
-    // Sales employee unchanged
+    // Engineering employees get 10% raise: 100→110, 200→220.
+    // `?sal / 10` is xsd:integer / xsd:integer, which yields xsd:decimal per
+    // XPath op:numeric-divide, so the summed salary is a decimal — rendered as
+    // a string to preserve exactness (the value is exactly 110 / 220).
+    assert_eq!(emp1.get("ex:salary"), Some(&json!("110")));
+    assert_eq!(emp2.get("ex:salary"), Some(&json!("220")));
+    // Sales employee unchanged — no arithmetic, so still an integer.
     assert_eq!(emp3.get("ex:salary"), Some(&json!(150)));
 }
 

--- a/fluree-db-api/tests/it_transact_update.rs
+++ b/fluree-db-api/tests/it_transact_update.rs
@@ -637,7 +637,14 @@ async fn update_where_bind_numeric_and_math_functions() {
     .await
     .expect("to_jsonld_async");
 
-    let num_val = |v: &serde_json::Value| v.as_i64().map(|n| n as f64).or_else(|| v.as_f64());
+    // xsd:decimal results render as a JSON string (to preserve exactness), so
+    // also accept a numeric string here.
+    let num_val = |v: &serde_json::Value| {
+        v.as_i64()
+            .map(|n| n as f64)
+            .or_else(|| v.as_f64())
+            .or_else(|| v.as_str().and_then(|s| s.parse::<f64>().ok()))
+    };
     assert_eq!(numeric.get("ex:abs").and_then(num_val), Some(2.0));
     assert_eq!(numeric.get("ex:round").and_then(num_val), Some(1.0));
     assert_eq!(numeric.get("ex:ceil").and_then(num_val), Some(2.0));

--- a/fluree-db-query/src/count_plan.rs
+++ b/fluree-db-query/src/count_plan.rs
@@ -1058,6 +1058,7 @@ mod tests {
             patterns,
             grouping,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             reasoning: ReasoningConfig::default(),

--- a/fluree-db-query/src/eval/arithmetic.rs
+++ b/fluree-db-query/src/eval/arithmetic.rs
@@ -105,10 +105,15 @@ mod tests {
 
     #[test]
     fn test_div_three_args() {
+        // Per XPath op:numeric-divide, integer / integer yields xsd:decimal:
+        // 24 / 4 = 6, then 6 / 3 = 2, carried as a decimal throughout.
         let row = empty_row();
         let args = vec![long(24), long(4), long(3)];
         let result = ArithmeticOp::Div.eval(&args, &row, None).unwrap();
-        assert_eq!(result, Some(ComparableValue::Long(2)));
+        assert_eq!(
+            result,
+            Some(ComparableValue::Decimal(Box::new("2".parse().unwrap())))
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/eval/value.rs
+++ b/fluree-db-query/src/eval/value.rs
@@ -53,6 +53,19 @@ pub enum ComparisonError {
 #[error("cannot convert null value")]
 pub struct NullValueError;
 
+/// Significant-digit cap for the `xsd:integer / xsd:integer` → `xsd:decimal`
+/// result. `BigDecimal::div` otherwise expands recurring quotients to its
+/// default 100-digit precision (e.g. 1 / 3 = 0.3333…). 34 digits matches
+/// IEEE-754 decimal128 — well past xsd:double precision but bounded. Mirrors
+/// `AVG_DECIMAL_PRECISION` in `aggregate.rs`, which applies the same XPath rule.
+const DIVISION_DECIMAL_PRECISION: u64 = 34;
+
+/// Divide two decimals with bounded precision and a canonical (normalized)
+/// scale, for the integer-division case where the result is an `xsd:decimal`.
+fn integer_divide(a: BigDecimal, b: BigDecimal) -> BigDecimal {
+    (a / b).with_prec(DIVISION_DECIMAL_PRECISION).normalized()
+}
+
 impl ArithmeticOp {
     /// Apply this arithmetic operation to two ComparableValue operands.
     ///
@@ -69,22 +82,37 @@ impl ArithmeticOp {
     ) -> Result<ComparableValue, ArithmeticError> {
         use num_traits::ToPrimitive;
 
+        // Normalize numeric values carried as a `TypedLiteral` (e.g. xsd:float,
+        // whose value is stored as a String) into their primitive numeric
+        // variant so the type-promotion arms below apply. Non-numeric typed
+        // literals pass through unchanged and fall to the TypeMismatch arm.
+        let left = left.coerce_numeric_operand();
+        let right = right.coerce_numeric_operand();
+
         match (left, right) {
-            // Long + Long = Long
-            (ComparableValue::Long(a), ComparableValue::Long(b)) => {
-                let result = match self {
-                    ArithmeticOp::Add => a.checked_add(b).ok_or(ArithmeticError::Overflow)?,
-                    ArithmeticOp::Sub => a.checked_sub(b).ok_or(ArithmeticError::Overflow)?,
-                    ArithmeticOp::Mul => a.checked_mul(b).ok_or(ArithmeticError::Overflow)?,
-                    ArithmeticOp::Div => {
-                        if b == 0 {
-                            return Err(ArithmeticError::DivideByZero);
-                        }
-                        a.checked_div(b).ok_or(ArithmeticError::Overflow)?
+            // Long <op> Long
+            (ComparableValue::Long(a), ComparableValue::Long(b)) => match self {
+                ArithmeticOp::Add => Ok(ComparableValue::Long(
+                    a.checked_add(b).ok_or(ArithmeticError::Overflow)?,
+                )),
+                ArithmeticOp::Sub => Ok(ComparableValue::Long(
+                    a.checked_sub(b).ok_or(ArithmeticError::Overflow)?,
+                )),
+                ArithmeticOp::Mul => Ok(ComparableValue::Long(
+                    a.checked_mul(b).ok_or(ArithmeticError::Overflow)?,
+                )),
+                // Per XPath op:numeric-divide, xsd:integer / xsd:integer yields
+                // xsd:decimal (e.g. 10 / 4 = 2.5), not a truncated integer.
+                ArithmeticOp::Div => {
+                    if b == 0 {
+                        return Err(ArithmeticError::DivideByZero);
                     }
-                };
-                Ok(ComparableValue::Long(result))
-            }
+                    Ok(ComparableValue::Decimal(Box::new(integer_divide(
+                        BigDecimal::from(a),
+                        BigDecimal::from(b),
+                    ))))
+                }
+            },
             // Double + Double = Double
             (ComparableValue::Double(a), ComparableValue::Double(b)) => {
                 let result = match self {
@@ -100,21 +128,22 @@ impl ArithmeticOp {
                 };
                 Ok(ComparableValue::Double(result))
             }
-            // BigInt + BigInt = BigInt
-            (ComparableValue::BigInt(a), ComparableValue::BigInt(b)) => {
-                let result = match self {
-                    ArithmeticOp::Add => *a + &*b,
-                    ArithmeticOp::Sub => *a - &*b,
-                    ArithmeticOp::Mul => *a * &*b,
-                    ArithmeticOp::Div => {
-                        if b.is_zero() {
-                            return Err(ArithmeticError::DivideByZero);
-                        }
-                        *a / &*b
+            // BigInt <op> BigInt
+            (ComparableValue::BigInt(a), ComparableValue::BigInt(b)) => match self {
+                ArithmeticOp::Add => Ok(ComparableValue::BigInt(Box::new(*a + &*b))),
+                ArithmeticOp::Sub => Ok(ComparableValue::BigInt(Box::new(*a - &*b))),
+                ArithmeticOp::Mul => Ok(ComparableValue::BigInt(Box::new(*a * &*b))),
+                // integer / integer → xsd:decimal (see the Long/Long arm).
+                ArithmeticOp::Div => {
+                    if b.is_zero() {
+                        return Err(ArithmeticError::DivideByZero);
                     }
-                };
-                Ok(ComparableValue::BigInt(Box::new(result)))
-            }
+                    Ok(ComparableValue::Decimal(Box::new(integer_divide(
+                        BigDecimal::from(*a),
+                        BigDecimal::from(*b),
+                    ))))
+                }
+            },
             // Decimal + Decimal = Decimal
             (ComparableValue::Decimal(a), ComparableValue::Decimal(b)) => {
                 let result = match self {
@@ -265,6 +294,53 @@ impl ComparableValue {
             ComparableValue::GeoPoint(_) => "geoPoint",
             ComparableValue::Iri(_) => "iri",
             ComparableValue::TypedLiteral { .. } => "typedLiteral",
+        }
+    }
+
+    /// Normalize a numeric value carried as a [`ComparableValue::TypedLiteral`]
+    /// into its primitive numeric variant, so arithmetic type promotion can
+    /// apply.
+    ///
+    /// `xsd:float` casts store their value as a String (to avoid f32→f64 display
+    /// artifacts — see `eval/cast.rs`), and other numeric XSD literals may arrive
+    /// wrapped as a `TypedLiteral`. Arithmetic needs the numeric value, so the
+    /// inner value is unwrapped (or parsed, for the string-encoded cases) here.
+    /// Non-numeric typed literals — and all other variants — are returned
+    /// unchanged, so they still fall to a `TypeMismatch` in [`ArithmeticOp::apply`].
+    fn coerce_numeric_operand(self) -> ComparableValue {
+        let ComparableValue::TypedLiteral { val, dtc } = self else {
+            return self;
+        };
+        match val {
+            FlakeValue::Long(n) => ComparableValue::Long(n),
+            FlakeValue::Double(d) => ComparableValue::Double(d),
+            FlakeValue::BigInt(n) => ComparableValue::BigInt(n),
+            FlakeValue::Decimal(d) => ComparableValue::Decimal(d),
+            FlakeValue::String(s) => {
+                use fluree_vocab::xsd;
+                let dt = match &dtc {
+                    Some(UnresolvedDatatypeConstraint::Explicit(iri)) => iri.as_ref(),
+                    _ => "",
+                };
+                if dt == xsd::FLOAT || dt == xsd::DOUBLE {
+                    if let Ok(d) = s.parse::<f64>() {
+                        return ComparableValue::Double(d);
+                    }
+                } else if dt == xsd::DECIMAL {
+                    if let Ok(d) = s.parse::<BigDecimal>() {
+                        return ComparableValue::Decimal(Box::new(d));
+                    }
+                } else if dt == xsd::INTEGER || dt == xsd::LONG || dt == xsd::INT {
+                    if let Ok(n) = s.parse::<i64>() {
+                        return ComparableValue::Long(n);
+                    }
+                }
+                ComparableValue::TypedLiteral {
+                    val: FlakeValue::String(s),
+                    dtc,
+                }
+            }
+            other => ComparableValue::TypedLiteral { val: other, dtc },
         }
     }
 
@@ -636,7 +712,45 @@ mod tests {
             ArithmeticOp::Mul.apply(a.clone(), b.clone()),
             Ok(ComparableValue::Long(30))
         );
-        assert_eq!(ArithmeticOp::Div.apply(a, b), Ok(ComparableValue::Long(3)));
+        // Per XPath op:numeric-divide, integer / integer yields xsd:decimal,
+        // not a truncated integer.
+        assert_eq!(
+            ArithmeticOp::Div.apply(a, b),
+            Ok(ComparableValue::Decimal(Box::new(integer_divide(
+                BigDecimal::from(10),
+                BigDecimal::from(3)
+            ))))
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_int_div_is_decimal() {
+        // 10 / 4 = 2.5 (xsd:decimal), not 2 (truncated xsd:integer).
+        assert_eq!(
+            ArithmeticOp::Div.apply(ComparableValue::Long(10), ComparableValue::Long(4)),
+            Ok(ComparableValue::Decimal(Box::new("2.5".parse().unwrap())))
+        );
+        // Exact integer quotient still yields a decimal (canonical form "5").
+        assert_eq!(
+            ArithmeticOp::Div.apply(ComparableValue::Long(10), ComparableValue::Long(2)),
+            Ok(ComparableValue::Decimal(Box::new("5".parse().unwrap())))
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_float_typed_literal_promotes() {
+        // Bug repro: xsd:float(?a) is carried as a String-backed TypedLiteral.
+        // Dividing it by an integer must promote, not error with TypeMismatch.
+        let float_ten = ComparableValue::TypedLiteral {
+            val: FlakeValue::String("10".to_string()),
+            dtc: Some(UnresolvedDatatypeConstraint::Explicit(Arc::from(
+                fluree_vocab::xsd::FLOAT,
+            ))),
+        };
+        assert_eq!(
+            ArithmeticOp::Div.apply(float_ten, ComparableValue::Long(4)),
+            Ok(ComparableValue::Double(2.5))
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/eval/value.rs
+++ b/fluree-db-query/src/eval/value.rs
@@ -11,7 +11,7 @@ use bigdecimal::BigDecimal;
 use fluree_db_core::temporal::{
     Date as FlureeDate, DateTime as FlureeDateTime, Time as FlureeTime,
 };
-use fluree_db_core::{FlakeValue, GeoPointBits};
+use fluree_db_core::{coerce_value, FlakeValue, GeoPointBits};
 use num_bigint::BigInt;
 use num_traits::Zero;
 use std::sync::Arc;
@@ -317,22 +317,25 @@ impl ComparableValue {
             FlakeValue::BigInt(n) => ComparableValue::BigInt(n),
             FlakeValue::Decimal(d) => ComparableValue::Decimal(d),
             FlakeValue::String(s) => {
-                use fluree_vocab::xsd;
-                let dt = match &dtc {
-                    Some(UnresolvedDatatypeConstraint::Explicit(iri)) => iri.as_ref(),
-                    _ => "",
-                };
-                if dt == xsd::FLOAT || dt == xsd::DOUBLE {
-                    if let Ok(d) = s.parse::<f64>() {
-                        return ComparableValue::Double(d);
-                    }
-                } else if dt == xsd::DECIMAL {
-                    if let Ok(d) = s.parse::<BigDecimal>() {
-                        return ComparableValue::Decimal(Box::new(d));
-                    }
-                } else if dt == xsd::INTEGER || dt == xsd::LONG || dt == xsd::INT {
-                    if let Ok(n) = s.parse::<i64>() {
-                        return ComparableValue::Long(n);
+                // Delegate string→numeric parsing to the canonical coercion
+                // layer (`fluree_db_core::coerce_value`), which covers the full
+                // XSD numeric lattice: the integer family (with BigInt overflow
+                // and per-type range validation), xsd:decimal, and
+                // xsd:float/double including the INF/-INF/NaN lexicals. Only a
+                // numeric result is adopted; non-numeric datatypes and parse
+                // failures keep the literal as-is so it still falls to a
+                // TypeMismatch in `apply`.
+                if let Some(UnresolvedDatatypeConstraint::Explicit(iri)) = &dtc {
+                    if let Ok(coerced) = coerce_value(FlakeValue::String(s.clone()), iri.as_ref()) {
+                        if let Ok(
+                            cv @ (ComparableValue::Long(_)
+                            | ComparableValue::Double(_)
+                            | ComparableValue::BigInt(_)
+                            | ComparableValue::Decimal(_)),
+                        ) = ComparableValue::try_from(coerced)
+                        {
+                            return cv;
+                        }
                     }
                 }
                 ComparableValue::TypedLiteral {
@@ -750,6 +753,48 @@ mod tests {
         assert_eq!(
             ArithmeticOp::Div.apply(float_ten, ComparableValue::Long(4)),
             Ok(ComparableValue::Double(2.5))
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_typed_literal_coercion_covers_full_xsd_lattice() {
+        // xsd:short carried as a typed literal coerces for arithmetic.
+        let short_five = ComparableValue::TypedLiteral {
+            val: FlakeValue::String("5".to_string()),
+            dtc: Some(UnresolvedDatatypeConstraint::Explicit(Arc::from(
+                fluree_vocab::xsd::SHORT,
+            ))),
+        };
+        assert_eq!(
+            ArithmeticOp::Mul.apply(short_five, ComparableValue::Long(2)),
+            Ok(ComparableValue::Long(10))
+        );
+
+        // A large xsd:integer beyond i64 coerces to BigInt rather than failing.
+        let big = "99999999999999999999999999999"; // > i64::MAX
+        let big_lit = ComparableValue::TypedLiteral {
+            val: FlakeValue::String(big.to_string()),
+            dtc: Some(UnresolvedDatatypeConstraint::Explicit(Arc::from(
+                fluree_vocab::xsd::INTEGER,
+            ))),
+        };
+        assert_eq!(
+            ArithmeticOp::Add.apply(big_lit, ComparableValue::Long(1)),
+            Ok(ComparableValue::BigInt(Box::new(
+                big.parse::<BigInt>().unwrap() + 1
+            )))
+        );
+
+        // The xsd:float INF lexical coerces to an infinite double.
+        let inf = ComparableValue::TypedLiteral {
+            val: FlakeValue::String("INF".to_string()),
+            dtc: Some(UnresolvedDatatypeConstraint::Explicit(Arc::from(
+                fluree_vocab::xsd::FLOAT,
+            ))),
+        };
+        assert_eq!(
+            ArithmeticOp::Mul.apply(inf, ComparableValue::Long(2)),
+            Ok(ComparableValue::Double(f64::INFINITY))
         );
     }
 

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -106,6 +106,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -131,6 +132,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -157,6 +159,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: vec![SortSpec::asc(VarId(99))], // Invalid var
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -49,6 +49,16 @@ pub fn compute_variable_deps(query: &Query) -> Option<VariableDeps> {
     }
     let required_sort_vars: Vec<VarId> = deps.iter().copied().collect();
 
+    // Expression-based ORDER BY binds run as a dedicated stage AFTER the
+    // post-aggregation binds, so they are traced FIRST in this backward walk:
+    // tracing their expression inputs keeps the referenced GROUP BY keys,
+    // aggregate outputs, and post-binds alive through grouping/trimming.
+    for (var, expr) in query.order_binds.iter().rev() {
+        if deps.remove(var) {
+            deps.extend(expr.referenced_vars());
+        }
+    }
+
     // Post-aggregation binds (reverse order): trace expression inputs.
     // Record deps BEFORE processing each bind backward, since that
     // represents what the bind's output must contain for downstream.
@@ -141,6 +151,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -156,6 +167,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -296,6 +308,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -320,6 +333,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -1007,6 +1007,11 @@ fn detect_sum_strlen_group_concat_subquery(query: &Query) -> Option<(Ref, Arc<st
 fn detect_predicate_object_count(
     query: &Query,
 ) -> Option<(Ref, VarId, crate::ir::triple::Term, VarId)> {
+    // Expression ORDER BY needs the generic pipeline's order-bind stage; this
+    // fast path sorts on `query.ordering` directly, so decline it.
+    if !query.order_binds.is_empty() {
+        return None;
+    }
     let (input_var, out_var) = detect_count_aggregate(query)?;
 
     if query.patterns.len() != 1 {
@@ -1520,6 +1525,12 @@ fn anchored_literal_regex_prefix(pattern: &str) -> Option<Arc<str>> {
 ///
 /// Returns `Some((predicate_var, count_output_var))` if the query matches the pattern.
 fn detect_stats_count_by_predicate(query: &Query) -> Option<(VarId, VarId)> {
+    // Expression ORDER BY needs the generic pipeline's order-bind stage; this
+    // fast path sorts on `query.ordering` directly (a synthetic, unbound sort
+    // var would be silently dropped), so decline it.
+    if !query.order_binds.is_empty() {
+        return None;
+    }
     // Must have stats available (checked by caller)
     // Must have exactly one triple pattern with all variables
     if query.patterns.len() != 1 {
@@ -2039,6 +2050,15 @@ fn build_operator_tree_inner(
     // optimistic-then-fallback pattern in each operator's `open()` into a
     // single planner-time decision.
     let enable_fused_fast_paths = enable_fused_fast_paths && !planning.is_history();
+
+    // Expression-based ORDER BY (`query.order_binds`) is materialized only by the
+    // generic pipeline's dedicated post-grouping bind stage. No fast path runs
+    // that stage, so any fast path that returns early would sort on a synthetic
+    // ORDER BY variable that was never bound (silently dropping the sort). Force
+    // the generic path whenever order binds are present. (The history-gated
+    // count fast paths below are guarded inside their detectors for the same
+    // reason.)
+    let enable_fused_fast_paths = enable_fused_fast_paths && query.order_binds.is_empty();
 
     if enable_fused_fast_paths {
         tracing::debug!(
@@ -2819,6 +2839,50 @@ fn build_operator_tree_inner(
         }
     }
 
+    // Expression-based ORDER BY binds (e.g. `ORDER BY DESC(?a / ?b)`).
+    //
+    // Evaluated once per solution as a dedicated stage AFTER
+    // grouping/aggregation/HAVING/post-binds and BEFORE the sort, so the sort
+    // keys can reference GROUP BY keys, aggregate outputs, and SELECT post-binds.
+    // For ungrouped queries this is simply a post-WHERE stage. This placement is
+    // what makes expression ORDER BY work uniformly across no-grouping,
+    // dedup-only GROUP BY (no aggregation stage), and aggregating queries.
+    if !query.order_binds.is_empty() {
+        // Under grouping, an order-key expression may only read GROUP BY keys,
+        // aggregate outputs, and post-aggregation bind outputs. Referencing any
+        // other variable means it is `Binding::Grouped` here — reject cleanly
+        // rather than evaluating the bind over a grouped binding (which panics
+        // in `eval`), matching how bare `ORDER BY ?groupedVar` is rejected.
+        if needs_grouping {
+            let mut allowed: HashSet<VarId> = group_by_vec.iter().copied().collect();
+            for spec in &aggregates_vec {
+                allowed.insert(spec.output_var);
+            }
+            for (var, _) in &post_binds_vec {
+                allowed.insert(*var);
+            }
+            for (out_var, expr) in &query.order_binds {
+                for v in expr.referenced_vars() {
+                    if !allowed.contains(&v) {
+                        return Err(QueryError::InvalidQuery(format!(
+                            "ORDER BY expression references variable {v:?}, which is not a GROUP BY key or aggregate result"
+                        )));
+                    }
+                }
+                // A later order bind may legitimately reference an earlier one.
+                allowed.insert(*out_var);
+            }
+        }
+        for (var, expr) in &query.order_binds {
+            operator = Box::new(crate::bind::BindOperator::new(
+                operator,
+                *var,
+                expr.clone(),
+                vec![],
+            ));
+        }
+    }
+
     // Get the schema after grouping/aggregation/binds (for validation)
     let post_group_schema: Arc<[VarId]> = Arc::from(operator.schema().to_vec().into_boxed_slice());
 
@@ -2863,6 +2927,17 @@ fn build_operator_tree_inner(
             }
             for spec in &aggregates_vec {
                 allowed.insert(spec.output_var);
+            }
+            // Post-aggregation binds (SELECT expressions like `(CEIL(?avg) AS
+            // ?c)`) are per-group scalars computed after aggregation — they are
+            // valid sort keys.
+            for (var, _) in &post_binds_vec {
+                allowed.insert(*var);
+            }
+            // Desugared expression-ORDER-BY keys run as a post-grouping stage
+            // and are validated above to read only allowed vars.
+            for (var, _) in &query.order_binds {
+                allowed.insert(*var);
             }
             allowed_sort_vars = Some(allowed);
         }
@@ -2996,10 +3071,60 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
         }
+    }
+
+    #[test]
+    fn detect_stats_count_by_predicate_declines_expression_order_by() {
+        // The count-by-predicate fast path sorts on `query.ordering` directly,
+        // so it must decline when `order_binds` are present (the synthetic sort
+        // var is only bound by the generic pipeline's order-bind stage).
+        let s = VarId(0);
+        let p = VarId(1);
+        let o = VarId(2);
+        let c = VarId(3);
+        let order_key = VarId(4);
+
+        let make = |order_binds: Vec<(VarId, Expression)>, ordering: Vec<SortSpec>| Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![p, c]),
+            patterns: vec![Pattern::Triple(TriplePattern::new(
+                Ref::Var(s),
+                Ref::Var(p),
+                Term::Var(o),
+            ))],
+            reasoning: ReasoningConfig::default(),
+            grouping: Grouping::assemble(
+                vec![p],
+                vec![AggregateSpec {
+                    function: AggregateFn::Count(s),
+                    output_var: c,
+                }],
+                vec![],
+                None,
+            ),
+            ordering,
+            order_binds,
+            limit: None,
+            offset: None,
+            post_values: None,
+        };
+
+        // Bare-variable ORDER BY (no order binds): fast path applies.
+        let plain = make(Vec::new(), vec![SortSpec::asc(c)]);
+        assert_eq!(detect_stats_count_by_predicate(&plain), Some((p, c)));
+
+        // Expression ORDER BY (order binds present): must decline.
+        let with_expr = make(
+            vec![(order_key, Expression::Const(crate::ir::FlakeValue::Long(0)))],
+            vec![SortSpec::asc(order_key)],
+        );
+        assert!(detect_stats_count_by_predicate(&with_expr).is_none());
     }
 
     #[test]
@@ -3044,6 +3169,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: vec![SortSpec::asc(label)],
+            order_binds: Vec::new(),
             limit: Some(10),
             offset: None,
             post_values: None,
@@ -3069,6 +3195,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -3095,6 +3222,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: vec![SortSpec::asc(VarId(99))], // Invalid var
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -3169,6 +3297,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: make_grouping(),
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -3192,6 +3321,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: make_grouping(),
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -3244,6 +3374,7 @@ mod tests {
                 having: None,
             }),
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -3293,6 +3424,7 @@ mod tests {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering,
+            order_binds: Vec::new(),
             limit,
             offset,
             post_values: None,

--- a/fluree-db-query/src/ir/query.rs
+++ b/fluree-db-query/src/ir/query.rs
@@ -248,6 +248,14 @@ pub struct Query {
     /// ORDER BY specs applied after grouping. Empty when the query is
     /// unordered.
     pub ordering: Vec<SortSpec>,
+    /// Synthetic `(var, expr)` binds for expression-based ORDER BY
+    /// (e.g. `ORDER BY DESC(?a / ?b)`). Evaluated once per solution as a
+    /// dedicated stage AFTER grouping/aggregation/HAVING/post-binds and BEFORE
+    /// the sort, so the keys can reference GROUP BY keys, aggregate outputs, and
+    /// SELECT post-binds. The matching `SortSpec` in `ordering` references the
+    /// synthetic var; these vars are never projected to the output. Empty for
+    /// var-only ORDER BY.
+    pub order_binds: Vec<(VarId, super::Expression)>,
     /// Maximum rows to return (applied last). `None` is unbounded;
     /// `Some(0)` is a legitimate "return nothing" some fast-paths bail on.
     pub limit: Option<usize>,
@@ -273,6 +281,7 @@ impl Query {
             patterns: Vec::new(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             reasoning: ReasoningConfig::default(),
@@ -292,6 +301,7 @@ impl Query {
             patterns,
             grouping: self.grouping.clone(),
             ordering: self.ordering.clone(),
+            order_binds: self.order_binds.clone(),
             limit: self.limit,
             offset: self.offset,
             reasoning: self.reasoning.clone(),

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -175,6 +175,8 @@ pub(crate) fn lower_query<E: IriEncoder>(
         patterns,
         grouping,
         ordering,
+        // JSON-LD query syntax has no expression-based ORDER BY form.
+        order_binds: Vec::new(),
         limit,
         offset,
         reasoning,

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -85,6 +85,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
         patterns,
         grouping: None,
         ordering: Vec::new(),
+        order_binds: Vec::new(),
         limit: None,
         offset: None,
         reasoning: ReasoningConfig::default(),

--- a/fluree-db-query/tests/values_bind_union_tests.rs
+++ b/fluree-db-query/tests/values_bind_union_tests.rs
@@ -46,6 +46,7 @@ fn make_query(select: Vec<VarId>, patterns: Vec<Pattern>) -> Query {
         reasoning: ReasoningConfig::default(),
         grouping: None,
         ordering: Vec::new(),
+        order_binds: Vec::new(),
         limit: None,
         offset: None,
         post_values: None,

--- a/fluree-db-sparql/src/ast/pattern.rs
+++ b/fluree-db-sparql/src/ast/pattern.rs
@@ -258,6 +258,12 @@ pub struct SubSelect {
     pub group_by: Option<GroupByClause>,
     /// ORDER BY variables (simplified - just variable names for now)
     pub order_by: Vec<SubSelectOrderBy>,
+    /// True when the subquery's ORDER BY contained a non-trivial expression
+    /// (e.g. `ORDER BY (0 - ?x)`). Subquery expression ORDER BY is not yet
+    /// wired through the subquery operator, so lowering rejects it rather than
+    /// silently mis-sorting on a grabbed variable. Bare/bracketed variables
+    /// leave this `false`.
+    pub order_by_unsupported_expr: bool,
     /// LIMIT value
     pub limit: Option<u64>,
     /// OFFSET value

--- a/fluree-db-sparql/src/lower/aggregate.rs
+++ b/fluree-db-sparql/src/lower/aggregate.rs
@@ -268,7 +268,47 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         })
     }
 
-    pub(super) fn collect_having_aggregates(
+    /// Returns `true` if `expr` contains an inline aggregate call anywhere
+    /// (e.g. `COUNT(?x)` inside `DESC(COUNT(?x) / 2)`). Used to decide whether an
+    /// ORDER BY expression must be deferred until aggregate hoisting has run.
+    pub(super) fn expr_contains_aggregate(&self, expr: &Expression) -> bool {
+        match expr.unwrap_bracketed() {
+            Expression::Aggregate { .. } => true,
+            Expression::Unary { operand, .. } => self.expr_contains_aggregate(operand),
+            Expression::Binary { left, right, .. } => {
+                self.expr_contains_aggregate(left) || self.expr_contains_aggregate(right)
+            }
+            Expression::FunctionCall { args, .. } | Expression::Coalesce { args, .. } => {
+                args.iter().any(|a| self.expr_contains_aggregate(a))
+            }
+            Expression::If {
+                condition,
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                self.expr_contains_aggregate(condition)
+                    || self.expr_contains_aggregate(then_expr)
+                    || self.expr_contains_aggregate(else_expr)
+            }
+            Expression::In { expr, list, .. } => {
+                self.expr_contains_aggregate(expr)
+                    || list.iter().any(|a| self.expr_contains_aggregate(a))
+            }
+            Expression::Var(_)
+            | Expression::Literal(_)
+            | Expression::Iri(_)
+            | Expression::Exists { .. }
+            | Expression::NotExists { .. }
+            | Expression::Bracketed { .. } => false,
+        }
+    }
+
+    /// Collect (hoist) every inline aggregate found anywhere in `expr` into
+    /// `aggregates` + the `aliases` map (deduped by aggregate key), rewriting is
+    /// left to [`Self::lower_expression`] once `self.aggregate_aliases` is set.
+    /// Shared by HAVING and expression-based ORDER BY lowering.
+    pub(super) fn collect_inline_aggregates(
         &mut self,
         expr: &Expression,
         aliases: &mut HashMap<String, VarId>,
@@ -281,7 +321,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 if !aliases.contains_key(&key) {
                     let output_var = self
                         .vars
-                        .get_or_insert(&format!("?__having_agg_{}", aliases.len()));
+                        .get_or_insert(&format!("?__inline_agg_{}", aliases.len()));
                     let spec = self.aggregate_spec_from_expr(agg, output_var, pre_binds)?;
                     aliases.insert(key, output_var);
                     aggregates.push(spec);
@@ -289,16 +329,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 Ok(())
             }
             Expression::Binary { left, right, .. } => {
-                self.collect_having_aggregates(left, aliases, aggregates, pre_binds)?;
-                self.collect_having_aggregates(right, aliases, aggregates, pre_binds)?;
+                self.collect_inline_aggregates(left, aliases, aggregates, pre_binds)?;
+                self.collect_inline_aggregates(right, aliases, aggregates, pre_binds)?;
                 Ok(())
             }
             Expression::Unary { operand, .. } => {
-                self.collect_having_aggregates(operand, aliases, aggregates, pre_binds)
+                self.collect_inline_aggregates(operand, aliases, aggregates, pre_binds)
             }
             Expression::FunctionCall { args, .. } => {
                 for arg in args {
-                    self.collect_having_aggregates(arg, aliases, aggregates, pre_binds)?;
+                    self.collect_inline_aggregates(arg, aliases, aggregates, pre_binds)?;
                 }
                 Ok(())
             }
@@ -308,20 +348,20 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 else_expr,
                 ..
             } => {
-                self.collect_having_aggregates(condition, aliases, aggregates, pre_binds)?;
-                self.collect_having_aggregates(then_expr, aliases, aggregates, pre_binds)?;
-                self.collect_having_aggregates(else_expr, aliases, aggregates, pre_binds)
+                self.collect_inline_aggregates(condition, aliases, aggregates, pre_binds)?;
+                self.collect_inline_aggregates(then_expr, aliases, aggregates, pre_binds)?;
+                self.collect_inline_aggregates(else_expr, aliases, aggregates, pre_binds)
             }
             Expression::Coalesce { args, .. } => {
                 for arg in args {
-                    self.collect_having_aggregates(arg, aliases, aggregates, pre_binds)?;
+                    self.collect_inline_aggregates(arg, aliases, aggregates, pre_binds)?;
                 }
                 Ok(())
             }
             Expression::In { expr, list, .. } => {
-                self.collect_having_aggregates(expr, aliases, aggregates, pre_binds)?;
+                self.collect_inline_aggregates(expr, aliases, aggregates, pre_binds)?;
                 for arg in list {
-                    self.collect_having_aggregates(arg, aliases, aggregates, pre_binds)?;
+                    self.collect_inline_aggregates(arg, aliases, aggregates, pre_binds)?;
                 }
                 Ok(())
             }

--- a/fluree-db-sparql/src/lower/ask.rs
+++ b/fluree-db-sparql/src/lower/ask.rs
@@ -32,6 +32,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: Some(1),
             offset: None,
             post_values: None,

--- a/fluree-db-sparql/src/lower/construct.rs
+++ b/fluree-db-sparql/src/lower/construct.rs
@@ -42,6 +42,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             limit,
             offset,
             ordering,
+            order_binds,
         } = self.lower_base_modifiers(&construct.modifiers)?;
 
         let ctx = self.build_jsonld_context()?;
@@ -55,6 +56,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering,
+            order_binds,
             limit,
             offset,
             post_values: None,

--- a/fluree-db-sparql/src/lower/construct.rs
+++ b/fluree-db-sparql/src/lower/construct.rs
@@ -13,7 +13,7 @@ use fluree_db_query::ir::{
 use fluree_db_query::parse::encode::IriEncoder;
 
 use super::select::BaseModifiers;
-use super::{LoweringContext, Result};
+use super::{LowerError, LoweringContext, Result};
 
 impl<E: IriEncoder> LoweringContext<'_, E> {
     /// Lower a CONSTRUCT query to a Query.
@@ -43,7 +43,17 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             offset,
             ordering,
             order_binds,
+            deferred_order_exprs,
         } = self.lower_base_modifiers(&construct.modifiers)?;
+
+        // CONSTRUCT has no aggregation stage here, so an inline-aggregate ORDER BY
+        // (e.g. `ORDER BY DESC(COUNT(?x))`) cannot be hoisted/lowered.
+        if !deferred_order_exprs.is_empty() {
+            return Err(LowerError::unsupported_form(
+                "aggregate ORDER BY in CONSTRUCT",
+                construct.span,
+            ));
+        }
 
         let ctx = self.build_jsonld_context()?;
         let ctx_val = self.build_jsonld_context_value();

--- a/fluree-db-sparql/src/lower/describe.rs
+++ b/fluree-db-sparql/src/lower/describe.rs
@@ -144,6 +144,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             reasoning: ReasoningConfig::default(),
             grouping: None,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             limit: None,
             offset: None,
             post_values: None,
@@ -195,7 +196,17 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             limit,
             offset,
             ordering,
+            order_binds,
         } = self.lower_base_modifiers(modifiers)?;
+
+        // DESCRIBE restricts ORDER BY to target variables (see below); an
+        // expression-based ORDER BY would sort on a synthetic, non-target var.
+        if !order_binds.is_empty() {
+            return Err(LowerError::unsupported_form(
+                "DESCRIBE ORDER BY by expression",
+                span,
+            ));
+        }
 
         // For simplicity and predictable performance, require ORDER BY vars to be part of the subquery select list.
         for spec in &ordering {

--- a/fluree-db-sparql/src/lower/describe.rs
+++ b/fluree-db-sparql/src/lower/describe.rs
@@ -197,11 +197,13 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             offset,
             ordering,
             order_binds,
+            deferred_order_exprs,
         } = self.lower_base_modifiers(modifiers)?;
 
         // DESCRIBE restricts ORDER BY to target variables (see below); an
-        // expression-based ORDER BY would sort on a synthetic, non-target var.
-        if !order_binds.is_empty() {
+        // expression-based ORDER BY (aggregate-free or aggregate-bearing) would
+        // sort on a synthetic, non-target var.
+        if !order_binds.is_empty() || !deferred_order_exprs.is_empty() {
             return Err(LowerError::unsupported_form(
                 "DESCRIBE ORDER BY by expression",
                 span,

--- a/fluree-db-sparql/src/lower/error.rs
+++ b/fluree-db-sparql/src/lower/error.rs
@@ -43,10 +43,6 @@ pub enum LowerError {
     #[error("Invalid integer literal '{value}'")]
     InvalidInteger { value: String, span: SourceSpan },
 
-    /// Unsupported ORDER BY expression (MVP only supports variables)
-    #[error("Expression-based ORDER BY is not yet supported; use a variable")]
-    UnsupportedOrderByExpression { span: SourceSpan },
-
     /// Aggregate without alias (SELECT COUNT(?x) without AS ?var)
     #[error("Aggregate expressions must have an alias (AS ?var)")]
     AggregateWithoutAlias { span: SourceSpan },
@@ -131,11 +127,6 @@ impl LowerError {
         }
     }
 
-    /// Create an unsupported ORDER BY expression error.
-    pub fn unsupported_order_by_expr(span: SourceSpan) -> Self {
-        Self::UnsupportedOrderByExpression { span }
-    }
-
     /// Create an aggregate without alias error.
     pub fn aggregate_without_alias(span: SourceSpan) -> Self {
         Self::AggregateWithoutAlias { span }
@@ -179,7 +170,6 @@ impl LowerError {
             Self::UnsupportedQueryForm { span, .. } => *span,
             Self::InvalidDecimal { span, .. } => *span,
             Self::InvalidInteger { span, .. } => *span,
-            Self::UnsupportedOrderByExpression { span } => *span,
             Self::AggregateWithoutAlias { span } => *span,
             Self::UnsupportedCountStar { span } => *span,
             Self::InvalidPropertyPath { span, .. } => *span,

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -151,6 +151,8 @@ struct LoweringContext<'a, E> {
     agg_counter: u32,
     /// Monotonic counter for generating intermediate property-path join variables (`?__pp0`, `?__pp1`, …).
     pp_counter: u32,
+    /// Monotonic counter for generating expression-based ORDER BY bind variables (`?__order_by_0`, …).
+    order_counter: u32,
     /// Original SPARQL source text (for extracting SERVICE body text).
     source_text: Option<&'a str>,
 }
@@ -181,6 +183,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
             agg_expr_binds: HashMap::new(),
             agg_counter: 0,
             pp_counter: 0,
+            order_counter: 0,
             source_text,
         }
     }
@@ -230,12 +233,17 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                     limit,
                     offset,
                     ordering,
+                    order_binds,
                 } = lowered_modifiers.base;
                 let distinct = lowered_modifiers.distinct;
 
                 // Assemble the grouping phase from the lowered components.
-                // Post-aggregation binds (`select_binds.post`) ride inside the
-                // aggregation stage when one exists.
+                // SELECT post-binds (`select_binds.post`) ride inside the
+                // aggregation stage. Expression-based ORDER BY binds ride on
+                // `Query.order_binds` (a dedicated post-grouping stage in the
+                // operator tree) so they evaluate uniformly with or without
+                // grouping — including dedup-only GROUP BY, which has no
+                // aggregation stage to carry binds.
                 let grouping = Grouping::assemble(
                     lowered_modifiers.group_by,
                     lowered_modifiers.aggregates,
@@ -267,6 +275,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                     patterns,
                     grouping,
                     ordering,
+                    order_binds,
                     limit,
                     offset,
                     reasoning: ReasoningConfig::default(),
@@ -1365,16 +1374,91 @@ mod tests {
     }
 
     #[test]
-    fn test_order_by_expr_unsupported() {
-        let result = lower_query(
+    fn test_order_by_expression_desugars_to_order_bind() {
+        // `ORDER BY (?o + 1)` desugars to a synthetic `(?__order_by_N, expr)`
+        // carried on `query.order_binds` and sorts on that synthetic var.
+        let (query, vars) = lower_query_with_vars(
             "PREFIX ex: <http://example.org/>
              SELECT ?s ?o WHERE { ?s ex:p ?o } ORDER BY (?o + 1)",
-        );
+        )
+        .unwrap();
 
-        assert!(matches!(
-            result,
-            Err(LowerError::UnsupportedOrderByExpression { .. })
-        ));
+        assert_eq!(query.ordering.len(), 1);
+        let sort_var = query.ordering[0].var;
+        assert!(
+            vars.name(sort_var).starts_with("?__order_by_"),
+            "expected synthetic ORDER BY var, got: {}",
+            vars.name(sort_var)
+        );
+        // The desugared bind rides on `order_binds`, never in WHERE patterns.
+        assert!(
+            query.order_binds.iter().any(|(var, _)| *var == sort_var),
+            "expected an order bind for the ORDER BY expression"
+        );
+        assert!(
+            !query
+                .patterns
+                .iter()
+                .any(|p| matches!(p, Pattern::Bind { var, .. } if *var == sort_var)),
+            "ORDER BY bind must not leak into WHERE patterns"
+        );
+        assert!(
+            query.grouping.is_none(),
+            "no aggregation expected for this query"
+        );
+    }
+
+    #[test]
+    fn test_order_by_desc_expression() {
+        // The BSBM ratio shape: ORDER BY DESC(expr) , ?var.
+        let (query, vars) = lower_query_with_vars(
+            "PREFIX ex: <http://example.org/>
+             SELECT ?s ?a ?b WHERE { ?s ex:a ?a . ?s ex:b ?b }
+             ORDER BY DESC(?a / ?b) ?s",
+        )
+        .unwrap();
+
+        assert_eq!(query.ordering.len(), 2);
+        assert_eq!(query.ordering[0].direction, SortDirection::Descending);
+        // First key is the synthetic expression var, second is the bare ?s.
+        assert!(vars.name(query.ordering[0].var).starts_with("?__order_by_"));
+        assert_eq!(vars.name(query.ordering[1].var), "?s");
+    }
+
+    #[test]
+    fn test_order_by_expression_over_aggregate_uses_order_bind() {
+        // `ORDER BY DESC(?c * 2)` over an aggregate output is carried on
+        // `order_binds` (a dedicated post-grouping stage), not in WHERE patterns
+        // and not in the aggregation stage's own post-binds.
+        let (query, vars) = lower_query_with_vars(
+            "PREFIX ex: <http://example.org/>
+             SELECT ?type (COUNT(?s) AS ?c) WHERE { ?s ex:type ?type }
+             GROUP BY ?type ORDER BY DESC(?c * 2)",
+        )
+        .unwrap();
+
+        assert_eq!(query.ordering.len(), 1);
+        let sort_var = query.ordering[0].var;
+        assert!(vars.name(sort_var).starts_with("?__order_by_"));
+
+        // Carried on order_binds.
+        assert!(
+            query.order_binds.iter().any(|(var, _)| *var == sort_var),
+            "expected the aggregate-referencing ORDER BY to be an order bind"
+        );
+        // Not a WHERE bind, and not in the grouping phase's post-binds.
+        assert!(
+            !query
+                .patterns
+                .iter()
+                .any(|p| matches!(p, Pattern::Bind { var, .. } if *var == sort_var)),
+            "order bind must not be a pre-WHERE bind"
+        );
+        let grouping = query.grouping.as_ref().expect("aggregation expected");
+        assert!(
+            !grouping.binds().any(|(var, _)| *var == sort_var),
+            "order bind must not be merged into the aggregation post-binds"
+        );
     }
 
     #[test]

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -234,6 +234,9 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                     offset,
                     ordering,
                     order_binds,
+                    // Consumed in `lower_solution_modifiers` (lowered into
+                    // `order_binds` after aggregate hoisting); empty here.
+                    deferred_order_exprs: _,
                 } = lowered_modifiers.base;
                 let distinct = lowered_modifiers.distinct;
 
@@ -1459,6 +1462,47 @@ mod tests {
             !grouping.binds().any(|(var, _)| *var == sort_var),
             "order bind must not be merged into the aggregation post-binds"
         );
+    }
+
+    #[test]
+    fn test_order_by_inline_aggregate_dedups_with_select_alias() {
+        // `ORDER BY DESC(COUNT(?s))` reuses the SELECT alias's aggregate, so
+        // exactly one aggregate is computed and the order bind references it.
+        let (query, _vars) = lower_query_with_vars(
+            "PREFIX ex: <http://example.org/>
+             SELECT ?type (COUNT(?s) AS ?c) WHERE { ?s ex:type ?type }
+             GROUP BY ?type ORDER BY DESC(COUNT(?s))",
+        )
+        .unwrap();
+
+        assert_eq!(
+            aggregates_of(&query).len(),
+            1,
+            "COUNT(?s) must not be computed twice"
+        );
+        assert_eq!(query.order_binds.len(), 1, "expected one ORDER BY bind");
+        assert_eq!(query.ordering.len(), 1);
+        let (bind_var, _) = &query.order_binds[0];
+        assert_eq!(query.ordering[0].var, *bind_var);
+    }
+
+    #[test]
+    fn test_order_by_inline_aggregate_hoisted_when_not_selected() {
+        // `ORDER BY DESC(COUNT(?s))` with no aggregate in SELECT hoists a new
+        // aggregate into the grouping phase with a synthetic output var.
+        let (query, vars) = lower_query_with_vars(
+            "PREFIX ex: <http://example.org/>
+             SELECT ?type WHERE { ?s ex:type ?type }
+             GROUP BY ?type ORDER BY DESC(COUNT(?s))",
+        )
+        .unwrap();
+
+        let aggs = aggregates_of(&query);
+        assert_eq!(aggs.len(), 1, "expected one hoisted aggregate");
+        assert!(vars.name(aggs[0].output_var).starts_with("?__inline_agg_"));
+        assert_eq!(query.order_binds.len(), 1);
+        let (bind_var, _) = &query.order_binds[0];
+        assert_eq!(query.ordering[0].var, *bind_var);
     }
 
     #[test]

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -17,7 +17,7 @@ use fluree_db_query::parse::encode::IriEncoder;
 use fluree_db_query::sort::{SortDirection, SortSpec};
 use fluree_db_query::var_registry::VarId;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::{LowerError, LoweringContext, Result};
@@ -37,12 +37,18 @@ pub(super) struct BaseModifiers {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
     pub ordering: Vec<SortSpec>,
-    /// Synthetic `(var, expr)` binds produced by expression-based ORDER BY
-    /// conditions (e.g. `ORDER BY DESC(?a / ?b)`). Each `SortSpec` in
-    /// `ordering` that came from an expression references the matching
-    /// synthetic var here. The caller decides where the bind is evaluated
-    /// (pre-WHERE vs. post-aggregation); ASK discards them entirely.
+    /// Synthetic `(var, expr)` binds produced by aggregate-free expression
+    /// ORDER BY conditions (e.g. `ORDER BY DESC(?a / ?b)`), lowered eagerly.
+    /// Each `SortSpec` in `ordering` that came from an expression references the
+    /// matching synthetic var here (or in `deferred_order_exprs`).
     pub order_binds: Vec<(VarId, Expression)>,
+    /// Expression ORDER BY conditions that contain an inline aggregate
+    /// (e.g. `ORDER BY DESC(COUNT(?x))`). They cannot be lowered until aggregate
+    /// hoisting has produced the alias map, so `lower_base_modifiers` stashes the
+    /// synthetic sort var + raw AST expression here. `lower_solution_modifiers`
+    /// (SELECT) hoists their aggregates and lowers them into `order_binds`;
+    /// CONSTRUCT/DESCRIBE reject a non-empty list (no aggregation stage there).
+    pub deferred_order_exprs: Vec<(VarId, AstExpression)>,
 }
 
 /// Result of lowering solution modifiers.
@@ -155,8 +161,10 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         let mut having: Option<Expression> = None;
         let mut pre_group_binds = Vec::new();
 
-        // LIMIT, OFFSET, ORDER BY
-        let base = self.lower_base_modifiers(modifiers)?;
+        // LIMIT, OFFSET, ORDER BY. Aggregate-bearing ORDER BY expressions are
+        // stashed in `base.deferred_order_exprs` and lowered below, after the
+        // aggregate alias map exists.
+        let mut base = self.lower_base_modifiers(modifiers)?;
 
         // GROUP BY — supports both variables and expressions.
         // Expression GROUP BY like `GROUP BY (expr AS ?alias)` desugars to
@@ -173,20 +181,31 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             group_by = group_vars;
         }
 
+        // Aggregate-alias map shared by HAVING and aggregate-bearing ORDER BY
+        // hoisting. Seeded with SELECT aggregate aliases so both reuse them, and
+        // so the synthetic `?__inline_agg_N` names stay unique across both (the
+        // names are keyed off the shared map's length).
+        let needs_alias_map = modifiers.having.is_some() || !base.deferred_order_exprs.is_empty();
+        let mut aggregate_aliases: HashMap<String, VarId> = if needs_alias_map {
+            self.build_aggregate_aliases(select)?
+        } else {
+            HashMap::new()
+        };
+        // Aggregates hoisted out of HAVING and/or ORDER BY expressions.
+        let mut hoisted_aggregates: Vec<AggregateSpec> = Vec::new();
+
         // HAVING (may reference aggregate expressions)
-        let mut having_aggregates: Vec<AggregateSpec> = Vec::new();
         if let Some(ref having_clause) = modifiers.having {
-            let mut aggregate_aliases = self.build_aggregate_aliases(select)?;
             let mut having_pre_binds: Vec<Pattern> = Vec::new();
             for cond in &having_clause.conditions {
-                self.collect_having_aggregates(
+                self.collect_inline_aggregates(
                     cond,
                     &mut aggregate_aliases,
-                    &mut having_aggregates,
+                    &mut hoisted_aggregates,
                     &mut having_pre_binds,
                 )?;
             }
-            self.aggregate_aliases = Some(aggregate_aliases);
+            self.aggregate_aliases = Some(aggregate_aliases.clone());
             // Combine all HAVING conditions with AND
             let filter = self.lower_having_conditions(&having_clause.conditions)?;
             having = Some(filter);
@@ -194,11 +213,36 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             pre_group_binds.extend(having_pre_binds);
         }
 
+        // Deferred ORDER BY expressions containing inline aggregates
+        // (e.g. `ORDER BY DESC(COUNT(?x))`). Hoist their aggregates into the same
+        // map, then lower the expression with the alias map in scope so the
+        // inline aggregate resolves to its synthetic output var. The resulting
+        // order bind is applied by the operator tree's post-grouping stage.
+        if !base.deferred_order_exprs.is_empty() {
+            let deferred = std::mem::take(&mut base.deferred_order_exprs);
+            let mut order_pre_binds: Vec<Pattern> = Vec::new();
+            for (_, ast_expr) in &deferred {
+                self.collect_inline_aggregates(
+                    ast_expr,
+                    &mut aggregate_aliases,
+                    &mut hoisted_aggregates,
+                    &mut order_pre_binds,
+                )?;
+            }
+            self.aggregate_aliases = Some(aggregate_aliases.clone());
+            for (var_id, ast_expr) in &deferred {
+                let lowered = self.lower_expression(ast_expr)?;
+                base.order_binds.push((*var_id, lowered));
+            }
+            self.aggregate_aliases = None;
+            pre_group_binds.extend(order_pre_binds);
+        }
+
         // Extract aggregates from SELECT clause, then append any aggregates
-        // lifted out of HAVING.
+        // lifted out of HAVING / ORDER BY.
         let (mut aggregates, select_agg_binds) = self.extract_aggregates(select)?;
         pre_group_binds.extend(select_agg_binds);
-        aggregates.extend(having_aggregates);
+        aggregates.extend(hoisted_aggregates);
 
         // Auto-populate GROUP BY when aggregates present but no explicit GROUP BY
         // Per SPARQL semantics, all non-aggregated SELECT variables must be in GROUP BY
@@ -228,11 +272,14 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             .as_ref()
             .map(|clause| clause.value as usize);
         let mut order_binds: Vec<(VarId, Expression)> = Vec::new();
+        let mut deferred_order_exprs: Vec<(VarId, AstExpression)> = Vec::new();
         let ordering = match &modifiers.order_by {
             Some(order_by) => order_by
                 .conditions
                 .iter()
-                .map(|cond| self.lower_order_condition(cond, &mut order_binds))
+                .map(|cond| {
+                    self.lower_order_condition(cond, &mut order_binds, &mut deferred_order_exprs)
+                })
                 .collect::<Result<Vec<_>>>()?,
             None => Vec::new(),
         };
@@ -242,6 +289,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             offset,
             ordering,
             order_binds,
+            deferred_order_exprs,
         })
     }
 
@@ -251,13 +299,18 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
     /// that variable. A non-trivial expression (`ORDER BY DESC(?a / ?b)`) is
     /// desugared to a synthetic `BIND(expr AS ?__order_by_N)`: the expression is
     /// evaluated once per solution into the synthetic var, which becomes the
-    /// sort key. The `(var, expr)` pair is pushed onto `order_binds` for the
-    /// caller to place in the pipeline (sorting an expression more than once —
-    /// e.g. inside the comparator — would re-evaluate it O(n log n) times).
+    /// sort key (sorting an expression inside the comparator would re-evaluate it
+    /// O(n log n) times).
+    ///
+    /// An expression that contains an inline aggregate (`ORDER BY DESC(COUNT(?x))`)
+    /// cannot be lowered yet — the aggregate alias map does not exist until
+    /// hoisting runs — so it is stashed in `deferred_order_exprs` and lowered
+    /// later by [`Self::lower_solution_modifiers`].
     fn lower_order_condition(
         &mut self,
         cond: &OrderCondition,
         order_binds: &mut Vec<(VarId, Expression)>,
+        deferred_order_exprs: &mut Vec<(VarId, AstExpression)>,
     ) -> Result<SortSpec> {
         let direction = match cond.direction {
             OrderDirection::Asc => SortDirection::Ascending,
@@ -283,13 +336,18 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     })
                 }
                 _ => {
-                    // Expression-based ORDER BY: desugar to a synthetic BIND and
-                    // sort on its output variable.
-                    let lowered = self.lower_expression(expr)?;
+                    // Expression-based ORDER BY: sort on a synthetic var bound to
+                    // the expression.
                     let name = format!("?__order_by_{}", self.order_counter);
                     self.order_counter += 1;
                     let var_id = self.vars.get_or_insert(&name);
-                    order_binds.push((var_id, lowered));
+                    if self.expr_contains_aggregate(expr) {
+                        // Defer: needs aggregate hoisting before it can be lowered.
+                        deferred_order_exprs.push((var_id, expr.clone()));
+                    } else {
+                        let lowered = self.lower_expression(expr)?;
+                        order_binds.push((var_id, lowered));
+                    }
                     Ok(SortSpec {
                         var: var_id,
                         direction,

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -37,6 +37,12 @@ pub(super) struct BaseModifiers {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
     pub ordering: Vec<SortSpec>,
+    /// Synthetic `(var, expr)` binds produced by expression-based ORDER BY
+    /// conditions (e.g. `ORDER BY DESC(?a / ?b)`). Each `SortSpec` in
+    /// `ordering` that came from an expression references the matching
+    /// synthetic var here. The caller decides where the bind is evaluated
+    /// (pre-WHERE vs. post-aggregation); ASK discards them entirely.
+    pub order_binds: Vec<(VarId, Expression)>,
 }
 
 /// Result of lowering solution modifiers.
@@ -221,11 +227,12 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             .offset
             .as_ref()
             .map(|clause| clause.value as usize);
+        let mut order_binds: Vec<(VarId, Expression)> = Vec::new();
         let ordering = match &modifiers.order_by {
             Some(order_by) => order_by
                 .conditions
                 .iter()
-                .map(|cond| self.lower_order_condition(cond))
+                .map(|cond| self.lower_order_condition(cond, &mut order_binds))
                 .collect::<Result<Vec<_>>>()?,
             None => Vec::new(),
         };
@@ -234,11 +241,24 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             limit,
             offset,
             ordering,
+            order_binds,
         })
     }
 
-    /// Lower an ORDER BY condition (vars-only MVP)
-    fn lower_order_condition(&mut self, cond: &OrderCondition) -> Result<SortSpec> {
+    /// Lower an ORDER BY condition to a [`SortSpec`].
+    ///
+    /// Bare variables (including `ASC(?var)` / `DESC((?var))`) sort directly on
+    /// that variable. A non-trivial expression (`ORDER BY DESC(?a / ?b)`) is
+    /// desugared to a synthetic `BIND(expr AS ?__order_by_N)`: the expression is
+    /// evaluated once per solution into the synthetic var, which becomes the
+    /// sort key. The `(var, expr)` pair is pushed onto `order_binds` for the
+    /// caller to place in the pipeline (sorting an expression more than once —
+    /// e.g. inside the comparator — would re-evaluate it O(n log n) times).
+    fn lower_order_condition(
+        &mut self,
+        cond: &OrderCondition,
+        order_binds: &mut Vec<(VarId, Expression)>,
+    ) -> Result<SortSpec> {
         let direction = match cond.direction {
             OrderDirection::Asc => SortDirection::Ascending,
             OrderDirection::Desc => SortDirection::Descending,
@@ -263,8 +283,17 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     })
                 }
                 _ => {
-                    // Complex expression-based ORDER BY not yet supported
-                    Err(LowerError::unsupported_order_by_expr(cond.span))
+                    // Expression-based ORDER BY: desugar to a synthetic BIND and
+                    // sort on its output variable.
+                    let lowered = self.lower_expression(expr)?;
+                    let name = format!("?__order_by_{}", self.order_counter);
+                    self.order_counter += 1;
+                    let var_id = self.vars.get_or_insert(&name);
+                    order_binds.push((var_id, lowered));
+                    Ok(SortSpec {
+                        var: var_id,
+                        direction,
+                    })
                 }
             },
         }
@@ -336,6 +365,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         subselect: &SubSelect,
         _span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
+        // Expression-based ORDER BY inside a subquery is not yet supported
+        // (the subquery operator sorts the projected output, with no stage to
+        // evaluate a synthetic key). Reject rather than silently mis-sort.
+        if subselect.order_by_unsupported_expr {
+            return Err(LowerError::unsupported_form(
+                "expression-based ORDER BY in a subquery",
+                subselect.span,
+            ));
+        }
+
         // Lower WHERE patterns (mut: expression GROUP BY may append pre-group BINDs)
         let mut patterns = self.lower_graph_pattern(&subselect.pattern)?;
 

--- a/fluree-db-sparql/src/parse/query/pattern.rs
+++ b/fluree-db-sparql/src/parse/query/pattern.rs
@@ -1,5 +1,6 @@
 //! Graph pattern parsing: WHERE, OPTIONAL, UNION, MINUS, FILTER, BIND, VALUES, subqueries.
 
+use crate::ast::expr::Expression;
 use crate::ast::pattern::{GraphName, ServiceEndpoint, SubSelect, SubSelectOrderBy};
 use crate::ast::query::SelectVariables;
 use crate::ast::{GraphPattern, Term, Var, WhereClause};
@@ -641,7 +642,8 @@ impl super::Parser<'_> {
         let pattern = self.parse_group_graph_pattern()?;
 
         // Parse solution modifiers (GROUP BY, ORDER BY, LIMIT, OFFSET)
-        let (group_by, order_by, limit, offset) = self.parse_subquery_modifiers();
+        let (group_by, order_by, limit, offset, order_by_unsupported_expr) =
+            self.parse_subquery_modifiers();
 
         // Expect closing brace for the subquery
         if !self.stream.match_token(&TokenKind::RBrace) {
@@ -658,6 +660,7 @@ impl super::Parser<'_> {
             pattern: Box::new(pattern),
             group_by,
             order_by,
+            order_by_unsupported_expr,
             limit,
             offset,
             span,
@@ -679,10 +682,14 @@ impl super::Parser<'_> {
         Vec<SubSelectOrderBy>,
         Option<u64>,
         Option<u64>,
+        bool,
     ) {
         let mut order_by = Vec::new();
         let mut limit = None;
         let mut offset = None;
+        // Set when a subquery ORDER BY contains a non-trivial expression, which
+        // lowering rejects (see `SubSelect::order_by_unsupported_expr`).
+        let mut order_by_unsupported_expr = false;
 
         // GROUP BY
         let group_by = if self.stream.check_keyword(TokenKind::KwGroupBy) {
@@ -713,20 +720,42 @@ impl super::Parser<'_> {
                     false
                 };
 
-                // Check for parenthesized expression or bare variable
-                if self.stream.match_token(&TokenKind::LParen) {
-                    // Skip expression content, look for variable
-                    if let Some((name, span)) = self.stream.consume_var() {
-                        order_by.push(SubSelectOrderBy {
-                            var: Var::new(name.as_ref(), span),
-                            descending,
-                        });
+                // Parenthesized order condition. Parse the full expression so a
+                // bracketed bare variable `(?v)` keeps working, but reject a
+                // genuine expression `(0 - ?v)` instead of silently grabbing its
+                // first variable and mis-sorting (subquery ORDER BY desugaring
+                // is not yet wired through the subquery operator).
+                if self.stream.check(&TokenKind::LParen) {
+                    let expr_start = self.stream.current_span();
+                    self.stream.advance(); // consume (
+                    match parse_expression(self.stream) {
+                        Ok(e) => {
+                            if !self.stream.match_token(&TokenKind::RParen) {
+                                self.stream.error_at_current("expected ')'");
+                            }
+                            match e.unwrap_bracketed() {
+                                Expression::Var(v) => order_by.push(SubSelectOrderBy {
+                                    var: v.clone(),
+                                    descending,
+                                }),
+                                _ => {
+                                    // Flag for lowering to reject (a parser
+                                    // diagnostic alone is swallowed once an AST
+                                    // is recovered). Also record a diagnostic for
+                                    // tooling/IDE feedback.
+                                    order_by_unsupported_expr = true;
+                                    self.stream.error_at(
+                                        "Expression-based ORDER BY is not yet supported in subqueries; \
+                                         alias the expression in the inner SELECT and ORDER BY the alias",
+                                        expr_start.union(self.stream.previous_span()),
+                                    );
+                                }
+                            }
+                        }
+                        Err(msg) => {
+                            self.stream.error_at_current(&msg);
+                        }
                     }
-                    // Skip to closing paren
-                    while !self.stream.check(&TokenKind::RParen) && !self.stream.is_eof() {
-                        self.stream.advance();
-                    }
-                    self.stream.match_token(&TokenKind::RParen);
                 } else if let Some((name, span)) = self.stream.consume_var() {
                     order_by.push(SubSelectOrderBy {
                         var: Var::new(name.as_ref(), span),
@@ -756,6 +785,6 @@ impl super::Parser<'_> {
             }
         }
 
-        (group_by, order_by, limit, offset)
+        (group_by, order_by, limit, offset, order_by_unsupported_expr)
     }
 }


### PR DESCRIPTION
## Summary

Fixes three SPARQL 1.1 correctness gaps in aggregate/analytic query evaluation. Each is an independent spec-compliance issue in core expression handling.

### 1. Mixed numeric-type arithmetic no longer errors

Arithmetic between two different XSD numeric types — e.g. `xsd:float(?x) / ?int` — failed with a type mismatch. XPath operator mapping requires numeric type promotion: the narrower operand is promoted to the wider type and the operation proceeds. Numeric operands carried as typed literals (string-backed `xsd:float`, the full integer family including values needing `BigInt`, `xsd:decimal`, and the `INF`/`-INF`/`NaN` float lexicals) are now normalized through the canonical core coercion layer before the operation, so promotion applies uniformly instead of falling through to an error.

### 2. Integer division yields `xsd:decimal`

`xsd:integer / xsd:integer` truncated to an integer (`10 / 4` → `2`) — a silent wrong-value deviation. Per XPath `op:numeric-divide`, integer division yields `xsd:decimal` (`10 / 4` → `2.5`). Division now returns a decimal, with precision capped at 34 significant digits (IEEE-754 decimal128, matching `AVG`) so recurring quotients stay bounded. As elsewhere, `xsd:decimal` serializes as a string to preserve exactness, while `xsd:double` remains a JSON number.

### 3. Expression-based `ORDER BY` is supported

`ORDER BY` with an expression rather than a bare variable was rejected at lowering time. SPARQL 1.1 §15.1 permits any expression as an order condition. Expression order keys (e.g. `ORDER BY DESC(?a / ?b)`) are now desugared to a synthetic per-solution bind evaluated after grouping/aggregation and before the sort, so the key may reference `GROUP BY` keys, aggregate outputs, and `SELECT`-expression aliases. Inline aggregates in the order condition (`ORDER BY DESC(COUNT(?x))`, SPARQL 1.1 §18.2.4.1) are hoisted into the grouping phase and deduplicated against any matching `SELECT` aggregate so the count is computed once.

## Scope / limitations

- Expression-based `ORDER BY` inside a subquery is intentionally rejected: the subquery operator sorts its projected output and has no stage to evaluate a synthetic sort key. Top-level queries are unaffected.
- `xsd:float` arithmetic uses the existing double representation (no distinct 32-bit float type), consistent with how `xsd:float`/`xsd:double` already collapse elsewhere in the engine.
