### PR TITLE
feat: unify subquery execution with the top-level query pipeline

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -150,8 +150,19 @@ WHERE {
 - `401 Unauthorized` - Authentication required
 - `403 Forbidden` - Not authorized for this ledger
 - `404 Not Found` - Ledger not found
+- `409 Conflict` - Optimistic-concurrency conflict that survived the server's
+  bounded reconcile-and-retry (rare; safe to retry the request)
 - `413 Payload Too Large` - Transaction exceeds size limit
 - `500 Internal Server Error` - Server error
+
+**Concurrency:** Writes to a single ledger are serialized by a per-ledger write
+lock (concurrent writes to *different* ledgers proceed in parallel). When a
+transaction is lowered/sequenced against a snapshot that is no longer the head
+by commit time — two writers racing on a first-time namespace code, or a cached
+writer state that fell behind the durable head — the server reconciles the
+cached state to the current head and re-tries (bounded, up to 16 attempts). A
+`409 Conflict` is returned only if the retry budget is exhausted; clients should
+treat it as retryable (distinct from a `400` bad request).
 
 **Examples:**
 

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -57,6 +57,46 @@ pub fn default_reindex_max_bytes() -> usize {
     DEFAULT_REINDEX_MAX_BYTES_FALLBACK
 }
 
+/// Fraction of system RAM used as the startup index-warming budget.
+///
+/// Warming touches forward-dictionary file pages into the OS page cache.
+/// Beyond this fraction, touching new pages would evict pages we just warmed
+/// (the page cache is finite), so warming stops once cumulative touched bytes
+/// reach this budget. Page-cache pages are clean and reclaimable, so two-thirds
+/// is a soft target that still leaves the OS room to back the heap, the leaflet
+/// cache, and in-flight requests.
+const WARM_BUDGET_NUMERATOR: u64 = 2;
+const WARM_BUDGET_DENOMINATOR: u64 = 3;
+
+/// Fallback warming budget when RAM detection is unavailable (WASM, sandbox).
+pub const DEFAULT_WARM_BUDGET_BYTES_FALLBACK: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
+
+/// Startup index-warming byte budget: ~2/3 of detected system RAM.
+///
+/// Returns [`DEFAULT_WARM_BUDGET_BYTES_FALLBACK`] when RAM detection is
+/// unavailable. Used to cap how many forward-dictionary bytes the background
+/// warmer touches so it never evicts the pages it just warmed.
+#[cfg(feature = "native")]
+pub fn warm_budget_bytes() -> u64 {
+    use sysinfo::{MemoryRefreshKind, System};
+
+    let mut sys = System::new();
+    sys.refresh_memory_specifics(MemoryRefreshKind::everything());
+
+    let total_memory_bytes = sys.total_memory();
+    if total_memory_bytes == 0 {
+        return DEFAULT_WARM_BUDGET_BYTES_FALLBACK;
+    }
+
+    (total_memory_bytes / WARM_BUDGET_DENOMINATOR).saturating_mul(WARM_BUDGET_NUMERATOR)
+}
+
+/// Startup index-warming byte budget (WASM/non-native fallback).
+#[cfg(not(feature = "native"))]
+pub fn warm_budget_bytes() -> u64 {
+    DEFAULT_WARM_BUDGET_BYTES_FALLBACK
+}
+
 /// Canonical default `IndexConfig` for API-layer callers.
 ///
 /// Combines [`DEFAULT_REINDEX_MIN_BYTES`] with [`default_reindex_max_bytes`]

--- a/fluree-db-api/src/tx_builder.rs
+++ b/fluree-db-api/src/tx_builder.rs
@@ -16,7 +16,7 @@
 use serde_json::Value as JsonValue;
 
 use crate::error::{BuilderError, BuilderErrors};
-use crate::ledger_manager::LedgerHandle;
+use crate::ledger_manager::{LedgerHandle, RefreshOpts};
 use crate::tx::{IndexingMode, IndexingStatus, StageResult, TransactResult, TransactResultRef};
 use crate::{
     ApiError, Fluree, PolicyContext, Result, TrackedErrorResponse, TrackedTransactionInput,
@@ -25,9 +25,26 @@ use crate::{
 use fluree_db_core::{ContentId, ContentKind};
 use fluree_db_ledger::{IndexConfig, LedgerState, StagedLedger};
 use fluree_db_transact::{
-    parse_trig_phase1, CommitOpts, NamedGraphBlock, NamespaceRegistry, RawTrigMeta, Txn, TxnOpts,
-    TxnType,
+    parse_trig_phase1, CommitOpts, NamedGraphBlock, NamespaceRegistry, RawTrigMeta, TransactError,
+    Txn, TxnOpts, TxnType,
 };
+
+/// Optimistic-concurrency conflicts that are resolved by reconciling the cached
+/// writer state to the current head and re-staging.
+///
+/// A `CommitConflict` / `PublishLostRace` from `commit_staged` means the cached
+/// in-memory `LedgerState` no longer matches the durable nameservice head —
+/// either another writer advanced it, or a prior commit published but a
+/// post-publish bookkeeping step stranded the cache behind the head. Both heal
+/// by `refresh()`-ing to the head and re-staging against fresh state.
+fn is_retryable_commit_conflict(e: &ApiError) -> bool {
+    matches!(
+        e,
+        ApiError::Transact(
+            TransactError::CommitConflict { .. } | TransactError::PublishLostRace { .. }
+        )
+    )
+}
 
 // ============================================================================
 // TransactOperation (private)
@@ -889,9 +906,36 @@ pub(crate) async fn commit_with_handle(
                     base,
                 )
             } else {
-                fluree
+                match fluree
                     .commit_staged(view, ns_registry, &index_config, commit_opts)
-                    .await?
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // The fast path (pre-built Txn / policy'd staging) cannot
+                        // retry in place — its inputs are already consumed. But if
+                        // the cached writer state fell behind the durable head
+                        // (e.g. a prior commit published but a post-publish step
+                        // stranded the cache), reconcile it to the head before
+                        // returning so a subsequent request is not permanently
+                        // wedged. Release the write lock first — `refresh`
+                        // re-acquires it. (SPARQL UPDATE additionally retries at
+                        // the route layer once the cache is healed.)
+                        if is_retryable_commit_conflict(&e) {
+                            drop(write_guard);
+                            if let Err(refresh_err) = fluree
+                                .refresh(handle.ledger_id(), RefreshOpts::default())
+                                .await
+                            {
+                                tracing::warn!(
+                                    error = %refresh_err,
+                                    "refresh after fast-path commit conflict failed"
+                                );
+                            }
+                        }
+                        return Err(e);
+                    }
+                }
             };
 
         // Compute indexing status
@@ -1075,9 +1119,36 @@ pub(crate) async fn commit_with_handle(
             });
         }
 
-        let (receipt, mut new_state) = fluree
+        let (receipt, mut new_state) = match fluree
             .commit_staged(view, ns_registry, &index_config, commit_opts)
-            .await?;
+            .await
+        {
+            Ok(v) => v,
+            Err(e) if _attempt + 1 < MAX_RETRIES && is_retryable_commit_conflict(&e) => {
+                // The cached writer state no longer matches the durable head.
+                // Release the write lock, reconcile the cache to the head
+                // (`refresh` applies the missing commit(s) incrementally and
+                // re-acquires the write lock internally — hence the explicit
+                // drop here), then loop to re-stage against the fresh state.
+                drop(write_guard);
+                tracing::warn!(
+                    attempt = _attempt,
+                    error = %e,
+                    "commit conflict; reconciling cached state and retrying"
+                );
+                if let Err(refresh_err) = fluree
+                    .refresh(handle.ledger_id(), RefreshOpts::default())
+                    .await
+                {
+                    tracing::warn!(
+                        error = %refresh_err,
+                        "refresh during commit-conflict retry failed; retrying anyway"
+                    );
+                }
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
 
         let indexing_status = IndexingStatus {
             enabled: fluree.indexing_mode.is_enabled(),

--- a/fluree-db-api/tests/it_concurrent_update_reconcile.rs
+++ b/fluree-db-api/tests/it_concurrent_update_reconcile.rs
@@ -1,0 +1,97 @@
+//! Regression: a cached writer whose in-memory `LedgerState` has fallen behind
+//! the durable nameservice head must RECONCILE and commit, not wedge.
+//!
+//! Background (see memory `concurrent_update_wedge_and_ns_race`): a transaction
+//! commits by CAS-publishing the new head to the nameservice and then updating
+//! the cached in-memory state. If the cache ever lags the durable head (e.g. a
+//! prior commit published but a post-publish bookkeeping step failed, or — as
+//! modelled here — a *second* connection advanced the shared head), then
+//! `verify_sequencing` returns `CommitConflict { expected_t, head_t }` with
+//! `expected_t > head_t`. Before the fix this repeated forever (permanent
+//! wedge). After the fix the writer `refresh()`-es the cache to the head and
+//! retries, committing successfully.
+//!
+//! We model the lag with two independent `Fluree` connections over the SAME
+//! on-disk storage + nameservice: connection B caches the ledger, connection A
+//! advances the shared head, then B writes through its now-stale cached handle.
+//!
+//! Run with:
+//!   cargo test -p fluree-db-api --test it_concurrent_update_reconcile --features native
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+
+#[tokio::test]
+async fn stale_cached_writer_reconciles_instead_of_wedging() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+
+    let ledger_id = "it/cu-reconcile:main";
+
+    // --- Connection A: owns the durable head (no cache reliance) ---
+    let fa = FlureeBuilder::file(path.clone()).build().expect("build A");
+
+    // Genesis + first commit (t=1) via the owned path so it publishes to the
+    // shared on-disk nameservice.
+    let l0 = fa.create_ledger(ledger_id).await.expect("create");
+    let tx_a1 = json!({
+        "@context": { "ex": "http://example.org/" },
+        "@graph": [{ "@id": "ex:a1", "ex:name": "a1" }]
+    });
+    let ra1 = fa.insert(l0, &tx_a1).await.expect("A insert t=1");
+    assert_eq!(ra1.receipt.t, 1, "first commit is t=1");
+    let la1 = ra1.ledger;
+
+    // --- Connection B: cache the ledger at t=1 (independent manager) ---
+    let fb = FlureeBuilder::file(path.clone()).build().expect("build B");
+    let hb = fb.ledger_cached(ledger_id).await.expect("B cache");
+    assert_eq!(hb.t().await, 1, "B cached at t=1");
+
+    // --- Connection A advances the durable head to t=2 ---
+    // B's cache is now STALE (still t=1) while the nameservice head is t=2.
+    let tx_a2 = json!({
+        "@context": { "ex": "http://example.org/" },
+        "@graph": [{ "@id": "ex:a2", "ex:name": "a2" }]
+    });
+    let ra2 = fa.insert(la1, &tx_a2).await.expect("A insert t=2");
+    assert_eq!(ra2.receipt.t, 2, "A advanced durable head to t=2");
+    assert_eq!(hb.t().await, 1, "B's cache is still behind at t=1");
+
+    // --- Connection B writes through its STALE cached handle ---
+    // The optimistic commit path hits `CommitConflict` (cache t=1 vs head t=2),
+    // reconciles via refresh (CommitCatchUp -> t=2), and retries -> commits t=3.
+    let tx_b = json!({
+        "@context": { "ex": "http://example.org/" },
+        "@graph": [{ "@id": "ex:b1", "ex:name": "b1" }]
+    });
+    let rb = fb
+        .stage(&hb)
+        .insert(&tx_b)
+        .execute()
+        .await
+        .expect("stale-cache writer must reconcile and commit, not wedge");
+    assert_eq!(
+        rb.receipt.t, 3,
+        "reconciled commit lands at t=3 (after catching up to the t=2 head)"
+    );
+
+    // The reconcile must have advanced B's cached state to the new head.
+    assert_eq!(hb.t().await, 3, "B's cache reflects the committed head t=3");
+
+    // A subsequent write through the same handle commits cleanly (no wedge).
+    let tx_b2 = json!({
+        "@context": { "ex": "http://example.org/" },
+        "@graph": [{ "@id": "ex:b2", "ex:name": "b2" }]
+    });
+    let rb2 = fb
+        .stage(&hb)
+        .insert(&tx_b2)
+        .execute()
+        .await
+        .expect("subsequent write after reconcile must succeed");
+    assert_eq!(rb2.receipt.t, 4, "next write proceeds normally at t=4");
+}

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -1322,6 +1322,100 @@ async fn sparql_select_unbound_variable_no_grouping() {
 }
 
 #[tokio::test]
+async fn sparql_filter_equality_equijoin_results_preserved() {
+    // Performance optimization (benchmark-db perf #1, BSBM BI-2): FILTER(?x = ?y)
+    // between two ref-valued triple objects folds into an equijoin (var unify).
+    // This verifies the rewrite preserves results — the shared-feature count per
+    // product, the BI-2 shape.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "features:main");
+    let insert = json!({
+        "@context": { "ex": "http://example.org/ns/" },
+        "@graph": [
+            {"@id":"ex:p1","ex:feature":[{"@id":"ex:fa"},{"@id":"ex:fb"},{"@id":"ex:fc"}]},
+            {"@id":"ex:p2","ex:feature":[{"@id":"ex:fa"},{"@id":"ex:fb"}]},
+            {"@id":"ex:p3","ex:feature":[{"@id":"ex:fc"},{"@id":"ex:fd"}]},
+            {"@id":"ex:p4","ex:feature":[{"@id":"ex:fx"}]}
+        ]
+    });
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert+commit should succeed")
+        .ledger;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?other (COUNT(?f2) AS ?shared)
+        WHERE {
+          ex:p1 ex:feature ?f1 .
+          ?other ex:feature ?f2 .
+          FILTER(?f1 = ?f2)
+        }
+        GROUP BY ?other
+    ";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // Shared features with p1's {fa,fb,fc}: p1 itself 3, p2 {fa,fb}=2, p3 {fc}=1;
+    // p4 ({fx}) shares none, so it never binds ?f2 and is absent.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:p1", 3], ["ex:p2", 2], ["ex:p3", 1]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_filter_equality_equijoin_inside_subquery() {
+    // The exact BSBM BI-2 shape: the FILTER(?f1 = ?f2) equijoin lives inside a
+    // grouped sub-SELECT. The fold must recurse into the subquery scope and
+    // preserve results (the aggregate COUNT(?f2) follows the unified variable).
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "features:sub");
+    let insert = json!({
+        "@context": { "ex": "http://example.org/ns/" },
+        "@graph": [
+            {"@id":"ex:p1","ex:feature":[{"@id":"ex:fa"},{"@id":"ex:fb"},{"@id":"ex:fc"}]},
+            {"@id":"ex:p2","ex:feature":[{"@id":"ex:fa"},{"@id":"ex:fb"}]},
+            {"@id":"ex:p3","ex:feature":[{"@id":"ex:fc"},{"@id":"ex:fd"}]}
+        ]
+    });
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert+commit should succeed")
+        .ledger;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?other ?shared {
+          { SELECT ?other (COUNT(?f2) AS ?shared)
+            {
+              ex:p1 ex:feature ?f1 .
+              ?other ex:feature ?f2 .
+              FILTER(?f1 = ?f2)
+            }
+            GROUP BY ?other }
+        }
+    ";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:p1", 3], ["ex:p2", 2], ["ex:p3", 1]]))
+    );
+}
+
+#[tokio::test]
 async fn sparql_delete_data_removes_specified_triples() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -864,7 +864,10 @@ async fn sparql_subquery_aggregate_order_by_with_limit() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     // Counts: jbob 7, jdoe 4, bbob 1; DESC top-1 = jbob.
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["jbob", 7]])));
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jbob", 7]]))
+    );
 }
 
 #[tokio::test]
@@ -918,7 +921,10 @@ async fn sparql_subquery_having() {
         .unwrap();
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     // Counts: jbob 7 (>5), jdoe 4, bbob 1 → only jbob survives HAVING.
-    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["jbob", 7]])));
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jbob", 7]]))
+    );
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -1256,6 +1256,72 @@ async fn sparql_aggregate_over_expression_in_joined_subqueries() {
 }
 
 #[tokio::test]
+async fn sparql_group_by_unbound_variable() {
+    // SPARQL 1.1 §11.4 / §18.5 (benchmark-db bug #5, BSBM BI-4): GROUP BY (and
+    // SELECT) of a variable the pattern never binds is legal — the variable is
+    // unbound, so all solutions share it and collapse to one group per the bound
+    // keys. Previously this failed at plan time ("GROUP BY variable not found in
+    // query schema").
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    // ?country is never bound in the WHERE.
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?country ?handle (COUNT(?favNum) AS ?c)
+        WHERE { ?p person:handle ?handle ; person:favNums ?favNum }
+        GROUP BY ?country ?handle
+    ";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("GROUP BY an unbound variable is legal")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // ?country unbound (null) for every group; counts: jdoe 4, bbob 1, jbob 7.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            [null, "jdoe", 4],
+            [null, "bbob", 1],
+            [null, "jbob", 7]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_select_unbound_variable_no_grouping() {
+    // Companion to the GROUP BY case: selecting a never-bound variable in an
+    // ungrouped query reports it unbound rather than erroring.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?missing
+        WHERE { ?p person:handle ?handle }
+    ";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("selecting an unbound variable is legal")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // Each handle (column order ?handle ?missing) with ?missing unbound (null).
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["jdoe", null],
+            ["bbob", null],
+            ["jbob", null],
+            ["dankeshön", null]
+        ]))
+    );
+}
+
+#[tokio::test]
 async fn sparql_delete_data_removes_specified_triples() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -1213,6 +1213,43 @@ async fn sparql_subquery_group_concat_sum_respects_inner_offset() {
 }
 
 #[tokio::test]
+async fn sparql_aggregate_over_expression_in_joined_subqueries() {
+    // Regression (benchmark-db bug #4, BSBM BI-5): an aggregate over a COMPUTED
+    // EXPRESSION (`AVG(xsd:float(?n))`) inside a grouped sub-SELECT used to fail
+    // when two such sub-SELECTs are joined — the shared aggregate-input
+    // expression was CSE-deduplicated across subquery scopes, leaving the second
+    // subquery's synthetic input var unbound. Each subquery must get its own.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SELECT ?handle {
+          { SELECT ?handle (AVG(xsd:float(?favNum)) AS ?x)
+            WHERE { ?p person:handle ?handle ; person:favNums ?favNum }
+            GROUP BY ?handle }
+          { SELECT ?handle (AVG(xsd:float(?favNum)) AS ?y)
+            WHERE { ?p2 person:handle ?handle ; person:favNums ?favNum }
+            GROUP BY ?handle }
+        }
+    ";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("aggregate-over-expression in joined sub-SELECTs should not error")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // The two grouped sub-SELECTs join on ?handle; handles with favNums are
+    // jdoe, bbob, jbob (dankeshön has none).
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jdoe"], ["bbob"], ["jbob"]]))
+    );
+}
+
+#[tokio::test]
 async fn sparql_delete_data_removes_specified_triples() {
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -803,11 +803,22 @@ async fn sparql_order_by_expression_over_grouped_var_errors_cleanly() {
     );
 }
 
+// =============================================================================
+// Subquery / top-level modifier unification (subquery-unification proposal).
+//
+// After unification, a `{ SELECT … }` subquery inherits the full top-level
+// solution-modifier tail (HAVING, post-aggregation binds, expression/aggregate
+// ORDER BY, ORDER-BY-before-PROJECT, sort-var validation) via the shared
+// `apply_solution_modifiers`. These mirror the top-level ORDER BY / aggregate
+// tests above. LIMIT inside the subquery makes the returned *set* reflect the
+// inner ordering, so `normalize_rows` (set comparison) stays order-robust.
+// =============================================================================
+
 #[tokio::test]
