### PR TITLE
fix: persist the namespace split mode chosen by bulk import

### DIFF
--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -2089,6 +2089,8 @@ struct IndexBuildInput<'a> {
     /// User-defined named graph g_ids (>= 2) to build index segments for.
     /// Empty for single-graph imports.
     named_g_ids: Vec<u16>,
+    /// Actual split mode the import used; written into the root and predicate sids.
+    ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode,
 }
 
 /// Run phases 2-6: import chunks, build indexes, upload to CAS, write V4 root, publish.
@@ -2147,6 +2149,7 @@ where
             collect_id_stats: config.collect_id_stats,
             prefix_map: &import_result.prefix_map,
             named_g_ids: import_result.named_g_ids,
+            ns_split_mode: import_result.ns_split_mode,
         };
         let index_result = build_and_upload(
             storage,
@@ -2254,6 +2257,10 @@ struct ChunkImportResult {
     /// User-defined named graph g_ids (>= 2) to build index segments for.
     /// Empty for single-graph imports.
     named_g_ids: Vec<u16>,
+    /// Split mode the allocator actually used (the ns preflight may coarsen it to
+    /// `HostPlusN`). Recorded into the root, predicate sids, and genesis commit so
+    /// reads split IRIs the same way the dictionary was keyed.
+    ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode,
 }
 
 /// Import all TTL chunks: parallel parse + serial commit + streaming runs.
@@ -2365,6 +2372,9 @@ where
         vocab_dir: &'a Path,
         spool_dir: &'a Path,
         datatype_alloc: &'a Arc<fluree_db_indexer::run_index::global_dict::SharedDictAllocator>,
+        /// Allocator whose actual split mode is mirrored into the genesis commit
+        /// (so a later reindex agrees with the index root).
+        shared_alloc: &'a Arc<fluree_db_transact::SharedNamespaceAllocator>,
         rdf_type_p_id: u32,
         import_time_epoch_ms: Option<i64>,
     }
@@ -2405,6 +2415,14 @@ where
 
                 // Capture previous commit hex BEFORE finalize advances state.
                 let previous_commit_hex = commit_metas.last().map(|m| m.commit_hash_hex.clone());
+
+                // The genesis commit records the registry's split mode, but the
+                // preflight flips only the allocator — mirror it so reindex agrees.
+                if state.parent.is_none() {
+                    state
+                        .ns_registry
+                        .set_split_mode(env.shared_alloc.split_mode());
+                }
 
                 let result = finalize_parsed_chunk(state, parsed, ns_delta, env.storage, env.alias)
                     .await
@@ -2715,6 +2733,7 @@ where
         vocab_dir: &vocab_dir,
         spool_dir: &spool_dir,
         datatype_alloc: &spool_config.datatype_alloc,
+        shared_alloc: &shared_alloc,
         rdf_type_p_id,
         import_time_epoch_ms,
     };
@@ -4012,6 +4031,8 @@ where
         dt_width,
         rdf_type_p_id,
         named_g_ids: v3_named_g_ids,
+        // Forwarder thread joined above, so this reflects any preflight coarsening.
+        ns_split_mode: shared_alloc.split_mode(),
     })
 }
 
