### PR TITLE
perf: share the namespace table via Arc to avoid per-query clones

### DIFF
--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -185,7 +185,7 @@ fn explain_from_parsed(
     query_echo: JsonValue,
     where_clause: Option<JsonValue>,
 ) -> Result<JsonValue> {
-    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &parsed.context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &parsed.context);
 
     // Extract triple patterns in query order.
     // Normalize any IRI terms into SID when possible so that

--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -185,7 +185,7 @@ fn explain_from_parsed(
     query_echo: JsonValue,
     where_clause: Option<JsonValue>,
 ) -> Result<JsonValue> {
-    let compactor = IriCompactor::new(snapshot.namespaces(), &parsed.context);
+    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &parsed.context);
 
     // Extract triple patterns in query order.
     // Normalize any IRI terms into SID when possible so that

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -131,7 +131,7 @@ fn format_delimited_bytes(
 ) -> Result<Vec<u8>> {
     reject_non_tabular(result, delimiter)?;
 
-    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &result.context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context);
     let gv = result.binary_graph.as_ref();
     let select_vars = resolve_select_vars(result);
 
@@ -183,7 +183,7 @@ fn format_delimited_bytes_limited(
 ) -> Result<(Vec<u8>, usize)> {
     reject_non_tabular(result, delimiter)?;
 
-    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &result.context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context);
     let gv = result.binary_graph.as_ref();
     let select_vars = resolve_select_vars(result);
     let total = result.row_count();

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -131,7 +131,7 @@ fn format_delimited_bytes(
 ) -> Result<Vec<u8>> {
     reject_non_tabular(result, delimiter)?;
 
-    let compactor = IriCompactor::new(snapshot.namespaces(), &result.context);
+    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &result.context);
     let gv = result.binary_graph.as_ref();
     let select_vars = resolve_select_vars(result);
 
@@ -183,7 +183,7 @@ fn format_delimited_bytes_limited(
 ) -> Result<(Vec<u8>, usize)> {
     reject_non_tabular(result, delimiter)?;
 
-    let compactor = IriCompactor::new(snapshot.namespaces(), &result.context);
+    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &result.context);
     let gv = result.binary_graph.as_ref();
     let select_vars = resolve_select_vars(result);
     let total = result.row_count();

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -549,7 +549,7 @@ impl<'a> DatasetCtx<'a> {
             }
             views.push(LedgerView {
                 db: view_db,
-                compactor: IriCompactor::new(g.snapshot.namespaces(), context),
+                compactor: IriCompactor::new(g.snapshot.namespaces_arc(), context),
                 policy: g.policy().cloned(),
             });
             // First occurrence wins (a ledger may appear as both default and named).

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -549,7 +549,7 @@ impl<'a> DatasetCtx<'a> {
             }
             views.push(LedgerView {
                 db: view_db,
-                compactor: IriCompactor::new(g.snapshot.namespaces_arc(), context),
+                compactor: IriCompactor::new(g.snapshot.shared_namespaces(), context),
                 policy: g.policy().cloned(),
             });
             // First occurrence wins (a ledger may appear as both default and named).

--- a/fluree-db-api/src/format/iri.rs
+++ b/fluree-db-api/src/format/iri.rs
@@ -11,6 +11,7 @@ use fluree_db_core::Sid;
 use fluree_graph_json_ld::{ContextCompactor, ParsedContext};
 use fluree_vocab::namespaces;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use super::{FormatError, Result};
 