-async fn sparql_subquery_expression_order_by_errors_cleanly() {
-    // Regression (P2): expression ORDER BY inside a subquery must be rejected
-    // rather than silently mis-sorting by a grabbed variable. (Bare-variable
-    // subquery ORDER BY still works.)
+async fn sparql_subquery_expression_order_by_with_limit() {
+    // Pattern 1: expression ORDER BY inside a subquery — previously REJECTED at
+    // lowering, now works. `(0 - ?favNum)` ascending = ?favNum descending; the
+    // synthetic order-bind key is evaluated and sorted before project/merge.
     assert_index_defaults();
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_people(&fluree, "people:main").await;
@@ -817,15 +828,388 @@ async fn sparql_subquery_expression_order_by_errors_cleanly() {
         SELECT ?favNum
         WHERE {
           { SELECT ?favNum WHERE { ?person person:favNums ?favNum }
-            ORDER BY (0 - ?favNum) }
+            ORDER BY (0 - ?favNum) LIMIT 1 }
         }
     ";
 
-    let result = support::query_sparql(&fluree, &ledger, query).await;
-    assert!(
-        result.is_err(),
-        "expression ORDER BY in a subquery should error, got: {result:?}"
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Max favNum across all people is 99 (jdoe); LIMIT 1 keeps the largest.
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[99]])));
+}
+
+#[tokio::test]
+async fn sparql_subquery_aggregate_order_by_with_limit() {
+    // Pattern 2: aggregate ORDER BY `DESC(COUNT(?favNum))` inside a subquery.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?c
+        WHERE {
+          { SELECT ?handle (COUNT(?favNum) AS ?c)
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle
+            ORDER BY DESC(COUNT(?favNum))
+            LIMIT 1 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Counts: jbob 7, jdoe 4, bbob 1; DESC top-1 = jbob.
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["jbob", 7]])));
+}
+
+#[tokio::test]
+async fn sparql_subquery_aggregate_order_by_not_selected() {
+    // Pattern 3: aggregate ORDER BY where the aggregate is NOT in the SELECT.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle
+        WHERE {
+          { SELECT ?handle
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle
+            ORDER BY DESC(COUNT(?favNum))
+            LIMIT 1 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Sorted by an aggregate not projected; top-1 by count = jbob.
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["jbob"]])));
+}
+
+#[tokio::test]
+async fn sparql_subquery_having() {
+    // Pattern 4: HAVING inside a subquery — previously a parse error, then a
+    // dropped clause. Now lowered and applied.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?c
+        WHERE {
+          { SELECT ?handle (COUNT(?favNum) AS ?c)
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle
+            HAVING (COUNT(?favNum) > 5) }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Counts: jbob 7 (>5), jdoe 4, bbob 1 → only jbob survives HAVING.
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["jbob", 7]])));
+}
+
+#[tokio::test]
+async fn sparql_subquery_post_aggregation_bind() {
+    // Pattern 5: post-aggregation SELECT expression inside a subquery —
+    // previously silently dropped. `(?c + 100 AS ?bumped)` references the
+    // aggregate alias `?c`, so it rides as a post-aggregation bind.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?bumped
+        WHERE {
+          { SELECT ?handle (COUNT(?favNum) AS ?c) (?c + 100 AS ?bumped)
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Counts jbob 7, jdoe 4, bbob 1 → bumped = count + 100.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jbob", 107], ["jdoe", 104], ["bbob", 101]]))
     );
+}
+
+#[tokio::test]
+async fn sparql_subquery_order_by_non_projected_var() {
+    // Pattern 6: ORDER BY a variable NOT in the subquery SELECT — previously
+    // silently unordered (sort ran after project, so the key was gone). Now the
+    // sort runs before project, so LIMIT 1 picks the max-?favNum row.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle
+        WHERE {
+          { SELECT ?handle
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            ORDER BY DESC(?favNum) LIMIT 1 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Max favNum is 99 (jdoe); sort-before-project makes LIMIT 1 deterministic.
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([["jdoe"]])));
+}
+
+#[tokio::test]
+async fn sparql_subquery_order_by_select_alias_expression() {
+    // Pattern 7: ORDER BY a select-expression alias inside a subquery.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?s
+        WHERE {
+          { SELECT ?handle (?favNum + 1000 AS ?s)
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            ORDER BY DESC(?s) LIMIT 1 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // ?s = favNum + 1000; max favNum 99 (jdoe) → s = 1099.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jdoe", 1099]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_subquery_full_modifier_stack() {
+    // Pattern 8: GROUP BY + HAVING + aggregate ORDER BY + LIMIT in one subquery.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?c
+        WHERE {
+          { SELECT ?handle (COUNT(?favNum) AS ?c)
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle
+            HAVING (COUNT(?favNum) > 0)
+            ORDER BY DESC(COUNT(?favNum))
+            LIMIT 2 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Counts jbob 7, jdoe 4, bbob 1; HAVING>0 keeps all; DESC top-2 = jbob, jdoe.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jbob", 7], ["jdoe", 4]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_correlated_subquery_group_by_aggregate_order_by() {
+    // Pattern 9: correlated subquery + GROUP BY + aggregate ORDER BY, with the
+    // per-row correlation preserved. The outer binds ?handle; the subquery
+    // correlates on ?handle (it appears in the subquery SELECT) and counts that
+    // person's favNums.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?c
+        WHERE {
+          ?person person:handle ?handle .
+          { SELECT ?handle (COUNT(?favNum) AS ?c)
+            WHERE { ?p2 person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle
+            ORDER BY DESC(COUNT(?favNum)) }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Each handle with its own favNum count; dankeshön (no favNums) drops out.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jbob", 7], ["jdoe", 4], ["bbob", 1]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_subquery_distinct_order_by_limit_reorder() {
+    // Pipeline-reorder safety: `SELECT DISTINCT ?x … ORDER BY DESC(?x) LIMIT k`
+    // (ORDER BY references only projected vars) takes the project-distinct-
+    // before-sort path. It must still yield the top-k distinct values.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?favNum
+        WHERE {
+          { SELECT DISTINCT ?favNum
+            WHERE { ?person person:favNums ?favNum }
+            ORDER BY DESC(?favNum) LIMIT 3 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Distinct favNums {0,3,5,6,7,8,9,23,42,99}; DESC top-3 = 99, 42, 23.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([[99], [42], [23]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_subquery_having_eliminates_all_groups() {
+    // HAVING inside a subquery that NO group satisfies must yield an empty
+    // result — proving the clause actually filters rather than passing through.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?c
+        WHERE {
+          { SELECT ?handle (COUNT(?favNum) AS ?c)
+            WHERE { ?person person:handle ?handle ; person:favNums ?favNum . }
+            GROUP BY ?handle
+            HAVING (COUNT(?favNum) > 100) }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Max count is 7 (jbob); none exceed 100 → every group removed.
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([])));
+}
+
+#[tokio::test]
+async fn sparql_correlated_subquery_order_by_limit_per_row() {
+    // Correlated subquery where the inner ORDER BY + LIMIT genuinely matter:
+    // for each outer ?person, pick that person's MAX favNum via
+    // `ORDER BY DESC(?top) LIMIT 1`. Proves per-row correlation seeding is
+    // preserved AND the inner sort/limit run before the merge-back.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let query = r"
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?handle ?top
+        WHERE {
+          ?person person:handle ?handle .
+          { SELECT ?person ?top
+            WHERE { ?person person:favNums ?top }
+            ORDER BY DESC(?top)
+            LIMIT 1 }
+        }
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Per-person max favNum: jdoe 99, bbob 23, jbob 9; dankeshön (no favNums) drops.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["jdoe", 99], ["bbob", 23], ["jbob", 9]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_subquery_group_concat_sum_respects_inner_offset() {
+    // Regression: the fused SUM(STRLEN(GROUP_CONCAT(..))) fast path sums over
+    // EVERY group and ignores the inner subquery's slice/distinct modifiers, so
+    // it must decline when any are present. Here OFFSET skips all groups, so the
+    // correct answer is the empty/zero sum — NOT the all-groups sum the fast path
+    // would otherwise return.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    // Baseline: no inner modifier → SUM of STRLEN(GROUP_CONCAT) over all groups.
+    // Per-group lengths (separator=""): jdoe "374299"=6, bbob "23"=2,
+    // jbob "8675309"=7 → 15 (STRLEN is order-invariant).
+    let all = r#"
+        PREFIX person: <http://example.org/Person#>
+        SELECT (SUM(STRLEN(?cat)) AS ?total)
+        WHERE {
+          { SELECT ?person (GROUP_CONCAT(?favNum; SEPARATOR="") AS ?cat)
+            WHERE { ?person person:favNums ?favNum }
+            GROUP BY ?person }
+        }
+    "#;
+    let all_rows = support::query_sparql(&fluree, &ledger, all)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(all_rows, json!([[15]]));
+
+    // Inner OFFSET past every group → empty subquery → sum over nothing (0).
+    let offset = r#"
+        PREFIX person: <http://example.org/Person#>
+        SELECT (SUM(STRLEN(?cat)) AS ?total)
+        WHERE {
+          { SELECT ?person (GROUP_CONCAT(?favNum; SEPARATOR="") AS ?cat)
+            WHERE { ?person person:favNums ?favNum }
+            GROUP BY ?person
+            OFFSET 100 }
+        }
+    "#;
+    let offset_rows = support::query_sparql(&fluree, &ledger, offset)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // With the guard, the fast path declines and the generic pipeline honors the
+    // OFFSET: the subquery is empty, so SUM has nothing to add (unbound). Without
+    // the guard this would wrongly equal the all-groups sum (15).
+    assert_eq!(offset_rows, json!([[null]]));
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_subquery.rs
+++ b/fluree-db-api/tests/it_query_subquery.rs
@@ -460,3 +460,87 @@ async fn subquery_with_values_filters_results() {
         normalize_rows(&json!(["ex:alice", "ex:liam"]))
     );
 }
+
+#[tokio::test]
+async fn subquery_having_groups_jsonld() {
+    // HAVING inside a JSON-LD subquery: counts favNums per name, keeps groups
+    // with more than one. Exercises the unified grouping/HAVING path.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "subquery:people").await;
+    let ctx = context_ex_schema();
+
+    let q = json!({
+        "@context": ctx,
+        "select": ["?name", "?count"],
+        "where": [
+            ["query", {
+                "@context": ctx,
+                "select": ["?name", "(as (count ?favNums) ?count)"],
+                "where": [
+                    {"@id":"?s","schema:name":"?name"},
+                    {"@id":"?s","ex:favNums":"?favNums"}
+                ],
+                "groupBy": ["?name"],
+                "having": [">", ["count", "?favNums"], 1]
+            }]
+        ]
+    });
+
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    // Counts: Brian 1, Alice 3, Cam 2, Liam 2 → HAVING(count > 1) drops Brian.
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([["Alice", 3], ["Cam", 2], ["Liam", 2]]))
+    );
+}
+
+#[tokio::test]
+async fn subquery_post_aggregation_bind_jsonld() {
+    // Post-aggregation SELECT bind inside a JSON-LD subquery — previously
+    // REJECTED ("post-aggregation BINDs are not supported inside subqueries").
+    // `(as (+ ?count 100) ?bumped)` references the aggregate alias `?count`, so
+    // it now rides in the grouping's aggregation stage like a top-level query.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "subquery:people").await;
+    let ctx = context_ex_schema();
+
+    let q = json!({
+        "@context": ctx,
+        "select": ["?name", "?bumped"],
+        "where": [
+            ["query", {
+                "@context": ctx,
+                "select": [
+                    "?name",
+                    "(as (count ?favNums) ?count)",
+                    "(as (+ ?count 100) ?bumped)"
+                ],
+                "where": [
+                    {"@id":"?s","schema:name":"?name"},
+                    {"@id":"?s","ex:favNums":"?favNums"}
+                ],
+                "groupBy": ["?name"]
+            }]
+        ]
+    });
+
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    // Counts: Brian 1, Alice 3, Cam 2, Liam 2 → bumped = count + 100.
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([
+            ["Brian", 101],
+            ["Alice", 103],
+            ["Cam", 102],
+            ["Liam", 102]
+        ]))
+    );
+}

--- a/fluree-db-binary-index/src/dict/pack_reader.rs
+++ b/fluree-db-binary-index/src/dict/pack_reader.rs
@@ -238,6 +238,36 @@ impl ForwardPackReader {
         self.packs.len()
     }
 
+    /// Pre-warm forward-dict pack pages into the OS page cache, up to
+    /// `budget_bytes` total across this reader's packs. Returns the number of
+    /// bytes touched.
+    ///
+    /// Locally-mmapped packs fault their pages in lazily (on first query); this
+    /// touches one byte per page so the first dictionary lookups after startup
+    /// don't pay that cold-fault I/O. Lazy (remote, not-yet-fetched) packs are
+    /// fetched + cached + mmapped first. A pack larger than the remaining budget
+    /// is partially warmed; warming stops once the budget is exhausted.
+    ///
+    /// This blocks on page faults / sequential reads — call it from a blocking
+    /// context (e.g. `tokio::task::spawn_blocking`), never on the hot async path.
+    /// Warming is best-effort: a pack that fails to load is skipped, never fatal.
+    pub fn prewarm(&self, budget_bytes: u64) -> u64 {
+        let mut warmed: u64 = 0;
+        for pack in &self.packs {
+            if warmed >= budget_bytes {
+                break;
+            }
+            let bytes = match pack.ensure_loaded(self.load_ctx.as_ref()) {
+                Ok((_meta, bytes)) => bytes,
+                Err(_) => continue,
+            };
+            let remaining = budget_bytes - warmed;
+            let take = (bytes.len() as u64).min(remaining) as usize;
+            warmed += touch_pages(&bytes[..take]);
+        }
+        warmed
+    }
+
     /// Hot-path: append value bytes to `out`. Returns `true` if the ID was found.
     ///
     /// Zero-alloc steady state: uses pre-parsed page directory for binary search,
@@ -489,6 +519,29 @@ fn mmap_file(path: &Path) -> io::Result<memmap2::Mmap> {
     unsafe { memmap2::Mmap::map(&file) }
 }
 
+/// Page size used to stride `touch_pages`. 4 KiB is the smallest common page
+/// size; reading one byte per 4 KiB faults every page on hosts with larger
+/// pages too (just with redundant in-page reads), so warming stays correct
+/// without querying the OS page size.
+const WARM_PAGE_STRIDE: usize = 4096;
+
+/// Fault `bytes` resident by reading one byte per page, returning the number of
+/// bytes covered (i.e. `bytes.len()`).
+///
+/// For an mmap-backed slice this pulls each page into the OS page cache; for an
+/// already-resident in-memory slice it is a cheap strided read. The accumulator
+/// is fed to [`std::hint::black_box`] so the reads are not optimized away.
+fn touch_pages(bytes: &[u8]) -> u64 {
+    let mut acc: u8 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        acc ^= bytes[i];
+        i += WARM_PAGE_STRIDE;
+    }
+    std::hint::black_box(acc);
+    bytes.len() as u64
+}
+
 /// Write bytes to a cache file atomically (temp file + rename).
 ///
 /// Ensures the parent directory exists so lazy fetches succeed even if the
@@ -641,6 +694,43 @@ mod tests {
             reader.forward_lookup_str(250).unwrap(),
             Some("val_250".to_string())
         );
+    }
+
+    #[test]
+    fn test_prewarm_respects_budget() {
+        let p1 = make_pack_bytes(0, 100);
+        let p2 = make_pack_bytes(100, 100);
+        let len1 = p1.len() as u64;
+        let len2 = p2.len() as u64;
+        let total = len1 + len2;
+        assert!(
+            len1 > 2,
+            "pack must be large enough to exercise partial warming"
+        );
+
+        let reader = ForwardPackReader::from_memory(vec![
+            Arc::from(p1.into_boxed_slice()),
+            Arc::from(p2.into_boxed_slice()),
+        ])
+        .unwrap();
+
+        // Unbounded budget warms every pack fully.
+        assert_eq!(reader.prewarm(u64::MAX), total);
+
+        // Zero budget warms nothing (and never touches a pack).
+        assert_eq!(reader.prewarm(0), 0);
+
+        // Budget below the first pack partially warms just it.
+        let partial = len1 / 2;
+        assert_eq!(reader.prewarm(partial), partial);
+
+        // Budget exactly the first pack warms only the first pack (the loop
+        // breaks before the second since `warmed >= budget`).
+        assert_eq!(reader.prewarm(len1), len1);
+
+        // Budget spanning pack1 + part of pack2 stops mid-second-pack.
+        let mid = len1 + len2 / 2;
+        assert_eq!(reader.prewarm(mid), mid);
     }
 
     #[test]

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -1577,7 +1577,35 @@ impl BinaryIndexStore {
         // The V3 format uses ForwardPack readers (already mmap'd) for forward dicts
         // and CoW trees for reverse dicts. Reverse-tree leaf preloading can be
         // added when cold-start latency is observed in production.
+        //
+        // Forward-dict page warming is implemented separately in
+        // [`Self::prewarm_forward_dicts`], which the server's background warmer
+        // calls at startup.
         Ok(0)
+    }
+
+    /// Pre-warm forward-dictionary pages (string + subject packs) into the OS
+    /// page cache, up to `budget_bytes` total across all packs. Returns the
+    /// number of bytes touched.
+    ///
+    /// The index root and reverse-dict tree readers are already resident after
+    /// [`load_from_root_v6`](Self::load_from_root_v6); this targets the forward
+    /// packs, which are mmapped lazily and otherwise fault in on the first query
+    /// that resolves an IRI/string ID. String packs are warmed first (broadest
+    /// query impact), then per-namespace subject packs. Warming stops once the
+    /// budget is exhausted.
+    ///
+    /// Blocking (page faults / sequential reads) — call from a blocking context
+    /// such as `tokio::task::spawn_blocking`, never on the hot async path.
+    pub fn prewarm_forward_dicts(&self, budget_bytes: u64) -> u64 {
+        let mut warmed = self.dicts.string_forward_packs.prewarm(budget_bytes);
+        for reader in self.dicts.subject_forward_packs.values() {
+            if warmed >= budget_bytes {
+                break;
+            }
+            warmed += reader.prewarm(budget_bytes - warmed);
+        }
+        warmed
     }
 
     /// Create a `BinaryGraphView` for a specific graph (no novelty).

--- a/fluree-db-core/src/stats_view.rs
+++ b/fluree-db-core/src/stats_view.rs
@@ -35,6 +35,14 @@ pub struct StatsView {
     /// property lookups with datatype breakdown. The aggregate Sid-keyed
     /// `properties` map remains the primary source for the query planner.
     pub graph_properties: HashMap<GraphId, HashMap<RuntimePredicateId, GraphPropertyStatData>>,
+    /// Property SID -> whether every object of this property is a node/IRI ref
+    /// (all datatype tags are [`ValueTypeTag::JSON_LD_ID`]). Derived from the
+    /// current-state (novelty-merged) per-datatype breakdown. Used by the
+    /// equijoin-filter fold to soundly rewrite `FILTER(?x = ?y)` into a join
+    /// only when value-equality coincides with term-equality (true for nodes).
+    pub property_ref_only: HashMap<Sid, bool>,
+    /// Property IRI -> ref-only flag (see [`Self::property_ref_only`]).
+    pub property_ref_only_by_iri: HashMap<Arc<str>, bool>,
 }
 
 /// Per-property statistics within a graph, keyed by numeric IDs.
@@ -121,13 +129,21 @@ impl StatsView {
                 // entry.sid is (namespace_code, name) - directly usable
                 let sid = Sid::new(entry.sid.0, &entry.sid.1);
                 view.properties.insert(
-                    sid,
+                    sid.clone(),
                     PropertyStatData {
                         count: entry.count,
                         ndv_values: entry.ndv_values,
                         ndv_subjects: entry.ndv_subjects,
                     },
                 );
+                // Ref-only iff every observed object datatype is a node/IRI ref.
+                // Empty datatypes (unknown) => not provably ref-only.
+                let ref_only = !entry.datatypes.is_empty()
+                    && entry
+                        .datatypes
+                        .iter()
+                        .all(|&(dt, _)| dt == ValueTypeTag::JSON_LD_ID.as_u8());
+                view.property_ref_only.insert(sid, ref_only);
             }
         }
 
@@ -190,7 +206,27 @@ impl StatsView {
             }
         }
 
+        // Derive IRI-keyed ref-only flags.
+        for (sid, ref_only) in &view.property_ref_only {
+            if let Some(prefix) = namespace_codes.get(&sid.namespace_code) {
+                let iri: Arc<str> = Arc::from(format!("{}{}", prefix, sid.name));
+                view.property_ref_only_by_iri.insert(iri, *ref_only);
+            }
+        }
+
         view
+    }
+
+    /// Whether every object of this property (by SID) is a node/IRI ref —
+    /// i.e. value-equality coincides with term-equality. `None` when the
+    /// property is unknown to stats. See [`Self::property_ref_only`].
+    pub fn is_property_ref_only(&self, sid: &Sid) -> Option<bool> {
+        self.property_ref_only.get(sid).copied()
+    }
+
+    /// Whether every object of this property (by IRI) is a node/IRI ref.
+    pub fn is_property_ref_only_by_iri(&self, iri: &str) -> Option<bool> {
+        self.property_ref_only_by_iri.get(iri).copied()
     }
 
     /// Get property statistics by SID.

--- a/fluree-db-novelty/src/runtime_stats.rs
+++ b/fluree-db-novelty/src/runtime_stats.rs
@@ -209,6 +209,10 @@ fn assemble_fast_stats_inner(
     }
 
     let mut property_counts = build_property_counts(indexed);
+    // Per-predicate (Sid) datatype deltas from novelty, so the aggregate
+    // `PropertyStatEntry.datatypes` stays current-state-exact (not index-only).
+    // Consumed by the equijoin-filter fold's node-only soundness guard.
+    let mut property_datatype_deltas: HashMap<(u16, String), HashMap<u8, i64>> = HashMap::new();
     let mut class_data = build_class_data(indexed);
     let mut graphs = indexed.graphs.clone().unwrap_or_default();
     let mut graph_index: HashMap<GraphId, usize> = graphs
@@ -258,7 +262,12 @@ fn assemble_fast_stats_inner(
         }
 
         let sid_key = (flake.p.namespace_code, flake.p.name.to_string());
-        *property_counts.entry(sid_key).or_insert(0) += delta;
+        *property_counts.entry(sid_key.clone()).or_insert(0) += delta;
+        *property_datatype_deltas
+            .entry(sid_key)
+            .or_default()
+            .entry(runtime_datatype_tag(flake))
+            .or_insert(0) += delta;
 
         if let Some(stats_lookup) = lookup {
             if let Some(p_id) = stats_lookup.runtime_predicate_id_for_sid(&flake.p) {
@@ -285,7 +294,12 @@ fn assemble_fast_stats_inner(
         }
     }
 
-    let mut stats = finalize_stats(indexed, property_counts, class_data);
+    let mut stats = finalize_stats(
+        indexed,
+        property_counts,
+        property_datatype_deltas,
+        class_data,
+    );
     stats.flakes = (indexed.flakes as i64 + flakes_delta).max(0) as u64;
     stats.size = indexed.size + novelty.size as u64;
     if !graphs.is_empty() {
@@ -588,9 +602,30 @@ fn build_class_data(indexed: &IndexStats) -> HashMap<Sid, ClassDataMut> {
     class_data
 }
 
+/// Merge index per-datatype counts with novelty deltas, dropping any datatype
+/// whose current-state count is zero. Keeps the aggregate `datatypes` breakdown
+/// current-state-exact so a predicate that gains/loses literal values via
+/// novelty is reflected (used by the equijoin-filter fold's node-only guard).
+fn merge_property_datatypes(index: &[(u8, u64)], deltas: Option<&HashMap<u8, i64>>) -> Vec<(u8, u64)> {
+    let mut merged: HashMap<u8, i64> = index.iter().map(|&(t, c)| (t, c as i64)).collect();
+    if let Some(deltas) = deltas {
+        for (&tag, &d) in deltas {
+            *merged.entry(tag).or_insert(0) += d;
+        }
+    }
+    let mut out: Vec<(u8, u64)> = merged
+        .into_iter()
+        .filter(|&(_, c)| c > 0)
+        .map(|(t, c)| (t, c as u64))
+        .collect();
+    out.sort_by_key(|&(t, _)| t);
+    out
+}
+
 fn finalize_stats(
     indexed: &IndexStats,
     property_counts: PropertyCountMap,
+    property_datatype_deltas: HashMap<(u16, String), HashMap<u8, i64>>,
     class_data: HashMap<Sid, ClassDataMut>,
 ) -> IndexStats {
     let properties = if property_counts.is_empty() {
@@ -609,15 +644,17 @@ fn finalize_stats(
             .filter(|(_, count)| *count > 0)
             .map(|(sid, count)| {
                 let indexed_entry = indexed_props.get(&sid);
+                let datatypes = merge_property_datatypes(
+                    indexed_entry.map(|e| e.datatypes.as_slice()).unwrap_or(&[]),
+                    property_datatype_deltas.get(&sid),
+                );
                 PropertyStatEntry {
                     sid,
                     count: count.max(0) as u64,
                     ndv_values: indexed_entry.map(|e| e.ndv_values).unwrap_or(0),
                     ndv_subjects: indexed_entry.map(|e| e.ndv_subjects).unwrap_or(0),
                     last_modified_t: indexed_entry.map(|e| e.last_modified_t).unwrap_or(0),
-                    datatypes: indexed_entry
-                        .map(|e| e.datatypes.clone())
-                        .unwrap_or_default(),
+                    datatypes,
                 }
             })
             .collect();

--- a/fluree-db-novelty/src/runtime_stats.rs
+++ b/fluree-db-novelty/src/runtime_stats.rs
@@ -606,7 +606,10 @@ fn build_class_data(indexed: &IndexStats) -> HashMap<Sid, ClassDataMut> {
 /// whose current-state count is zero. Keeps the aggregate `datatypes` breakdown
 /// current-state-exact so a predicate that gains/loses literal values via
 /// novelty is reflected (used by the equijoin-filter fold's node-only guard).
-fn merge_property_datatypes(index: &[(u8, u64)], deltas: Option<&HashMap<u8, i64>>) -> Vec<(u8, u64)> {
+fn merge_property_datatypes(
+    index: &[(u8, u64)],
+    deltas: Option<&HashMap<u8, i64>>,
+) -> Vec<(u8, u64)> {
     let mut merged: HashMap<u8, i64> = index.iter().map(|&(t, c)| (t, c as i64)).collect();
     if let Some(deltas) = deltas {
         for (&tag, &d) in deltas {

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -501,7 +501,9 @@ fn integer_binding_from_bigdecimal(sum: BigDecimal) -> Binding {
 pub(crate) fn binding_to_numeric(binding: &Binding) -> Option<NumericValue> {
     use fluree_db_core::value_id::{ObjKey, ObjKind};
     match binding {
-        Binding::Lit { val, .. } => flake_value_to_numeric(val),
+        Binding::Lit { val, dtc, .. } => {
+            flake_value_to_numeric(val).or_else(|| string_lit_to_numeric(val, dtc))
+        }
         Binding::EncodedLit { o_kind, o_key, .. } => {
             if *o_kind == ObjKind::NUM_INT.as_u8() {
                 Some(NumericValue::Long(ObjKey::from_u64(*o_key).decode_i64()))
@@ -535,6 +537,54 @@ pub(crate) fn flake_value_to_numeric(val: &FlakeValue) -> Option<NumericValue> {
         FlakeValue::Decimal(d) => Some(NumericValue::Decimal((**d).clone())),
         _ => None,
     }
+}
+
+/// Coerce a numeric value that is stored as a `FlakeValue::String` to a number.
+///
+/// The query-time `xsd:float(?x)` cast is kept string-backed (to preserve f32
+/// precision — see `eval/cast.rs`), so SUM/AVG/etc. would otherwise silently
+/// drop it (`flake_value_to_numeric` has no `String` arm) and return unbound.
+/// Parse the string when the literal's datatype is a numeric XSD type. Yields
+/// `Double` (f64 is exact for f32-sourced values); NaN is dropped like other
+/// non-finite aggregate inputs.
+fn string_lit_to_numeric(
+    val: &FlakeValue,
+    dtc: &fluree_db_core::DatatypeConstraint,
+) -> Option<NumericValue> {
+    let FlakeValue::String(s) = val else {
+        return None;
+    };
+    if !is_numeric_xsd_datatype(dtc.datatype()) {
+        return None;
+    }
+    let d = s.parse::<f64>().ok()?;
+    (!d.is_nan()).then_some(NumericValue::Double(d))
+}
+
+/// Whether `sid` is a numeric XSD datatype (the family that should accumulate
+/// in SUM/AVG even when carried as a string-backed literal).
+fn is_numeric_xsd_datatype(sid: &Sid) -> bool {
+    use fluree_vocab::{namespaces, xsd_names};
+    sid.namespace_code == namespaces::XSD
+        && matches!(
+            sid.name.as_ref(),
+            xsd_names::FLOAT
+                | xsd_names::DOUBLE
+                | xsd_names::DECIMAL
+                | xsd_names::INTEGER
+                | xsd_names::LONG
+                | xsd_names::INT
+                | xsd_names::SHORT
+                | xsd_names::BYTE
+                | xsd_names::UNSIGNED_LONG
+                | xsd_names::UNSIGNED_INT
+                | xsd_names::UNSIGNED_SHORT
+                | xsd_names::UNSIGNED_BYTE
+                | xsd_names::NON_NEGATIVE_INTEGER
+                | xsd_names::POSITIVE_INTEGER
+                | xsd_names::NON_POSITIVE_INTEGER
+                | xsd_names::NEGATIVE_INTEGER
+        )
 }
 
 /// COUNT - count non-Unbound values

--- a/fluree-db-query/src/aggregate_complement_fold.rs
+++ b/fluree-db-query/src/aggregate_complement_fold.rs
@@ -1,0 +1,360 @@
+//! Rewrite `avg` over an anti-join complement into a difference of aggregates.
+//!
+//! BSBM BI-4's "average price of products WITHOUT feature F" sub-SELECT is
+//! written as a cartesian product of every feature with every product-offer,
+//! filtered by `FILTER NOT EXISTS { ?product bsbm:productFeature ?feature }`:
+//!
+//! ```sparql
+//! SELECT ?feature (avg(EXPR(?price)) AS ?out) {
+//!   { SELECT DISTINCT ?feature { ... } }               # feature universe
+//!   ?product a <Type> .
+//!   ?offer bsbm:product ?product ; bsbm:price ?price .  # universe offers
+//!   FILTER NOT EXISTS { ?product bsbm:productFeature ?feature }
+//! } GROUP BY ?feature
+//! ```
+//!
+//! Because `SUM` and `COUNT` are distributive over set difference, the
+//! complement average is derivable without the cross-product:
+//!
+//! ```text
+//! without(F) = (universeSum - withSum(F)) / (universeCount - withCount(F))
+//! ```
+//!
+//! where `universe` is the offers of all type-`Type` products and `withSum/Cnt(F)`
+//! are over offers of products that DO have `F` (the `NOT EXISTS` inner as a
+//! positive join, grouped by `?feature`). We rewrite the sub-SELECT to compute a
+//! scalar universe total once and a per-feature WITH aggregate, driving the row
+//! set from the original DISTINCT-feature universe (so a feature whose products
+//! have no offers still appears, defaulting its WITH aggregate to 0), and drop
+//! features whose complement is empty (`without count == 0`) to match the
+//! original `GROUP BY`'s empty-group semantics.
+//!
+//! ## Scope
+//!
+//! Intentionally narrow: a single `AVG` aggregate, a single-key explicit
+//! `GROUP BY`, one `FILTER NOT EXISTS` referencing that key, and a `DISTINCT`
+//! feature-universe subquery var-disjoint from the universe triples. Anything
+//! else is left untouched (safe no-op). `AVG` only — the empty-complement filter
+//! needs the count, and `MIN`/`MAX`/`COUNT(DISTINCT)`/etc. are not distributive.
+
+use crate::ir::{
+    AggregateFn, AggregateSpec, Aggregation, Expression, Function, Grouping, InputSemantics,
+    Pattern, Query, SubqueryPattern,
+};
+use crate::var_registry::VarId;
+use fluree_db_core::{FlakeValue, NonEmpty};
+use std::collections::HashSet;
+
+/// Cheap structural pre-check: is there a sub-SELECT that might match the
+/// avg-over-anti-join-complement shape? Lets callers skip cloning the IR.
+pub fn has_aggregate_complement_candidate(query: &Query) -> bool {
+    // Kill-switch for this new rewrite (set the env var to fall back to the
+    // original cross-product execution — used to A/B correctness and as a safety
+    // valve).
+    if std::env::var_os("FLUREE_DISABLE_AGG_COMPLEMENT_FOLD").is_some() {
+        return false;
+    }
+    patterns_have_candidate(&query.patterns)
+}
+
+fn patterns_have_candidate(patterns: &[Pattern]) -> bool {
+    patterns.iter().any(|p| match p {
+        Pattern::Subquery(sq) => is_candidate_subquery(sq) || patterns_have_candidate(&sq.patterns),
+        Pattern::Optional(inner)
+        | Pattern::Graph {
+            patterns: inner, ..
+        } => patterns_have_candidate(inner),
+        Pattern::Union(branches) => branches.iter().any(|b| patterns_have_candidate(b)),
+        _ => false,
+    })
+}
+
+/// Loose shape check used by the pre-check (full validation happens in the fold).
+fn is_candidate_subquery(sq: &SubqueryPattern) -> bool {
+    matches!(&sq.grouping, Some(Grouping::Explicit { .. }))
+        && sq.patterns.iter().any(|p| not_exists_inner(p).is_some())
+        && sq
+            .patterns
+            .iter()
+            .any(|p| matches!(p, Pattern::Subquery(inner) if inner.distinct))
+}
+
+/// The inner patterns of a NOT EXISTS, whether lowered as the pattern-level
+/// `Pattern::NotExists` (which is what `FILTER NOT EXISTS { ... }` becomes — see
+/// `fluree-db-sparql` `lower/pattern.rs`) or as a negated `Expression::Exists`
+/// inside a `Pattern::Filter` (the compound-expression form).
+fn not_exists_inner(p: &Pattern) -> Option<&[Pattern]> {
+    match p {
+        Pattern::NotExists(inner) => Some(inner),
+        Pattern::Filter(Expression::Exists {
+            patterns,
+            negated: true,
+        }) => Some(patterns),
+        _ => None,
+    }
+}
+
+/// Rewrite every matching avg-over-complement sub-SELECT in `query`, recursing
+/// into nested scopes. No-op for queries that do not match.
+pub fn fold_aggregate_complements(query: &mut Query) {
+    let mut next_var = max_var_id(query).saturating_add(1);
+    fold_in_patterns(&mut query.patterns, &mut next_var);
+}
+
+fn fold_in_patterns(patterns: &mut [Pattern], next_var: &mut u16) {
+    for p in patterns.iter_mut() {
+        match p {
+            Pattern::Subquery(sq) => {
+                // Recurse first (inner scopes), then try to rewrite this scope.
+                fold_in_patterns(&mut sq.patterns, next_var);
+                try_rewrite_without_feature(sq, next_var);
+            }
+            Pattern::Optional(inner)
+            | Pattern::Graph {
+                patterns: inner, ..
+            } => fold_in_patterns(inner, next_var),
+            Pattern::Union(branches) => {
+                for b in branches.iter_mut() {
+                    fold_in_patterns(b, next_var);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn alloc_var(next_var: &mut u16) -> VarId {
+    let v = VarId(*next_var);
+    *next_var = next_var.saturating_add(1);
+    v
+}
+
+/// If `sq` matches the avg-over-anti-join-complement shape, rewrite its body in
+/// place into the distributive-difference form and return `true`.
+fn try_rewrite_without_feature(sq: &mut SubqueryPattern, next_var: &mut u16) -> bool {
+    // --- match the grouping: explicit single-key, single AVG, no binds/having ---
+    let Some(Grouping::Explicit {
+        group_by,
+        aggregation: Some(agg),
+        having: None,
+    }) = &sq.grouping
+    else {
+        return false;
+    };
+    if group_by.len() != 1 || !agg.binds.is_empty() || agg.aggregates.len() != 1 {
+        return false;
+    }
+    let key = *group_by.iter().next().expect("len checked == 1");
+    let spec = agg.aggregates.iter().next().expect("len checked == 1");
+    let AggregateFn::Avg(av, _) = spec.function else {
+        return false;
+    };
+    let out = spec.output_var;
+
+    // --- locate the NOT EXISTS (referencing the key) and the DISTINCT universe ---
+    let mut ne_inner: Option<Vec<Pattern>> = None;
+    let mut has_distinct_universe = false;
+    for p in &sq.patterns {
+        if let Some(inner) = not_exists_inner(p) {
+            if inner
+                .iter()
+                .flat_map(Pattern::referenced_vars)
+                .any(|v| v == key)
+            {
+                if ne_inner.is_some() {
+                    return false; // more than one NOT EXISTS — bail
+                }
+                ne_inner = Some(inner.to_vec());
+            }
+        } else if matches!(p, Pattern::Subquery(s) if s.distinct) {
+            has_distinct_universe = true;
+        }
+    }
+    let Some(ne_inner) = ne_inner else {
+        return false;
+    };
+    if !has_distinct_universe {
+        return false;
+    }
+
+    // --- find the aggregate-input coercion bind: `BIND(EXPR(?price) AS ?av)` ---
+    let coercion = sq.patterns.iter().find_map(|p| match p {
+        Pattern::Bind { var, expr } if *var == av => Some(expr.clone()),
+        _ => None,
+    });
+    let Some(coercion) = coercion else {
+        return false; // avg input is not a recognizable pre-aggregation bind
+    };
+
+    // --- partition the body ----------------------------------------------------
+    // Keep the DISTINCT feature-universe subquery as the driving set; the
+    // "universe" patterns are everything except it, the NOT EXISTS filter, and
+    // the aggregate-input bind (which we rebuild per synthesized subquery).
+    let mut distinct_universe: Option<Pattern> = None;
+    let mut universe: Vec<Pattern> = Vec::new();
+    for p in &sq.patterns {
+        if not_exists_inner(p).is_some() {
+            // dropped here — re-added to the WITH set as a positive join below.
+        } else if matches!(p, Pattern::Subquery(s) if s.distinct) && distinct_universe.is_none() {
+            distinct_universe = Some(p.clone());
+        } else if matches!(p, Pattern::Bind { var, .. } if *var == av) {
+            // the aggregate-input coercion — rebuilt per synthesized subquery.
+        } else {
+            universe.push(p.clone());
+        }
+    }
+    let Some(distinct_universe) = distinct_universe else {
+        return false;
+    };
+
+    // Soundness guard: the decomposition `without = total - with` is valid only
+    // when the GROUP BY key is partitioned purely by the DISTINCT universe and
+    // the NOT EXISTS — i.e. the key must NOT be bound by the universe triples.
+    // If it were, the "scalar total" (computed ignoring the key) would actually
+    // be per-key, and `total - with` would be wrong. Bail in that case.
+    if universe
+        .iter()
+        .flat_map(Pattern::produced_vars)
+        .any(|v| v == key)
+    {
+        return false;
+    }
+
+    // The WITH set = universe + the NOT EXISTS inner as a POSITIVE join.
+    let mut with_patterns = universe.clone();
+    with_patterns.extend(ne_inner);
+
+    // --- synthesize fresh variables -------------------------------------------
+    let u_sum = alloc_var(next_var);
+    let u_cnt = alloc_var(next_var);
+    let w_sum = alloc_var(next_var);
+    let w_cnt = alloc_var(next_var);
+    let wo_sum = alloc_var(next_var);
+    let wo_cnt = alloc_var(next_var);
+    let av_u = alloc_var(next_var);
+    let av_w = alloc_var(next_var);
+
+    // --- scalar universe total: SELECT (SUM(av_u) AS u_sum)(COUNT(av_u) AS u_cnt) ---
+    let mut universe_body = universe;
+    universe_body.push(Pattern::Bind {
+        var: av_u,
+        expr: coercion.clone(),
+    });
+    let universe_sq =
+        SubqueryPattern::new(vec![u_sum, u_cnt], universe_body).with_grouping(Grouping::Implicit {
+            aggregation: Aggregation {
+                aggregates: non_empty(vec![
+                    AggregateSpec {
+                        function: AggregateFn::Sum(av_u, InputSemantics::List),
+                        output_var: u_sum,
+                    },
+                    AggregateSpec {
+                        function: AggregateFn::Count(av_u),
+                        output_var: u_cnt,
+                    },
+                ]),
+                binds: Vec::new(),
+            },
+            having: None,
+        });
+
+    // --- per-feature WITH aggregate: SELECT ?key (SUM(av_w))(COUNT(av_w)) GROUP BY ?key ---
+    with_patterns.push(Pattern::Bind {
+        var: av_w,
+        expr: coercion,
+    });
+    let with_sq = SubqueryPattern::new(vec![key, w_sum, w_cnt], with_patterns).with_grouping(
+        Grouping::Explicit {
+            group_by: non_empty(vec![key]),
+            aggregation: Some(Aggregation {
+                aggregates: non_empty(vec![
+                    AggregateSpec {
+                        function: AggregateFn::Sum(av_w, InputSemantics::List),
+                        output_var: w_sum,
+                    },
+                    AggregateSpec {
+                        function: AggregateFn::Count(av_w),
+                        output_var: w_cnt,
+                    },
+                ]),
+                binds: Vec::new(),
+            }),
+            having: None,
+        },
+    );
+
+    // --- assemble the rewritten body ------------------------------------------
+    // distinct features (drive) + scalar total (broadcast) + OPTIONAL with-agg
+    // (left join: missing features default to 0) + complement arithmetic.
+    let zero = || Expression::Const(FlakeValue::Long(0));
+    let coalesce0 = |v: VarId| {
+        Expression::call(
+            Function::If,
+            vec![
+                Expression::call(Function::Bound, vec![Expression::Var(v)]),
+                Expression::Var(v),
+                zero(),
+            ],
+        )
+    };
+
+    let new_patterns = vec![
+        distinct_universe,
+        Pattern::Subquery(universe_sq),
+        Pattern::Optional(vec![Pattern::Subquery(with_sq)]),
+        // without_count = universeCount - (withCount or 0)
+        Pattern::Bind {
+            var: wo_cnt,
+            expr: Expression::sub(Expression::Var(u_cnt), coalesce0(w_cnt)),
+        },
+        // without_sum = universeSum - (withSum or 0)
+        Pattern::Bind {
+            var: wo_sum,
+            expr: Expression::sub(Expression::Var(u_sum), coalesce0(w_sum)),
+        },
+        // drop features whose complement is empty (matches GROUP BY group-drop)
+        Pattern::Filter(Expression::gt(Expression::Var(wo_cnt), zero())),
+        // out = without_sum / without_count (AVG of the complement)
+        Pattern::Bind {
+            var: out,
+            expr: Expression::div(Expression::Var(wo_sum), Expression::Var(wo_cnt)),
+        },
+    ];
+
+    sq.patterns = new_patterns;
+    sq.grouping = None;
+    // sq.select already projects [?key, ?out] — unchanged.
+    true
+}
+
+fn non_empty<T>(v: Vec<T>) -> NonEmpty<T> {
+    NonEmpty::try_from_vec(v).expect("constructed with at least one element")
+}
+
+/// Largest `VarId` referenced anywhere in the query (patterns recursively,
+/// grouping, ordering, select), so synthetic vars can be minted above it.
+fn max_var_id(query: &Query) -> u16 {
+    let mut vars: HashSet<VarId> = HashSet::new();
+    for p in &query.patterns {
+        vars.extend(p.referenced_vars());
+        vars.extend(p.produced_vars());
+    }
+    if let Some(g) = &query.grouping {
+        vars.extend(g.group_by_vars());
+        for spec in g.aggregates() {
+            vars.insert(spec.output_var);
+            if let Some(iv) = spec.function.input_var() {
+                vars.insert(iv);
+            }
+        }
+        for (v, e) in g.binds() {
+            vars.insert(*v);
+            vars.extend(e.referenced_vars());
+        }
+    }
+    for (v, e) in &query.order_binds {
+        vars.insert(*v);
+        vars.extend(e.referenced_vars());
+    }
+    vars.into_iter().map(|VarId(n)| n).max().unwrap_or(0)
+}

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -259,6 +259,21 @@ impl CompareOp {
 /// Returns `None` for type mismatches (incomparable types).
 /// Delegates to FlakeValue's comparison methods for numeric and temporal types.
 fn cmp_values(left: &ComparableValue, right: &ComparableValue) -> Option<Ordering> {
+    // Normalize numeric values carried as a `TypedLiteral` (e.g. xsd:float, whose
+    // value is stored string-backed) into their primitive numeric variant so the
+    // numeric comparison below applies — mirroring arithmetic's operand coercion.
+    // Only clone when a typed literal is actually present (the uncommon case).
+    let (lc, rc);
+    let (left, right) = if matches!(left, ComparableValue::TypedLiteral { .. })
+        || matches!(right, ComparableValue::TypedLiteral { .. })
+    {
+        lc = left.clone().coerce_numeric_operand();
+        rc = right.clone().coerce_numeric_operand();
+        (&lc, &rc)
+    } else {
+        (left, right)
+    };
+
     let left_fv: FlakeValue = left.into();
     let right_fv: FlakeValue = right.into();
 

--- a/fluree-db-query/src/eval/value.rs
+++ b/fluree-db-query/src/eval/value.rs
@@ -307,7 +307,7 @@ impl ComparableValue {
     /// inner value is unwrapped (or parsed, for the string-encoded cases) here.
     /// Non-numeric typed literals — and all other variants — are returned
     /// unchanged, so they still fall to a `TypeMismatch` in [`ArithmeticOp::apply`].
-    fn coerce_numeric_operand(self) -> ComparableValue {
+    pub(crate) fn coerce_numeric_operand(self) -> ComparableValue {
         let ComparableValue::TypedLiteral { val, dtc } = self else {
             return self;
         };

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -123,7 +123,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_operator_tree_validates_select_vars() {
+    fn test_build_operator_tree_allows_unbound_select_var() {
+        // SPARQL 1.1 §18.5: selecting a variable not bound by the pattern is
+        // legal — it is reported unbound, not an error.
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
@@ -143,10 +145,10 @@ mod tests {
             None,
             &crate::temporal_mode::PlanningContext::current(),
         );
-        match result {
-            Err(e) => assert!(e.to_string().contains("not found")),
-            Ok(_) => panic!("Expected error for invalid select var"),
-        }
+        assert!(
+            result.is_ok(),
+            "selecting an unbound variable should succeed (reported unbound)"
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -50,6 +50,7 @@ use crate::operator::BoxedOperator;
 use crate::project::ProjectOperator;
 use crate::sort::SortDirection;
 use crate::sort::SortOperator;
+use crate::sort::SortSpec;
 use crate::stats_query::StatsCountByPredicateOperator;
 use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
@@ -57,7 +58,7 @@ use fluree_db_core::StatsView;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use super::dependency::compute_variable_deps;
+use super::dependency::{compute_variable_deps, VariableDeps};
 use super::where_plan::build_where_operators_with_needed;
 use super::where_plan::collect_var_stats;
 
@@ -924,6 +925,21 @@ fn detect_sum_strlen_group_concat_subquery(query: &Query) -> Option<(Ref, Arc<st
     let (Some(sq), Some((bind_var, bind_expr))) = (subq, bind) else {
         return None;
     };
+    // The fused operator sums STRLEN(GROUP_CONCAT(..)) over EVERY group directly
+    // and ignores the inner subquery's slice / distinct / ordering modifiers.
+    // Only fire for the exact unmodified inner shape; otherwise an inner
+    // DISTINCT (collapsing duplicate concatenations) or LIMIT/OFFSET (summing a
+    // subset of groups) would change the answer. Falling back to the generic
+    // pipeline keeps those modifiers honored. ORDER BY alone is sum-invariant,
+    // but is declined too so the matched shape stays exact.
+    if sq.distinct
+        || sq.limit.is_some()
+        || sq.offset.is_some()
+        || !sq.ordering.is_empty()
+        || !sq.order_binds.is_empty()
+    {
+        return None;
+    }
     if bind_var != strlen_var {
         return None;
     }
@@ -2639,27 +2655,14 @@ fn build_operator_tree_inner(
         needed_where_vars = vars;
     }
 
-    // Flatten the grouping phase's data for consumption below. The variant
-    // distinction has already done its structural work at the IR boundary;
-    // the operator-tree builder treats both variants uniformly. Cloning is
-    // cheap here — both vectors are short (typically a handful of items)
-    // and this is one-shot setup, not per-row work.
+    // The WHERE planner takes the GROUP BY keys as a hint (it can stream-group
+    // a sorted scan). The remainder of the grouping phase (aggregates, HAVING,
+    // post-binds) is consumed by the shared `apply_solution_modifiers` tail.
     let group_by_vec: Vec<VarId> = query
         .grouping
         .iter()
         .flat_map(Grouping::group_by_vars)
         .collect();
-    let aggregates_vec: Vec<AggregateSpec> = query
-        .grouping
-        .as_ref()
-        .map(|g| g.aggregates().cloned().collect())
-        .unwrap_or_default();
-    let post_binds_vec: Vec<(VarId, Expression)> = query
-        .grouping
-        .as_ref()
-        .map(|g| g.binds().cloned().collect())
-        .unwrap_or_default();
-    let having_expr: Option<&Expression> = query.grouping.as_ref().and_then(Grouping::having);
 
     let mut operator = build_where_operators_with_needed(
         &query.patterns,
@@ -2681,6 +2684,69 @@ fn build_operator_tree_inner(
             rows.clone(),
         ));
     }
+
+    // The solution-modifier tail (grouping → HAVING → post-binds → order-binds
+    // → sort/validate → PROJECT → DISTINCT → OFFSET → LIMIT) is shared with the
+    // per-row correlated-subquery pipeline (`SubqueryOperator`) via
+    // `apply_solution_modifiers`, so both inherit identical modifier semantics.
+    // Only the WHERE build and outermost-only concerns (post-VALUES) stay here.
+    let projected = query.output.projected_vars();
+    apply_solution_modifiers(
+        operator,
+        query.grouping.as_ref(),
+        &query.order_binds,
+        &query.ordering,
+        projected.as_deref(),
+        query.output.is_distinct(),
+        query.offset,
+        query.limit,
+        detect_partitioned_group_by(query),
+        variable_deps.as_ref(),
+    )
+}
+
+/// Apply the SPARQL solution-modifier tail to an already-built WHERE operator.
+///
+/// Shared by the top-level query pipeline (`build_operator_tree_inner`) and the
+/// per-row correlated-subquery pipeline (`SubqueryOperator`). Runs, in order:
+/// GROUP BY + aggregation, HAVING, post-aggregation binds, expression/aggregate
+/// ORDER-BY binds, sort-var validation, ORDER BY (with safe top-k and the
+/// project-distinct-before-sort optimization), PROJECT, DISTINCT, OFFSET, LIMIT.
+///
+/// `operator` is the WHERE output (seeded or not). `select_vars` is the plain
+/// projected-variable list (`None` = no projection, e.g. wildcard). Outermost-
+/// only concerns (output formatting, CONSTRUCT/ASK, post-VALUES) stay in the
+/// caller. `variable_deps` drives projection trimming; pass `None` to skip it.
+/// `partitioned` is the streaming-GroupAggregate partition hint (callers that
+/// don't benefit pass `false`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn apply_solution_modifiers(
+    mut operator: BoxedOperator,
+    grouping: Option<&Grouping>,
+    order_binds: &[(VarId, Expression)],
+    ordering: &[SortSpec],
+    select_vars: Option<&[VarId]>,
+    distinct: bool,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    partitioned: bool,
+    variable_deps: Option<&VariableDeps>,
+) -> Result<BoxedOperator> {
+    // Flatten the grouping phase's data for consumption below. The variant
+    // distinction has already done its structural work at the IR boundary; the
+    // tail treats both variants uniformly. Cloning is cheap — both vectors are
+    // short and this is one-shot setup, not per-row work.
+    let group_by_vec: Vec<VarId> = grouping
+        .into_iter()
+        .flat_map(Grouping::group_by_vars)
+        .collect();
+    let aggregates_vec: Vec<AggregateSpec> = grouping
+        .map(|g| g.aggregates().cloned().collect())
+        .unwrap_or_default();
+    let post_binds_vec: Vec<(VarId, Expression)> = grouping
+        .map(|g| g.binds().cloned().collect())
+        .unwrap_or_default();
+    let having_expr: Option<&Expression> = grouping.and_then(Grouping::having);
 
     // Get the schema after WHERE (before grouping)
     let where_schema: Arc<[VarId]> = Arc::from(operator.schema().to_vec().into_boxed_slice());
@@ -2757,7 +2823,7 @@ fn build_operator_tree_inner(
         // If the SELECT projects any *grouped* variables (non-key, non-aggregate),
         // we must use the traditional GroupByOperator path so those vars become
         // `Binding::Grouped(Vec<Binding>)` and remain selectable.
-        let select_needs_grouped_vars = query.output.projected_vars().is_some_and(|vars| {
+        let select_needs_grouped_vars = select_vars.is_some_and(|vars| {
             vars.iter().any(|v| {
                 !group_by_vec.contains(v) && !aggregates_vec.iter().any(|a| a.output_var == *v)
             })
@@ -2769,7 +2835,6 @@ fn build_operator_tree_inner(
 
         if use_streaming {
             // Streaming path: O(groups) memory
-            let partitioned = detect_partitioned_group_by(query);
             tracing::debug!(
                 group_by_count = group_by_vec.len(),
                 agg_count = streaming_specs.len(),
@@ -2847,7 +2912,7 @@ fn build_operator_tree_inner(
     // For ungrouped queries this is simply a post-WHERE stage. This placement is
     // what makes expression ORDER BY work uniformly across no-grouping,
     // dedup-only GROUP BY (no aggregation stage), and aggregating queries.
-    if !query.order_binds.is_empty() {
+    if !order_binds.is_empty() {
         // Under grouping, an order-key expression may only read GROUP BY keys,
         // aggregate outputs, and post-aggregation bind outputs. Referencing any
         // other variable means it is `Binding::Grouped` here — reject cleanly
@@ -2861,7 +2926,7 @@ fn build_operator_tree_inner(
             for (var, _) in &post_binds_vec {
                 allowed.insert(*var);
             }
-            for (out_var, expr) in &query.order_binds {
+            for (out_var, expr) in order_binds {
                 for v in expr.referenced_vars() {
                     if !allowed.contains(&v) {
                         return Err(QueryError::InvalidQuery(format!(
@@ -2873,7 +2938,7 @@ fn build_operator_tree_inner(
                 allowed.insert(*out_var);
             }
         }
-        for (var, expr) in &query.order_binds {
+        for (var, expr) in order_binds {
             operator = Box::new(crate::bind::BindOperator::new(
                 operator,
                 *var,
@@ -2896,15 +2961,14 @@ fn build_operator_tree_inner(
     // size (and allow top-k truncation) while preserving semantics:
     // duplicates eliminated by DISTINCT have identical sort keys, so removing
     // them before sorting does not change the ordered set of unique solutions.
-    let select_vars_opt: Option<Vec<VarId>> = query.output.projected_vars();
-    let can_project_distinct_before_sort = query.output.is_distinct()
-        && !query.ordering.is_empty()
-        && select_vars_opt.as_ref().is_some_and(|vars| {
-            !vars.is_empty() && query.ordering.iter().all(|s| vars.contains(&s.var))
+    let can_project_distinct_before_sort = distinct
+        && !ordering.is_empty()
+        && select_vars.is_some_and(|vars| {
+            !vars.is_empty() && ordering.iter().all(|s| vars.contains(&s.var))
         });
 
     // Validate SELECT vars (when present) exist in the post-group schema.
-    if let Some(vars) = &select_vars_opt {
+    if let Some(vars) = select_vars {
         if !vars.is_empty() {
             for var in vars {
                 if !post_group_schema.contains(var) {
@@ -2917,7 +2981,7 @@ fn build_operator_tree_inner(
     }
 
     // Validate ORDER BY vars exist in the post-group schema and are allowed under grouping.
-    if !query.ordering.is_empty() {
+    if !ordering.is_empty() {
         // Disallow sorting on Grouped variables (non-key, non-aggregated) because comparison is undefined.
         let mut allowed_sort_vars: Option<HashSet<VarId>> = None;
         if needs_grouping {
@@ -2936,12 +3000,12 @@ fn build_operator_tree_inner(
             }
             // Desugared expression-ORDER-BY keys run as a post-grouping stage
             // and are validated above to read only allowed vars.
-            for (var, _) in &query.order_binds {
+            for (var, _) in order_binds {
                 allowed.insert(*var);
             }
             allowed_sort_vars = Some(allowed);
         }
-        for spec in &query.ordering {
+        for spec in ordering {
             if !post_group_schema.contains(&spec.var) {
                 return Err(QueryError::VariableNotFound(format!(
                     "Sort variable {:?} not found in query schema",
@@ -2961,23 +3025,23 @@ fn build_operator_tree_inner(
 
     if can_project_distinct_before_sort {
         // PROJECT
-        if let Some(vars) = select_vars_opt {
+        if let Some(vars) = select_vars {
             operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
         }
         // DISTINCT (pre-sort)
         operator = Box::new(DistinctOperator::new(operator));
 
         // ORDER BY (post-distinct, projected vars only)
-        let k = match (query.limit, query.offset) {
+        let k = match (limit, offset) {
             (Some(limit), Some(offset)) => limit.saturating_add(offset),
             (Some(limit), None) => limit,
             _ => 0,
         };
-        let can_topk = query.limit.is_some();
+        let can_topk = limit.is_some();
         let mut sort_op = if can_topk {
-            SortOperator::new_topk(operator, query.ordering.clone(), k)
+            SortOperator::new_topk(operator, ordering.to_vec(), k)
         } else {
-            SortOperator::new(operator, query.ordering.clone())
+            SortOperator::new(operator, ordering.to_vec())
         };
         sort_op = sort_op.with_out_schema(
             variable_deps
@@ -2987,20 +3051,20 @@ fn build_operator_tree_inner(
         operator = Box::new(sort_op);
     } else {
         // ORDER BY (before projection - may reference vars not in SELECT)
-        if !query.ordering.is_empty() {
+        if !ordering.is_empty() {
             // Safe top-k: ORDER BY + (OFFSET o) + LIMIT l can keep only (o + l) rows.
             //
             // This is safe when DISTINCT is not in play because slicing happens after sorting.
-            let can_topk = query.limit.is_some() && !query.output.is_distinct();
-            let k = match (query.limit, query.offset) {
+            let can_topk = limit.is_some() && !distinct;
+            let k = match (limit, offset) {
                 (Some(limit), Some(offset)) => limit.saturating_add(offset),
                 (Some(limit), None) => limit,
                 _ => 0,
             };
             let mut sort_op = if can_topk {
-                SortOperator::new_topk(operator, query.ordering.clone(), k)
+                SortOperator::new_topk(operator, ordering.to_vec(), k)
             } else {
-                SortOperator::new(operator, query.ordering.clone())
+                SortOperator::new(operator, ordering.to_vec())
             };
             sort_op = sort_op.with_out_schema(
                 variable_deps
@@ -3011,27 +3075,27 @@ fn build_operator_tree_inner(
         }
 
         // PROJECT
-        if let Some(vars) = select_vars_opt {
+        if let Some(vars) = select_vars {
             if !vars.is_empty() {
                 operator = Box::new(ProjectOperator::new(operator, vars.to_vec()));
             }
         }
 
         // DISTINCT (after projection)
-        if query.output.is_distinct() {
+        if distinct {
             operator = Box::new(DistinctOperator::new(operator));
         }
     }
 
     // OFFSET
-    if let Some(offset) = query.offset {
+    if let Some(offset) = offset {
         if offset > 0 {
             operator = Box::new(OffsetOperator::new(operator, offset));
         }
     }
 
     // LIMIT
-    if let Some(limit) = query.limit {
+    if let Some(limit) = limit {
         operator = Box::new(LimitOperator::new(operator, limit));
     }
 

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2748,13 +2748,43 @@ pub(crate) fn apply_solution_modifiers(
         .unwrap_or_default();
     let having_expr: Option<&Expression> = grouping.and_then(Grouping::having);
 
-    // Get the schema after WHERE (before grouping)
-    let where_schema: Arc<[VarId]> = Arc::from(operator.schema().to_vec().into_boxed_slice());
+    let needs_grouping = !group_by_vec.is_empty() || !aggregates_vec.is_empty();
+
+    // SPARQL 1.1 §11.4 (GROUP BY) / §18.5: a GROUP BY variable — or, in an
+    // ungrouped query, a SELECT variable — that the WHERE never binds is legal.
+    // It is simply unbound: every solution shares the same unbound value, so
+    // they collapse into one group on that key, and the variable is reported
+    // unbound. Materialize such variables as Unbound columns (an identity
+    // `BIND(?v AS ?v)` over the absent var evaluates to Unbound) so grouping and
+    // projection treat them as unbound instead of failing the schema lookup.
+    // Aggregate INPUT variables are intentionally NOT padded here — a missing
+    // aggregate input stays an error.
+    let mut where_schema_vec: Vec<VarId> = operator.schema().to_vec();
+    {
+        let mut want: Vec<VarId> = group_by_vec.clone();
+        if !needs_grouping {
+            if let Some(sv) = select_vars {
+                want.extend_from_slice(sv);
+            }
+        }
+        for v in want {
+            if !where_schema_vec.contains(&v) {
+                operator = Box::new(crate::bind::BindOperator::new(
+                    operator,
+                    v,
+                    Expression::Var(v),
+                    Vec::new(),
+                ));
+                where_schema_vec.push(v);
+            }
+        }
+    }
+    // Get the schema after WHERE (before grouping), including any unbound pads.
+    let where_schema: Arc<[VarId]> = Arc::from(where_schema_vec.into_boxed_slice());
 
     // GROUP BY + Aggregates
     // We use streaming GroupAggregateOperator when all aggregates are streamable
     // (COUNT, SUM, AVG, MIN, MAX). This is O(groups) memory instead of O(rows).
-    let needs_grouping = !group_by_vec.is_empty() || !aggregates_vec.is_empty();
     if needs_grouping {
         // Validate group vars exist in where schema
         for var in &group_by_vec {
@@ -3249,7 +3279,10 @@ mod tests {
     }
 
     #[test]
-    fn test_build_operator_tree_validates_select_vars() {
+    fn test_build_operator_tree_allows_unbound_select_var() {
+        // SPARQL 1.1 §18.5: selecting a variable not bound by the pattern is
+        // legal — it is reported unbound, not an error. The tree pads it as an
+        // Unbound column rather than failing the schema lookup.
         let query = Query {
             context: ParsedContext::default(),
             orig_context: None,
@@ -3269,10 +3302,10 @@ mod tests {
             None,
             &crate::temporal_mode::PlanningContext::current(),
         );
-        match result {
-            Err(e) => assert!(e.to_string().contains("not found")),
-            Ok(_) => panic!("Expected error for invalid select var"),
-        }
+        assert!(
+            result.is_ok(),
+            "selecting an unbound variable should succeed (reported unbound)"
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2059,6 +2059,14 @@ pub fn build_operator_tree(
         crate::filter_fold::fold_equijoin_filters(&mut folded, stats.as_deref());
         return build_operator_tree_inner(&folded, stats, true, planning);
     }
+    // Rewrite `avg` over an anti-join complement into a difference of aggregates
+    // (universe total minus the per-key WITH aggregate), eliminating the
+    // feature x product cross-product. Clone only when a candidate is present.
+    if crate::aggregate_complement_fold::has_aggregate_complement_candidate(query) {
+        let mut rewritten = query.clone();
+        crate::aggregate_complement_fold::fold_aggregate_complements(&mut rewritten);
+        return build_operator_tree_inner(&rewritten, stats, true, planning);
+    }
     build_operator_tree_inner(query, stats, true, planning)
 }
 

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2963,9 +2963,8 @@ pub(crate) fn apply_solution_modifiers(
     // them before sorting does not change the ordered set of unique solutions.
     let can_project_distinct_before_sort = distinct
         && !ordering.is_empty()
-        && select_vars.is_some_and(|vars| {
-            !vars.is_empty() && ordering.iter().all(|s| vars.contains(&s.var))
-        });
+        && select_vars
+            .is_some_and(|vars| !vars.is_empty() && ordering.iter().all(|s| vars.contains(&s.var)));
 
     // Validate SELECT vars (when present) exist in the post-group schema.
     if let Some(vars) = select_vars {

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2050,6 +2050,15 @@ pub fn build_operator_tree(
     stats: Option<Arc<StatsView>>,
     planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
+    // Fold `FILTER(?x = ?y)` equijoins into variable unification before planning,
+    // so the rewrite feeds the stats-driven reorder, count planner, and index
+    // fast paths (rather than running as a cross-product + filter). Only clone
+    // the IR when there is actually something to fold. Recurses into subqueries.
+    if stats.is_some() && crate::filter_fold::has_equijoin_filter(query) {
+        let mut folded = query.clone();
+        crate::filter_fold::fold_equijoin_filters(&mut folded, stats.as_deref());
+        return build_operator_tree_inner(&folded, stats, true, planning);
+    }
     build_operator_tree_inner(query, stats, true, planning)
 }
 

--- a/fluree-db-query/src/explain.rs
+++ b/fluree-db-query/src/explain.rs
@@ -799,6 +799,7 @@ mod tests {
             properties_by_iri: HashMap::new(),
             classes_by_iri: HashMap::new(),
             graph_properties: HashMap::new(),
+            ..Default::default()
         };
 
         let p1 = make_pattern(VarId(0), "name", VarId(1));
@@ -828,6 +829,7 @@ mod tests {
             properties_by_iri: HashMap::new(),
             classes_by_iri: HashMap::new(),
             graph_properties: HashMap::new(),
+            ..Default::default()
         };
 
         let patterns = vec![make_pattern(VarId(0), "name", VarId(1))];
@@ -912,6 +914,7 @@ mod tests {
             properties_by_iri: HashMap::new(),
             classes_by_iri: HashMap::new(),
             graph_properties: HashMap::new(),
+            ..Default::default()
         };
 
         let pattern = make_pattern(VarId(0), "name", VarId(1));

--- a/fluree-db-query/src/filter_fold.rs
+++ b/fluree-db-query/src/filter_fold.rs
@@ -40,10 +40,9 @@ pub fn has_equijoin_filter(query: &Query) -> bool {
 fn patterns_have_equijoin_filter(patterns: &[Pattern]) -> bool {
     patterns.iter().any(|p| match p {
         Pattern::Filter(e) => equality_vars(e).is_some(),
-        Pattern::Optional(i)
-        | Pattern::Minus(i)
-        | Pattern::Exists(i)
-        | Pattern::NotExists(i) => patterns_have_equijoin_filter(i),
+        Pattern::Optional(i) | Pattern::Minus(i) | Pattern::Exists(i) | Pattern::NotExists(i) => {
+            patterns_have_equijoin_filter(i)
+        }
         Pattern::Union(branches) => branches.iter().any(|b| patterns_have_equijoin_filter(b)),
         Pattern::Graph { patterns, .. } => patterns_have_equijoin_filter(patterns),
         Pattern::Service(sp) => patterns_have_equijoin_filter(&sp.patterns),
@@ -449,7 +448,11 @@ mod tests {
                 Ref::Sid(feat.clone()),
                 Term::Var(x),
             )),
-            Pattern::Triple(TriplePattern::new(Ref::Var(s2), Ref::Sid(feat), Term::Var(y))),
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(s2),
+                Ref::Sid(feat),
+                Term::Var(y),
+            )),
             Pattern::Filter(Expression::Call {
                 func: Function::Eq,
                 args: vec![Expression::Var(x), Expression::Var(y)],

--- a/fluree-db-query/src/filter_fold.rs
+++ b/fluree-db-query/src/filter_fold.rs
@@ -90,6 +90,12 @@ pub fn fold_equijoin_filters(query: &mut Query, stats: Option<&StatsView>) {
                 }
                 expr.substitute_var(drop, keep);
             }
+            // The post-query VALUES clause lives outside `patterns`; it must be
+            // unified too, or a `VALUES ?y { … }` on the dropped side would be
+            // left referencing a variable the join no longer produces.
+            if let Some(post_values) = &mut query.post_values {
+                post_values.substitute_var(drop, keep);
+            }
         }
     }
 
@@ -424,6 +430,54 @@ mod tests {
         let mut query = shared_feature_query(Function::Eq);
         fold_equijoin_filters(&mut query, None);
         assert_eq!(query.patterns.len(), 3);
+    }
+
+    #[test]
+    fn rewrites_post_values_on_dropped_var() {
+        // `{ ?s1 feature ?x . ?s2 feature ?y . FILTER(?x = ?y) } VALUES ?y { … }`
+        // with `?x` projected. Folding drops `?y` (renamed to `?x`); the
+        // post-query VALUES must follow, or it would constrain a variable the
+        // unified join no longer produces.
+        let s1 = VarId(0);
+        let s2 = VarId(1);
+        let x = VarId(2);
+        let y = VarId(3);
+        let feat = feature_pred();
+        let patterns = vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(s1),
+                Ref::Sid(feat.clone()),
+                Term::Var(x),
+            )),
+            Pattern::Triple(TriplePattern::new(Ref::Var(s2), Ref::Sid(feat), Term::Var(y))),
+            Pattern::Filter(Expression::Call {
+                func: Function::Eq,
+                args: vec![Expression::Var(x), Expression::Var(y)],
+            }),
+        ];
+        let mut query = Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![x]),
+            patterns,
+            reasoning: ReasoningConfig::default(),
+            grouping: None,
+            ordering: Vec::new(),
+            order_binds: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: Some(Pattern::Values {
+                vars: vec![y],
+                rows: Vec::new(),
+            }),
+        };
+        fold_equijoin_filters(&mut query, Some(&stats_with_feature_ref_only(true)));
+
+        assert_eq!(query.patterns.len(), 2);
+        match &query.post_values {
+            Some(Pattern::Values { vars, .. }) => assert_eq!(vars, &vec![x]),
+            other => panic!("expected post-query VALUES, got {other:?}"),
+        }
     }
 
     #[test]

--- a/fluree-db-query/src/filter_fold.rs
+++ b/fluree-db-query/src/filter_fold.rs
@@ -1,0 +1,478 @@
+//! Fold `FILTER(?x = ?y)` / `FILTER(sameTerm(?x, ?y))` into an equijoin.
+//!
+//! When a filter equates two variables that are each bound by triple patterns
+//! in the same scope, unifying the variables — renaming one to the other and
+//! dropping the filter — turns a cross-product-plus-filter into a shared-
+//! variable join. The stats-driven pattern reordering, the count planner, and
+//! the index fast paths all then apply, which is a large, common analytic
+//! speedup (e.g. BSBM BI-2: ~28s → ~0.03s).
+//!
+//! ## Soundness
+//!
+//! A join unifies on the *encoded term*; SPARQL `=` is *value* equality. They
+//! coincide for nodes (IRIs / blank nodes have no `"1" = "1.0"`-style cross-
+//! datatype equality) but diverge for literals. So `=` is folded only when both
+//! variables are provably **node-valued**: each is used as a subject/predicate
+//! position (always a node) or appears only as the object of predicates whose
+//! stats prove every object is a ref ([`StatsView::is_property_ref_only`],
+//! current-state-exact including novelty). `sameTerm` *is* term equality, so it
+//! folds with no node guard. When node-ness can't be proven, the filter is left
+//! untouched — correct, just not accelerated.
+//!
+//! The fold runs once over the lowered query (recursing into every sub-SELECT
+//! scope) before operator construction. It only rewrites variables it can
+//! safely rename; eligibility rejects any case where the renamed variable
+//! appears in a pattern [`Pattern::substitute_var`] cannot rewrite (property
+//! paths, search adapters) or in a nested scope.
+
+use crate::ir::triple::{Ref, Term};
+use crate::ir::{Expression, Function, Pattern, Query, SubqueryPattern};
+use crate::var_registry::VarId;
+use fluree_db_core::StatsView;
+
+/// Cheap structural pre-check: does the query contain any `FILTER(?x = ?y)` /
+/// `sameTerm(?x, ?y)` (recursively, including subqueries)? Lets callers skip
+/// cloning the IR for the (common) queries with nothing to fold.
+pub fn has_equijoin_filter(query: &Query) -> bool {
+    patterns_have_equijoin_filter(&query.patterns)
+}
+
+fn patterns_have_equijoin_filter(patterns: &[Pattern]) -> bool {
+    patterns.iter().any(|p| match p {
+        Pattern::Filter(e) => equality_vars(e).is_some(),
+        Pattern::Optional(i)
+        | Pattern::Minus(i)
+        | Pattern::Exists(i)
+        | Pattern::NotExists(i) => patterns_have_equijoin_filter(i),
+        Pattern::Union(branches) => branches.iter().any(|b| patterns_have_equijoin_filter(b)),
+        Pattern::Graph { patterns, .. } => patterns_have_equijoin_filter(patterns),
+        Pattern::Service(sp) => patterns_have_equijoin_filter(&sp.patterns),
+        Pattern::Subquery(sq) => patterns_have_equijoin_filter(&sq.patterns),
+        _ => false,
+    })
+}
+
+/// Fold equijoin filters across the whole query, recursing into every subquery
+/// scope. No-op without stats (the node guard needs the per-predicate datatype
+/// breakdown).
+pub fn fold_equijoin_filters(query: &mut Query, stats: Option<&StatsView>) {
+    let Some(stats) = stats else {
+        return;
+    };
+
+    // Top-level scope. We do NOT rewrite `QueryOutput`, so we only fold when the
+    // projection is a concrete variable list: the survivor choice keeps a
+    // projected variable (skipping when both sides are projected), so the
+    // dropped variable is never an output column. A wildcard / non-tuple output
+    // (`projected_vars()` is `None`, e.g. `SELECT *`, CONSTRUCT, ASK) implicitly
+    // projects every variable, so dropping one would change the result shape —
+    // skip the top-level scope there (subquery scopes still fold; their SELECT
+    // list is always concrete and is rewritten in place).
+    if let Some(output_vars) = query.output.projected_vars() {
+        while let Some((drop, keep, idx)) =
+            find_foldable(&query.patterns, Some(&output_vars), stats)
+        {
+            query.patterns.remove(idx);
+            for p in &mut query.patterns {
+                p.substitute_var(drop, keep);
+            }
+            if let Some(g) = &mut query.grouping {
+                g.substitute_var(drop, keep);
+            }
+            for spec in &mut query.ordering {
+                if spec.var == drop {
+                    spec.var = keep;
+                }
+            }
+            for (v, expr) in &mut query.order_binds {
+                if *v == drop {
+                    *v = keep;
+                }
+                expr.substitute_var(drop, keep);
+            }
+        }
+    }
+
+    for p in &mut query.patterns {
+        fold_in_pattern(p, stats);
+    }
+}
+
+/// Recurse through container patterns to find and fold subquery scopes. Only
+/// `SubqueryPattern` bodies are folded as scopes; OPTIONAL/UNION/etc. inner
+/// blocks are traversed for nested subqueries but not folded themselves
+/// (their join semantics make in-place unification subtler — conservative).
+fn fold_in_pattern(p: &mut Pattern, stats: &StatsView) {
+    match p {
+        Pattern::Subquery(sq) => fold_subquery(sq, stats),
+        Pattern::Optional(inner)
+        | Pattern::Minus(inner)
+        | Pattern::Exists(inner)
+        | Pattern::NotExists(inner) => {
+            for q in inner {
+                fold_in_pattern(q, stats);
+            }
+        }
+        Pattern::Graph { patterns, .. } => {
+            for q in patterns {
+                fold_in_pattern(q, stats);
+            }
+        }
+        Pattern::Service(sp) => {
+            for q in &mut sp.patterns {
+                fold_in_pattern(q, stats);
+            }
+        }
+        Pattern::Union(branches) => {
+            for branch in branches {
+                for q in branch {
+                    fold_in_pattern(q, stats);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Fold a subquery scope. The subquery's SELECT list is rewritten, so there's
+/// no output restriction (unlike the top-level scope).
+fn fold_subquery(sq: &mut SubqueryPattern, stats: &StatsView) {
+    // Pass the SELECT list as the protected set: when both equated vars are
+    // selected, keeping one and renaming the other would collapse two output
+    // columns into one — so the survivor rule skips that case.
+    while let Some((drop, keep, idx)) = find_foldable(&sq.patterns, Some(&sq.select), stats) {
+        sq.patterns.remove(idx);
+        // Rewrites SELECT list, remaining WHERE patterns, grouping, ORDER BY,
+        // and expression-ORDER-BY binds in one pass.
+        sq.substitute_var(drop, keep);
+    }
+    for p in &mut sq.patterns {
+        fold_in_pattern(p, stats);
+    }
+}
+
+/// Find the first foldable `FILTER(?x = ?y)` / `sameTerm` in `patterns`.
+///
+/// Returns `(drop, keep, filter_index)`: rename `drop` to `keep` and remove the
+/// filter at `filter_index`. `output_vars` (the enclosing scope's projected
+/// variables, when its projection is NOT rewritten — i.e. the top-level query)
+/// constrains the survivor so the dropped variable is never a projected output.
+fn find_foldable(
+    patterns: &[Pattern],
+    output_vars: Option<&[VarId]>,
+    stats: &StatsView,
+) -> Option<(VarId, VarId, usize)> {
+    for (idx, p) in patterns.iter().enumerate() {
+        let Pattern::Filter(expr) = p else {
+            continue;
+        };
+        let Some((x, y, same_term)) = equality_vars(expr) else {
+            continue;
+        };
+
+        // Both variables must be bound by a triple pattern at this scope level,
+        // so unifying them is a valid equijoin (not a cross-scope correlation).
+        if !var_bound_by_triple(patterns, x) || !var_bound_by_triple(patterns, y) {
+            continue;
+        }
+
+        // Skip when a single triple already binds both vars (e.g. a self-loop
+        // `?s :p ?o FILTER(?s = ?o)`): there is no cross-product to eliminate,
+        // and dedicated overlay-aware encoded-filter count fast paths handle
+        // that shape — folding would bypass them.
+        if triple_binds_both(patterns, x, y) {
+            continue;
+        }
+
+        // `=` is value equality; a join is term equality. Equivalent only when
+        // both vars are node-valued. `sameTerm` is term equality unconditionally.
+        if !same_term
+            && (!var_node_valued(patterns, x, stats) || !var_node_valued(patterns, y, stats))
+        {
+            continue;
+        }
+
+        // Choose the survivor. The dropped variable is renamed away, so prefer
+        // to keep a projected output variable; skip when both are projected.
+        let projected = |v: VarId| output_vars.is_some_and(|o| o.contains(&v));
+        let (drop, keep) = match (projected(x), projected(y)) {
+            (true, true) => continue,
+            (true, false) => (y, x),
+            (false, true) => (x, y),
+            (false, false) if x.0 <= y.0 => (y, x),
+            (false, false) => (x, y),
+        };
+
+        // The dropped variable must appear only in patterns `substitute_var`
+        // can rewrite (triple / filter / bind), never in a property path or
+        // search adapter (where substitution is a no-op).
+        if !drop_safe_to_substitute(patterns, drop) {
+            continue;
+        }
+
+        return Some((drop, keep, idx));
+    }
+    None
+}
+
+/// Match `FILTER(?x = ?y)` or `FILTER(sameTerm(?x, ?y))`; returns the two
+/// variables and whether the comparison was `sameTerm` (term equality).
+fn equality_vars(expr: &Expression) -> Option<(VarId, VarId, bool)> {
+    let Expression::Call { func, args } = expr else {
+        return None;
+    };
+    let same_term = match func {
+        Function::Eq => false,
+        Function::SameTerm => true,
+        _ => return None,
+    };
+    if args.len() != 2 {
+        return None;
+    }
+    match (&args[0], &args[1]) {
+        (Expression::Var(x), Expression::Var(y)) => Some((*x, *y, same_term)),
+        _ => None,
+    }
+}
+
+/// True if `v` appears in any position of triple pattern `tp`.
+fn triple_has_var(tp: &crate::ir::TriplePattern, v: VarId) -> bool {
+    matches!(tp.s, Ref::Var(x) if x == v)
+        || matches!(tp.p, Ref::Var(x) if x == v)
+        || matches!(tp.o, Term::Var(x) if x == v)
+}
+
+/// True if `v` appears in any top-level triple pattern (s/p/o) of `patterns`.
+fn var_bound_by_triple(patterns: &[Pattern], v: VarId) -> bool {
+    patterns
+        .iter()
+        .any(|p| matches!(p, Pattern::Triple(tp) if triple_has_var(tp, v)))
+}
+
+/// True if any single top-level triple binds BOTH `x` and `y`.
+fn triple_binds_both(patterns: &[Pattern], x: VarId, y: VarId) -> bool {
+    patterns
+        .iter()
+        .any(|p| matches!(p, Pattern::Triple(tp) if triple_has_var(tp, x) && triple_has_var(tp, y)))
+}
+
+/// True if `v` is provably node-valued across the scope's top-level triples:
+/// used as a subject/predicate (always a node), or only as the object of
+/// predicates whose stats prove every object is a ref.
+fn var_node_valued(patterns: &[Pattern], v: VarId, stats: &StatsView) -> bool {
+    let mut has_object = false;
+    let mut all_object_predicates_ref = true;
+    for p in patterns {
+        let Pattern::Triple(tp) = p else {
+            continue;
+        };
+        if matches!(tp.s, Ref::Var(x) if x == v) || matches!(tp.p, Ref::Var(x) if x == v) {
+            return true;
+        }
+        if matches!(tp.o, Term::Var(x) if x == v) {
+            has_object = true;
+            if !predicate_ref_only(&tp.p, stats) {
+                all_object_predicates_ref = false;
+            }
+        }
+    }
+    has_object && all_object_predicates_ref
+}
+
+/// Whether the predicate's objects are provably all node/IRI refs.
+fn predicate_ref_only(pred: &Ref, stats: &StatsView) -> bool {
+    match pred {
+        Ref::Sid(sid) => stats.is_property_ref_only(sid).unwrap_or(false),
+        Ref::Iri(iri) => stats.is_property_ref_only_by_iri(iri).unwrap_or(false),
+        // A variable predicate has no known object datatype.
+        Ref::Var(_) => false,
+    }
+}
+
+/// True if the dropped variable appears only in patterns that
+/// [`Pattern::substitute_var`] can rewrite (triple / filter / bind). Any other
+/// top-level pattern (property path, search adapter, container, VALUES, …) that
+/// references it makes the fold ineligible.
+fn drop_safe_to_substitute(patterns: &[Pattern], drop: VarId) -> bool {
+    patterns.iter().all(|p| match p {
+        Pattern::Triple(_) | Pattern::Filter(_) | Pattern::Bind { .. } => true,
+        other => !other.referenced_vars().contains(&drop),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{
+        AggregateFn, AggregateSpec, Grouping, Query, QueryOutput, ReasoningConfig, TriplePattern,
+    };
+    use fluree_db_core::Sid;
+    use fluree_graph_json_ld::ParsedContext;
+
+    const FEAT: u16 = 100;
+
+    fn feature_pred() -> Sid {
+        Sid::new(FEAT, "feature")
+    }
+
+    // `<p1> feature ?f1 . ?other feature ?f2 . FILTER(?f1 <op> ?f2)` GROUP BY
+    // ?other, COUNT(?f2). Mirrors BSBM BI-2 (shared-feature count).
+    fn shared_feature_query(eq_func: Function) -> Query {
+        let f1 = VarId(0);
+        let f2 = VarId(1);
+        let other = VarId(2);
+        let cnt = VarId(3);
+        let feat = feature_pred();
+        let patterns = vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Sid(Sid::new(FEAT, "p1")),
+                Ref::Sid(feat.clone()),
+                Term::Var(f1),
+            )),
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(other),
+                Ref::Sid(feat),
+                Term::Var(f2),
+            )),
+            Pattern::Filter(Expression::Call {
+                func: eq_func,
+                args: vec![Expression::Var(f1), Expression::Var(f2)],
+            }),
+        ];
+        let grouping = Grouping::assemble(
+            vec![other],
+            vec![AggregateSpec {
+                function: AggregateFn::Count(f2),
+                output_var: cnt,
+            }],
+            vec![],
+            None,
+        );
+        Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![other, cnt]),
+            patterns,
+            reasoning: ReasoningConfig::default(),
+            grouping,
+            ordering: Vec::new(),
+            order_binds: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: None,
+        }
+    }
+
+    fn stats_with_feature_ref_only(ref_only: bool) -> StatsView {
+        let mut stats = StatsView::default();
+        stats.property_ref_only.insert(feature_pred(), ref_only);
+        stats
+    }
+
+    fn count_input_var(query: &Query) -> Option<VarId> {
+        query
+            .grouping
+            .as_ref()?
+            .aggregates()
+            .next()?
+            .function
+            .input_var()
+    }
+
+    #[test]
+    fn folds_equality_on_ref_predicate() {
+        let mut query = shared_feature_query(Function::Eq);
+        fold_equijoin_filters(&mut query, Some(&stats_with_feature_ref_only(true)));
+
+        // FILTER removed, two triples remain.
+        assert_eq!(query.patterns.len(), 2);
+        assert!(query
+            .patterns
+            .iter()
+            .all(|p| !matches!(p, Pattern::Filter(_))));
+        // The two feature objects are now the SAME variable (an equijoin), and
+        // the aggregate counts that surviving variable.
+        let object_vars: Vec<VarId> = query
+            .patterns
+            .iter()
+            .filter_map(|p| match p {
+                Pattern::Triple(tp) => tp.o.as_var(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(object_vars, vec![VarId(0), VarId(0)]);
+        assert_eq!(count_input_var(&query), Some(VarId(0)));
+    }
+
+    #[test]
+    fn does_not_fold_equality_on_literal_predicate() {
+        // Not ref-only => `=` is value equality, which a term-join would not
+        // preserve. The filter must stay.
+        let mut query = shared_feature_query(Function::Eq);
+        fold_equijoin_filters(&mut query, Some(&stats_with_feature_ref_only(false)));
+
+        assert_eq!(query.patterns.len(), 3);
+        assert!(query
+            .patterns
+            .iter()
+            .any(|p| matches!(p, Pattern::Filter(_))));
+        assert_eq!(count_input_var(&query), Some(VarId(1)));
+    }
+
+    #[test]
+    fn does_not_fold_without_stats() {
+        let mut query = shared_feature_query(Function::Eq);
+        fold_equijoin_filters(&mut query, None);
+        assert_eq!(query.patterns.len(), 3);
+    }
+
+    #[test]
+    fn does_not_fold_self_loop_in_single_triple() {
+        // `?s feature ?o . FILTER(?s = ?o)` — both vars in one triple; there is
+        // no cross-product to eliminate and a dedicated encoded-filter count
+        // fast path owns this shape. Must not fold.
+        let s = VarId(0);
+        let o = VarId(1);
+        let patterns = vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(s),
+                Ref::Sid(feature_pred()),
+                Term::Var(o),
+            )),
+            Pattern::Filter(Expression::Call {
+                func: Function::Eq,
+                args: vec![Expression::Var(s), Expression::Var(o)],
+            }),
+        ];
+        let mut query = Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![s, o]),
+            patterns,
+            reasoning: ReasoningConfig::default(),
+            grouping: None,
+            ordering: Vec::new(),
+            order_binds: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: None,
+        };
+        fold_equijoin_filters(&mut query, Some(&stats_with_feature_ref_only(true)));
+        assert_eq!(query.patterns.len(), 2);
+        assert!(query
+            .patterns
+            .iter()
+            .any(|p| matches!(p, Pattern::Filter(_))));
+    }
+
+    #[test]
+    fn sameterm_folds_without_node_guard() {
+        // sameTerm is term equality, so it folds even when the predicate is not
+        // provably ref-only.
+        let mut query = shared_feature_query(Function::SameTerm);
+        fold_equijoin_filters(&mut query, Some(&stats_with_feature_ref_only(false)));
+
+        assert_eq!(query.patterns.len(), 2);
+        assert_eq!(count_input_var(&query), Some(VarId(0)));
+    }
+}

--- a/fluree-db-query/src/ir/expression.rs
+++ b/fluree-db-query/src/ir/expression.rs
@@ -37,6 +37,29 @@ pub enum Expression {
 }
 
 impl Expression {
+    /// Rename every occurrence of variable `old` to `new` (recursively through
+    /// call arguments and EXISTS sub-patterns). Used by the equijoin-filter fold.
+    pub fn substitute_var(&mut self, old: VarId, new: VarId) {
+        match self {
+            Expression::Var(v) => {
+                if *v == old {
+                    *v = new;
+                }
+            }
+            Expression::Const(_) => {}
+            Expression::Call { args, .. } => {
+                for arg in args {
+                    arg.substitute_var(old, new);
+                }
+            }
+            Expression::Exists { patterns, .. } => {
+                for p in patterns {
+                    p.substitute_var(old, new);
+                }
+            }
+        }
+    }
+
     /// True if this expression (or any sub-expression / sub-pattern it
     /// contains) calls the given built-in function.
     ///

--- a/fluree-db-query/src/ir/grouping.rs
+++ b/fluree-db-query/src/ir/grouping.rs
@@ -109,6 +109,31 @@ impl AggregateFn {
     }
 }
 
+impl AggregateFn {
+    /// Rename the input variable from `old` to `new` (no-op for `CountAll`).
+    pub fn substitute_var(&mut self, old: VarId, new: VarId) {
+        let rename = |v: &mut VarId| {
+            if *v == old {
+                *v = new;
+            }
+        };
+        match self {
+            Self::CountAll => {}
+            Self::Count(v)
+            | Self::CountDistinct(v)
+            | Self::Sum(v, _)
+            | Self::Avg(v, _)
+            | Self::Min(v)
+            | Self::Max(v)
+            | Self::Median(v, _)
+            | Self::Variance(v, _)
+            | Self::Stddev(v, _)
+            | Self::Sample(v) => rename(v),
+            Self::GroupConcat { input, .. } => rename(input),
+        }
+    }
+}
+
 /// Specification for a single aggregate operation: the function applied to
 /// each group plus the variable the result is bound to.
 #[derive(Debug, Clone)]
@@ -254,5 +279,45 @@ impl Grouping {
         self.aggregation()
             .into_iter()
             .flat_map(|agg| agg.binds.iter())
+    }
+
+    /// Rename every occurrence of variable `old` to `new` across GROUP BY keys,
+    /// aggregate input/output vars, post-aggregation binds, and HAVING. Used by
+    /// the equijoin-filter fold to unify two provably-equal variables.
+    pub fn substitute_var(&mut self, old: VarId, new: VarId) {
+        let rename = |v: &mut VarId| {
+            if *v == old {
+                *v = new;
+            }
+        };
+        let (aggregation, having) = match self {
+            Self::Implicit {
+                aggregation,
+                having,
+            } => (Some(aggregation), having),
+            Self::Explicit {
+                group_by,
+                aggregation,
+                having,
+            } => {
+                for v in group_by.iter_mut() {
+                    rename(v);
+                }
+                (aggregation.as_mut(), having)
+            }
+        };
+        if let Some(agg) = aggregation {
+            for spec in agg.aggregates.iter_mut() {
+                spec.function.substitute_var(old, new);
+                rename(&mut spec.output_var);
+            }
+            for (var, expr) in &mut agg.binds {
+                rename(var);
+                expr.substitute_var(old, new);
+            }
+        }
+        if let Some(expr) = having {
+            expr.substitute_var(old, new);
+        }
     }
 }

--- a/fluree-db-query/src/ir/pattern.rs
+++ b/fluree-db-query/src/ir/pattern.rs
@@ -35,6 +35,13 @@ pub struct SubqueryPattern {
     pub distinct: bool,
     /// ORDER BY specs. Empty when the subquery is unordered.
     pub ordering: Vec<SortSpec>,
+    /// Expression-based ORDER BY binds (e.g. `ORDER BY DESC(?a / ?b)` or
+    /// `ORDER BY DESC(COUNT(?o))`). Mirrors [`crate::ir::Query::order_binds`]:
+    /// each `(var, expr)` is evaluated once per solution as a dedicated stage
+    /// after grouping/aggregation/HAVING/post-binds and before the sort, and
+    /// the matching [`SortSpec`] in `ordering` references the synthetic `var`.
+    /// Empty for JSON-LD subqueries (no expression-ORDER-BY surface syntax).
+    pub order_binds: Vec<(VarId, Expression)>,
     /// Optional aggregation phase (GROUP BY / aggregates / HAVING).
     pub grouping: Option<Grouping>,
 }
@@ -49,6 +56,7 @@ impl SubqueryPattern {
             offset: None,
             distinct: false,
             ordering: Vec::new(),
+            order_binds: Vec::new(),
             grouping: None,
         }
     }
@@ -74,6 +82,12 @@ impl SubqueryPattern {
     /// Set ORDER BY specs.
     pub fn with_ordering(mut self, specs: Vec<SortSpec>) -> Self {
         self.ordering = specs;
+        self
+    }
+
+    /// Set the expression-based ORDER BY binds (see [`Self::order_binds`]).
+    pub fn with_order_binds(mut self, order_binds: Vec<(VarId, Expression)>) -> Self {
+        self.order_binds = order_binds;
         self
     }
 

--- a/fluree-db-query/src/ir/pattern.rs
+++ b/fluree-db-query/src/ir/pattern.rs
@@ -102,6 +102,34 @@ impl SubqueryPattern {
         self.select.clone()
     }
 
+    /// Rename every occurrence of variable `old` to `new` across the whole
+    /// subquery scope: SELECT list, WHERE patterns, grouping, ORDER BY, and
+    /// expression-ORDER-BY binds. Used by the equijoin-filter fold.
+    pub fn substitute_var(&mut self, old: VarId, new: VarId) {
+        for v in &mut self.select {
+            if *v == old {
+                *v = new;
+            }
+        }
+        for p in &mut self.patterns {
+            p.substitute_var(old, new);
+        }
+        if let Some(g) = &mut self.grouping {
+            g.substitute_var(old, new);
+        }
+        for spec in &mut self.ordering {
+            if spec.var == old {
+                spec.var = new;
+            }
+        }
+        for (v, expr) in &mut self.order_binds {
+            if *v == old {
+                *v = new;
+            }
+            expr.substitute_var(old, new);
+        }
+    }
+
     /// Variables mentioned anywhere in the subquery, including inside its
     /// body. Body-internal variables that aren't in `select` are still
     /// listed; correlation analysis at the call site can subtract
@@ -386,6 +414,80 @@ impl Pattern {
                 ..sp
             }),
             other => other,
+        }
+    }
+
+    /// Rename every occurrence of variable `old` to `new` within this pattern,
+    /// recursively. Used by the equijoin-filter fold ([`crate::filter_fold`])
+    /// after it proves `old` and `new` are equal. The fold's eligibility check
+    /// guarantees the renamed variable never appears in a property-path or
+    /// search-adapter pattern, so those arms are debug-asserted no-ops.
+    pub fn substitute_var(&mut self, old: VarId, new: VarId) {
+        const UNHANDLED: &str =
+            "filter_fold: substitute_var reached an unhandled pattern containing the renamed var";
+        let rename = |v: &mut VarId| {
+            if *v == old {
+                *v = new;
+            }
+        };
+        match self {
+            Pattern::Triple(tp) => tp.substitute_var(old, new),
+            Pattern::Filter(expr) => expr.substitute_var(old, new),
+            Pattern::Bind { var, expr } => {
+                rename(var);
+                expr.substitute_var(old, new);
+            }
+            Pattern::Values { vars, .. } => vars.iter_mut().for_each(rename),
+            Pattern::Optional(inner)
+            | Pattern::Minus(inner)
+            | Pattern::Exists(inner)
+            | Pattern::NotExists(inner) => {
+                for p in inner {
+                    p.substitute_var(old, new);
+                }
+            }
+            Pattern::Union(branches) => {
+                for branch in branches {
+                    for p in branch {
+                        p.substitute_var(old, new);
+                    }
+                }
+            }
+            Pattern::Subquery(sq) => sq.substitute_var(old, new),
+            Pattern::Graph { name, patterns } => {
+                if let GraphName::Var(v) = name {
+                    rename(v);
+                }
+                for p in patterns {
+                    p.substitute_var(old, new);
+                }
+            }
+            Pattern::Service(sp) => {
+                if let ServiceEndpoint::Var(v) = &mut sp.endpoint {
+                    rename(v);
+                }
+                for p in &mut sp.patterns {
+                    p.substitute_var(old, new);
+                }
+            }
+            Pattern::PropertyPath(pp) => {
+                debug_assert!(!pp.referenced_vars().contains(&old), "{UNHANDLED}");
+            }
+            Pattern::IndexSearch(p) => {
+                debug_assert!(!p.referenced_vars().contains(&old), "{UNHANDLED}");
+            }
+            Pattern::VectorSearch(p) => {
+                debug_assert!(!p.referenced_vars().contains(&old), "{UNHANDLED}");
+            }
+            Pattern::R2rml(p) => {
+                debug_assert!(!p.referenced_vars().contains(&old), "{UNHANDLED}");
+            }
+            Pattern::GeoSearch(p) => {
+                debug_assert!(!p.referenced_vars().contains(&old), "{UNHANDLED}");
+            }
+            Pattern::S2Search(p) => {
+                debug_assert!(!p.referenced_vars().contains(&old), "{UNHANDLED}");
+            }
         }
     }
 

--- a/fluree-db-query/src/ir/triple.rs
+++ b/fluree-db-query/src/ir/triple.rs
@@ -198,6 +198,22 @@ impl TriplePattern {
         Self { s, p, o, dtc: None }
     }
 
+    /// Rename every occurrence of variable `old` to `new` in s/p/o.
+    ///
+    /// Used by the equijoin-filter fold ([`crate::filter_fold`]) to unify two
+    /// variables proven equal by a `FILTER(?x = ?y)` (or `sameTerm`).
+    pub fn substitute_var(&mut self, old: VarId, new: VarId) {
+        if matches!(self.s, Ref::Var(v) if v == old) {
+            self.s = Ref::Var(new);
+        }
+        if matches!(self.p, Ref::Var(v) if v == old) {
+            self.p = Ref::Var(new);
+        }
+        if matches!(self.o, Term::Var(v) if v == old) {
+            self.o = Term::Var(new);
+        }
+    }
+
     /// Variables this pattern mentions, in order: s, p, o.
     ///
     /// For a triple pattern, every variable position is both *referenced*

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -48,6 +48,7 @@ pub(crate) mod fast_string_prefix_count_all;
 pub(crate) mod fast_sum_strlen_group_concat;
 pub(crate) mod fast_union_star_count_all;
 pub mod filter;
+pub(crate) mod filter_fold;
 pub mod geo_rewrite;
 pub mod geo_search;
 pub mod graph;

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -14,6 +14,7 @@
 //! Build a `TriplePattern` with a `VarRegistry`, then call `execute_pattern` with a `GraphDbRef` to get result batches.
 
 pub mod aggregate;
+pub(crate) mod aggregate_complement_fold;
 pub mod binary_history;
 pub mod binary_range;
 pub mod binary_scan;

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -1064,9 +1064,10 @@ enum SelectExprPlacement {
 ///     in via `post_bind_aliases` so the caller can chain dependencies).
 ///   - `Pre` otherwise.
 ///
-/// Both `lower_query` and `lower_subquery` call this. `lower_query` routes
-/// the result by placement; `lower_subquery` errors on `Post` because
-/// [`SubqueryPattern`] has no `post_binds` field.
+/// Both `lower_query` and `lower_subquery` call this and route the result by
+/// placement: `Pre` binds append to WHERE, `Post` binds ride inside the
+/// grouping's aggregation stage (applied by the shared `apply_solution_modifiers`
+/// tail).
 fn lower_select_expr_bind<E: IriEncoder>(
     expr: &UnresolvedExpression,
     alias: &Arc<str>,
@@ -1141,17 +1142,20 @@ fn lower_subquery<E: IriEncoder>(
     // Lower WHERE patterns, then append select-expression BINDs.
     let mut patterns = lower_unresolved_patterns(&subquery.patterns, encoder, vars, pp_counter)?;
 
-    // Subqueries do not currently expose post-aggregation binds, so we use
-    // the shared `lower_select_expr_bind` helper but reject any column it
-    // classifies as `Post`. This mirrors the limitation of `SubqueryPattern`
-    // (no `post_binds` field).
+    // SELECT-expression binds split into pre-aggregation (appended to WHERE)
+    // and post-aggregation (referencing an aggregate output or an earlier
+    // post-bind). Post-binds ride inside the grouping's aggregation stage and
+    // are applied by the shared `apply_solution_modifiers` tail — the same
+    // channel the top-level SELECT uses, so subquery post-aggregation binds
+    // now work identically.
     let aggregate_output_vars: std::collections::HashSet<VarId> = subquery
         .options
         .aggregates
         .iter()
         .map(|spec| vars.get_or_insert(&spec.output_var))
         .collect();
-    let empty_post_binds: std::collections::HashSet<VarId> = std::collections::HashSet::new();
+    let mut post_binds: Vec<(VarId, Expression)> = Vec::new();
+    let mut post_bind_aliases: std::collections::HashSet<VarId> = std::collections::HashSet::new();
     for column in columns {
         if let UnresolvedColumn::Computation { expr, alias } = column {
             let (placement, alias_var, lowered_expr) = lower_select_expr_bind(
@@ -1161,14 +1165,12 @@ fn lower_subquery<E: IriEncoder>(
                 vars,
                 pp_counter,
                 &aggregate_output_vars,
-                &empty_post_binds,
+                &post_bind_aliases,
             )?;
             match placement {
                 SelectExprPlacement::Post => {
-                    return Err(ParseError::InvalidSelect(format!(
-                        "select expression '{alias}' references an aggregate output; \
-                         post-aggregation BINDs are not supported inside subqueries"
-                    )));
+                    post_binds.push((alias_var, lowered_expr));
+                    post_bind_aliases.insert(alias_var);
                 }
                 SelectExprPlacement::Pre => {
                     patterns.push(Pattern::Bind {
@@ -1202,10 +1204,10 @@ fn lower_subquery<E: IriEncoder>(
         sq = sq.with_ordering(sort_specs);
     }
 
-    // GROUP BY / aggregates / HAVING (needed for subqueries used in filters/unions).
-    // Subqueries have no post-aggregation bind channel; the loop above
-    // already rejects any SELECT computation classified as `Post`.
-    sq.grouping = lower_grouping(&subquery.options, vars, Vec::new())?;
+    // GROUP BY / aggregates / HAVING / post-aggregation binds (needed for
+    // subqueries used in filters/unions). Post-binds collected above ride inside
+    // the grouping's aggregation stage.
+    sq.grouping = lower_grouping(&subquery.options, vars, post_binds)?;
 
     Ok(sq)
 }
@@ -1730,9 +1732,8 @@ fn lower_ordering(opts: &UnresolvedOptions, vars: &mut VarRegistry) -> Vec<SortS
 /// post-aggregation binds).
 ///
 /// `post_binds` are derived bindings that fire after every aggregate has
-/// been computed; they ride inside the resulting `Aggregation`. Subquery
-/// callers pass `Vec::new()` because [`SubqueryPattern`] has no post-bind
-/// channel.
+/// been computed; they ride inside the resulting `Aggregation`. Both top-level
+/// and subquery callers populate them from post-aggregation SELECT expressions.
 fn lower_grouping(
     opts: &UnresolvedOptions,
     vars: &mut VarRegistry,

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1353,6 +1353,22 @@ fn drain_ready_deferred(
 /// produced by some OTHER pattern in the enclosing group. These must be bound
 /// before the subquery runs, so the planner defers it until they are. An empty
 /// result means the subquery is uncorrelated (safe to place early).
+///
+/// A shared variable that the subquery **produces itself** (binds in its own
+/// WHERE — e.g. a `GROUP BY` key) is a JOIN key, not a correlation input:
+/// seeding it per outer row is equivalent to evaluating the subquery once and
+/// filtering its output to that value, so it can run once and be hash-joined.
+///
+/// Two safety conditions on this declassification:
+/// 1. **No inner slice.** With `LIMIT`/`OFFSET`, the per-row restriction changes
+///    which rows survive the slice (e.g. `ORDER BY DESC(?x) LIMIT 1` means "top
+///    row per outer binding"), so such a subquery stays genuinely correlated.
+/// 2. **Unconditionally bound.** The variable must be bound in *every* subquery
+///    solution — produced by a top-level required pattern (a triple or property
+///    path), NOT inside a `UNION` branch or `OPTIONAL`. A conditionally-bound
+///    var can be Unbound in some output rows; evaluating once and joining would
+///    then differ from per-row seeding (an Unbound join key would scan rather
+///    than filter). We only count always-bound producers.
 fn subquery_correlation_vars(
     sq: &SubqueryPattern,
     siblings: &[Pattern],
@@ -1362,13 +1378,26 @@ fn subquery_correlation_vars(
     if select.is_empty() {
         return HashSet::new();
     }
+    // Variables the subquery binds in EVERY solution on its own — but only when
+    // no inner slice makes per-row seeding result-sensitive. Restricted to
+    // top-level required producers (triples / property paths) so a var that is
+    // only conditionally bound (UNION branch, OPTIONAL) is NOT declassified.
+    let self_produced: HashSet<VarId> = if sq.limit.is_none() && sq.offset.is_none() {
+        sq.patterns
+            .iter()
+            .filter(|p| matches!(p, Pattern::Triple(_) | Pattern::PropertyPath(_)))
+            .flat_map(Pattern::produced_vars)
+            .collect()
+    } else {
+        HashSet::new()
+    };
     let mut corr = HashSet::new();
     for (j, p) in siblings.iter().enumerate() {
         if j == self_idx {
             continue;
         }
         for v in p.produced_vars() {
-            if select.contains(&v) {
+            if select.contains(&v) && !self_produced.contains(&v) {
                 corr.insert(v);
             }
         }

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -8,7 +8,7 @@
 //! `build_where_operators_seeded` in `execute/where_plan.rs`.
 
 use crate::ir::triple::{Ref, Term, TriplePattern};
-use crate::ir::{CompareOp, Function, Pattern};
+use crate::ir::{CompareOp, Function, Grouping, Pattern, SubqueryPattern};
 use crate::var_registry::VarId;
 use fluree_db_core::{FlakeValue, PropertyStatData, StatsView};
 use std::collections::{HashMap, HashSet};
@@ -780,9 +780,28 @@ pub fn estimate_pattern(
             }
         }
 
-        Pattern::Subquery(sq) => PatternEstimate::Source {
-            row_count: estimate_branch_cardinality(&sq.patterns, stats),
-        },
+        Pattern::Subquery(sq) => {
+            // Join ordering cares about a subquery's OUTPUT cardinality, not the
+            // size of its internal scan. A scalar aggregate (no `GROUP BY`) emits
+            // exactly one row. Estimating it by the (large) body cardinality
+            // wrongly ranks the subquery as a huge source and pushes it to the
+            // END of the join order — precisely where, if it is uncorrelated, it
+            // gets re-executed once per parent row (see `SubqueryOperator`'s
+            // uncorrelated fast-path). Treat a scalar-aggregate subquery as a
+            // single row so the planner places it early.
+            let rows = match &sq.grouping {
+                Some(Grouping::Implicit { .. }) => HIGHLY_SELECTIVE,
+                // `Explicit` GROUP BY emits one row per distinct key combination
+                // and `None` emits one row per solution; absent per-key NDV we
+                // keep the body estimate (an upper bound) for these.
+                _ => estimate_branch_cardinality(&sq.patterns, stats),
+            };
+            // A LIMIT caps the output regardless of grouping.
+            let rows = sq.limit.map_or(rows, |l| rows.min(l as f64));
+            PatternEstimate::Source {
+                row_count: rows.max(HIGHLY_SELECTIVE),
+            }
+        }
 
         Pattern::Optional(_) => PatternEstimate::Expander { multiplier: 1.0 },
 
@@ -1042,6 +1061,29 @@ pub fn reorder_patterns(
                 pattern: pattern.clone(),
             });
             continue;
+        }
+
+        // A CORRELATED subquery — one whose SELECT list shares variables with
+        // other patterns in this group — must execute AFTER those variables are
+        // bound. `SubqueryOperator` derives its correlation set from the
+        // variables its child (the patterns placed before it) provides; if the
+        // subquery were hoisted ahead of them, that set would be empty and it
+        // would compute a single global result instead of a per-row correlated
+        // one. Defer it on its correlation variables, exactly like MINUS/EXISTS.
+        //
+        // UNCORRELATED subqueries are intentionally NOT deferred: they fall
+        // through to source classification, so a scalar-aggregate subquery is
+        // still placed early via its (now accurate) single-row estimate.
+        if let Pattern::Subquery(sq) = pattern {
+            let corr = subquery_correlation_vars(sq, patterns, i);
+            if !corr.is_empty() {
+                deferred.push(DeferredPattern {
+                    orig_index: i,
+                    required_vars: corr,
+                    pattern: pattern.clone(),
+                });
+                continue;
+            }
         }
 
         match estimate_pattern(pattern, &bound_vars, stats) {
@@ -1306,6 +1348,34 @@ fn drain_ready_deferred(
 ///
 /// - FILTER: all referenced variables
 /// - BIND: the expression's variables (not the target variable)
+///
+/// Variables a subquery correlates on: its SELECT-list variables that are also
+/// produced by some OTHER pattern in the enclosing group. These must be bound
+/// before the subquery runs, so the planner defers it until they are. An empty
+/// result means the subquery is uncorrelated (safe to place early).
+fn subquery_correlation_vars(
+    sq: &SubqueryPattern,
+    siblings: &[Pattern],
+    self_idx: usize,
+) -> HashSet<VarId> {
+    let select: HashSet<VarId> = sq.select.iter().copied().collect();
+    if select.is_empty() {
+        return HashSet::new();
+    }
+    let mut corr = HashSet::new();
+    for (j, p) in siblings.iter().enumerate() {
+        if j == self_idx {
+            continue;
+        }
+        for v in p.produced_vars() {
+            if select.contains(&v) {
+                corr.insert(v);
+            }
+        }
+    }
+    corr
+}
+
 fn deferred_required_vars(pattern: &Pattern) -> Vec<VarId> {
     match pattern {
         Pattern::Filter(expr) => expr.referenced_vars(),

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -62,6 +62,14 @@ pub struct SubqueryOperator {
     planning: PlanningContext,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
+    /// Cached result rows for an UNCORRELATED subquery (`correlation_vars`
+    /// empty). Such a subquery shares no variables with the parent, so its seed
+    /// is always the empty solution (see `execute_subquery_for_row`) and it
+    /// yields the identical result for every parent row. We execute it once,
+    /// cache the rows here, and broadcast them to every parent row (and across
+    /// batches) instead of rebuilding and re-running the subquery operator tree
+    /// per row. Mirrors `FilterOperator::pre_resolve_uncorrelated` for EXISTS.
+    uncorrelated_cache: Option<Vec<Vec<Binding>>>,
 }
 
 impl SubqueryOperator {
@@ -120,6 +128,7 @@ impl SubqueryOperator {
             stats,
             planning,
             out_schema: None,
+            uncorrelated_cache: None,
         }
     }
 
@@ -146,6 +155,7 @@ impl Operator for SubqueryOperator {
 
         self.child.open(ctx).await?;
         self.state = OperatorState::Open;
+        self.uncorrelated_cache = None;
         Ok(())
     }
 
@@ -172,11 +182,29 @@ impl Operator for SubqueryOperator {
         self.result_buffer.clear();
         self.buffer_pos = 0;
 
+        let uncorrelated = self.correlation_vars.is_empty();
         for row_idx in 0..parent_batch.len() {
-            // Execute subquery for this parent row
-            let subquery_results = self
-                .execute_subquery_for_row(ctx, &parent_batch, row_idx)
-                .await?;
+            // Execute the subquery for this parent row.
+            //
+            // UNCORRELATED subqueries (no variables shared with the parent)
+            // produce the identical result for every parent row — their seed is
+            // always the empty solution. Execute once, cache, and reuse for all
+            // rows and all subsequent batches. This collapses an
+            // O(parent_rows) re-execution — each rebuilding and re-running the
+            // full subquery operator tree — into a single run. The clone is of
+            // the (typically single-row) cached result, not of any scan work.
+            let subquery_results = if uncorrelated {
+                if self.uncorrelated_cache.is_none() {
+                    let rows = self
+                        .execute_subquery_for_row(ctx, &parent_batch, row_idx)
+                        .await?;
+                    self.uncorrelated_cache = Some(rows);
+                }
+                self.uncorrelated_cache.as_ref().unwrap().clone()
+            } else {
+                self.execute_subquery_for_row(ctx, &parent_batch, row_idx)
+                    .await?
+            };
 
             // Merge results with parent row
             for subquery_row in subquery_results {

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -310,8 +310,8 @@ impl SubqueryOperator {
         // Projection trimming (`variable_deps`) and the streaming-group
         // partition hint are skipped: the subquery runs once per correlated
         // parent row, and its full select list flows back into the merge.
-        let select_vars: Option<&[VarId]> = (!self.subquery.select.is_empty())
-            .then_some(self.subquery.select.as_slice());
+        let select_vars: Option<&[VarId]> =
+            (!self.subquery.select.is_empty()).then_some(self.subquery.select.as_slice());
         let mut operator = crate::execute::operator_tree::apply_solution_modifiers(
             where_op,
             self.subquery.grouping.as_ref(),

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -20,23 +20,15 @@
 //! - If `?s` is bound in the parent, the subquery filters to only those `?s` values
 //! - Results are merged back to the parent solution
 
-use crate::aggregate::AggregateOperator;
 use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
-use crate::distinct::DistinctOperator;
 use crate::error::{QueryError, Result};
 use crate::execute::build_where_operators_seeded;
-use crate::groupby::GroupByOperator;
-use crate::having::HavingOperator;
 use crate::ir::SubqueryPattern;
-use crate::limit::LimitOperator;
-use crate::offset::OffsetOperator;
 use crate::operator::{
     compute_trimmed_vars, effective_schema, trim_batch, BoxedOperator, Operator, OperatorState,
 };
-use crate::project::ProjectOperator;
 use crate::seed::{EmptyOperator, SeedOperator};
-use crate::sort::SortOperator;
 use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
@@ -301,7 +293,7 @@ impl SubqueryOperator {
         };
 
         // Build full operator tree for subquery patterns (supports filters, optionals, union, etc.)
-        let mut operator: BoxedOperator = build_where_operators_seeded(
+        let where_op: BoxedOperator = build_where_operators_seeded(
             Some(seed),
             &self.subquery.patterns,
             self.stats.clone(),
@@ -309,38 +301,29 @@ impl SubqueryOperator {
             &self.planning,
         )?;
 
-        // Apply GROUP BY / aggregates / HAVING for subqueries that use them.
-        if let Some(grouping) = &self.subquery.grouping {
-            let group_by: Vec<_> = grouping.group_by_vars().collect();
-            let aggregates: Vec<_> = grouping.aggregates().cloned().collect();
-            operator = Box::new(GroupByOperator::new(operator, group_by));
-            if !aggregates.is_empty() {
-                operator = Box::new(AggregateOperator::new(operator, aggregates));
-            }
-            if let Some(having) = grouping.having().cloned() {
-                operator = Box::new(HavingOperator::new(operator, having));
-            }
-        }
-
-        // Project to subquery select list before DISTINCT/ORDER BY/OFFSET/LIMIT so those modifiers
-        // apply to the intended output shape.
-        if !self.subquery.select.is_empty() {
-            operator = Box::new(ProjectOperator::new(operator, self.subquery.select.clone()));
-        }
-
-        // Apply modifiers (distinct, orderBy, offset, limit) to the projected shape.
-        if self.subquery.distinct {
-            operator = Box::new(DistinctOperator::new(operator));
-        }
-        if !self.subquery.ordering.is_empty() {
-            operator = Box::new(SortOperator::new(operator, self.subquery.ordering.clone()));
-        }
-        if let Some(offset) = self.subquery.offset {
-            operator = Box::new(OffsetOperator::new(operator, offset));
-        }
-        if let Some(limit) = self.subquery.limit {
-            operator = Box::new(LimitOperator::new(operator, limit));
-        }
+        // Apply the shared solution-modifier tail — GROUP BY + aggregation,
+        // HAVING, post-aggregation binds, expression/aggregate ORDER-BY binds,
+        // sort-var validation, ORDER BY (sort *before* project, with safe top-k),
+        // PROJECT, DISTINCT, OFFSET, LIMIT — so a subquery inherits identical
+        // modifier semantics to a top-level SELECT (same code path).
+        //
+        // Projection trimming (`variable_deps`) and the streaming-group
+        // partition hint are skipped: the subquery runs once per correlated
+        // parent row, and its full select list flows back into the merge.
+        let select_vars: Option<&[VarId]> = (!self.subquery.select.is_empty())
+            .then_some(self.subquery.select.as_slice());
+        let mut operator = crate::execute::operator_tree::apply_solution_modifiers(
+            where_op,
+            self.subquery.grouping.as_ref(),
+            &self.subquery.order_binds,
+            &self.subquery.ordering,
+            select_vars,
+            self.subquery.distinct,
+            self.subquery.offset,
+            self.subquery.limit,
+            false,
+            None,
+        )?;
 
         // Execute and collect results
         operator.open(ctx).await?;

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -24,7 +24,8 @@ use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::execute::build_where_operators_seeded;
-use crate::ir::SubqueryPattern;
+use crate::group_aggregate::{binding_to_group_key_owned, GroupKeyOwned};
+use crate::ir::{Pattern, SubqueryPattern};
 use crate::operator::{
     compute_trimmed_vars, effective_schema, trim_batch, BoxedOperator, Operator, OperatorState,
 };
@@ -62,14 +63,37 @@ pub struct SubqueryOperator {
     planning: PlanningContext,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
-    /// Cached result rows for an UNCORRELATED subquery (`correlation_vars`
-    /// empty). Such a subquery shares no variables with the parent, so its seed
-    /// is always the empty solution (see `execute_subquery_for_row`) and it
-    /// yields the identical result for every parent row. We execute it once,
-    /// cache the rows here, and broadcast them to every parent row (and across
-    /// batches) instead of rebuilding and re-running the subquery operator tree
-    /// per row. Mirrors `FilterOperator::pre_resolve_uncorrelated` for EXISTS.
-    uncorrelated_cache: Option<Vec<Vec<Binding>>>,
+    /// The subset of `correlation_vars` used as the hash-join key in join-mode:
+    /// the variables the subquery PRODUCES itself (bound by a top-level required
+    /// triple / property path). Seeding such a variable per parent row only
+    /// filters the subquery's output to that value, so it is equivalent to
+    /// evaluating the subquery once and joining on the variable. A correlation
+    /// variable that the subquery does NOT bind (e.g. a `GROUP BY` key never
+    /// constrained in the body — the BSBM BI-5 quirk) is a pass-through: it is
+    /// omitted from the key and flows from the parent, matching SPARQL join
+    /// semantics (the subquery's unbound value joins with the parent's bound
+    /// value). Empty when there is no correlation (broadcast).
+    join_keys: Vec<VarId>,
+    /// Whether the subquery is evaluated ONCE and hash-joined (on `join_keys`)
+    /// rather than re-executed per parent row. Requires no inner `LIMIT`/`OFFSET`
+    /// and that every non-key correlation variable is an unreferenced
+    /// pass-through. Gated by a parent-cardinality check so we only materialize
+    /// when it beats per-row seeding; an uncorrelated subquery always
+    /// materializes. Mirrors `SemijoinOperator`'s hash probe.
+    join_mode: bool,
+    /// Lazily materialized subquery result (built once when `join_mode`): all
+    /// result rows plus a hash index from the correlation-variable values to the
+    /// rows carrying them. Reused across every parent row and batch.
+    materialized: Option<MaterializedSubquery>,
+}
+
+/// A once-evaluated subquery result, indexed for hash-join probing.
+struct MaterializedSubquery {
+    /// All subquery result rows (projected to the subquery SELECT list).
+    rows: Vec<Vec<Binding>>,
+    /// Correlation-variable values -> indices into `rows`. An empty key vector
+    /// (no correlation) maps every row under a single bucket (broadcast).
+    index: HashMap<Vec<GroupKeyOwned>, Vec<usize>>,
 }
 
 impl SubqueryOperator {
@@ -115,6 +139,39 @@ impl SubqueryOperator {
         schema_vec.extend(&new_vars);
         let schema = Arc::from(schema_vec.into_boxed_slice());
 
+        // Partition correlation vars: a JOIN KEY is one the subquery binds in
+        // every solution itself (a top-level required triple / property path);
+        // seeding it only filters the output, so it can be a hash key.
+        let produced = self_produced_vars(&subquery.patterns);
+        let join_keys: Vec<VarId> = correlation_vars
+            .iter()
+            .copied()
+            .filter(|v| produced.contains(v))
+            .collect();
+
+        // Eligible for evaluate-once + hash-join when there is no inner slice and
+        // every NON-key correlation var is an unreferenced pass-through (it
+        // appears only in the SELECT, never constraining the body). Omitting such
+        // a var from the join key matches SPARQL join semantics. A correlation
+        // var that is referenced but not produced is a genuine per-row input.
+        let body_referenced = referenced_vars_set(&subquery.patterns);
+        let pass_through_ok = correlation_vars
+            .iter()
+            .all(|v| produced.contains(v) || !body_referenced.contains(v));
+        let eligible = subquery.limit.is_none() && subquery.offset.is_none() && pass_through_ok;
+
+        // Cardinality guard: evaluating once + hash-join removes the per-row
+        // operator-rebuild overhead, which pays off when the parent drives many
+        // rows; for a small parent, per-row seeding (with its pruning seed) can
+        // be cheaper, so fall back to it (the pre-existing behavior — this guard
+        // never regresses below it). An uncorrelated subquery has no shared key
+        // and MUST be evaluated once regardless (per-row recomputes identically).
+        let join_mode = eligible
+            && (correlation_vars.is_empty()
+                || child
+                    .estimated_rows()
+                    .is_none_or(|n| n >= SUBQUERY_MATERIALIZE_MIN_PARENT_ROWS));
+
         Self {
             child,
             subquery,
@@ -128,7 +185,9 @@ impl SubqueryOperator {
             stats,
             planning,
             out_schema: None,
-            uncorrelated_cache: None,
+            join_keys,
+            join_mode,
+            materialized: None,
         }
     }
 
@@ -155,7 +214,7 @@ impl Operator for SubqueryOperator {
 
         self.child.open(ctx).await?;
         self.state = OperatorState::Open;
-        self.uncorrelated_cache = None;
+        self.materialized = None;
         Ok(())
     }
 
@@ -182,25 +241,38 @@ impl Operator for SubqueryOperator {
         self.result_buffer.clear();
         self.buffer_pos = 0;
 
-        let uncorrelated = self.correlation_vars.is_empty();
         for row_idx in 0..parent_batch.len() {
-            // Execute the subquery for this parent row.
+            // Produce this parent row's matching subquery rows.
             //
-            // UNCORRELATED subqueries (no variables shared with the parent)
-            // produce the identical result for every parent row — their seed is
-            // always the empty solution. Execute once, cache, and reuse for all
-            // rows and all subsequent batches. This collapses an
-            // O(parent_rows) re-execution — each rebuilding and re-running the
-            // full subquery operator tree — into a single run. The clone is of
-            // the (typically single-row) cached result, not of any scan work.
-            let subquery_results = if uncorrelated {
-                if self.uncorrelated_cache.is_none() {
-                    let rows = self
-                        .execute_subquery_for_row(ctx, &parent_batch, row_idx)
-                        .await?;
-                    self.uncorrelated_cache = Some(rows);
+            // JOIN MODE: evaluate the subquery ONCE (empty seed), index it by
+            // the correlation-variable values, and for each parent row take only
+            // the subquery rows whose join key matches — equivalent to seeding
+            // per row but without rebuilding/re-running the subquery N times.
+            // An empty correlation set indexes every row under one bucket, so
+            // the match is a broadcast (the uncorrelated case).
+            //
+            // Otherwise (a genuine per-row correlation, or an inner slice that
+            // makes seeding result-sensitive), fall back to per-row seeding.
+            let subquery_results: Vec<Vec<Binding>> = if self.join_mode {
+                if self.materialized.is_none() {
+                    let m = self.materialize(ctx).await?;
+                    self.materialized = Some(m);
                 }
-                self.uncorrelated_cache.as_ref().unwrap().clone()
+                let mat = self.materialized.as_ref().unwrap();
+                let parent_key: Vec<GroupKeyOwned> = self
+                    .join_keys
+                    .iter()
+                    .map(|v| {
+                        parent_batch
+                            .get(row_idx, *v)
+                            .map(binding_to_group_key_owned)
+                            .unwrap_or(GroupKeyOwned::Absent)
+                    })
+                    .collect();
+                match mat.index.get(&parent_key) {
+                    Some(idxs) => idxs.iter().map(|&i| mat.rows[i].clone()).collect(),
+                    None => Vec::new(),
+                }
             } else {
                 self.execute_subquery_for_row(ctx, &parent_batch, row_idx)
                     .await?
@@ -320,6 +392,42 @@ impl SubqueryOperator {
             Box::new(SeedOperator::from_row(schema, seed_row))
         };
 
+        self.run_subquery_with_seed(ctx, seed).await
+    }
+
+    /// Evaluate the subquery ONCE with an empty seed and index its result rows
+    /// by their correlation-variable values, for hash-join probing in join-mode.
+    /// An empty correlation set produces a single bucket (broadcast).
+    async fn materialize(&self, ctx: &ExecutionContext<'_>) -> Result<MaterializedSubquery> {
+        let rows = self
+            .run_subquery_with_seed(ctx, Box::new(EmptyOperator::new()))
+            .await?;
+        let mut index: HashMap<Vec<GroupKeyOwned>, Vec<usize>> = HashMap::new();
+        for (i, row) in rows.iter().enumerate() {
+            let key: Vec<GroupKeyOwned> = self
+                .join_keys
+                .iter()
+                .map(|v| {
+                    self.select_index
+                        .get(v)
+                        .and_then(|&si| row.get(si))
+                        .map(binding_to_group_key_owned)
+                        .unwrap_or(GroupKeyOwned::Absent)
+                })
+                .collect();
+            index.entry(key).or_default().push(i);
+        }
+        Ok(MaterializedSubquery { rows, index })
+    }
+
+    /// Build and run the subquery's operator tree from `seed`, returning rows
+    /// projected to the subquery SELECT list. Shared by the per-row (correlated)
+    /// and once (join-mode) execution paths.
+    async fn run_subquery_with_seed(
+        &self,
+        ctx: &ExecutionContext<'_>,
+        seed: BoxedOperator,
+    ) -> Result<Vec<Vec<Binding>>> {
         // Build full operator tree for subquery patterns (supports filters, optionals, union, etc.)
         let where_op: BoxedOperator = build_where_operators_seeded(
             Some(seed),
@@ -336,8 +444,8 @@ impl SubqueryOperator {
         // modifier semantics to a top-level SELECT (same code path).
         //
         // Projection trimming (`variable_deps`) and the streaming-group
-        // partition hint are skipped: the subquery runs once per correlated
-        // parent row, and its full select list flows back into the merge.
+        // partition hint are skipped: the subquery's full select list flows
+        // back into the merge.
         let select_vars: Option<&[VarId]> =
             (!self.subquery.select.is_empty()).then_some(self.subquery.select.as_slice());
         let mut operator = crate::execute::operator_tree::apply_solution_modifiers(
@@ -378,6 +486,47 @@ impl SubqueryOperator {
         operator.close();
         Ok(results)
     }
+}
+
+/// Minimum estimated parent (driving) rows above which evaluating a self-keyed
+/// subquery once + hash-join beats per-row seeding. Below this the per-row path
+/// (with its pruning seed) can be cheaper, so it is kept — the pre-existing
+/// behavior, which this never regresses below. An unknown parent size defaults
+/// to materialize: the per-row operator-rebuild overhead, paid once per parent
+/// row, is the larger risk.
+const SUBQUERY_MATERIALIZE_MIN_PARENT_ROWS: usize = 8;
+
+/// Variables bound in *every* solution of `patterns` — produced by a top-level
+/// required pattern (triple / property path), or exported by a slice-free nested
+/// sub-SELECT whose own body always-binds them. NOT vars bound only inside a
+/// `UNION` branch or `OPTIONAL` (conditional), nor a sub-SELECT's pass-throughs.
+/// These are the only correlation variables safe to use as evaluate-once
+/// hash-join keys.
+fn self_produced_vars(patterns: &[Pattern]) -> HashSet<VarId> {
+    let mut produced: HashSet<VarId> = HashSet::new();
+    for p in patterns {
+        match p {
+            Pattern::Triple(_) | Pattern::PropertyPath(_) => {
+                produced.extend(p.produced_vars());
+            }
+            // A nested sub-SELECT binds the SELECT vars its own body always
+            // binds, so those are always-bound here too. A slice would make
+            // per-row seeding of such a var result-sensitive, so skip it then.
+            Pattern::Subquery(sq) if sq.limit.is_none() && sq.offset.is_none() => {
+                let inner = self_produced_vars(&sq.patterns);
+                produced.extend(sq.select.iter().copied().filter(|v| inner.contains(v)));
+            }
+            _ => {}
+        }
+    }
+    produced
+}
+
+/// All variables referenced anywhere in `patterns` (filters, binds, unions,
+/// optionals, nested subquery bodies). A correlation variable that is referenced
+/// but not produced is a genuine per-row input, not an omittable pass-through.
+fn referenced_vars_set(patterns: &[Pattern]) -> HashSet<VarId> {
+    patterns.iter().flat_map(Pattern::referenced_vars).collect()
 }
 
 #[cfg(test)]

--- a/fluree-db-server/src/error.rs
+++ b/fluree-db-server/src/error.rs
@@ -98,6 +98,13 @@ impl ServerError {
             // Query/Transaction errors
             ServerError::Api(ApiError::Query(_)) => errors::INVALID_QUERY,
             ServerError::Api(ApiError::Batch(_)) => errors::INVALID_QUERY,
+            // Optimistic-concurrency conflicts: a distinct, retryable class so
+            // clients can branch on `@type` (and the 409 status below).
+            ServerError::Api(ApiError::Transact(
+                fluree_db_api::TransactError::CommitConflict { .. }
+                | fluree_db_api::TransactError::PublishLostRace { .. }
+                | fluree_db_api::TransactError::NamespaceConflict(_),
+            )) => errors::COMMIT_CONFLICT,
             ServerError::Api(ApiError::Transact(_)) => errors::INVALID_TRANSACTION,
 
             // API-level errors
@@ -153,6 +160,15 @@ impl ServerError {
 
             // 409 - Conflict
             ServerError::Api(ApiError::LedgerExists(_)) => StatusCode::CONFLICT,
+            // Optimistic-concurrency / namespace-allocation conflicts are
+            // retryable: 409 lets clients distinguish "retry" from a 400 "bad
+            // request". (After server-side reconcile-and-retry these only reach
+            // the client when the bounded retry budget is exhausted.)
+            ServerError::Api(ApiError::Transact(
+                fluree_db_api::TransactError::CommitConflict { .. }
+                | fluree_db_api::TransactError::PublishLostRace { .. }
+                | fluree_db_api::TransactError::NamespaceConflict(_),
+            )) => StatusCode::CONFLICT,
 
             // 400 - Bad Request (client errors)
             ServerError::Api(ApiError::Parse(_)) => StatusCode::BAD_REQUEST,

--- a/fluree-db-server/src/lib.rs
+++ b/fluree-db-server/src/lib.rs
@@ -88,22 +88,34 @@ impl FlureeServer {
             }
         }
 
-        // Pre-load all ledgers into the LRU cache so the first query
-        // against each ledger doesn't pay the cold-start penalty (loading
-        // the binary index root from CAS, deserializing dicts, etc.).
-        Self::preload_all_ledgers(&state).await;
+        // NOTE: ledger preloading + forward-dict warming is deliberately NOT
+        // done here. It runs as a background task spawned in `run()` AFTER the
+        // listener binds, so the server accepts requests immediately instead of
+        // blocking startup until every (potentially large) ledger is loaded.
+        // Preload is a pure latency optimization — a ledger not yet warmed is
+        // still served correctly via an on-demand cold load on first access.
 
         let router = routes::build_router(state.clone());
 
         Ok(Self { state, router })
     }
 
-    /// Pre-load all non-retracted ledgers into the LRU cache.
+    /// Pre-load non-retracted ledgers into the LRU cache and warm their
+    /// forward-dictionary pages into the OS page cache.
     ///
-    /// This warms the binary index store cache for every ledger so that the
-    /// first query doesn't pay a cold-start penalty. Errors are logged but
-    /// do not prevent the server from starting.
-    async fn preload_all_ledgers(state: &Arc<AppState>) {
+    /// Runs in the background (spawned from [`run`](Self::run) after the
+    /// listener binds) so it never delays the server accepting requests. Each
+    /// ledger is structurally loaded (index root + dict readers + arenas), then
+    /// its forward-dict pack pages are touched into the page cache so the first
+    /// queries don't pay cold page-fault I/O resolving IRIs/strings.
+    ///
+    /// Forward-dict warming is capped at [`warm_budget_bytes`] (~2/3 of system
+    /// RAM): beyond that, touching more pages would evict pages we just warmed,
+    /// so the warming (not the structural load) stops and remaining ledgers warm
+    /// lazily on first query. Errors are logged, never fatal.
+    ///
+    /// [`warm_budget_bytes`]: fluree_db_api::server_defaults::warm_budget_bytes
+    async fn preload_all_ledgers(state: Arc<AppState>) {
         let start = std::time::Instant::now();
 
         let records = match state.fluree.nameservice().all_records().await {
@@ -120,38 +132,44 @@ impl FlureeServer {
         }
 
         let total = active.len();
+        let warm_budget = fluree_db_api::server_defaults::warm_budget_bytes();
         let mut loaded = 0usize;
+        let mut warmed_ledgers = 0usize;
+        let mut warmed_bytes: u64 = 0;
 
         for record in &active {
-            let handle = state.fluree.ledger_cached(&record.ledger_id).await;
-
-            match handle {
+            match state.fluree.ledger_cached(&record.ledger_id).await {
                 Ok(handle) => {
                     loaded += 1;
 
-                    // Warm dict tree leaves into the LeafletCache so the first
-                    // query doesn't pay cold-start disk I/O for IRI/string resolution.
-                    let snap = handle.snapshot().await;
-                    if let Some(store) = &snap.binary_store {
-                        match store.preload_dict_leaves() {
-                            Ok(leaf_count) => {
-                                tracing::debug!(
-                                    ledger = %record.ledger_id,
-                                    leaf_count,
-                                    "Preloaded ledger + dict leaves"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    ledger = %record.ledger_id,
-                                    error = %e,
-                                    "Preloaded ledger but dict leaf warming failed"
-                                );
-                            }
-                        }
-                    } else {
-                        tracing::debug!(ledger = %record.ledger_id, "Preloaded ledger (no binary index)");
+                    // Warm forward-dict pages until the budget is reached. The
+                    // structural load above still runs for every ledger; only
+                    // the (dominant, file-touching) page warming is capped, so
+                    // we never evict pages we just warmed.
+                    if warmed_bytes >= warm_budget {
+                        continue;
                     }
+                    // Take just the binary store; the rest of the snapshot is
+                    // dropped here so no view is held across the blocking warm.
+                    let Some(store) = handle.snapshot().await.binary_store else {
+                        tracing::debug!(ledger = %record.ledger_id, "Preloaded ledger (no binary index)");
+                        continue;
+                    };
+                    let remaining = warm_budget - warmed_bytes;
+                    // Page-touching blocks (faults) — keep it off the async workers.
+                    let n =
+                        tokio::task::spawn_blocking(move || store.prewarm_forward_dicts(remaining))
+                            .await
+                            .unwrap_or(0);
+                    if n > 0 {
+                        warmed_bytes += n;
+                        warmed_ledgers += 1;
+                    }
+                    tracing::debug!(
+                        ledger = %record.ledger_id,
+                        warmed_bytes = n,
+                        "Preloaded ledger + warmed forward dicts"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -164,11 +182,16 @@ impl FlureeServer {
         }
 
         let elapsed = start.elapsed();
+        let budget_reached = warmed_bytes >= warm_budget && loaded > warmed_ledgers;
         info!(
             loaded,
             total,
+            warmed_ledgers,
+            warmed_mb = warmed_bytes / (1024 * 1024),
+            warm_budget_mb = warm_budget / (1024 * 1024),
+            budget_reached,
             elapsed_ms = elapsed.as_millis() as u64,
-            "Ledger preload complete"
+            "Background ledger preload + forward-dict warming complete"
         );
     }
 
@@ -223,6 +246,14 @@ impl FlureeServer {
         // Start ledger manager maintenance task for idle eviction
         let ledger_maintenance_task = self.state.fluree.spawn_maintenance();
 
+        // Warm ledger caches + forward-dict pages in the BACKGROUND, after the
+        // listener is bound, so the server accepts requests immediately rather
+        // than blocking startup until every (potentially large) ledger loads.
+        // Safe to race with on-demand request loads: `get_or_load` is
+        // single-flight (concurrent loads of the same ledger coalesce), and the
+        // leaflet cache is concurrency-safe. Aborted on shutdown.
+        let warm_task = tokio::spawn(Self::preload_all_ledgers(Arc::clone(&self.state)));
+
         info!(
             addr = %addr,
             storage = %self.state.config.storage_type_str(),
@@ -235,7 +266,8 @@ impl FlureeServer {
         // Run server
         let result = axum::serve(listener, self.router).await;
 
-        // Cancel maintenance tasks on shutdown
+        // Cancel background tasks on shutdown
+        warm_task.abort();
         if let Some(task) = subscription_task {
             task.abort();
         }

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -106,6 +106,26 @@ fn record_tracking_on_span(span: &tracing::Span, tally: &TrackingTally) {
     }
 }
 
+/// Optimistic-concurrency / namespace-allocation conflicts that are resolved by
+/// reconciling the cached writer state to the current head and retrying.
+///
+/// All three arise when a transaction was lowered/sequenced against a snapshot
+/// that is no longer the head by commit time: `NamespaceConflict` (two writers
+/// raced on a first-time namespace code), `CommitConflict` (cached `t` fell
+/// behind the durable head), and `PublishLostRace` (another writer won the
+/// head CAS). Re-fetching the snapshot + re-lowering after a `refresh()`
+/// resolves all three.
+fn is_retryable_txn_conflict(e: &fluree_db_api::ApiError) -> bool {
+    matches!(
+        e,
+        fluree_db_api::ApiError::Transact(
+            fluree_db_api::TransactError::CommitConflict { .. }
+                | fluree_db_api::TransactError::PublishLostRace { .. }
+                | fluree_db_api::TransactError::NamespaceConflict(_)
+        )
+    )
+}
+
 /// Compute transaction ID from request body (SHA-256 hash)
 ///
 /// This matches the legacy derive-tx-id behavior which hashes the JSON-LD normalized data.
@@ -1786,22 +1806,34 @@ async fn execute_sparql_update_request(
         "sparql-update",
     );
 
-    // Bounded retry around snapshot fetch + lowering + execute.
+    // Bounded reconcile-and-retry around snapshot fetch + lowering + execute.
     //
-    // `lower_sparql_update` allocates IRIs against a `NamespaceRegistry` built
-    // from the *current* snapshot to assign Sids to template terms. Two
-    // concurrent SPARQL UPDATEs racing on a fresh namespace can both pick the
-    // same first-time code for *different* prefixes, then the second writer
-    // hits `TransactError::NamespaceConflict` at staging because the staging
-    // registry sees the first writer's commit. The fix: re-fetch the snapshot
-    // and re-lower against the latest namespace allocations. Bounded to 3
-    // attempts to avoid livelock; the conflict is rare (requires concurrent
-    // writers AND first-time-namespace contention), so 1 retry is usually
-    // enough.
-    const MAX_NS_RETRIES: usize = 3;
+    // Two distinct write-path conflicts are both resolved here by reconciling
+    // the cached writer state to the current nameservice head and re-lowering:
+    //
+    //  * Namespace-allocation race: `lower_sparql_update` allocates IRIs
+    //    against a `NamespaceRegistry` built from the *current* snapshot to
+    //    assign Sids to template terms. Two concurrent SPARQL UPDATEs racing on
+    //    a fresh namespace can both pick the same first-time code for
+    //    *different* prefixes; the loser hits `TransactError::NamespaceConflict`
+    //    at staging. Re-lowering against the latest snapshot picks a fresh,
+    //    non-colliding code.
+    //
+    //  * Commit conflict / lost publish race: if the cached in-memory
+    //    `LedgerState` has fallen behind the durable nameservice head (e.g. a
+    //    prior commit published but a post-publish bookkeeping step failed,
+    //    stranding the cache), `verify_sequencing` returns `CommitConflict`
+    //    forever. `refresh()` below reconciles the cache to the head (applying
+    //    the missing commit incrementally) so the retry targets the right `t`.
+    //
+    // On any of these conflicts we `refresh()` the ledger before retrying so
+    // the next attempt observes both the latest namespace allocations and the
+    // latest `t`. Bounded to avoid livelock; under heavy new-namespace
+    // contention a writer may need several re-lowers before its code is free.
+    const MAX_TXN_RETRIES: usize = 16;
     let mut last_error: Option<ServerError> = None;
     let mut result = None;
-    for attempt in 1..=MAX_NS_RETRIES {
+    for attempt in 1..=MAX_TXN_RETRIES {
         let cached_state = handle.snapshot().await;
         let mut ns = NamespaceRegistry::from_db(&cached_state.snapshot);
 
@@ -1884,15 +1916,31 @@ async fn execute_sparql_update_request(
                 result = Some(r);
                 break;
             }
-            Err(fluree_db_api::ApiError::Transact(
-                fluree_db_api::TransactError::NamespaceConflict(msg),
-            )) if attempt < MAX_NS_RETRIES => {
+            Err(e) if attempt < MAX_TXN_RETRIES && is_retryable_txn_conflict(&e) => {
+                // Reconcile the cached writer state to the current nameservice
+                // head before re-lowering: this advances `t` if the cache fell
+                // behind the durable head (heals a `CommitConflict` wedge) and
+                // surfaces the latest namespace allocations (so the re-lower
+                // picks a non-colliding code). `refresh` re-acquires the
+                // per-ledger write lock internally; the prior `execute()` has
+                // already released it, so there is no deadlock.
                 tracing::warn!(
                     attempt,
-                    max_attempts = MAX_NS_RETRIES,
-                    %msg,
-                    "SPARQL UPDATE namespace conflict; re-lowering against latest snapshot"
+                    max_attempts = MAX_TXN_RETRIES,
+                    error = %e,
+                    "SPARQL UPDATE write conflict; reconciling cached state and retrying"
                 );
+                if let Err(refresh_err) = fluree
+                    .refresh(&ledger_id, fluree_db_api::RefreshOpts::default())
+                    .await
+                {
+                    tracing::warn!(
+                        attempt,
+                        error = %refresh_err,
+                        "refresh during SPARQL UPDATE conflict retry failed; retrying anyway"
+                    );
+                }
+                last_error = Some(ServerError::Api(e));
                 continue;
             }
             Err(e) => {

--- a/fluree-db-sparql/src/ast/pattern.rs
+++ b/fluree-db-sparql/src/ast/pattern.rs
@@ -5,7 +5,7 @@
 
 use super::expr::Expression;
 use super::path::PropertyPath;
-use super::query::{GroupByClause, SelectVariables};
+use super::query::{SelectVariables, SolutionModifiers};
 use super::term::{Iri, ObjectTerm, PredicateTerm, SubjectTerm, Term, Var};
 use crate::span::SourceSpan;
 
@@ -254,31 +254,14 @@ pub struct SubSelect {
     pub variables: SelectVariables,
     /// The WHERE clause pattern
     pub pattern: Box<GraphPattern>,
-    /// GROUP BY clause (for aggregation)
-    pub group_by: Option<GroupByClause>,
-    /// ORDER BY variables (simplified - just variable names for now)
-    pub order_by: Vec<SubSelectOrderBy>,
-    /// True when the subquery's ORDER BY contained a non-trivial expression
-    /// (e.g. `ORDER BY (0 - ?x)`). Subquery expression ORDER BY is not yet
-    /// wired through the subquery operator, so lowering rejects it rather than
-    /// silently mis-sorting on a grabbed variable. Bare/bracketed variables
-    /// leave this `false`.
-    pub order_by_unsupported_expr: bool,
-    /// LIMIT value
-    pub limit: Option<u64>,
-    /// OFFSET value
-    pub offset: Option<u64>,
+    /// Solution modifiers (GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET), parsed
+    /// with the same machinery as a top-level SELECT (`parse_solution_modifiers`)
+    /// and lowered through the same `lower_solution_modifiers` path, so a
+    /// subquery inherits HAVING, post-aggregation SELECT binds, and
+    /// expression/aggregate ORDER BY identically.
+    pub modifiers: SolutionModifiers,
     /// Source span
     pub span: SourceSpan,
-}
-
-/// Order by specification for subqueries.
-#[derive(Clone, Debug, PartialEq)]
-pub struct SubSelectOrderBy {
-    /// The variable to order by
-    pub var: Var,
-    /// True for descending, false for ascending
-    pub descending: bool,
 }
 
 #[cfg(test)]

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -430,6 +430,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         subselect: &SubSelect,
         _span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
+        // Aggregate-input-expression CSE (`agg_expr_binds`) is scoped to a single
+        // WHERE clause. A subquery is its own execution scope, so the synthetic
+        // `?__agg_expr_N` bind for an aggregate over an expression (e.g.
+        // `AVG(xsd:float(?n))`) must live in THIS subquery's patterns. Without
+        // resetting the cache, two sibling subqueries sharing the same aggregate
+        // input expression would dedup to one synthetic var that is bound only in
+        // the first subquery's scope, leaving the second's aggregate input
+        // unbound (benchmark-db bug #4). Save here, restore before returning.
+        let saved_agg_expr_binds = std::mem::take(&mut self.agg_expr_binds);
+
         // Lower WHERE patterns (mut: SELECT-expression / GROUP BY / aggregate-
         // input BINDs are appended below, just as in the top-level pipeline).
         let mut patterns = self.lower_graph_pattern(&subselect.pattern)?;
@@ -528,6 +538,10 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         if lowered.distinct || subselect.reduced {
             sq = sq.with_distinct();
         }
+
+        // Restore the enclosing scope's aggregate-expression CSE cache (an early
+        // `?` error abandons the whole lowering, so success-path restore is enough).
+        self.agg_expr_binds = saved_agg_expr_binds;
 
         Ok(vec![Pattern::Subquery(sq)])
     }

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -20,7 +20,7 @@ use fluree_db_query::var_registry::VarId;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use super::{LowerError, LoweringContext, Result};
+use super::{LoweringContext, Result};
 
 /// Result of lowering SELECT expression binds.
 pub(super) struct SelectBinds {
@@ -416,28 +416,26 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
 
     /// Lower a SPARQL subquery (SubSelect) to the IR.
     ///
-    /// Subqueries have the form: `{ SELECT ?vars WHERE { ... } GROUP BY ?v LIMIT n }`
-    /// Supports aggregate expressions like `(COUNT(?x) AS ?count)` in the SELECT clause.
+    /// Subqueries have the form: `{ SELECT ?vars WHERE { ... } GROUP BY ?v
+    /// HAVING (..) ORDER BY (..) LIMIT n }`. This mirrors the top-level SELECT
+    /// lowering — SELECT-expression binds, GROUP BY / aggregates / HAVING, and
+    /// expression/aggregate ORDER BY all go through the same shared helpers
+    /// (`lower_select_expression_binds`, `lower_solution_modifiers`) — so a
+    /// subquery inherits exactly the same modifier semantics as a top-level
+    /// query. The resulting `SubqueryPattern` is executed per correlated parent
+    /// row by `SubqueryOperator`, which applies the shared solution-modifier
+    /// tail (`apply_solution_modifiers`).
     pub(super) fn lower_subselect(
         &mut self,
         subselect: &SubSelect,
         _span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
-        // Expression-based ORDER BY inside a subquery is not yet supported
-        // (the subquery operator sorts the projected output, with no stage to
-        // evaluate a synthetic key). Reject rather than silently mis-sort.
-        if subselect.order_by_unsupported_expr {
-            return Err(LowerError::unsupported_form(
-                "expression-based ORDER BY in a subquery",
-                subselect.span,
-            ));
-        }
-
-        // Lower WHERE patterns (mut: expression GROUP BY may append pre-group BINDs)
+        // Lower WHERE patterns (mut: SELECT-expression / GROUP BY / aggregate-
+        // input BINDs are appended below, just as in the top-level pipeline).
         let mut patterns = self.lower_graph_pattern(&subselect.pattern)?;
 
-        // Build a temporary SelectClause so we can reuse extract_aggregates /
-        // collect_non_aggregate_select_vars which operate on SelectClause.
+        // Build a SelectClause so the shared SELECT/modifier lowering applies.
+        // REDUCED is treated as DISTINCT (handled when assembling the pattern).
         let select_clause = SelectClause {
             modifier: if subselect.distinct {
                 Some(SelectModifier::Distinct)
@@ -450,13 +448,12 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             span: subselect.span,
         };
 
-        // Lower SELECT variables
+        // Projected variable list.
         //
-        // IMPORTANT: In the query engine, an empty select list does NOT mean "SELECT *".
-        // It means "select no variables", which yields no output schema and therefore no rows.
-        //
-        // For SPARQL `SELECT *`, we approximate the spec by selecting all variables referenced
-        // by the subquery's WHERE patterns (in stable encounter order).
+        // IMPORTANT: In the query engine, an empty select list does NOT mean
+        // "SELECT *" — it means "select no variables". For SPARQL `SELECT *` we
+        // approximate the spec by selecting all variables produced by the
+        // (just-lowered) WHERE patterns, in stable encounter order.
         let select: Vec<VarId> = match &subselect.variables {
             SelectVariables::Star => {
                 let mut seen: HashSet<VarId> = HashSet::new();
@@ -474,90 +471,62 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 let mut result = Vec::with_capacity(vars.len());
                 for var in vars {
                     match var {
-                        SelectVariable::Var(v) => {
-                            result.push(self.register_var(v));
-                        }
-                        SelectVariable::Expr { alias, .. } => {
-                            result.push(self.register_var(alias));
-                        }
+                        SelectVariable::Var(v) => result.push(self.register_var(v)),
+                        SelectVariable::Expr { alias, .. } => result.push(self.register_var(alias)),
                     }
                 }
                 result
             }
         };
 
-        // Extract aggregates from SELECT clause (e.g. COUNT(?x) AS ?count)
-        let (aggregates, agg_binds) = self.extract_aggregates(&select_clause)?;
+        // SELECT-expression binds: pre-aggregation ones append to WHERE; post-
+        // aggregation ones (referencing an aggregate alias) ride in the grouping.
+        let aggregate_aliases = self.collect_aggregate_alias_names(&select_clause);
+        let select_binds = self.lower_select_expression_binds(&select_clause, &aggregate_aliases)?;
+        patterns.extend(select_binds.pre);
 
-        // Lower GROUP BY (expression GROUP BY produces pre-group BINDs)
-        let mut group_vars = Vec::new();
-        if let Some(ref group_by) = subselect.group_by {
-            for cond in &group_by.conditions {
-                let (var_id, bind_pattern) = self.lower_group_condition(cond)?;
-                group_vars.push(var_id);
-                if let Some(pattern) = bind_pattern {
-                    patterns.push(pattern);
-                }
-            }
-        }
+        // Solution modifiers (GROUP BY / HAVING / ORDER BY / LIMIT / OFFSET /
+        // aggregates) through the same path as a top-level SELECT. This lowers
+        // HAVING, hoists inline aggregates from HAVING / ORDER BY, and produces
+        // expression-ORDER-BY binds — all previously dropped or rejected here.
+        let lowered = self.lower_solution_modifiers(&subselect.modifiers, &select_clause)?;
+        patterns.extend(lowered.pre_group_binds);
+        let BaseModifiers {
+            limit,
+            offset,
+            ordering,
+            order_binds,
+            // Consumed by `lower_solution_modifiers` (lowered into `order_binds`
+            // after aggregate hoisting); always empty here.
+            deferred_order_exprs: _,
+        } = lowered.base;
 
-        // Aggregate expression inputs (e.g. SUM(YEAR(?o))) are desugared to
-        // pre-aggregation BIND patterns + aggregate over the synthetic var.
-        patterns.extend(agg_binds);
-
-        // Build SubqueryPattern (after injecting any pre-group BINDs into patterns)
+        // Assemble the SubqueryPattern. Post-aggregation SELECT binds ride inside
+        // the grouping's aggregation stage; expression/aggregate ORDER BY binds
+        // ride on `order_binds` (a dedicated post-grouping stage in the shared
+        // modifier tail) so they evaluate uniformly with or without grouping.
         let mut sq = SubqueryPattern::new(select, patterns);
-
-        // Auto-populate GROUP BY when aggregates present but no explicit GROUP BY.
-        // Per SPARQL semantics, all non-aggregated SELECT variables must be grouped.
-        if !aggregates.is_empty() && group_vars.is_empty() {
-            group_vars = self.collect_non_aggregate_select_vars(&select_clause);
-        }
-
-        // Lift GROUP BY / aggregates into the SubqueryPattern's grouping
-        // phase. Subselect HAVING isn't lowered here (its surface syntax is
-        // captured upstream and would require its own lowering); same for
-        // post-aggregation binds.
-        if let Some(grouping) = Grouping::assemble(group_vars, aggregates, Vec::new(), None) {
+        if let Some(grouping) = Grouping::assemble(
+            lowered.group_by,
+            lowered.aggregates,
+            select_binds.post,
+            lowered.having,
+        ) {
             sq = sq.with_grouping(grouping);
         }
-
-        // Apply LIMIT
-        if let Some(limit) = subselect.limit {
-            sq = sq.with_limit(limit as usize);
+        sq = sq.with_order_binds(order_binds);
+        if !ordering.is_empty() {
+            sq = sq.with_ordering(ordering);
         }
-
-        // Apply OFFSET
-        if let Some(offset) = subselect.offset {
-            sq = sq.with_offset(offset as usize);
+        if let Some(limit) = limit {
+            sq = sq.with_limit(limit);
         }
-
-        // Apply DISTINCT
-        if subselect.distinct {
+        if let Some(offset) = offset {
+            sq = sq.with_offset(offset);
+        }
+        // DISTINCT (REDUCED is treated as DISTINCT).
+        if lowered.distinct || subselect.reduced {
             sq = sq.with_distinct();
-        }
-
-        // Note: REDUCED is treated as DISTINCT for simplicity
-        if subselect.reduced {
-            sq = sq.with_distinct();
-        }
-
-        // Apply ORDER BY
-        if !subselect.order_by.is_empty() {
-            let mut sort_specs = Vec::with_capacity(subselect.order_by.len());
-            for order in &subselect.order_by {
-                let var_id = self.register_var(&order.var);
-                let direction = if order.descending {
-                    SortDirection::Descending
-                } else {
-                    SortDirection::Ascending
-                };
-                sort_specs.push(SortSpec {
-                    var: var_id,
-                    direction,
-                });
-            }
-            sq = sq.with_ordering(sort_specs);
         }
 
         Ok(vec![Pattern::Subquery(sq)])

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -492,7 +492,8 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         // SELECT-expression binds: pre-aggregation ones append to WHERE; post-
         // aggregation ones (referencing an aggregate alias) ride in the grouping.
         let aggregate_aliases = self.collect_aggregate_alias_names(&select_clause);
-        let select_binds = self.lower_select_expression_binds(&select_clause, &aggregate_aliases)?;
+        let select_binds =
+            self.lower_select_expression_binds(&select_clause, &aggregate_aliases)?;
         patterns.extend(select_binds.pre);
 
         // Solution modifiers (GROUP BY / HAVING / ORDER BY / LIMIT / OFFSET /

--- a/fluree-db-sparql/src/parse/query/modifier.rs
+++ b/fluree-db-sparql/src/parse/query/modifier.rs
@@ -314,15 +314,4 @@ impl super::Parser<'_> {
         }
     }
 
-    // =========================================================================
-    // Skip helpers for features not yet implemented
-    // =========================================================================
-
-    pub(super) fn skip_parenthesized_content(&mut self) {
-        if !self.stream.match_token(&TokenKind::LParen) {
-            return;
-        }
-        self.stream
-            .skip_balanced(&TokenKind::LParen, &TokenKind::RParen);
-    }
 }

--- a/fluree-db-sparql/src/parse/query/modifier.rs
+++ b/fluree-db-sparql/src/parse/query/modifier.rs
@@ -313,5 +313,4 @@ impl super::Parser<'_> {
             None
         }
     }
-
 }

--- a/fluree-db-sparql/src/parse/query/pattern.rs
+++ b/fluree-db-sparql/src/parse/query/pattern.rs
@@ -1,7 +1,6 @@
 //! Graph pattern parsing: WHERE, OPTIONAL, UNION, MINUS, FILTER, BIND, VALUES, subqueries.
 
-use crate::ast::expr::Expression;
-use crate::ast::pattern::{GraphName, ServiceEndpoint, SubSelect, SubSelectOrderBy};
+use crate::ast::pattern::{GraphName, ServiceEndpoint, SubSelect};
 use crate::ast::query::SelectVariables;
 use crate::ast::{GraphPattern, Term, Var, WhereClause};
 use crate::diag::{DiagCode, Diagnostic};
@@ -641,9 +640,11 @@ impl super::Parser<'_> {
 
         let pattern = self.parse_group_graph_pattern()?;
 
-        // Parse solution modifiers (GROUP BY, ORDER BY, LIMIT, OFFSET)
-        let (group_by, order_by, limit, offset, order_by_unsupported_expr) =
-            self.parse_subquery_modifiers();
+        // Parse solution modifiers (GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET)
+        // with the same machinery as a top-level SELECT, so subqueries inherit
+        // HAVING and expression/aggregate ORDER BY. `parse_solution_modifiers`
+        // stops at the first non-modifier token (here, the closing `}`).
+        let modifiers = self.parse_solution_modifiers();
 
         // Expect closing brace for the subquery
         if !self.stream.match_token(&TokenKind::RBrace) {
@@ -658,11 +659,7 @@ impl super::Parser<'_> {
             reduced,
             variables,
             pattern: Box::new(pattern),
-            group_by,
-            order_by,
-            order_by_unsupported_expr,
-            limit,
-            offset,
+            modifiers,
             span,
         };
 
@@ -670,121 +667,5 @@ impl super::Parser<'_> {
             query: Box::new(subquery),
             span,
         })
-    }
-
-    /// Parse solution modifiers for a subquery (GROUP BY, ORDER BY, LIMIT, OFFSET).
-    ///
-    /// Returns (group_by, order_by, limit, offset).
-    pub(super) fn parse_subquery_modifiers(
-        &mut self,
-    ) -> (
-        Option<crate::ast::query::GroupByClause>,
-        Vec<SubSelectOrderBy>,
-        Option<u64>,
-        Option<u64>,
-        bool,
-    ) {
-        let mut order_by = Vec::new();
-        let mut limit = None;
-        let mut offset = None;
-        // Set when a subquery ORDER BY contains a non-trivial expression, which
-        // lowering rejects (see `SubSelect::order_by_unsupported_expr`).
-        let mut order_by_unsupported_expr = false;
-
-        // GROUP BY
-        let group_by = if self.stream.check_keyword(TokenKind::KwGroupBy) {
-            self.parse_group_by()
-        } else {
-            None
-        };
-
-        // HAVING — not yet supported in subqueries; emit error instead of silently skipping.
-        if self.stream.check_keyword(TokenKind::KwHaving) {
-            self.stream
-                .error_at_current("HAVING is not yet supported in subqueries");
-            self.stream.advance();
-            self.skip_parenthesized_content();
-        }
-
-        // ORDER BY
-        if self.stream.check_keyword(TokenKind::KwOrderBy) {
-            self.stream.advance(); // consume ORDER
-            self.stream.match_keyword(TokenKind::KwBy); // consume BY
-
-            // Parse order conditions (simplified: just variables)
-            loop {
-                let descending = if self.stream.match_keyword(TokenKind::KwDesc) {
-                    true
-                } else {
-                    self.stream.match_keyword(TokenKind::KwAsc);
-                    false
-                };
-
-                // Parenthesized order condition. Parse the full expression so a
-                // bracketed bare variable `(?v)` keeps working, but reject a
-                // genuine expression `(0 - ?v)` instead of silently grabbing its
-                // first variable and mis-sorting (subquery ORDER BY desugaring
-                // is not yet wired through the subquery operator).
-                if self.stream.check(&TokenKind::LParen) {
-                    let expr_start = self.stream.current_span();
-                    self.stream.advance(); // consume (
-                    match parse_expression(self.stream) {
-                        Ok(e) => {
-                            if !self.stream.match_token(&TokenKind::RParen) {
-                                self.stream.error_at_current("expected ')'");
-                            }
-                            match e.unwrap_bracketed() {
-                                Expression::Var(v) => order_by.push(SubSelectOrderBy {
-                                    var: v.clone(),
-                                    descending,
-                                }),
-                                _ => {
-                                    // Flag for lowering to reject (a parser
-                                    // diagnostic alone is swallowed once an AST
-                                    // is recovered). Also record a diagnostic for
-                                    // tooling/IDE feedback.
-                                    order_by_unsupported_expr = true;
-                                    self.stream.error_at(
-                                        "Expression-based ORDER BY is not yet supported in subqueries; \
-                                         alias the expression in the inner SELECT and ORDER BY the alias",
-                                        expr_start.union(self.stream.previous_span()),
-                                    );
-                                }
-                            }
-                        }
-                        Err(msg) => {
-                            self.stream.error_at_current(&msg);
-                        }
-                    }
-                } else if let Some((name, span)) = self.stream.consume_var() {
-                    order_by.push(SubSelectOrderBy {
-                        var: Var::new(name.as_ref(), span),
-                        descending,
-                    });
-                } else {
-                    break;
-                }
-            }
-        }
-
-        // LIMIT
-        if self.stream.match_keyword(TokenKind::KwLimit) {
-            if let Some((n, _)) = self.stream.consume_integer() {
-                if n >= 0 {
-                    limit = Some(n as u64);
-                }
-            }
-        }
-
-        // OFFSET
-        if self.stream.match_keyword(TokenKind::KwOffset) {
-            if let Some((n, _)) = self.stream.consume_integer() {
-                if n >= 0 {
-                    offset = Some(n as u64);
-                }
-            }
-        }
-
-        (group_by, order_by, limit, offset, order_by_unsupported_expr)
     }
 }

--- a/fluree-db-sparql/src/parse/query/tests.rs
+++ b/fluree-db-sparql/src/parse/query/tests.rs
@@ -394,7 +394,7 @@ fn test_subquery_with_limit() {
     let ast = assert_parses("SELECT * WHERE { { SELECT ?x WHERE { ?x ?p ?o } LIMIT 10 } }");
     if let QueryBody::Select(q) = &ast.body {
         if let GraphPattern::SubSelect { query, .. } = &q.where_clause.pattern {
-            assert_eq!(query.limit, Some(10));
+            assert_eq!(query.modifiers.limit.as_ref().map(|l| l.value), Some(10));
         } else {
             panic!("Expected SubSelect pattern");
         }
@@ -406,9 +406,17 @@ fn test_subquery_with_order_by() {
     let ast = assert_parses("SELECT * WHERE { { SELECT ?x WHERE { ?x ?p ?o } ORDER BY ?x } }");
     if let QueryBody::Select(q) = &ast.body {
         if let GraphPattern::SubSelect { query, .. } = &q.where_clause.pattern {
-            assert_eq!(query.order_by.len(), 1);
-            assert_eq!(query.order_by[0].var.name.as_ref(), "x");
-            assert!(!query.order_by[0].descending);
+            let order = query
+                .modifiers
+                .order_by
+                .as_ref()
+                .expect("Expected ORDER BY");
+            assert_eq!(order.conditions.len(), 1);
+            assert_eq!(order.conditions[0].direction, OrderDirection::Asc);
+            match &order.conditions[0].expr {
+                OrderExpr::Var(v) => assert_eq!(v.name.as_ref(), "x"),
+                other => panic!("Expected bare variable ORDER BY, got {other:?}"),
+            }
         } else {
             panic!("Expected SubSelect pattern");
         }
@@ -421,8 +429,13 @@ fn test_subquery_with_order_by_desc() {
         assert_parses("SELECT * WHERE { { SELECT ?x WHERE { ?x ?p ?o } ORDER BY DESC(?x) } }");
     if let QueryBody::Select(q) = &ast.body {
         if let GraphPattern::SubSelect { query, .. } = &q.where_clause.pattern {
-            assert_eq!(query.order_by.len(), 1);
-            assert!(query.order_by[0].descending);
+            let order = query
+                .modifiers
+                .order_by
+                .as_ref()
+                .expect("Expected ORDER BY");
+            assert_eq!(order.conditions.len(), 1);
+            assert_eq!(order.conditions[0].direction, OrderDirection::Desc);
         } else {
             panic!("Expected SubSelect pattern");
         }


### PR DESCRIPTION
Subqueries (`{ SELECT … }`, SPARQL and JSON-LD) re-implemented a subset of the query pipeline and silently lacked several solution modifiers. This routes them through the **same** modifier tail and lowering as top-level queries, so a subquery inherits the full feature set — HAVING, post-aggregation binds, expression/aggregate ORDER BY, correct ORDER-BY-before-PROJECT ordering, and grouped-variable sort validation — from one shared code path.

Per-row correlation is untouched: the seeded WHERE still runs once per parent row and merges back.

### Queries that used to fail (or silently return wrong results) — now correct

- **HAVING in a subquery** — was a parse error, then a dropped clause:
  `{ SELECT ?p (COUNT(?o) AS ?c) WHERE { … } GROUP BY ?p HAVING (COUNT(?o) > 5) }`
- **Expression ORDER BY in a subquery** — was rejected at lowering:
  `{ SELECT ?x WHERE { … } ORDER BY DESC(?score / ?weight) LIMIT 10 }`
- **Aggregate ORDER BY in a subquery** (including when the aggregate is not selected) — was rejected:
  `{ SELECT ?p WHERE { … } GROUP BY ?p ORDER BY DESC(COUNT(?o)) }`
- **Post-aggregation SELECT expression** — was silently dropped:
  `{ SELECT ?p (CEIL(AVG(?o)) AS ?avg) WHERE { … } GROUP BY ?p }`
- **ORDER BY a non-projected variable** — was silently unordered (the sort ran after the projection removed the key):
  `{ SELECT ?x WHERE { ?x :p ?y } ORDER BY ?y }`
- **Aggregate over an expression in joined grouped sub-SELECTs** — was an HTTP 500 at plan time (blocks BSBM BI-5):
  two `{ SELECT ?f (AVG(xsd:float(?n)) AS ?x) … GROUP BY ?f }` joined on `?f`. The shared aggregate-input expression was deduplicated across subquery scopes, leaving the second's input variable unbound; it is now scoped per subquery.
- **GROUP BY / SELECT of a variable the pattern never binds** — was an HTTP 500 at plan time (blocks BSBM BI-4); per SPARQL 1.1 §11.4/§18.5 the variable is simply unbound (one group), now reported as such:
  `SELECT ?country ?product (AVG(?price) AS ?a) WHERE { … } GROUP BY ?country ?product` where `?country` is bound only by an enclosing join. (Not subquery-specific — fixed for top-level queries too.)

Grouped-variable sort attempts now produce a clean error instead of undefined ordering.