### PR TITLE
fix: do not compact JSON-LD @id node identifiers against @vocab

### DIFF
--- a/docs/concepts/iri-and-context.md
+++ b/docs/concepts/iri-and-context.md
@@ -139,6 +139,26 @@ Fluree includes many standard prefixes by default:
 }
 ```
 
+### How `@vocab` and `@base` compact results
+
+When a query `@context` sets `@vocab` and/or `@base`, Fluree follows JSON-LD 1.1
+about *which* IRIs each keyword may shorten:
+
+- **`@vocab`** governs **property names, `@type` values, and `@type: @vocab`
+  term values** only. A predicate or class IRI that falls under `@vocab` is
+  emitted as a bare term (e.g. `name`, `Person`).
+- **`@base`** governs **node identifiers** — `@id` and reference values. An
+  `@id` that falls under `@base` is emitted as a base-relative reference.
+- **`@id` is never shortened by `@vocab`.** A node identifier whose IRI falls
+  under the `@vocab` namespace keeps its full IRI (or an explicit-prefix /
+  `@base`-relative form) — it is *not* collapsed to a bare term, because a
+  compliant JSON-LD processor would re-resolve a bare `@id` against `@base`,
+  not `@vocab`.
+
+Explicit prefix/term mappings apply in both positions. As a special case,
+setting `@vocab: ""` maps the vocabulary to `@base`, so bare terms and
+base-relative identifiers share the same namespace.
+
 ## IRI Resolution Rules
 
 Fluree follows strict IRI resolution rules:

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -794,15 +794,20 @@ impl<'a> HydrationFormatter<'a> {
             // The `@id` of THIS subject: prefer the canonical IRI from a
             // multi-ledger `IriMatch` root over decoding the SID against this
             // formatter's single-snapshot dict, which would mis-decode a SID
-            // that originated in a different ledger (issue #1259). `compact_iri`
+            // that originated in a different ledger (issue #1259). The compaction
             // is a pure context operation, independent of the namespace dict.
             // `root_iri` is only ever set for the root subject; nested refs
             // (recursive calls below) pass `None` and decode their SID against
             // the ledger whose flakes produced them.
+            //
+            // `@id` is a node-identifier position, so compaction must go through
+            // the `compact_id_*` path (`@base` + explicit prefixes only); using
+            // the `@vocab`-applying path would non-conformantly shorten the IRI
+            // to a bare term when it falls under `@vocab` (issue #1280).
             let id_json = |compactor: &IriCompactor| -> Result<JsonValue> {
                 Ok(json!(match root_iri.as_deref() {
-                    Some(iri) => compactor.compact_iri(iri)?,
-                    None => compactor.compact_sid(sid)?,
+                    Some(iri) => compactor.compact_id_iri(iri),
+                    None => compactor.compact_id_sid(sid)?,
                 }))
             };
 
@@ -1001,7 +1006,7 @@ impl<'a> HydrationFormatter<'a> {
             // No view could resolve the subject → bare canonical @id.
             match merged {
                 Some(v) => Ok(v),
-                None => Ok(json!({ "@id": self.compactor.compact_iri(&iri)? })),
+                None => Ok(json!({ "@id": self.compactor.compact_id_iri(&iri) })),
             }
         }
         .boxed()
@@ -1100,7 +1105,9 @@ impl<'a> HydrationFormatter<'a> {
                                 .await?,
                             ),
                             None => {
-                                values.push(json!({ "@id": self.compactor.compact_sid(ref_sid)? }));
+                                values.push(
+                                    json!({ "@id": self.compactor.compact_id_sid(ref_sid)? }),
+                                );
                             }
                         }
                     }
@@ -1143,7 +1150,7 @@ impl<'a> HydrationFormatter<'a> {
                 ),
                 None => {
                     // No expansion - just @id
-                    values.push(json!({ "@id": self.compactor.compact_sid(subject_sid)? }));
+                    values.push(json!({ "@id": self.compactor.compact_id_sid(subject_sid)? }));
                 }
             }
         }
@@ -1212,7 +1219,7 @@ impl<'a> HydrationFormatter<'a> {
                 FlakeValue::Null => Ok(JsonValue::Null),
                 FlakeValue::Ref(sid) => {
                     // This shouldn't happen for literals, but handle gracefully
-                    Ok(json!({ "@id": self.compactor.compact_sid(sid)? }))
+                    Ok(json!({ "@id": self.compactor.compact_id_sid(sid)? }))
                 }
                 // Extended numeric types - serialize as string
                 FlakeValue::BigInt(n) => Ok(JsonValue::String(n.to_string())),
@@ -1256,7 +1263,7 @@ impl<'a> HydrationFormatter<'a> {
             FlakeValue::Json(json_str) => JsonValue::String(json_str.clone()), // Fallback for non-@json context
             FlakeValue::Null => return Ok(JsonValue::Null),
             FlakeValue::Ref(sid) => {
-                return Ok(json!({ "@id": self.compactor.compact_sid(sid)? }));
+                return Ok(json!({ "@id": self.compactor.compact_id_sid(sid)? }));
             }
             // Extended numeric types - serialize as string with @type
             FlakeValue::BigInt(n) => JsonValue::String(n.to_string()),
@@ -1355,7 +1362,9 @@ impl<'a> HydrationFormatter<'a> {
                 serde_json::from_str::<JsonValue>(s).unwrap_or_else(|_| json!(s))
             }
             FlakeValue::Null => return Ok(JsonValue::Null),
-            FlakeValue::Ref(sid) => return Ok(json!({ "@id": self.compactor.compact_sid(sid)? })),
+            FlakeValue::Ref(sid) => {
+                return Ok(json!({ "@id": self.compactor.compact_id_sid(sid)? }))
+            }
             FlakeValue::BigInt(n) => json!(n.to_string()),
             FlakeValue::Decimal(d) => json!(d.to_string()),
             FlakeValue::DateTime(dt) => json!(dt.to_string()),
@@ -1470,7 +1479,7 @@ impl<'a> HydrationFormatter<'a> {
                 "@json should have been handled above".to_string(),
             )),
             FlakeValue::Null => Ok(JsonValue::Null),
-            FlakeValue::Ref(sid) => Ok(json!({ "@id": self.compactor.compact_sid(sid)? })),
+            FlakeValue::Ref(sid) => Ok(json!({ "@id": self.compactor.compact_id_sid(sid)? })),
             FlakeValue::BigInt(n) => Ok(JsonValue::String(n.to_string())),
             FlakeValue::Decimal(d) => Ok(JsonValue::String(d.to_string())),
             FlakeValue::DateTime(dt) => Ok(JsonValue::String(dt.to_string())),

--- a/fluree-db-api/src/format/iri.rs
+++ b/fluree-db-api/src/format/iri.rs
@@ -125,6 +125,19 @@ impl IriCompactor {
         self.compactor.compact_id(iri)
     }
 
+    /// Decode a Sid and compact it for an `@id` position.
+    ///
+    /// The `@id` counterpart to [`compact_sid`](Self::compact_sid): it decodes
+    /// the SID to a full IRI and then compacts via `@base` + explicit
+    /// prefixes/terms only — never `@vocab`. Per JSON-LD 1.1, `@vocab` governs
+    /// predicates and `@type` values, but must NOT shorten node identifiers, so
+    /// every `@id` / node-reference output site uses this instead of
+    /// `compact_sid`.
+    pub fn compact_id_sid(&self, sid: &Sid) -> Result<String> {
+        let iri = self.decode_sid(sid)?;
+        Ok(self.compact_id_iri(&iri))
+    }
+
     /// Compact an IRI for **display purposes** (CLI table/CSV output).
     ///
     /// Like `compact_vocab_iri`, but also tries auto-derived fallback prefixes
@@ -580,6 +593,96 @@ mod tests {
         assert!(a.ends_with(":bar"), "expected prefix:bar, got {a}");
         assert!(b.ends_with(":bar"), "expected prefix:bar, got {b}");
         assert_ne!(a, b, "should have different prefixes");
+    }
+
+    /// Regression for #1280: `@vocab` governs predicate / `@type` compaction,
+    /// but must NOT shorten `@id` node identifiers. An `@id` IRI that falls
+    /// under `@vocab` keeps its full IRI; explicit prefixes and `@base` still
+    /// apply to `@id`.
+    #[test]
+    fn test_compact_id_does_not_apply_vocab() {
+        let mut namespaces = HashMap::new();
+        namespaces.insert(100, "http://example.org/lists/".to_string());
+        namespaces.insert(101, "http://example.org/items/".to_string());
+        namespaces.insert(102, "http://base.example/".to_string());
+        let context = ParsedContext::parse(
+            None,
+            &json!({
+                "@vocab": "http://example.org/lists/",
+                "@base": "http://base.example/",
+                "items": "http://example.org/items/"
+            }),
+        )
+        .unwrap();
+        let compactor = IriCompactor::new(&namespaces, &context);
+
+        // SID under @vocab: the @id path must NOT collapse it to the bare term.
+        let summer = Sid::new(100, "summer"); // http://example.org/lists/summer
+        assert_eq!(
+            compactor.compact_id_sid(&summer).unwrap(),
+            "http://example.org/lists/summer"
+        );
+        // Predicate / @type path: @vocab DOES shorten it (unchanged behavior).
+        assert_eq!(compactor.compact_sid(&summer).unwrap(), "summer");
+
+        // @id still honors explicit prefixes.
+        let q1 = Sid::new(101, "q1"); // http://example.org/items/q1
+        assert_eq!(compactor.compact_id_sid(&q1).unwrap(), "items:q1");
+
+        // @id still honors @base (relative form).
+        let thing = Sid::new(102, "thing"); // http://base.example/thing
+        assert_eq!(compactor.compact_id_sid(&thing).unwrap(), "thing");
+
+        // The IRI-string variant matches the SID variant for @id positions.
+        assert_eq!(
+            compactor.compact_id_iri("http://example.org/lists/summer"),
+            "http://example.org/lists/summer"
+        );
+    }
+
+    /// With BOTH `@base` and `@vocab` set to distinct namespaces, each governs
+    /// only its own position: `@base` shortens `@id` node identifiers, `@vocab`
+    /// shortens predicate / `@type` values, and neither bleeds into the other's
+    /// position.
+    ///
+    /// NOTE: `@base` *also* participates in vocab compaction as Fluree's
+    /// fallback vocabulary — a bare `@type`/predicate in an `@base`-only context
+    /// (no `@vocab`) is expanded against `@base` on insert and must round-trip
+    /// back through `@base` on output. So a predicate IRI that happens to fall
+    /// under `@base` does compact to a relative term; that is intentional and is
+    /// exercised end-to-end by `it_query_misc::base_context_parity`. The
+    /// asymmetry that matters for #1280 is the reverse: `@vocab` must NEVER
+    /// shorten an `@id`.
+    #[test]
+    fn test_base_and_vocab_govern_their_own_positions() {
+        let mut namespaces = HashMap::new();
+        namespaces.insert(100, "https://flur.ee/base/".to_string());
+        namespaces.insert(101, "https://flur.ee/vocab/".to_string());
+        let context = ParsedContext::parse(
+            None,
+            &json!({
+                "@base": "https://flur.ee/base/",
+                "@vocab": "https://flur.ee/vocab/"
+            }),
+        )
+        .unwrap();
+        let compactor = IriCompactor::new(&namespaces, &context);
+
+        let under_base = Sid::new(100, "alice"); // https://flur.ee/base/alice
+        let under_vocab = Sid::new(101, "bob"); //  https://flur.ee/vocab/bob
+
+        // @id position: @base applies (relative form); @vocab must NOT.
+        assert_eq!(compactor.compact_id_sid(&under_base).unwrap(), "alice");
+        assert_eq!(
+            compactor.compact_id_sid(&under_vocab).unwrap(),
+            "https://flur.ee/vocab/bob",
+            "#1280: @vocab must not shorten an @id node identifier"
+        );
+
+        // Predicate / @type position: @vocab applies (bare term).
+        assert_eq!(compactor.compact_sid(&under_vocab).unwrap(), "bob");
+        // ...and @base acts as the vocab fallback here (intentional, see note).
+        assert_eq!(compactor.compact_sid(&under_base).unwrap(), "alice");
     }
 
     #[test]

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -76,11 +76,13 @@ pub(crate) fn format_binding(binding: &Binding, compactor: &IriCompactor) -> Res
     match binding {
         Binding::Unbound | Binding::Poisoned => Ok(JsonValue::Null),
 
-        // Reference (IRI or blank node) - compact using @context
-        Binding::Sid { sid, .. } => Ok(JsonValue::String(compactor.compact_sid(sid)?)),
+        // Reference (IRI or blank node) - compact using @context.
+        // A reference binding names a node, so it's an `@id`-position value:
+        // compact via `@base` + explicit prefixes, never `@vocab` (issue #1280).
+        Binding::Sid { sid, .. } => Ok(JsonValue::String(compactor.compact_id_sid(sid)?)),
 
         // IriMatch: use canonical IRI, then compact (multi-ledger mode)
-        Binding::IriMatch { iri, .. } => Ok(JsonValue::String(compactor.compact_iri(iri)?)),
+        Binding::IriMatch { iri, .. } => Ok(JsonValue::String(compactor.compact_id_iri(iri))),
 
         // Raw IRI string (from graph source, not in namespace table)
         // Output as-is without compaction (no namespace mapping available)
@@ -334,6 +336,7 @@ fn format_row_wildcard(
 mod tests {
     use super::*;
     use fluree_db_core::Sid;
+    use fluree_graph_json_ld::ParsedContext;
     use std::collections::HashMap;
 
     fn make_test_compactor() -> IriCompactor {
@@ -342,6 +345,35 @@ mod tests {
         namespaces.insert(3, "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string());
         namespaces.insert(100, "http://example.org/".to_string());
         IriCompactor::from_namespaces(&namespaces)
+    }
+
+    /// A compactor whose context sets `@vocab` to the same namespace as the
+    /// `lists` subject, so the `@vocab`-vs-`@id` distinction is observable.
+    fn make_vocab_compactor() -> IriCompactor {
+        let mut namespaces = HashMap::new();
+        namespaces.insert(100, "http://example.org/lists/".to_string());
+        let context = ParsedContext::parse(
+            None,
+            &serde_json::json!({"@vocab": "http://example.org/lists/"}),
+        )
+        .unwrap();
+        IriCompactor::new(&namespaces, &context)
+    }
+
+    /// Regression for #1280: a reference binding is a node identifier (`@id`
+    /// position). Even when its IRI falls under `@vocab`, the flat JSON-LD
+    /// formatter must emit the full IRI, not the bare `@vocab` term.
+    #[test]
+    fn test_format_binding_sid_id_not_vocab_compacted() {
+        let compactor = make_vocab_compactor();
+        let binding = Binding::sid(Sid::new(100, "summer")); // http://example.org/lists/summer
+        let result = format_binding(&binding, &compactor).unwrap();
+        assert_eq!(result, json!("http://example.org/lists/summer"));
+        assert_ne!(
+            result,
+            json!("summer"),
+            "an @id under @vocab must not collapse to a bare term"
+        );
     }
 
     #[test]

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -135,7 +135,9 @@ fn format_binding(
         // Reference (IRI or blank node)
         Binding::Sid { sid, .. } => {
             // SPARQL JSON output uses compact IRIs where possible (not full IRIs).
-            let iri = compactor.compact_sid(sid)?;
+            // A `uri` value names a node, so it's an `@id`-position identifier:
+            // compact via `@base` + explicit prefixes, never `@vocab` (issue #1280).
+            let iri = compactor.compact_id_sid(sid)?;
             // Check if it's a blank node (starts with _:)
             if iri.starts_with("_:") {
                 Ok(Some(json!({
@@ -152,7 +154,7 @@ fn format_binding(
 
         // IriMatch: use canonical IRI, then compact (multi-ledger mode)
         Binding::IriMatch { iri, .. } => {
-            let compacted = compactor.compact_iri(iri)?;
+            let compacted = compactor.compact_id_iri(iri);
             if compacted.starts_with("_:") {
                 Ok(Some(json!({
                     "type": "bnode",

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -81,15 +81,17 @@ pub(crate) fn format_binding(
     match binding {
         Binding::Unbound | Binding::Poisoned => Ok(JsonValue::Null),
 
-        // Reference - use @id notation
+        // Reference - use @id notation. An `@id` is a node identifier, so it
+        // compacts via `@base` + explicit prefixes only, never `@vocab`
+        // (issue #1280).
         Binding::Sid { sid, .. } => {
-            let iri = compactor.compact_sid(sid)?;
+            let iri = compactor.compact_id_sid(sid)?;
             Ok(json!({"@id": iri}))
         }
 
         // IriMatch: use canonical IRI, then compact (multi-ledger mode)
         Binding::IriMatch { iri, .. } => {
-            let compacted = compactor.compact_iri(iri)?;
+            let compacted = compactor.compact_id_iri(iri);
             Ok(json!({"@id": compacted}))
         }
 
@@ -319,6 +321,7 @@ fn format_row_wildcard(
 mod tests {
     use super::*;
     use fluree_db_core::Sid;
+    use fluree_graph_json_ld::ParsedContext;
     use std::collections::HashMap;
 
     fn make_test_compactor() -> IriCompactor {
@@ -327,6 +330,30 @@ mod tests {
         namespaces.insert(3, "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string());
         namespaces.insert(100, "http://example.org/".to_string());
         IriCompactor::from_namespaces(&namespaces)
+    }
+
+    /// A compactor whose context sets `@vocab` to the same namespace as the
+    /// `lists` subject, so the `@vocab`-vs-`@id` distinction is observable.
+    fn make_vocab_compactor() -> IriCompactor {
+        let mut namespaces = HashMap::new();
+        namespaces.insert(100, "http://example.org/lists/".to_string());
+        let context = ParsedContext::parse(
+            None,
+            &serde_json::json!({"@vocab": "http://example.org/lists/"}),
+        )
+        .unwrap();
+        IriCompactor::new(&namespaces, &context)
+    }
+
+    /// Regression for #1280: the `@id` of a reference must not be compacted
+    /// against `@vocab`, even when its IRI falls under the vocab namespace.
+    #[test]
+    fn test_format_binding_sid_id_not_vocab_compacted() {
+        let compactor = make_vocab_compactor();
+        let result = make_test_result();
+        let binding = Binding::sid(Sid::new(100, "summer")); // http://example.org/lists/summer
+        let formatted = format_binding(&result, &binding, &compactor).unwrap();
+        assert_eq!(formatted, json!({"@id": "http://example.org/lists/summer"}));
     }
 
     /// Create a minimal QueryResult for tests that don't need binary_store.

--- a/fluree-db-api/tests/it_query_vocab_id_compaction.rs
+++ b/fluree-db-api/tests/it_query_vocab_id_compaction.rs
@@ -1,0 +1,303 @@
+//! Regression tests for #1280: the JSON-LD result formatters must not compact
+//! `@id` node identifiers against `@vocab`.
+//!
+//! Per JSON-LD 1.1, `@vocab` governs property names, `@type` values, and
+//! `@type: @vocab` term values — it must NOT be used to shorten node
+//! identifiers (`@id` / reference values). Only `@base` and explicit
+//! term/prefix mappings apply at `@id` positions. Before the fix, a result
+//! `@id` whose IRI fell under the query `@vocab` was emitted as a bare term
+//! (e.g. `"summer"` for `http://example.org/lists/summer`), which a compliant
+//! JSON-LD processor would re-resolve against `@base`, not `@vocab`.
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+use support::{genesis_ledger, query_jsonld_formatted, MemoryFluree, MemoryLedger};
+
+/// Seed two subjects in distinct namespaces:
+/// - `http://example.org/lists/summer` (a List, will sit under the query `@vocab`)
+/// - `http://example.org/items/q1`     (an Item, referenced by the list)
+async fn seed_lists() -> (MemoryFluree, MemoryLedger) {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/vocab-id:lists");
+
+    let tx = json!({
+        "@context": {
+            "lists": "http://example.org/lists/",
+            "items": "http://example.org/items/"
+        },
+        "@graph": [
+            {
+                "@id": "lists:summer",
+                "@type": "lists:List",
+                "lists:name": "Summer",
+                "lists:contains": {"@id": "items:q1"}
+            },
+            {
+                "@id": "items:q1",
+                "@type": "items:Item",
+                "items:name": "Item One"
+            }
+        ]
+    });
+
+    let committed = fluree.insert(ledger0, &tx).await.expect("insert lists");
+    (fluree, committed.ledger)
+}
+
+/// Hydration path: the root `@id` under `@vocab` must stay a full IRI, while
+/// predicate keys and `@type` values still compact via `@vocab`, and a nested
+/// reference `@id` still compacts via its explicit prefix.
+#[tokio::test]
+async fn hydration_id_under_vocab_is_not_bare_term() {
+    let (fluree, ledger) = seed_lists().await;
+
+    let query = json!({
+        "@context": {
+            "@vocab": "http://example.org/lists/",
+            "items": "http://example.org/items/"
+        },
+        // Wildcard so the row carries @id, @type, every predicate, and the
+        // un-expanded `contains` reference (depth 0 → bare nested @id).
+        "select": {"?list": ["*"]},
+        "where": {"@id": "?list", "@type": "List"}
+    });
+
+    let result = query_jsonld_formatted(&fluree, &ledger, &query)
+        .await
+        .expect("query should succeed");
+
+    let list = result
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one list row");
+
+    // The fix: an @id under @vocab keeps its full IRI, never a bare "summer".
+    assert_eq!(
+        list.get("@id").and_then(JsonValue::as_str),
+        Some("http://example.org/lists/summer"),
+        "root @id must not be compacted against @vocab: {result:#}"
+    );
+
+    // @vocab still governs predicate keys (so the key is the bare "name").
+    assert_eq!(
+        list.get("name").and_then(JsonValue::as_str),
+        Some("Summer"),
+        "predicate keys should still compact via @vocab: {result:#}"
+    );
+
+    // @vocab still governs @type values (bare "List").
+    assert_eq!(
+        list.get("@type").and_then(JsonValue::as_str),
+        Some("List"),
+        "@type values should still compact via @vocab: {result:#}"
+    );
+
+    // A nested reference @id still compacts via its explicit prefix (items:),
+    // proving @id compaction uses prefixes — just not @vocab.
+    assert_eq!(
+        list.get("contains")
+            .and_then(|c| c.get("@id"))
+            .and_then(JsonValue::as_str),
+        Some("items:q1"),
+        "nested @id should use the explicit prefix: {result:#}"
+    );
+
+    // Belt and suspenders: the bare-term form must not appear anywhere.
+    let s = result.to_string();
+    assert!(
+        !s.contains("\"@id\":\"summer\""),
+        "the non-conformant bare @id must not appear: {s}"
+    );
+}
+
+/// Flat-select path (`Binding::Sid` → bare string): a reference column whose
+/// IRI falls under `@vocab` must serialize as the full IRI, not a bare term.
+#[tokio::test]
+async fn flat_select_ref_under_vocab_is_not_bare_term() {
+    let (fluree, ledger) = seed_lists().await;
+
+    let query = json!({
+        "@context": { "@vocab": "http://example.org/lists/" },
+        "select": ["?list"],
+        "where": {"@id": "?list", "@type": "List"}
+    });
+
+    let result = query_jsonld_formatted(&fluree, &ledger, &query)
+        .await
+        .expect("query should succeed");
+
+    // Array-form select → one row `["<iri>"]`.
+    let cell = result
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(JsonValue::as_array)
+        .and_then(|cols| cols.first())
+        .and_then(JsonValue::as_str);
+
+    assert_eq!(
+        cell,
+        Some("http://example.org/lists/summer"),
+        "flat-select reference under @vocab must be the full IRI: {result:#}"
+    );
+}
+
+/// `@base` and `@vocab` set together (to *distinct* namespaces): each governs
+/// only its own position, across both the insert (expansion) and the query
+/// (compaction) directions.
+///
+/// - `@id`        → governed by `@base` (relative form), never by `@vocab`.
+/// - `@type` / predicate → governed by `@vocab` (bare term), never by `@base`.
+/// - a reference whose target `@id` falls under the `@vocab` namespace stays a
+///   full IRI on output (the #1280 guarantee), even though `@vocab` is active.
+#[tokio::test]
+async fn base_and_vocab_each_govern_their_position() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/vocab-id:base-vocab");
+
+    // Insert: a relative @id (→ @base), bare @type/predicates (→ @vocab), and a
+    // reference whose @id is written under the @vocab namespace (via `v:`).
+    let insert = json!({
+        "@context": {
+            "@base": "https://flur.ee/base/",
+            "@vocab": "https://flur.ee/vocab/",
+            "v": "https://flur.ee/vocab/"
+        },
+        "@graph": [
+            {
+                "@id": "alice",
+                "@type": "Person",
+                "name": "Alice",
+                "knows": {"@id": "v:bob"}
+            }
+        ]
+    });
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert")
+        .ledger;
+
+    // Query back under the same @base + @vocab.
+    let query = json!({
+        "@context": {
+            "@base": "https://flur.ee/base/",
+            "@vocab": "https://flur.ee/vocab/"
+        },
+        "where": {"@id": "?s", "@type": "Person"},
+        "select": {"?s": ["*"]}
+    });
+    let result = support::query_jsonld_formatted(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let row = result.as_array().and_then(|a| a.first()).expect("one row");
+
+    // @id is governed by @base → relative form (NOT shortened by @vocab).
+    assert_eq!(
+        row.get("@id").and_then(JsonValue::as_str),
+        Some("alice"),
+        "@id should compact via @base, not @vocab: {result:#}"
+    );
+    // @type is governed by @vocab → bare term.
+    assert_eq!(
+        row.get("@type").and_then(JsonValue::as_str),
+        Some("Person"),
+        "@type should compact via @vocab: {result:#}"
+    );
+    // Predicate key is governed by @vocab → bare term.
+    assert_eq!(
+        row.get("name").and_then(JsonValue::as_str),
+        Some("Alice"),
+        "predicate key should compact via @vocab: {result:#}"
+    );
+    // The reference's @id falls under the @vocab namespace, yet must remain a
+    // full IRI — @vocab must not shorten a node identifier (#1280).
+    assert_eq!(
+        row.get("knows")
+            .and_then(|k| k.get("@id"))
+            .and_then(JsonValue::as_str),
+        Some("https://flur.ee/vocab/bob"),
+        "an @id under @vocab must not collapse to a bare term: {result:#}"
+    );
+
+    // Insert-side check: re-query with explicit prefixes to confirm the stored
+    // IRIs expanded correctly — `alice` against @base, `Person` against @vocab.
+    let prefixed = json!({
+        "@context": {
+            "base": "https://flur.ee/base/",
+            "v": "https://flur.ee/vocab/"
+        },
+        "where": {"@id": "?s", "@type": "v:Person"},
+        "select": {"?s": ["@id"]}
+    });
+    let result2 = support::query_jsonld_formatted(&fluree, &ledger, &prefixed)
+        .await
+        .expect("prefixed query");
+    assert_eq!(
+        result2
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|r| r.get("@id"))
+            .and_then(JsonValue::as_str),
+        Some("base:alice"),
+        "stored @id should be https://flur.ee/base/alice (resolved via @base on insert): {result2:#}"
+    );
+}
+
+/// JSON-LD `@vocab: ""` sets the vocabulary mapping to `@base`. Bare
+/// `@type`/predicates then expand against `@base` on insert and must
+/// round-trip back to bare terms on output, while the `@id` stays a (matching)
+/// base-relative form.
+#[tokio::test]
+async fn vocab_empty_string_maps_to_base() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/vocab-id:vocab-empty");
+
+    let insert = json!({
+        "@context": {"@base": "https://flur.ee/ledger/", "@vocab": ""},
+        "@graph": [
+            {"@id": "carol", "@type": "Member", "label": "Carol"}
+        ]
+    });
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert")
+        .ledger;
+
+    // Round-trip under the same @vocab:"" context.
+    let query = json!({
+        "@context": {"@base": "https://flur.ee/ledger/", "@vocab": ""},
+        "where": {"@id": "?s", "@type": "Member"},
+        "select": {"?s": ["*"]}
+    });
+    let result = support::query_jsonld_formatted(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    assert_eq!(
+        result,
+        json!([{"@id": "carol", "@type": "Member", "label": "Carol"}]),
+        "@vocab:\"\" should map to @base so the row round-trips: {result:#}"
+    );
+
+    // Confirm the stored IRIs are base-resolved by reading them through an
+    // explicit prefix: both `carol` and `Member` live under the ledger base.
+    let prefixed = json!({
+        "@context": {"led": "https://flur.ee/ledger/"},
+        "where": {"@id": "?s", "@type": "led:Member"},
+        "select": {"?s": ["@id"]}
+    });
+    let result2 = support::query_jsonld_formatted(&fluree, &ledger, &prefixed)
+        .await
+        .expect("prefixed query");
+    assert_eq!(
+        result2
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|r| r.get("@id"))
+            .and_then(JsonValue::as_str),
+        Some("led:carol"),
+        "@id/@type under @vocab:\"\" should resolve against @base: {result2:#}"
+    );
+}