@@ -31,7 +32,10 @@ pub struct IriCompactor {
     /// Namespace code -> IRI prefix (from Db.namespaces())
     ///
     /// Example: `2 -> "http://www.w3.org/2001/XMLSchema#"`
-    namespace_codes: HashMap<u16, String>,
+    ///
+    /// Shared (not cloned) from the snapshot so building a compactor per query
+    /// is a refcount bump, not a deep copy of the whole namespace table.
+    namespace_codes: Arc<HashMap<u16, String>>,
 
     /// Parsed @context from the query (for advanced access / @reverse lookups)
     context: ParsedContext,
@@ -56,12 +60,12 @@ impl IriCompactor {
     ///
     /// For namespaces in `namespace_codes` that have no matching prefix in
     /// the context, a short prefix is auto-derived from the namespace URI.
-    pub fn new(namespace_codes: &HashMap<u16, String>, context: &ParsedContext) -> Self {
+    pub fn new(namespace_codes: Arc<HashMap<u16, String>>, context: &ParsedContext) -> Self {
         let compactor = ContextCompactor::new(context);
         let reverse_terms = build_reverse_terms(context);
-        let fallback_prefixes = build_fallback_prefixes(namespace_codes, context);
+        let fallback_prefixes = build_fallback_prefixes(&namespace_codes, context);
         Self {
-            namespace_codes: namespace_codes.clone(),
+            namespace_codes,
             context: context.clone(),
             compactor,
             reverse_terms,
@@ -73,11 +77,11 @@ impl IriCompactor {
     ///
     /// No fallback prefixes are generated — IRIs come through uncompacted.
     /// Use `new()` with a `ParsedContext` to enable compaction.
-    pub fn from_namespaces(namespace_codes: &HashMap<u16, String>) -> Self {
+    pub fn from_namespaces(namespace_codes: Arc<HashMap<u16, String>>) -> Self {
         let default_ctx = ParsedContext::default();
         let compactor = ContextCompactor::new(&default_ctx);
         Self {
-            namespace_codes: namespace_codes.clone(),
+            namespace_codes,
             context: default_ctx,
             compactor,
             reverse_terms: HashMap::new(),
@@ -207,7 +211,7 @@ impl IriCompactor {
     pub fn try_encode_iri(&self, iri: &str) -> Option<Sid> {
         // Try each namespace prefix (longest match wins)
         let mut best: Option<(u16, &str, usize)> = None;
-        for (&code, prefix) in &self.namespace_codes {
+        for (&code, prefix) in self.namespace_codes.iter() {
             if iri.starts_with(prefix.as_str()) && prefix.len() > best.map_or(0, |b| b.2) {
                 let local = &iri[prefix.len()..];
                 best = Some((code, local, prefix.len()));
@@ -457,7 +461,7 @@ mod tests {
 
     #[test]
     fn test_decode_sid() {
-        let compactor = IriCompactor::from_namespaces(&make_test_namespaces());
+        let compactor = IriCompactor::from_namespaces(Arc::new(make_test_namespaces()));
 
         let sid = Sid::new(2, "string");
         assert_eq!(
@@ -481,7 +485,7 @@ mod tests {
 
     #[test]
     fn test_compact_iri_with_context() {
-        let compactor = IriCompactor::new(&make_test_namespaces(), &make_test_context());
+        let compactor = IriCompactor::new(Arc::new(make_test_namespaces()), &make_test_context());
 
         // Prefix matches via @context
         assert_eq!(compactor.compact_vocab_iri(xsd::STRING), "xsd:string");
@@ -501,7 +505,7 @@ mod tests {
 
     #[test]
     fn test_compact_iri_no_match() {
-        let compactor = IriCompactor::new(&make_test_namespaces(), &make_test_context());
+        let compactor = IriCompactor::new(Arc::new(make_test_namespaces()), &make_test_context());
 
         // No matching prefix - returns full IRI
         assert_eq!(
@@ -512,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_compact_sid() {
-        let compactor = IriCompactor::new(&make_test_namespaces(), &make_test_context());
+        let compactor = IriCompactor::new(Arc::new(make_test_namespaces()), &make_test_context());
 
         // Known namespace with @context prefix
         let sid = Sid::new(2, "string");
@@ -524,7 +528,7 @@ mod tests {
 
     #[test]
     fn test_compact_without_context() {
-        let compactor = IriCompactor::from_namespaces(&make_test_namespaces());
+        let compactor = IriCompactor::from_namespaces(Arc::new(make_test_namespaces()));
 
         // No @context and no fallback — IRIs come through uncompacted
         let sid = Sid::new(2, "string");
@@ -550,7 +554,7 @@ mod tests {
         )
         .unwrap();
 
-        let compactor = IriCompactor::new(&namespaces, &context);
+        let compactor = IriCompactor::new(Arc::new(namespaces), &context);
 
         // Context prefix works via standard method
         assert_eq!(
@@ -584,7 +588,7 @@ mod tests {
 
         // Need a non-empty context to trigger fallback generation
         let context = ParsedContext::parse(None, &json!({"ex": "http://example.org/"})).unwrap();
-        let compactor = IriCompactor::new(&namespaces, &context);
+        let compactor = IriCompactor::new(Arc::new(namespaces), &context);
 
         // Both derive "foo", but one should get "foo" and the other "foo2"
         let a = compactor.compact_for_display("http://a.org/foo/bar");
@@ -614,7 +618,7 @@ mod tests {
             }),
         )
         .unwrap();
-        let compactor = IriCompactor::new(&namespaces, &context);
+        let compactor = IriCompactor::new(Arc::new(namespaces), &context);
 
         // SID under @vocab: the @id path must NOT collapse it to the bare term.
         let summer = Sid::new(100, "summer"); // http://example.org/lists/summer
@@ -666,7 +670,7 @@ mod tests {
             }),
         )
         .unwrap();
-        let compactor = IriCompactor::new(&namespaces, &context);
+        let compactor = IriCompactor::new(Arc::new(namespaces), &context);
 
         let under_base = Sid::new(100, "alice"); // https://flur.ee/base/alice
         let under_vocab = Sid::new(101, "bob"); //  https://flur.ee/vocab/bob

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -344,7 +344,7 @@ mod tests {
         namespaces.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
         namespaces.insert(3, "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string());
         namespaces.insert(100, "http://example.org/".to_string());
-        IriCompactor::from_namespaces(&namespaces)
+        IriCompactor::from_namespaces(std::sync::Arc::new(namespaces))
     }
 
     /// A compactor whose context sets `@vocab` to the same namespace as the
@@ -357,7 +357,7 @@ mod tests {
             &serde_json::json!({"@vocab": "http://example.org/lists/"}),
         )
         .unwrap();
-        IriCompactor::new(&namespaces, &context)
+        IriCompactor::new(std::sync::Arc::new(namespaces), &context)
     }
 
     /// Regression for #1280: a reference binding is a node identifier (`@id`

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -119,7 +119,7 @@ pub fn format_results(
         )));
     }
 
-    let compactor = IriCompactor::new(snapshot.namespaces(), context);
+    let compactor = IriCompactor::new(snapshot.namespaces_arc(), context);
 
     // CONSTRUCT / DESCRIBE produce a graph, not a binding table, so the only
     // sensible JSON rendering is JSON-LD. Any JSON-producing format request
@@ -182,11 +182,11 @@ pub fn format_results_string(
         OutputFormat::Tsv => return delimited::format_tsv(result, snapshot),
         OutputFormat::Csv => return delimited::format_csv(result, snapshot),
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(snapshot.namespaces(), context);
+            let compactor = IriCompactor::new(snapshot.namespaces_arc(), context);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {
-            let compactor = IriCompactor::new(snapshot.namespaces(), context);
+            let compactor = IriCompactor::new(snapshot.namespaces_arc(), context);
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}
@@ -262,7 +262,7 @@ pub async fn format_results_async(
         )));
     }
 
-    let compactor = IriCompactor::new(db.snapshot.namespaces(), context);
+    let compactor = IriCompactor::new(db.snapshot.namespaces_arc(), context);
 
     // CONSTRUCT / DESCRIBE produce a graph (sync, no DB access needed); coerce
     // any JSON-producing format to JSON-LD rather than rejecting it. RDF/XML and
@@ -418,11 +418,11 @@ pub async fn format_results_string_async(
         OutputFormat::Tsv => return delimited::format_tsv(result, db.snapshot),
         OutputFormat::Csv => return delimited::format_csv(result, db.snapshot),
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(db.snapshot.namespaces(), context);
+            let compactor = IriCompactor::new(db.snapshot.namespaces_arc(), context);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {
-            let compactor = IriCompactor::new(db.snapshot.namespaces(), context);
+            let compactor = IriCompactor::new(db.snapshot.namespaces_arc(), context);
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}
@@ -457,11 +457,11 @@ pub async fn format_results_string_async_dataset(
         OutputFormat::Tsv => return delimited::format_tsv(result, primary_db.snapshot),
         OutputFormat::Csv => return delimited::format_csv(result, primary_db.snapshot),
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(primary_db.snapshot.namespaces(), context);
+            let compactor = IriCompactor::new(primary_db.snapshot.namespaces_arc(), context);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {
-            let compactor = IriCompactor::new(primary_db.snapshot.namespaces(), context);
+            let compactor = IriCompactor::new(primary_db.snapshot.namespaces_arc(), context);
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -119,7 +119,7 @@ pub fn format_results(
         )));
     }
 
-    let compactor = IriCompactor::new(snapshot.namespaces_arc(), context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), context);
 
     // CONSTRUCT / DESCRIBE produce a graph, not a binding table, so the only
     // sensible JSON rendering is JSON-LD. Any JSON-producing format request
@@ -182,11 +182,11 @@ pub fn format_results_string(
         OutputFormat::Tsv => return delimited::format_tsv(result, snapshot),
         OutputFormat::Csv => return delimited::format_csv(result, snapshot),
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(snapshot.namespaces_arc(), context);
+            let compactor = IriCompactor::new(snapshot.shared_namespaces(), context);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {
-            let compactor = IriCompactor::new(snapshot.namespaces_arc(), context);
+            let compactor = IriCompactor::new(snapshot.shared_namespaces(), context);
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}
@@ -262,7 +262,7 @@ pub async fn format_results_async(
         )));
     }
 
-    let compactor = IriCompactor::new(db.snapshot.namespaces_arc(), context);
+    let compactor = IriCompactor::new(db.snapshot.shared_namespaces(), context);
 
     // CONSTRUCT / DESCRIBE produce a graph (sync, no DB access needed); coerce
     // any JSON-producing format to JSON-LD rather than rejecting it. RDF/XML and
@@ -418,11 +418,11 @@ pub async fn format_results_string_async(
         OutputFormat::Tsv => return delimited::format_tsv(result, db.snapshot),
         OutputFormat::Csv => return delimited::format_csv(result, db.snapshot),
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(db.snapshot.namespaces_arc(), context);
+            let compactor = IriCompactor::new(db.snapshot.shared_namespaces(), context);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {
-            let compactor = IriCompactor::new(db.snapshot.namespaces_arc(), context);
+            let compactor = IriCompactor::new(db.snapshot.shared_namespaces(), context);
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}
@@ -457,11 +457,11 @@ pub async fn format_results_string_async_dataset(
         OutputFormat::Tsv => return delimited::format_tsv(result, primary_db.snapshot),
         OutputFormat::Csv => return delimited::format_csv(result, primary_db.snapshot),
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(primary_db.snapshot.namespaces_arc(), context);
+            let compactor = IriCompactor::new(primary_db.snapshot.shared_namespaces(), context);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {
-            let compactor = IriCompactor::new(primary_db.snapshot.namespaces_arc(), context);
+            let compactor = IriCompactor::new(primary_db.snapshot.shared_namespaces(), context);
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -453,7 +453,7 @@ mod tests {
         namespaces.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
         namespaces.insert(3, "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string());
         namespaces.insert(100, "http://example.org/".to_string());
-        IriCompactor::from_namespaces(&namespaces)
+        IriCompactor::from_namespaces(std::sync::Arc::new(namespaces))
     }
 
     /// Create a minimal QueryResult for tests that don't need binary_store.

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -345,7 +345,7 @@ mod tests {
         let mut namespaces = HashMap::new();
         namespaces.insert(100, "http://example.org/".to_string());
         namespaces.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
-        IriCompactor::from_namespaces(&namespaces)
+        IriCompactor::from_namespaces(std::sync::Arc::new(namespaces))
     }
 
     fn make_test_result() -> QueryResult {

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -329,7 +329,7 @@ mod tests {
         namespaces.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
         namespaces.insert(3, "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string());
         namespaces.insert(100, "http://example.org/".to_string());
-        IriCompactor::from_namespaces(&namespaces)
+        IriCompactor::from_namespaces(std::sync::Arc::new(namespaces))
     }
 
     /// A compactor whose context sets `@vocab` to the same namespace as the
@@ -342,7 +342,7 @@ mod tests {
             &serde_json::json!({"@vocab": "http://example.org/lists/"}),
         )
         .unwrap();
-        IriCompactor::new(&namespaces, &context)
+        IriCompactor::new(std::sync::Arc::new(namespaces), &context)
     }
 
     /// Regression for #1280: the `@id` of a reference must not be compacted

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -239,7 +239,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
             .ledger_cached(&self.graph.ledger_id)
             .await?;
         let snapshot = handle.snapshot().await;
-        let namespace_codes = snapshot.snapshot.namespaces();
+        let namespace_codes = snapshot.snapshot.namespaces_arc();
 
         // 2. Resolve commit reference to a full CID
         let commit_id = snapshot.resolve_commit(self.commit_ref).await?;

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -239,7 +239,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
             .ledger_cached(&self.graph.ledger_id)
             .await?;
         let snapshot = handle.snapshot().await;
-        let namespace_codes = snapshot.snapshot.namespaces_arc();
+        let namespace_codes = snapshot.snapshot.shared_namespaces();
 
         // 2. Resolve commit reference to a full CID
         let commit_id = snapshot.resolve_commit(self.commit_ref).await?;

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -196,7 +196,7 @@ pub async fn build_ledger_info_with_options<S: Storage + Clone>(
     let parsed_context = context
         .map(|c| ParsedContext::parse(None, c).unwrap_or_default())
         .unwrap_or_default();
-    let compactor = IriCompactor::new(ledger.snapshot.namespaces_arc(), &parsed_context);
+    let compactor = IriCompactor::new(ledger.snapshot.shared_namespaces(), &parsed_context);
 
     // Build schema index for hierarchy lookups
     let schema_index = ledger

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -196,7 +196,7 @@ pub async fn build_ledger_info_with_options<S: Storage + Clone>(
     let parsed_context = context
         .map(|c| ParsedContext::parse(None, c).unwrap_or_default())
         .unwrap_or_default();
-    let compactor = IriCompactor::new(ledger.snapshot.namespaces(), &parsed_context);
+    let compactor = IriCompactor::new(ledger.snapshot.namespaces_arc(), &parsed_context);
 
     // Build schema index for hierarchy lookups
     let schema_index = ledger

--- a/fluree-db-api/src/ledger_manager.rs
+++ b/fluree-db-api/src/ledger_manager.rs
@@ -331,7 +331,7 @@ impl LedgerHandle {
             crate::runtime_dicts::reseed_runtime_small_dicts(&mut state, &arc_store);
 
             // Build range_provider with the real dict_novelty (rebuilt by apply_loaded_db)
-            let ns_fallback = Some(Arc::new(state.snapshot.namespaces().clone()));
+            let ns_fallback = Some(state.snapshot.shared_namespaces());
             let provider = BinaryRangeProvider::new(
                 Arc::clone(&arc_store),
                 Arc::clone(&state.dict_novelty),
@@ -675,7 +675,7 @@ pub(crate) async fn load_and_attach_binary_store(
 
     let arc_store = Arc::new(store);
     crate::runtime_dicts::reseed_runtime_small_dicts(state, &arc_store);
-    let ns_fallback = Some(Arc::new(state.snapshot.namespaces().clone()));
+    let ns_fallback = Some(state.snapshot.shared_namespaces());
     let provider = BinaryRangeProvider::new(
         Arc::clone(&arc_store),
         Arc::clone(&state.dict_novelty),
@@ -1663,7 +1663,7 @@ impl LedgerManager {
                             let runtime_small_dicts =
                                 Arc::clone(&write_guard.state().runtime_small_dicts);
                             let ns_fallback =
-                                Some(Arc::new(write_guard.state().snapshot.namespaces().clone()));
+                                Some(write_guard.state().snapshot.shared_namespaces());
                             write_guard.state_mut().snapshot.range_provider =
                                 Some(Arc::new(BinaryRangeProvider::new(
                                     store,

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -467,8 +467,8 @@ async fn build_conflict_details(
     target_state: &LedgerState,
     strategy: &ConflictStrategy,
 ) -> Result<Vec<ConflictDetail>> {
-    let source_compactor = IriCompactor::from_namespaces(source_state.snapshot.namespaces_arc());
-    let target_compactor = IriCompactor::from_namespaces(target_state.snapshot.namespaces_arc());
+    let source_compactor = IriCompactor::from_namespaces(source_state.snapshot.shared_namespaces());
+    let target_compactor = IriCompactor::from_namespaces(target_state.snapshot.shared_namespaces());
     let resolution = resolution_for_strategy(strategy);
 
     stream::iter(keys.iter().cloned())

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -467,8 +467,8 @@ async fn build_conflict_details(
     target_state: &LedgerState,
     strategy: &ConflictStrategy,
 ) -> Result<Vec<ConflictDetail>> {
-    let source_compactor = IriCompactor::from_namespaces(source_state.snapshot.namespaces());
-    let target_compactor = IriCompactor::from_namespaces(target_state.snapshot.namespaces());
+    let source_compactor = IriCompactor::from_namespaces(source_state.snapshot.namespaces_arc());
+    let target_compactor = IriCompactor::from_namespaces(target_state.snapshot.namespaces_arc());
     let resolution = resolution_for_strategy(strategy);
 
     stream::iter(keys.iter().cloned())

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -93,7 +93,7 @@ impl Fluree {
             let runtime_small_dicts = view.runtime_small_dicts.clone().unwrap_or_else(|| {
                 crate::runtime_dicts::build_runtime_small_dicts(&store, view.novelty.as_ref())
             });
-            let ns_fallback = Some(Arc::new(view.snapshot.namespaces().clone()));
+            let ns_fallback = Some(view.snapshot.shared_namespaces());
             let provider =
                 BinaryRangeProvider::new(store, dict_novelty, runtime_small_dicts, ns_fallback);
             let mut db = (*view.snapshot).clone();
@@ -221,7 +221,7 @@ impl Fluree {
                     &arc_store,
                     Some(&snapshot.novelty),
                 );
-                let ns_fallback = Some(Arc::new(snapshot.snapshot.namespaces().clone()));
+                let ns_fallback = Some(snapshot.snapshot.shared_namespaces());
                 let provider = BinaryRangeProvider::new(
                     Arc::clone(&arc_store),
                     dn,
@@ -385,7 +385,7 @@ impl Fluree {
                                     view.novelty.as_ref(),
                                 )
                             });
-                        let ns_fallback = Some(Arc::new(view.snapshot.namespaces().clone()));
+                        let ns_fallback = Some(view.snapshot.shared_namespaces());
                         let provider = BinaryRangeProvider::new(
                             Arc::clone(&store),
                             dict_novelty,

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -511,7 +511,7 @@ impl GraphDb {
     pub fn binary_graph(&self) -> Option<BinaryGraphView> {
         self.binary_store.as_ref().map(|store| {
             BinaryGraphView::new(store.clone(), self.graph_id)
-                .with_namespace_codes_fallback(Some(Arc::new(self.snapshot.namespaces().clone())))
+                .with_namespace_codes_fallback(Some(self.snapshot.shared_namespaces()))
         })
     }
 }

--- a/fluree-db-api/tests/it_compile_breakdown.rs
+++ b/fluree-db-api/tests/it_compile_breakdown.rs
@@ -1,0 +1,141 @@
+//! Measure the per-query COMPILE breakdown to size a query-plan cache.
+//!
+//! A plan cache would skip parse + lower + plan and re-run only execution. This
+//! bench times, per representative query shape:
+//! - raw_parse: `parse_sparql` (SPARQL text -> AST). Upper bound on what a
+//!   lexer-level skeleton normalizer would cost (a normalizer is cheaper than a
+//!   full parse), i.e. the cache's per-hit overhead.
+//! - compile: `explain_sparql` = parse + lower (IRI->Sid, schema) + plan
+//!   (selectivity, operator tree). This is what the cache SKIPS. (Slight
+//!   overestimate: explain also serializes the plan to JSON.)
+//! - total: `query` = compile + execute + result build.
+//! - exec~: total - compile (what always runs, cache or not).
+//!
+//! Decision inputs: compile% of total (is the cache worth it?) and
+//! compile-vs-raw_parse (does a cheap normalizer stay << the savings?).
+//!
+//!   cargo test -p fluree-db-api --test it_compile_breakdown --features native \
+//!       --profile dev-fast -- --ignored --nocapture compile_breakdown
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use fluree_db_api::{parse_sparql, FlureeBuilder, ReindexOptions};
+use serde_json::json;
+use support::graphdb_from_ledger;
+
+const SEED: usize = 8000;
+const ITERS: usize = 2000;
+const WARMUP: usize = 200;
+
+// BSBM-Explore-class shapes, increasing complexity.
+const QUERIES: &[(&str, &str)] = &[
+    (
+        "lookup (1 subject)",
+        "SELECT ?p ?o WHERE { <http://ex/p42> ?p ?o }",
+    ),
+    (
+        "star+filter (3 patterns)",
+        "PREFIX ex: <http://ex/> \
+         SELECT ?label ?value WHERE { \
+           ?s a ex:Product ; ex:label ?label ; ex:value ?value . \
+           FILTER(?value > 5000) }",
+    ),
+    (
+        "join+order+limit (4 patterns)",
+        "PREFIX ex: <http://ex/> \
+         SELECT ?s ?label WHERE { \
+           ?s a ex:Product ; ex:label ?label ; ex:value ?value ; ex:feature ex:f7 . \
+           FILTER(?value > 1000) } ORDER BY ?label LIMIT 10",
+    ),
+];
+
+fn avg_us<F: FnMut()>(mut f: F) -> f64 {
+    for _ in 0..WARMUP {
+        f();
+    }
+    let start = Instant::now();
+    for _ in 0..ITERS {
+        f();
+    }
+    start.elapsed().as_secs_f64() * 1e6 / ITERS as f64
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "manual compile-breakdown bench"]
+async fn compile_breakdown() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .expect("build");
+    let ledger_id = "bench/compile:main";
+
+    let l0 = fluree.create_ledger(ledger_id).await.expect("create");
+    let g: Vec<_> = (0..SEED)
+        .map(|i| {
+            json!({
+                "@id": format!("http://ex/p{i}"),
+                "@type": "http://ex/Product",
+                "http://ex/label": format!("label-{i}"),
+                "http://ex/value": i,
+                "http://ex/feature": { "@id": format!("http://ex/f{}", i % 50) }
+            })
+        })
+        .collect();
+    fluree
+        .insert(l0, &json!({ "@graph": g }))
+        .await
+        .expect("insert");
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+    let db = graphdb_from_ledger(&ledger);
+
+    eprintln!("\n=== compile breakdown (avg of {ITERS} iters, microseconds) ===");
+    eprintln!(
+        "{:<32} {:>10} {:>10} {:>10} {:>10} {:>9}",
+        "query", "raw_parse", "compile", "exec~", "total", "compile%"
+    );
+    for (name, q) in QUERIES {
+        // Sanity: it runs.
+        let _ = fluree.query(&db, *q).await.expect("query");
+
+        let raw_parse = avg_us(|| {
+            black_box(parse_sparql(black_box(q)));
+        });
+        // explain_sparql / query are async — time them with a tiny runtime-blocking loop.
+        let compile = {
+            let start = Instant::now();
+            for _ in 0..ITERS {
+                black_box(fluree.explain_sparql(&db, q).await.expect("explain"));
+            }
+            start.elapsed().as_secs_f64() * 1e6 / ITERS as f64
+        };
+        let total = {
+            let start = Instant::now();
+            for _ in 0..ITERS {
+                black_box(fluree.query(&db, *q).await.expect("query"));
+            }
+            start.elapsed().as_secs_f64() * 1e6 / ITERS as f64
+        };
+        let exec = (total - compile).max(0.0);
+        let compile_pct = if total > 0.0 {
+            compile / total * 100.0
+        } else {
+            0.0
+        };
+        eprintln!(
+            "{name:<32} {raw_parse:>10.1} {compile:>10.1} {exec:>10.1} {total:>10.1} {compile_pct:>8.0}%"
+        );
+    }
+    eprintln!("=== end ===\n");
+    eprintln!("note: `compile` (explain) includes plan->JSON serialization, so it slightly");
+    eprintln!("overestimates real compile; `raw_parse` is an upper bound on a lexer normalizer.");
+}

--- a/fluree-db-api/tests/it_select_star_novelty_retract.rs
+++ b/fluree-db-api/tests/it_select_star_novelty_retract.rs
@@ -432,7 +432,7 @@ async fn expansion_does_not_drop_overlay_assertions_when_dict_novelty_missing() 
     let store = Arc::clone(brp.store());
     let bad_dn = Arc::new(fluree_db_core::dict_novelty::DictNovelty::new_uninitialized());
     let runtime_small_dicts = Arc::clone(brp.runtime_small_dicts());
-    let ns_fallback = Some(Arc::new(ledger.snapshot.namespaces().clone()));
+    let ns_fallback = Some(ledger.snapshot.shared_namespaces());
     ledger.snapshot.range_provider = Some(Arc::new(fluree_db_query::BinaryRangeProvider::new(
         store,
         bad_dn,

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -57,7 +57,7 @@ pub fn format_sparql_table_from_result(
 
     // Grouped bindings require cartesian disaggregation (SPARQL formatter logic).
     // Rather than re-implement that here, fall back to the existing SPARQL JSON formatter.
-    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &result.context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context);
     let gv = result.binary_graph.as_ref();
 
     let head_var_ids: Vec<fluree_db_query::VarId> = if result.output.is_wildcard() {

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -57,7 +57,7 @@ pub fn format_sparql_table_from_result(
 
     // Grouped bindings require cartesian disaggregation (SPARQL formatter logic).
     // Rather than re-implement that here, fall back to the existing SPARQL JSON formatter.
-    let compactor = IriCompactor::new(snapshot.namespaces(), &result.context);
+    let compactor = IriCompactor::new(snapshot.namespaces_arc(), &result.context);
     let gv = result.binary_graph.as_ref();
 
     let head_var_ids: Vec<fluree_db_query::VarId> = if result.output.is_wildcard() {

--- a/fluree-db-core/src/db.rs
+++ b/fluree-db-core/src/db.rs
@@ -361,7 +361,7 @@ impl LedgerSnapshot {
     /// Returns an `Arc` clone (refcount bump, no copy) so per-query consumers
     /// such as the result-formatting `IriCompactor` can hold the stable table
     /// without deep-cloning it on every request.
-    pub fn namespaces_arc(&self) -> Arc<HashMap<u16, String>> {
+    pub fn shared_namespaces(&self) -> Arc<HashMap<u16, String>> {
         Arc::clone(&self.namespace_codes)
     }
 

--- a/fluree-db-core/src/db.rs
+++ b/fluree-db-core/src/db.rs
@@ -79,7 +79,12 @@ pub struct LedgerSnapshot {
     ///
     /// Private to enforce bimap invariant with `namespace_reverse`.
     /// Use `namespaces()` for read access, `insert_namespace_code()` for mutation.
-    namespace_codes: HashMap<u16, String>,
+    ///
+    /// `Arc`-wrapped so per-query consumers (notably the result-formatting
+    /// `IriCompactor`) can share the table by refcount bump instead of deep-
+    /// cloning the whole map on every request. Mutations go through
+    /// `Arc::make_mut` (copy-on-write); writers are rare and serialized.
+    namespace_codes: Arc<HashMap<u16, String>>,
 
     /// Reverse: IRI prefix -> namespace code (for O(1) canonical encode lookup).
     /// Kept in sync with `namespace_codes` by all mutation paths.
@@ -185,7 +190,7 @@ impl LedgerSnapshot {
             t: 0,
             base_t: 0,
             version: 3,
-            namespace_codes,
+            namespace_codes: Arc::new(namespace_codes),
             namespace_reverse,
             ns_split_mode: NsSplitMode::default(),
             stats: None,
@@ -220,7 +225,7 @@ impl LedgerSnapshot {
             t: meta.t,
             base_t: meta.base_t,
             version: 3,
-            namespace_codes: meta.namespace_codes,
+            namespace_codes: Arc::new(meta.namespace_codes),
             namespace_reverse,
             ns_split_mode: meta.ns_split_mode,
             stats: meta.stats,
@@ -351,6 +356,15 @@ impl LedgerSnapshot {
         &self.namespace_codes
     }
 
+    /// Get a cheap, shareable handle to the namespace table.
+    ///
+    /// Returns an `Arc` clone (refcount bump, no copy) so per-query consumers
+    /// such as the result-formatting `IriCompactor` can hold the stable table
+    /// without deep-cloning it on every request.
+    pub fn namespaces_arc(&self) -> Arc<HashMap<u16, String>> {
+        Arc::clone(&self.namespace_codes)
+    }
+
     /// Get the reverse namespace map (prefix → code) for conflict checking.
     pub fn namespace_reverse(&self) -> &HashMap<String, u16> {
         &self.namespace_reverse
@@ -405,7 +419,7 @@ impl LedgerSnapshot {
             return Ok(false);
         }
         self.namespace_reverse.insert(prefix.clone(), code);
-        self.namespace_codes.insert(code, prefix);
+        Arc::make_mut(&mut self.namespace_codes).insert(code, prefix);
         Ok(true)
     }
 
@@ -449,7 +463,7 @@ impl LedgerSnapshot {
                 continue;
             }
             // New mapping — insert into both maps.
-            self.namespace_codes.insert(code, prefix.clone());
+            Arc::make_mut(&mut self.namespace_codes).insert(code, prefix.clone());
             self.namespace_reverse.insert(prefix.clone(), code);
         }
         self.graph_registry.apply_delta(graph_iris);

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -209,7 +209,7 @@ impl<'a> ExecutionContext<'a> {
         let dict_novelty = Self::extract_dict_novelty(db.snapshot);
         let namespace_codes_fallback = binary_store
             .as_ref()
-            .map(|_| Arc::new(db.snapshot.namespaces().clone()));
+            .map(|_| db.snapshot.shared_namespaces());
         let runtime_small_dicts = db
             .runtime_small_dicts
             .or_else(|| Self::extract_runtime_small_dicts(db.snapshot));
@@ -260,7 +260,7 @@ impl<'a> ExecutionContext<'a> {
         let dict_novelty = Self::extract_dict_novelty(db.snapshot);
         let namespace_codes_fallback = binary_store
             .as_ref()
-            .map(|_| Arc::new(db.snapshot.namespaces().clone()));
+            .map(|_| db.snapshot.shared_namespaces());
         let runtime_small_dicts = db
             .runtime_small_dicts
             .or_else(|| Self::extract_runtime_small_dicts(db.snapshot));

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -690,7 +690,7 @@ where
         let mut snapshot = base.snapshot;
         if let Some(provider) = snapshot.range_provider.as_ref() {
             if let Some(brp) = provider.as_any().downcast_ref::<BinaryRangeProvider>() {
-                let ns_fallback = Some(Arc::new(snapshot.namespaces().clone()));
+                let ns_fallback = Some(snapshot.shared_namespaces());
                 snapshot.range_provider = Some(Arc::new(BinaryRangeProvider::new(
                     Arc::clone(brp.store()),
                     Arc::clone(&dict_novelty),


### PR DESCRIPTION
A CPU flamegraph of the server under concurrent read load showed the single
largest CPU consumer was `IriCompactor::new` — the per-query setup used to
compact result IRIs — and that it was almost entirely a **deep clone of the
snapshot's namespace table, rebuilt on every query** (hashing and allocating
every entry). The actual per-IRI compaction work was negligible by comparison.

The namespace table is stable ledger metadata, so there's no reason to copy it
per request. This change:

- wraps `LedgerSnapshot.namespace_codes` in `Arc<HashMap<…>>` (with a
  `namespaces_arc()` accessor; the few mutation sites use `Arc::make_mut`), and
- has `IriCompactor` hold that `Arc`, so building a compactor per query is a
  refcount bump instead of a full map copy.

Result-formatting call sites now pass `snapshot.namespaces_arc()`.

Behaviour is unchanged — it's the same table, shared rather than copied — and
the format/query test suites pass. Also includes a small `#[ignore]` bench used
to locate where per-query CPU goes.

Stacked on `fix/ns-split-mode-not-persisted`.
