### PR TITLE
perf: query read scaling, object→subject hash join, planner fixes, and EXPLAIN physical-plan tooling

### DIFF
--- a/docs/query/explain.md
+++ b/docs/query/explain.md
@@ -157,45 +157,74 @@ last among sources, minimizing data sent to the remote endpoint.
 
 ## Reading Explain Output
 
-The explain plan shows two sections: the original pattern order and the
-optimized order. Each pattern is annotated with its category and estimate.
+Explain returns a JSON object `{ "query": <echo>, "plan": { ... } }`. The
+`plan` object contains:
 
-Example output for a multi-pattern query:
+| Field                  | Meaning |
+| ---------------------- | ------- |
+| `optimization`         | `"reordered"`, `"unchanged"`, or `"none"` (no statistics) |
+| `statistics-available` | whether HLL statistics were available for cost estimation |
+| `statistics`           | summary stats (e.g. `total-flakes`) |
+| `logical`              | the **compound-aware** join order the planner produces (see below) |
+| `original`             | the query's triple patterns in original order, with selectivity inputs |
+| `optimized`            | the same triples in the planner's chosen order |
+| `execution-hints`      | specialized execution strategies the executor will use (see [Execution Hints](#execution-hints)) |
 
-```
-=== Query Optimization Explain (Generalized) ===
+The `original` and `optimized` arrays are a flattened, triple-level view. The
+`optimized` order is produced by the **same** `reorder_patterns` routine the
+executor uses, so the order shown is the order that runs — there is no separate
+explain-only ordering algorithm.
 
-Statistics available: yes
-Optimization: patterns reordered
+### The `logical` plan
 
---- Original Pattern Order ---
-  [1] ?s :age ?age | category=Source row_count=5000
-  [2] ?s :name ?name | category=Source row_count=10000
-  [3] FILTER((> ?age 25)) | category=Deferred
-  [4] OPTIONAL { ?s :email ?email } | category=Expander multiplier=1.00
+`logical` is the recommended view. Unlike `original`/`optimized` (which flatten
+all triples into one list), it preserves compound structure — `OPTIONAL`,
+`UNION`, `MINUS`, `EXISTS`, subqueries — and shows each node in the planner's
+chosen execution order. It is present even when statistics are unavailable
+(the planner falls back to heuristic estimates). Each node carries:
 
---- Optimized Pattern Order ---
-  [1] ?s :age ?age | category=Source row_count=5000
-  [2] FILTER((> ?age 25)) | category=Deferred
-  [3] ?s :name ?name | category=Source row_count=10000
-  [4] OPTIONAL { ?s :email ?email } | category=Expander multiplier=1.00
+- `kind`: `triple`, `optional`, `union`, `minus`, `exists`, `not-exists`,
+  `subquery`, `filter`, `bind`, `values`, `property-path`, `graph`, `service`,
+  or a search kind.
+- `category`: `source` (produces rows), `reducer` (shrinks), `expander`
+  (grows — e.g. `OPTIONAL`), or `deferred` (`FILTER`/`BIND`).
+- `estimate`: `{ "row-count": N }` for sources, `{ "multiplier": M }` for
+  reducers/expanders.
+- For triples, a `pattern` object (`subject`/`property`/`object`); for compound
+  nodes, a `patterns` array (or `branches` for `UNION`) of child nodes.
+
+Example (`?person :name ?name . OPTIONAL { ?person :email ?email }`):
+
+```jsonc
+"logical": [
+  { "kind": "triple",   "category": "source",
+    "estimate": { "row-count": 50 },
+    "pattern": { "subject": "?person", "property": "ex:name", "object": "?name" } },
+  { "kind": "optional", "category": "expander",
+    "estimate": { "multiplier": 1.0 },
+    "patterns": [
+      { "kind": "triple", "category": "source",
+        "estimate": { "row-count": 50 },
+        "pattern": { "subject": "?person", "property": "ex:email", "object": "?email" } }
+    ] }
+]
 ```
 
 Key things to look for:
 
-- **Source row_count**: Lower values are placed first. If a pattern with a
-  high row count appears early, it may indicate missing statistics or an
-  inherently broad pattern.
-- **Reducer multiplier**: Values below 1.0 indicate the fraction of rows
-  that survive. A MINUS with multiplier 0.90 removes ~10% of rows.
+- **Source `row-count`**: Lower values are placed first. A high row count early
+  in the plan may indicate missing statistics or an inherently broad pattern.
+- **Reducer `multiplier`**: Values below 1.0 indicate the fraction of rows that
+  survive. A MINUS with multiplier 0.90 removes ~10% of rows.
 - **Deferred placement**: FILTERs and BINDs appear immediately after all of
   their input variables become bound. BIND outputs cascade — a BIND placed
   early can enable subsequent FILTERs or BINDs that depend on its target
   variable. If a FILTER appears late, check whether its variables could be
   bound sooner.
-- **Statistics available: no**: Without statistics, the planner uses
-  conservative heuristics. Run at least one indexing cycle to enable
-  statistics-based optimization.
+- **`optimization: "none"`**: No statistics were available, so cost-based
+  reordering is skipped for the `original`/`optimized` arrays. The `logical`
+  view still shows the planner's heuristic order. Run at least one indexing
+  cycle to enable statistics-based optimization.
 
 ### Execution Hints
 

--- a/docs/query/explain.md
+++ b/docs/query/explain.md
@@ -242,9 +242,19 @@ Each node has:
   `PropertyJoinOperator`, `NestedLoopJoinOperator`, `DatasetOperator`, a count
   or other fast-path operator).
 - `est-rows`: build-time cardinality estimate, when the operator exposes one.
-- `details`: operator-specific attributes (e.g. a nested-loop join's `right`
-  probe pattern).
+- `details`: operator-specific attributes (e.g. a scan's `pattern` and planned
+  `index-hint`; a `PropertyJoinOperator`'s fused `predicates`).
 - `children`: child edges, each `{ "rel": ..., "node": { ... } }`.
+
+For an object→subject join, the node carries the planner's hash-join decision,
+so you can see **whether** a hash join was chosen and **why**:
+
+- `hash-join-chosen`: `true` on a `HashJoinOperator`, `false` on a
+  `NestedLoopJoinOperator` that was a hash-join candidate but lost.
+- `hash-join-reason`: `forced-on` / `forced-off` (the `FLUREE_HASH_JOIN` env),
+  `cost-wins`, `probe-too-small`, `scan-ratio-too-high`, or `no-probe-stats`.
+- `probe-count`, `driving-est`, `scan-ratio`: the cost inputs the planner
+  weighed (present when statistics are available).
 
 The edge `rel` distinguishes a real input from an alternative:
 

--- a/docs/query/explain.md
+++ b/docs/query/explain.md
@@ -166,6 +166,7 @@ Explain returns a JSON object `{ "query": <echo>, "plan": { ... } }`. The
 | `statistics-available` | whether HLL statistics were available for cost estimation |
 | `statistics`           | summary stats (e.g. `total-flakes`) |
 | `logical`              | the **compound-aware** join order the planner produces (see below) |
+| `physical`             | the **planned physical operator tree** the executor will build (see below) |
 | `original`             | the query's triple patterns in original order, with selectivity inputs |
 | `optimized`            | the same triples in the planner's chosen order |
 | `execution-hints`      | specialized execution strategies the executor will use (see [Execution Hints](#execution-hints)) |
@@ -225,6 +226,51 @@ Key things to look for:
   reordering is skipped for the `original`/`optimized` arrays. The `logical`
   view still shows the planner's heuristic order. Run at least one indexing
   cycle to enable statistics-based optimization.
+
+### The `physical` plan
+
+`physical` is the operator tree the executor will actually build — the
+"join plan". It is produced by building the **real** operator tree (the same
+`build_operator_tree` execution uses) and walking it; the query is **not
+executed** (no scans, no joins run). Because the fast-path / count-planner /
+fold selection happens at build time, `physical` shows what `logical` cannot:
+the chosen physical operators.
+
+Each node has:
+
+- `op`: the operator (e.g. `ProjectOperator`, `HashJoinOperator`,
+  `PropertyJoinOperator`, `NestedLoopJoinOperator`, `DatasetOperator`, a count
+  or other fast-path operator).
+- `est-rows`: build-time cardinality estimate, when the operator exposes one.
+- `details`: operator-specific attributes (e.g. a nested-loop join's `right`
+  probe pattern).
+- `children`: child edges, each `{ "rel": ..., "node": { ... } }`.
+
+The edge `rel` distinguishes a real input from an alternative:
+
+| `rel`         | Meaning |
+| ------------- | ------- |
+| `child`       | a real input the operator consumes |
+| `fallback`    | a correctness fallback run *instead* of the fast path when it bails at open (overlay/history/policy/multi-graph). Only one of the two executes. |
+| `conditional` | a path chosen at runtime |
+
+Example — a same-subject star collapses to a single fused operator:
+
+```jsonc
+"physical": {
+  "op": "ProjectOperator",
+  "children": [
+    { "rel": "child", "node": { "op": "PropertyJoinOperator" } }
+  ]
+}
+```
+
+**Planned vs. actual.** `physical` is the *planned* tree. A few decisions are
+finalized only at execution `open()` and are **not** reflected here: the
+multi-graph hash-join → nested-loop downgrade, whether a fast path takes its
+fallback, and the exact index permutation (SPOT/POST/OPST/PSOT) a scan chooses.
+Surfacing those requires actually running the query (a future `EXPLAIN ANALYZE`
+mode), which `EXPLAIN` deliberately does not do.
 
 ### Execution Hints
 

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -200,8 +200,7 @@ impl Fluree {
 
             // ns_split_mode immutability: locked once user namespaces are allocated.
             if let Some(mode) = c.commit.ns_split_mode {
-                base_state
-                    .snapshot
+                std::sync::Arc::make_mut(&mut base_state.snapshot)
                     .set_ns_split_mode(mode, c.commit.t)
                     .map_err(|e| PushError::Invalid(e.to_string()).into_api_error())?;
             }
@@ -879,12 +878,12 @@ fn apply_pushed_commits_to_state(
             }
             // Apply ns_split_mode (immutable after user namespace allocation).
             if let Some(mode) = c.commit.ns_split_mode {
-                base.snapshot
+                std::sync::Arc::make_mut(&mut base.snapshot)
                     .set_ns_split_mode(mode, c.commit.t)
                     .map_err(|e| PushError::Internal(e.to_string()))?;
             }
         }
-        base.snapshot
+        std::sync::Arc::make_mut(&mut base.snapshot)
             .apply_envelope_deltas(&merged_ns_delta, &all_graph_iris)
             .map_err(|e| PushError::Internal(format!("apply_envelope_deltas failed: {e}")))?;
     }

--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -9,7 +9,7 @@ use crate::query::helpers::{parse_jsonld_query, parse_sparql_to_ir};
 use fluree_db_core::{is_rdf_type, StatsView};
 use fluree_db_query::{
     explain_execution_hints, parse_query, ExplainPlan, OptimizationStatus, Pattern, Query, Ref,
-    Term, TriplePattern, VarRegistry,
+    Term, TriplePattern, VarId, VarRegistry,
 };
 use serde_json::{json, Map, Value as JsonValue};
 use std::collections::HashSet;
@@ -120,11 +120,12 @@ fn logical_node(
     vars: &VarRegistry,
     compactor: &IriCompactor,
     stats: Option<&StatsView>,
+    bound_vars: &HashSet<VarId>,
 ) -> JsonValue {
     use fluree_db_query::planner::{estimate_pattern, PatternEstimate};
 
     let mut node = Map::new();
-    let category = match estimate_pattern(p, &HashSet::new(), stats) {
+    let category = match estimate_pattern(p, bound_vars, stats) {
         PatternEstimate::Source { row_count } => {
             node.insert(
                 "estimate".into(),
@@ -144,10 +145,18 @@ fn logical_node(
     };
     node.insert("category".into(), json!(category));
 
+    // Inner pattern lists bind progressively against the set entering this node, so
+    // a nested node's estimate reflects what earlier siblings bound (as execution
+    // sees it). A fresh local per list means UNION branches each start from `bound_vars`.
     let children = |ps: &[Pattern]| -> JsonValue {
+        let mut local = bound_vars.clone();
         JsonValue::Array(
             ps.iter()
-                .map(|c| logical_node(c, vars, compactor, stats))
+                .map(|c| {
+                    let n = logical_node(c, vars, compactor, stats, &local);
+                    local.extend(c.produced_vars());
+                    n
+                })
                 .collect(),
         )
     };
@@ -448,10 +457,17 @@ fn explain_from_parsed(
             stats_view.as_ref(),
             &HashSet::new(),
         );
+        // Thread the evolving bound-var set through the ordered plan so each node's
+        // estimate is context-aware (a bound-subject scan, not a full predicate scan).
+        let mut bound: HashSet<VarId> = HashSet::new();
         JsonValue::Array(
             ordered
                 .iter()
-                .map(|p| logical_node(p, vars, &compactor, stats_view.as_ref()))
+                .map(|p| {
+                    let n = logical_node(p, vars, &compactor, stats_view.as_ref(), &bound);
+                    bound.extend(p.produced_vars());
+                    n
+                })
                 .collect(),
         )
     };

--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -126,7 +126,10 @@ fn logical_node(
     let mut node = Map::new();
     let category = match estimate_pattern(p, &HashSet::new(), stats) {
         PatternEstimate::Source { row_count } => {
-            node.insert("estimate".into(), json!({ "row-count": row_count.round() as i64 }));
+            node.insert(
+                "estimate".into(),
+                json!({ "row-count": row_count.round() as i64 }),
+            );
             "source"
         }
         PatternEstimate::Reducer { multiplier } => {

--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -12,6 +12,7 @@ use fluree_db_query::{
     Term, TriplePattern, VarRegistry,
 };
 use serde_json::{json, Map, Value as JsonValue};
+use std::collections::HashSet;
 
 fn status_to_str(s: OptimizationStatus) -> &'static str {
     match s {
@@ -68,6 +69,182 @@ fn triple_pattern_to_user_object(
         "property": property,
         "object": term_to_user_string(&tp.o, vars, compactor),
     })
+}
+
+fn normalize_ref_snap(snapshot: &fluree_db_core::LedgerSnapshot, r: &Ref) -> Ref {
+    match r {
+        Ref::Iri(iri) => snapshot
+            .encode_iri(iri)
+            .map(Ref::Sid)
+            .unwrap_or_else(|| r.clone()),
+        _ => r.clone(),
+    }
+}
+
+fn normalize_term_snap(snapshot: &fluree_db_core::LedgerSnapshot, t: &Term) -> Term {
+    match t {
+        Term::Iri(iri) => snapshot
+            .encode_iri(iri)
+            .map(Term::Sid)
+            .unwrap_or_else(|| t.clone()),
+        _ => t.clone(),
+    }
+}
+
+/// Structure-preserving IRI→SID normalization. Mirrors the term normalization
+/// applied to the flattened triple list, but keeps compound structure intact so
+/// the `logical` plan view scores and renders patterns the way execution sees
+/// them (stats are SID-keyed).
+fn normalize_pattern(snapshot: &fluree_db_core::LedgerSnapshot, p: Pattern) -> Pattern {
+    match p {
+        Pattern::Triple(tp) => Pattern::Triple(TriplePattern {
+            s: normalize_ref_snap(snapshot, &tp.s),
+            p: normalize_ref_snap(snapshot, &tp.p),
+            o: normalize_term_snap(snapshot, &tp.o),
+            dtc: tp.dtc,
+        }),
+        other => other.map_subpatterns(&mut |inner| {
+            inner
+                .into_iter()
+                .map(|c| normalize_pattern(snapshot, c))
+                .collect()
+        }),
+    }
+}
+
+/// Render one pattern (in `planner::reorder_patterns` order) as a `logical`
+/// plan node: its cardinality category + estimate, and — for compound
+/// patterns — its inner patterns. Recurses for compound containers.
+fn logical_node(
+    p: &Pattern,
+    vars: &VarRegistry,
+    compactor: &IriCompactor,
+    stats: Option<&StatsView>,
+) -> JsonValue {
+    use fluree_db_query::planner::{estimate_pattern, PatternEstimate};
+
+    let mut node = Map::new();
+    let category = match estimate_pattern(p, &HashSet::new(), stats) {
+        PatternEstimate::Source { row_count } => {
+            node.insert("estimate".into(), json!({ "row-count": row_count.round() as i64 }));
+            "source"
+        }
+        PatternEstimate::Reducer { multiplier } => {
+            node.insert("estimate".into(), json!({ "multiplier": multiplier }));
+            "reducer"
+        }
+        PatternEstimate::Expander { multiplier } => {
+            node.insert("estimate".into(), json!({ "multiplier": multiplier }));
+            "expander"
+        }
+        PatternEstimate::Deferred => "deferred",
+    };
+    node.insert("category".into(), json!(category));
+
+    let children = |ps: &[Pattern]| -> JsonValue {
+        JsonValue::Array(
+            ps.iter()
+                .map(|c| logical_node(c, vars, compactor, stats))
+                .collect(),
+        )
+    };
+
+    match p {
+        Pattern::Triple(tp) => {
+            node.insert("kind".into(), json!("triple"));
+            node.insert(
+                "pattern".into(),
+                triple_pattern_to_user_object(tp, vars, compactor),
+            );
+        }
+        Pattern::Optional(inner) => {
+            node.insert("kind".into(), json!("optional"));
+            node.insert("patterns".into(), children(inner));
+        }
+        Pattern::Minus(inner) => {
+            node.insert("kind".into(), json!("minus"));
+            node.insert("patterns".into(), children(inner));
+        }
+        Pattern::Exists(inner) => {
+            node.insert("kind".into(), json!("exists"));
+            node.insert("patterns".into(), children(inner));
+        }
+        Pattern::NotExists(inner) => {
+            node.insert("kind".into(), json!("not-exists"));
+            node.insert("patterns".into(), children(inner));
+        }
+        Pattern::Union(branches) => {
+            node.insert("kind".into(), json!("union"));
+            node.insert(
+                "branches".into(),
+                JsonValue::Array(branches.iter().map(|b| children(b)).collect()),
+            );
+        }
+        Pattern::Subquery(sq) => {
+            node.insert("kind".into(), json!("subquery"));
+            node.insert(
+                "select".into(),
+                json!(sq
+                    .select
+                    .iter()
+                    .map(|v| vars.name(*v).to_string())
+                    .collect::<Vec<_>>()),
+            );
+            node.insert("patterns".into(), children(&sq.patterns));
+        }
+        Pattern::Filter(_) => {
+            node.insert("kind".into(), json!("filter"));
+        }
+        Pattern::Bind { var, .. } => {
+            node.insert("kind".into(), json!("bind"));
+            node.insert("var".into(), json!(vars.name(*var).to_string()));
+        }
+        Pattern::Values {
+            vars: value_vars,
+            rows,
+        } => {
+            node.insert("kind".into(), json!("values"));
+            node.insert(
+                "vars".into(),
+                json!(value_vars
+                    .iter()
+                    .map(|v| vars.name(*v).to_string())
+                    .collect::<Vec<_>>()),
+            );
+            node.insert("rows".into(), json!(rows.len()));
+        }
+        Pattern::PropertyPath(pp) => {
+            node.insert("kind".into(), json!("property-path"));
+            node.insert(
+                "subject".into(),
+                json!(ref_to_user_string(&pp.subject, vars, compactor)),
+            );
+        }
+        Pattern::Graph { patterns, .. } => {
+            node.insert("kind".into(), json!("graph"));
+            node.insert("patterns".into(), children(patterns));
+        }
+        Pattern::Service(sp) => {
+            node.insert("kind".into(), json!("service"));
+            node.insert("patterns".into(), children(&sp.patterns));
+        }
+        Pattern::IndexSearch(_) => {
+            node.insert("kind".into(), json!("index-search"));
+        }
+        Pattern::VectorSearch(_) => {
+            node.insert("kind".into(), json!("vector-search"));
+        }
+        Pattern::GeoSearch(_) => {
+            node.insert("kind".into(), json!("geo-search"));
+        }
+        Pattern::S2Search(_) => {
+            node.insert("kind".into(), json!("s2-search"));
+        }
+        Pattern::R2rml(_) => {
+            node.insert("kind".into(), json!("r2rml"));
+        }
+    }
+    JsonValue::Object(node)
 }
 
 fn plan_patterns_to_json(
@@ -190,24 +367,8 @@ fn explain_from_parsed(
     // Extract triple patterns in query order.
     // Normalize any IRI terms into SID when possible so that
     // stats lookups (which are SID-keyed) work for explain/optimization parity.
-    let normalize_ref = |r: &Ref| -> Ref {
-        match r {
-            Ref::Iri(iri) => snapshot
-                .encode_iri(iri)
-                .map(Ref::Sid)
-                .unwrap_or_else(|| r.clone()),
-            _ => r.clone(),
-        }
-    };
-    let normalize_term = |t: &Term| -> Term {
-        match t {
-            Term::Iri(iri) => snapshot
-                .encode_iri(iri)
-                .map(Term::Sid)
-                .unwrap_or_else(|| t.clone()),
-            _ => t.clone(),
-        }
-    };
+    let normalize_ref = |r: &Ref| -> Ref { normalize_ref_snap(snapshot, r) };
+    let normalize_term = |t: &Term| -> Term { normalize_term_snap(snapshot, t) };
 
     fn collect_triples_in_order(
         out: &mut Vec<TriplePattern>,
@@ -268,11 +429,36 @@ fn explain_from_parsed(
         .unwrap_or(false);
     let execution_hints = explain_execution_hints(&parsed.patterns, stats_view.as_ref());
 
+    // Compound-aware logical plan: the join order `planner::reorder_patterns`
+    // produces (the same routine execution uses), rendered with user-facing
+    // IRIs. Computed even without stats (the planner falls back to heuristic
+    // estimates), so the planned order is always visible.
+    let logical_value = {
+        let normalized: Vec<Pattern> = parsed
+            .patterns
+            .iter()
+            .cloned()
+            .map(|p| normalize_pattern(snapshot, p))
+            .collect();
+        let ordered = fluree_db_query::planner::reorder_patterns(
+            &normalized,
+            stats_view.as_ref(),
+            &HashSet::new(),
+        );
+        JsonValue::Array(
+            ordered
+                .iter()
+                .map(|p| logical_node(p, vars, &compactor, stats_view.as_ref()))
+                .collect(),
+        )
+    };
+
     if !stats_available {
         let mut plan = serde_json::Map::new();
         plan.insert("optimization".into(), json!("none"));
         plan.insert("reason".into(), json!("No statistics available"));
         plan.insert("execution-hints".into(), json!(execution_hints));
+        plan.insert("logical".into(), logical_value);
         if let Some(wc) = where_clause {
             plan.insert("where-clause".into(), wc);
         }
@@ -299,6 +485,7 @@ fn explain_from_parsed(
             "statistics-available": explain.statistics_available,
             "statistics": statistics,
             "execution-hints": execution_hints,
+            "logical": logical_value,
             "original": original,
             "optimized": optimized
         }

--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -453,12 +453,29 @@ fn explain_from_parsed(
         )
     };
 
+    // Planned physical plan: build the REAL operator tree (pure — no `open()`,
+    // no I/O) and walk it via `Operator::describe`. This reflects fast-path /
+    // count-planner / fold selection that the pattern-level views cannot show.
+    // It is built from `parsed`; the reasoning/geo rewrites the executor applies
+    // in `prepare` *before* building are not yet reflected here. Best-effort: a
+    // build error (e.g. an unbound select var the executor would reject) is
+    // surfaced in-band rather than failing the whole explain.
+    let physical_value = {
+        let planning = fluree_db_query::PlanningContext::current();
+        let stats_arc = stats_view.clone().map(std::sync::Arc::new);
+        match fluree_db_query::build_operator_tree(parsed, stats_arc, &planning) {
+            Ok(op) => serde_json::to_value(op.describe()).unwrap_or(JsonValue::Null),
+            Err(e) => json!({ "error": e.to_string() }),
+        }
+    };
+
     if !stats_available {
         let mut plan = serde_json::Map::new();
         plan.insert("optimization".into(), json!("none"));
         plan.insert("reason".into(), json!("No statistics available"));
         plan.insert("execution-hints".into(), json!(execution_hints));
         plan.insert("logical".into(), logical_value);
+        plan.insert("physical".into(), physical_value);
         if let Some(wc) = where_clause {
             plan.insert("where-clause".into(), wc);
         }
@@ -486,6 +503,7 @@ fn explain_from_parsed(
             "statistics": statistics,
             "execution-hints": execution_hints,
             "logical": logical_value,
+            "physical": physical_value,
             "original": original,
             "optimized": optimized
         }

--- a/fluree-db-api/src/graph_source/bm25.rs
+++ b/fluree-db-api/src/graph_source/bm25.rs
@@ -215,7 +215,7 @@ impl crate::Fluree {
     ) -> Result<Vec<JsonValue>> {
         // Parse the query
         let mut vars = VarRegistry::new();
-        let parsed = parse_query(query_json, &ledger.snapshot, &mut vars, None)?;
+        let parsed = parse_query(query_json, ledger.snapshot.as_ref(), &mut vars, None)?;
 
         // Execute with a wildcard select so the operator pipeline does not project away
         // bindings we need for indexing

--- a/fluree-db-api/src/graph_source/vector.rs
+++ b/fluree-db-api/src/graph_source/vector.rs
@@ -241,7 +241,7 @@ impl crate::Fluree {
     ) -> Result<Vec<JsonValue>> {
         // Parse the query
         let mut vars = VarRegistry::new();
-        let parsed = parse_query(query_json, &ledger.snapshot, &mut vars, None)?;
+        let parsed = parse_query(query_json, ledger.snapshot.as_ref(), &mut vars, None)?;
 
         // Execute with a wildcard select so the operator pipeline does not project away
         // bindings we need for indexing (Wildcard naturally drops any hydration).

--- a/fluree-db-api/src/ledger_manager.rs
+++ b/fluree-db-api/src/ledger_manager.rs
@@ -33,7 +33,7 @@ use fluree_db_core::trace_commits_by_id;
 use fluree_db_core::{ledger_id::normalize_ledger_id, ContentId, ContentStore, StorageBackend};
 use fluree_db_ledger::{LedgerState, TypeErasedStore};
 use fluree_db_nameservice::NsRecord;
-use tokio::sync::{oneshot, Mutex, RwLock};
+use tokio::sync::{oneshot, RwLock};
 
 use crate::error::{ApiError, Result};
 use crate::ledger_view::LedgerView;
@@ -66,7 +66,7 @@ fn monotonic_secs() -> u64 {
 /// Transactions hold this guard across stage+commit to serialize writes
 /// to the same ledger.
 pub struct LedgerWriteGuard<'a> {
-    guard: tokio::sync::MutexGuard<'a, LedgerState>,
+    guard: tokio::sync::RwLockWriteGuard<'a, LedgerState>,
 }
 
 impl LedgerWriteGuard<'_> {
@@ -117,8 +117,11 @@ impl Clone for LedgerHandle {
 /// All paths that touch both locks (snapshot, apply_index_v2, reload)
 /// follow this order to prevent deadlock and ensure coherence.
 struct LedgerHandleInner {
-    /// Single mutex for all access (queries clone snapshot, txns hold for duration)
-    state: Mutex<LedgerState>,
+    /// Guards all access to the ledger state. A `RwLock` so concurrent reads
+    /// (every query takes a brief shared `read()` to clone a cheap, Arc-backed
+    /// snapshot) run in parallel instead of serializing; transactions take an
+    /// exclusive `write()` for the stage+commit duration.
+    state: RwLock<LedgerState>,
     /// Ledger ID (e.g., "mydb:main")
     ledger_id: String,
     /// Last access time (monotonic secs since process start)
@@ -127,7 +130,7 @@ struct LedgerHandleInner {
     ///
     /// Always coherent with `state.snapshot.range_provider` — writers hold
     /// the `state` lock while updating this.
-    binary_store: Mutex<Option<Arc<BinaryIndexStore>>>,
+    binary_store: RwLock<Option<Arc<BinaryIndexStore>>>,
 }
 
 impl LedgerHandle {
@@ -139,10 +142,10 @@ impl LedgerHandle {
     ) -> Self {
         Self {
             inner: Arc::new(LedgerHandleInner {
-                state: Mutex::new(state),
+                state: RwLock::new(state),
                 ledger_id,
                 last_access: AtomicU64::new(monotonic_secs()),
-                binary_store: Mutex::new(binary_store),
+                binary_store: RwLock::new(binary_store),
             }),
         }
     }
@@ -161,8 +164,8 @@ impl LedgerHandle {
     /// The snapshot is a cheap clone; the lock is released immediately after.
     pub async fn snapshot(&self) -> LedgerView {
         self.touch();
-        let state = self.inner.state.lock().await;
-        let binary_store = self.inner.binary_store.lock().await.clone();
+        let state = self.inner.state.read().await;
+        let binary_store = self.inner.binary_store.read().await.clone();
         let mut snap = LedgerView::from_state(&state);
         snap.binary_store = binary_store;
         debug_assert!(
@@ -177,7 +180,7 @@ impl LedgerHandle {
     pub async fn lock_for_write(&self) -> LedgerWriteGuard<'_> {
         self.touch();
         LedgerWriteGuard {
-            guard: self.inner.state.lock().await,
+            guard: self.inner.state.write().await,
         }
     }
 
@@ -194,7 +197,7 @@ impl LedgerHandle {
                 .downcast::<BinaryIndexStore>()
                 .ok()
         });
-        *self.inner.binary_store.lock().await = binary_store;
+        *self.inner.binary_store.write().await = binary_store;
     }
 
     /// Update last access time
@@ -216,7 +219,7 @@ impl LedgerHandle {
 
     /// Check if currently locked (for eviction - skip if in use)
     pub fn is_locked(&self) -> bool {
-        self.inner.state.try_lock().is_err()
+        self.inner.state.try_write().is_err()
     }
 
     /// Get current index_t (brief lock to read)
@@ -224,7 +227,7 @@ impl LedgerHandle {
     /// This returns the indexed DB's t value, NOT including novelty.
     /// For freshness checking against remote watermarks, use this method.
     pub async fn index_t(&self) -> i64 {
-        let state = self.inner.state.lock().await;
+        let state = self.inner.state.read().await;
         state.index_t()
     }
 
@@ -233,7 +236,7 @@ impl LedgerHandle {
     /// This returns the ledger's current t including any unindexed novelty.
     /// Use this for comparing against nameservice commit_t to detect staleness.
     pub async fn t(&self) -> i64 {
-        let state = self.inner.state.lock().await;
+        let state = self.inner.state.read().await;
         state.t()
     }
 
@@ -241,7 +244,7 @@ impl LedgerHandle {
     ///
     /// Returns (t, index_t, index_head_id) needed for UpdatePlan::plan()
     pub async fn state_metrics(&self) -> (i64, i64, Option<ContentId>) {
-        let state = self.inner.state.lock().await;
+        let state = self.inner.state.read().await;
         (
             state.t(),
             state.index_t(),
@@ -317,7 +320,7 @@ impl LedgerHandle {
         // then wire up range_provider with the correct dict_novelty.
         // Lock ordering: state → binary_store (same as snapshot()).
         {
-            let mut state = self.inner.state.lock().await;
+            let mut state = self.inner.state.write().await;
 
             // apply_loaded_db: validates, trims novelty, rebuilds dict_novelty
             state
@@ -325,7 +328,10 @@ impl LedgerHandle {
                 .map_err(|e| ApiError::internal(format!("apply_loaded_db failed: {e}")))?;
 
             // Sync namespace codes between store and snapshot (bimap validation).
-            crate::ns_helpers::sync_store_and_snapshot_ns(&mut store, &mut state.snapshot)?;
+            crate::ns_helpers::sync_store_and_snapshot_ns(
+                &mut store,
+                Arc::make_mut(&mut state.snapshot),
+            )?;
 
             let arc_store = Arc::new(store);
             crate::runtime_dicts::reseed_runtime_small_dicts(&mut state, &arc_store);
@@ -338,11 +344,11 @@ impl LedgerHandle {
                 Arc::clone(&state.runtime_small_dicts),
                 ns_fallback,
             );
-            state.snapshot.range_provider = Some(Arc::new(provider));
+            Arc::make_mut(&mut state.snapshot).range_provider = Some(Arc::new(provider));
 
             let te_store: Arc<dyn std::any::Any + Send + Sync> = arc_store.clone();
             state.binary_store = Some(TypeErasedStore(te_store));
-            *self.inner.binary_store.lock().await = Some(arc_store);
+            *self.inner.binary_store.write().await = Some(arc_store);
         }
 
         Ok(())
@@ -633,15 +639,18 @@ pub(crate) async fn load_and_attach_binary_store(
     // DictNovelty/DictOverlay correctness (especially bound-object filters and overlay merges).
     let root = fluree_db_binary_index::IndexRoot::decode(&bytes)
         .map_err(|e| ApiError::internal(format!("failed to decode FIR6 root: {e}")))?;
-    state.snapshot.subject_watermarks = root.subject_watermarks;
-    state.snapshot.string_watermark = root.string_watermark;
-    if root.stats.is_some() && state.snapshot.stats.is_none() {
-        state.snapshot.stats = root.stats;
-        tracing::debug!("loaded stats from FIR6 root");
-    }
-    if root.schema.is_some() && state.snapshot.schema.is_none() {
-        state.snapshot.schema = root.schema;
-        tracing::debug!("loaded schema from FIR6 root");
+    {
+        let snap = Arc::make_mut(&mut state.snapshot);
+        snap.subject_watermarks = root.subject_watermarks;
+        snap.string_watermark = root.string_watermark;
+        if root.stats.is_some() && snap.stats.is_none() {
+            snap.stats = root.stats;
+            tracing::debug!("loaded stats from FIR6 root");
+        }
+        if root.schema.is_some() && snap.schema.is_none() {
+            snap.schema = root.schema;
+            tracing::debug!("loaded schema from FIR6 root");
+        }
     }
     state.dict_novelty = Arc::new(DictNovelty::with_watermarks(
         state.snapshot.subject_watermarks.clone(),
@@ -654,7 +663,7 @@ pub(crate) async fn load_and_attach_binary_store(
             .map_err(|e| ApiError::internal(format!("failed to load binary index: {e}")))?;
 
     // Sync namespace codes between store and snapshot (bimap validation).
-    crate::ns_helpers::sync_store_and_snapshot_ns(&mut store, &mut state.snapshot)?;
+    crate::ns_helpers::sync_store_and_snapshot_ns(&mut store, Arc::make_mut(&mut state.snapshot))?;
 
     // Re-populate DictNovelty from already-loaded novelty flakes, but *only* for
     // entries not present in the persisted dictionaries (canonical IDs must win).
@@ -684,7 +693,7 @@ pub(crate) async fn load_and_attach_binary_store(
     );
     // Always rebuild the provider here so it is coherent with the freshly
     // loaded BinaryIndexStore, DictNovelty, and runtime dictionary state.
-    state.snapshot.range_provider = Some(Arc::new(provider));
+    Arc::make_mut(&mut state.snapshot).range_provider = Some(Arc::new(provider));
     // Also attach the type-erased store to the state so transaction staging
     // (which clones LedgerState under the write lock) can construct
     // graph-scoped BinaryRangeProviders (needed for named-graph upsert deletions).
@@ -1146,7 +1155,7 @@ impl LedgerManager {
                         // index, which the next reload picks up. Never clobber a
                         // newer in-memory commit to adopt a newer index.
                         if new_state.t() >= write_guard.state().t() {
-                            let mut bs_guard = handle.inner.binary_store.lock().await;
+                            let mut bs_guard = handle.inner.binary_store.write().await;
                             write_guard.replace(new_state);
                             *bs_guard = new_binary_store;
                         } else {
@@ -1664,7 +1673,7 @@ impl LedgerManager {
                                 Arc::clone(&write_guard.state().runtime_small_dicts);
                             let ns_fallback =
                                 Some(Arc::new(write_guard.state().snapshot.namespaces().clone()));
-                            write_guard.state_mut().snapshot.range_provider =
+                            Arc::make_mut(&mut write_guard.state_mut().snapshot).range_provider =
                                 Some(Arc::new(BinaryRangeProvider::new(
                                     store,
                                     dn,

--- a/fluree-db-api/src/ledger_view.rs
+++ b/fluree-db-api/src/ledger_view.rs
@@ -68,8 +68,10 @@ impl CommitRef {
 /// Holds no locks. Safe to clone, pass to subtasks, or keep across `.await`
 /// points. Underlying state is Arc-shared, so cloning is cheap.
 pub struct LedgerView {
-    /// The indexed database snapshot (cheap clone - Arc fields)
-    pub snapshot: LedgerSnapshot,
+    /// The indexed database snapshot. `Arc`-shared so deriving a view from the
+    /// cached `LedgerState` (the per-query hot path) is a refcount bump, not a
+    /// deep copy of the namespace maps / stats / schema / graph registry.
+    pub snapshot: Arc<LedgerSnapshot>,
     /// In-memory overlay of uncommitted transactions
     pub novelty: Arc<Novelty>,
     /// Dictionary novelty layer (subjects and strings since last index build)
@@ -98,7 +100,10 @@ impl LedgerView {
     /// binary store must set it after construction (see `LedgerHandle::snapshot()`).
     pub(crate) fn from_state(state: &LedgerState) -> Self {
         Self {
-            snapshot: state.snapshot.clone(),
+            // Arc::clone — refcount bump, not a deep snapshot copy. This is the
+            // per-query hot path; the old `state.snapshot.clone()` deep-copied
+            // the namespace maps / stats / schema under the state lock.
+            snapshot: Arc::clone(&state.snapshot),
             novelty: Arc::clone(&state.novelty),
             dict_novelty: Arc::clone(&state.dict_novelty),
             runtime_small_dicts: Arc::clone(&state.runtime_small_dicts),

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -318,7 +318,7 @@ impl crate::Fluree {
         // Replay stages commits as writes to the branch. Start from the
         // source's queryable state, but relabel the snapshot before staging so
         // commit conflict checks and nameservice updates target the branch.
-        current_state.snapshot.ledger_id = ctx.branch_id.to_string();
+        std::sync::Arc::make_mut(&mut current_state.snapshot).ledger_id = ctx.branch_id.to_string();
 
         let mut report = RebaseReport {
             replayed: 0,

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -213,7 +213,10 @@ impl Fluree {
                 .map_err(|e| ApiError::internal(format!("load binary index: {e}")))?;
 
                 // Sync namespace codes between store and snapshot (bimap validation).
-                crate::ns_helpers::sync_store_and_snapshot_ns(&mut store, &mut snapshot.snapshot)?;
+                crate::ns_helpers::sync_store_and_snapshot_ns(
+                    &mut store,
+                    Arc::make_mut(&mut snapshot.snapshot),
+                )?;
 
                 let arc_store = Arc::new(store);
                 let dn = snapshot.dict_novelty.clone();
@@ -228,7 +231,7 @@ impl Fluree {
                     Arc::clone(&runtime_small_dicts),
                     ns_fallback,
                 );
-                snapshot.snapshot.range_provider = Some(Arc::new(provider));
+                Arc::make_mut(&mut snapshot.snapshot).range_provider = Some(Arc::new(provider));
                 snapshot.binary_store = Some(arc_store);
                 snapshot.runtime_small_dicts = runtime_small_dicts;
             }

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -276,7 +276,9 @@ impl GraphDb {
     pub fn from_ledger_state(ledger: &LedgerState) -> Self {
         let novelty = ledger.novelty.clone();
         let mut gdb = Self::new(
-            Arc::new(ledger.snapshot.clone()),
+            // `ledger.snapshot` is already `Arc<LedgerSnapshot>`; share it
+            // (refcount bump) rather than deep-cloning the snapshot.
+            Arc::clone(&ledger.snapshot),
             novelty.clone() as Arc<dyn OverlayProvider>,
             Some(novelty),
             ledger.t(),
@@ -354,7 +356,9 @@ impl GraphDb {
         let mut snapshot = base.snapshot.clone();
         let has_deltas = staged.ns_registry.has_delta() || !staged.graph_delta.is_empty();
         if has_deltas {
-            snapshot
+            // Copy-on-write: staging mutates the snapshot to register new
+            // namespace/graph codes for preview queries.
+            Arc::make_mut(&mut snapshot)
                 .apply_envelope_deltas(
                     staged.ns_registry.delta(),
                     staged.graph_delta.values().map(std::string::String::as_str),
@@ -384,7 +388,7 @@ impl GraphDb {
         let combined = Arc::new(combined);
 
         let mut gdb = Self::new(
-            Arc::new(snapshot),
+            snapshot,
             combined.clone() as Arc<dyn OverlayProvider>,
             Some(combined),
             staged_t,
@@ -417,7 +421,7 @@ impl GraphDb {
         let base = staged.view.base();
         let novelty = base.novelty.clone();
         let mut gdb = Self::new(
-            Arc::new(base.snapshot.clone()),
+            Arc::clone(&base.snapshot),
             novelty.clone() as Arc<dyn OverlayProvider>,
             Some(novelty),
             base.t(),

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -403,8 +403,7 @@ async fn e2e_r2rml_query_iceberg_table() {
     let mut ledger = genesis_ledger(&fluree, "e2e-iceberg:main");
 
     // Register example.org namespace
-    ledger
-        .snapshot
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
         .insert_namespace_code(9_999, "http://example.org/".to_string())
         .unwrap();
 
@@ -575,8 +574,7 @@ async fn e2e_fluree_r2rml_provider_full_flow() {
 
     // Create a ledger for query execution
     let mut ledger = genesis_ledger(&fluree, "e2e-provider:main");
-    ledger
-        .snapshot
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
         .insert_namespace_code(9_999, "http://example.org/".to_string())
         .unwrap();
 
@@ -1055,8 +1053,7 @@ async fn engine_e2e_graph_pattern_r2rml_scan() {
     // Register the example.org namespace prefix in this Db so the R2RML operator
     // can encode subject IRIs produced by rr:template. Without this, encode_iri()
     // returns None and the operator will skip all rows as "IRI not encodable".
-    ledger
-        .snapshot
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
         .insert_namespace_code(9_999, "http://example.org/".to_string())
         .unwrap();
 
@@ -1812,8 +1809,7 @@ async fn engine_e2e_ref_object_map_join_execution() {
     let mut ledger = genesis_ledger(&fluree, "ref-join-test:main");
 
     // Register example.org namespace
-    ledger
-        .snapshot
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
         .insert_namespace_code(9_999, "http://example.org/".to_string())
         .unwrap();
 

--- a/fluree-db-api/tests/it_host_plus_n_e2e.rs
+++ b/fluree-db-api/tests/it_host_plus_n_e2e.rs
@@ -64,8 +64,7 @@ async fn host_plus_n_insert_index_reload_query() {
         .run_until(async {
             // Create ledger and set HostPlusN(1) split mode on genesis snapshot.
             let mut ledger0 = fluree.create_ledger(ledger_id).await.unwrap();
-            ledger0
-                .snapshot
+            std::sync::Arc::make_mut(&mut ledger0.snapshot)
                 .set_ns_split_mode(NsSplitMode::HostPlusN(1), 0)
                 .expect("set HostPlusN(1) on genesis");
 

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -76,6 +76,69 @@ async fn explain_sparql_no_stats_reports_none_and_reason() {
 }
 
 #[tokio::test]
+async fn explain_physical_plan_present_and_concretely_named() {
+    // plan.physical is built from the REAL operator tree (build-only, no exec).
+    // Validate it is present and operators resolve to concrete names (the
+    // default op_name() must see through dyn dispatch, not report "dyn Operator").
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "physical-names:main");
+
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@id":"ex:alice",
+                "ex:name":"Alice"
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+
+    let sparql = "PREFIX ex: <http://example.org/>\nSELECT ?person ?name WHERE { ?person ex:name ?name }";
+
+    let db = graphdb_from_ledger(&ledger);
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+
+    let physical = &resp["plan"]["physical"];
+    eprintln!(
+        "PHYSICAL = {}",
+        serde_json::to_string_pretty(physical).unwrap()
+    );
+    assert!(
+        physical.get("error").is_none(),
+        "physical build errored: {physical}"
+    );
+    let op = physical["op"].as_str().expect("physical.op is a string");
+    assert!(!op.is_empty());
+    assert!(
+        !op.contains("dyn Operator"),
+        "operator name should be concrete, got {op:?}"
+    );
+    // The tree is connected (not truncated at the root): the scan leaf is reachable.
+    assert!(
+        physical_contains_op(physical, "DatasetOperator"),
+        "expected a DatasetOperator scan leaf in the physical tree: {physical}"
+    );
+}
+
+/// Recursively search a `plan.physical` node (and its `children[].node`) for an
+/// operator whose `op` equals `name`.
+fn physical_contains_op(node: &serde_json::Value, name: &str) -> bool {
+    if node["op"] == name {
+        return true;
+    }
+    node["children"]
+        .as_array()
+        .map(|cs| cs.iter().any(|e| physical_contains_op(&e["node"], name)))
+        .unwrap_or(false)
+}
+
+#[tokio::test]
 async fn explain_logical_plan_preserves_compound_structure() {
     // The `logical` plan view is the compound-aware reorder_patterns order,
     // available even without stats. Verify a triple + OPTIONAL render as a

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -6,10 +6,50 @@ mod support;
 
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use support::{genesis_ledger, graphdb_from_ledger};
+
+/// Serializes `FLUREE_HASH_JOIN` access across this file's tests and restores the
+/// prior value on drop. `HashJoinPlanner` reads this var at plan time, so a test
+/// that forces the hash join must not run while another builds a plan, and must not
+/// leak the override on panic. Every plan-building test holds one for its duration;
+/// `acquire()` starts each test in the default (AUTO) mode.
+struct HashJoinEnv {
+    _guard: MutexGuard<'static, ()>,
+    prev: Option<String>,
+}
+
+impl HashJoinEnv {
+    fn acquire() -> Self {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let guard = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = std::env::var("FLUREE_HASH_JOIN").ok();
+        std::env::remove_var("FLUREE_HASH_JOIN");
+        Self {
+            _guard: guard,
+            prev,
+        }
+    }
+    fn force_on(&self) {
+        std::env::set_var("FLUREE_HASH_JOIN", "1");
+    }
+}
+
+impl Drop for HashJoinEnv {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => std::env::set_var("FLUREE_HASH_JOIN", v),
+            None => std::env::remove_var("FLUREE_HASH_JOIN"),
+        }
+    }
+}
 
 #[tokio::test]
 async fn explain_no_stats_reports_none_and_reason() {
+    let _env = HashJoinEnv::acquire();
     // Scenario: explain-no-stats-test
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger0 = genesis_ledger(&fluree, "no-stats:main");
@@ -45,6 +85,7 @@ async fn explain_no_stats_reports_none_and_reason() {
 
 #[tokio::test]
 async fn explain_sparql_no_stats_reports_none_and_reason() {
+    let _env = HashJoinEnv::acquire();
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger0 = genesis_ledger(&fluree, "no-stats-sparql:main");
 
@@ -77,6 +118,7 @@ async fn explain_sparql_no_stats_reports_none_and_reason() {
 
 #[tokio::test]
 async fn explain_physical_plan_present_and_concretely_named() {
+    let _env = HashJoinEnv::acquire();
     // plan.physical is built from the REAL operator tree (build-only, no exec).
     // Validate it is present and operators resolve to concrete names (the
     // default op_name() must see through dyn dispatch, not report "dyn Operator").
@@ -149,6 +191,7 @@ async fn explain_physical_object_subject_join_shows_hash_join_decision() {
     // `?a ex:knows ?x`. This is the exact shape the object→subject hash join
     // targets. Default (no stats): the planner keeps the NestedLoop and records
     // the rejected hash-join reason. FLUREE_HASH_JOIN=1: the hash join is chosen.
+    let env = HashJoinEnv::acquire(); // AUTO mode; restored (and serialized) via guard
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger0 = genesis_ledger(&fluree, "physical-join:main");
     let ledger = fluree
@@ -168,8 +211,7 @@ async fn explain_physical_object_subject_join_shows_hash_join_decision() {
         "PREFIX ex: <http://example.org/>\nSELECT ?a ?b WHERE { ?a ex:knows ?x . ?b ex:knows ?x }";
     let db = graphdb_from_ledger(&ledger);
 
-    // Default: nested-loop join, hash join evaluated and rejected.
-    std::env::remove_var("FLUREE_HASH_JOIN");
+    // Default (AUTO): nested-loop join, hash join evaluated and rejected.
     let resp = fluree
         .explain_sparql(&db, sparql)
         .await
@@ -191,12 +233,11 @@ async fn explain_physical_object_subject_join_shows_hash_join_decision() {
     );
 
     // Forced: the object→subject hash join is selected.
-    std::env::set_var("FLUREE_HASH_JOIN", "1");
+    env.force_on();
     let resp_forced = fluree
         .explain_sparql(&db, sparql)
         .await
         .expect("explain_sparql");
-    std::env::remove_var("FLUREE_HASH_JOIN");
     let physical_forced = &resp_forced["plan"]["physical"];
     eprintln!(
         "PHYSICAL(hash) = {}",
@@ -209,7 +250,49 @@ async fn explain_physical_object_subject_join_shows_hash_join_decision() {
 }
 
 #[tokio::test]
+async fn explain_logical_estimates_are_bound_var_aware() {
+    let _env = HashJoinEnv::acquire();
+    // `?s ex:p ?o . ?o ex:q ?x`: the second triple's subject ?o is bound by the
+    // first, so its logical estimate must be the (selective) bound-subject estimate,
+    // not a full predicate scan as if no earlier variable were bound. Even without
+    // stats the defaults differ (bound-subject vs property-scan), so this catches a
+    // node rendered with an empty bound set.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "logical-bound:main");
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@id":"ex:a",
+                "ex:p": {"@id":"ex:b", "ex:q": {"@id":"ex:c"}}
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+    let db = graphdb_from_ledger(&ledger);
+    let sparql = "PREFIX ex: <http://example.org/>\nSELECT ?s ?x WHERE { ?s ex:p ?o . ?o ex:q ?x }";
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+    let logical = resp["plan"]["logical"]
+        .as_array()
+        .expect("logical plan array");
+    assert_eq!(logical.len(), 2, "two triples expected: {logical:?}");
+    let row_count = |n: &serde_json::Value| n["estimate"]["row-count"].as_i64();
+    let first = row_count(&logical[0]).expect("first row-count");
+    let second = row_count(&logical[1]).expect("second row-count");
+    assert!(
+        second < first,
+        "bound-subject second triple must estimate below the first full scan: {first} then {second}"
+    );
+}
+
+#[tokio::test]
 async fn explain_physical_plan_surfaces_fast_path() {
+    let _env = HashJoinEnv::acquire();
     // A COUNT(*) over a predicate is answered by a metadata fast path. The
     // planner selects it at build time, so plan.physical names the fast-path
     // operator (label-tagged) — the signal the pattern-level views cannot give.
@@ -252,6 +335,7 @@ async fn explain_physical_plan_surfaces_fast_path() {
 
 #[tokio::test]
 async fn explain_physical_expands_subquery_inner_plan() {
+    let _env = HashJoinEnv::acquire();
     // BSBM-BI queries are subquery-based; the inner joins are where the time is.
     // The SubqueryOperator builds its subplan lazily, so explain rebuilds it
     // (build-only) and exposes it under a `SubqueryBody` node.
@@ -306,6 +390,7 @@ async fn explain_physical_expands_subquery_inner_plan() {
 
 #[tokio::test]
 async fn explain_logical_plan_preserves_compound_structure() {
+    let _env = HashJoinEnv::acquire();
     // The `logical` plan view is the compound-aware reorder_patterns order,
     // available even without stats. Verify a triple + OPTIONAL render as a
     // `triple` node and an `optional` node containing its inner triple.

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -96,7 +96,8 @@ async fn explain_physical_plan_present_and_concretely_named() {
         .expect("seed")
         .ledger;
 
-    let sparql = "PREFIX ex: <http://example.org/>\nSELECT ?person ?name WHERE { ?person ex:name ?name }";
+    let sparql =
+        "PREFIX ex: <http://example.org/>\nSELECT ?person ?name WHERE { ?person ex:name ?name }";
 
     let db = graphdb_from_ledger(&ledger);
     let resp = fluree
@@ -133,17 +134,13 @@ fn physical_contains_op(node: &serde_json::Value, name: &str) -> bool {
 }
 
 /// Recursively find the first `plan.physical` node whose `op` equals `name`.
-fn physical_find_op<'a>(
-    node: &'a serde_json::Value,
-    name: &str,
-) -> Option<&'a serde_json::Value> {
+fn physical_find_op<'a>(node: &'a serde_json::Value, name: &str) -> Option<&'a serde_json::Value> {
     if node["op"] == name {
         return Some(node);
     }
-    node["children"].as_array().and_then(|cs| {
-        cs.iter()
-            .find_map(|e| physical_find_op(&e["node"], name))
-    })
+    node["children"]
+        .as_array()
+        .and_then(|cs| cs.iter().find_map(|e| physical_find_op(&e["node"], name)))
 }
 
 #[tokio::test]
@@ -178,7 +175,10 @@ async fn explain_physical_object_subject_join_shows_hash_join_decision() {
         .await
         .expect("explain_sparql");
     let physical = &resp["plan"]["physical"];
-    eprintln!("PHYSICAL(nl) = {}", serde_json::to_string_pretty(physical).unwrap());
+    eprintln!(
+        "PHYSICAL(nl) = {}",
+        serde_json::to_string_pretty(physical).unwrap()
+    );
     let nl = physical_find_op(physical, "NestedLoopJoinOperator")
         .expect("expected a NestedLoopJoinOperator in physical plan");
     assert_eq!(
@@ -192,7 +192,10 @@ async fn explain_physical_object_subject_join_shows_hash_join_decision() {
 
     // Forced: the object→subject hash join is selected.
     std::env::set_var("FLUREE_HASH_JOIN", "1");
-    let resp_forced = fluree.explain_sparql(&db, sparql).await.expect("explain_sparql");
+    let resp_forced = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
     std::env::remove_var("FLUREE_HASH_JOIN");
     let physical_forced = &resp_forced["plan"]["physical"];
     eprintln!(
@@ -291,9 +294,7 @@ async fn explain_physical_expands_subquery_inner_plan() {
         .expect("subquery inner plan should be expanded under SubqueryBody");
     // The inner operator tree is visible (a real operator under the body).
     assert!(
-        body["children"]
-            .as_array()
-            .is_some_and(|cs| !cs.is_empty()),
+        body["children"].as_array().is_some_and(|cs| !cs.is_empty()),
         "SubqueryBody should contain the inner operator tree"
     );
     // The inner aggregation (the GROUP BY / COUNT) is no longer opaque.

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -74,3 +74,63 @@ async fn explain_sparql_no_stats_reports_none_and_reason() {
     // SPARQL explain does not include where-clause (that's a JSON-LD concept)
     assert!(resp["plan"].get("where-clause").is_none());
 }
+
+#[tokio::test]
+async fn explain_logical_plan_preserves_compound_structure() {
+    // The `logical` plan view is the compound-aware reorder_patterns order,
+    // available even without stats. Verify a triple + OPTIONAL render as a
+    // `triple` node and an `optional` node containing its inner triple.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "logical-compound:main");
+
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@id":"ex:alice",
+                "ex:name":"Alice",
+                "ex:email":"alice@example.org"
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+
+    let sparql = "PREFIX ex: <http://example.org/>\nSELECT ?person ?email WHERE { ?person ex:name ?name . OPTIONAL { ?person ex:email ?email } }";
+
+    let db = graphdb_from_ledger(&ledger);
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+
+    let logical = resp["plan"]["logical"]
+        .as_array()
+        .expect("plan.logical is an array");
+    assert!(!logical.is_empty(), "logical plan should not be empty");
+
+    // Every node carries a kind + category.
+    assert!(logical
+        .iter()
+        .all(|n| n.get("kind").is_some() && n.get("category").is_some()));
+
+    // The OPTIONAL renders as an expander node holding its inner triple,
+    // not flattened away.
+    let optional = logical
+        .iter()
+        .find(|n| n["kind"] == "optional")
+        .expect("optional node present in logical plan");
+    assert_eq!(optional["category"], "expander");
+    let inner = optional["patterns"]
+        .as_array()
+        .expect("optional has inner patterns");
+    assert!(inner.iter().any(|n| n["kind"] == "triple"));
+
+    // The required triple is a source.
+    let triple = logical
+        .iter()
+        .find(|n| n["kind"] == "triple")
+        .expect("required triple present");
+    assert_eq!(triple["category"], "source");
+}

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -139,6 +139,48 @@ fn physical_contains_op(node: &serde_json::Value, name: &str) -> bool {
 }
 
 #[tokio::test]
+async fn explain_physical_plan_surfaces_fast_path() {
+    // A COUNT(*) over a predicate is answered by a metadata fast path. The
+    // planner selects it at build time, so plan.physical names the fast-path
+    // operator (label-tagged) — the signal the pattern-level views cannot give.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "physical-fastpath:main");
+
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@id":"ex:alice",
+                "ex:name":"Alice"
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+
+    let sparql =
+        "PREFIX ex: <http://example.org/>\nSELECT (COUNT(?o) AS ?c) WHERE { ?s ex:name ?o }";
+
+    let db = graphdb_from_ledger(&ledger);
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+
+    let physical = &resp["plan"]["physical"];
+    eprintln!(
+        "PHYSICAL(count) = {}",
+        serde_json::to_string_pretty(physical).unwrap()
+    );
+    let s = serde_json::to_string(physical).unwrap();
+    assert!(
+        s.contains("FastPath"),
+        "expected a fast-path operator in physical plan: {s}"
+    );
+}
+
+#[tokio::test]
 async fn explain_logical_plan_preserves_compound_structure() {
     // The `logical` plan view is the compound-aware reorder_patterns order,
     // available even without stats. Verify a triple + OPTIONAL render as a

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -129,13 +129,80 @@ async fn explain_physical_plan_present_and_concretely_named() {
 /// Recursively search a `plan.physical` node (and its `children[].node`) for an
 /// operator whose `op` equals `name`.
 fn physical_contains_op(node: &serde_json::Value, name: &str) -> bool {
+    physical_find_op(node, name).is_some()
+}
+
+/// Recursively find the first `plan.physical` node whose `op` equals `name`.
+fn physical_find_op<'a>(
+    node: &'a serde_json::Value,
+    name: &str,
+) -> Option<&'a serde_json::Value> {
     if node["op"] == name {
-        return true;
+        return Some(node);
     }
-    node["children"]
-        .as_array()
-        .map(|cs| cs.iter().any(|e| physical_contains_op(&e["node"], name)))
-        .unwrap_or(false)
+    node["children"].as_array().and_then(|cs| {
+        cs.iter()
+            .find_map(|e| physical_find_op(&e["node"], name))
+    })
+}
+
+#[tokio::test]
+async fn explain_physical_object_subject_join_shows_hash_join_decision() {
+    // 2-pattern object→subject join: `?b ex:knows ?x` with `?x` bound from
+    // `?a ex:knows ?x`. This is the exact shape the object→subject hash join
+    // targets. Default (no stats): the planner keeps the NestedLoop and records
+    // the rejected hash-join reason. FLUREE_HASH_JOIN=1: the hash join is chosen.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "physical-join:main");
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@id":"ex:alice",
+                "ex:knows": {"@id":"ex:bob"}
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+
+    let sparql =
+        "PREFIX ex: <http://example.org/>\nSELECT ?a ?b WHERE { ?a ex:knows ?x . ?b ex:knows ?x }";
+    let db = graphdb_from_ledger(&ledger);
+
+    // Default: nested-loop join, hash join evaluated and rejected.
+    std::env::remove_var("FLUREE_HASH_JOIN");
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+    let physical = &resp["plan"]["physical"];
+    eprintln!("PHYSICAL(nl) = {}", serde_json::to_string_pretty(physical).unwrap());
+    let nl = physical_find_op(physical, "NestedLoopJoinOperator")
+        .expect("expected a NestedLoopJoinOperator in physical plan");
+    assert_eq!(
+        nl["details"]["hash-join-chosen"], false,
+        "nested loop should record the rejected hash join"
+    );
+    assert!(
+        nl["details"]["hash-join-reason"].is_string(),
+        "nested loop should carry a hash-join reason"
+    );
+
+    // Forced: the object→subject hash join is selected.
+    std::env::set_var("FLUREE_HASH_JOIN", "1");
+    let resp_forced = fluree.explain_sparql(&db, sparql).await.expect("explain_sparql");
+    std::env::remove_var("FLUREE_HASH_JOIN");
+    let physical_forced = &resp_forced["plan"]["physical"];
+    eprintln!(
+        "PHYSICAL(hash) = {}",
+        serde_json::to_string_pretty(physical_forced).unwrap()
+    );
+    let hj = physical_find_op(physical_forced, "HashJoinOperator")
+        .expect("expected a HashJoinOperator under FLUREE_HASH_JOIN=1");
+    assert_eq!(hj["details"]["hash-join-chosen"], true);
+    assert_eq!(hj["details"]["hash-join-reason"], "forced-on");
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -248,6 +248,62 @@ async fn explain_physical_plan_surfaces_fast_path() {
 }
 
 #[tokio::test]
+async fn explain_physical_expands_subquery_inner_plan() {
+    // BSBM-BI queries are subquery-based; the inner joins are where the time is.
+    // The SubqueryOperator builds its subplan lazily, so explain rebuilds it
+    // (build-only) and exposes it under a `SubqueryBody` node.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "physical-subquery:main");
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@id":"ex:alice",
+                "ex:name":"Alice",
+                "ex:knows": {"@id":"ex:bob"}
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+
+    let sparql = "PREFIX ex: <http://example.org/>\n\
+        SELECT ?a ?c WHERE { \
+          ?a ex:name ?n . \
+          { SELECT ?a (COUNT(?x) AS ?c) WHERE { ?a ex:knows ?x } GROUP BY ?a } \
+        }";
+    let db = graphdb_from_ledger(&ledger);
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+    let physical = &resp["plan"]["physical"];
+    eprintln!(
+        "PHYSICAL(subquery) = {}",
+        serde_json::to_string_pretty(physical).unwrap()
+    );
+
+    let sub = physical_find_op(physical, "SubqueryOperator")
+        .expect("expected a SubqueryOperator in physical plan");
+    // The inner plan is expanded under a SubqueryBody node, not opaque.
+    let body = physical_find_op(sub, "SubqueryBody")
+        .expect("subquery inner plan should be expanded under SubqueryBody");
+    // The inner operator tree is visible (a real operator under the body).
+    assert!(
+        body["children"]
+            .as_array()
+            .is_some_and(|cs| !cs.is_empty()),
+        "SubqueryBody should contain the inner operator tree"
+    );
+    // The inner aggregation (the GROUP BY / COUNT) is no longer opaque.
+    assert!(
+        physical_find_op(body, "GroupAggregateOperator").is_some(),
+        "inner subquery aggregation should be visible: {body}"
+    );
+}
+
+#[tokio::test]
 async fn explain_logical_plan_preserves_compound_structure() {
     // The `logical` plan view is the compound-aware reorder_patterns order,
     // available even without stats. Verify a triple + OPTIONAL render as a

--- a/fluree-db-api/tests/it_query_explain_native.rs
+++ b/fluree-db-api/tests/it_query_explain_native.rs
@@ -172,6 +172,18 @@ async fn explain_reorders_bound_object_email_first() {
             assert_eq!(logical[0]["pattern"]["property"], "ex:email");
             assert_eq!(logical[0]["category"], "source");
 
+            // The physical plan is built from the real operator tree (no exec).
+            let physical = &resp["plan"]["physical"];
+            eprintln!(
+                "PHYSICAL(star) = {}",
+                serde_json::to_string_pretty(physical).unwrap()
+            );
+            assert!(
+                physical.get("error").is_none(),
+                "physical build errored: {physical}"
+            );
+            assert!(physical["op"].as_str().is_some_and(|s| !s.is_empty()));
+
             // SPARQL equivalent
             let sparql = "PREFIX ex: <http://example.org/>\nSELECT ?person WHERE { ?person a ex:Person . ?person ex:email \"rare@example.org\" }";
             let resp_s = fluree

--- a/fluree-db-api/tests/it_query_explain_native.rs
+++ b/fluree-db-api/tests/it_query_explain_native.rs
@@ -163,6 +163,15 @@ async fn explain_reorders_bound_object_email_first() {
             assert_eq!(resp["plan"]["optimization"], "reordered");
             assert_eq!(resp["plan"]["optimized"][0]["pattern"]["property"], "ex:email");
 
+            // The compound-aware `logical` view reflects the same reorder: the
+            // selective bound-object email triple is placed first.
+            let logical = resp["plan"]["logical"]
+                .as_array()
+                .expect("plan.logical array");
+            assert_eq!(logical[0]["kind"], "triple");
+            assert_eq!(logical[0]["pattern"]["property"], "ex:email");
+            assert_eq!(logical[0]["category"], "source");
+
             // SPARQL equivalent
             let sparql = "PREFIX ex: <http://example.org/>\nSELECT ?person WHERE { ?person a ex:Person . ?person ex:email \"rare@example.org\" }";
             let resp_s = fluree
@@ -287,6 +296,10 @@ async fn explain_includes_inputs_fields_and_flags() {
 
             assert!(original.iter().all(|p| p.get("inputs").is_some()));
             assert!(optimized.iter().all(|p| p.get("inputs").is_some()));
+
+            // execution-hints and the compound-aware logical view are always present.
+            assert!(resp["plan"]["execution-hints"].is_array());
+            assert!(resp["plan"]["logical"].is_array());
 
             // Bound object pattern should have used-values-ndv? + clamped-to-one? flags.
             let email_pat = original

--- a/fluree-db-api/tests/it_scaling_bench.rs
+++ b/fluree-db-api/tests/it_scaling_bench.rs
@@ -1,0 +1,122 @@
+//! In-process concurrency-scaling micro-benchmark for the read/query path.
+//!
+//! Drives many concurrent simple SPARQL queries against a single cached ledger
+//! and reports aggregate QPS at increasing concurrency. This isolates the
+//! `LedgerHandle::snapshot()` read path (which clones `LedgerSnapshot` under an
+//! exclusive Mutex per query) without HTTP/client noise, so it directly
+//! measures whether concurrent reads scale across cores.
+//!
+//! Manual run (release-ish optimization matters for absolute numbers, but the
+//! SCALING ratio is the signal):
+//!   cargo test -p fluree-db-api --test it_scaling_bench --features native --release -- --ignored --nocapture
+//!
+//! Interpreting output: look at QPS(C)/QPS(1). Linear-ish scaling => reads run
+//! concurrently. Flat after a few cores => a read-path serialization bottleneck.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use fluree_db_api::{Fluree, FlureeBuilder, ReindexOptions};
+use serde_json::json;
+
+const SEED_SUBJECTS: usize = 8000;
+const RUN_SECS: u64 = 3;
+const CONCURRENCIES: &[usize] = &[1, 2, 4, 8, 16];
+
+// A trivial lookup-style query (BSBM-Explore-class): tiny work, so per-query
+// fixed overhead (parse/plan/snapshot) dominates — exactly where serialization
+// on the snapshot clone shows up.
+const QUERY: &str = "PREFIX ex: <http://ex/> SELECT ?name WHERE { ex:s42 ex:name ?name }";
+
+async fn setup(path: &str) -> (Arc<Fluree>, String) {
+    let fluree = FlureeBuilder::file(path.to_string())
+        .build()
+        .expect("build");
+    let ledger_id = "bench/scaling:main";
+
+    let l0 = fluree.create_ledger(ledger_id).await.expect("create");
+    // Many namespaces/predicates would enlarge the snapshot clone; one ns with
+    // many subjects is enough to populate stats/schema and exercise the path.
+    let g: Vec<_> = (0..SEED_SUBJECTS)
+        .map(|i| json!({ "@id": format!("http://ex/s{i}"), "http://ex/name": format!("n{i}"), "http://ex/k": i }))
+        .collect();
+    let tx = json!({ "@graph": g });
+    fluree.insert(l0, &tx).await.expect("insert");
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    // Warm the cache so every bench query hits the cached snapshot() path.
+    let _ = fluree.ledger_cached(ledger_id).await.expect("cache");
+    eprintln!("caching_enabled = {}", fluree.is_caching_enabled());
+
+    (Arc::new(fluree), ledger_id.to_string())
+}
+
+async fn run_concurrency(fluree: &Arc<Fluree>, ledger_id: &str, concurrency: usize) -> f64 {
+    let counter = Arc::new(AtomicU64::new(0));
+    let deadline = Instant::now() + Duration::from_secs(RUN_SECS);
+    let start = Instant::now();
+
+    let mut handles = Vec::with_capacity(concurrency);
+    for _ in 0..concurrency {
+        let fluree = Arc::clone(fluree);
+        let ledger_id = ledger_id.to_string();
+        let counter = Arc::clone(&counter);
+        handles.push(tokio::spawn(async move {
+            let mut local = 0u64;
+            while Instant::now() < deadline {
+                let r = fluree
+                    .graph(&ledger_id)
+                    .query()
+                    .sparql(QUERY)
+                    .execute()
+                    .await;
+                if r.is_ok() {
+                    local += 1;
+                }
+            }
+            counter.fetch_add(local, Ordering::Relaxed);
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    counter.load(Ordering::Relaxed) as f64 / elapsed
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+#[ignore = "manual scaling benchmark"]
+async fn scaling_bench() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (fluree, ledger_id) = setup(&tmp.path().to_string_lossy()).await;
+
+    // Sanity: query returns the expected single row.
+    let r = fluree
+        .graph(&ledger_id)
+        .query()
+        .sparql(QUERY)
+        .execute()
+        .await
+        .expect("warm query");
+    eprintln!("sanity rows = {}", r.row_count());
+
+    eprintln!("\n=== concurrency scaling (in-process, {RUN_SECS}s per level) ===");
+    eprintln!("{:>6}  {:>12}  {:>8}", "conc", "QPS", "speedup");
+    let mut base = 0.0f64;
+    for (i, &c) in CONCURRENCIES.iter().enumerate() {
+        let qps = run_concurrency(&fluree, &ledger_id, c).await;
+        if i == 0 {
+            base = qps;
+        }
+        eprintln!("{c:>6}  {qps:>12.0}  {:>7.2}x", qps / base);
+    }
+    eprintln!("=== end ===\n");
+}

--- a/fluree-db-api/tests/it_select_star_novelty_retract.rs
+++ b/fluree-db-api/tests/it_select_star_novelty_retract.rs
@@ -433,12 +433,9 @@ async fn expansion_does_not_drop_overlay_assertions_when_dict_novelty_missing() 
     let bad_dn = Arc::new(fluree_db_core::dict_novelty::DictNovelty::new_uninitialized());
     let runtime_small_dicts = Arc::clone(brp.runtime_small_dicts());
     let ns_fallback = Some(Arc::new(ledger.snapshot.namespaces().clone()));
-    ledger.snapshot.range_provider = Some(Arc::new(fluree_db_query::BinaryRangeProvider::new(
-        store,
-        bad_dn,
-        runtime_small_dicts,
-        ns_fallback,
-    )));
+    Arc::make_mut(&mut ledger.snapshot).range_provider = Some(Arc::new(
+        fluree_db_query::BinaryRangeProvider::new(store, bad_dn, runtime_small_dicts, ns_fallback),
+    ));
 
     // Graph crawl should still return the updated value (correctness over speed).
     let crawl_query = json!({

--- a/fluree-db-ledger/src/lib.rs
+++ b/fluree-db-ledger/src/lib.rs
@@ -79,8 +79,14 @@ pub struct IndexConfig {
 /// - In-memory uncommitted changes (Novelty)
 #[derive(Debug, Clone)]
 pub struct LedgerState {
-    /// The indexed snapshot
-    pub snapshot: LedgerSnapshot,
+    /// The indexed snapshot.
+    ///
+    /// `Arc`-wrapped so cloning a `LedgerState` (and deriving read views /
+    /// query snapshots from it — the per-query hot path) is a cheap refcount
+    /// bump rather than a deep copy of the namespace maps, stats, schema, and
+    /// graph registry. Mutations go through `Arc::make_mut` (copy-on-write),
+    /// which is fine because writers are rare and already serialized.
+    pub snapshot: Arc<LedgerSnapshot>,
     /// In-memory overlay of uncommitted transactions
     pub novelty: Arc<Novelty>,
     /// Dictionary novelty layer for subjects and strings.
@@ -219,7 +225,7 @@ impl LedgerState {
                         .map(|id| novelty_overlay.get_flake(id)),
                 );
                 return Ok(Self {
-                    snapshot,
+                    snapshot: Arc::new(snapshot),
                     novelty: Arc::new(novelty_overlay),
                     dict_novelty: Arc::new(dict_novelty),
                     runtime_small_dicts: Arc::new(runtime_small_dicts),
@@ -236,7 +242,7 @@ impl LedgerState {
         let head_index_id = record.index_head_id.clone();
         let novelty_t = snapshot.t;
         Ok(Self {
-            snapshot,
+            snapshot: Arc::new(snapshot),
             novelty: Arc::new(Novelty::new(novelty_t)),
             dict_novelty: Arc::new(dict_novelty),
             runtime_small_dicts: Arc::new(RuntimeSmallDicts::new()),
@@ -367,7 +373,7 @@ impl LedgerState {
                 .map(|id| novelty.get_flake(id)),
         );
         Self {
-            snapshot,
+            snapshot: Arc::new(snapshot),
             novelty: Arc::new(novelty),
             dict_novelty: Arc::new(dict_novelty),
             runtime_small_dicts: Arc::new(runtime_small_dicts),
@@ -511,7 +517,7 @@ impl LedgerState {
         }
 
         // Update state
-        self.snapshot = new_snapshot;
+        self.snapshot = Arc::new(new_snapshot);
         self.novelty = Arc::new(new_novelty);
         self.dict_novelty = Arc::new(new_dict_novelty);
         self.runtime_small_dicts = Arc::new(new_runtime_small_dicts);
@@ -613,7 +619,7 @@ impl LedgerState {
         }
 
         // Update state
-        self.snapshot = merged_snapshot;
+        self.snapshot = Arc::new(merged_snapshot);
         self.novelty = Arc::new(new_novelty);
         self.dict_novelty = Arc::new(new_dict_novelty);
         self.runtime_small_dicts = Arc::new(new_runtime_small_dicts);
@@ -664,11 +670,11 @@ impl LedgerState {
         // declaring a non-default mode doesn't fail the immutability check
         // when its namespace codes are inserted under the wrong mode.
         if let Some(mode) = commit.ns_split_mode {
-            self.snapshot.set_ns_split_mode(mode, commit_t)?;
+            Arc::make_mut(&mut self.snapshot).set_ns_split_mode(mode, commit_t)?;
         }
 
         // Apply namespace + graph deltas to snapshot
-        self.snapshot
+        Arc::make_mut(&mut self.snapshot)
             .apply_envelope_deltas(&commit.namespace_delta, &graph_iris)?;
 
         // Generate commit metadata flakes
@@ -1452,8 +1458,7 @@ mod tests {
         let mut state = LedgerState::new(snapshot, Novelty::new(0));
 
         // Simulate commit t=1: add namespace code + flake
-        state
-            .snapshot
+        Arc::make_mut(&mut state.snapshot)
             .insert_namespace_code(100, "http://example.org/ns/".to_string())
             .unwrap();
         let reverse_graph = state.snapshot.build_reverse_graph().unwrap_or_default();
@@ -1505,8 +1510,7 @@ mod tests {
 
         // Register a custom graph in the old snapshot (simulating commit t=1)
         let graph_iri = "http://example.org/graph/test";
-        state
-            .snapshot
+        Arc::make_mut(&mut state.snapshot)
             .graph_registry
             .apply_delta(&[graph_iri.to_string()]);
 
@@ -1561,8 +1565,7 @@ mod tests {
         let mut state = LedgerState::new(snapshot, Novelty::new(0));
 
         // Add custom namespace to old snapshot
-        state
-            .snapshot
+        Arc::make_mut(&mut state.snapshot)
             .insert_namespace_code(200, "http://old.example.org/".to_string())
             .unwrap();
 

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -145,6 +145,9 @@ impl AggregateOperator {
 
 #[async_trait]
 impl Operator for AggregateOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/bind.rs
+++ b/fluree-db-query/src/bind.rs
@@ -117,6 +117,9 @@ impl BindOperator {
 
 #[async_trait]
 impl Operator for BindOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/count_rows.rs
+++ b/fluree-db-query/src/count_rows.rs
@@ -53,6 +53,13 @@ impl CountRowsOperator {
 
 #[async_trait]
 impl Operator for CountRowsOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        let mut v = vec![crate::plan_node::PlanChild::child(self.fast_child.as_ref())];
+        if let Some(fb) = self.fallback.as_deref() {
+            v.push(crate::plan_node::PlanChild::fallback(fb));
+        }
+        v
+    }
     fn schema(&self) -> &[VarId] {
         std::slice::from_ref(&self.out_var)
     }

--- a/fluree-db-query/src/dataset_operator.rs
+++ b/fluree-db-query/src/dataset_operator.rs
@@ -56,6 +56,12 @@ pub trait DatasetBuilder: Send + Sync {
 
     /// Output schema. Must be stable across all `build()` calls.
     fn schema(&self) -> &[VarId];
+
+    /// Plan-introspection details for `EXPLAIN` (e.g. predicate, planned index
+    /// hint). Default: none. Scan builders override to expose the access path.
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        serde_json::Map::new()
+    }
 }
 
 // =============================================================================
@@ -110,6 +116,21 @@ impl ScanDatasetBuilder {
 }
 
 impl DatasetBuilder for ScanDatasetBuilder {
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut m = serde_json::Map::new();
+        m.insert(
+            "pattern".into(),
+            crate::explain::format_pattern(&self.pattern).into(),
+        );
+        if let Some(idx) = self.index_hint {
+            m.insert("index-hint".into(), format!("{idx:?}").into());
+        }
+        if self.object_bounds.is_some() {
+            m.insert("object-bounds".into(), true.into());
+        }
+        m
+    }
+
     fn build(&self) -> Result<BoxedOperator> {
         match self.mode {
             TemporalMode::History => Ok(Box::new(
@@ -316,6 +337,10 @@ async fn count_member(op: &mut BoxedOperator, ctx: &ExecutionContext<'_>) -> Res
 impl Operator for DatasetOperator {
     fn schema(&self) -> &[VarId] {
         self.builder.schema()
+    }
+
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        self.builder.plan_details()
     }
 
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {

--- a/fluree-db-query/src/distinct.rs
+++ b/fluree-db-query/src/distinct.rs
@@ -81,6 +81,9 @@ impl DistinctOperator {
 
 #[async_trait]
 impl Operator for DistinctOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1966,32 +1966,41 @@ pub(crate) fn build_scan_or_join(
             // For object→subject "path" joins, build a hash table from the small
             // (left/driving) side and probe a single contiguous scan of the large
             // predicate, instead of the per-driving-row OPST object seek that degrades
-            // superlinearly at scale. The planner owns the shape + cost decision.
-            if let Some(join_var) = hash_planner.choose_object_hash_join(
+            // superlinearly at scale. The planner owns the shape + cost decision; we
+            // compute the annotated decision once, apply `chosen`, and stash it on the
+            // chosen operator so EXPLAIN can report why.
+            let decision = hash_planner.explain_object_hash_join(
                 &left_schema,
                 tp,
                 bounds.is_some(),
                 inline_ops.is_empty(),
-            ) {
-                let index_hint = scan_index_hint_for_triple(tp, group_by, &[]);
-                let probe: BoxedOperator =
-                    Box::new(crate::dataset_operator::DatasetOperator::scan(
-                        tp.clone(),
-                        None,
-                        Vec::new(),
-                        EmitMask::ALL,
-                        index_hint,
-                        planning.mode(),
-                    ));
-                return Box::new(crate::hash_join::HashJoinOperator::new(
-                    left,
-                    probe,
-                    join_var,
-                    downstream_vars,
-                    tp.clone(),
-                    bounds.clone(),
-                    planning.mode(),
-                ));
+            );
+
+            if let Some(d) = decision {
+                if d.chosen {
+                    let index_hint = scan_index_hint_for_triple(tp, group_by, &[]);
+                    let probe: BoxedOperator =
+                        Box::new(crate::dataset_operator::DatasetOperator::scan(
+                            tp.clone(),
+                            None,
+                            Vec::new(),
+                            EmitMask::ALL,
+                            index_hint,
+                            planning.mode(),
+                        ));
+                    return Box::new(
+                        crate::hash_join::HashJoinOperator::new(
+                            left,
+                            probe,
+                            d.join_var,
+                            downstream_vars,
+                            tp.clone(),
+                            bounds.clone(),
+                            planning.mode(),
+                        )
+                        .with_hash_join_decision(d),
+                    );
+                }
             }
 
             Box::new(
@@ -2004,7 +2013,10 @@ pub(crate) fn build_scan_or_join(
                     EmitMask::ALL,
                     planning.mode(),
                 )
-                .with_out_schema(downstream_vars),
+                .with_out_schema(downstream_vars)
+                // A shape-eligible-but-rejected hash join attaches its reason; a
+                // non-candidate (subject chain, bounds, etc.) attaches nothing.
+                .with_hash_join_decision(decision),
             )
         }
     }

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1992,7 +1992,8 @@ pub(crate) fn build_scan_or_join(
                         crate::hash_join::HashJoinOperator::new(
                             left,
                             probe,
-                            d.join_var,
+                            d.join_var
+                                .expect("a chosen object→subject hash join has a join var"),
                             downstream_vars,
                             tp.clone(),
                             bounds.clone(),

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -853,6 +853,8 @@ fn build_single_pattern(
             emit_mask_for_triple(tp, var_counts, protected_vars),
             group_by,
             planning,
+            None,
+            None,
         )),
         _ => operator,
     }
@@ -1049,6 +1051,7 @@ fn build_sequential_join_block(
     group_by: &[VarId],
     distinct_query: bool,
     planning: &PlanningContext,
+    stats: Option<&StatsView>,
 ) -> Result<Option<BoxedOperator>> {
     let mut operator = operator;
 
@@ -1065,7 +1068,17 @@ fn build_sequential_join_block(
     let base_vars: Option<HashSet<VarId>> =
         required_where_vars.map(|rwv| rwv.iter().copied().collect());
 
+    // Running cardinality of the driving (left) chain built so far — the product of
+    // per-triple estimates for triples[0..k] against the live bound set. This is the
+    // hash-join cost model's `driving_est`. The snapshot is taken BEFORE multiplying
+    // in the current `tp`: the probe `tp` has its object bound from the left, so
+    // estimating it would classify as BoundObject and give the wrong number.
+    let mut driving_est: f64 = 1.0;
     for (k, tp) in triples.iter().enumerate() {
+        let driving_est_for_step = stats.map(|_| driving_est);
+        if stats.is_some() {
+            driving_est *= crate::planner::estimate_triple_row_count(tp, &bound, stats);
+        }
         let mut vars_after: HashSet<VarId> = bound.clone();
         for v in tp.produced_vars() {
             vars_after.insert(v);
@@ -1125,6 +1138,8 @@ fn build_sequential_join_block(
             emit,
             group_by,
             planning,
+            stats,
+            driving_est_for_step,
         );
         bound.extend(op.schema().iter().copied());
         operator = Some(op);
@@ -1450,6 +1465,7 @@ pub fn build_where_operators_seeded_with_needed(
                         group_by,
                         distinct_query,
                         planning,
+                        stats.as_deref(),
                     )?;
                     if values_after_triples {
                         built = apply_values(Some(built), block.values)
@@ -1618,6 +1634,7 @@ pub fn build_where_operators_seeded_with_needed(
                         group_by,
                         distinct_query,
                         planning,
+                        stats.as_deref(),
                     )?;
                 }
             }
@@ -1920,6 +1937,77 @@ fn make_first_scan(
     ))
 }
 
+/// Force-override for the cost-based object→subject hash-join decision.
+///
+/// `FLUREE_HASH_JOIN` is a force-override only: unset/other => `Auto` (the cost
+/// model decides), `1`/`true` => `On` (force the hash join whenever the shape
+/// matches, ignoring cost — preserves force-on on stats-less ledgers), `0`/`false`
+/// => `Off` (never hash-join).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HashJoinForce {
+    Auto,
+    On,
+    Off,
+}
+
+pub(crate) fn hash_join_force() -> HashJoinForce {
+    match std::env::var("FLUREE_HASH_JOIN") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => HashJoinForce::On,
+        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => HashJoinForce::Off,
+        _ => HashJoinForce::Auto,
+    }
+}
+
+/// Probe-predicate floor: below this, scattered OPST object seeks stay cheap and
+/// the hash join is a wash (the BSBM crossover is between 55.7k @1M and 560k @10M).
+pub(crate) const HASH_JOIN_PROBE_MIN: u64 = 250_000;
+/// Don't scan a probe predicate more than this many times the driving-set size
+/// (tiny-driving guard; keeps the 100M case at ratio ~46x inside the cap).
+pub(crate) const HASH_JOIN_MAX_SCAN_RATIO: f64 = 64.0;
+
+/// The hash join wins when the probe predicate is large enough that scattered OPST
+/// seeks dominate, but not so large relative to the driving set that the single
+/// contiguous scan is wasteful. `false` when probe stats are absent (=> the safe
+/// `NestedLoopJoinOperator` default). Constants tuned to BSBM 1M/10M/100M; heuristic.
+pub(crate) fn hash_join_cost_wins(probe_count: Option<u64>, driving_est: Option<f64>) -> bool {
+    let Some(pc) = probe_count else { return false };
+    let drive = driving_est.unwrap_or(0.0).max(1.0);
+    pc >= HASH_JOIN_PROBE_MIN && (pc as f64) <= drive * HASH_JOIN_MAX_SCAN_RATIO
+}
+
+/// Eligibility for the object→subject hash join. The right pattern `tp` must be a
+/// single fixed-predicate scan whose OBJECT is the (only) variable shared with the
+/// left side (the join key), whose SUBJECT is a new variable, with no object bounds,
+/// no datatype constraint, and no inline ops. Returns the shared join variable.
+///
+/// This is exactly the shape that `NestedLoopJoinOperator` would otherwise run via
+/// the batched-OBJECT (OPST) path — the slow case the hash join replaces.
+fn hash_join_object_join_var(
+    left_schema: &[VarId],
+    tp: &TriplePattern,
+    has_bounds: bool,
+    inline_ops_empty: bool,
+) -> Option<VarId> {
+    if has_bounds || !inline_ops_empty || tp.dtc.is_some() {
+        return None;
+    }
+    // Predicate must be a fixed SID (so the probe scans one contiguous partition).
+    if !tp.p.is_sid() {
+        return None;
+    }
+    // Object must be a var already bound from the left (the join key).
+    let o_var = tp.o.as_var()?;
+    if !left_schema.contains(&o_var) {
+        return None;
+    }
+    // Subject must be a brand-new var (not shared with the left).
+    let s_var = tp.s.as_var()?;
+    if left_schema.contains(&s_var) {
+        return None;
+    }
+    Some(o_var)
+}
+
 /// Build a single scan or join operator for a triple pattern
 ///
 /// This is the extracted helper that eliminates the duplication between
@@ -1941,6 +2029,8 @@ pub fn build_scan_or_join(
     emit: EmitMask,
     group_by: &[VarId],
     planning: &PlanningContext,
+    stats: Option<&StatsView>,
+    driving_est: Option<f64>,
 ) -> BoxedOperator {
     match left {
         None => make_first_scan(tp, object_bounds, inline_ops, emit, group_by, planning),
@@ -1950,6 +2040,54 @@ pub fn build_scan_or_join(
 
             // Extract object bounds if available for this pattern's object variable
             let bounds = tp.o.as_var().and_then(|v| object_bounds.get(&v).cloned());
+
+            // For object→subject "path" joins, build a hash table from the small
+            // (left/driving) side and probe a single contiguous scan of the large
+            // predicate, instead of the per-driving-row OPST object seek that degrades
+            // superlinearly at scale. A cost model decides; FLUREE_HASH_JOIN is a
+            // force-override only (see hash_join_force).
+            let force = hash_join_force();
+            if force != HashJoinForce::Off {
+                if let Some(join_var) = hash_join_object_join_var(
+                    &left_schema,
+                    tp,
+                    bounds.is_some(),
+                    inline_ops.is_empty(),
+                ) {
+                    let use_hash = match force {
+                        HashJoinForce::On => true,
+                        HashJoinForce::Off => false,
+                        HashJoinForce::Auto => {
+                            let probe_count =
+                                tp.p.as_sid()
+                                    .and_then(|sid| stats.and_then(|s| s.get_property(sid)))
+                                    .map(|p| p.count);
+                            hash_join_cost_wins(probe_count, driving_est)
+                        }
+                    };
+                    if use_hash {
+                        let index_hint = scan_index_hint_for_triple(tp, group_by, &[]);
+                        let probe: BoxedOperator =
+                            Box::new(crate::dataset_operator::DatasetOperator::scan(
+                                tp.clone(),
+                                None,
+                                Vec::new(),
+                                EmitMask::ALL,
+                                index_hint,
+                                planning.mode(),
+                            ));
+                        return Box::new(crate::hash_join::HashJoinOperator::new(
+                            left,
+                            probe,
+                            join_var,
+                            downstream_vars,
+                            tp.clone(),
+                            bounds.clone(),
+                            planning.mode(),
+                        ));
+                    }
+                }
+            }
 
             Box::new(
                 NestedLoopJoinOperator::new(
@@ -2050,6 +2188,7 @@ pub fn build_triple_operators(
     group_by: &[VarId],
     distinct_query: bool,
     planning: &PlanningContext,
+    stats: Option<&StatsView>,
 ) -> Result<BoxedOperator> {
     if triples.is_empty() {
         return existing
@@ -2092,8 +2231,15 @@ pub fn build_triple_operators(
     // Build chain of scan/join operators using the shared helper
     let rwv_set: Option<HashSet<VarId>> = required_where_vars.map(|v| v.iter().copied().collect());
 
+    // Running cardinality of the driving (left) chain — see build_sequential_join_block.
+    // The snapshot is taken against `seen_vars` BEFORE the current pattern is folded in.
     let mut seen_vars: HashSet<VarId> = HashSet::new();
+    let mut driving_est: f64 = 1.0;
     for (k, pattern) in triples_for_exec.iter().enumerate() {
+        let driving_est_for_step = stats.map(|_| driving_est);
+        if stats.is_some() {
+            driving_est *= crate::planner::estimate_triple_row_count(pattern, &seen_vars, stats);
+        }
         seen_vars.extend(pattern.produced_vars());
         // Compute live vars: required_where_vars ∪ vars from subsequent triples
         let live_vars = rwv_set.as_ref().map(|base| {
@@ -2114,6 +2260,8 @@ pub fn build_triple_operators(
             emit,
             group_by,
             planning,
+            stats,
+            driving_est_for_step,
         ));
 
         // DISTINCT query optimization: if any variables seen so far are no longer live,
@@ -2198,6 +2346,7 @@ mod tests {
             &[],
             false,
             &crate::temporal_mode::PlanningContext::current(),
+            None,
         )
     }
 
@@ -2605,6 +2754,8 @@ mod tests {
             EmitMask::ALL,
             &[],
             &crate::temporal_mode::PlanningContext::current(),
+            None,
+            None,
         );
 
         assert_eq!(op.schema(), &[VarId(0), VarId(1)]);
@@ -2625,6 +2776,8 @@ mod tests {
             EmitMask::ALL,
             &[],
             &crate::temporal_mode::PlanningContext::current(),
+            None,
+            None,
         );
         let second = build_scan_or_join(
             Some(first),
@@ -2635,6 +2788,8 @@ mod tests {
             EmitMask::ALL,
             &[],
             &crate::temporal_mode::PlanningContext::current(),
+            None,
+            None,
         );
 
         // Schema should include all vars from both patterns

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -17,6 +17,7 @@ use crate::error::{QueryError, Result};
 use crate::eval::PreparedBoolExpression;
 use crate::exists::ExistsOperator;
 use crate::filter::{contains_exists, FilterOperator};
+use crate::hash_join::HashJoinPlanner;
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::{Expression, Pattern};
 use crate::join::NestedLoopJoinOperator;
@@ -853,8 +854,8 @@ fn build_single_pattern(
             emit_mask_for_triple(tp, var_counts, protected_vars),
             group_by,
             planning,
-            None,
-            None,
+            // No chain context here: only a force-`On` override can fire the hash join.
+            &HashJoinPlanner::new(None),
         )),
         _ => operator,
     }
@@ -1068,17 +1069,11 @@ fn build_sequential_join_block(
     let base_vars: Option<HashSet<VarId>> =
         required_where_vars.map(|rwv| rwv.iter().copied().collect());
 
-    // Running cardinality of the driving (left) chain built so far — the product of
-    // per-triple estimates for triples[0..k] against the live bound set. This is the
-    // hash-join cost model's `driving_est`. The snapshot is taken BEFORE multiplying
-    // in the current `tp`: the probe `tp` has its object bound from the left, so
-    // estimating it would classify as BoundObject and give the wrong number.
-    let mut driving_est: f64 = 1.0;
+    // Tracks the running driving-chain cardinality across steps for the hash-join
+    // cost model; `before_step` snapshots it against the live `bound` set per pattern.
+    let mut hash_planner = HashJoinPlanner::new(stats);
     for (k, tp) in triples.iter().enumerate() {
-        let driving_est_for_step = stats.map(|_| driving_est);
-        if stats.is_some() {
-            driving_est *= crate::planner::estimate_triple_row_count(tp, &bound, stats);
-        }
+        hash_planner.before_step(tp, &bound);
         let mut vars_after: HashSet<VarId> = bound.clone();
         for v in tp.produced_vars() {
             vars_after.insert(v);
@@ -1138,8 +1133,7 @@ fn build_sequential_join_block(
             emit,
             group_by,
             planning,
-            stats,
-            driving_est_for_step,
+            &hash_planner,
         );
         bound.extend(op.schema().iter().copied());
         operator = Some(op);
@@ -1937,77 +1931,6 @@ fn make_first_scan(
     ))
 }
 
-/// Force-override for the cost-based object→subject hash-join decision.
-///
-/// `FLUREE_HASH_JOIN` is a force-override only: unset/other => `Auto` (the cost
-/// model decides), `1`/`true` => `On` (force the hash join whenever the shape
-/// matches, ignoring cost — preserves force-on on stats-less ledgers), `0`/`false`
-/// => `Off` (never hash-join).
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum HashJoinForce {
-    Auto,
-    On,
-    Off,
-}
-
-pub(crate) fn hash_join_force() -> HashJoinForce {
-    match std::env::var("FLUREE_HASH_JOIN") {
-        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => HashJoinForce::On,
-        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => HashJoinForce::Off,
-        _ => HashJoinForce::Auto,
-    }
-}
-
-/// Probe-predicate floor: below this, scattered OPST object seeks stay cheap and
-/// the hash join is a wash (the BSBM crossover is between 55.7k @1M and 560k @10M).
-pub(crate) const HASH_JOIN_PROBE_MIN: u64 = 250_000;
-/// Don't scan a probe predicate more than this many times the driving-set size
-/// (tiny-driving guard; keeps the 100M case at ratio ~46x inside the cap).
-pub(crate) const HASH_JOIN_MAX_SCAN_RATIO: f64 = 64.0;
-
-/// The hash join wins when the probe predicate is large enough that scattered OPST
-/// seeks dominate, but not so large relative to the driving set that the single
-/// contiguous scan is wasteful. `false` when probe stats are absent (=> the safe
-/// `NestedLoopJoinOperator` default). Constants tuned to BSBM 1M/10M/100M; heuristic.
-pub(crate) fn hash_join_cost_wins(probe_count: Option<u64>, driving_est: Option<f64>) -> bool {
-    let Some(pc) = probe_count else { return false };
-    let drive = driving_est.unwrap_or(0.0).max(1.0);
-    pc >= HASH_JOIN_PROBE_MIN && (pc as f64) <= drive * HASH_JOIN_MAX_SCAN_RATIO
-}
-
-/// Eligibility for the object→subject hash join. The right pattern `tp` must be a
-/// single fixed-predicate scan whose OBJECT is the (only) variable shared with the
-/// left side (the join key), whose SUBJECT is a new variable, with no object bounds,
-/// no datatype constraint, and no inline ops. Returns the shared join variable.
-///
-/// This is exactly the shape that `NestedLoopJoinOperator` would otherwise run via
-/// the batched-OBJECT (OPST) path — the slow case the hash join replaces.
-fn hash_join_object_join_var(
-    left_schema: &[VarId],
-    tp: &TriplePattern,
-    has_bounds: bool,
-    inline_ops_empty: bool,
-) -> Option<VarId> {
-    if has_bounds || !inline_ops_empty || tp.dtc.is_some() {
-        return None;
-    }
-    // Predicate must be a fixed SID (so the probe scans one contiguous partition).
-    if !tp.p.is_sid() {
-        return None;
-    }
-    // Object must be a var already bound from the left (the join key).
-    let o_var = tp.o.as_var()?;
-    if !left_schema.contains(&o_var) {
-        return None;
-    }
-    // Subject must be a brand-new var (not shared with the left).
-    let s_var = tp.s.as_var()?;
-    if left_schema.contains(&s_var) {
-        return None;
-    }
-    Some(o_var)
-}
-
 /// Build a single scan or join operator for a triple pattern
 ///
 /// This is the extracted helper that eliminates the duplication between
@@ -2020,7 +1943,7 @@ fn hash_join_object_join_var(
 /// The `inline_ops` are evaluated inline on the operator: baked into the scan
 /// for the first pattern, or evaluated per combined row in `NestedLoopJoinOperator` for joins.
 #[allow(clippy::too_many_arguments)]
-pub fn build_scan_or_join(
+pub(crate) fn build_scan_or_join(
     left: Option<BoxedOperator>,
     tp: &TriplePattern,
     object_bounds: &HashMap<VarId, ObjectBounds>,
@@ -2029,8 +1952,7 @@ pub fn build_scan_or_join(
     emit: EmitMask,
     group_by: &[VarId],
     planning: &PlanningContext,
-    stats: Option<&StatsView>,
-    driving_est: Option<f64>,
+    hash_planner: &HashJoinPlanner,
 ) -> BoxedOperator {
     match left {
         None => make_first_scan(tp, object_bounds, inline_ops, emit, group_by, planning),
@@ -2044,49 +1966,32 @@ pub fn build_scan_or_join(
             // For object→subject "path" joins, build a hash table from the small
             // (left/driving) side and probe a single contiguous scan of the large
             // predicate, instead of the per-driving-row OPST object seek that degrades
-            // superlinearly at scale. A cost model decides; FLUREE_HASH_JOIN is a
-            // force-override only (see hash_join_force).
-            let force = hash_join_force();
-            if force != HashJoinForce::Off {
-                if let Some(join_var) = hash_join_object_join_var(
-                    &left_schema,
-                    tp,
-                    bounds.is_some(),
-                    inline_ops.is_empty(),
-                ) {
-                    let use_hash = match force {
-                        HashJoinForce::On => true,
-                        HashJoinForce::Off => false,
-                        HashJoinForce::Auto => {
-                            let probe_count =
-                                tp.p.as_sid()
-                                    .and_then(|sid| stats.and_then(|s| s.get_property(sid)))
-                                    .map(|p| p.count);
-                            hash_join_cost_wins(probe_count, driving_est)
-                        }
-                    };
-                    if use_hash {
-                        let index_hint = scan_index_hint_for_triple(tp, group_by, &[]);
-                        let probe: BoxedOperator =
-                            Box::new(crate::dataset_operator::DatasetOperator::scan(
-                                tp.clone(),
-                                None,
-                                Vec::new(),
-                                EmitMask::ALL,
-                                index_hint,
-                                planning.mode(),
-                            ));
-                        return Box::new(crate::hash_join::HashJoinOperator::new(
-                            left,
-                            probe,
-                            join_var,
-                            downstream_vars,
-                            tp.clone(),
-                            bounds.clone(),
-                            planning.mode(),
-                        ));
-                    }
-                }
+            // superlinearly at scale. The planner owns the shape + cost decision.
+            if let Some(join_var) = hash_planner.choose_object_hash_join(
+                &left_schema,
+                tp,
+                bounds.is_some(),
+                inline_ops.is_empty(),
+            ) {
+                let index_hint = scan_index_hint_for_triple(tp, group_by, &[]);
+                let probe: BoxedOperator =
+                    Box::new(crate::dataset_operator::DatasetOperator::scan(
+                        tp.clone(),
+                        None,
+                        Vec::new(),
+                        EmitMask::ALL,
+                        index_hint,
+                        planning.mode(),
+                    ));
+                return Box::new(crate::hash_join::HashJoinOperator::new(
+                    left,
+                    probe,
+                    join_var,
+                    downstream_vars,
+                    tp.clone(),
+                    bounds.clone(),
+                    planning.mode(),
+                ));
             }
 
             Box::new(
@@ -2231,15 +2136,12 @@ pub fn build_triple_operators(
     // Build chain of scan/join operators using the shared helper
     let rwv_set: Option<HashSet<VarId>> = required_where_vars.map(|v| v.iter().copied().collect());
 
-    // Running cardinality of the driving (left) chain — see build_sequential_join_block.
-    // The snapshot is taken against `seen_vars` BEFORE the current pattern is folded in.
+    // Drives the hash-join cost model; snapshots cardinality against `seen_vars`
+    // (the chain bound so far) before each pattern — see build_sequential_join_block.
     let mut seen_vars: HashSet<VarId> = HashSet::new();
-    let mut driving_est: f64 = 1.0;
+    let mut hash_planner = HashJoinPlanner::new(stats);
     for (k, pattern) in triples_for_exec.iter().enumerate() {
-        let driving_est_for_step = stats.map(|_| driving_est);
-        if stats.is_some() {
-            driving_est *= crate::planner::estimate_triple_row_count(pattern, &seen_vars, stats);
-        }
+        hash_planner.before_step(pattern, &seen_vars);
         seen_vars.extend(pattern.produced_vars());
         // Compute live vars: required_where_vars ∪ vars from subsequent triples
         let live_vars = rwv_set.as_ref().map(|base| {
@@ -2260,8 +2162,7 @@ pub fn build_triple_operators(
             emit,
             group_by,
             planning,
-            stats,
-            driving_est_for_step,
+            &hash_planner,
         ));
 
         // DISTINCT query optimization: if any variables seen so far are no longer live,
@@ -2754,8 +2655,7 @@ mod tests {
             EmitMask::ALL,
             &[],
             &crate::temporal_mode::PlanningContext::current(),
-            None,
-            None,
+            &HashJoinPlanner::new(None),
         );
 
         assert_eq!(op.schema(), &[VarId(0), VarId(1)]);
@@ -2776,8 +2676,7 @@ mod tests {
             EmitMask::ALL,
             &[],
             &crate::temporal_mode::PlanningContext::current(),
-            None,
-            None,
+            &HashJoinPlanner::new(None),
         );
         let second = build_scan_or_join(
             Some(first),
@@ -2788,8 +2687,7 @@ mod tests {
             EmitMask::ALL,
             &[],
             &crate::temporal_mode::PlanningContext::current(),
-            None,
-            None,
+            &HashJoinPlanner::new(None),
         );
 
         // Schema should include all vars from both patterns

--- a/fluree-db-query/src/exists.rs
+++ b/fluree-db-query/src/exists.rs
@@ -142,6 +142,9 @@ impl ExistsOperator {
 
 #[async_trait]
 impl Operator for ExistsOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/explain.rs
+++ b/fluree-db-query/src/explain.rs
@@ -112,8 +112,22 @@ pub fn explain_patterns(patterns: &[TriplePattern], stats: Option<&StatsView>) -
         .map(|p| build_pattern_display(p, stats))
         .collect();
 
-    // Reorder patterns using the same algorithm as planner
-    let optimized = reorder_for_explain(patterns.to_vec(), stats);
+    // Reorder using the SAME planner the executor uses, so the explained order
+    // matches execution. Triples are wrapped as `Pattern::Triple`, reordered via
+    // `planner::reorder_patterns`, then unwrapped — no separate explain-only
+    // ordering algorithm that could drift.
+    let optimized: Vec<TriplePattern> = if patterns.len() <= 1 {
+        patterns.to_vec()
+    } else {
+        let wrapped: Vec<Pattern> = patterns.iter().cloned().map(Pattern::Triple).collect();
+        reorder_patterns(&wrapped, stats, &HashSet::new())
+            .into_iter()
+            .filter_map(|p| match p {
+                Pattern::Triple(tp) => Some(tp),
+                _ => None,
+            })
+            .collect()
+    };
     let optimized_patterns: Vec<PatternDisplay> = optimized
         .iter()
         .map(|p| build_pattern_display(p, stats))
@@ -333,87 +347,6 @@ fn format_term(term: &Term) -> String {
         Term::Iri(iri) => format!("<{iri}>"),
         Term::Value(val) => format!("{val:?}"),
     }
-}
-
-/// Reorder patterns for explain (reuses planner's algorithm via shared helpers)
-fn reorder_for_explain(
-    patterns: Vec<TriplePattern>,
-    stats: Option<&StatsView>,
-) -> Vec<TriplePattern> {
-    if patterns.len() <= 1 {
-        return patterns;
-    }
-
-    // If *all* patterns are using fallback scoring (no relevant stats),
-    // don't reorder (optimization would be arbitrary/noisy).
-    let all_fallback = patterns.iter().all(|p| {
-        let ty = classify_pattern(p, &HashSet::new());
-        let inputs = capture_selectivity_inputs(p, ty, stats);
-        inputs.fallback.is_some()
-    });
-    if all_fallback {
-        return patterns;
-    }
-
-    // If all patterns have identical selectivity, don't reorder (no benefit).
-    let mut first_score: Option<i64> = None;
-    let mut all_equal = true;
-    for p in &patterns {
-        let s = estimate_triple_row_count(p, &HashSet::new(), stats) as i64;
-        match first_score {
-            None => first_score = Some(s),
-            Some(fs) if fs == s => {}
-            Some(_) => all_equal = false,
-        }
-    }
-    if all_equal {
-        return patterns;
-    }
-
-    let mut remaining: Vec<_> = patterns.into_iter().collect();
-    let mut ordered = Vec::with_capacity(remaining.len());
-    let mut bound_vars: HashSet<VarId> = HashSet::new();
-
-    while !remaining.is_empty() {
-        let has_bound = !bound_vars.is_empty();
-        let candidates: Vec<usize> = remaining
-            .iter()
-            .enumerate()
-            .filter(|(_, p)| {
-                if !has_bound {
-                    true
-                } else {
-                    p.produced_vars().iter().any(|v| bound_vars.contains(v))
-                }
-            })
-            .map(|(i, _)| i)
-            .collect();
-
-        let pool: Vec<usize> = if candidates.is_empty() {
-            (0..remaining.len()).collect()
-        } else {
-            candidates
-        };
-
-        let best_idx = pool
-            .into_iter()
-            .min_by(|&i, &j| {
-                let score_i =
-                    estimate_triple_row_count(&remaining[i], &HashSet::new(), stats) as i64;
-                let score_j =
-                    estimate_triple_row_count(&remaining[j], &HashSet::new(), stats) as i64;
-                score_i.cmp(&score_j).then_with(|| i.cmp(&j))
-            })
-            .unwrap();
-
-        let chosen = remaining.remove(best_idx);
-        for var in chosen.produced_vars() {
-            bound_vars.insert(var);
-        }
-        ordered.push(chosen);
-    }
-
-    ordered
 }
 
 impl fmt::Display for ExplainPlan {
@@ -756,18 +689,20 @@ mod tests {
 
     #[test]
     fn test_explain_reordering() {
-        // Pattern with higher selectivity should be reordered to come first
-        // p1: ?s :name ?name (PropertyScan, score=1000)
-        // p2: ex:person1 :age ?age (BoundSubject, score=10)
+        // The more selective pattern is reordered to come first.
+        // p1: ?s :name ?name (PropertyScan, fallback score=1000)
+        // p2: ex:person1 :age ?age (BoundSubject, fallback score=10)
         let p1 = make_pattern(VarId(0), "name", VarId(1));
         let p2 = make_bound_subject_pattern(Sid::new(50, "person1"), "age", VarId(2));
 
         let patterns = vec![p1, p2];
         let explain = explain_patterns(&patterns, None);
 
-        // When *all* patterns are using fallback scoring (no relevant stats),
-        // we don't reorder to avoid noisy/unstable explain output.
-        assert_eq!(explain.optimization, OptimizationStatus::Unchanged);
+        // Explain now delegates to the real planner (`planner::reorder_patterns`),
+        // which orders by estimated cardinality even without stats — the cheaper
+        // BoundSubject pattern is placed ahead of the broad property scan.
+        assert_eq!(explain.optimization, OptimizationStatus::Reordered);
+        assert!(explain.optimized_patterns[0].pattern.contains("age"));
     }
 
     #[test]

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -158,6 +158,12 @@ impl PredicateGroupCountFirstsOperator {
 
 #[async_trait]
 impl Operator for PredicateGroupCountFirstsOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        self.fallback
+            .as_deref()
+            .map(|fb| vec![crate::plan_node::PlanChild::fallback(fb)])
+            .unwrap_or_default()
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }
@@ -397,6 +403,12 @@ impl PredicateObjectCountFirstsOperator {
 
 #[async_trait]
 impl Operator for PredicateObjectCountFirstsOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        self.fallback
+            .as_deref()
+            .map(|fb| vec![crate::plan_node::PlanChild::fallback(fb)])
+            .unwrap_or_default()
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }
@@ -1126,6 +1138,12 @@ impl GroupByObjectStarTopKOperator {
 
 #[async_trait]
 impl Operator for GroupByObjectStarTopKOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        self.fallback
+            .as_deref()
+            .map(|fb| vec![crate::plan_node::PlanChild::fallback(fb)])
+            .unwrap_or_default()
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -2763,6 +2763,15 @@ impl FastPathOperator {
 
 #[async_trait]
 impl Operator for FastPathOperator {
+    fn op_name(&self) -> String {
+        format!("FastPath:{}", self.label)
+    }
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        self.fallback
+            .as_deref()
+            .map(|fb| vec![crate::plan_node::PlanChild::fallback(fb)])
+            .unwrap_or_default()
+    }
     fn schema(&self) -> &[VarId] {
         match &self.schema {
             FastPathSchema::Single(v) => std::slice::from_ref(v),

--- a/fluree-db-query/src/fast_union_star_count_all.rs
+++ b/fluree-db-query/src/fast_union_star_count_all.rs
@@ -85,6 +85,12 @@ impl UnionStarCountAllOperator {
 
 #[async_trait]
 impl Operator for UnionStarCountAllOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        self.fallback
+            .as_deref()
+            .map(|fb| vec![crate::plan_node::PlanChild::fallback(fb)])
+            .unwrap_or_default()
+    }
     fn schema(&self) -> &[VarId] {
         std::slice::from_ref(&self.out_var)
     }

--- a/fluree-db-query/src/filter.rs
+++ b/fluree-db-query/src/filter.rs
@@ -531,6 +531,9 @@ impl FilterOperator {
 
 #[async_trait]
 impl Operator for FilterOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/geo_search.rs
+++ b/fluree-db-query/src/geo_search.rs
@@ -319,6 +319,9 @@ impl GeoSearchOperator {
 
 #[async_trait]
 impl Operator for GeoSearchOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -307,6 +307,9 @@ impl GraphOperator {
 
 #[async_trait]
 impl Operator for GraphOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/group_aggregate.rs
+++ b/fluree-db-query/src/group_aggregate.rs
@@ -642,6 +642,9 @@ impl GroupAggregateOperator {
 
 #[async_trait]
 impl Operator for GroupAggregateOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/groupby.rs
+++ b/fluree-db-query/src/groupby.rs
@@ -154,6 +154,9 @@ impl GroupByOperator {
 
 #[async_trait]
 impl Operator for GroupByOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -408,34 +408,42 @@ enum JoinKey {
     Other(GroupKeyOwned),
 }
 
-/// Build a comparable join key for a binding, normalising refs to a `u64` s_id when
-/// a store is available. Returns `None` for Unbound/Poisoned (cannot participate in
-/// an inner join).
-fn join_key(binding: &Binding, store: Option<&BinaryIndexStore>) -> Option<JoinKey> {
+/// How a binding's join-var value participates in the join.
+enum JoinKeyClass {
+    /// A comparable key — matches probe rows carrying the same value.
+    Keyed(JoinKey),
+    /// Unbound join var: unconstrained from the left, so it matches EVERY probe row
+    /// (the right side fills it — the nested-loop "take the right value" semantics).
+    Wildcard,
+    /// Poisoned join var: a failed OPTIONAL/required binding *blocks* matching (see
+    /// `optional.rs` — Poisoned yields no matches, not "match anything"), so the row
+    /// produces no output and is dropped. Collapsing this into `Wildcard` would fan a
+    /// failed OPTIONAL out to every probe row instead of producing no match.
+    Dead,
+}
+
+/// Classify a binding's join key, normalising refs to a `u64` s_id when a store is
+/// available. Unbound → wildcard; Poisoned → dead (drop); everything else → keyed.
+fn join_key(binding: &Binding, store: Option<&BinaryIndexStore>) -> JoinKeyClass {
+    let keyed_ref_or_group = |sid: &fluree_db_core::Sid| {
+        store
+            .and_then(|s| {
+                s.find_subject_id_by_parts(sid.namespace_code, &sid.name)
+                    .ok()
+                    .flatten()
+            })
+            .map(JoinKey::Ref)
+            .unwrap_or_else(|| JoinKey::Other(binding_to_group_key_owned(binding)))
+    };
     match binding {
-        Binding::EncodedSid { s_id, .. } => Some(JoinKey::Ref(*s_id)),
-        Binding::Sid { sid, .. } => Some(
-            store
-                .and_then(|s| {
-                    s.find_subject_id_by_parts(sid.namespace_code, &sid.name)
-                        .ok()
-                        .flatten()
-                })
-                .map(JoinKey::Ref)
-                .unwrap_or_else(|| JoinKey::Other(binding_to_group_key_owned(binding))),
-        ),
-        Binding::IriMatch { primary_sid, .. } => Some(
-            store
-                .and_then(|s| {
-                    s.find_subject_id_by_parts(primary_sid.namespace_code, &primary_sid.name)
-                        .ok()
-                        .flatten()
-                })
-                .map(JoinKey::Ref)
-                .unwrap_or_else(|| JoinKey::Other(binding_to_group_key_owned(binding))),
-        ),
-        Binding::Unbound | Binding::Poisoned => None,
-        other => Some(JoinKey::Other(binding_to_group_key_owned(other))),
+        Binding::EncodedSid { s_id, .. } => JoinKeyClass::Keyed(JoinKey::Ref(*s_id)),
+        Binding::Sid { sid, .. } => JoinKeyClass::Keyed(keyed_ref_or_group(sid)),
+        Binding::IriMatch { primary_sid, .. } => {
+            JoinKeyClass::Keyed(keyed_ref_or_group(primary_sid))
+        }
+        Binding::Unbound => JoinKeyClass::Wildcard,
+        Binding::Poisoned => JoinKeyClass::Dead,
+        other => JoinKeyClass::Keyed(JoinKey::Other(binding_to_group_key_owned(other))),
     }
 }
 
@@ -571,9 +579,11 @@ impl HashJoinOperator {
                     .map(|c| batch.get_by_col(row, c).clone())
                     .collect();
                 match join_key(batch.get_by_col(row, self.build_key_col), store) {
-                    Some(key) => self.table.entry(key).or_default().push(row_vals),
-                    // Unbound/Poisoned join var: unconstrained, matches every probe row.
-                    None => self.wildcard_rows.push(row_vals),
+                    JoinKeyClass::Keyed(key) => self.table.entry(key).or_default().push(row_vals),
+                    // Unbound join var: unconstrained, matches every probe row.
+                    JoinKeyClass::Wildcard => self.wildcard_rows.push(row_vals),
+                    // Poisoned join var: blocks matching — drop the row (no output).
+                    JoinKeyClass::Dead => {}
                 }
             }
         }
@@ -683,7 +693,11 @@ impl Operator for HashJoinOperator {
                 let row = self.cur_probe_row;
                 self.cur_probe_row += 1;
 
-                let Some(key) = join_key(pb.get_by_col(row, self.probe_key_col), store) else {
+                // The probe scan always binds the join var, so a non-keyed probe row
+                // (unbound/poisoned) cannot match — skip it.
+                let JoinKeyClass::Keyed(key) =
+                    join_key(pb.get_by_col(row, self.probe_key_col), store)
+                else {
                     continue;
                 };
                 if let Some(matches) = self.table.get(&key) {
@@ -764,7 +778,8 @@ impl Operator for HashJoinOperator {
             match probe.next_batch(ctx).await? {
                 Some(batch) if !batch.is_empty() => {
                     for row in 0..batch.len() {
-                        let Some(key) = join_key(batch.get_by_col(row, self.probe_key_col), store)
+                        let JoinKeyClass::Keyed(key) =
+                            join_key(batch.get_by_col(row, self.probe_key_col), store)
                         else {
                             continue;
                         };
@@ -800,6 +815,122 @@ mod tests {
     use super::*;
     use crate::ir::triple::{Ref, Term};
     use fluree_db_core::{PropertyStatData, Sid};
+
+    #[test]
+    fn join_key_class_unbound_wildcard_poisoned_dead() {
+        // Unbound => matches every probe row; Poisoned => blocks matching (drop).
+        // Collapsing both to one class is the bug this guards against.
+        assert!(matches!(
+            join_key(&Binding::Unbound, None),
+            JoinKeyClass::Wildcard
+        ));
+        assert!(matches!(
+            join_key(&Binding::Poisoned, None),
+            JoinKeyClass::Dead
+        ));
+        assert!(matches!(
+            join_key(
+                &Binding::lit(fluree_db_core::FlakeValue::Long(1), Sid::new(2, "long")),
+                None
+            ),
+            JoinKeyClass::Keyed(_)
+        ));
+    }
+
+    /// Emits one fixed batch then EOF — a stand-in build/probe input.
+    struct OnceOp {
+        schema: Arc<[VarId]>,
+        batch: Option<Batch>,
+    }
+
+    #[async_trait]
+    impl Operator for OnceOp {
+        fn schema(&self) -> &[VarId] {
+            &self.schema
+        }
+        async fn open(&mut self, _: &ExecutionContext<'_>) -> Result<()> {
+            Ok(())
+        }
+        async fn next_batch(&mut self, _: &ExecutionContext<'_>) -> Result<Option<Batch>> {
+            Ok(self.batch.take())
+        }
+        fn close(&mut self) {}
+    }
+
+    #[tokio::test]
+    async fn poisoned_build_key_blocks_matching_not_wildcard() {
+        // BSBM/SKOS shape: OPTIONAL { ... ?x } . ?s :p ?x — a failed OPTIONAL leaves
+        // ?x Poisoned on the driving side. The object→subject hash join must produce
+        // NO match for that row (Poisoned blocks), not fan it out to every probe row.
+        use crate::context::ExecutionContext;
+        use crate::var_registry::VarRegistry;
+        use fluree_db_core::{FlakeValue, LedgerSnapshot};
+
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let mut vars = VarRegistry::new();
+        let x = vars.get_or_insert("?x"); // join var (bound object)
+        let driver = vars.get_or_insert("?driver");
+        let s = vars.get_or_insert("?s");
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+
+        let key = || Binding::lit(FlakeValue::Long(1), Sid::new(2, "long"));
+        let d_ok = Binding::lit(FlakeValue::Long(10), Sid::new(2, "long"));
+        let d_poisoned = Binding::lit(FlakeValue::Long(20), Sid::new(2, "long"));
+
+        // Build (driving) side, columns [?x, ?driver]: row0 has a POISONED ?x, row1 keyed.
+        let build_schema: Arc<[VarId]> = Arc::from(vec![x, driver].into_boxed_slice());
+        let build_batch = Batch::new(
+            build_schema.clone(),
+            vec![
+                vec![Binding::Poisoned, key()], // ?x column
+                vec![d_poisoned, d_ok],         // ?driver column
+            ],
+        )
+        .unwrap();
+
+        // Probe side, columns [?x, ?s]: two rows, both ?x = key.
+        let probe_schema: Arc<[VarId]> = Arc::from(vec![x, s].into_boxed_slice());
+        let probe_batch = Batch::new(
+            probe_schema.clone(),
+            vec![
+                vec![key(), key()], // ?x column
+                vec![
+                    Binding::lit(FlakeValue::Long(100), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(200), Sid::new(2, "long")),
+                ], // ?s column
+            ],
+        )
+        .unwrap();
+
+        let right_pattern =
+            TriplePattern::new(Ref::Var(s), Ref::Sid(Sid::new(1, "p")), Term::Var(x));
+        let mut hj = HashJoinOperator::new(
+            Box::new(OnceOp {
+                schema: build_schema,
+                batch: Some(build_batch),
+            }),
+            Box::new(OnceOp {
+                schema: probe_schema,
+                batch: Some(probe_batch),
+            }),
+            x,
+            None,
+            right_pattern,
+            None,
+            crate::temporal_mode::PlanningContext::current().mode(),
+        );
+        hj.open(&ctx).await.unwrap();
+        let mut rows = 0;
+        while let Some(b) = hj.next_batch(&ctx).await.unwrap() {
+            rows += b.len();
+        }
+        // Only the keyed build row joins (× 2 probe rows). The Poisoned row is dropped;
+        // the old wildcard behaviour would have produced 4 rows.
+        assert_eq!(
+            rows, 2,
+            "Poisoned build row must not fan out to every probe row"
+        );
+    }
 
     #[test]
     fn explains_subject_driven_forward_join() {

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -125,6 +125,19 @@ fn hash_join_cost_wins(probe_count: Option<u64>, driving_est: Option<f64>) -> bo
     pc >= HASH_JOIN_PROBE_MIN && (pc as f64) <= drive * HASH_JOIN_MAX_SCAN_RATIO
 }
 
+/// Probe-predicate row count from stats, keyed by SID or — for the un-encoded IRI
+/// predicates that non-reasoning queries carry — by IRI. Mirrors the planner's
+/// `property_stats` fallback so the cost model sees the same numbers reorder did.
+fn predicate_count(stats: &StatsView, pred: &crate::ir::triple::Ref) -> Option<u64> {
+    if let Some(sid) = pred.as_sid() {
+        return stats.get_property(sid).map(|p| p.count);
+    }
+    if let Some(iri) = pred.as_iri() {
+        return stats.get_property_by_iri(iri).map(|p| p.count);
+    }
+    None
+}
+
 /// Eligibility for the object→subject hash join. The right pattern `tp` must be a
 /// single fixed-predicate scan whose OBJECT is the (only) variable shared with the
 /// left side (the join key), whose SUBJECT is a new variable, with no object bounds,
@@ -141,8 +154,11 @@ fn hash_join_object_join_var(
     if has_bounds || !inline_ops_empty || tp.dtc.is_some() {
         return None;
     }
-    // Predicate must be a fixed SID (so the probe scans one contiguous partition).
-    if !tp.p.is_sid() {
+    // Predicate must be fixed — a SID or an IRI — so the probe scans one contiguous
+    // partition. Non-reasoning SPARQL/JSON-LD queries reach planning with IRI
+    // predicates (only reasoning queries are pre-encoded to SIDs in runner.rs), so a
+    // SID-only check here silently excluded the exact BSBM joins this operator targets.
+    if tp.p.as_var().is_some() {
         return None;
     }
     // Object must be a var already bound from the left (the join key).
@@ -220,10 +236,7 @@ impl<'a> HashJoinPlanner<'a> {
             HashJoinForce::On => true,
             HashJoinForce::Off => false,
             HashJoinForce::Auto => {
-                let probe_count =
-                    tp.p.as_sid()
-                        .and_then(|sid| self.stats.and_then(|s| s.get_property(sid)))
-                        .map(|p| p.count);
+                let probe_count = self.stats.and_then(|s| predicate_count(s, &tp.p));
                 hash_join_cost_wins(probe_count, self.step_est)
             }
         };
@@ -601,6 +614,36 @@ impl Operator for HashJoinOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::triple::{Ref, Term};
+
+    #[test]
+    fn iri_predicate_is_eligible_like_a_sid() {
+        // Non-reasoning SPARQL keeps predicates as IRIs (not pre-encoded to SIDs).
+        // The probe `?review <rev:reviewer> ?reviewer` with ?reviewer bound from the
+        // left must be eligible — a SID-only check here was why the BSBM BI-1 join
+        // never reached the cost gate.
+        let review = VarId(0);
+        let reviewer = VarId(1);
+        let left_schema = [reviewer];
+        let iri_tp = TriplePattern::new(
+            Ref::Var(review),
+            Ref::Iri(Arc::from("http://purl.org/stuff/rev#reviewer")),
+            Term::Var(reviewer),
+        );
+        assert_eq!(
+            hash_join_object_join_var(&left_schema, &iri_tp, false, true),
+            Some(reviewer),
+            "IRI-predicate probe must be eligible for the object→subject hash join"
+        );
+
+        // A variable predicate is still rejected (can't scan one contiguous partition).
+        let var_pred_tp =
+            TriplePattern::new(Ref::Var(review), Ref::Var(VarId(2)), Term::Var(reviewer));
+        assert_eq!(
+            hash_join_object_join_var(&left_schema, &var_pred_tp, false, true),
+            None
+        );
+    }
 
     #[test]
     fn cost_gate_fires_for_skewed_bound_object_bi1() {

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -142,6 +142,10 @@ pub(crate) enum HashJoinReason {
     ScanRatioTooHigh,
     /// No probe-predicate stats, so the cost model can't justify the hash join.
     NoProbeStats,
+    /// The subject (not the object) is bound from the left, so this is a forward
+    /// join the object→subject hash can't replace. Reordering to drive the other
+    /// end is what helps (the BSBM-BI bowtie case).
+    SubjectDriven,
 }
 
 impl HashJoinReason {
@@ -153,6 +157,7 @@ impl HashJoinReason {
             HashJoinReason::ProbeTooSmall => "probe-too-small",
             HashJoinReason::ScanRatioTooHigh => "scan-ratio-too-high",
             HashJoinReason::NoProbeStats => "no-probe-stats",
+            HashJoinReason::SubjectDriven => "subject-driven-forward-join",
         }
     }
 }
@@ -163,7 +168,9 @@ impl HashJoinReason {
 /// re-deriving (the driving-set estimate depends on per-block chain order).
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct HashJoinDecision {
-    pub(crate) join_var: VarId,
+    /// The shared join var when the hash join was chosen; `None` for a rejected or
+    /// non-object→subject (forward) join, which carries only a reason.
+    pub(crate) join_var: Option<VarId>,
     pub(crate) probe_count: Option<u64>,
     pub(crate) driving_est: Option<f64>,
     pub(crate) scan_ratio: Option<f64>,
@@ -201,40 +208,60 @@ fn predicate_count(stats: &StatsView, pred: &crate::ir::triple::Ref) -> Option<u
     None
 }
 
-/// Eligibility for the object→subject hash join. The right pattern `tp` must be a
-/// single fixed-predicate scan whose OBJECT is the (only) variable shared with the
-/// left side (the join key), whose SUBJECT is a new variable, with no object bounds,
-/// no datatype constraint, and no inline ops. Returns the shared join variable.
-///
-/// This is exactly the shape that `NestedLoopJoinOperator` would otherwise run via
-/// the batched-OBJECT (OPST) path — the slow case the hash join replaces.
+/// Classification of a join pattern relative to the object→subject hash join.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObjectHashShape {
+    /// Fixed predicate, object bound from the left (the join key), subject new —
+    /// the exact shape the hash join replaces (else the batched-OBJECT OPST path).
+    Eligible(VarId),
+    /// Fixed predicate, but the SUBJECT is bound from the left and the OBJECT is
+    /// new: a forward (subject-driven) join. The object→subject hash can't help —
+    /// reordering to drive the other end is the fix. Surfaced in EXPLAIN.
+    SubjectDriven,
+    /// Not an object→subject candidate at all (var predicate, object bounds, a
+    /// datatype constraint, inline ops, or both endpoints already bound).
+    NotCandidate,
+}
+
+/// Classify the right pattern `tp` for the object→subject hash join. A fixed
+/// predicate may be a SID or an IRI: non-reasoning SPARQL/JSON-LD queries reach
+/// planning with IRI predicates (only reasoning queries are pre-encoded to SIDs in
+/// runner.rs), so a SID-only check would silently exclude the exact BSBM joins this
+/// operator targets.
+fn object_hash_shape(
+    left_schema: &[VarId],
+    tp: &TriplePattern,
+    has_bounds: bool,
+    inline_ops_empty: bool,
+) -> ObjectHashShape {
+    if has_bounds || !inline_ops_empty || tp.dtc.is_some() || tp.p.as_var().is_some() {
+        return ObjectHashShape::NotCandidate;
+    }
+    let (Some(o_var), Some(s_var)) = (tp.o.as_var(), tp.s.as_var()) else {
+        return ObjectHashShape::NotCandidate;
+    };
+    let o_bound = left_schema.contains(&o_var);
+    let s_bound = left_schema.contains(&s_var);
+    match (o_bound, s_bound) {
+        // Object bound from the left, subject new: the hash-join shape.
+        (true, false) => ObjectHashShape::Eligible(o_var),
+        // Subject bound, object new: a forward join the hash join can't replace.
+        (false, true) => ObjectHashShape::SubjectDriven,
+        _ => ObjectHashShape::NotCandidate,
+    }
+}
+
+#[cfg(test)]
 fn hash_join_object_join_var(
     left_schema: &[VarId],
     tp: &TriplePattern,
     has_bounds: bool,
     inline_ops_empty: bool,
 ) -> Option<VarId> {
-    if has_bounds || !inline_ops_empty || tp.dtc.is_some() {
-        return None;
+    match object_hash_shape(left_schema, tp, has_bounds, inline_ops_empty) {
+        ObjectHashShape::Eligible(v) => Some(v),
+        _ => None,
     }
-    // Predicate must be fixed — a SID or an IRI — so the probe scans one contiguous
-    // partition. Non-reasoning SPARQL/JSON-LD queries reach planning with IRI
-    // predicates (only reasoning queries are pre-encoded to SIDs in runner.rs), so a
-    // SID-only check here silently excluded the exact BSBM joins this operator targets.
-    if tp.p.as_var().is_some() {
-        return None;
-    }
-    // Object must be a var already bound from the left (the join key).
-    let o_var = tp.o.as_var()?;
-    if !left_schema.contains(&o_var) {
-        return None;
-    }
-    // Subject must be a brand-new var (not shared with the left).
-    let s_var = tp.s.as_var()?;
-    if left_schema.contains(&s_var) {
-        return None;
-    }
-    Some(o_var)
 }
 
 /// Per-WHERE-block planning state for the object→subject hash join.
@@ -283,9 +310,10 @@ impl<'a> HashJoinPlanner<'a> {
     /// Compute the annotated object→subject hash-join decision for the current
     /// probe pattern: the shared join var (when the shape is eligible), the cost
     /// inputs weighed, and the chosen/why outcome. Returns `None` only when the
-    /// pattern is not an object→subject shape (no hash join was ever a candidate).
-    /// Honors the force mode; under `Auto` it weighs the probe predicate's size
-    /// against the latest `before_step` snapshot.
+    /// pattern is not even a fixed-predicate two-var join (no decision to explain);
+    /// a subject-driven forward join returns a decision carrying its reason + the
+    /// driving-set size. Honors the force mode; under `Auto` it weighs the probe
+    /// predicate's size against the latest `before_step` snapshot.
     ///
     /// `build_scan_or_join` applies `chosen` to pick the operator and stashes the
     /// decision so `EXPLAIN` can render it. The hot path reads only `chosen`.
@@ -296,12 +324,27 @@ impl<'a> HashJoinPlanner<'a> {
         has_bounds: bool,
         inline_ops_empty: bool,
     ) -> Option<HashJoinDecision> {
-        let join_var = hash_join_object_join_var(left_schema, tp, has_bounds, inline_ops_empty)?;
         let driving_est = self.step_est;
+        let join_var = match object_hash_shape(left_schema, tp, has_bounds, inline_ops_empty) {
+            ObjectHashShape::Eligible(v) => v,
+            // Forward join: surface why the NestedLoop was chosen + the driving size
+            // (reordering to drive the other end is the fix), but no cost gate runs.
+            ObjectHashShape::SubjectDriven => {
+                return Some(HashJoinDecision {
+                    join_var: None,
+                    probe_count: self.stats.and_then(|s| predicate_count(s, &tp.p)),
+                    driving_est,
+                    scan_ratio: None,
+                    chosen: false,
+                    reason: HashJoinReason::SubjectDriven,
+                });
+            }
+            ObjectHashShape::NotCandidate => return None,
+        };
 
         if self.force == HashJoinForce::Off {
             return Some(HashJoinDecision {
-                join_var,
+                join_var: Some(join_var),
                 probe_count: None,
                 driving_est,
                 scan_ratio: None,
@@ -344,7 +387,7 @@ impl<'a> HashJoinPlanner<'a> {
         );
 
         Some(HashJoinDecision {
-            join_var,
+            join_var: Some(join_var),
             probe_count,
             driving_est,
             scan_ratio,
@@ -756,6 +799,39 @@ impl Operator for HashJoinOperator {
 mod tests {
     use super::*;
     use crate::ir::triple::{Ref, Term};
+    use fluree_db_core::{PropertyStatData, Sid};
+
+    #[test]
+    fn explains_subject_driven_forward_join() {
+        // `?review rev:reviewer ?reviewer` with ?review bound from the left and
+        // ?reviewer new is a forward (subject-driven) join — not an object→subject
+        // hash candidate. The decision must still surface a reason + the driving-set
+        // size so EXPLAIN's NestedLoop isn't opaque (this was the BSBM-BI F2 case).
+        let review = VarId(0);
+        let reviewer = VarId(1);
+        let left_schema = [review]; // subject bound, object new
+        let tp = TriplePattern::new(
+            Ref::Var(review),
+            Ref::Sid(Sid::new(1, "reviewer")),
+            Term::Var(reviewer),
+        );
+        let mut stats = StatsView::default();
+        stats.properties.insert(
+            Sid::new(1, "reviewer"),
+            PropertyStatData {
+                count: 2_848_260,
+                ndv_values: 570_000,
+                ndv_subjects: 2_848_260,
+            },
+        );
+        let d = HashJoinPlanner::new(Some(&stats))
+            .explain_object_hash_join(&left_schema, &tp, false, true)
+            .expect("a subject-driven join still yields a decision to explain");
+        assert!(!d.chosen);
+        assert_eq!(d.join_var, None);
+        assert_eq!(d.reason, HashJoinReason::SubjectDriven);
+        assert_eq!(d.probe_count, Some(2_848_260));
+    }
 
     #[test]
     fn iri_predicate_is_eligible_like_a_sid() {

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -39,21 +39,23 @@
 //!
 //! ## Selection
 //!
-//! `where_plan::build_scan_or_join` chooses this operator with a cost model
-//! (`hash_join_cost_wins`): the shape must match (single shared var = the bound
-//! object, fixed predicate, new subject var, no object bounds/inline ops) AND the
-//! probe predicate must be large enough that scattered seeks dominate. `FLUREE_HASH_JOIN`
-//! is a force-override only (`On`/`Off`). At `open()`, if the query is a true
-//! multi-graph dataset (ledger-local key normalisation would be wrong), it falls back
-//! to a `NestedLoopJoinOperator` over the same inputs.
+//! [`HashJoinPlanner`] (below) chooses this operator with a cost model: the shape
+//! must match (single shared var = the bound object, fixed predicate, new subject
+//! var, no object bounds/inline ops) AND the probe predicate must be large enough
+//! that scattered seeks dominate. `FLUREE_HASH_JOIN` is a force-override only
+//! (`On`/`Off`). `where_plan` threads one planner through a join block; at `open()`,
+//! if the query is a true multi-graph dataset (ledger-local key normalisation would
+//! be wrong), the operator falls back to a `NestedLoopJoinOperator` over the same
+//! inputs.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use fluree_db_binary_index::BinaryIndexStore;
 use rustc_hash::FxHashMap;
 
-use fluree_db_core::ObjectBounds;
+use fluree_db_core::{ObjectBounds, StatsView};
 
 use crate::binary_scan::EmitMask;
 use crate::binding::{Batch, Binding};
@@ -71,6 +73,155 @@ use crate::var_registry::VarId;
 
 /// Target number of output rows per produced batch.
 const OUTPUT_BATCH_TARGET: usize = 4096;
+
+// ── Planning: when to use the hash join ──────────────────────────────────────
+//
+// `HashJoinPlanner` is threaded through a WHERE join block by `where_plan`. It owns
+// the force mode, the `StatsView`, and the running cardinality of the driving chain,
+// and decides per pattern whether the object→subject join should use this operator.
+
+/// Force-override for the cost-based object→subject hash-join decision.
+///
+/// `FLUREE_HASH_JOIN`: unset/other => `Auto` (the cost model decides), `1`/`true`
+/// => `On` (force the hash join whenever the shape matches, ignoring cost — keeps
+/// force-on usable on stats-less ledgers), `0`/`false` => `Off` (never hash-join).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HashJoinForce {
+    Auto,
+    On,
+    Off,
+}
+
+fn hash_join_force() -> HashJoinForce {
+    match std::env::var("FLUREE_HASH_JOIN") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => HashJoinForce::On,
+        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => HashJoinForce::Off,
+        _ => HashJoinForce::Auto,
+    }
+}
+
+/// Probe-predicate floor: below this, scattered OPST object seeks stay cheap and the
+/// hash join is a wash (the BSBM crossover is between 55.7k @1M and 560k @10M).
+const HASH_JOIN_PROBE_MIN: u64 = 250_000;
+/// Don't scan a probe predicate more than this many times the driving-set size
+/// (tiny-driving guard; keeps the 100M case at ratio ~46x inside the cap).
+const HASH_JOIN_MAX_SCAN_RATIO: f64 = 64.0;
+
+/// The hash join wins when the probe predicate is large enough that scattered OPST
+/// seeks dominate, but not so large relative to the driving set that the single
+/// contiguous scan is wasteful. `false` when probe stats are absent (=> the safe
+/// `NestedLoopJoinOperator` default). Constants tuned to BSBM 1M/10M/100M; heuristic.
+fn hash_join_cost_wins(probe_count: Option<u64>, driving_est: Option<f64>) -> bool {
+    let Some(pc) = probe_count else { return false };
+    let drive = driving_est.unwrap_or(0.0).max(1.0);
+    pc >= HASH_JOIN_PROBE_MIN && (pc as f64) <= drive * HASH_JOIN_MAX_SCAN_RATIO
+}
+
+/// Eligibility for the object→subject hash join. The right pattern `tp` must be a
+/// single fixed-predicate scan whose OBJECT is the (only) variable shared with the
+/// left side (the join key), whose SUBJECT is a new variable, with no object bounds,
+/// no datatype constraint, and no inline ops. Returns the shared join variable.
+///
+/// This is exactly the shape that `NestedLoopJoinOperator` would otherwise run via
+/// the batched-OBJECT (OPST) path — the slow case the hash join replaces.
+fn hash_join_object_join_var(
+    left_schema: &[VarId],
+    tp: &TriplePattern,
+    has_bounds: bool,
+    inline_ops_empty: bool,
+) -> Option<VarId> {
+    if has_bounds || !inline_ops_empty || tp.dtc.is_some() {
+        return None;
+    }
+    // Predicate must be a fixed SID (so the probe scans one contiguous partition).
+    if !tp.p.is_sid() {
+        return None;
+    }
+    // Object must be a var already bound from the left (the join key).
+    let o_var = tp.o.as_var()?;
+    if !left_schema.contains(&o_var) {
+        return None;
+    }
+    // Subject must be a brand-new var (not shared with the left).
+    let s_var = tp.s.as_var()?;
+    if left_schema.contains(&s_var) {
+        return None;
+    }
+    Some(o_var)
+}
+
+/// Per-WHERE-block planning state for the object→subject hash join.
+///
+/// One instance is threaded through a join block so `build_triple_operators` and
+/// `build_sequential_join_block` share the same cost state — the running driving-set
+/// cardinality, the resolved force mode, and stats — instead of each re-deriving it
+/// and widening every helper signature.
+pub(crate) struct HashJoinPlanner<'a> {
+    stats: Option<&'a StatsView>,
+    force: HashJoinForce,
+    /// Running product of per-pattern estimates for the chain built so far.
+    driving_est: f64,
+    /// `driving_est` snapshot from the most recent [`before_step`](Self::before_step)
+    /// — the driving-set size the next probe is weighed against. `None` until
+    /// `before_step` runs with stats present, so single-pattern / stats-less callers
+    /// never auto-fire (force-`On` still does).
+    step_est: Option<f64>,
+}
+
+impl<'a> HashJoinPlanner<'a> {
+    pub(crate) fn new(stats: Option<&'a StatsView>) -> Self {
+        Self {
+            stats,
+            force: hash_join_force(),
+            driving_est: 1.0,
+            step_est: None,
+        }
+    }
+
+    /// Advance the running driving cardinality past one pattern. Call once per
+    /// pattern, in chain order, BEFORE building its operator. Snapshots the product
+    /// of the patterns to the LEFT of `tp` (this becomes `step_est`, the size the
+    /// probe is weighed against), then folds `tp`'s own estimate in for later steps.
+    /// The snapshot excludes `tp` on purpose: as a probe its object is bound from the
+    /// left, so estimating it would misclassify as a selective BoundObject scan.
+    /// `bound` is the set of variables bound by the chain to the left of `tp`.
+    pub(crate) fn before_step(&mut self, tp: &TriplePattern, bound: &HashSet<VarId>) {
+        self.step_est = self.stats.map(|stats| {
+            let snapshot = self.driving_est;
+            self.driving_est *= crate::planner::estimate_triple_row_count(tp, bound, Some(stats));
+            snapshot
+        });
+    }
+
+    /// Decide whether the join for the current pattern should use the object→subject
+    /// hash join, returning the shared join variable when it should (and `None` to
+    /// keep the `NestedLoopJoinOperator` default). Honors the force mode; under `Auto`
+    /// it weighs the probe predicate's size against the latest `before_step` snapshot.
+    pub(crate) fn choose_object_hash_join(
+        &self,
+        left_schema: &[VarId],
+        tp: &TriplePattern,
+        has_bounds: bool,
+        inline_ops_empty: bool,
+    ) -> Option<VarId> {
+        if self.force == HashJoinForce::Off {
+            return None;
+        }
+        let join_var = hash_join_object_join_var(left_schema, tp, has_bounds, inline_ops_empty)?;
+        let use_hash = match self.force {
+            HashJoinForce::On => true,
+            HashJoinForce::Off => false,
+            HashJoinForce::Auto => {
+                let probe_count =
+                    tp.p.as_sid()
+                        .and_then(|sid| self.stats.and_then(|s| s.get_property(sid)))
+                        .map(|p| p.count);
+                hash_join_cost_wins(probe_count, self.step_est)
+            }
+        };
+        use_hash.then_some(join_var)
+    }
+}
 
 /// A join key that is comparable across build/probe sides regardless of whether a
 /// ref was delivered as `EncodedSid` or materialised `Sid`.

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -125,6 +125,69 @@ fn hash_join_cost_wins(probe_count: Option<u64>, driving_est: Option<f64>) -> bo
     pc >= HASH_JOIN_PROBE_MIN && (pc as f64) <= drive * HASH_JOIN_MAX_SCAN_RATIO
 }
 
+/// Why the object→subject hash join was (or was not) chosen. Mirrors the
+/// `FallbackReason` pattern in `explain.rs` — surfaced by `EXPLAIN` so a
+/// `HashJoin` vs `NestedLoop` choice carries its rationale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HashJoinReason {
+    /// `FLUREE_HASH_JOIN=1` forced the hash join.
+    ForcedOn,
+    /// `FLUREE_HASH_JOIN=0` forced the nested-loop default.
+    ForcedOff,
+    /// Auto mode: probe is large enough and the scan ratio is within bounds.
+    CostWins,
+    /// Probe predicate count below [`HASH_JOIN_PROBE_MIN`] — scattered seeks stay cheap.
+    ProbeTooSmall,
+    /// Probe is more than [`HASH_JOIN_MAX_SCAN_RATIO`]× the driving set — scan too wasteful.
+    ScanRatioTooHigh,
+    /// No probe-predicate stats, so the cost model can't justify the hash join.
+    NoProbeStats,
+}
+
+impl HashJoinReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            HashJoinReason::ForcedOn => "forced-on",
+            HashJoinReason::ForcedOff => "forced-off",
+            HashJoinReason::CostWins => "cost-wins",
+            HashJoinReason::ProbeTooSmall => "probe-too-small",
+            HashJoinReason::ScanRatioTooHigh => "scan-ratio-too-high",
+            HashJoinReason::NoProbeStats => "no-probe-stats",
+        }
+    }
+}
+
+/// The annotated object→subject hash-join decision for one probe pattern: the
+/// cost inputs the planner weighed and the outcome. Computed at plan time and
+/// stashed on the chosen operator so `EXPLAIN` can render *why* without
+/// re-deriving (the driving-set estimate depends on per-block chain order).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HashJoinDecision {
+    pub(crate) join_var: VarId,
+    pub(crate) probe_count: Option<u64>,
+    pub(crate) driving_est: Option<f64>,
+    pub(crate) scan_ratio: Option<f64>,
+    pub(crate) chosen: bool,
+    pub(crate) reason: HashJoinReason,
+}
+
+impl HashJoinDecision {
+    /// Render the decision into an `EXPLAIN` plan-node detail map.
+    pub(crate) fn write_details(&self, m: &mut serde_json::Map<String, serde_json::Value>) {
+        m.insert("hash-join-chosen".into(), self.chosen.into());
+        m.insert("hash-join-reason".into(), self.reason.as_str().into());
+        if let Some(pc) = self.probe_count {
+            m.insert("probe-count".into(), pc.into());
+        }
+        if let Some(d) = self.driving_est {
+            m.insert("driving-est".into(), (d.round() as i64).into());
+        }
+        if let Some(r) = self.scan_ratio {
+            m.insert("scan-ratio".into(), format!("{r:.1}").into());
+        }
+    }
+}
+
 /// Probe-predicate row count from stats, keyed by SID or — for the un-encoded IRI
 /// predicates that non-reasoning queries carry — by IRI. Mirrors the planner's
 /// `property_stats` fallback so the cost model sees the same numbers reorder did.
@@ -217,30 +280,77 @@ impl<'a> HashJoinPlanner<'a> {
         });
     }
 
-    /// Decide whether the join for the current pattern should use the object→subject
-    /// hash join, returning the shared join variable when it should (and `None` to
-    /// keep the `NestedLoopJoinOperator` default). Honors the force mode; under `Auto`
-    /// it weighs the probe predicate's size against the latest `before_step` snapshot.
-    pub(crate) fn choose_object_hash_join(
+    /// Compute the annotated object→subject hash-join decision for the current
+    /// probe pattern: the shared join var (when the shape is eligible), the cost
+    /// inputs weighed, and the chosen/why outcome. Returns `None` only when the
+    /// pattern is not an object→subject shape (no hash join was ever a candidate).
+    /// Honors the force mode; under `Auto` it weighs the probe predicate's size
+    /// against the latest `before_step` snapshot.
+    ///
+    /// `build_scan_or_join` applies `chosen` to pick the operator and stashes the
+    /// decision so `EXPLAIN` can render it. The hot path reads only `chosen`.
+    pub(crate) fn explain_object_hash_join(
         &self,
         left_schema: &[VarId],
         tp: &TriplePattern,
         has_bounds: bool,
         inline_ops_empty: bool,
-    ) -> Option<VarId> {
-        if self.force == HashJoinForce::Off {
-            return None;
-        }
+    ) -> Option<HashJoinDecision> {
         let join_var = hash_join_object_join_var(left_schema, tp, has_bounds, inline_ops_empty)?;
-        let use_hash = match self.force {
-            HashJoinForce::On => true,
-            HashJoinForce::Off => false,
-            HashJoinForce::Auto => {
-                let probe_count = self.stats.and_then(|s| predicate_count(s, &tp.p));
-                hash_join_cost_wins(probe_count, self.step_est)
-            }
+        let driving_est = self.step_est;
+
+        if self.force == HashJoinForce::Off {
+            return Some(HashJoinDecision {
+                join_var,
+                probe_count: None,
+                driving_est,
+                scan_ratio: None,
+                chosen: false,
+                reason: HashJoinReason::ForcedOff,
+            });
+        }
+
+        let probe_count = self.stats.and_then(|s| predicate_count(s, &tp.p));
+        let scan_ratio = match (probe_count, driving_est) {
+            (Some(pc), Some(d)) => Some(pc as f64 / d.max(1.0)),
+            _ => None,
         };
-        use_hash.then_some(join_var)
+
+        let (chosen, reason) = match self.force {
+            HashJoinForce::On => (true, HashJoinReason::ForcedOn),
+            HashJoinForce::Off => unreachable!("handled above"),
+            HashJoinForce::Auto => match probe_count {
+                None => (false, HashJoinReason::NoProbeStats),
+                Some(pc) if pc < HASH_JOIN_PROBE_MIN => (false, HashJoinReason::ProbeTooSmall),
+                Some(pc) => {
+                    let drive = driving_est.unwrap_or(0.0).max(1.0);
+                    if (pc as f64) <= drive * HASH_JOIN_MAX_SCAN_RATIO {
+                        (true, HashJoinReason::CostWins)
+                    } else {
+                        (false, HashJoinReason::ScanRatioTooHigh)
+                    }
+                }
+            },
+        };
+
+        debug_assert_eq!(
+            chosen,
+            self.force != HashJoinForce::Off
+                && match self.force {
+                    HashJoinForce::On => true,
+                    _ => hash_join_cost_wins(probe_count, self.step_est),
+                },
+            "explain_object_hash_join must agree with the cost gate"
+        );
+
+        Some(HashJoinDecision {
+            join_var,
+            probe_count,
+            driving_est,
+            scan_ratio,
+            chosen,
+            reason,
+        })
     }
 }
 
@@ -328,6 +438,8 @@ pub struct HashJoinOperator {
     cur_probe: Option<Batch>,
     cur_probe_row: usize,
     state: OperatorState,
+    /// The planner's annotated decision, for `EXPLAIN`. Never read on the hot path.
+    hj_decision: Option<HashJoinDecision>,
 }
 
 impl HashJoinOperator {
@@ -390,7 +502,15 @@ impl HashJoinOperator {
             cur_probe: None,
             cur_probe_row: 0,
             state: OperatorState::Created,
+            hj_decision: None,
         }
+    }
+
+    /// Attach the planner's object→subject hash-join decision for `EXPLAIN`.
+    /// Plan-only — does not affect execution.
+    pub(crate) fn with_hash_join_decision(mut self, decision: HashJoinDecision) -> Self {
+        self.hj_decision = Some(decision);
+        self
     }
 
     /// Drain `build` into the hash table. Called once in `open()` on the hash path.
@@ -437,6 +557,9 @@ impl Operator for HashJoinOperator {
             "probe".into(),
             crate::explain::format_pattern(&self.right_pattern).into(),
         );
+        if let Some(d) = &self.hj_decision {
+            d.write_details(&mut m);
+        }
         m
     }
     fn schema(&self) -> &[VarId] {

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -1,0 +1,440 @@
+//! `HashJoinOperator` — build/probe inner join for object→subject "path" joins.
+//!
+//! This is the cure for the BSBM-BI "small + large" two-pattern join slowdown
+//! (see `docs/troubleshooting/performance-tracing.md` and the benchmark report
+//! `bsbm-bi-fluree-100m-join-scaling.md`). The minimal repro:
+//!
+//! ```sparql
+//! SELECT (COUNT(*) AS ?c) WHERE {
+//!   ?review  rev:reviewer ?reviewer .            # LARGE: full predicate scan
+//!   ?reviewer bsbm:country <US> .                 # SMALL: selective bound object
+//! }
+//! ```
+//!
+//! The planner correctly drives from the selective bound-object (country) side,
+//! which makes the large `rev:reviewer` pattern a right scan whose **object** is
+//! bound from the left. The default `NestedLoopJoinOperator` then resolves it via
+//! the batched-OBJECT path (`flush_batched_object_accumulator_binary`), seeking the
+//! **object-major global OPST index** once per distinct driving object. Because a
+//! single predicate's triples are scattered across the whole OPST key space, that
+//! degrades superlinearly (≈47 s at 100M for ~61.8K driving objects).
+//!
+//! `HashJoinOperator` instead:
+//!   1. **Build** a hash table from the small (driving) side, keyed by the join var.
+//!   2. **Probe** by scanning the large predicate's *contiguous* PSOT/POST partition
+//!      exactly once and looking each row's object up in the table.
+//!
+//! This turns N scattered object seeks into one sequential predicate scan + hash
+//! probes (the large `rev:reviewer` scan alone is ~75 ms at 100M), which is what
+//! cardinality-aware engines do for this shape.
+//!
+//! ## Correctness of the join key
+//!
+//! Ref bindings can appear as late-materialised `EncodedSid` *or* materialised `Sid`
+//! for the *same* entity, and `binding_to_group_key_owned` hashes those to different
+//! keys. To make build- and probe-side keys comparable we normalise every resolvable
+//! ref to its `u64` subject id via the binary store (mirroring the batched-object
+//! path in `join.rs`); unresolvable/non-ref values fall back to the group key, which
+//! is consistent across sides in store-less (memory) mode.
+//!
+//! ## Selection
+//!
+//! `where_plan::build_scan_or_join` chooses this operator with a cost model
+//! (`hash_join_cost_wins`): the shape must match (single shared var = the bound
+//! object, fixed predicate, new subject var, no object bounds/inline ops) AND the
+//! probe predicate must be large enough that scattered seeks dominate. `FLUREE_HASH_JOIN`
+//! is a force-override only (`On`/`Off`). At `open()`, if the query is a true
+//! multi-graph dataset (ledger-local key normalisation would be wrong), it falls back
+//! to a `NestedLoopJoinOperator` over the same inputs.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fluree_db_binary_index::BinaryIndexStore;
+use rustc_hash::FxHashMap;
+
+use fluree_db_core::ObjectBounds;
+
+use crate::binary_scan::EmitMask;
+use crate::binding::{Batch, Binding};
+use crate::context::ExecutionContext;
+use crate::dataset::ActiveGraphs;
+use crate::error::{QueryError, Result};
+use crate::group_aggregate::{binding_to_group_key_owned, GroupKeyOwned};
+use crate::ir::triple::TriplePattern;
+use crate::join::NestedLoopJoinOperator;
+use crate::operator::{
+    compute_trimmed_vars, effective_schema, trim_batch, BoxedOperator, Operator, OperatorState,
+};
+use crate::temporal_mode::TemporalMode;
+use crate::var_registry::VarId;
+
+/// Target number of output rows per produced batch.
+const OUTPUT_BATCH_TARGET: usize = 4096;
+
+/// A join key that is comparable across build/probe sides regardless of whether a
+/// ref was delivered as `EncodedSid` or materialised `Sid`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum JoinKey {
+    /// A resolved subject id (ledger-local; valid because the operator is
+    /// single-store / native).
+    Ref(u64),
+    /// Fallback for literals or refs that could not be resolved to a subject id.
+    Other(GroupKeyOwned),
+}
+
+/// Build a comparable join key for a binding, normalising refs to a `u64` s_id when
+/// a store is available. Returns `None` for Unbound/Poisoned (cannot participate in
+/// an inner join).
+fn join_key(binding: &Binding, store: Option<&BinaryIndexStore>) -> Option<JoinKey> {
+    match binding {
+        Binding::EncodedSid { s_id, .. } => Some(JoinKey::Ref(*s_id)),
+        Binding::Sid { sid, .. } => Some(
+            store
+                .and_then(|s| {
+                    s.find_subject_id_by_parts(sid.namespace_code, &sid.name)
+                        .ok()
+                        .flatten()
+                })
+                .map(JoinKey::Ref)
+                .unwrap_or_else(|| JoinKey::Other(binding_to_group_key_owned(binding))),
+        ),
+        Binding::IriMatch { primary_sid, .. } => Some(
+            store
+                .and_then(|s| {
+                    s.find_subject_id_by_parts(primary_sid.namespace_code, &primary_sid.name)
+                        .ok()
+                        .flatten()
+                })
+                .map(JoinKey::Ref)
+                .unwrap_or_else(|| JoinKey::Other(binding_to_group_key_owned(binding))),
+        ),
+        Binding::Unbound | Binding::Poisoned => None,
+        other => Some(JoinKey::Other(binding_to_group_key_owned(other))),
+    }
+}
+
+/// Inner hash join: build a table from `build` (the small side), probe with `probe`
+/// (a contiguous scan of the large predicate), joining on a single shared variable.
+pub struct HashJoinOperator {
+    /// Small (driving) side. Consumed in `open()` — drained into the hash table on
+    /// the hash path, or handed to the nested-loop on the multi-graph fallback path.
+    build: Option<BoxedOperator>,
+    /// Large side — streamed once during `next_batch()` / `drain_count()`. Dropped
+    /// unused when the fallback path is taken.
+    probe: Option<BoxedOperator>,
+    /// Probe pattern + params, kept so `open()` can build a `NestedLoopJoinOperator`
+    /// fallback when the hash path is not safe (true multi-graph dataset, where the
+    /// ledger-local key normalisation would be wrong).
+    right_pattern: TriplePattern,
+    nl_bounds: Option<ObjectBounds>,
+    nl_mode: TemporalMode,
+    nl_downstream: Option<Arc<[VarId]>>,
+    /// Set in `open()` when the hash path is unsafe; all output is delegated to it.
+    fallback: Option<BoxedOperator>,
+    /// `build.schema()` captured at construction (column order of build rows).
+    build_schema: Arc<[VarId]>,
+    /// Full output schema: `build_schema` ++ probe vars not already in build_schema.
+    full_schema: Arc<[VarId]>,
+    /// Trimmed output schema when downstream only needs a subset.
+    out_schema: Option<Arc<[VarId]>>,
+    /// Column of the join var within `build_schema`.
+    build_key_col: usize,
+    /// Column of the join var within `probe.schema()`.
+    probe_key_col: usize,
+    /// Columns of `probe.schema()` appended to the output (probe vars not in build).
+    probe_emit_cols: Vec<usize>,
+    /// Hash table: join key → all build rows with that key (each row aligned to
+    /// `build_schema`). Multiplicity is preserved for correct COUNT semantics.
+    table: FxHashMap<JoinKey, Vec<Vec<Binding>>>,
+    /// Build rows whose join key is Unbound/Poisoned. The nested-loop join treats an
+    /// unbound shared var as unconstrained — the right side fills it — so these rows
+    /// must match EVERY probe row (with the join var taking the probe value), not be
+    /// dropped. Empty in the common case (join var always bound), so zero overhead.
+    wildcard_rows: Vec<Vec<Binding>>,
+    /// Current probe batch being consumed and the next row to process.
+    cur_probe: Option<Batch>,
+    cur_probe_row: usize,
+    state: OperatorState,
+}
+
+impl HashJoinOperator {
+    /// Construct from a build (small) side, a probe (large) scan, and the single
+    /// shared join variable. `downstream_vars` trims the output when provided.
+    ///
+    /// Caller (`build_scan_or_join`) guarantees `join_var` is present in both
+    /// schemas via its eligibility check, so column lookups cannot fail.
+    pub fn new(
+        build: BoxedOperator,
+        probe: BoxedOperator,
+        join_var: VarId,
+        downstream_vars: Option<&[VarId]>,
+        right_pattern: TriplePattern,
+        nl_bounds: Option<ObjectBounds>,
+        nl_mode: TemporalMode,
+    ) -> Self {
+        let build_schema: Arc<[VarId]> = Arc::from(build.schema().to_vec().into_boxed_slice());
+        let probe_schema: Vec<VarId> = probe.schema().to_vec();
+
+        let build_key_col = build_schema
+            .iter()
+            .position(|v| *v == join_var)
+            .expect("hash join: join var must be in build schema");
+        let probe_key_col = probe_schema
+            .iter()
+            .position(|v| *v == join_var)
+            .expect("hash join: join var must be in probe schema");
+
+        // Output = build columns, then probe vars not already produced by build.
+        let mut full = build_schema.to_vec();
+        let mut probe_emit_cols = Vec::new();
+        for (i, v) in probe_schema.iter().enumerate() {
+            if !build_schema.contains(v) {
+                probe_emit_cols.push(i);
+                full.push(*v);
+            }
+        }
+        let full_schema: Arc<[VarId]> = Arc::from(full.into_boxed_slice());
+        let out_schema = compute_trimmed_vars(&full_schema, downstream_vars);
+        let nl_downstream: Option<Arc<[VarId]>> =
+            downstream_vars.map(|d| Arc::from(d.to_vec().into_boxed_slice()));
+
+        Self {
+            build: Some(build),
+            probe: Some(probe),
+            right_pattern,
+            nl_bounds,
+            nl_mode,
+            nl_downstream,
+            fallback: None,
+            build_schema,
+            full_schema,
+            out_schema,
+            build_key_col,
+            probe_key_col,
+            probe_emit_cols,
+            table: FxHashMap::default(),
+            wildcard_rows: Vec::new(),
+            cur_probe: None,
+            cur_probe_row: 0,
+            state: OperatorState::Created,
+        }
+    }
+
+    /// Drain `build` into the hash table. Called once in `open()` on the hash path.
+    async fn build_table(
+        &mut self,
+        ctx: &ExecutionContext<'_>,
+        mut build: BoxedOperator,
+    ) -> Result<()> {
+        let store = ctx.binary_store.as_deref();
+        let ncols = self.build_schema.len();
+        build.open(ctx).await?;
+        while let Some(batch) = build.next_batch(ctx).await? {
+            for row in 0..batch.len() {
+                let row_vals: Vec<Binding> = (0..ncols)
+                    .map(|c| batch.get_by_col(row, c).clone())
+                    .collect();
+                match join_key(batch.get_by_col(row, self.build_key_col), store) {
+                    Some(key) => self.table.entry(key).or_default().push(row_vals),
+                    // Unbound/Poisoned join var: unconstrained, matches every probe row.
+                    None => self.wildcard_rows.push(row_vals),
+                }
+            }
+        }
+        build.close();
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Operator for HashJoinOperator {
+    fn schema(&self) -> &[VarId] {
+        effective_schema(&self.out_schema, &self.full_schema)
+    }
+
+    async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
+        if self.state != OperatorState::Created {
+            return Err(QueryError::Internal(
+                "HashJoinOperator::open() called in invalid state".into(),
+            ));
+        }
+        let build = self.build.take().expect("hash join build side");
+        // Join keys normalise refs to ledger-local subject ids, which would collide
+        // across ledgers in a true multi-graph dataset (Many with >1 graph). Rather
+        // than error (the cost planner can auto-select us), fall back to a nested-loop
+        // join over the same driving side + probe pattern, which is graph-correct.
+        let multi_graph =
+            matches!(ctx.active_graphs(), ActiveGraphs::Many(graphs) if graphs.len() > 1);
+        if multi_graph {
+            let mut nl = NestedLoopJoinOperator::new(
+                build,
+                Arc::clone(&self.build_schema),
+                self.right_pattern.clone(),
+                self.nl_bounds.clone(),
+                Vec::new(),
+                EmitMask::ALL,
+                self.nl_mode,
+            )
+            .with_out_schema(self.nl_downstream.as_deref());
+            nl.open(ctx).await?;
+            self.fallback = Some(Box::new(nl));
+        } else {
+            self.build_table(ctx, build).await?;
+            self.probe
+                .as_mut()
+                .expect("hash join probe")
+                .open(ctx)
+                .await?;
+        }
+        self.state = OperatorState::Open;
+        Ok(())
+    }
+
+    async fn next_batch(&mut self, ctx: &ExecutionContext<'_>) -> Result<Option<Batch>> {
+        if !self.state.can_next() {
+            return Ok(None);
+        }
+        if let Some(fallback) = self.fallback.as_mut() {
+            return fallback.next_batch(ctx).await;
+        }
+        let store = ctx.binary_store.as_deref();
+        let ncols = self.full_schema.len();
+        let build_cols = self.build_schema.len();
+        let probe = self.probe.as_mut().expect("hash join probe");
+
+        loop {
+            // Ensure we have a probe batch to consume.
+            if self.cur_probe.is_none() {
+                match probe.next_batch(ctx).await? {
+                    Some(b) if !b.is_empty() => {
+                        self.cur_probe = Some(b);
+                        self.cur_probe_row = 0;
+                    }
+                    Some(_) => continue,
+                    None => {
+                        self.state = OperatorState::Exhausted;
+                        return Ok(None);
+                    }
+                }
+            }
+
+            let pb = self.cur_probe.as_ref().unwrap();
+            let mut out_cols: Vec<Vec<Binding>> = (0..ncols).map(|_| Vec::new()).collect();
+            let mut produced = 0usize;
+
+            while self.cur_probe_row < pb.len() {
+                let row = self.cur_probe_row;
+                self.cur_probe_row += 1;
+
+                let Some(key) = join_key(pb.get_by_col(row, self.probe_key_col), store) else {
+                    continue;
+                };
+                if let Some(matches) = self.table.get(&key) {
+                    for build_row in matches {
+                        for (c, b) in build_row.iter().enumerate() {
+                            out_cols[c].push(b.clone());
+                        }
+                        for (i, &pc) in self.probe_emit_cols.iter().enumerate() {
+                            out_cols[build_cols + i].push(pb.get_by_col(row, pc).clone());
+                        }
+                        produced += 1;
+                    }
+                }
+                // Unbound-key build rows match every probe row; the join var takes the
+                // probe value (the nested-loop "take the right side" semantics).
+                if !self.wildcard_rows.is_empty() {
+                    let probe_key = pb.get_by_col(row, self.probe_key_col);
+                    for wild in &self.wildcard_rows {
+                        for (c, b) in wild.iter().enumerate() {
+                            out_cols[c].push(if c == self.build_key_col {
+                                probe_key.clone()
+                            } else {
+                                b.clone()
+                            });
+                        }
+                        for (i, &pc) in self.probe_emit_cols.iter().enumerate() {
+                            out_cols[build_cols + i].push(pb.get_by_col(row, pc).clone());
+                        }
+                        produced += 1;
+                    }
+                }
+                if produced >= OUTPUT_BATCH_TARGET {
+                    break;
+                }
+            }
+
+            if self.cur_probe_row >= pb.len() {
+                self.cur_probe = None;
+            }
+            if produced == 0 {
+                continue;
+            }
+            let batch = Batch::new(Arc::clone(&self.full_schema), out_cols)
+                .map_err(|e| QueryError::Internal(format!("hash join batch: {e}")))?;
+            return Ok(trim_batch(&self.out_schema, batch));
+        }
+    }
+
+    fn close(&mut self) {
+        if let Some(b) = self.build.as_mut() {
+            b.close();
+        }
+        if let Some(p) = self.probe.as_mut() {
+            p.close();
+        }
+        if let Some(f) = self.fallback.as_mut() {
+            f.close();
+        }
+        self.table.clear();
+        self.wildcard_rows.clear();
+        self.cur_probe = None;
+        self.state = OperatorState::Closed;
+    }
+
+    /// COUNT(*) fast path: stream the probe side and sum build-side multiplicity per
+    /// matching key, without materialising any output bindings.
+    async fn drain_count(&mut self, ctx: &ExecutionContext<'_>) -> Result<Option<u64>> {
+        if !self.state.can_next() {
+            return Ok(None);
+        }
+        if let Some(fallback) = self.fallback.as_mut() {
+            return fallback.drain_count(ctx).await;
+        }
+        let store = ctx.binary_store.as_deref();
+        let probe = self.probe.as_mut().expect("hash join probe");
+        let mut count: u64 = 0;
+        loop {
+            match probe.next_batch(ctx).await? {
+                Some(batch) if !batch.is_empty() => {
+                    for row in 0..batch.len() {
+                        let Some(key) = join_key(batch.get_by_col(row, self.probe_key_col), store)
+                        else {
+                            continue;
+                        };
+                        // Each probe row matches its keyed build rows plus every
+                        // wildcard (unbound-key) build row.
+                        let matched =
+                            self.table.get(&key).map_or(0, Vec::len) + self.wildcard_rows.len();
+                        count = count.checked_add(matched as u64).ok_or_else(|| {
+                            QueryError::execution("COUNT(*) overflow in hash join drain_count")
+                        })?;
+                    }
+                }
+                Some(_) => continue,
+                None => break,
+            }
+        }
+        self.state = OperatorState::Exhausted;
+        Ok(Some(count))
+    }
+
+    fn estimated_rows(&self) -> Option<usize> {
+        // Output is bounded by the probe side's matching subset; use the probe
+        // estimate as a coarse upper bound for downstream sizing.
+        if let Some(f) = self.fallback.as_ref() {
+            return f.estimated_rows();
+        }
+        self.probe.as_ref().and_then(|p| p.estimated_rows())
+    }
+}

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -421,6 +421,24 @@ impl HashJoinOperator {
 
 #[async_trait]
 impl Operator for HashJoinOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        let mut v = Vec::new();
+        if let Some(b) = self.build.as_deref() {
+            v.push(crate::plan_node::PlanChild::child(b));
+        }
+        if let Some(p) = self.probe.as_deref() {
+            v.push(crate::plan_node::PlanChild::child(p));
+        }
+        v
+    }
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut m = serde_json::Map::new();
+        m.insert(
+            "probe".into(),
+            crate::explain::format_pattern(&self.right_pattern).into(),
+        );
+        m
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.full_schema)
     }

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -103,9 +103,17 @@ fn hash_join_force() -> HashJoinForce {
 /// Probe-predicate floor: below this, scattered OPST object seeks stay cheap and the
 /// hash join is a wash (the BSBM crossover is between 55.7k @1M and 560k @10M).
 const HASH_JOIN_PROBE_MIN: u64 = 250_000;
-/// Don't scan a probe predicate more than this many times the driving-set size
-/// (tiny-driving guard; keeps the 100M case at ratio ~46x inside the cap).
-const HASH_JOIN_MAX_SCAN_RATIO: f64 = 64.0;
+/// Don't scan a probe predicate more than this many times the driving-set size —
+/// a guard against the pathological "scan a huge predicate for a handful of driving
+/// rows" case. It is deliberately loose: the alternative we replace is the scattered
+/// OPST object seek, measured at ~760 µs/seek (47 s / 61.8K driving rows at 100M)
+/// versus ~26 ns per sequential probe row, so the *true* break-even ratio is ≈29,000×.
+/// We sit far below that (room for the build-side hash + memory), but well above the
+/// estimate error from skewed objects: `driving_est` for a bound object is the AVERAGE
+/// object size (`count/ndv`), which undershoots a popular value like BSBM `country=US`
+/// (avg ~28K vs actual ~61.8K), so a tight cap (the old 64×) wrongly rejected the very
+/// join this operator exists for. See the BI-1 case in `hash_join_cost_wins` tests.
+const HASH_JOIN_MAX_SCAN_RATIO: f64 = 1024.0;
 
 /// The hash join wins when the probe predicate is large enough that scattered OPST
 /// seeks dominate, but not so large relative to the driving set that the single
@@ -587,5 +595,32 @@ impl Operator for HashJoinOperator {
             return f.estimated_rows();
         }
         self.probe.as_ref().and_then(|p| p.estimated_rows())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cost_gate_fires_for_skewed_bound_object_bi1() {
+        // BSBM BI-1: probe rev:reviewer (2.85M rows) vs a driving `country=US` set.
+        // The cost model estimates the driving side as the AVERAGE country size
+        // (count/ndv ≈ 28k), not US's actual 61.8k. The 1024× cap must accept this
+        // (28k×1024 = 28.6M ≥ 2.85M); the old 64× cap rejected it (28k×64 = 1.79M <
+        // 2.85M), which is the regression this fixes.
+        assert!(hash_join_cost_wins(Some(2_848_260), Some(28_000.0)));
+        // Also passes against US's true (un-averaged) selectivity.
+        assert!(hash_join_cost_wins(Some(2_848_260), Some(61_847.0)));
+    }
+
+    #[test]
+    fn cost_gate_still_guards_pathological_and_small_probes() {
+        // Huge probe for a handful of driving rows is still rejected (ratio ≫ 1024×).
+        assert!(!hash_join_cost_wins(Some(2_848_260), Some(100.0)));
+        // Probe below the floor never qualifies, regardless of ratio.
+        assert!(!hash_join_cost_wins(Some(100_000), Some(10.0)));
+        // No probe stats => fall back to the safe nested-loop default.
+        assert!(!hash_join_cost_wins(None, Some(1_000_000.0)));
     }
 }