@@ -4560,10 +4581,8 @@ where
             by_id
                 .iter()
                 .map(|iri| {
-                    let (prefix, suffix) = fluree_db_core::canonical_split(
-                        iri,
-                        fluree_db_core::NsSplitMode::default(),
-                    );
+                    let (prefix, suffix) =
+                        fluree_db_core::canonical_split(iri, input.ns_split_mode);
                     match ns_reverse_v6.get(prefix) {
                         Some(&code) => (code, suffix.to_string()),
                         None => (0u16, iri.clone()),
@@ -4782,7 +4801,7 @@ where
             prev_index: None,
             garbage: None,
             sketch_ref: None,
-            ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),
+            ns_split_mode: input.ns_split_mode,
         };
 
         // Encode and upload FIR6 root.

--- a/fluree-db-api/tests/it_import_ns_split_mode.rs
+++ b/fluree-db-api/tests/it_import_ns_split_mode.rs
@@ -1,0 +1,103 @@
+//! Regression test: bulk import must persist the namespace split mode it actually
+//! used so concrete-IRI lookups resolve.
+//!
+//! When the bulk-import namespace preflight sees more than `NS_PREFLIGHT_BUDGET`
+//! (255) distinct prefixes in the streamed input, it coarsens the dict allocator
+//! to `NsSplitMode::HostPlusN`. The index root, predicate sids, and genesis commit
+//! must record THAT mode; otherwise the read path splits query IRIs `MostGranular`
+//! against a coarse-keyed dictionary and every bound-IRI lookup returns nothing.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use std::io::Write;
+
+use fluree_db_api::{Fluree, FlureeBuilder, ReindexOptions};
+
+const LEDGER: &str = "test/ns-split:main";
+// A class IRI with 3 path segments: its MostGranular split (`.../schema/classes/`)
+// differs from HostPlusN(1) (`.../schema/`), which is exactly the case that breaks
+// when the recorded split mode disagrees with the dictionary.
+const CLASS_IRI: &str = "http://ex.com/schema/classes/Item";
+const SUBJECT_COUNT: usize = 14_000;
+const DISTINCT_NS: usize = 300; // > 255 budget, so the preflight flips the allocator
+
+/// Write `SUBJECT_COUNT` `rdf:type` triples spread across `DISTINCT_NS` subject
+/// namespaces. At ~110 bytes/line this exceeds 1 MB, so `chunk_size_mb(1)` routes
+/// it through the streaming reader where the preflight runs.
+fn write_dataset(path: &std::path::Path) {
+    let mut f = std::io::BufWriter::new(std::fs::File::create(path).unwrap());
+    for j in 0..SUBJECT_COUNT {
+        writeln!(
+            f,
+            "<http://ex.com/ns{}/s{j}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{CLASS_IRI}> .",
+            j % DISTINCT_NS
+        )
+        .unwrap();
+    }
+}
+
+/// Load the ledger fresh and return the row count for `COUNT(*)`-style `sparql`.
+async fn count(fluree: &Fluree, sparql: &str) -> u64 {
+    let ledger = fluree.ledger(LEDGER).await.expect("load ledger");
+    let result = support::query_sparql(fluree, &ledger, sparql)
+        .await
+        .expect("query");
+    let json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("sparql json");
+    json["results"]["bindings"][0]["c"]["value"]
+        .as_str()
+        .expect("count value")
+        .parse()
+        .expect("count is a number")
+}
+
+#[tokio::test]
+async fn flipped_split_mode_persisted_for_bound_iri_lookups() {
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let nt_path = data_dir.path().join("data.nt");
+    write_dataset(&nt_path);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create(LEDGER)
+        .import(&nt_path)
+        .threads(1)
+        .memory_budget_mb(128)
+        .chunk_size_mb(1) // force the streaming path (file > 1 MB) so the preflight runs
+        .execute()
+        .await
+        .expect("import");
+    assert!(result.root_id.is_some(), "index should have been built");
+
+    let query = format!("SELECT (COUNT(*) AS ?c) WHERE {{ ?s a <{CLASS_IRI}> }}");
+
+    // Fresh-from-index read path (uses root.ns_split_mode).
+    assert_eq!(
+        count(&fluree, &query).await,
+        SUBJECT_COUNT as u64,
+        "bound-IRI lookup after import returned nothing — root recorded the wrong split mode"
+    );
+
+    // Reindex from the commit chain (uses the genesis commit's split mode).
+    fluree
+        .reindex(LEDGER, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    // Read with a fresh instance so the reindexed root is loaded, not a cached one.
+    let fluree2 = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build second Fluree");
+    assert_eq!(
+        count(&fluree2, &query).await,
+        SUBJECT_COUNT as u64,
+        "bound-IRI lookup after reindex returned nothing — genesis commit recorded the wrong split mode"
+    );
+}


### PR DESCRIPTION
## Problem

On a bulk import large/diverse enough to trip the namespace preflight, every concrete-IRI object/subject lookup silently returns zero rows (e.g. `?s a <ClassIRI>`, `?s <p> <obj>`), while predicate scans and `GROUP BY` are unaffected. `reindex` does not recover it.

This is triggered by first-chunk namespace diversity, not commit count or dataset scale: a single large import that crosses the prefix budget flips; a small one does not.

## Root cause

When the import preflight sees more than `NS_PREFLIGHT_BUDGET` (255) distinct namespace prefixes in the streamed input, it coarsens the forward-dict allocator to `NsSplitMode::HostPlusN(1)`, and the whole index is keyed with that mode. But three write-side records the read path consults hard-coded `NsSplitMode::default()` (`MostGranular`):

- the published FIR6 index root,
- the predicate-sid split,
- the genesis commit (recorded from `ns_registry`, which the allocator flip never touched).

At query time, `find_subject_id` splits the query IRI `MostGranular` against the coarse-keyed dictionary, so the namespace prefix is absent and the reverse lookup returns `None`. Scans are unaffected because they read the forward (s_id → IRI) dict and never re-split a query IRI. `reindex` reproduces the bug because it rebuilds from the genesis commit's wrong mode.

## Fix

Thread the allocator's actual split mode through `ChunkImportResult` → `IndexBuildInput` into the root and predicate sids, and mirror it into the genesis commit's `ns_registry` so a later reindex agrees. The mode is captured once (one relaxed atomic load) and copied — ingestion, namespace splitting, encoding, and index building are unchanged, so there is **no import-speed impact** (correctness only).

A regression test forces the streaming/preflight path with >255 namespaces and asserts a bound-IRI lookup resolves after both import and reindex; it returns 0 without this change.

## Migration

Ledgers imported before this fix that tripped the preflight still have the wrong split mode recorded and will keep returning empty results for concrete-IRI lookups. They need a **re-import** to recover — `reindex` alone is not sufficient, since the genesis commit carries the wrong mode.