### PR TITLE
fix: preserve language-tagged literals that share a value (#1273)

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1289,6 +1289,35 @@ mem:fact-01kj8k5nzpe59p5vp7zrehbrr9 a mem:Fact ;
     mem:branch "feature/memory" ;
     mem:createdAt "2026-02-24T19:49:14.358637+00:00"^^xsd:dateTime .
 
+mem:fact-01kta2t986nsjneban0hgbwzq7 a mem:Fact ;
+    mem:content "RDF term/fact identity in Fluree is (s, p, o, dt, m) where m=FlakeMeta{lang, i} — matching Flake::eq/hash. Any dedup/stale-removal key that omits m collapses distinct facts: langString variants sharing a value (\"animal\"@en vs @fr), and @list members repeating a value at different indices. Issue #1273 was range::remove_stale_flakes (overlay-only/genesis read path) keying on (s,p,o,dt) only; the binary-scan stale-removal (binary_scan.rs FactKeyRef) already included m. Including m also correctly scopes retraction cancellation per variant." ;
+    mem:tag "dedup" ;
+    mem:tag "flake-identity" ;
+    mem:tag "issue-1273" ;
+    mem:tag "langstring" ;
+    mem:tag "range" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-core/src/flake.rs" ;
+    mem:artifactRef "fluree-db-core/src/range.rs" ;
+    mem:artifactRef "fluree-db-query/src/binary_scan.rs" ;
+    mem:branch "fix/langstring-novelty-dedup-1273" ;
+    mem:createdAt "2026-06-04T19:47:27.110421+00:00"^^xsd:dateTime ;
+    mem:rationale "Recurring class of bug: parallel dedup implementations diverging on whether the key includes FlakeMeta. Recall before touching any flake-dedup/stale-removal code." .
+
+mem:fact-01kta3264pg54aabvt97spk5qt a mem:Fact ;
+    mem:content "RDF export raw-flake emitters (write_raw_flake_ntriples/turtle, flake_to_jsonld_raw) for untranslated novelty overlay flakes correctly use store.sid_to_iri(&flake.s/.p), NOT ExportResolver.resolve_subject_iri/resolve_predicate_iri. The resolver methods take integer IDs (u64 s_id / u32 p_id) and exist to recover a Sid from an ID via DictNovelty/ephemeral maps. Raw flakes already carry the full Sid (ns_code+name), so sid_to_iri is correct+complete. Both paths bottom out at the same namespace_codes map for the prefix, so the resolver gives ZERO fallback advantage for novelty-only subjects/predicates. DictNovelty never invents namespace codes (only local IDs within an existing ns_code)." ;
+    mem:tag "binary-index" ;
+    mem:tag "export" ;
+    mem:tag "novelty" ;
+    mem:tag "overlay" ;
+    mem:tag "rdf" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/export.rs" ;
+    mem:artifactRef "fluree-db-binary-index/src/read/binary_index_store.rs" ;
+    mem:branch "fix/langstring-novelty-dedup-1273" ;
+    mem:createdAt "2026-06-04T19:51:46.070663+00:00"^^xsd:dateTime ;
+    mem:rationale "A reviewer flagged \"use resolver fallback instead of sid_to_iri for novelty subjects\" as a major data-loss bug; it is a false positive due to the Sid-vs-integer-ID distinction." .
+
 mem:fact-01kqfy6r0w86fcsd9km0707xzg a mem:Fact ;
     mem:content "v3 commit envelope reader at `legacy_v3.rs:305-309` deliberately stubs `graph_delta = HashMap::new()` since v3 never encoded the field. Envelope-only walkers (`first_t_where_graph_registered`) therefore return `None` on any chain that includes v3 commits, regardless of whether the named graph was actually registered. Callers that rely on the result for short-circuiting must either fall through to a full load on `None`, detect v3 envelopes and signal \"inconclusive\", or accept silent correctness regressions on legacy chains." ;
     mem:tag "commit-envelope" ;

--- a/docs/transactions/insert.md
+++ b/docs/transactions/insert.md
@@ -253,6 +253,11 @@ Add language-tagged strings:
 }
 ```
 
+The language tag is part of a value's identity. Two language-tagged values
+that share the same string but differ in their `@language` (for example
+`"animal"@en` and `"animal"@fr`) are **distinct** facts and are both retained;
+they are not deduplicated against each other.
+
 ## Blank Nodes
 
 Create entities without explicit IRIs:
@@ -329,6 +334,14 @@ Inserting the same triple again is a no-op:
 t=1: INSERT { ex:alice schema:name "Alice" }
 t=2: INSERT { ex:alice schema:name "Alice" }
      (No change—triple already exists)
+```
+
+A triple's identity includes its datatype and language tag, so values that
+differ only by language tag are not duplicates:
+
+```text
+INSERT { ex:alice schema:name "Alice"@en, "Alice"@fr }
+     Result: ex:alice has TWO name values (one per language tag)
 ```
 
 ### Multi-Value Handling

--- a/fluree-db-api/src/export.rs
+++ b/fluree-db-api/src/export.rs
@@ -5,13 +5,14 @@
 
 use fluree_db_binary_index::read::types::sort_overlay_ops;
 use fluree_db_binary_index::{
-    BinaryCursor, BinaryFilter, BinaryIndexStore, ColumnBatch, ColumnProjection, ColumnSet,
-    RunSortOrder,
+    BinaryCursor, BinaryFilter, BinaryIndexStore, ColumnBatch, ColumnProjection, RunSortOrder,
 };
 use fluree_db_core::dict_novelty::DictNovelty;
 use fluree_db_core::value::FlakeValue;
-use fluree_db_core::{DecodeKind, GraphId, OType, OverlayProvider, Sid};
-use fluree_db_query::binary_scan::{translate_overlay_flakes, EphemeralPredicateMap};
+use fluree_db_core::{DecodeKind, Flake, GraphId, OType, OverlayProvider, Sid};
+use fluree_db_query::binary_scan::{
+    translate_overlay_flakes_with_untranslated, EphemeralPredicateMap,
+};
 use fluree_vocab::xsd;
 use std::collections::{BTreeMap, HashMap};
 use std::io::{self, Write};