--- a/fluree-db-query/src/having.rs
+++ b/fluree-db-query/src/having.rs
@@ -76,6 +76,9 @@ impl HavingOperator {
 
 #[async_trait]
 impl Operator for HavingOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -411,6 +411,10 @@ pub struct NestedLoopJoinOperator {
     logged_runtime_mode: bool,
     /// Temporal mode captured at planner-time for the late per-row right scan.
     mode: crate::temporal_mode::TemporalMode,
+    /// The object→subject hash-join decision that was evaluated and *lost* for
+    /// this join (shape-eligible but rejected by cost/force), for `EXPLAIN`.
+    /// `None` when no hash join was ever a candidate. Never read on the hot path.
+    hj_decision: Option<crate::hash_join::HashJoinDecision>,
 }
 
 impl NestedLoopJoinOperator {
@@ -672,12 +676,23 @@ impl NestedLoopJoinOperator {
             out_schema: None,
             logged_runtime_mode: false,
             mode,
+            hj_decision: None,
         }
     }
 
     /// Trim output to only the specified downstream variables.
     pub fn with_out_schema(mut self, downstream_vars: Option<&[VarId]>) -> Self {
         self.out_schema = compute_trimmed_vars(&self.combined_schema, downstream_vars);
+        self
+    }
+
+    /// Attach the object→subject hash-join decision that lost to this nested-loop
+    /// join, for `EXPLAIN`. Plan-only — does not affect execution.
+    pub(crate) fn with_hash_join_decision(
+        mut self,
+        decision: Option<crate::hash_join::HashJoinDecision>,
+    ) -> Self {
+        self.hj_decision = decision;
         self
     }
 
@@ -992,6 +1007,9 @@ impl Operator for NestedLoopJoinOperator {
             "right".into(),
             crate::explain::format_pattern(&self.right_pattern).into(),
         );
+        if let Some(d) = &self.hj_decision {
+            d.write_details(&mut m);
+        }
         m
     }
     fn schema(&self) -> &[VarId] {

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -983,6 +983,17 @@ impl NestedLoopJoinOperator {
 
 #[async_trait]
 impl Operator for NestedLoopJoinOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.left.as_ref())]