### PR DESCRIPTION
## Summary

Per JSON-LD 1.1, `@vocab` governs only property names, `@type` values, and `@type: @vocab` term values — it must not shorten node identifiers. The result formatters were compacting `@id` positions through the `@vocab` path, so with a query `@context` of `{"@vocab": "http://example.org/lists/"}` an `@id` of `http://example.org/lists/summer` was emitted as the bare term `"summer"`, which a conformant processor re-resolves against `@base`, not `@vocab`.

## Changes

- Add `IriCompactor::compact_id_sid` (decode then `@id`-position compaction: `@base` + explicit prefixes only, never `@vocab`).
- Route every `@id` / node-reference output site through the `compact_id_*` path:
  - `hydration.rs`: root `@id`, `expand_ref` bare-`@id` fallback, nested-ref `@id`, reverse-value `@id`, and the defensive Ref-in-literal `@id` fallbacks
  - `jsonld.rs`: flat-select `Binding::Sid` / `IriMatch`
  - `typed.rs`: `Binding::Sid` / `IriMatch`
  - `sparql.rs`: SPARQL JSON `uri` value (a `uri` is a node identifier too)
- Predicate keys, `@type` values, datatype `@type`, and reverse-predicate keys keep the `@vocab` path. `construct.rs` was already correct; `agent_json.rs` inherits the fix via its `jsonld` delegation.

## Behavior preserved

`compact_vocab` intentionally keeps `@base` as a fallback vocabulary so a bare `@type`/predicate in an `@base`-only context round-trips — unchanged. `@vocab: ""` still maps the vocabulary to `@base`.

## Tests & docs

- Unit tests (`iri`/`jsonld`/`typed`) plus an integration suite covering the hydration root and nested `@id`, flat-select references, combined `@base`+`@vocab` separation, and the `@vocab: ""` → `@base` round-trip.
- Documented the `@vocab`/`@base` compaction rules in `docs/concepts/iri-and-context.md`.

Closes: #1280