@@ -68,15 +69,21 @@ pub fn is_system_graph(g_id: GraphId) -> bool {
 
 /// Configure a `BinaryCursor` with time-travel bounds and novelty overlay.
 ///
-/// Returns the ephemeral predicate map for novelty-only predicates.
+/// Returns the ephemeral predicate map for novelty-only predicates and any
+/// overlay flakes that could not be encoded into V3 overlay ops (e.g.
+/// language-tagged literals whose BCP-47 tag is not yet in the persisted
+/// language dictionary, or vector/bigint/decimal values). These "untranslated"
+/// flakes carry their fully-decoded `(s, p, o, dt, m)` and are emitted directly
+/// by the per-format writers so committed-but-not-yet-indexed novelty is never
+/// silently dropped from the export.
 fn apply_time_travel(
     cursor: &mut BinaryCursor,
     config: &ExportConfig,
     store: &Arc<BinaryIndexStore>,
-) -> EphemeralPredicateMap {
+) -> (EphemeralPredicateMap, Vec<Flake>) {
     cursor.set_to_t(config.to_t);
     if let Some(overlay) = config.overlay {
-        let (mut ops, ephemeral_preds) = translate_overlay_flakes(
+        let (mut ops, untranslated, ephemeral_preds) = translate_overlay_flakes_with_untranslated(
             overlay,
             store,
             config.dict_novelty,
@@ -89,10 +96,29 @@ fn apply_time_travel(
             cursor.set_overlay_ops(ops);
             cursor.set_epoch(overlay.epoch());
         }
-        ephemeral_preds
+        (ephemeral_preds, surviving_untranslated(untranslated))
     } else {
-        HashMap::new()
+        (HashMap::new(), Vec::new())
     }
+}
+
+/// Resolve assert/retract set-semantics among the untranslated overlay flakes.
+///
+/// Untranslated flakes bypass the cursor's overlay merge, so we apply the same
+/// rule here: for each fact identity `(s, p, o, dt, m)` keep the highest-`t`
+/// flake and emit it only if it is an assertion. `Flake`'s `Eq`/`Hash` key on
+/// fact identity (ignoring `t`/`op`), so the map collapses each identity.
+fn surviving_untranslated(flakes: Vec<Flake>) -> Vec<Flake> {
+    let mut latest: HashMap<Flake, Flake> = HashMap::with_capacity(flakes.len());
+    for f in flakes {
+        match latest.get(&f) {
+            Some(existing) if existing.t >= f.t => {}
+            _ => {
+                latest.insert(f.clone(), f);
+            }
+        }
+    }
+    latest.into_values().filter(|f| f.op).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -345,10 +371,11 @@ pub fn export_graph_turtle<W: Write>(
     let branch = Arc::clone(branch_ref);
 
     let filter = BinaryFilter::default();
-    let projection = ColumnProjection {
-        output: ColumnSet::CORE,
-        internal: ColumnSet::EMPTY,
-    };
+    // Full identity projection (incl. OI): when a novelty overlay is attached,
+    // the cursor merges base rows against overlay ops on the full V3 identity
+    // (s_id, p_id, o_type, o_key, o_i). A narrower projection makes the missing
+    // columns read as defaults and corrupts the merge.
+    let projection = ColumnProjection::all();
 
     let mut cursor = BinaryCursor::scan_all(
         Arc::clone(store),
@@ -357,7 +384,7 @@ pub fn export_graph_turtle<W: Write>(
         filter,
         projection,
     );
-    let ephemeral_preds = apply_time_travel(&mut cursor, config, store);
+    let (ephemeral_preds, untranslated) = apply_time_travel(&mut cursor, config, store);
     let resolver = ExportResolver::new(store, config.dict_novelty, &ephemeral_preds);
 
     let mut stats = ExportStats::default();
@@ -378,6 +405,11 @@ pub fn export_graph_turtle<W: Write>(
     // Close last subject if any
     if prev_subject.is_some() {
         writeln!(writer, " .")?;
+    }
+
+    // Emit untranslated overlay flakes as standalone Turtle statements.
+    for flake in &untranslated {
+        write_raw_flake_turtle(&resolver, flake, prefixes, &mut stats, writer)?;
     }
 
     Ok(stats)
@@ -522,10 +554,11 @@ pub fn export_graph_jsonld<W: Write>(
     let branch = Arc::clone(branch_ref);
 
     let filter = BinaryFilter::default();
-    let projection = ColumnProjection {
-        output: ColumnSet::CORE,
-        internal: ColumnSet::EMPTY,
-    };
+    // Full identity projection (incl. OI): when a novelty overlay is attached,
+    // the cursor merges base rows against overlay ops on the full V3 identity
+    // (s_id, p_id, o_type, o_key, o_i). A narrower projection makes the missing
+    // columns read as defaults and corrupts the merge.
+    let projection = ColumnProjection::all();
 
     let mut cursor = BinaryCursor::scan_all(
         Arc::clone(store),
@@ -534,7 +567,7 @@ pub fn export_graph_jsonld<W: Write>(
         filter,
         projection,
     );
-    let ephemeral_preds = apply_time_travel(&mut cursor, config, store);
+    let (ephemeral_preds, untranslated) = apply_time_travel(&mut cursor, config, store);
     let resolver = ExportResolver::new(store, config.dict_novelty, &ephemeral_preds);
 
     let mut stats = ExportStats::default();
@@ -596,9 +629,114 @@ pub fn export_graph_jsonld<W: Write>(
     // Flush last subject
     if let Some(ref subj_iri) = current_subject {
         write_jsonld_node(writer, subj_iri, &current_props, prefixes, first_node)?;
+        first_node = false;
+    }
+
+    // Emit untranslated overlay flakes as additional JSON-LD nodes, grouped by
+    // subject (a repeated @id node object is valid JSON-LD; it merges on parse).
+    // (subject IRI, [(predicate, [values])]) — mirrors the cursor accumulator.
+    type JsonLdNode = (String, Vec<(String, Vec<serde_json::Value>)>);
+    let mut raw_nodes: Vec<JsonLdNode> = Vec::new();
+    for flake in &untranslated {
+        let (Some(s_iri), Some(p_iri)) = (store.sid_to_iri(&flake.s), store.sid_to_iri(&flake.p))
+        else {
+            stats.rows_skipped += 1;
+            continue;
+        };
+        let Some(jval) = flake_to_jsonld_raw(flake, store, prefixes) else {
+            stats.rows_skipped += 1;
+            continue;
+        };
+        let compact_p = compact_iri(&p_iri, prefixes);
+        let node = match raw_nodes.iter_mut().find(|(s, _)| *s == s_iri) {
+            Some(n) => n,
+            None => {
+                raw_nodes.push((s_iri, Vec::new()));
+                raw_nodes.last_mut().unwrap()
+            }
+        };
+        if let Some(entry) = node.1.iter_mut().find(|(k, _)| *k == compact_p) {
+            entry.1.push(jval);
+        } else {
+            node.1.push((compact_p, vec![jval]));
+        }
+        stats.triples_written += 1;
+    }
+    for (subj_iri, props) in &raw_nodes {
+        write_jsonld_node(writer, subj_iri, props, prefixes, first_node)?;
+        first_node = false;
     }
 
     Ok(stats)
+}
+
+/// JSON-LD value for an untranslated overlay flake, deriving the language tag
+/// from `flake.m` and the datatype from `flake.dt`. Returns `None` for value
+/// variants that should never reach the untranslated set.
+fn flake_to_jsonld_raw(
+    flake: &Flake,
+    store: &BinaryIndexStore,
+    prefixes: &PrefixMap,
+) -> Option<serde_json::Value> {
+    let lang = flake.m.as_ref().and_then(|m| m.lang.as_deref());
+    let dt_iri = || store.sid_to_iri(&flake.dt);
+    let typed = |s: String, dt: String| serde_json::json!({ "@value": s, "@type": compact_iri(&dt, prefixes) });
+    match &flake.o {
+        FlakeValue::Ref(sid) => {
+            let iri = store
+                .sid_to_iri(sid)
+                .unwrap_or_else(|| format!("_:unknown_{sid}"));
+            Some(serde_json::json!({ "@id": compact_iri(&iri, prefixes) }))
+        }
+        FlakeValue::String(s) => {
+            if let Some(lang) = lang {
+                return Some(serde_json::json!({ "@value": s, "@language": lang }));
+            }
+            match dt_iri().as_deref() {
+                None | Some(xsd::STRING) => Some(serde_json::Value::String(s.clone())),
+                Some(dt) => {
+                    Some(serde_json::json!({ "@value": s, "@type": compact_iri(dt, prefixes) }))
+                }
+            }
+        }
+        FlakeValue::Boolean(b) => Some(serde_json::Value::Bool(*b)),
+        FlakeValue::Long(n) => Some(serde_json::json!({
+            "@value": n,
+            "@type": compact_iri(&dt_iri().unwrap_or_else(|| xsd::LONG.to_string()), prefixes)
+        })),
+        FlakeValue::BigInt(n) => Some(typed(
+            n.to_string(),
+            dt_iri().unwrap_or_else(|| xsd::INTEGER.to_string()),
+        )),
+        FlakeValue::Decimal(d) => Some(typed(
+            d.to_string(),
+            dt_iri().unwrap_or_else(|| xsd::DECIMAL.to_string()),
+        )),
+        FlakeValue::Double(f) => {
+            let dt = compact_iri(
+                &dt_iri().unwrap_or_else(|| xsd::DOUBLE.to_string()),
+                prefixes,
+            );
+            if f.is_finite() {
+                Some(serde_json::json!({ "@value": f, "@type": dt }))
+            } else {
+                let lexical = if f.is_nan() {
+                    "NaN"
+                } else if f.is_sign_positive() {
+                    "INF"
+                } else {
+                    "-INF"
+                };
+                Some(serde_json::json!({ "@value": lexical, "@type": dt }))
+            }
+        }
+        FlakeValue::Vector(v) => Some(serde_json::json!({
+            "@value": v,
+            "@type": compact_iri(&dt_iri().unwrap_or_else(|| "https://ns.flur.ee/db#vector".to_string()), prefixes)
+        })),
+        // Temporal / other types always encode into V3 ops.
+        _ => None,
+    }
 }
 
 /// Write the JSON-LD document header: `{"@context": {...}, "@graph": [`
@@ -926,10 +1064,11 @@ pub fn export_graph_ntriples<W: Write>(
     let branch = Arc::clone(branch_ref);
 
     let filter = BinaryFilter::default();
-    let projection = ColumnProjection {
-        output: ColumnSet::CORE,
-        internal: ColumnSet::EMPTY,
-    };
+    // Full identity projection (incl. OI): when a novelty overlay is attached,
+    // the cursor merges base rows against overlay ops on the full V3 identity
+    // (s_id, p_id, o_type, o_key, o_i). A narrower projection makes the missing
+    // columns read as defaults and corrupts the merge.
+    let projection = ColumnProjection::all();
 
     let mut cursor = BinaryCursor::scan_all(
         Arc::clone(store),
@@ -938,7 +1077,7 @@ pub fn export_graph_ntriples<W: Write>(
         filter,
         projection,
     );
-    let ephemeral_preds = apply_time_travel(&mut cursor, config, store);
+    let (ephemeral_preds, untranslated) = apply_time_travel(&mut cursor, config, store);
     let resolver = ExportResolver::new(store, config.dict_novelty, &ephemeral_preds);
 
     let mut stats = ExportStats::default();
@@ -959,6 +1098,12 @@ pub fn export_graph_ntriples<W: Write>(
             &mut stats,
             writer,
         )?;
+    }
+
+    // Emit overlay flakes that could not be encoded into V3 ops (e.g.
+    // novelty-only language tags) directly from their decoded form.
+    for flake in &untranslated {
+        write_raw_flake_ntriples(&resolver, flake, graph_term.as_deref(), &mut stats, writer)?;
     }
 
     Ok(stats)
@@ -1229,6 +1374,191 @@ fn write_object<W: Write>(
 
         FlakeValue::Null => Ok(()), // should have been filtered above
     }
+}
+
+// ---------------------------------------------------------------------------
+// Raw (untranslated) overlay flake emission
+// ---------------------------------------------------------------------------
+//
+// Overlay flakes that could not be encoded into V3 ops (novelty-only language
+// tags, vector/bigint/decimal values, novelty-only custom datatypes) carry
+// their fully-decoded `(s, p, o, dt, m)`. These writers emit them directly,
+// deriving the language tag from `flake.m` and the datatype IRI from
+// `flake.dt`, instead of from an `o_type` the cursor never produced.
+
+/// Resolve a raw flake's object term lexical form + datatype/lang, writing it
+/// in N-Triples literal syntax. `prefixes` enables Turtle prefixed-name
+/// compression for IRI refs (N-Triples passes `None`). Returns `false` if the
+/// value variant is not representable (the caller counts it as skipped).
+fn write_raw_object<W: Write>(
+    w: &mut W,
+    store: &BinaryIndexStore,
+    flake: &Flake,
+    prefixes: Option<&PrefixMap>,
+) -> io::Result<bool> {
+    let lang = flake.m.as_ref().and_then(|m| m.lang.as_deref());
+    let dt_iri = || store.sid_to_iri(&flake.dt);
+    match &flake.o {
+        FlakeValue::Ref(sid) => {
+            let iri = store
+                .sid_to_iri(sid)
+                .unwrap_or_else(|| format!("_:unknown_{sid}"));
+            match prefixes {
+                Some(p) => write_turtle_iri_or_bnode(w, &iri, p)?,
+                None => write_iri_or_bnode(w, &iri)?,
+            }
+            Ok(true)
+        }
+        FlakeValue::String(s) => {
+            if let Some(lang) = lang {
+                w.write_all(b"\"")?;
+                write_escaped_ntriples_string(w, s)?;
+                w.write_all(b"\"@")?;
+                w.write_all(lang.as_bytes())?;
+            } else {
+                w.write_all(b"\"")?;
+                write_escaped_ntriples_string(w, s)?;
+                w.write_all(b"\"")?;
+                if let Some(dt) = dt_iri() {
+                    if dt != xsd::STRING {
+                        w.write_all(b"^^<")?;
+                        write_escaped_iri(w, &dt)?;
+                        w.write_all(b">")?;
+                    }
+                }
+            }
+            Ok(true)
+        }
+        FlakeValue::Json(s) => {
+            let dt = dt_iri()
+                .unwrap_or_else(|| "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON".to_string());
+            write_typed_literal(w, s, &dt)?;
+            Ok(true)
+        }
+        FlakeValue::Boolean(b) => {
+            write_typed_literal(w, if *b { "true" } else { "false" }, xsd::BOOLEAN)?;
+            Ok(true)
+        }
+        FlakeValue::Long(n) => {
+            write_typed_literal(
+                w,
+                &n.to_string(),
+                &dt_iri().unwrap_or_else(|| xsd::LONG.to_string()),
+            )?;
+            Ok(true)
+        }
+        FlakeValue::BigInt(n) => {
+            write_typed_literal(
+                w,
+                &n.to_string(),
+                &dt_iri().unwrap_or_else(|| xsd::INTEGER.to_string()),
+            )?;
+            Ok(true)
+        }
+        FlakeValue::Decimal(d) => {
+            write_typed_literal(
+                w,
+                &d.to_string(),
+                &dt_iri().unwrap_or_else(|| "http://www.w3.org/2001/XMLSchema#decimal".to_string()),
+            )?;
+            Ok(true)
+        }
+        FlakeValue::Double(f) => {
+            let lexical = if f.is_infinite() {
+                if f.is_sign_positive() {
+                    "INF".to_string()
+                } else {
+                    "-INF".to_string()
+                }
+            } else if f.is_nan() {
+                "NaN".to_string()
+            } else {
+                format!("{f:E}")
+            };
+            write_typed_literal(w, &lexical, xsd::DOUBLE)?;
+            Ok(true)
+        }
+        FlakeValue::Vector(v) => {
+            let dt = dt_iri().unwrap_or_else(|| "https://ns.flur.ee/db#vector".to_string());
+            let json = serde_json::to_string(v).unwrap_or_else(|_| "[]".to_string());
+            write_typed_literal(w, &json, &dt)?;
+            Ok(true)
+        }
+        // Temporal and other types always encode into V3 ops, so they should
+        // never reach the untranslated set. Decline rather than emit a
+        // potentially non-canonical lexical form.
+        _ => Ok(false),
+    }
+}
+
+/// Emit a single untranslated overlay flake as an N-Triples / N-Quads statement.
+fn write_raw_flake_ntriples<W: Write>(
+    resolver: &ExportResolver,
+    flake: &Flake,
+    graph_term: Option<&str>,
+    stats: &mut ExportStats,
+    writer: &mut W,
+) -> io::Result<()> {
+    let (Some(s_iri), Some(p_iri)) = (
+        resolver.store.sid_to_iri(&flake.s),
+        resolver.store.sid_to_iri(&flake.p),
+    ) else {
+        stats.rows_skipped += 1;
+        return Ok(());
+    };
+
+    let mut body: Vec<u8> = Vec::new();
+    write_iri_or_bnode(&mut body, &s_iri)?;
+    body.write_all(b" <")?;
+    write_escaped_iri(&mut body, &p_iri)?;
+    body.write_all(b"> ")?;
+    if !write_raw_object(&mut body, resolver.store, flake, None)? {
+        stats.rows_skipped += 1;
+        return Ok(());
+    }
+    writer.write_all(&body)?;
+    if let Some(g) = graph_term {
+        writer.write_all(b" ")?;
+        writer.write_all(g.as_bytes())?;
+    }
+    writer.write_all(b" .\n")?;
+    stats.triples_written += 1;
+    Ok(())
+}
+
+/// Emit a single untranslated overlay flake as a standalone Turtle statement.
+fn write_raw_flake_turtle<W: Write>(
+    resolver: &ExportResolver,
+    flake: &Flake,
+    prefixes: &PrefixMap,
+    stats: &mut ExportStats,
+    writer: &mut W,
+) -> io::Result<()> {
+    let (Some(s_iri), Some(p_iri)) = (
+        resolver.store.sid_to_iri(&flake.s),
+        resolver.store.sid_to_iri(&flake.p),
+    ) else {
+        stats.rows_skipped += 1;
+        return Ok(());
+    };
+
+    let mut body: Vec<u8> = Vec::new();
+    write_turtle_iri_or_bnode(&mut body, &s_iri, prefixes)?;
+    body.write_all(b" ")?;
+    if p_iri == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" {
+        body.write_all(b"a")?;
+    } else {
+        write_turtle_iri(&mut body, &p_iri, prefixes)?;
+    }
+    body.write_all(b" ")?;
+    if !write_raw_object(&mut body, resolver.store, flake, Some(prefixes))? {
+        stats.rows_skipped += 1;
+        return Ok(());
+    }
+    writer.write_all(&body)?;
+    writer.write_all(b" .\n")?;
+    stats.triples_written += 1;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/fluree-db-api/tests/it_query_datatype.rs
+++ b/fluree-db-api/tests/it_query_datatype.rs
@@ -419,6 +419,203 @@ async fn language_binding_value_object_language_variable() {
     );
 }
 
+/// Issue #1273: a subject with several language-tagged values where two
+/// variants share the same `@value` but differ in `@language` ("animal"@en vs
+/// "animal"@fr) must keep all variants. Exercises the genesis / overlay-only
+/// read path (`range::remove_stale_flakes`), whose fact key must include the
+/// language tag.
+#[tokio::test]
+async fn langstring_same_value_different_tags_novelty() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "langbug:main");
+    let ctx = ctx_datatype();
+
+    let insert = json!({
+        "@context": ctx,
+        "@id": "ex:animal", "@type": "ex:Concept",
+        "ex:prefLabel": [
+            {"@language":"en","@value":"animal"},
+            {"@language":"es","@value":"animales"},
+            {"@language":"fr","@value":"animal"}
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": ctx,
+        "select": ["?val","?lang"],
+        "where": [
+            {"@id":"ex:animal","ex:prefLabel":"?val"},
+            ["bind","?lang",["expr",["lang","?val"]]]
+        ]
+    });
+
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let langs: std::collections::BTreeSet<String> = rows
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_array().unwrap()[1].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        langs,
+        std::collections::BTreeSet::from([
+            "en".to_string(),
+            "es".to_string(),
+            "fr".to_string()
+        ]),
+        "expected en/es/fr to all survive, got {langs:?}"
+    );
+}
+
+/// Issue #1273, indexed variant: the same scenario but with the langStrings
+/// landing in novelty *over a persisted binary index* whose language dict does
+/// not yet contain the new tags. Exercises the binary-overlay encode path
+/// (`value_to_otype_okey`), which must not collapse novelty-only tags to a
+/// single fallback lang_id.
+#[tokio::test]
+async fn langstring_same_value_different_tags_indexed_overlay() {
+    use fluree_db_api::ReindexOptions;
+    use fluree_db_transact::{CommitOpts, TxnOpts};
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "langbug:indexed";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let ctx = ctx_datatype();
+
+    // Base insert with an indexed langString (populates persisted lang dict with "de").
+    let base = json!({
+        "@context": ctx,
+        "@id": "ex:base", "ex:prefLabel": {"@language":"de","@value":"Tier"}
+    });
+    let _l1 = fluree.insert(ledger0, &base).await.unwrap().ledger;
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let indexed = fluree.ledger(ledger_id).await.expect("load indexed");
+    assert!(indexed.snapshot.range_provider.is_some());
+
+    // Novelty insert mixing a PERSISTED tag ("de", already indexed → encoded
+    // overlay path) with BRAND-NEW tags (en/fr/es not yet in persisted dict →
+    // raw-flake path) on the same subject/predicate, stressing the merge of
+    // encoded ops and raw flakes. en and fr share the value "animal".
+    let novelty = json!({
+        "@context": ctx,
+        "@id": "ex:animal",
+        "ex:prefLabel": [
+            {"@language":"de","@value":"Tier"},
+            {"@language":"en","@value":"animal"},
+            {"@language":"es","@value":"animales"},
+            {"@language":"fr","@value":"animal"}
+        ]
+    });
+    let ledger2 = fluree
+        .insert_with_opts(
+            indexed,
+            &novelty,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &fluree_db_api::IndexConfig {
+                reindex_min_bytes: 1_000_000_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
+        )
+        .await
+        .unwrap()
+        .ledger;
+
+    let q = json!({
+        "@context": ctx,
+        "select": ["?val","?lang"],
+        "where": [
+            {"@id":"ex:animal","ex:prefLabel":"?val"},
+            ["bind","?lang",["expr",["lang","?val"]]]
+        ]
+    });
+    let rows = support::query_jsonld(&fluree, &ledger2, &q)
+        .await
+        .unwrap()
+        .to_jsonld_async(ledger2.as_graph_db_ref(0))
+        .await
+        .unwrap();
+    let langs: std::collections::BTreeSet<String> = rows
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_array().unwrap()[1].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        langs,
+        std::collections::BTreeSet::from([
+            "de".to_string(),
+            "en".to_string(),
+            "es".to_string(),
+            "fr".to_string()
+        ]),
+        "indexed-overlay: expected de/en/es/fr to all survive, got {langs:?}"
+    );
+}
+
+/// Issue #1273 follow-up: deleting one language variant must retract exactly
+/// that variant and leave the others — confirming the retraction flake carries
+/// the language tag in `m` and that `remove_stale_flakes`' `m`-aware fact key
+/// scopes cancellation per language tag.
+#[tokio::test]
+async fn langstring_delete_one_variant_keeps_others() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "langbug:delete");
+    let ctx = ctx_datatype();
+
+    let insert = json!({
+        "@context": ctx,
+        "@id": "ex:animal",
+        "ex:prefLabel": [
+            {"@language":"en","@value":"animal"},
+            {"@language":"fr","@value":"animal"},
+            {"@language":"es","@value":"animales"}
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.unwrap().ledger;
+
+    // Delete only the en variant (same value "animal" as fr).
+    let delete = json!({
+        "@context": ctx,
+        "delete": {"@id":"ex:animal","ex:prefLabel":{"@language":"en","@value":"animal"}},
+        "where": {"@id":"ex:animal","ex:prefLabel":{"@language":"en","@value":"animal"}}
+    });
+    let ledger = fluree.update(ledger, &delete).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": ctx,
+        "select": ["?val","?lang"],
+        "where": [
+            {"@id":"ex:animal","ex:prefLabel":"?val"},
+            ["bind","?lang",["expr",["lang","?val"]]]
+        ]
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let langs: std::collections::BTreeSet<String> = rows
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_array().unwrap()[1].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        langs,
+        std::collections::BTreeSet::from(["es".to_string(), "fr".to_string()]),
+        "deleting @en must leave @fr (same value) and @es, got {langs:?}"
+    );
+}
+
 #[tokio::test]
 async fn language_binding_rejects_type_and_language_conflict() {
     // Per JSON-LD §9.5 / RDF 1.1, a value object cannot have both @type (non-langString)

--- a/fluree-db-api/tests/it_query_datatype.rs
+++ b/fluree-db-api/tests/it_query_datatype.rs
@@ -463,11 +463,7 @@ async fn langstring_same_value_different_tags_novelty() {
         .collect();
     assert_eq!(
         langs,
-        std::collections::BTreeSet::from([
-            "en".to_string(),
-            "es".to_string(),
-            "fr".to_string()
-        ]),
+        std::collections::BTreeSet::from(["en".to_string(), "es".to_string(), "fr".to_string()]),
         "expected en/es/fr to all survive, got {langs:?}"
     );
 }
@@ -558,6 +554,100 @@ async fn langstring_same_value_different_tags_indexed_overlay() {
             "fr".to_string()
         ]),
         "indexed-overlay: expected de/en/es/fr to all survive, got {langs:?}"
+    );
+}
+
+/// Issue #1273, export variant: a langString that lives in novelty over an
+/// indexed ledger (its BCP-47 tag not yet persisted) is encoded via the
+/// raw-flake path; the RDF export must still emit it (and its language tag),
+/// not silently drop it.
+#[tokio::test]
+async fn langstring_novelty_only_tag_exported() {
+    use fluree_db_api::export::ExportFormat;
+    use fluree_db_api::ReindexOptions;
+    use fluree_db_transact::{CommitOpts, TxnOpts};
+
+    // File-backed (production-like: leaflet cache loads full column projection,
+    // matching how export runs in deployment).
+    let tmp = tempfile::TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build file fluree");
+    let ledger_id = "langbug/export:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.unwrap();
+    let ctx = ctx_datatype();
+
+    // Index a plain-string base so the ledger is indexed (export requires it).
+    let base = json!({
+        "@context": ctx,
+        "@id": "ex:base", "ex:name": "Base"
+    });
+    let _l1 = fluree.insert(ledger0, &base).await.unwrap().ledger;
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let indexed = fluree.ledger(ledger_id).await.expect("load indexed");
+
+    // Novelty langStrings with brand-new tags fr/es (share value "animal").
+    // Neither tag is in the persisted lang dict, so both route through the
+    // raw-flake overlay path.
+    let novelty = json!({
+        "@context": ctx,
+        "@id": "ex:animal",
+        "ex:prefLabel": [
+            {"@language":"fr","@value":"animal"},
+            {"@language":"es","@value":"animal"}
+        ]
+    });
+    fluree
+        .insert_with_opts(
+            indexed,
+            &novelty,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &fluree_db_api::IndexConfig {
+                reindex_min_bytes: 1_000_000_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
+        )
+        .await
+        .unwrap();
+
+    // N-Triples / Turtle: language tag in `"value"@lang` syntax.
+    for fmt in [ExportFormat::NTriples, ExportFormat::Turtle] {
+        let mut buf: Vec<u8> = Vec::new();
+        fluree
+            .export(ledger_id)
+            .format(fmt)
+            .write_to(&mut buf)
+            .await
+            .unwrap_or_else(|e| panic!("export {fmt:?} failed: {e}"));
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("\"animal\"@fr"),
+            "{fmt:?} export must contain @fr langString; got:\n{out}"
+        );
+        assert!(
+            out.contains("\"animal\"@es"),
+            "{fmt:?} export must contain @es langString; got:\n{out}"
+        );
+    }
+
+    // JSON-LD: language tag in a value object.
+    let mut buf: Vec<u8> = Vec::new();
+    fluree
+        .export(ledger_id)
+        .format(ExportFormat::JsonLd)
+        .write_to(&mut buf)
+        .await
+        .expect("export jsonld");
+    let out = String::from_utf8(buf).unwrap();
+    let parsed: JsonValue = serde_json::from_str(&out).expect("valid JSON-LD");
+    let blob = parsed.to_string();
+    assert!(
+        blob.contains("\"@language\":\"fr\"") && blob.contains("\"@language\":\"es\""),
+        "JSON-LD export must contain @fr and @es language tags; got:\n{out}"
     );
 }
 

--- a/fluree-db-api/tests/it_query_datatype.rs
+++ b/fluree-db-api/tests/it_query_datatype.rs
@@ -651,6 +651,78 @@ async fn langstring_novelty_only_tag_exported() {
     );
 }
 
+/// Guards the export path against the namespace edge raised in review: when
+/// novelty introduces a BRAND-NEW namespace (never persisted at index time),
+/// export must still resolve its subject/predicate IRIs. This works because
+/// `fluree.ledger()` loads a store synced with the snapshot's commit-chain
+/// namespaces (`sync_store_and_snapshot_ns`) before export — covering both the
+/// encoded cursor path (integer) and the raw-flake path (novelty-only langString).
+#[tokio::test]
+async fn langstring_brand_new_namespace_exported() {
+    use fluree_db_api::export::ExportFormat;
+    use fluree_db_api::ReindexOptions;
+    use fluree_db_transact::{CommitOpts, TxnOpts};
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build file fluree");
+    let ledger_id = "langbug/newns:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.unwrap();
+
+    // Index a base under the `ex:` namespace only.
+    let base = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id": "ex:base", "ex:name": "Base"
+    });
+    let _l1 = fluree.insert(ledger0, &base).await.unwrap().ledger;
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let indexed = fluree.ledger(ledger_id).await.expect("load indexed");
+
+    // Novelty under a BRAND-NEW namespace `zz:` covering both export paths:
+    // a novelty-only langString (raw path) and a plain integer (encoded path).
+    let novelty = json!({
+        "@context": {"zz": "http://zz.example/ns/"},
+        "@id": "zz:thing",
+        "zz:label": {"@language":"qq","@value":"hello"},
+        "zz:count": 5
+    });
+    fluree
+        .insert_with_opts(
+            indexed,
+            &novelty,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &fluree_db_api::IndexConfig {
+                reindex_min_bytes: 1_000_000_000,
+                reindex_max_bytes: 1_000_000_000,
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+    fluree
+        .export(ledger_id)
+        .format(ExportFormat::NTriples)
+        .write_to(&mut buf)
+        .await
+        .expect("export ntriples");
+    let out = String::from_utf8(buf).unwrap();
+    // Raw path (langString) and encoded path (integer) under the new namespace.
+    assert!(
+        out.contains("\"hello\"@qq"),
+        "export must contain the brand-new-namespace langString (raw path); got:\n{out}"
+    );
+    assert!(
+        out.contains("zz.example/ns/count"),
+        "export must contain the brand-new-namespace integer (encoded path); got:\n{out}"
+    );
+}
+
 /// Issue #1273 follow-up: deleting one language variant must retract exactly
 /// that variant and leave the others — confirming the retraction flake carries
 /// the language tag in `m` and that `remove_stale_flakes`' `m`-aware fact key

--- a/fluree-db-api/tests/it_transact_list_container.rs
+++ b/fluree-db-api/tests/it_transact_list_container.rs
@@ -141,6 +141,98 @@ async fn list_container_multiple_values_test() {
     );
 }
 
+/// A `@list` may legitimately repeat the same value at different positions
+/// (`["a", "b", "a"]`). Those members share `(s, p, o, dt)` but differ in their
+/// list index `i`, so they are **distinct** facts and must all survive. This is
+/// the list-index counterpart to the language-tag case in issue #1273: the
+/// overlay-only read path's fact key must include the full flake metadata `m`
+/// (`{lang, i}`), matching the canonical `Flake` identity. Run against an
+/// in-memory genesis ledger so it exercises `range::remove_stale_flakes`.
+#[tokio::test]
+async fn list_container_duplicate_values_at_distinct_positions_preserved() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = support::genesis_ledger(&fluree, "test/lists:dups");
+
+    let txn = json!({
+        "@context": [
+            support::default_context(),
+            {
+                "ex": "http://example.org/ns/",
+                "ex:orderedItems": {"@container": "@list"}
+            }
+        ],
+        "insert": {
+            "@id": "ex:thing1",
+            "ex:orderedItems": ["a", "b", "a"]
+        }
+    });
+    let ledger = fluree.update(ledger0, &txn).await.unwrap().ledger;
+
+    let query = json!({
+        "@context": [
+            support::default_context(),
+            {"ex": "http://example.org/ns/"}
+        ],
+        "select": {"ex:thing1": ["*"]}
+    });
+    let jsonld = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .unwrap()
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .unwrap();
+    let thing = &jsonld.as_array().unwrap()[0];
+    assert_eq!(
+        thing["ex:orderedItems"],
+        json!(["a", "b", "a"]),
+        "duplicate list members at distinct positions must all survive in order"
+    );
+}
+
+/// Counterpart to the list-duplicate test: a plain JSON-LD array is a SET, so
+/// repeated scalar values (no list index) ARE the same fact and collapse to one.
+/// Confirms the `m`-aware fact key does not over-distinguish set values.
+#[tokio::test]
+async fn set_container_duplicate_scalar_values_collapse() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = support::genesis_ledger(&fluree, "test/lists:set-dups");
+
+    let txn = json!({
+        "@context": [
+            support::default_context(),
+            {"ex": "http://example.org/ns/"}
+        ],
+        // Plain array (no @container:@list) → set semantics.
+        "insert": {"@id": "ex:thing1", "ex:tags": ["x", "x", "y"]}
+    });
+    let ledger = fluree.update(ledger0, &txn).await.unwrap().ledger;
+
+    let query = json!({
+        "@context": [
+            support::default_context(),
+            {"ex": "http://example.org/ns/"}
+        ],
+        "select": {"ex:thing1": ["*"]}
+    });
+    let jsonld = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .unwrap()
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .unwrap();
+    let thing = &jsonld.as_array().unwrap()[0];
+    let mut tags: Vec<String> = thing["ex:tags"]
+        .as_array()
+        .map(|a| a.iter().map(|v| v.as_str().unwrap().to_string()).collect())
+        .unwrap_or_else(|| vec![thing["ex:tags"].as_str().unwrap().to_string()]);
+    tags.sort();
+    assert_eq!(
+        tags,
+        vec!["x".to_string(), "y".to_string()],
+        "set duplicates must collapse to distinct values"
+    );
+}
+
 #[tokio::test]
 async fn list_container_with_objects_test() {
     // Create a temporary directory for file-backed storage

--- a/fluree-db-core/src/range.rs
+++ b/fluree-db-core/src/range.rs
@@ -24,7 +24,7 @@ use crate::comparator::IndexType;
 use crate::db::LedgerSnapshot;
 use crate::dt_compatible;
 use crate::error::Result;
-use crate::flake::Flake;
+use crate::flake::{Flake, FlakeMeta};
 use crate::ids::GraphId;
 use crate::overlay::{NoOverlay, OverlayProvider};
 use crate::sid::Sid;
@@ -327,6 +327,13 @@ fn collect_overlay_only<O: OverlayProvider + ?Sized>(
 ///
 /// Iterates in reverse (newest first for identical facts), keeps only the
 /// first occurrence of each fact key, and drops retractions.
+///
+/// The fact key includes the flake metadata `m` (language tag and list
+/// index), not just `(s, p, o, dt)`. Two flakes that share a subject,
+/// predicate, object value, and datatype but differ in their language tag
+/// (e.g. `"animal"@en` vs `"animal"@fr`) or list position are **distinct
+/// RDF facts** and must both survive — omitting `m` here silently collapses
+/// language variants on insert (issue #1273).
 fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
     use std::collections::HashSet;
 
@@ -336,6 +343,7 @@ fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
         p: &'a Sid,
         o: &'a FlakeValue,
         dt: &'a Sid,
+        m: &'a Option<FlakeMeta>,
     }
 
     let mut seen: HashSet<FactKeyRef<'_>> = HashSet::new();
@@ -347,6 +355,7 @@ fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
             p: &f.p,
             o: &f.o,
             dt: &f.dt,
+            m: &f.m,
         };
         if !seen.insert(key) {
             continue;

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2203,7 +2203,7 @@ pub fn translate_overlay_flakes(
 /// The `ephemeral_preds` map contains predicate IRI → ephemeral p_id for predicates that
 /// don't exist in the persisted index dictionary. Callers must use this to extend their
 /// p_id → Sid lookup tables so that novelty-only predicates can be resolved during decode.
-fn translate_overlay_flakes_with_untranslated(
+pub fn translate_overlay_flakes_with_untranslated(
     overlay: &dyn OverlayProvider,
     store: &Arc<BinaryIndexStore>,
     dict_novelty: Option<&Arc<fluree_db_core::dict_novelty::DictNovelty>>,

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2443,13 +2443,22 @@ fn value_to_otype_okey(
             store,
             dict_novelty,
         )?;
-        let lang_id = store.resolve_lang_id(lang_tag).unwrap_or_else(|| {
-            tracing::warn!(
-                tag = lang_tag,
-                "language tag not found in persisted dict, using 1"
-            );
-            1
-        });
+        // Resolve the BCP-47 tag to a persisted lang_id. A novelty-introduced
+        // tag that has never been indexed has no persisted lang_id; encoding it
+        // as a fixed fallback (e.g. lang_id=1) would collapse every such tag to
+        // one OType, silently dropping distinct language variants that share a
+        // string value ("animal"@en vs "animal"@fr) and mis-decoding their tags
+        // (issue #1273). Instead, decline the encoded fast path with Unsupported
+        // so the caller merges this flake via the raw-flake path, which carries
+        // the real `FlakeMeta` lang tag and dedups on full identity. This mirrors
+        // how a novelty-only custom datatype is handled below (unresolvable
+        // `dt_otype` → Unsupported → raw fallback).
+        let lang_id = store.resolve_lang_id(lang_tag).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "language tag not in persisted dict (novelty-only); use raw flake path",
+            )
+        })?;
         return Ok((OType::lang_string(lang_id), str_id as u64));
     }
 