+    }
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut m = serde_json::Map::new();
+        m.insert(
+            "right".into(),
+            crate::explain::format_pattern(&self.right_pattern).into(),
+        );
+        m
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.combined_schema)
     }

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -55,6 +55,7 @@ pub mod geo_search;
 pub mod graph;
 pub mod group_aggregate;
 pub mod groupby;
+pub mod hash_join;
 pub mod having;
 pub mod ir;
 pub mod join;

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -114,7 +114,6 @@ pub use explain::{
     OptimizationStatus, PatternDisplay, SelectivityInputs,
 };
 pub use filter::FilterOperator;
-pub use plan_node::{PlanEdge, PlanEdgeRel, PlanNode};
 pub use geo_rewrite::rewrite_geo_patterns;
 pub use graph::GraphOperator;
 pub use group_aggregate::{GroupAggregateOperator, StreamingAggSpec};
@@ -133,6 +132,7 @@ pub use minus::MinusOperator;
 pub use offset::OffsetOperator;
 pub use operator::{BoxedOperator, Operator, OperatorState};
 pub use optional::OptionalOperator;
+pub use plan_node::{PlanEdge, PlanEdgeRel, PlanNode};
 pub use planner::{
     extract_object_bounds_for_var, extract_range_constraints, is_property_join, PatternType,
     RangeConstraint, RangeValue,

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -67,6 +67,7 @@ pub mod offset;
 pub mod operator;
 pub mod optional;
 pub mod parse;
+pub mod plan_node;
 pub mod planner;
 pub mod policy;
 pub mod project;
@@ -113,6 +114,7 @@ pub use explain::{
     OptimizationStatus, PatternDisplay, SelectivityInputs,
 };
 pub use filter::FilterOperator;
+pub use plan_node::{PlanEdge, PlanEdgeRel, PlanNode};
 pub use geo_rewrite::rewrite_geo_patterns;
 pub use graph::GraphOperator;
 pub use group_aggregate::{GroupAggregateOperator, StreamingAggSpec};

--- a/fluree-db-query/src/limit.rs
+++ b/fluree-db-query/src/limit.rs
@@ -58,6 +58,9 @@ impl LimitOperator {
 
 #[async_trait]
 impl Operator for LimitOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/minus.rs
+++ b/fluree-db-query/src/minus.rs
@@ -303,6 +303,9 @@ fn rows_match(
 
 #[async_trait]
 impl Operator for MinusOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/offset.rs
+++ b/fluree-db-query/src/offset.rs
@@ -58,6 +58,9 @@ impl OffsetOperator {
 
 #[async_trait]
 impl Operator for OffsetOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/operator.rs
+++ b/fluree-db-query/src/operator.rs
@@ -77,6 +77,53 @@ pub trait Operator: Send + Sync {
     async fn drain_count(&mut self, _ctx: &ExecutionContext<'_>) -> Result<Option<u64>> {
         Ok(None)
     }
+
+    // ------------------------------------------------------------------
+    // EXPLAIN introspection (never called on the hot path)
+    // ------------------------------------------------------------------
+    //
+    // `describe()` renders the *planned* physical plan from the built (but not
+    // opened) operator tree. Composite operators override `plan_children()` to
+    // expose their inputs so the tree connects; leaves can add `plan_details()`.
+    // Decisions finalized at `open()` (multi-graph hash→nested-loop downgrade,
+    // fast-path-vs-fallback, the actual index permutation) are NOT reflected
+    // here — that is `EXPLAIN ANALYZE` territory. See `docs`/the plan note.
+
+    /// Operator display name. Defaults to the bare Rust type name.
+    fn op_name(&self) -> String {
+        crate::plan_node::short_type_name(std::any::type_name_of_val(self)).to_string()
+    }
+
+    /// Operator-specific attributes for the plan node (join var, predicate,
+    /// chosen index hint, …). Default: none.
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        serde_json::Map::new()
+    }
+
+    /// Child operators this node will consume, tagged with their edge kind.
+    /// Override on every operator that owns inputs, or the rendered plan tree
+    /// truncates at this node. Default: none (leaf).
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        Vec::new()
+    }
+
+    /// Render this operator (and, recursively, its children) as a [`PlanNode`].
+    /// Provided — operators customize via `op_name`/`plan_details`/`plan_children`.
+    fn describe(&self) -> crate::plan_node::PlanNode {
+        crate::plan_node::PlanNode {
+            op: self.op_name(),
+            est_rows: self.estimated_rows(),
+            details: self.plan_details(),
+            children: self
+                .plan_children()
+                .into_iter()
+                .map(|c| crate::plan_node::PlanEdge {
+                    rel: c.rel,
+                    node: c.op.describe(),
+                })
+                .collect(),
+        }
+    }
 }
 
 /// Boxed operator for dynamic dispatch

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -1298,6 +1298,9 @@ impl OptionalOperator {
 
 #[async_trait]
 impl Operator for OptionalOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.required.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.combined_schema)
     }

--- a/fluree-db-query/src/plan_node.rs
+++ b/fluree-db-query/src/plan_node.rs
@@ -1,0 +1,111 @@
+//! Physical-plan introspection nodes for `EXPLAIN`.
+//!
+//! [`Operator::describe`](crate::operator::Operator::describe) walks the real
+//! operator tree built by [`build_operator_tree`](crate::build_operator_tree)
+//! and produces a [`PlanNode`] tree — the planned physical plan, rendered
+//! without executing (no `open()`/`next_batch()`).
+//!
+//! Edges carry a [`PlanEdgeRel`] so the renderer distinguishes a real input
+//! ([`Child`](PlanEdgeRel::Child)) from a correctness fallback an operator
+//! keeps but only runs conditionally ([`Fallback`](PlanEdgeRel::Fallback)).
+//! A fallback must never read as a co-executing child.
+
+use crate::operator::Operator;
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+/// How a child node relates to its parent in the physical plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PlanEdgeRel {
+    /// A real input the parent consumes during execution.
+    Child,
+    /// A correctness fallback the parent runs *instead* of its fast path when
+    /// the fast path bails at `open()` (overlay/history/policy/multi-graph).
+    /// Only one of the fast path or the fallback executes.
+    Fallback,
+    /// A path taken only under a runtime condition decided at `open()`.
+    Conditional,
+}
+
+/// An edge to a child [`PlanNode`], tagged with its [`PlanEdgeRel`].
+#[derive(Debug, Clone, Serialize)]
+pub struct PlanEdge {
+    pub rel: PlanEdgeRel,
+    pub node: PlanNode,
+}
+
+fn map_is_empty(m: &Map<String, Value>) -> bool {
+    m.is_empty()
+}
+
+/// One node in the planned physical plan.
+#[derive(Debug, Clone, Serialize)]
+pub struct PlanNode {
+    /// Operator name (e.g. `"HashJoinOperator"`, `"DatasetOperator"`).
+    pub op: String,
+    /// Build-time cardinality estimate, when the operator exposes one.
+    #[serde(rename = "est-rows", skip_serializing_if = "Option::is_none")]
+    pub est_rows: Option<usize>,
+    /// Operator-specific attributes (join var, predicate, index hint, …).
+    #[serde(skip_serializing_if = "map_is_empty")]
+    pub details: Map<String, Value>,
+    /// Child edges (inputs, fallbacks, conditionals).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<PlanEdge>,
+}
+
+impl PlanNode {
+    /// A leaf node with just a name and optional estimate.
+    pub fn leaf(op: impl Into<String>, est_rows: Option<usize>) -> Self {
+        Self {
+            op: op.into(),
+            est_rows,
+            details: Map::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
+/// A child operator reference for [`Operator::plan_children`], tagged with the
+/// edge kind. Borrows the child so [`Operator::describe`] can recurse without
+/// cloning the tree.
+pub struct PlanChild<'a> {
+    pub rel: PlanEdgeRel,
+    pub op: &'a dyn Operator,
+}
+
+impl<'a> PlanChild<'a> {
+    /// A real input edge.
+    pub fn child(op: &'a dyn Operator) -> Self {
+        Self {
+            rel: PlanEdgeRel::Child,
+            op,
+        }
+    }
+
+    /// A correctness-fallback edge (see [`PlanEdgeRel::Fallback`]).
+    pub fn fallback(op: &'a dyn Operator) -> Self {
+        Self {
+            rel: PlanEdgeRel::Fallback,
+            op,
+        }
+    }
+
+    /// A conditional edge decided at `open()` (see [`PlanEdgeRel::Conditional`]).
+    /// Reserved for operators whose `open()`-time branch is a distinct
+    /// conditional node; no current `describe()` impl needs it yet.
+    pub fn conditional(op: &'a dyn Operator) -> Self {
+        Self {
+            rel: PlanEdgeRel::Conditional,
+            op,
+        }
+    }
+}
+
+/// Strip a fully-qualified type name to its bare type, e.g.
+/// `"fluree_db_query::project::ProjectOperator"` → `"ProjectOperator"`.
+pub(crate) fn short_type_name(full: &str) -> &str {
+    let base = full.split('<').next().unwrap_or(full);
+    base.rsplit("::").next().unwrap_or(base)
+}

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -50,6 +50,13 @@ const DEFAULT_BOUND_OBJECT_SELECTIVITY: f64 = 1_000.0;
 /// With no statistics, assume these are relatively large so we avoid placing
 /// them before bound-object constraints.
 const DEFAULT_PROPERTY_SCAN_SELECTIVITY: f64 = 1_000_000.0;
+/// Output estimate for a transitive path (`<s> <p>+ ?o`, etc.) anchored at a bound
+/// endpoint: a constant subject/object, or a variable already bound by an earlier
+/// pattern. Such a path enumerates the reachable set from that fixed node — a small
+/// bounded closure, not a world scan — so it should drive a join (the planner then
+/// probes the joined predicate by the produced var) instead of letting a
+/// high-cardinality predicate scan run first. See issue #1287.
+const ANCHORED_PROPERTY_PATH_SELECTIVITY: f64 = 100.0;
 /// Full scan - all variables unbound
 const FULL_SCAN: f64 = 1e12;
 
@@ -833,9 +840,21 @@ pub fn estimate_pattern(
             row_count: estimate_branch_cardinality(patterns, stats),
         },
 
-        Pattern::PropertyPath(_) => PatternEstimate::Source {
-            row_count: DEFAULT_PROPERTY_SCAN_SELECTIVITY,
-        },
+        Pattern::PropertyPath(pp) => {
+            // Anchored at a bound endpoint => a bounded closure from a fixed node,
+            // not a full predicate scan. Estimating it as a world scan made reorder
+            // drive a high-cardinality join predicate first (issue #1287).
+            let anchored = |r: &Ref| match r {
+                Ref::Var(v) => bound_vars.contains(v),
+                _ => true, // constant Sid/Iri endpoint
+            };
+            let row_count = if anchored(&pp.subject) || anchored(&pp.object) {
+                ANCHORED_PROPERTY_PATH_SELECTIVITY
+            } else {
+                DEFAULT_PROPERTY_SCAN_SELECTIVITY
+            };
+            PatternEstimate::Source { row_count }
+        }
 
         Pattern::R2rml(_) => PatternEstimate::Source {
             row_count: DEFAULT_PROPERTY_SCAN_SELECTIVITY,
@@ -1477,6 +1496,61 @@ mod tests {
 
     fn make_pattern(s: VarId, p_name: &str, o: VarId) -> TriplePattern {
         TriplePattern::new(Ref::Var(s), Ref::Sid(Sid::new(100, p_name)), Term::Var(o))
+    }
+
+    #[test]
+    fn anchored_property_path_is_selective_and_drives_the_join() {
+        // Issue #1287: <c912> skos:broader+ ?b . ?b skos:prefLabel ?lbl
+        use crate::ir::path::{PathModifier, PropertyPathPattern};
+        let b = VarId(0);
+        let lbl = VarId(1);
+        let bound = HashSet::new();
+
+        // Anchored at a constant subject => bounded closure (selective).
+        let anchored = Pattern::PropertyPath(PropertyPathPattern::new(
+            Ref::Sid(Sid::new(9, "c912")),
+            Sid::new(1, "broader"),
+            PathModifier::OneOrMore,
+            Ref::Var(b),
+        ));
+        assert_eq!(
+            estimate_pattern(&anchored, &bound, None).row_count(),
+            ANCHORED_PROPERTY_PATH_SELECTIVITY
+        );
+
+        // Both endpoints free => genuinely unbounded, keep the world-scan estimate.
+        let unanchored = Pattern::PropertyPath(PropertyPathPattern::new(
+            Ref::Var(VarId(2)),
+            Sid::new(1, "broader"),
+            PathModifier::OneOrMore,
+            Ref::Var(b),
+        ));
+        assert_eq!(
+            estimate_pattern(&unanchored, &bound, None).row_count(),
+            DEFAULT_PROPERTY_SCAN_SELECTIVITY
+        );
+
+        // End to end: the anchored path drives ahead of a 150k prefLabel scan even
+        // when written after it — otherwise the planner full-scans prefLabel (88s).
+        let pref = Pattern::Triple(TriplePattern::new(
+            Ref::Var(b),
+            Ref::Sid(Sid::new(2, "prefLabel")),
+            Term::Var(lbl),
+        ));
+        let mut stats = StatsView::default();
+        stats.properties.insert(
+            Sid::new(2, "prefLabel"),
+            PropertyStatData {
+                count: 150_000,
+                ndv_values: 150_000,
+                ndv_subjects: 6_000,
+            },
+        );
+        let ordered = reorder_patterns(&[pref, anchored], Some(&stats), &HashSet::new());
+        assert!(
+            matches!(&ordered[0], Pattern::PropertyPath(_)),
+            "anchored path must drive before the high-cardinality scan: {ordered:?}"
+        );
     }
 
     /// Count top-level patterns matching a predicate.

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1187,6 +1187,47 @@ fn try_place_reducer(
     }
 }
 
+/// Tie-break signal for join ordering: if the candidate source is placed (binding
+/// its produced vars), the largest probe-predicate count that would become an
+/// object→subject hash join — a remaining triple `?s <p> ?o` whose object `?o` the
+/// candidate binds while the subject `?s` stays new. Driving from such a start keeps
+/// that high-cardinality predicate a single contiguous hash-probe scan instead of a
+/// forward join over a large intermediate, so among equally-selective starts we
+/// prefer the one unlocking the biggest such scan. Returns `0` when nothing is
+/// unlocked or stats are absent, so it only ever breaks exact row-count ties.
+fn unlocked_object_hash_scan(
+    candidate: usize,
+    remaining: &[RankedPattern],
+    bound_vars: &HashSet<VarId>,
+    stats: Option<&StatsView>,
+) -> u64 {
+    let Some(stats) = stats else { return 0 };
+    let produced: HashSet<VarId> = remaining[candidate]
+        .pattern
+        .produced_vars()
+        .into_iter()
+        .collect();
+    remaining
+        .iter()
+        .enumerate()
+        .filter(|(k, _)| *k != candidate)
+        .filter_map(|(_, rp)| {
+            let Pattern::Triple(tp) = &rp.pattern else {
+                return None;
+            };
+            let o = tp.o.as_var()?;
+            let s = tp.s.as_var()?;
+            // Object newly bound by the candidate; subject still new (the probe shape).
+            if produced.contains(&o) && !produced.contains(&s) && !bound_vars.contains(&s) {
+                property_stats(stats, &tp.p).map(|p| p.count)
+            } else {
+                None
+            }
+        })
+        .max()
+        .unwrap_or(0)
+}
+
 /// Try to place the best source. Returns true if one was placed.
 fn try_place_source(
     remaining: &mut Vec<RankedPattern>,
@@ -1236,6 +1277,17 @@ fn try_place_source(
             ci.row_count()
                 .partial_cmp(&cj.row_count())
                 .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        // Before falling back to original index: among equally-selective starts,
+        // prefer the one that turns the LARGER predicate into an object→subject
+        // hash join rather than a forward join over a big intermediate. This flips
+        // a BSBM-BI bowtie (two equally-selective country filters, written
+        // producer/DE-first) onto the side whose chain keeps the 2.85M-row
+        // predicate hash-able — 46x on BI-1's F2.
+        .then_with(|| {
+            let bi = unlocked_object_hash_scan(i, &remaining[..], bound_vars, stats);
+            let bj = unlocked_object_hash_scan(j, &remaining[..], bound_vars, stats);
+            bj.cmp(&bi)
         })
         .then_with(|| remaining[i].orig_index.cmp(&remaining[j].orig_index))
     });
@@ -1544,6 +1596,73 @@ mod tests {
         assert!(
             first.produced_vars().contains(&s),
             "expected first pattern to join with seeded bound vars"
+        );
+    }
+
+    #[test]
+    fn reorder_bowtie_drives_the_side_that_unlocks_the_bigger_hash_join() {
+        // BSBM-BI F2 shape, written producer/DE-first:
+        //   ?product producer ?producer . ?producer country DE .
+        //   ?review reviewFor ?product . ?review reviewer ?reviewer . ?reviewer country US .
+        // Both country filters tie on estimate (same predicate). The tie-break must
+        // drive from the US side, because that makes the 2.85M-row rev:reviewer join
+        // an object→subject hash join; DE-first only unlocks the 285K producer join
+        // and leaves the reviewer chain as forward joins (the 110s→2.38s case).
+        let product = VarId(0);
+        let producer = VarId(1);
+        let review = VarId(2);
+        let reviewer = VarId(3);
+        let pat = |s: VarId, p: &str, o: Term| {
+            Pattern::Triple(TriplePattern::new(Ref::Var(s), Ref::Sid(Sid::new(1, p)), o))
+        };
+        let patterns = vec![
+            pat(product, "producer", Term::Var(producer)),
+            pat(producer, "country", Term::Sid(Sid::new(9, "DE"))),
+            pat(review, "reviewFor", Term::Var(product)),
+            pat(review, "reviewer", Term::Var(reviewer)),
+            pat(reviewer, "country", Term::Sid(Sid::new(9, "US"))),
+        ];
+
+        let mut stats = StatsView::default();
+        let mut put = |name: &str, count: u64, ndv_values: u64| {
+            stats.properties.insert(
+                Sid::new(1, name),
+                PropertyStatData {
+                    count,
+                    ndv_values,
+                    ndv_subjects: count,
+                },
+            );
+        };
+        put("producer", 284_826, 5_600);
+        put("country", 386_525, 25); // count/ndv = 15,461 — both filters tie here
+        put("reviewFor", 2_848_260, 280_000);
+        put("reviewer", 2_848_260, 570_000);
+
+        let ordered = reorder_patterns(&patterns, Some(&stats), &HashSet::new());
+        let first = match &ordered[0] {
+            Pattern::Triple(tp) => tp,
+            _ => panic!("expected Triple first"),
+        };
+        // Drives from the US country filter (binds ?reviewer), not the DE one.
+        assert_eq!(first.p.as_sid().map(|s| &*s.name), Some("country"));
+        assert_eq!(
+            first.o.as_sid().map(|s| &*s.name),
+            Some("US"),
+            "tie-break should drive the side that unlocks the 2.85M rev:reviewer hash join, got {ordered:?}"
+        );
+        // ...and rev:reviewer is placed before producer (US chain first).
+        let pred_order: Vec<&str> = ordered
+            .iter()
+            .filter_map(|p| match p {
+                Pattern::Triple(tp) => tp.p.as_sid().map(|s| &*s.name),
+                _ => None,
+            })
+            .collect();
+        let pos = |name: &str| pred_order.iter().position(|p| *p == name).unwrap();
+        assert!(
+            pos("reviewer") < pos("producer"),
+            "reviewer chain should precede producer chain: {pred_order:?}"
         );
     }
 

--- a/fluree-db-query/src/project.rs
+++ b/fluree-db-query/src/project.rs
@@ -33,6 +33,9 @@ impl ProjectOperator {
 
 #[async_trait]
 impl Operator for ProjectOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.vars
     }

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -611,6 +611,25 @@ impl PropertyJoinOperator {
 
 #[async_trait]
 impl Operator for PropertyJoinOperator {
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut m = serde_json::Map::new();
+        m.insert("subject".into(), format!("?v{}", self.subject_var.0).into());
+        let preds: Vec<serde_json::Value> = self
+            .predicates
+            .iter()
+            .map(|p| {
+                let name = match &p.pred_ref {
+                    Ref::Sid(sid) => format!("{}:{}", sid.namespace_code, sid.name),
+                    Ref::Iri(iri) => iri.to_string(),
+                    Ref::Var(v) => format!("?v{}", v.0),
+                };
+                serde_json::Value::String(name)
+            })
+            .collect();
+        m.insert("predicates".into(), serde_json::Value::Array(preds));
+        m
+    }
+
     fn schema(&self) -> &[VarId] {
         &self.output_schema
     }

--- a/fluree-db-query/src/property_path.rs
+++ b/fluree-db-query/src/property_path.rs
@@ -632,6 +632,12 @@ impl PropertyPathOperator {
 
 #[async_trait]
 impl Operator for PropertyPathOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        self.child
+            .as_deref()
+            .map(|c| vec![crate::plan_node::PlanChild::child(c)])
+            .unwrap_or_default()
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/s2_search.rs
+++ b/fluree-db-query/src/s2_search.rs
@@ -209,6 +209,9 @@ impl QueryGeomResolved {
 
 #[async_trait]
 impl Operator for S2SearchOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/semijoin.rs
+++ b/fluree-db-query/src/semijoin.rs
@@ -127,6 +127,9 @@ impl SemijoinOperator {
 
 #[async_trait]
 impl Operator for SemijoinOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/service.rs
+++ b/fluree-db-query/src/service.rs
@@ -375,6 +375,9 @@ impl ServiceOperator {
 
 #[async_trait]
 impl Operator for ServiceOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-query/src/sort.rs
+++ b/fluree-db-query/src/sort.rs
@@ -494,6 +494,9 @@ impl SortOperator {
 
 #[async_trait]
 impl Operator for SortOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -478,13 +478,23 @@ impl SubqueryOperator {
 
     /// Build the subquery's inner operator tree for `EXPLAIN` (build-only — no
     /// `open()`/exec). Mirrors [`run_subquery_with_seed`](Self::run_subquery_with_seed)'s
-    /// construction, but with a schema-only seed carrying the correlation vars
-    /// (so the inner reorder sees the same initial bound set) and no execution.
+    /// construction with no execution.
+    ///
+    /// The seed must match the path that actually runs, because the seed's schema
+    /// is the inner `reorder_patterns`' initial bound set AND the child every nested
+    /// subquery sees (a `SeedOperator`'s 1-row estimate flips their cardinality-guard
+    /// `join_mode` to per-row). `join_mode` evaluates the body ONCE with an empty
+    /// seed (`materialize`); per-row seeds the correlation vars
+    /// (`execute_subquery_for_row`). An uncorrelated subquery has no seed either way.
     fn build_inner_plan_for_explain(&self) -> Result<BoxedOperator> {
-        let seed_schema: Arc<[VarId]> =
-            Arc::from(self.correlation_vars.clone().into_boxed_slice());
-        let seed_row = vec![Binding::Unbound; self.correlation_vars.len()];
-        let seed: BoxedOperator = Box::new(crate::seed::SeedOperator::from_row(seed_schema, seed_row));
+        let seed: BoxedOperator = if self.join_mode || self.correlation_vars.is_empty() {
+            Box::new(EmptyOperator::new())
+        } else {
+            let seed_schema: Arc<[VarId]> =
+                Arc::from(self.correlation_vars.clone().into_boxed_slice());
+            let seed_row = vec![Binding::Unbound; self.correlation_vars.len()];
+            Box::new(SeedOperator::from_row(seed_schema, seed_row))
+        };
 
         let where_op = build_where_operators_seeded(
             Some(seed),

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -200,9 +200,62 @@ impl SubqueryOperator {
 
 #[async_trait]
 impl Operator for SubqueryOperator {
-    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
-        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut m = serde_json::Map::new();
+        m.insert("join-mode".into(), self.join_mode.into());
+        if !self.correlation_vars.is_empty() {
+            m.insert(
+                "correlation-vars".into(),
+                serde_json::Value::Array(
+                    self.correlation_vars
+                        .iter()
+                        .map(|v| serde_json::Value::String(format!("?v{}", v.0)))
+                        .collect(),
+                ),
+            );
+        }
+        m
     }
+
+    /// The subquery's inner operator tree is built lazily at runtime (it is not
+    /// held as a field), so the default `plan_children` walk can't reach it.
+    /// Rebuild it here — build-only, no `open()`/exec — from the stored IR +
+    /// stats + planning, and attach it under a `SubqueryBody` node so the inner
+    /// joins (where BSBM-BI time lives) are visible. The first child is the outer
+    /// input the subquery correlates against.
+    fn describe(&self) -> crate::plan_node::PlanNode {
+        use crate::plan_node::{PlanEdge, PlanEdgeRel, PlanNode};
+
+        let mut children = vec![PlanEdge {
+            rel: PlanEdgeRel::Child,
+            node: self.child.describe(),
+        }];
+
+        let body = match self.build_inner_plan_for_explain() {
+            Ok(inner) => PlanNode {
+                op: "SubqueryBody".into(),
+                est_rows: None,
+                details: serde_json::Map::new(),
+                children: vec![PlanEdge {
+                    rel: PlanEdgeRel::Child,
+                    node: inner.describe(),
+                }],
+            },
+            Err(e) => PlanNode::leaf(format!("SubqueryBody <error: {e}>"), None),
+        };
+        children.push(PlanEdge {
+            rel: PlanEdgeRel::Child,
+            node: body,
+        });
+
+        PlanNode {
+            op: self.op_name(),
+            est_rows: self.estimated_rows(),
+            details: self.plan_details(),
+            children,
+        }
+    }
+
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }
@@ -421,6 +474,40 @@ impl SubqueryOperator {
             index.entry(key).or_default().push(i);
         }
         Ok(MaterializedSubquery { rows, index })
+    }
+
+    /// Build the subquery's inner operator tree for `EXPLAIN` (build-only — no
+    /// `open()`/exec). Mirrors [`run_subquery_with_seed`](Self::run_subquery_with_seed)'s
+    /// construction, but with a schema-only seed carrying the correlation vars
+    /// (so the inner reorder sees the same initial bound set) and no execution.
+    fn build_inner_plan_for_explain(&self) -> Result<BoxedOperator> {
+        let seed_schema: Arc<[VarId]> =
+            Arc::from(self.correlation_vars.clone().into_boxed_slice());
+        let seed_row = vec![Binding::Unbound; self.correlation_vars.len()];
+        let seed: BoxedOperator = Box::new(crate::seed::SeedOperator::from_row(seed_schema, seed_row));
+
+        let where_op = build_where_operators_seeded(
+            Some(seed),
+            &self.subquery.patterns,
+            self.stats.clone(),
+            None,
+            &self.planning,
+        )?;
+
+        let select_vars: Option<&[VarId]> =
+            (!self.subquery.select.is_empty()).then_some(self.subquery.select.as_slice());
+        crate::execute::operator_tree::apply_solution_modifiers(
+            where_op,
+            self.subquery.grouping.as_ref(),
+            &self.subquery.order_binds,
+            &self.subquery.ordering,
+            select_vars,
+            self.subquery.distinct,
+            self.subquery.offset,
+            self.subquery.limit,
+            false,
+            None,
+        )
     }
 
     /// Build and run the subquery's operator tree from `seed`, returning rows

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -200,6 +200,9 @@ impl SubqueryOperator {
 
 #[async_trait]
 impl Operator for SubqueryOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         effective_schema(&self.out_schema, &self.in_schema)
     }

--- a/fluree-db-query/src/union.rs
+++ b/fluree-db-query/src/union.rs
@@ -200,6 +200,9 @@ impl UnionOperator {
 
 #[async_trait]
 impl Operator for UnionOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.effective_schema
     }

--- a/fluree-db-query/src/values.rs
+++ b/fluree-db-query/src/values.rs
@@ -160,6 +160,9 @@ impl ValuesOperator {
 
 #[async_trait]
 impl Operator for ValuesOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
     fn schema(&self) -> &[VarId] {
         &self.schema
     }

--- a/fluree-db-transact/src/commit.rs
+++ b/fluree-db-transact/src/commit.rs
@@ -412,7 +412,7 @@ where
 
         // Apply envelope deltas (namespace + graph) to the in-memory LedgerSnapshot.
         // This must happen before novelty apply so encode_iri() works for graph routing.
-        base.snapshot.apply_envelope_deltas(
+        Arc::make_mut(&mut base.snapshot).apply_envelope_deltas(
             &ns_delta,
             graph_delta.values().map(std::string::String::as_str),
         )?;
@@ -688,16 +688,26 @@ where
         // updated `dict_novelty` so overlay translation can resolve newly-introduced
         // subject/string IDs (otherwise the provider holds a stale Arc).
         let mut snapshot = base.snapshot;
-        if let Some(provider) = snapshot.range_provider.as_ref() {
-            if let Some(brp) = provider.as_any().downcast_ref::<BinaryRangeProvider>() {
-                let ns_fallback = Some(Arc::new(snapshot.namespaces().clone()));
-                snapshot.range_provider = Some(Arc::new(BinaryRangeProvider::new(
-                    Arc::clone(brp.store()),
-                    Arc::clone(&dict_novelty),
-                    Arc::clone(&runtime_small_dicts),
-                    ns_fallback,
-                )));
-            }
+        // Build the re-attached provider first so the read-borrow of `snapshot`
+        // ends before the `Arc::make_mut` (copy-on-write) assignment below.
+        let new_range_provider: Option<Arc<dyn fluree_db_core::range_provider::RangeProvider>> =
+            snapshot.range_provider.as_ref().and_then(|provider| {
+                provider
+                    .as_any()
+                    .downcast_ref::<BinaryRangeProvider>()
+                    .map(|brp| {
+                        let ns_fallback = Some(Arc::new(snapshot.namespaces().clone()));
+                        Arc::new(BinaryRangeProvider::new(
+                            Arc::clone(brp.store()),
+                            Arc::clone(&dict_novelty),
+                            Arc::clone(&runtime_small_dicts),
+                            ns_fallback,
+                        ))
+                            as Arc<dyn fluree_db_core::range_provider::RangeProvider>
+                    })
+            });
+        if let Some(rp) = new_range_provider {
+            Arc::make_mut(&mut snapshot).range_provider = Some(rp);
         }
 
         let new_state = LedgerState {


### PR DESCRIPTION
This PR improves query scaling and planner diagnostics for large read/query workloads.

- Replaces per-query deep snapshot clones with `Arc<LedgerSnapshot>` and switches cached ledger state to `RwLock`, allowing concurrent read snapshots to proceed in parallel while preserving exclusive write access.
- Adds a cost-based object-to-subject `HashJoinOperator` for large path joins, including planner tie-breaks that choose the driving side most likely to unlock a large hashable predicate scan.
- Extends `/fluree/explain` with compound-aware logical plans and planned physical operator trees, including fast-path labels, scan details, hash-join decisions, and expanded subquery bodies.
- Fixes planner estimates for anchored property paths so bounded closures drive joins instead of being treated like full-world scans.

Closes: #1287 

## Performance Notes

- Concurrent read benchmark improved from roughly flat scaling after 2 cores to about `8.05x` at 16 cores, with peak QPS reported around `107k`.
- BSBM-BI object-to-subject joins avoid repeated scattered OPST seeks by scanning the large predicate partition once and probing a hash table.
- Bowtie join ordering now prefers the side that unlocks the larger hash join, with the commit notes reporting a `110s -> 2.38s` improvement for the BI F2 shape.
- Anchored property paths such as `<concept/912> skos:broader+ ?b` are estimated as bounded closures rather than million-row scans.

## Explain Changes

`plan.logical` now preserves compound query structure while reflecting the same planner order used by execution.

`plan.physical` renders the planned operator tree without executing the query, including:

- `HashJoinOperator` vs `NestedLoopJoinOperator` selection
- hash-join cost inputs and rejection reasons
- fast-path operator labels and fallback edges
- dataset scan details such as predicate and planned index hints
- nested subquery bodies under `SubqueryBody`