### PR DESCRIPTION
Inserting a subject with several language-tagged values whose strings are
identical but whose `@language` tags differ — e.g. `"animal"@en` and
`"animal"@fr` — silently dropped all but one variant. Ingesting a multilingual
SKOS thesaurus lost hundreds of labels, hitting English hardest because EN and
FR share many literal forms.

The root cause is fact identity. A language-tagged literal's identity includes
its language tag, and a list member's includes its position, so both live in the
flake metadata `m` alongside `(s, p, o, dt)`. The overlay-only read path
(`range::remove_stale_flakes`, used for committed-but-not-yet-indexed data and
genesis ledgers) keyed its set-semantics dedup on `(s, p, o, dt)` only and
dropped `m`. Two variants that shared a value therefore looked like one fact and
collapsed. The binary-scan path already keyed on the full identity; this just
brings the two into agreement with `Flake`'s own equality.

Adding `m` to that key fixes three failure modes from the same omission:

- distinct language variants sharing a value are preserved on insert;
- deleting one language variant no longer over-cancels the others (a retraction
  matches only the variant it names);
- `@list` members that repeat a value at different positions
  (`["a", "b", "a"]`) are no longer collapsed.

A second, related path is the binary overlay encoder. When a language tag has
not yet been added to the persisted language dictionary (a fresh tag in novelty
over an indexed ledger), it was encoded with a fixed fallback id, collapsing
every such tag to one value and mis-labelling the survivor. It now declines that
encoding and routes the flake through the raw-flake overlay path — which carries
the real metadata and dedups on full identity — mirroring how novelty-only
custom datatypes are already handled.

Finally, RDF export attaches the same novelty overlay so it can dump
committed-but-unindexed data. It previously discarded any flake it could not
encode into the columnar overlay (the new-tag language literals above, plus
vector/bigint/decimal and novelty-only custom datatypes), and it scanned with a
projection too narrow for the overlay merge. Export now emits those values
directly in every format (Turtle, N-Triples, N-Quads, JSON-LD), deriving the
language tag and datatype from the flake, and scans with the full identity
projection.

Closes #1273.